### PR TITLE
Share event-history snapshots off the RIB actor

### DIFF
--- a/crates/api/src/event_history_sinks.rs
+++ b/crates/api/src/event_history_sinks.rs
@@ -11,7 +11,7 @@
 //! - the proto-conversion helpers from `crate::event_service::convert`,
 //! - the workspace [`BgpMetrics`] for drop counters.
 //!
-//! The RIB sink's on-actor publish is clone + producer timestamp +
+//! The RIB sink's on-actor publish is one `Arc` clone + producer timestamp +
 //! bounded `try_send` of the owned event snapshot. Proto conversion,
 //! prost encoding, and envelope string construction run in the
 //! conversion stage task spawned by [`make_rib_event_sink`], which
@@ -53,20 +53,13 @@ use crate::proto;
 /// their already-assigned process-local `event_id` inside the event
 /// itself. No proto message, payload bytes, or envelope strings cross
 /// this channel.
-#[allow(
-    clippy::large_enum_variant,
-    reason = "the EVPN variant is several hundred bytes larger than the route \
-              variant, but boxing it would put a heap allocation back on the \
-              RIB actor's publish path — the exact cost this offload removes — \
-              so the enum stays by-value"
-)]
 enum RibEventSnapshot {
     Route {
-        event: RouteEvent,
+        event: Arc<RouteEvent>,
         timestamp_ns: i64,
     },
     Evpn {
-        event: EvpnRouteEvent,
+        event: Arc<EvpnRouteEvent>,
         timestamp_ns: i64,
     },
 }
@@ -80,7 +73,7 @@ impl RibEventSnapshot {
     }
 }
 
-/// Concrete sink installed on the RIB actor. Publish is a clone, a
+/// Concrete sink installed on the RIB actor. Publish is one `Arc` clone, a
 /// timestamp stamp, and a bounded `try_send`; proto conversion, prost
 /// encoding, and envelope string construction all run off-actor in
 /// the conversion stage spawned by [`make_rib_event_sink`].
@@ -118,15 +111,25 @@ impl EhmRibSink {
 
 impl RibEventSink for EhmRibSink {
     fn publish_route_event(&self, event: &RouteEvent) {
+        let event = Arc::new(event.clone());
+        self.publish_route_event_shared(&event);
+    }
+
+    fn publish_route_event_shared(&self, event: &Arc<RouteEvent>) {
         self.enqueue(RibEventSnapshot::Route {
-            event: event.clone(),
+            event: Arc::clone(event),
             timestamp_ns: timestamp_ns_now(),
         });
     }
 
     fn publish_evpn_event(&self, event: &EvpnRouteEvent) {
+        let event = Arc::new(event.clone());
+        self.publish_evpn_event_shared(&event);
+    }
+
+    fn publish_evpn_event_shared(&self, event: &Arc<EvpnRouteEvent>) {
         self.enqueue(RibEventSnapshot::Evpn {
-            event: event.clone(),
+            event: Arc::clone(event),
             timestamp_ns: timestamp_ns_now(),
         });
     }
@@ -194,11 +197,11 @@ fn convert_and_forward(
         RibEventSnapshot::Route {
             event,
             timestamp_ns,
-        } => route_event_envelope(event, timestamp_ns),
+        } => route_event_envelope(Arc::unwrap_or_clone(event), timestamp_ns),
         RibEventSnapshot::Evpn {
             event,
             timestamp_ns,
-        } => evpn_event_envelope(event, timestamp_ns),
+        } => evpn_event_envelope(Arc::unwrap_or_clone(event), timestamp_ns),
     };
     try_send_envelope(handle, metrics, envelope);
 }
@@ -260,7 +263,7 @@ fn evpn_event_envelope(event: EvpnRouteEvent, timestamp_ns: i64) -> EventEnvelop
 /// plus its off-actor conversion stage.
 ///
 /// The sink's publish path runs synchronously on the RIB actor and is
-/// deliberately minimal: clone the event, stamp `timestamp_ns`,
+/// deliberately minimal: clone the event's `Arc`, stamp `timestamp_ns`,
 /// bounded `try_send`. Proto conversion, prost encoding, and envelope
 /// construction run in the returned stage's task, in publish order
 /// (single producer, one FIFO channel). The snapshot channel is sized
