### PR TITLE
Share negotiated session state across FSM and transport

### DIFF
--- a/crates/fsm/src/session.rs
+++ b/crates/fsm/src/session.rs
@@ -1,6 +1,7 @@
 //! Core FSM session — `(State, Event) -> (State, Vec<Action>)`.
 
 use bytes::Bytes;
+use std::sync::Arc;
 
 use rustbgpd_wire::notification::{NotificationCode, cease_subcode, open_subcode};
 use rustbgpd_wire::{Capability, OpenMessage};
@@ -34,7 +35,7 @@ const INITIAL_HOLD_SECS: u32 = 240;
 pub struct Session {
     state: SessionState,
     config: PeerConfig,
-    negotiated: Option<NegotiatedSession>,
+    negotiated: Option<Arc<NegotiatedSession>>,
     connect_retry_counter: u32,
 }
 
@@ -62,7 +63,14 @@ impl Session {
     /// never report stale metadata from a failed handshake.
     #[must_use]
     pub fn negotiated(&self) -> Option<&NegotiatedSession> {
-        self.negotiated.as_ref()
+        self.negotiated.as_deref()
+    }
+
+    /// Shared negotiated session parameters for ownership across subsystem
+    /// boundaries while OpenConfirm/Established state is live.
+    #[must_use]
+    pub fn negotiated_shared(&self) -> Option<Arc<NegotiatedSession>> {
+        self.negotiated.clone()
     }
 
     /// Current connect-retry counter (for diagnostics).
@@ -264,7 +272,7 @@ impl Session {
                 Ok(neg) => {
                     let hold = u32::from(neg.hold_time);
                     let ka = u32::from(neg.keepalive_interval);
-                    self.negotiated = Some(neg);
+                    self.negotiated = Some(Arc::new(neg));
                     let mut actions = vec![Action::SendKeepalive];
                     if hold > 0 {
                         actions.push(Action::StartTimer(TimerType::Hold, hold));
@@ -362,7 +370,7 @@ impl Session {
                         actions.push(Action::StartTimer(TimerType::Hold, hold));
                     }
                     actions.push(self.transition_to(SessionState::Established));
-                    actions.push(Action::SessionEstablished(Box::new(neg)));
+                    actions.push(Action::SessionEstablished(Box::new((*neg).clone())));
                     actions
                 } else {
                     // Should not happen — negotiated is set in OpenSent

--- a/crates/fsm/tests/lifecycle.rs
+++ b/crates/fsm/tests/lifecycle.rs
@@ -1,11 +1,14 @@
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 
 use bytes::Bytes;
 
 use rustbgpd_wire::notification::NotificationCode;
 use rustbgpd_wire::{Afi, Capability, OpenMessage, Safi};
 
-use rustbgpd_fsm::{Action, Event, PeerConfig, Session, SessionState, TimerType};
+use rustbgpd_fsm::{
+    Action, Event, NegotiatedSession, PeerConfig, Session, SessionState, TimerType,
+};
 
 fn test_config() -> PeerConfig {
     let mut config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
@@ -40,6 +43,7 @@ fn has_action(actions: &[Action], pred: impl Fn(&Action) -> bool) -> bool {
 fn full_lifecycle_idle_to_established_to_idle() {
     let mut s = Session::new(test_config());
     assert_eq!(s.state(), SessionState::Idle);
+    assert!(s.negotiated_shared().is_none());
 
     // ── Idle → Connect: ManualStart ────────────────────────────────
     let actions = s.handle_event(Event::ManualStart);
@@ -88,6 +92,22 @@ fn full_lifecycle_idle_to_established_to_idle() {
         Action::SessionEstablished(_)
     )));
 
+    let shared = s.negotiated_shared().unwrap();
+    let legacy = actions
+        .iter()
+        .find_map(|action| match action {
+            Action::SessionEstablished(negotiated) => Some(negotiated.as_ref()),
+            _ => None,
+        })
+        .unwrap();
+    assert!(std::ptr::eq(s.negotiated().unwrap(), shared.as_ref()));
+    assert!(!std::ptr::eq(shared.as_ref(), legacy));
+    assert_ne!(
+        shared.negotiated_families.as_ptr(),
+        legacy.negotiated_families.as_ptr()
+    );
+    assert_eq!(Arc::strong_count(&shared), 2);
+
     // Verify negotiated parameters
     let neg = s.negotiated().unwrap();
     assert_eq!(neg.peer_asn, 65002);
@@ -107,11 +127,19 @@ fn full_lifecycle_idle_to_established_to_idle() {
     // ── Established → Idle: ManualStop ─────────────────────────────
     let actions = s.handle_event(Event::ManualStop { reason: None });
     assert_eq!(s.state(), SessionState::Idle);
+    assert!(s.negotiated_shared().is_none());
     assert!(has_action(&actions, |a| matches!(a, Action::SessionDown)));
     assert!(has_action(&actions, |a| matches!(
         a,
         Action::SendNotification(n) if n.code == NotificationCode::Cease
     )));
+}
+
+#[test]
+fn session_established_payload_remains_boxed_negotiated_session() {
+    let negotiated: Box<NegotiatedSession> = Box::default();
+    let action = Action::SessionEstablished(negotiated);
+    assert!(matches!(action, Action::SessionEstablished(_)));
 }
 
 /// Connect failure → Active → retry → Connect → full handshake

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1141,7 +1141,7 @@ impl PeerSession {
                 // critical for collision detection: handle_inbound() reads
                 // remote_router_id via QueryState when the session is in
                 // OpenConfirm.
-                let neg = self.fsm.negotiated().or(self.negotiated.as_ref());
+                let neg = self.fsm.negotiated().or(self.negotiated.as_deref());
                 let (messages_received, messages_sent) =
                     self.metrics.peer_message_totals(&self.peer_label);
                 let prefix_count = self.known_prefix_count();
@@ -1250,7 +1250,7 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::QueryWarmCheckpointState { reply } => {
-                let neg = self.fsm.negotiated().or(self.negotiated.as_ref());
+                let neg = self.fsm.negotiated().or(self.negotiated.as_deref());
                 let mut negotiated_families = neg
                     .map(|negotiated| negotiated.negotiated_families.clone())
                     .unwrap_or_default();
@@ -1308,7 +1308,7 @@ impl PeerSession {
                     let _ = reply.send(Err(PeerCommandError::RouteRefreshUnsupported));
                     return ControlFlow::Continue(());
                 }
-                if !self.negotiated_families.contains(&(afi, safi)) {
+                if !self.negotiated_families().contains(&(afi, safi)) {
                     let _ = reply.send(Err(PeerCommandError::FamilyNotNegotiated { afi, safi }));
                     return ControlFlow::Continue(());
                 }

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -2271,7 +2271,7 @@ mod tests {
         );
         let mut negotiated = NegotiatedSession::default();
         negotiated.peer_asn = negotiated_remote_asn;
-        session.negotiated = Some(negotiated);
+        session.negotiated = Some(Arc::new(negotiated));
         SessionExportProfile::capture(&session)
     }
 

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -1,6 +1,6 @@
 use super::{
-    Action, AddPathMode, Afi, BmpEvent, Bytes, Duration, Event, Instant, IpAddr, Ipv4Addr, Message,
-    NotificationCode, OUTBOUND_BUFFER, PeerDownReason, PeerSession, RibUpdate, Safi,
+    Action, AddPathMode, Afi, Arc, BmpEvent, Bytes, Duration, Event, Instant, IpAddr, Ipv4Addr,
+    Message, NotificationCode, OUTBOUND_BUFFER, PeerDownReason, PeerSession, RibUpdate, Safi,
     SessionLifecycleNotification, SessionNotification, SessionNotificationDirection, SessionState,
     cease_subcode, debug, info, mpsc, warn,
 };
@@ -362,7 +362,15 @@ impl PeerSession {
                         )));
                     }
                 }
-                Action::SessionEstablished(neg) => {
+                Action::SessionEstablished(legacy_negotiated) => {
+                    let negotiated = if let Some(shared) = self.fsm.negotiated_shared() {
+                        debug_assert_eq!(shared.as_ref(), legacy_negotiated.as_ref());
+                        drop(legacy_negotiated);
+                        shared
+                    } else {
+                        Arc::from(legacy_negotiated)
+                    };
+                    let neg = negotiated.as_ref();
                     let peer_asn = neg.peer_asn;
                     info!(
                         peer = %self.peer_label,
@@ -372,8 +380,6 @@ impl PeerSession {
                         four_octet_as = neg.four_octet_as,
                         "session established"
                     );
-                    self.negotiated_families
-                        .clone_from(&neg.negotiated_families);
                     self.add_path_receive_families = neg
                         .add_path_families
                         .iter()
@@ -479,7 +485,7 @@ impl PeerSession {
                         .map(|family| (family.afi, family.safi))
                         .collect();
                     let peer_enhanced_refresh = neg.peer_enhanced_route_refresh;
-                    self.negotiated = Some(*neg);
+                    self.negotiated = Some(negotiated);
                     self.publish_export_profile();
                     self.established_at = Some(Instant::now());
                     // Publish the empty/current capacity snapshot only after
@@ -721,7 +727,6 @@ impl PeerSession {
                     });
 
                     self.negotiated = None;
-                    self.negotiated_families.clear();
                     self.add_path_receive_families.clear();
                     self.clear_known_routes();
                     // A disconnected session has no live capacity usage.
@@ -792,7 +797,7 @@ impl PeerSession {
 
     fn try_send_lifecycle_state_changed(&self, old: SessionState, new: SessionState) {
         if let Some(ref lifecycle_tx) = self.session_lifecycle_tx {
-            let negotiated = self.fsm.negotiated().or(self.negotiated.as_ref());
+            let negotiated = self.fsm.negotiated().or(self.negotiated.as_deref());
             match lifecycle_tx.try_send(SessionLifecycleNotification::StateChanged {
                 session_id: self.session_identity.id,
                 role: self.session_identity.role,

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -523,7 +523,7 @@ impl PeerSession {
             let family = (mp.afi, mp.safi);
             if mp.safi != Safi::Unicast
                 || !matches!(mp.afi, Afi::Ipv4 | Afi::Ipv6)
-                || !self.negotiated_families.contains(&family)
+                || !self.negotiated_families().contains(&family)
                 || family == (Afi::Ipv4, Safi::Unicast) && !self.use_extended_nexthop_ipv4()
             {
                 continue;
@@ -575,7 +575,7 @@ impl PeerSession {
             if mp.announced.is_empty()
                 || mp.safi != Safi::Unicast
                 || !matches!(mp.afi, Afi::Ipv4 | Afi::Ipv6)
-                || !self.negotiated_families.contains(&family)
+                || !self.negotiated_families().contains(&family)
                 || family == (Afi::Ipv4, Safi::Unicast) && !self.use_extended_nexthop_ipv4()
             {
                 continue;
@@ -742,7 +742,7 @@ impl PeerSession {
             Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
             Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
         };
-        self.negotiated_families.contains(&family)
+        self.negotiated_families().contains(&family)
     }
     pub(super) fn use_extended_nexthop_ipv4(&self) -> bool {
         self.negotiated.as_ref().is_some_and(|n| {
@@ -849,7 +849,7 @@ impl PeerSession {
         for attr in &parsed.attributes {
             if let PathAttribute::MpUnreachNlri(mp) = attr {
                 let family = (mp.afi, mp.safi);
-                if self.negotiated_families.contains(&family) {
+                if self.negotiated_families().contains(&family) {
                     loop_withdrawn.extend(mp.withdrawn.iter().map(|e| (e.prefix, e.path_id)));
                     loop_fs_withdrawn.extend(
                         mp.flowspec_withdrawn
@@ -895,7 +895,7 @@ impl PeerSession {
             }
             if let PathAttribute::MpReachNlri(mp) = attr
                 && let Some(bgpls_family) = bgpls_family_from_safi(mp.safi)
-                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                && self.negotiated_families().contains(&(mp.afi, mp.safi))
             {
                 loop_bgpls_rejected.extend(mp.bgpls_announced.iter().map(|nlri| BgpLsRouteKey {
                     family: bgpls_family,
@@ -907,7 +907,7 @@ impl PeerSession {
             // that this session previously accepted.
             if let PathAttribute::MpReachNlri(mp) = attr
                 && mp.safi == Safi::MplsVpn
-                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                && self.negotiated_families().contains(&(mp.afi, mp.safi))
             {
                 loop_l3vpn_rejected.extend(mp.vpn_announced.iter().map(|entry| VpnRibRouteKey {
                     nlri_key: entry.nlri.key(),
@@ -916,7 +916,7 @@ impl PeerSession {
             }
             if let PathAttribute::MpReachNlri(mp) = attr
                 && mp.safi == Safi::LabeledUnicast
-                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                && self.negotiated_families().contains(&(mp.afi, mp.safi))
             {
                 loop_labeled_rejected.extend(mp.labeled_announced.iter().map(|entry| {
                     LabeledRibRouteKey {
@@ -927,7 +927,7 @@ impl PeerSession {
             }
             if let PathAttribute::MpReachNlri(mp) = attr
                 && mp.safi == Safi::RtConstrain
-                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                && self.negotiated_families().contains(&(mp.afi, mp.safi))
             {
                 loop_rtc_rejected.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
                     nlri: *nlri,
@@ -941,7 +941,7 @@ impl PeerSession {
             // family-specific announced vectors are only populated for their
             // own SAFI, so the negotiated-family check is the only guard.
             if let PathAttribute::MpReachNlri(mp) = attr
-                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                && self.negotiated_families().contains(&(mp.afi, mp.safi))
             {
                 loop_fs_rejected.extend(
                     mp.flowspec_announced
@@ -1995,7 +1995,7 @@ impl PeerSession {
             match attr {
                 PathAttribute::MpReachNlri(mp) => {
                     let family = (mp.afi, mp.safi);
-                    if !self.negotiated_families.contains(&family) {
+                    if !self.negotiated_families().contains(&family) {
                         warn!(
                             peer = %self.peer_label,
                             afi = ?mp.afi,
@@ -2569,7 +2569,7 @@ impl PeerSession {
                 }
                 PathAttribute::MpUnreachNlri(mp) => {
                     let family = (mp.afi, mp.safi);
-                    if !self.negotiated_families.contains(&family) {
+                    if !self.negotiated_families().contains(&family) {
                         continue;
                     }
                     if family == (Afi::Ipv4, Safi::Unicast) && !self.use_extended_nexthop_ipv4() {

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -670,7 +670,7 @@ impl PeerSession {
                                 continue;
                             };
                             // Ignore requests for unnegotiated families
-                            if !self.negotiated_families.contains(&(afi, safi)) {
+                            if !self.negotiated_families().contains(&(afi, safi)) {
                                 warn!(
                                     peer = %self.peer_label,
                                     ?afi, ?safi,

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -211,10 +211,7 @@ pub(crate) struct PeerSession {
     /// interface-bound peers. Built once from immutable transport config.
     link_local_next_hop_scope: Option<NextHopScope>,
     /// Negotiated session parameters (set when `SessionEstablished`).
-    negotiated: Option<NegotiatedSession>,
-    /// Address families negotiated via MP-BGP capabilities. Used to filter
-    /// inbound `MP_REACH_NLRI` and outbound route advertisements.
-    negotiated_families: Vec<(Afi, Safi)>,
+    negotiated: Option<Arc<NegotiatedSession>>,
     /// Families for which Add-Path receive was negotiated. Built once at
     /// `SessionEstablished` and reused by inbound UPDATE decode instead of
     /// rebuilding from `NegotiatedSession::add_path_families` per UPDATE.
@@ -827,6 +824,12 @@ impl PeerSession {
         self.add_path_receive_families.contains(&family)
     }
 
+    fn negotiated_families(&self) -> &[(Afi, Safi)] {
+        self.negotiated
+            .as_deref()
+            .map_or(&[], |negotiated| negotiated.negotiated_families.as_slice())
+    }
+
     fn receives_add_path_for_prefix(&self, prefix: Prefix) -> bool {
         self.receives_add_path_for_family(match prefix {
             Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
@@ -1097,7 +1100,6 @@ impl PeerSession {
             peer_ip,
             link_local_next_hop_scope,
             negotiated: None,
-            negotiated_families: Vec::new(),
             add_path_receive_families: Vec::new(),
             received_eor_families: HashSet::new(),
             stop_requested: false,
@@ -1266,7 +1268,6 @@ impl PeerSession {
             peer_ip,
             link_local_next_hop_scope,
             negotiated: None,
-            negotiated_families: Vec::new(),
             add_path_receive_families: Vec::new(),
             received_eor_families: HashSet::new(),
             stop_requested: false,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -190,12 +190,12 @@ impl PeerSession {
         // cannot be asked, so the staleness window lasts until its next
         // natural re-advertisement — surfaced by the warning.
         if update.request_refresh_all_negotiated {
-            let peer_route_refresh = self
-                .negotiated
-                .as_ref()
-                .is_some_and(|n| n.peer_route_refresh);
-            if peer_route_refresh {
-                for (afi, safi) in self.negotiated_families().to_vec() {
+            let negotiated = match self.negotiated.clone() {
+                Some(negotiated) if negotiated.peer_route_refresh => Some(negotiated),
+                _ => None,
+            };
+            if let Some(negotiated) = negotiated {
+                for &(afi, safi) in &negotiated.negotiated_families {
                     let msg = Message::RouteRefresh(RouteRefreshMessage::new(afi, safi));
                     if let Err(e) = self.enqueue_bulk(&msg) {
                         warn!(

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -195,7 +195,7 @@ impl PeerSession {
                 .as_ref()
                 .is_some_and(|n| n.peer_route_refresh);
             if peer_route_refresh {
-                for (afi, safi) in self.negotiated_families.clone() {
+                for (afi, safi) in self.negotiated_families().to_vec() {
                     let msg = Message::RouteRefresh(RouteRefreshMessage::new(afi, safi));
                     if let Err(e) = self.enqueue_bulk(&msg) {
                         warn!(
@@ -673,7 +673,7 @@ impl PeerSession {
                     unreachable!("BGP-LS key must prepare as BGP-LS")
                 };
                 if !self
-                    .negotiated_families
+                    .negotiated_families()
                     .contains(&(prepared.afi, prepared.safi))
                 {
                     continue;
@@ -719,7 +719,7 @@ impl PeerSession {
                     unreachable!("VPN key must prepare as VPN")
                 };
                 let family = (prepared.afi, prepared.safi);
-                if !self.negotiated_families.contains(&family) {
+                if !self.negotiated_families().contains(&family) {
                     continue;
                 }
                 if let Some((_, _, _, routes)) = groups.iter_mut().find(|(afi, safi, mode, _)| {
@@ -768,7 +768,7 @@ impl PeerSession {
                     unreachable!("labeled key must prepare as labeled unicast")
                 };
                 let family = (prepared.afi, prepared.safi);
-                if !self.negotiated_families.contains(&family) {
+                if !self.negotiated_families().contains(&family) {
                     continue;
                 }
                 if let Some((_, _, _, routes)) = groups.iter_mut().find(|(afi, safi, mode, _)| {
@@ -804,7 +804,7 @@ impl PeerSession {
         // family tuple (AFI 1 only).
         if !update.rtc_withdraw.is_empty()
             && self
-                .negotiated_families
+                .negotiated_families()
                 .contains(&(Afi::Ipv4, Safi::RtConstrain))
         {
             let mut routes = Vec::with_capacity(update.rtc_withdraw.len());
@@ -868,7 +868,7 @@ impl PeerSession {
             )> = Vec::new();
             for bgpls_route in &update.bgpls_announce {
                 let safi = bgpls_route.family.to_afi_safi().1;
-                if !self.negotiated_families.contains(&(Afi::BgpLs, safi)) {
+                if !self.negotiated_families().contains(&(Afi::BgpLs, safi)) {
                     continue;
                 }
                 let prepared = export.prepare_bgpls_candidate(bgpls_route);
@@ -914,7 +914,7 @@ impl PeerSession {
             )> = Vec::new();
             for vpn_route in &update.vpn_announce {
                 let family = vpn_route.afi_safi();
-                if !self.negotiated_families.contains(&family) {
+                if !self.negotiated_families().contains(&family) {
                     continue;
                 }
                 let prepared = export.prepare_vpn_candidate(vpn_route);
@@ -967,7 +967,7 @@ impl PeerSession {
             )> = Vec::new();
             for labeled_route in &update.labeled_announce {
                 let family = labeled_route.afi_safi();
-                if !self.negotiated_families.contains(&family) {
+                if !self.negotiated_families().contains(&family) {
                     continue;
                 }
                 let prepared = export.prepare_labeled_candidate(labeled_route);
@@ -1009,7 +1009,7 @@ impl PeerSession {
         // emitted as the session-local address (mirroring next-hop-self).
         if !update.rtc_announce.is_empty()
             && self
-                .negotiated_families
+                .negotiated_families()
                 .contains(&(Afi::Ipv4, Safi::RtConstrain))
         {
             let mut rtc_groups: Vec<(IpAddr, Vec<PathAttribute>, Vec<rustbgpd_wire::RtcNlri>)> =
@@ -1954,7 +1954,9 @@ mod tests {
     fn ipv6_ebgp_without_local_next_hop_trips_debug_contract() {
         let mut session = make_test_session();
         session.config.peer.families = vec![(Afi::Ipv6, Safi::Unicast)];
-        session.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
+        let mut negotiated = rustbgpd_fsm::NegotiatedSession::default();
+        negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
+        session.negotiated = Some(Arc::new(negotiated));
         let snapshot = session
             .export_encoder
             .publish(SessionExportProfile::capture(&session).with_test_ebgp(true));

--- a/crates/transport/src/session/shared_group.rs
+++ b/crates/transport/src/session/shared_group.rs
@@ -621,7 +621,7 @@ impl PeerSession {
     fn wants_shared_chunk(&self, update: &OutboundRouteUpdate, chunk: &SharedUnicastChunk) -> bool {
         update.announce_source_exclusion != Some(chunk.source)
             && self
-                .negotiated_families
+                .negotiated_families()
                 .contains(&(chunk.afi, Safi::Unicast))
     }
 }

--- a/crates/transport/src/session/tests/bmp.rs
+++ b/crates/transport/src/session/tests/bmp.rs
@@ -55,7 +55,7 @@ async fn accept_any_session_established_uses_learned_asn_for_bmp_and_rib() {
 #[tokio::test]
 async fn session_down_emits_bmp_peer_down() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     session.established_at = Some(Instant::now());
     session.last_down_reason = Some(PeerDownReason::RemoteNoNotification);
     session.execute_actions(vec![Action::SessionDown]).await;
@@ -71,8 +71,8 @@ async fn session_down_emits_bmp_peer_down() {
 #[tokio::test]
 async fn inbound_update_emits_bmp_route_monitoring() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
-    session.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let negotiated = negotiated_session(65002, false);
+    session.negotiated = Some(Arc::new(negotiated));
     let update = rustbgpd_wire::UpdateMessage::build(
         &[Ipv4NlriEntry {
             path_id: 0,
@@ -225,8 +225,8 @@ async fn legacy_as4_suffix_reaches_loop_detection_after_raw_bmp_tap() {
 #[tokio::test]
 async fn ebgp_local_pref_is_ignored_after_pre_policy_bmp_tap() {
     let (mut session, mut rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
-    session.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let negotiated = negotiated_session(65002, false);
+    session.negotiated = Some(Arc::new(negotiated));
     let update = UpdateMessage::build(
         &[Ipv4NlriEntry {
             path_id: 0,
@@ -287,8 +287,9 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
         RouteDistinguisher,
     };
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
-    session.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
+    session.negotiated = Some(Arc::new(negotiated));
     let evpn_route = EvpnRoute::MacIp(EvpnMacIp {
         rd: RouteDistinguisher([0x00, 0x00, 0xFD, 0xE8, 0x00, 0x00, 0x00, 0x64]),
         esi: EthernetSegmentIdentifier::ZERO,
@@ -378,10 +379,7 @@ async fn outbound_update_emits_rib_out_bmp_route_monitoring() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let mut update = empty_outbound_update();
     update.exact_export_snapshot = Some(session.publish_export_profile());
     update.announce = vec![make_route(100)].into();
@@ -405,10 +403,7 @@ async fn outbound_withdraw_and_eor_emit_rib_out_bmp() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let mut update = empty_outbound_update();
     update.exact_export_snapshot = Some(session.publish_export_profile());
     update.withdraw = vec![(
@@ -436,10 +431,7 @@ async fn rib_out_tap_default_off_and_skips_non_update_messages() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     // Default: bmp_rib_out is false — outbound UPDATE not tapped.
     let mut update = empty_outbound_update();
     update.exact_export_snapshot = Some(session.publish_export_profile());
@@ -475,10 +467,7 @@ async fn outbound_vpn_update_emits_rib_out_bmp_byte_exact() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::MplsVpn)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let mut update = empty_outbound_update();
     update.exact_export_snapshot = Some(session.publish_export_profile());
     update.vpn_announce = vec![make_vpn_rib_route(4093)];
@@ -501,10 +490,7 @@ async fn outbound_evpn_update_emits_rib_out_bmp_byte_exact() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let evpn_route = rustbgpd_rib::EvpnRibRoute {
         route: EvpnRoute::MacIp(EvpnMacIp {
             rd: RouteDistinguisher([0x00, 0x00, 0xFD, 0xE8, 0x00, 0x00, 0x00, 0x64]),
@@ -552,10 +538,7 @@ async fn rib_out_tap_full_channel_increments_source_drop_counter() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     // The helper's BMP channel holds 16 events; never drain it. The
     // 17th tapped UPDATE hits Full and must count a source drop.
     for _ in 0..17 {
@@ -665,10 +648,7 @@ async fn bmp_channel_full_after_wire_send_forces_peer_state_reset() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     session.local_open_pdu = Some(Bytes::from_static(&[1, 2, 3]));
     session.remote_open_pdu = Some(Bytes::from_static(&[4, 5, 6]));
     // 16 mirrored UPDATEs fill the channel; the 17th reaches the wire
@@ -717,7 +697,7 @@ async fn bmp_channel_full_after_wire_send_forces_peer_state_reset() {
 #[tokio::test]
 async fn bmp_repair_timer_retries_until_channel_drains() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     // Fill the 16-deep channel, then latch divergence with one more RM.
     let tx = session.bmp_tx.clone().unwrap();
     for _ in 0..16 {
@@ -762,7 +742,7 @@ async fn bmp_repair_timer_retries_until_channel_drains() {
 #[tokio::test]
 async fn bmp_peer_down_survives_full_channel() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     session.established_at = Some(Instant::now());
     session.last_down_reason = Some(PeerDownReason::RemoteNoNotification);
     let tx = session.bmp_tx.clone().unwrap();
@@ -800,7 +780,7 @@ async fn bmp_peer_down_survives_full_channel() {
 #[tokio::test]
 async fn tcp_disconnect_clears_bmp_repair_latch() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     session.tcp_ao_info = Some(crate::TcpAoInfoSnapshot {
         has_current_key: true,
         has_rnext_key: true,
@@ -863,7 +843,7 @@ async fn tcp_disconnect_clears_bmp_repair_latch() {
 #[tokio::test]
 async fn repair_partial_enqueue_duplicate_peer_down_is_acceptable() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let tx = session.bmp_tx.clone().unwrap();
     // Leave exactly one free slot in the 16-deep channel: PeerDown will
     // enqueue, the following PeerUp hits Full.

--- a/crates/transport/src/session/tests/denied_replacements.rs
+++ b/crates/transport/src/session/tests/denied_replacements.rs
@@ -16,7 +16,7 @@ async fn denied_classic_replacement_withdraws_exact_route_and_remains_explainabl
     let mut session = PeerSession::new(
         config, metrics, cmd_rx, rib_tx, None, None, None, None, None, false,
     );
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),

--- a/crates/transport/src/session/tests/import_policy.rs
+++ b/crates/transport/src/session/tests/import_policy.rs
@@ -59,10 +59,7 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
     );
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     // Send an UPDATE with 198.51.100.0/24 — should be denied by import policy
     let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
@@ -178,8 +175,9 @@ async fn import_policy_prefix_term_does_not_match_destination_less_flowspec() {
         ],
         default_action: PolicyAction::Permit,
     }])));
-    session.negotiated = Some(negotiated_session(65002, false));
-    session.negotiated_families = vec![(Afi::Ipv4, Safi::FlowSpec), (Afi::Ipv6, Safi::FlowSpec)];
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::FlowSpec), (Afi::Ipv6, Safi::FlowSpec)];
+    session.negotiated = Some(Arc::new(negotiated));
 
     let destless_v4 = destless_rule(6);
     let destless_v6 = destless_rule(17);
@@ -356,10 +354,7 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
     );
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -474,10 +469,7 @@ async fn session_down_flushes_import_decision_cache() {
     );
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -533,10 +525,7 @@ async fn explain_import_policy_command_does_not_touch_counters() {
     session.import_explain_enabled = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     // Populate the cache with one permitted prefix (permit-all default).
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
     let attrs = vec![
@@ -624,10 +613,7 @@ async fn query_import_policy_term_hits_snapshots_without_counting() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 
     // No import chain installed → nothing to report.
     assert!(snapshot(&mut session).await.is_none());
@@ -824,10 +810,7 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     );
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -945,10 +928,7 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
     session.import_explain_enabled = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let v6 = Ipv6Prefix::new("2001:db8:1::".parse().unwrap(), 64);
     let mp_reach = rustbgpd_wire::MpReachNlri {
         afi: Afi::Ipv6,
@@ -1011,10 +991,7 @@ async fn explain_disabled_stores_no_decisions() {
     );
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -1133,10 +1110,7 @@ async fn explain_trace_renders_as_path_from_the_cached_typed_value() {
     );
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -1329,7 +1303,7 @@ async fn import_policy_chain_accumulates_community_and_local_pref() {
         None,
         false,
     );
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 10, 0, 0), 16);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -1403,7 +1377,7 @@ async fn import_policy_match_next_hop_filters_route() {
         None,
         false,
     );
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {

--- a/crates/transport/src/session/tests/inbound_update.rs
+++ b/crates/transport/src/session/tests/inbound_update.rs
@@ -4,10 +4,7 @@ use super::*;
 async fn process_update_ignores_ipv4_mp_without_extended_nexthop() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -39,10 +36,7 @@ async fn process_update_ignores_ipv4_mp_without_extended_nexthop() {
 async fn process_update_accepts_ipv4_mp_with_extended_nexthop() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -87,7 +81,7 @@ async fn no_modification_update_shares_attribute_arc_across_nlri() {
     // no modifications. They must share one attribute `Arc` (the PR2 CoW
     // win), not deep-clone per route.
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -128,7 +122,7 @@ async fn no_modification_update_shares_attribute_arc_across_nlri() {
 #[tokio::test]
 async fn ibgp_local_pref_is_preserved() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65001);
-    session.negotiated = Some(negotiated_session(65001, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65001, false)));
     let update = UpdateMessage::build(
         &[Ipv4NlriEntry {
             path_id: 0,
@@ -214,7 +208,7 @@ async fn ebgp_import_policy_sees_default_local_pref_and_can_set_it() {
         ],
         default_action: PolicyAction::Deny,
     }])));
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let update = UpdateMessage::build(
         &[Ipv4NlriEntry { path_id: 0, prefix }],
         &[],
@@ -305,7 +299,7 @@ async fn modified_policy_update_owns_distinct_arc_per_nlri() {
     // rather than sharing the canonical one, and the mutation must land.
     const ADDED_COMMUNITY: u32 = 0xFDE9_0064; // 65001:100
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     session.install_import_policy(Some(PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: Some(Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))),

--- a/crates/transport/src/session/tests/labeled.rs
+++ b/crates/transport/src/session/tests/labeled.rs
@@ -15,10 +15,7 @@ async fn send_route_update_emits_labeled_reach_and_unreach() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::LabeledUnicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let route = make_labeled_rib_route(4093);
     let key = route.key();
     session.send_route_update(OutboundRouteUpdate {
@@ -134,10 +131,7 @@ async fn send_route_update_reflects_labeled_v6_link_local_next_hop() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::LabeledUnicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 
     let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
     let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
@@ -224,10 +218,7 @@ async fn send_route_update_emits_labeled_add_path_reach_and_unreach() {
     negotiated
         .add_path_families
         .insert((Afi::Ipv4, Safi::LabeledUnicast), AddPathMode::Both);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let mut route = make_labeled_rib_route(4093);
     route.path_id = 2;
     let key = route.key();

--- a/crates/transport/src/session/tests/loop_detection.rs
+++ b/crates/transport/src/session/tests/loop_detection.rs
@@ -24,10 +24,7 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
     negotiated.keepalive_interval = 30;
     negotiated.four_octet_as = true;
     negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     // Build the withdrawn EVPN Type 2 key.
     let withdrawn_route = EvpnRoute::MacIp(EvpnMacIp {
         rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
@@ -551,10 +548,7 @@ async fn rr_loop_detected_update_synthesizes_rtc_withdrawals() {
     negotiated.keepalive_interval = 30;
     negotiated.four_octet_as = true;
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::RtConstrain)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let announced_nlri = RtcNlri::new(65001, 0x0002_FDE9_0000_0064, 96).unwrap();
     let withdrawn_nlri = RtcNlri::new(65001, 0x0002_FDE9_0000_00C8, 96).unwrap();
     session.known_rtc.extend([
@@ -655,10 +649,7 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
     negotiated.keepalive_interval = 30;
     negotiated.four_octet_as = true;
     negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let withdrawn_route = EvpnRoute::MacIp(EvpnMacIp {
         rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
         esi: EthernetSegmentIdentifier::ZERO,

--- a/crates/transport/src/session/tests/max_prefix.rs
+++ b/crates/transport/src/session/tests/max_prefix.rs
@@ -958,10 +958,7 @@ async fn evpn_routes_counted_toward_max_prefix() {
     negotiated.keepalive_interval = 30;
     negotiated.four_octet_as = true;
     negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let make_route = |mac_lo: u8| -> EvpnRoute {
         EvpnRoute::MacIp(EvpnMacIp {
             rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
@@ -1038,10 +1035,7 @@ async fn rtc_routes_counted_toward_max_prefix() {
     negotiated.keepalive_interval = 30;
     negotiated.four_octet_as = true;
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::RtConstrain)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let make_nlri = |admin: u64| RtcNlri::new(65001, 0x0002_FDE9_0000_0000 | admin, 96).unwrap();
     let send_announces = |nlris: Vec<RtcNlri>| {
         let attrs = vec![

--- a/crates/transport/src/session/tests/mod.rs
+++ b/crates/transport/src/session/tests/mod.rs
@@ -288,9 +288,6 @@ fn negotiated_session(remote_asn: u32, extended_nexthop: bool) -> NegotiatedSess
     negotiated
 }
 fn install_test_negotiated_session(session: &mut PeerSession, negotiated: NegotiatedSession) {
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
     session.add_path_receive_families = negotiated
         .add_path_families
         .iter()
@@ -302,7 +299,7 @@ fn install_test_negotiated_session(session: &mut PeerSession, negotiated: Negoti
             }
         })
         .collect();
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 }
 
 fn max_prefix_gauge(metrics: &BgpMetrics, name: &str, peer: &str, scope: &str) -> Option<f64> {
@@ -1023,10 +1020,7 @@ async fn shared_group_member(local_asn: u32) -> (PeerSession, TcpStream) {
     let (client, server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     session.config.route_server_client = true;
     (session, server)
 }
@@ -1668,10 +1662,7 @@ fn retention_session_with_chain(
         false,
     );
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     (session, metrics)
 }
 
@@ -1714,6 +1705,134 @@ fn rejected_route_prototype_builds(session: &PeerSession) -> usize {
     session
         .rejected_route_prototype_builds
         .load(std::sync::atomic::Ordering::Relaxed)
+}
+
+#[tokio::test]
+async fn real_establishment_shares_fsm_arc_until_transport_finishes_teardown() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.peer.graceful_restart = true;
+    session.fsm = Session::new(session.config.peer.clone());
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    session.drive_fsm(Event::ManualStart).await;
+    session
+        .drive_fsm(Event::OpenReceived(rustbgpd_wire::OpenMessage {
+            version: 4,
+            my_as: 65002,
+            hold_time: 90,
+            bgp_identifier: Ipv4Addr::new(10, 0, 0, 2),
+            capabilities: vec![
+                Capability::MultiProtocol {
+                    afi: Afi::Ipv4,
+                    safi: Safi::Unicast,
+                },
+                Capability::FourOctetAs { asn: 65002 },
+                Capability::GracefulRestart {
+                    restart_state: true,
+                    notification: true,
+                    restart_time: 120,
+                    families: vec![rustbgpd_wire::GracefulRestartFamily {
+                        afi: Afi::Ipv4,
+                        safi: Safi::Unicast,
+                        forwarding_preserved: true,
+                    }],
+                },
+                Capability::LongLivedGracefulRestart(vec![LlgrFamily {
+                    afi: Afi::Ipv4,
+                    safi: Safi::Unicast,
+                    forwarding_preserved: true,
+                    stale_time: 3600,
+                }]),
+            ],
+        }))
+        .await;
+
+    let actions = session.fsm.handle_event(Event::KeepaliveReceived);
+    let shared = session.fsm.negotiated_shared().unwrap();
+    let shared_ptr = Arc::as_ptr(&shared);
+    let legacy = actions
+        .iter()
+        .find_map(|action| match action {
+            Action::SessionEstablished(negotiated) => Some(negotiated.as_ref()),
+            _ => None,
+        })
+        .unwrap();
+    assert!(!std::ptr::eq(shared.as_ref(), legacy));
+    assert_ne!(
+        shared.peer_capabilities.as_ptr(),
+        legacy.peer_capabilities.as_ptr()
+    );
+    assert_ne!(
+        shared.negotiated_families.as_ptr(),
+        legacy.negotiated_families.as_ptr()
+    );
+    drop(shared);
+
+    session.execute_actions(actions).await;
+    let transport = session.negotiated.as_ref().unwrap();
+    assert_eq!(Arc::as_ptr(transport), shared_ptr);
+    assert!(std::ptr::eq(
+        session.fsm.negotiated().unwrap(),
+        transport.as_ref()
+    ));
+    assert_eq!(Arc::strong_count(transport), 2);
+    assert_eq!(session.add_path_receive_families, Vec::<(Afi, Safi)>::new());
+
+    let weak = Arc::downgrade(transport);
+    let down_actions = session.fsm.handle_event(Event::TcpConnectionFails);
+    assert!(session.fsm.negotiated_shared().is_none());
+    let final_owner = session.negotiated.as_ref().unwrap();
+    assert_eq!(Arc::strong_count(final_owner), 1);
+    assert_eq!(final_owner.peer_asn, 65002);
+    assert_eq!(final_owner.peer_router_id, Ipv4Addr::new(10, 0, 0, 2));
+    assert!(final_owner.four_octet_as);
+    assert!(final_owner.peer_gr_capable);
+    assert!(final_owner.peer_llgr_capable);
+    assert!(final_owner.peer_notification_gr);
+    session.execute_actions(down_actions).await;
+    assert!(session.negotiated.is_none());
+    assert!(weak.upgrade().is_none());
+}
+
+#[tokio::test]
+async fn direct_action_fallback_rebuilds_fresh_arc_and_add_path_projection() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut first = negotiated_session(65002, false);
+    first
+        .add_path_families
+        .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Receive);
+    session
+        .execute_actions(vec![Action::SessionEstablished(Box::new(first))])
+        .await;
+    let first_arc = session.negotiated.as_ref().unwrap();
+    assert_eq!(Arc::strong_count(first_arc), 1);
+    assert_eq!(
+        session.add_path_receive_families,
+        vec![(Afi::Ipv4, Safi::Unicast)]
+    );
+    let first_weak = Arc::downgrade(first_arc);
+    session.execute_actions(vec![Action::SessionDown]).await;
+    assert!(first_weak.upgrade().is_none());
+
+    let mut second = negotiated_session(65003, false);
+    second.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
+    second
+        .add_path_families
+        .insert((Afi::Ipv6, Safi::Unicast), AddPathMode::Both);
+    session
+        .execute_actions(vec![Action::SessionEstablished(Box::new(second))])
+        .await;
+    let second_arc = session.negotiated.as_ref().unwrap();
+    assert_ne!(Arc::as_ptr(second_arc), first_weak.as_ptr());
+    assert_eq!(second_arc.peer_asn, 65003);
+    assert_eq!(
+        second_arc.negotiated_families,
+        vec![(Afi::Ipv6, Safi::Unicast)]
+    );
+    assert_eq!(
+        session.add_path_receive_families,
+        vec![(Afi::Ipv6, Safi::Unicast)]
+    );
 }
 
 mod bmp;

--- a/crates/transport/src/session/tests/next_hop.rs
+++ b/crates/transport/src/session/tests/next_hop.rs
@@ -5,10 +5,7 @@ async fn process_update_accepts_ipv4_mp_link_local_for_scoped_unnumbered_peer() 
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     configure_scoped_link_local_peer(&mut session);
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let next_hop: Ipv6Addr = "fe80::1".parse().unwrap();
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -53,10 +50,7 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     configure_scoped_link_local_peer(&mut session);
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let replacement_next_hop: IpAddr = "2001:db8::99".parse().unwrap();
     session.install_import_policy(Some(PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
@@ -126,10 +120,7 @@ async fn process_update_rejects_ipv4_mp_link_local_without_extended_nexthop() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     configure_scoped_link_local_peer(&mut session);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let next_hop: Ipv6Addr = "fe80::1".parse().unwrap();
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -175,10 +166,7 @@ async fn process_update_ignores_ipv4_body_nlri_for_scoped_unnumbered_peer() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     configure_scoped_link_local_peer(&mut session);
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -211,10 +199,7 @@ async fn route_server_client_extended_nexthop_preserves_ipv6_next_hop() {
     session.test_install_stream(client);
     session.config.route_server_client = true;
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let v6_nh: Ipv6Addr = "2001:db8::1".parse().unwrap();
     let update = OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
@@ -288,10 +273,7 @@ async fn unnumbered_ipv4_extended_nexthop_sends_link_local_mp_reach() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let update = OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
         announce_source_exclusion: None,
@@ -344,10 +326,7 @@ async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let remote_ll: Ipv6Addr = "fe80::2".parse().unwrap();
     let mut route = make_route(100);
     route.next_hop = IpAddr::V6(remote_ll);
@@ -405,10 +384,7 @@ async fn extended_nexthop_clears_companion_when_primary_next_hop_is_rewritten() 
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, true);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let mut route = make_route(100);
     route.next_hop = IpAddr::V6("2001:db8::2".parse().unwrap());
     route.link_local_next_hop = Some("fe80::2".parse().unwrap());
@@ -463,10 +439,7 @@ async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let update = OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
         announce_source_exclusion: None,
@@ -509,10 +482,7 @@ async fn route_server_client_ipv6_preserves_next_hop() {
     session.config.route_server_client = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let v6_nh: Ipv6Addr = "2001:db8::2".parse().unwrap();
     let update = OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
@@ -587,10 +557,7 @@ async fn ipv6_next_hop_self_clears_stale_link_local_companion() {
     session.config.local_ipv6_nexthop = Some("2001:db8::1".parse().unwrap());
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let remote_global: Ipv6Addr = "2001:db8::2".parse().unwrap();
     let mut route = make_v6_unicast_route(remote_global);
     route.link_local_next_hop = Some("fe80::2".parse().unwrap());
@@ -649,10 +616,7 @@ async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65001, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let route_next_hop = "2001:db8::2".parse().unwrap();
     let update = OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
@@ -712,7 +676,7 @@ async fn strict_peer_next_hop_rejects_foreign_ipv4_body_and_withdraws_replacemen
 
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.next_hop_ownership_strict_peer = true;
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let accepted = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let first_seen = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let withdrawn_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
@@ -1076,7 +1040,7 @@ async fn strict_peer_next_hop_rejects_link_local_companion_pair() {
 #[tokio::test]
 async fn next_hop_ownership_disabled_by_default_accepts_foreign_next_hop() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -334,7 +334,7 @@ async fn notification_teardown_without_n_bit_uses_peer_down() {
     }];
     neg.peer_notification_gr = false;
     session.config.peer.graceful_restart = true;
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     session.notification_teardown = true;
     session.execute_actions(vec![Action::SessionDown]).await;
     match rib_rx.try_recv().unwrap() {
@@ -356,7 +356,7 @@ async fn notification_teardown_with_n_bit_uses_peer_graceful_restart() {
     }];
     neg.peer_notification_gr = true;
     session.config.peer.graceful_restart = true;
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     session.notification_teardown = true;
     session.execute_actions(vec![Action::SessionDown]).await;
     match rib_rx.try_recv().unwrap() {
@@ -378,7 +378,7 @@ async fn peer_gr_restart_time_is_capped_before_rib_retention() {
     }];
     session.config.peer.graceful_restart = true;
     session.config.gr_peer_restart_time_max = 300;
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
 
     session.execute_actions(vec![Action::SessionDown]).await;
 
@@ -406,7 +406,7 @@ async fn hard_reset_always_bypasses_gr_even_with_n_bit() {
     }];
     neg.peer_notification_gr = true;
     session.config.peer.graceful_restart = true;
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     session.notification_teardown = true;
     session.received_hard_reset = true;
     session.execute_actions(vec![Action::SessionDown]).await;

--- a/crates/transport/src/session/tests/orf.rs
+++ b/crates/transport/src/session/tests/orf.rs
@@ -5,7 +5,7 @@ async fn inbound_orf_emits_peer_orf_update_when_negotiated() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let (handled, update) =
         drive_inbound_orf_with_reply(&mut session, &mut rib_rx, &rr, Ok(())).await;
@@ -20,7 +20,7 @@ async fn inbound_orf_preserves_defer_when_negotiated() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     let rr = orf_rr_with_when(
         WhenToRefresh::Defer,
         OrfType::AddressPrefix,
@@ -37,7 +37,7 @@ async fn inbound_orf_preserves_defer_when_negotiated() {
 async fn inbound_orf_ignored_when_family_not_negotiated() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     // negotiated_session() leaves negotiated_orf_recv empty.
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let handled = session
         .process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr)
@@ -54,7 +54,7 @@ async fn inbound_orf_ignores_legacy_type_128() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     // Family negotiated, but the legacy type 128 is never negotiated by us.
     let rr = orf_rr(OrfType::AddressPrefixLegacy, one_permit_entry());
     let handled = session
@@ -69,7 +69,7 @@ async fn inbound_orf_malformed_group_resets_via_remove_all() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     // A malformed Address-Prefix group → RFC 5291 §6 reset (REMOVE-ALL).
     let rr = orf_rr(
         OrfType::AddressPrefix,
@@ -87,7 +87,7 @@ async fn inbound_orf_rejected_by_rib_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let (handled, update) = drive_inbound_orf_with_reply(
         &mut session,
@@ -108,7 +108,7 @@ async fn inbound_orf_any_rib_group_rejection_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     let rr = orf_rr_with_groups(vec![
         OrfEntryGroup {
             orf_type: OrfType::AddressPrefix,
@@ -153,7 +153,7 @@ async fn inbound_orf_dropped_rib_reply_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
     tokio::pin!(process);
@@ -177,7 +177,7 @@ async fn inbound_orf_rib_reply_timeout_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
-    session.negotiated = Some(neg);
+    session.negotiated = Some(Arc::new(neg));
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
     tokio::pin!(process);

--- a/crates/transport/src/session/tests/otc.rs
+++ b/crates/transport/src/session/tests/otc.rs
@@ -88,7 +88,7 @@ async fn otc_ingress_adds_remote_asn_for_route_from_provider_unicast() {
     for role in [BgpRole::Customer, BgpRole::Peer, BgpRole::RouteServerClient] {
         let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
         session.config.peer.local_role = Some(role);
-        session.negotiated = Some(negotiated_session(65002, false));
+        session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
         let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
@@ -125,7 +125,7 @@ async fn otc_ingress_provider_drops_tagged_unicast_from_customer_but_keeps_withd
     for role in [BgpRole::Provider, BgpRole::RouteServer] {
         let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
         session.config.peer.local_role = Some(role);
-        session.negotiated = Some(negotiated_session(65002, false));
+        session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
         let announced_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
         let withdrawn_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
         let attrs = vec![
@@ -327,7 +327,7 @@ async fn otc_replacements_withdraw_accepted_classic_and_mp_routes_only() {
 async fn otc_ingress_peer_drops_tagged_unicast_from_wrong_as() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Peer);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -446,7 +446,7 @@ async fn otc_ingress_malformed_length_withdraws_a_real_accepted_replacement() {
 fn rib_staged_otc_denial_publishes_existing_egress_diagnostics() {
     let mut session = make_test_session(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Customer);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let sink = install_recording_sink(&mut session);
     let route = replace_route_attrs(
         &make_route(100),
@@ -482,7 +482,7 @@ async fn otc_ingress_provider_publishes_structured_event() {
     // the decoded OTC value.
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Provider);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let sink = install_recording_sink(&mut session);
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
@@ -519,7 +519,7 @@ async fn otc_ingress_peer_mismatch_publishes_structured_event() {
     // I2: Peer role with OTC ASN != peer ASN.
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Peer);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let sink = install_recording_sink(&mut session);
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
@@ -555,7 +555,7 @@ async fn otc_ingress_malformed_publishes_structured_event_with_no_otc_value() {
     // event's otc_value field is None.
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Provider);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let sink = install_recording_sink(&mut session);
     let announced_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
@@ -601,7 +601,7 @@ async fn otc_ingress_event_collects_mp_reach_v6_prefixes() {
     // an IPv6-only OTC violation.
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Provider);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let sink = install_recording_sink(&mut session);
     let v6_prefix = Ipv6Prefix::new(std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 32);
     let mp_reach = rustbgpd_wire::MpReachNlri {
@@ -652,7 +652,7 @@ async fn otc_ingress_skips_event_when_rejected_count_is_zero() {
     // and the per-peer counter bump are skipped.
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Provider);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let sink = install_recording_sink(&mut session);
     let baseline_blocked = session.otc_routes_blocked;
     let withdrawn_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
@@ -703,7 +703,7 @@ async fn otc_ingress_no_event_when_no_decision() {
     // local — no OTC rule fires, so the sink must stay empty.
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Customer);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     let sink = install_recording_sink(&mut session);
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![

--- a/crates/transport/src/session/tests/outbound_attrs.rs
+++ b/crates/transport/src/session/tests/outbound_attrs.rs
@@ -251,7 +251,7 @@ fn llgr_peer_keeps_llgr_stale_community() {
         stale_time: 3600,
         forwarding_preserved: false,
     }];
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let route = Route {
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),

--- a/crates/transport/src/session/tests/outbound_encode.rs
+++ b/crates/transport/src/session/tests/outbound_encode.rs
@@ -6,10 +6,7 @@ async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = Arc::new(vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -77,10 +74,7 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
     session.config.route_server_client = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let attrs = Arc::new(vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -176,10 +170,7 @@ async fn send_route_update_splits_oversized_ipv4_group_across_updates() {
     session.config.route_server_client = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 
     // One shared attribute set + next hop => one attribute group. 1500 /24s
     // (4 NLRI bytes each = 6000 bytes) cannot fit a single 4096-byte UPDATE.
@@ -278,10 +269,7 @@ async fn send_route_update_splits_oversized_ipv4_withdrawals_across_updates() {
     session.config.route_server_client = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 
     let count: u32 = 2000;
     let withdraw: Vec<(Prefix, u32)> = (0..count)
@@ -627,7 +615,9 @@ async fn send_route_update_chunks_ipv6_at_negotiated_message_limit() {
     assert!(withdraw_updates >= 2);
     assert_eq!(withdrawn.len(), count as usize);
 
-    session.negotiated.as_mut().unwrap().peer_extended_message = true;
+    let mut negotiated = session.negotiated.as_deref().unwrap().clone();
+    negotiated.peer_extended_message = true;
+    session.negotiated = Some(Arc::new(negotiated));
     session.send_route_update(OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
         announce_source_exclusion: None,
@@ -1265,7 +1255,9 @@ async fn send_route_update_chunks_flowspec_without_infallible_build() {
     assert!(withdraw_updates >= 3);
     assert_eq!(withdrawn.len(), (count * 2) as usize);
 
-    session.negotiated.as_mut().unwrap().peer_extended_message = true;
+    let mut negotiated = session.negotiated.as_deref().unwrap().clone();
+    negotiated.peer_extended_message = true;
+    session.negotiated = Some(Arc::new(negotiated));
     session.send_route_update(OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
         announce_source_exclusion: None,
@@ -1304,10 +1296,7 @@ async fn send_route_update_uses_ipv6_specific_next_hop_override() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let route = make_v6_unicast_route("2001:db8::1".parse().unwrap());
     let override_nh =
         rustbgpd_policy::NextHopAction::Specific(IpAddr::V6("2001:db8::42".parse().unwrap()));

--- a/crates/transport/src/session/tests/refresh.rs
+++ b/crates/transport/src/session/tests/refresh.rs
@@ -770,10 +770,7 @@ async fn send_route_update_emits_route_refresh_requests_for_all_negotiated_famil
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_route_refresh = true;
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     session.send_route_update(OutboundRouteUpdate {
         exact_export_snapshot: None,
         announce_source_exclusion: None,
@@ -829,10 +826,7 @@ async fn send_route_update_skips_route_refresh_request_without_capability() {
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
     assert!(!negotiated.peer_route_refresh);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     session.send_route_update(OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
         announce_source_exclusion: None,

--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -481,7 +481,11 @@ async fn rfc7606_treat_as_withdraw_covers_previously_accepted_evpn_routes() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-    session.negotiated_families.push((Afi::L2Vpn, Safi::Evpn));
+    let mut negotiated = session.negotiated.as_deref().unwrap().clone();
+    negotiated
+        .negotiated_families
+        .push((Afi::L2Vpn, Safi::Evpn));
+    session.negotiated = Some(Arc::new(negotiated));
     rfc7606_drain(&mut rib_rx);
     let evpn_route = EvpnRoute::MacIp(EvpnMacIp {
         rd: RouteDistinguisher([0x00, 0x00, 0xFD, 0xE8, 0x00, 0x00, 0x00, 0x64]),

--- a/crates/transport/src/session/tests/rpki_aspa.rs
+++ b/crates/transport/src/session/tests/rpki_aspa.rs
@@ -4,7 +4,7 @@ use super::*;
 fn aspa_validation_context_uses_negotiated_asn_and_local_role() {
     let mut session = make_test_session(65001, 65002);
     session.config.peer.local_role = Some(rustbgpd_wire::BgpRole::RouteServerClient);
-    session.negotiated = Some(negotiated_session(65099, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65099, false)));
     let context = session.aspa_validation_context();
     assert_eq!(context.neighbor_asn, Some(65099));
     assert_eq!(
@@ -19,7 +19,7 @@ fn aspa_validation_context_uses_negotiated_asn_and_local_role() {
 #[test]
 fn aspa_validation_context_carries_neighbor_asn_without_a_role() {
     let mut session = make_test_session(65001, 65002);
-    session.negotiated = Some(negotiated_session(65099, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65099, false)));
     let context = session.aspa_validation_context();
     assert_eq!(context.neighbor_asn, Some(65099));
     assert_eq!(context.local_role, None);
@@ -206,10 +206,7 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         false,
     );
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     // UPDATE with two prefixes from AS 65002:
     //   192.0.2.0/24   → RPKI Valid  (VRP: AS 65002 covers it)   → permitted
     //   198.51.100.0/24 → RPKI Invalid (VRP says AS 65099)        → denied
@@ -442,10 +439,7 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         false,
     );
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     // UPDATE with AS_PATH [65002, 65003] — ASPA Valid (65003 authorizes 65002).
     // Two prefixes: both should be permitted (same AS_PATH, same ASPA state).
     let valid_attrs = vec![

--- a/crates/transport/src/session/tests/rtc_bgpls.rs
+++ b/crates/transport/src/session/tests/rtc_bgpls.rs
@@ -7,10 +7,7 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::BgpLs, Safi::BgpLs)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let route = make_bgpls_route(0xcc);
     let key = route.key();
     session.send_route_update(OutboundRouteUpdate {
@@ -102,10 +99,7 @@ async fn oversized_bgpls_output_tears_down_session() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::BgpLs, Safi::BgpLs)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let mut route = make_bgpls_route(0xdd);
     route.nlri = BgpLsNlri::try_new(
         BgpLsNlriType::Unknown(65_000),
@@ -556,10 +550,7 @@ async fn send_route_update_emits_rtc_reach_and_unreach() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::RtConstrain)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let route = make_rtc_rib_route(100);
     let key = route.key();
     // A locally-originated default rides in the same update; its stored

--- a/crates/transport/src/session/tests/run_loop.rs
+++ b/crates/transport/src/session/tests/run_loop.rs
@@ -401,8 +401,8 @@ async fn saturation_teardown_from_run_loop_ceases_closes_and_deregisters() {
 #[tokio::test]
 async fn full_rib_channel_parks_session_and_never_drops_routes() {
     let (mut session, mut rib_rx, metrics) = backpressure_test_session(1);
-    session.negotiated = Some(negotiated_session(65002, false));
-    session.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let negotiated = negotiated_session(65002, false);
+    session.negotiated = Some(Arc::new(negotiated));
     // Fill the capacity-1 channel so the delivery must block.
     session
         .rib_tx
@@ -896,7 +896,7 @@ async fn inbound_extended_message_accepted_from_peer_without_capability() {
 #[tokio::test]
 async fn outbound_extended_message_gated_on_peer_capability() {
     let mut session = make_test_session(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     assert_eq!(
         session.outbound_max_message_len(),
         rustbgpd_wire::MAX_MESSAGE_LEN
@@ -910,7 +910,9 @@ async fn outbound_extended_message_gated_on_peer_capability() {
         session.enqueue_priority(&big).is_err(),
         "oversized NOTIFICATION must not encode toward a peer without the capability"
     );
-    session.negotiated.as_mut().unwrap().peer_extended_message = true;
+    let mut negotiated = session.negotiated.as_deref().unwrap().clone();
+    negotiated.peer_extended_message = true;
+    session.negotiated = Some(Arc::new(negotiated));
     assert_eq!(
         session.outbound_max_message_len(),
         rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN

--- a/crates/transport/src/session/tests/shared_group_encode.rs
+++ b/crates/transport/src/session/tests/shared_group_encode.rs
@@ -6,10 +6,7 @@ async fn shared_transition_payload_excludes_only_the_target_source() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     let negotiated = negotiated_session(65002, false);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 
     let own = make_route(100);
     assert_eq!(own.peer, session.peer_ip);
@@ -580,7 +577,9 @@ async fn shared_group_consumer_streams_concurrently_with_live_encoder() {
 async fn shared_group_wire_equivalence_proof_ignores_only_byte_inert_fields() {
     let (a, _wire_a) = shared_group_member(65001).await;
     let (mut b, _wire_b) = shared_group_member(65001).await;
-    b.negotiated.as_mut().unwrap().peer_extended_message = true;
+    let mut negotiated = b.negotiated.as_deref().unwrap().clone();
+    negotiated.peer_extended_message = true;
+    b.negotiated = Some(Arc::new(negotiated));
     let profile_a = a.publish_export_profile();
     let profile_b = b.publish_export_profile();
     assert!(
@@ -588,11 +587,11 @@ async fn shared_group_wire_equivalence_proof_ignores_only_byte_inert_fields() {
         "extended-message ceiling is byte-inert at the shared 4096 ceiling"
     );
     let (mut c, _wire_c) = shared_group_member(65001).await;
-    c.negotiated
-        .as_mut()
-        .unwrap()
+    let mut negotiated = c.negotiated.as_deref().unwrap().clone();
+    negotiated
         .add_path_families
         .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Send);
+    c.negotiated = Some(Arc::new(negotiated));
     let profile_c = c.publish_export_profile();
     assert!(
         !profile_a.has_same_wire_encoding(&profile_c),

--- a/crates/transport/src/session/tests/state_query.rs
+++ b/crates/transport/src/session/tests/state_query.rs
@@ -189,7 +189,7 @@ async fn query_state_sorts_both_paths_limit_vectors_by_numeric_family() {
             .effective_add_path_send_limits
             .insert(family, effective_limit);
     }
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 
     let (reply, state) = oneshot::channel();
     assert!(matches!(

--- a/crates/transport/src/session/tests/vpn.rs
+++ b/crates/transport/src/session/tests/vpn.rs
@@ -12,10 +12,7 @@ async fn send_route_update_reflects_vpnv6_link_local_next_hop() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::MplsVpn)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
 
     let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
     let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
@@ -106,10 +103,7 @@ async fn send_route_update_emits_vpn_reach_and_unreach() {
     session.test_install_stream(client);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::MplsVpn)];
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let route = make_vpn_rib_route(4093);
     let key = route.key();
     session.send_route_update(OutboundRouteUpdate {
@@ -226,10 +220,7 @@ async fn send_route_update_emits_vpn_add_path_reach_and_unreach() {
     negotiated
         .add_path_families
         .insert((Afi::Ipv4, Safi::MplsVpn), AddPathMode::Both);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    session.negotiated = Some(Arc::new(negotiated));
     let mut route = make_vpn_rib_route(4093);
     route.path_id = 2;
     let key = route.key();


### PR DESCRIPTION
## Summary

- Share immutable negotiated-session state between the FSM and transport.
- Preserve the public boxed `SessionEstablished` action and direct-action fallback.
- Keep Add-Path receive projection and teardown/reestablishment behavior intact.

## Validation

- Named compatibility and ownership tests
- Full locked FSM, transport, and `rustbgpd` binary suites
- Workspace all-target/all-feature check
- Strict Clippy, warning-denied rustdoc, formatting, and diff checks

## Documentation

No documentation, changelog, or roadmap update is needed because this is an internal ownership refactor with no public API or behavior change.