@@ -709,6 +712,28 @@ mod tests {
         manager.shutdown().await;
     }
 
+    #[test]
+    fn shared_snapshot_queue_retains_the_published_arc() {
+        let state = Arc::new(EhmState::default());
+        let metrics = BgpMetrics::new();
+        let (snapshot_tx, mut snapshot_rx) = mpsc::channel(1);
+        let sink = EhmRibSink {
+            snapshot_tx,
+            state,
+            metrics,
+        };
+        let event = Arc::new(sample_route_event(RouteEventType::Added, 0));
+
+        sink.publish_route_event_shared(&event);
+
+        match snapshot_rx.try_recv().expect("snapshot accepted") {
+            RibEventSnapshot::Route { event: queued, .. } => {
+                assert!(Arc::ptr_eq(&event, &queued));
+            }
+            RibEventSnapshot::Evpn { .. } => panic!("route publish queued as EVPN"),
+        }
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn direct_queue_full_advances_loss_generation() {
         // Load-bearing break: removing `record_loss` from
@@ -756,12 +781,14 @@ mod tests {
             metrics: metrics.clone(),
         };
 
-        sink.publish_route_event(&sample_route_event(RouteEventType::Added, 0));
+        let first = Arc::new(sample_route_event(RouteEventType::Added, 0));
+        sink.publish_route_event_shared(&first);
         assert!(!state.degraded(), "accepted publish must not degrade");
         assert!(!losses.has_changed().unwrap());
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 0);
 
-        sink.publish_route_event(&sample_route_event(RouteEventType::Added, 1));
+        let second = Arc::new(sample_route_event(RouteEventType::Added, 1));
+        sink.publish_route_event_shared(&second);
         assert!(state.degraded(), "queue-full drop must flip EHM state");
         assert!(losses.has_changed().unwrap());
         assert_eq!(*losses.borrow_and_update(), 1);
@@ -771,7 +798,8 @@ mod tests {
         );
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 1);
 
-        sink.publish_route_event(&sample_route_event(RouteEventType::Added, 2));
+        let third = Arc::new(sample_route_event(RouteEventType::Added, 2));
+        sink.publish_route_event_shared(&third);
         assert!(losses.has_changed().unwrap());
         assert_eq!(*losses.borrow_and_update(), 2);
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 2);
@@ -793,7 +821,8 @@ mod tests {
             metrics: metrics.clone(),
         };
 
-        sink.publish_evpn_event(&sample_evpn_event());
+        let event = Arc::new(sample_evpn_event());
+        sink.publish_evpn_event_shared(&event);
         assert!(!state.degraded(), "closed drop must not flip EHM state");
         assert!(!losses.has_changed().unwrap());
         assert!(
@@ -819,7 +848,8 @@ mod tests {
         let (sink, stage) = make_rib_event_sink(handle.clone(), metrics.clone());
 
         for index in 0..16u32 {
-            sink.publish_route_event(&sample_route_event(RouteEventType::Added, index));
+            let event = Arc::new(sample_route_event(RouteEventType::Added, index));
+            sink.publish_route_event_shared(&event);
         }
         stage.shutdown().await;
 
@@ -831,7 +861,8 @@ mod tests {
             assert_eq!(committed.event_id, index + 1);
         }
 
-        sink.publish_route_event(&sample_route_event(RouteEventType::Added, 99));
+        let late = Arc::new(sample_route_event(RouteEventType::Added, 99));
+        sink.publish_route_event_shared(&late);
         assert_eq!(drop_counter(&metrics, "route", "closed"), 1);
         assert!(
             !handle.state().degraded(),

--- a/crates/api/src/event_history_sinks.rs
+++ b/crates/api/src/event_history_sinks.rs
@@ -112,7 +112,11 @@ impl EhmRibSink {
 impl RibEventSink for EhmRibSink {
     fn publish_route_event(&self, event: &RouteEvent) {
         let event = Arc::new(event.clone());
-        self.publish_route_event_shared(&event);
+        let timestamp_ns = timestamp_ns_now();
+        self.enqueue(RibEventSnapshot::Route {
+            event,
+            timestamp_ns,
+        });
     }
 
     fn publish_route_event_shared(&self, event: &Arc<RouteEvent>) {
@@ -124,7 +128,11 @@ impl RibEventSink for EhmRibSink {
 
     fn publish_evpn_event(&self, event: &EvpnRouteEvent) {
         let event = Arc::new(event.clone());
-        self.publish_evpn_event_shared(&event);
+        let timestamp_ns = timestamp_ns_now();
+        self.enqueue(RibEventSnapshot::Evpn {
+            event,
+            timestamp_ns,
+        });
     }
 
     fn publish_evpn_event_shared(&self, event: &Arc<EvpnRouteEvent>) {

--- a/crates/rib/src/event_sink.rs
+++ b/crates/rib/src/event_sink.rs
@@ -17,6 +17,8 @@
 //! `ListRouteEvents`) are unchanged. The durable cursor
 //! (`SubscribeFromEvent`) is the consumer of the sink path.
 
+use std::sync::Arc;
+
 use crate::event::{EvpnRouteEvent, RouteEvent};
 
 /// Object-safe sink that hands a snapshot of each emitted RIB event
@@ -44,12 +46,24 @@ pub trait RibEventSink: Send + Sync + 'static {
     /// the wire path.
     fn publish_route_event(&self, event: &RouteEvent);
 
+    /// Hand a shared route event to the sink. Legacy implementors keep
+    /// working through the borrowed-event method; sinks that can retain the
+    /// existing allocation may override this additive path.
+    fn publish_route_event_shared(&self, event: &Arc<RouteEvent>) {
+        self.publish_route_event(event.as_ref());
+    }
+
     /// Hand an EVPN best-path event to the sink. Called from
     /// `RibManager::publish_evpn_route_event` after the existing
     /// ring + broadcast work. EVPN events do not currently carry a
     /// process-local `event_id`; the durable envelope id is the only
     /// id surfaced on the EHM-backed wire path.
     fn publish_evpn_event(&self, event: &EvpnRouteEvent);
+
+    /// Shared counterpart to [`Self::publish_evpn_event`].
+    fn publish_evpn_event_shared(&self, event: &Arc<EvpnRouteEvent>) {
+        self.publish_evpn_event(event.as_ref());
+    }
 }
 
 /// No-op sink used when `[event_history]` is disabled or EHM failed
@@ -62,5 +76,7 @@ pub struct NoopRibEventSink;
 
 impl RibEventSink for NoopRibEventSink {
     fn publish_route_event(&self, _event: &RouteEvent) {}
+    fn publish_route_event_shared(&self, _event: &Arc<RouteEvent>) {}
     fn publish_evpn_event(&self, _event: &EvpnRouteEvent) {}
+    fn publish_evpn_event_shared(&self, _event: &Arc<EvpnRouteEvent>) {}
 }

--- a/crates/rib/src/event_sink.rs
+++ b/crates/rib/src/event_sink.rs
@@ -11,11 +11,11 @@
 //! the cycle on the binary side.
 //!
 //! See `docs/adr/0072-durable-event-history.md` "Producer wiring"
-//! for the contract: the sink fires **after** the existing
-//! `route_event_history` ring + `route_events_tx` broadcast so the
-//! legacy live surfaces (`WatchRoutes`, `WatchEvents`,
-//! `ListRouteEvents`) are unchanged. The durable cursor
-//! (`SubscribeFromEvent`) is the consumer of the sink path.
+//! for the contract: after insertion into `route_event_history` or
+//! `evpn_route_event_history`, the non-blocking sink sidecar fires before the
+//! corresponding `route_events_tx` or `evpn_events_tx` live broadcast. The
+//! legacy live surfaces (`WatchRoutes`, `WatchEvents`, `ListRouteEvents`)
+//! remain unchanged; `SubscribeFromEvent` consumes the durable sink path.
 
 use std::sync::Arc;
 

--- a/crates/rib/src/event_sink.rs
+++ b/crates/rib/src/event_sink.rs
@@ -38,9 +38,10 @@ use crate::event::{EvpnRouteEvent, RouteEvent};
 /// another).
 pub trait RibEventSink: Send + Sync + 'static {
     /// Hand a route event to the sink. Called from
-    /// `RibManager::publish_route_event` **after** the event has been
+    /// `RibManager::publish_route_event` after the event has been
     /// stamped with its process-local `event_id`, appended to the
-    /// bounded ring, and broadcast on `route_events_tx`. Legacy
+    /// bounded ring; the shared sink callback (defaulting here) runs before
+    /// live broadcast on `route_events_tx`. Legacy
     /// `event_id` value is preserved as-is on the snapshot the sink
     /// sees; the durable cursor overwrites it from the EHM commit on
     /// the wire path.
@@ -54,8 +55,9 @@ pub trait RibEventSink: Send + Sync + 'static {
     }
 
     /// Hand an EVPN best-path event to the sink. Called from
-    /// `RibManager::publish_evpn_route_event` after the existing
-    /// ring + broadcast work. EVPN events do not currently carry a
+    /// `RibManager::publish_evpn_route_event` after ring insertion and through
+    /// the shared sink callback (defaulting here) before live broadcast. EVPN
+    /// events do not currently carry a
     /// process-local `event_id`; the durable envelope id is the only
     /// id surfaced on the EHM-backed wire path.
     fn publish_evpn_event(&self, event: &EvpnRouteEvent);

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2629,7 +2629,7 @@ impl RibManager {
         // not load-bearing for correctness; pick the order that
         // avoids the second clone (sink first, then move into
         // broadcast).
-        self.event_sink.publish_route_event(event.as_ref());
+        self.event_sink.publish_route_event_shared(&event);
         let _ = self.route_events_tx.send(event);
     }
 
@@ -2690,7 +2690,7 @@ impl RibManager {
         self.evpn_route_event_history.push_back(Arc::clone(&event));
         // ADR-0072: durable outbox sink fires alongside the legacy
         // broadcast. See `publish_route_event` for the ordering note.
-        self.event_sink.publish_evpn_event(event.as_ref());
+        self.event_sink.publish_evpn_event_shared(&event);
         let _ = self.evpn_events_tx.send(event);
     }
 

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -1,4 +1,31 @@
 use super::*;
+use crate::event_sink::RibEventSink;
+
+#[derive(Default)]
+struct SharedRouteCapture(std::sync::Mutex<Option<Arc<crate::event::RouteEvent>>>);
+
+impl RibEventSink for SharedRouteCapture {
+    fn publish_route_event(&self, _event: &crate::event::RouteEvent) {
+        panic!("manager must use the shared route-event path")
+    }
+
+    fn publish_route_event_shared(&self, event: &Arc<crate::event::RouteEvent>) {
+        *self.0.lock().unwrap() = Some(Arc::clone(event));
+    }
+
+    fn publish_evpn_event(&self, _event: &crate::event::EvpnRouteEvent) {}
+}
+
+#[derive(Default)]
+struct LegacyRouteSink(std::sync::atomic::AtomicUsize);
+
+impl RibEventSink for LegacyRouteSink {
+    fn publish_route_event(&self, _event: &crate::event::RouteEvent) {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn publish_evpn_event(&self, _event: &crate::event::EvpnRouteEvent) {}
+}
 
 #[cfg(target_pointer_width = "64")]
 #[test]
@@ -19,7 +46,9 @@ fn event_storage_layout_and_lazy_history_capacity_are_pinned() {
 #[tokio::test]
 async fn route_history_and_live_broadcast_share_arc_but_queries_are_owned() {
     let (_tx, rx) = mpsc::channel(1);
-    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let capture = Arc::new(SharedRouteCapture::default());
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_event_sink(capture.clone());
     let mut live = manager.route_events_tx.subscribe();
     manager.publish_route_event(crate::event::RouteEvent {
         event_id: 0,
@@ -34,10 +63,12 @@ async fn route_history_and_live_broadcast_share_arc_but_queries_are_owned() {
     });
 
     let broadcast = live.try_recv().unwrap();
+    let captured = capture.0.lock().unwrap().take().unwrap();
     assert!(Arc::ptr_eq(
         manager.route_event_history.back().unwrap(),
         &broadcast
     ));
+    assert!(Arc::ptr_eq(&captured, &broadcast));
 
     let (reply, result) = oneshot::channel();
     manager.handle_query_route_event_history(None, None, None, 0, reply);
@@ -47,6 +78,28 @@ async fn route_history_and_live_broadcast_share_arc_but_queries_are_owned() {
         manager.route_event_history.back().unwrap().reason,
         "original"
     );
+}
+
+#[test]
+fn shared_trait_default_preserves_legacy_sink_and_noop_is_empty() {
+    let event = Arc::new(crate::event::RouteEvent {
+        event_id: 0,
+        event_type: RouteEventType::Added,
+        prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
+        peer: None,
+        previous_peer: None,
+        target_peer: None,
+        timestamp: String::new(),
+        path_id: 0,
+        reason: String::new(),
+    });
+    let legacy = LegacyRouteSink::default();
+    legacy.publish_route_event_shared(&event);
+    assert_eq!(legacy.0.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+    let before = Arc::strong_count(&event);
+    crate::event_sink::NoopRibEventSink.publish_route_event_shared(&event);
+    assert_eq!(Arc::strong_count(&event), before);
 }
 
 async fn subscribe_events(

--- a/crates/rib/src/manager/tests/evpn.rs
+++ b/crates/rib/src/manager/tests/evpn.rs
@@ -2039,10 +2039,27 @@ async fn subscribe_evpn_events(
     reply_rx.await.unwrap()
 }
 
+#[derive(Default)]
+struct SharedEvpnCapture(std::sync::Mutex<Option<Arc<crate::event::EvpnRouteEvent>>>);
+
+impl crate::event_sink::RibEventSink for SharedEvpnCapture {
+    fn publish_route_event(&self, _event: &crate::event::RouteEvent) {}
+
+    fn publish_evpn_event(&self, _event: &crate::event::EvpnRouteEvent) {
+        panic!("manager must use the shared EVPN-event path")
+    }
+
+    fn publish_evpn_event_shared(&self, event: &Arc<crate::event::EvpnRouteEvent>) {
+        *self.0.lock().unwrap() = Some(Arc::clone(event));
+    }
+}
+
 #[test]
 fn evpn_history_and_live_broadcast_share_arc() {
     let (_tx, rx) = mpsc::channel(1);
-    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let capture = Arc::new(SharedEvpnCapture::default());
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_event_sink(capture.clone());
     let mut live = manager.evpn_events_tx.subscribe();
     let route = make_evpn_macip(
         Ipv4Addr::new(10, 0, 0, 1),
@@ -2061,10 +2078,12 @@ fn evpn_history_and_live_broadcast_share_arc() {
     });
 
     let broadcast = live.try_recv().unwrap();
+    let captured = capture.0.lock().unwrap().take().unwrap();
     assert!(Arc::ptr_eq(
         manager.evpn_route_event_history.back().unwrap(),
         &broadcast
     ));
+    assert!(Arc::ptr_eq(&captured, &broadcast));
 
     let (reply, result) = oneshot::channel();
     manager.handle_query_evpn_route_event_history(None, None, None, &BTreeSet::new(), 0, reply);


### PR DESCRIPTION
## Summary

- Add additive shared-`Arc` event-sink paths while preserving the required legacy borrowed-event trait methods.
- Pass the same route or EVPN event allocation through the RIB history ring, enabled event-history sink, and live broadcast in the existing order.
- Keep bounded admission, producer timestamps, FIFO ordering, loss/degraded accounting, and off-actor conversion semantics unchanged.

## Measurement

The fixed existing `event_history_producer` Criterion control-to-candidate campaign measured enabled event-history manager self-time improvements of 39.14%, 30.44%, and 29.22% for route-added, policy-filtered, and EVPN-best-changed events.

The corresponding Noop candidate/control ratios were 1.0296, 1.0421, and 0.8636. The first two are disclosed as small positive shifts; all three remain within the frozen one-sided 10% materiality budget.

SQLite point changes were +0.55%, +0.01%, and -1.27%, all within the frozen no-regression gate. These SQLite results are treated only as no-regression evidence, not as an improvement claim.

No claim is made about RSS, default-off exact equivalence, throughput, or SQLite improvement.

## Validation

- Seven focused compatibility, pointer-identity, queue-full/closed, and shutdown tests
- `cargo test --locked -p rustbgpd-rib`
- `cargo test --locked -p rustbgpd-api event_history_sinks`
- `cargo test --locked -p rustbgpd-event-history`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo clippy --locked -p rustbgpd-rib -p rustbgpd-api -p rustbgpd-event-history --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Repository pre-push formatting, Clippy, tests, and rustdoc hooks

## Documentation

No documentation, changelog, or roadmap update is needed: public behavior, default configuration, operator-visible semantics, and the legacy embedding surface are unchanged.
