### PR TITLE
LAN-18: route-server flagship 24h soak (SIGHUP reload + max-prefix trip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,8 @@ jobs:
           python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py
           python3 -m unittest -v tests/soak/test_gate8b_recovery_contract.py
           python3 -m unittest -v tests/soak/test_m67_link_drain_analyzer.py
+          python3 -m unittest -v tests/soak/test_analyze_soak_rs_flagship.py
+          shellcheck -x tests/soak/run-soak-rs-flagship.sh
           python3 bench/scale/rebaseline/test_classifiers.py
           python3 bench/scale/rebaseline/test_parse_rrharness.py
           python3 bench/scale/rebaseline/test_validate_lan395_criterion.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Route-server flagship 24 h soak (`tests/soak/run-soak-rs-flagship.sh` +
+  `analyze-soak-rs-flagship.py`): 1000 real eBGP RS-client sessions × 400
+  routes against a bare-host daemon, with periodic real SIGHUP policy-file
+  reloads (barrier-verified by the reloadstall engine) and periodic
+  max-prefix trip/timed-restart cycles on a designated member, asserting
+  the full breach → countdown → timed-restart → compliant-recovery
+  evidence chain per cycle. Precommitted gates land as scenario 10 in
+  `docs/soaks/soak-acceptance-gates.md`, closing the SIGHUP-reload and
+  prefix-limit soak coverage gaps. The reloadstall engine grows additive
+  soak env knobs (`RELOADSTALL_CYCLE_QUIESCE_SECS`,
+  `RELOADSTALL_TRIP_EVERY`, `RELOADSTALL_TRIP_PREFIXES`,
+  `RELOADSTALL_TRIP_REESTABLISH_SECS`) and `gen-scenario.py` gains
+  `GEN_TRIP_MAX_PREFIXES` / `GEN_TRIP_RESTART_SECONDS`; every knob absent
+  reproduces the frozen one-shot contract byte-for-byte. (LAN-18)
+
 - `PolicyService.TestPolicy` now evaluates import and export routes through
   version-fenced pages capped at 1,000 instead of retaining a whole-table route
   snapshot. Compilation still precedes RIB access; evaluation and global

--- a/bench/scale/reloadstall/README.md
+++ b/bench/scale/reloadstall/README.md
@@ -109,6 +109,42 @@ columns report 0); that requires `reload_cmd`, `--flapstorm`, or `--convergence-
 9/10-positional-arg SIGHUP invocation above is a frozen contract and behaves
 exactly as before.
 
+### Soak extensions (env vars, all additive)
+
+Every knob absent reproduces the frozen one-shot contract exactly. The
+route-server flagship soak (`tests/soak/run-soak-rs-flagship.sh`) sets them to
+turn the fixed reload sequence into a self-paced long window with periodic
+max-prefix trip cycles:
+
+- `RELOADSTALL_CYCLE_QUIESCE_SECS` — inter-reload quiesce in seconds
+  (default 20, the historical value). The soak sets this to its reload
+  interval, so `reloads × interval` paces the whole window.
+- `RELOADSTALL_TRIP_EVERY` — after every K-th reload cycle, run one
+  max-prefix trip cycle on the designated member, stub 0 (0/absent = never).
+  Requires the SIGHUP reload mode with `changed_peers == n_peers`, no
+  overlap file, and `n_peers > 8` (stub 0 must not be a churner). A trip
+  cycle: disarm generation markers → arm survivors' withdraw bitmap over
+  stub 0's slice → announce `RELOADSTALL_TRIP_PREFIXES` prefixes over the
+  daemon's configured `max_prefixes` bound → wait for the Cease teardown →
+  verify withdraw propagation at every survivor → arm the announce bitmap →
+  reconnect-retry through the hold-down until the daemon's one timed
+  restart admits the session → re-announce only the compliant base slice →
+  verify re-announce propagation → integrity check (all sessions up, zero
+  parse errors). Each phase prints a `trip N <phase> wall_us=…` marker and
+  each cycle emits one `trip_csv` record
+  (`trip_csv_header,trip,peers_total,teardown_s,withdraw_s,holddown_s,reannounce_s,rss_mib,sessions_up,parse_errors`).
+- `RELOADSTALL_TRIP_PREFIXES` — over-limit block size (default 64), drawn
+  from base indexes `[total, total + K)`: outside every observer's
+  completion bitmap and the churn space, but shaped like base routes for
+  the daemon's import path and session accounting.
+- `RELOADSTALL_TRIP_REESTABLISH_SECS` — teardown-to-re-established deadline
+  (default 300); must exceed the daemon-side `max_prefix_restart_seconds`.
+
+`gen-scenario.py` grows a matching additive pair: setting both
+`GEN_TRIP_MAX_PREFIXES` and `GEN_TRIP_RESTART_SECONDS` adds
+`max_prefixes` / `max_prefix_restart_seconds` to neighbor 0; absent, the
+emitted config is byte-for-byte the historical one.
+
 Cross-daemon cells (BIRD 3.3.1 / OpenBGPD 9.1) generate their route-server
 configs with `gen-bird-scenario.py` / `gen-obgpd-scenario.py` (same
 addressing contract) and are sequenced by `bench/scale/matrix/run-matrix.sh`.

--- a/bench/scale/reloadstall/gen-scenario.py
+++ b/bench/scale/reloadstall/gen-scenario.py
@@ -40,7 +40,14 @@ per-neighbor `stable-out` chain, while the import chain remains content-stable
 for every neighbor. Omitting it preserves the historical changed-import-plus-
 export scenario. The mixed export-only receipt uses 700 peers, 600 changed
 peers, 400400 total prefixes (harness arg), and port 1790.
+
+Soak extension (route-server flagship soak): setting BOTH
+`GEN_TRIP_MAX_PREFIXES` and `GEN_TRIP_RESTART_SECONDS` in the environment adds
+`max_prefixes` / `max_prefix_restart_seconds` to neighbor 0 — the harness's
+designated max-prefix trip member. Absent (the default), the emitted config is
+byte-for-byte the historical one.
 """
+import os
 import pathlib
 import sys
 
@@ -54,6 +61,15 @@ changed_peers = int(sys.argv[4]) if len(sys.argv) > 4 else n_peers
 if not 0 < changed_peers <= n_peers:
     sys.exit(f"changed_peers must be in 1..={n_peers}, got {changed_peers}")
 mixed_export_only = len(sys.argv) > 4
+trip_max_prefixes = os.environ.get("GEN_TRIP_MAX_PREFIXES")
+trip_restart_seconds = os.environ.get("GEN_TRIP_RESTART_SECONDS")
+if (trip_max_prefixes is None) != (trip_restart_seconds is None):
+    sys.exit("GEN_TRIP_MAX_PREFIXES and GEN_TRIP_RESTART_SECONDS must be set together")
+if trip_max_prefixes is not None:
+    trip_max_prefixes = int(trip_max_prefixes)
+    trip_restart_seconds = int(trip_restart_seconds)
+    if trip_max_prefixes < 1 or trip_restart_seconds < 1:
+        sys.exit("GEN_TRIP_MAX_PREFIXES and GEN_TRIP_RESTART_SECONDS must be positive")
 out.mkdir(parents=True, exist_ok=True)
 rundir = out.resolve()
 
@@ -172,13 +188,24 @@ for i in range(n_peers):
         'families = ["ipv4_unicast"]',
         "hold_time = 180",
     ]
+    if i == 0 and trip_max_prefixes is not None:
+        # The soak's designated trip member: the harness announces over
+        # this bound and rides the Cease teardown + timed restart.
+        neighbor.append(f"max_prefixes = {trip_max_prefixes}")
+        neighbor.append(f"max_prefix_restart_seconds = {trip_restart_seconds}")
     if i >= changed_peers:
         neighbor.append('export_policy_chain = ["stable-out"]')
     config += neighbor + [""]
 (out / "config.toml").write_text("\n".join(config))
 
+trip_note = (
+    f", trip_member_0(max_prefixes={trip_max_prefixes}, "
+    f"max_prefix_restart_seconds={trip_restart_seconds})"
+    if trip_max_prefixes is not None
+    else ""
+)
 print(
     f"wrote {rundir}/config.toml ({n_peers} neighbors), member.rpol, "
     f"gen-a.rpol, gen-b.rpol; listen_port={port}, changed_peers={changed_peers}, "
-    f"stable_peers={n_peers - changed_peers}, grpc_uds={rundir}/grpc.sock"
+    f"stable_peers={n_peers - changed_peers}, grpc_uds={rundir}/grpc.sock{trip_note}"
 )

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -40,6 +40,27 @@
 //!   all K slices' withdrawals, reconnect the K after 10 s, re-announce
 //!   their slices, and timestamp survivors' re-announce completion.
 //!   3 rounds, per-round percentiles + `flapstorm_csv` lines.
+//!
+//! Soak extensions (route-server flagship soak) — all additive env vars;
+//! every one absent reproduces the frozen one-shot contract exactly:
+//! - `RELOADSTALL_CYCLE_QUIESCE_SECS`: inter-reload quiesce (default 20).
+//!   The 24 h soak sets this to its reload interval so the existing
+//!   reload loop self-paces for the whole window.
+//! - `RELOADSTALL_TRIP_EVERY`: after every K-th reload cycle, run one
+//!   max-prefix trip cycle on the designated member (stub 0): announce
+//!   `RELOADSTALL_TRIP_PREFIXES` prefixes over the daemon-configured
+//!   `max_prefixes` bound, ride the Cease teardown, verify withdraw
+//!   propagation at every survivor, reconnect-retry through the
+//!   hold-down until the daemon's one timed restart admits the session,
+//!   re-announce only the compliant base slice, and verify re-announce
+//!   propagation. 0/absent = never. Requires the SIGHUP reload mode with
+//!   `changed_peers == n_peers`, no overlap, and `n_peers > CHURNERS`.
+//! - `RELOADSTALL_TRIP_PREFIXES`: over-limit block size (default 64);
+//!   drawn from base indexes `[total, total + K)` so observers'
+//!   completion bitmaps ignore it and member-in treats it as base.
+//! - `RELOADSTALL_TRIP_REESTABLISH_SECS`: teardown-to-re-established
+//!   deadline (default 300); must exceed the daemon's configured
+//!   `max_prefix_restart_seconds`.
 
 // Event.other and Ctx.n_peers are recorded for the observation/context
 // model but not read by the percentile analysis; keep them so the
@@ -98,6 +119,19 @@ const FIRST_OUTPUT_WINDOW: Duration = Duration::from_secs(600);
 const CONNECT_WINDOW: Duration = Duration::from_secs(120);
 const FLAP_ROUNDS: u32 = 3;
 const FLAP_RECONNECT_SECS: u64 = 10;
+/// Designated max-prefix trip member (soak mode): always stub 0, which is
+/// never a churner (churners are the last CHURNERS stubs) and whose slice
+/// is the contiguous window `[0, per_peer)` the flapstorm bitmap shape
+/// already tracks.
+const TRIP_MEMBER: u32 = 0;
+/// How long the daemon may take to tear the designated member down after
+/// the over-limit announcement (breach detection is per-UPDATE, so this is
+/// generous headroom, not a measurement).
+const TRIP_TEARDOWN_WINDOW: Duration = Duration::from_secs(60);
+/// Cap on one reconnect attempt during the trip hold-down: a daemon that
+/// accepts and then silently holds the socket must not wedge the retry
+/// loop (the loop itself runs until the configured re-establish deadline).
+const TRIP_ATTEMPT_WINDOW: Duration = Duration::from_secs(30);
 const EVIDENCE_TIMEOUT: Duration = Duration::from_secs(15);
 const PRE_CHURN_EVIDENCE_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -915,6 +949,13 @@ fn arm_survivors(ctx: &Ctx, k: u32, flap_prefixes: u32, total: u32, mode: u32) {
     }
 }
 
+/// Disarm every survivor's shared bitmap (flapstorm rounds and trip cycles).
+fn disarm_survivors(ctx: &Ctx, first: usize) {
+    for observer in ctx.obs.iter().skip(first) {
+        observer.flap_mode.store(FLAP_OFF, Ordering::Release);
+    }
+}
+
 /// `--flapstorm K` mode: the alternative to the reload loop (see the crate
 /// doc). The flapped cohort is the first K stubs — never the churners,
 /// which are the last CHURNERS.
@@ -998,9 +1039,7 @@ async fn run_flapstorm(ctx: &Arc<Ctx>, stubs: &mut [Stub], k: u32, pid: i32) {
             })
             .collect();
         stats_line(&format!("flap {round} first_reann_s"), first_s);
-        for observer in ctx.obs.iter().skip(k as usize) {
-            observer.flap_mode.store(FLAP_OFF, Ordering::Release);
-        }
+        disarm_survivors(ctx, k as usize);
         let rss = rss_mib(pid);
         let up = ctx
             .obs
@@ -1029,6 +1068,166 @@ async fn run_flapstorm(ctx: &Arc<Ctx>, stubs: &mut [Stub], k: u32, pid: i32) {
         // Quiesce between rounds.
         tokio::time::sleep(Duration::from_secs(10)).await;
     }
+}
+
+/// Strictly-parsed u64 env knob: absent = default, garbage = usage error.
+fn env_u64(name: &str, default: u64) -> u64 {
+    match std::env::var(name) {
+        Err(_) => default,
+        Ok(value) => value.parse().unwrap_or_else(|_| {
+            eprintln!("{name} must be a non-negative integer, got {value:?}");
+            std::process::exit(2);
+        }),
+    }
+}
+
+/// Reload slots that carry a trailing max-prefix trip cycle (soak mode).
+fn is_trip_slot(reload: u32, trip_every: u32) -> bool {
+    trip_every != 0 && reload.is_multiple_of(trip_every)
+}
+
+/// Over-limit trip block: base indexes `[total, total + count)`. Outside
+/// every observer's completion bitmap (`base_prefix_index` rejects
+/// `>= total`) and outside the churn space, but shaped exactly like base
+/// routes for the daemon's import path and session accounting.
+fn trip_block(total: u32, count: u32) -> Vec<Ipv4Prefix> {
+    (total..total + count).map(base_prefix).collect()
+}
+
+/// One max-prefix trip cycle on the designated member (soak mode). The
+/// flap bitmap machinery is reused with the K=1 window shape: survivors
+/// track the designated member's slice `[0, per_peer)` through the
+/// daemon-driven teardown (withdraws) and the post-restart re-announce.
+/// Fail-closed at every phase, mirroring the flapstorm discipline.
+async fn run_trip_cycle(
+    ctx: &Arc<Ctx>,
+    stubs: &mut [Stub],
+    trip: u32,
+    pid: i32,
+    trip_prefix_count: u32,
+    reestablish_window: Duration,
+) {
+    let n_peers = ctx.n_peers;
+    let total = n_peers * ctx.per_peer;
+    let survivors = TRIP_MEMBER as usize + 1;
+    // Stale reload-generation markers must not feed the trip bitmaps.
+    for observer in &ctx.obs {
+        observer.expected_community.store(0, Ordering::Release);
+    }
+    // Arm withdraw tracking before the breach so no withdrawal is missed.
+    arm_survivors(ctx, 1, ctx.per_peer, total, FLAP_TRACK_WITHDRAWS);
+    println!(
+        "trip {trip} announce_over wall_us={} member={TRIP_MEMBER} prefixes={trip_prefix_count}",
+        wall_us()
+    );
+    let t_over = now_us(ctx);
+    for msg in announce_msgs(TRIP_MEMBER, &trip_block(total, trip_prefix_count)) {
+        if stubs[TRIP_MEMBER as usize].tx.send(msg).await.is_err() {
+            eprintln!("FAIL: trip {trip} over-limit announce send failed");
+            std::process::exit(1);
+        }
+    }
+    let teardown_deadline = Instant::now() + TRIP_TEARDOWN_WINDOW;
+    while ctx.obs[TRIP_MEMBER as usize]
+        .established
+        .load(Ordering::Relaxed)
+    {
+        if Instant::now() >= teardown_deadline {
+            eprintln!(
+                "FAIL: trip {trip} daemon did not tear down the designated member within {}s",
+                TRIP_TEARDOWN_WINDOW.as_secs()
+            );
+            std::process::exit(1);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    // Abort the dead session's split-half tasks so a lingering writer
+    // keepalive cannot stomp the NEW session's established flag later
+    // (same discipline as the flapstorm close).
+    stubs[TRIP_MEMBER as usize].reader.abort();
+    stubs[TRIP_MEMBER as usize].writer.abort();
+    let t_down = now_us(ctx);
+    let teardown_s = t_down.saturating_sub(t_over) as f64 / 1e6;
+    println!(
+        "trip {trip} torn_down wall_us={} after_s={teardown_s:.3}",
+        wall_us()
+    );
+    wait_flap_completion(ctx, survivors, trip, "trip-withdraw").await;
+    let withdraw_s = (survivors..ctx.obs.len())
+        .filter_map(|i| completion_us(ctx, i))
+        .max()
+        .map_or(f64::NAN, |tc| tc.saturating_sub(t_down) as f64 / 1e6);
+    // Re-arm announce tracking before any reconnect can succeed so no
+    // re-announce is missed.
+    arm_survivors(ctx, 1, ctx.per_peer, total, FLAP_TRACK_ANNOUNCES);
+    let reconnect_deadline = Instant::now() + reestablish_window;
+    let stub = loop {
+        match tokio::time::timeout(
+            TRIP_ATTEMPT_WINDOW,
+            establish_stub(Arc::clone(ctx), TRIP_MEMBER),
+        )
+        .await
+        {
+            Ok(Ok(stub)) => break stub,
+            Ok(Err(error)) => {
+                if Instant::now() >= reconnect_deadline {
+                    eprintln!(
+                        "FAIL: trip {trip} designated member not re-established within {}s: {error}",
+                        reestablish_window.as_secs()
+                    );
+                    std::process::exit(1);
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(_) => {
+                if Instant::now() >= reconnect_deadline {
+                    eprintln!(
+                        "FAIL: trip {trip} designated member not re-established within {}s: attempt timed out",
+                        reestablish_window.as_secs()
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+    };
+    stubs[TRIP_MEMBER as usize] = stub;
+    let t_up = now_us(ctx);
+    let holddown_s = t_up.saturating_sub(t_down) as f64 / 1e6;
+    println!(
+        "trip {trip} reestablished wall_us={} holddown_s={holddown_s:.3}",
+        wall_us()
+    );
+    // Compliant base slice only — the over-limit block stays withdrawn.
+    for msg in announce_msgs(TRIP_MEMBER, &own_slice(ctx, TRIP_MEMBER)) {
+        if stubs[TRIP_MEMBER as usize].tx.send(msg).await.is_err() {
+            eprintln!("FAIL: trip {trip} compliant re-announce send failed");
+            std::process::exit(1);
+        }
+    }
+    println!("trip {trip} reannounced wall_us={}", wall_us());
+    wait_flap_completion(ctx, survivors, trip, "trip-reannounce").await;
+    let reannounce_s = (survivors..ctx.obs.len())
+        .filter_map(|i| completion_us(ctx, i))
+        .max()
+        .map_or(f64::NAN, |tc| tc.saturating_sub(t_up) as f64 / 1e6);
+    disarm_survivors(ctx, survivors);
+    let up = ctx
+        .obs
+        .iter()
+        .filter(|o| o.established.load(Ordering::Relaxed))
+        .count();
+    let parse_errors = ctx.parse_errors.load(Ordering::Relaxed);
+    if up != n_peers as usize || parse_errors != 0 {
+        eprintln!(
+            "FAIL: trip {trip} integrity check failed: sessions_up={up}/{n_peers}, parse_errors={parse_errors}"
+        );
+        std::process::exit(1);
+    }
+    let rss = rss_mib(pid);
+    println!(
+        "trip_csv,{trip},{n_peers},{teardown_s:.3},{withdraw_s:.3},{holddown_s:.3},{reannounce_s:.3},{rss},{up},{parse_errors}"
+    );
+    println!("trip {trip} complete wall_us={} rss_mib={rss}", wall_us());
 }
 
 /// Hold the live stub sessions open while an outer measurement runner captures
@@ -1212,6 +1411,11 @@ fn main() {
         std::env::var_os("RELOADSTALL_PRE_CHURN_EVIDENCE_DIR").map(PathBuf::from);
     let overlap_file = std::env::var_os("RELOADSTALL_OVERLAP_FILE").map(PathBuf::from);
     let received_view_file = std::env::var_os("RELOADSTALL_RECEIVED_VIEW_FILE").map(PathBuf::from);
+    // Soak-mode knobs; every default reproduces the frozen one-shot contract.
+    let cycle_quiesce_secs = env_u64("RELOADSTALL_CYCLE_QUIESCE_SECS", 20);
+    let trip_every = u32::try_from(env_u64("RELOADSTALL_TRIP_EVERY", 0)).unwrap();
+    let trip_prefix_count = u32::try_from(env_u64("RELOADSTALL_TRIP_PREFIXES", 64)).unwrap();
+    let trip_reestablish = Duration::from_secs(env_u64("RELOADSTALL_TRIP_REESTABLISH_SECS", 300));
     assert!(n_peers >= CHURNERS, "n_peers must be at least {CHURNERS}");
     assert!(
         (1..=n_peers).contains(&changed_peers),
@@ -1246,6 +1450,28 @@ fn main() {
     }
     let per_peer = total / n_peers;
     assert_eq!(total % n_peers, 0, "total must divide evenly");
+    if trip_every > 0 {
+        assert!(
+            reloads > 0 && flapstorm.is_none() && !convergence_only && reload_cmd.is_none(),
+            "RELOADSTALL_TRIP_EVERY requires the SIGHUP reload mode (reloads > 0)"
+        );
+        assert!(
+            n_peers > CHURNERS,
+            "trips need a non-churner designated member: n_peers must exceed {CHURNERS}"
+        );
+        assert!(
+            changed_peers == n_peers,
+            "trips require the all-changed reload shape (changed_peers == n_peers)"
+        );
+        assert!(
+            overlap_file.is_none(),
+            "trips require disjoint announcements (no RELOADSTALL_OVERLAP_FILE)"
+        );
+        assert!(
+            trip_prefix_count >= 1,
+            "RELOADSTALL_TRIP_PREFIXES must be at least 1"
+        );
+    }
     // Overlap and the received-view dump are reload-mode instruments only:
     // flapstorm and convergence-only completion accounting assumes the
     // historical disjoint announcements.
@@ -1561,6 +1787,12 @@ fn main() {
              changed_first_generation_update_p95_ms,changed_first_generation_update_max_ms,\
              rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors"
         );
+        if trip_every > 0 {
+            println!(
+                "trip_csv_header,trip,peers_total,teardown_s,withdraw_s,holddown_s,\
+                 reannounce_s,rss_mib,sessions_up,parse_errors"
+            );
+        }
 
         // --- Reload loop. ---
         for r in 1..=reloads {
@@ -1803,8 +2035,20 @@ fn main() {
                 first_generation_update.p95,
                 first_generation_update.max,
             );
-            // Quiesce between reloads.
-            tokio::time::sleep(Duration::from_secs(20)).await;
+            // Quiesce between cycles (soak mode overrides the historical 20 s
+            // to self-pace the whole window).
+            tokio::time::sleep(Duration::from_secs(cycle_quiesce_secs)).await;
+            if is_trip_slot(r, trip_every) {
+                run_trip_cycle(
+                    &ctx,
+                    &mut stubs,
+                    r / trip_every,
+                    pid,
+                    trip_prefix_count,
+                    trip_reestablish,
+                )
+                .await;
+            }
         }
 
         let parse_errors = ctx.parse_errors.load(Ordering::Relaxed);
@@ -2221,6 +2465,42 @@ mod tests {
         progress.reset(8, 6, 2, 2);
         assert!(progress.excluded_extra.is_empty(), "reset clears extras");
         assert!(progress.received.iter().all(|&slot| slot == 0));
+    }
+
+    #[test]
+    fn trip_slot_schedule_matches_planned_counts() {
+        // trip_every 0 (the frozen one-shot default) never trips.
+        assert!((1..=48).all(|r| !is_trip_slot(r, 0)));
+        // The flagship shape: 48 reloads, trip every 8th -> 6 trips.
+        let slots: Vec<u32> = (1..=48).filter(|&r| is_trip_slot(r, 8)).collect();
+        assert_eq!(slots, vec![8, 16, 24, 32, 40, 48]);
+        // The smoke shape: 5 reloads, trip every 2nd -> 2 trips.
+        let slots: Vec<u32> = (1..=5).filter(|&r| is_trip_slot(r, 2)).collect();
+        assert_eq!(slots, vec![2, 4]);
+    }
+
+    #[test]
+    fn trip_block_is_outside_every_completion_bitmap() {
+        for total in [600, 400_000] {
+            let block = trip_block(total, 64);
+            assert_eq!(block.len(), 64);
+            assert_eq!(block[0], base_prefix(total));
+            for prefix in &block {
+                assert_eq!(
+                    base_prefix_index(*prefix, total),
+                    None,
+                    "trip prefixes must never advance an observer bitmap"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn soak_env_defaults_preserve_the_one_shot_contract() {
+        // Absent env vars must reproduce the historical quiesce and
+        // trip-free behavior exactly.
+        assert_eq!(env_u64("RELOADSTALL_TEST_UNSET_KNOB", 20), 20);
+        assert!(!is_trip_slot(4, 0));
     }
 
     #[test]

--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -211,6 +211,48 @@ every post-warmup sample; `tenant_present` ↔ `pe1_observed_routes`
 agree within one sample interval (wake-path latency ceiling);
 `churn_cycles` strictly monotone.
 
+### 10. Route-server flagship (SIGHUP reload + max-prefix trip) — `run-soak-rs-flagship.sh` (`analyze-soak-rs-flagship.py`)
+
+The flagship shape on a bare-host daemon: 1000 real eBGP route-server-client
+sessions × 400 routes each (400 k total), driven by the
+`bench/scale/reloadstall` engine with its steady churn running throughout.
+Two serialized injections: a real SIGHUP policy-file reload every
+`RELOAD_INTERVAL_SEC` (default 1800 s → 48/24 h), each verified by the
+engine's generation-marker completion barriers, and a max-prefix
+trip/timed-restart cycle every `TRIP_INTERVAL_SEC` (default 14 400 s →
+6/24 h) on the designated member (stub 0, `127.1.0.1`,
+`max_prefixes = routes + 50`, `max_prefix_restart_seconds = 120`).
+
+RSS bounds rationale: the ceiling is calibrated from the
+`bench/scale/route-server-1000` retained receipt, whose one-shot
+4-reload run at this exact shape enforces a 2 GiB process-tree ceiling;
+repeated reload cycles add glibc allocator retention (a known-benign
+pattern — see the LAN-461 finding: jemalloc erases it, it is not an
+intern/RIB leak), so the soak ceiling adds 1 GiB of reload-cycle
+headroom (3 GiB). Because that retention front-loads, the slope gate
+bounds only the LATE window (final 25 % of the run), not the early
+settle; 10 MB/h is well above the ±30–50 MiB allocator-arena noise
+floor averaged over ≥ 6 h of 30 s samples, while still catching a
+~240 MB/day leak. The late-window slope gates are evaluated only when
+the late window spans ≥ 1 h (`--min-slope-seconds`); on shorter smokes
+the analyzer records the values and annotates them as not evaluated —
+never as silent green.
+
+| Gate | Precommitted bound | Evidence | Refreshes under scenario via |
+|------|--------------------|----------|------------------------------|
+| Session floor | `established == 1000` on every post-warmup sample, EXCEPT exactly `999` inside a declared trip window (`announce_over` → `reestablished` ± one sample interval, from `cycles.log`) for the designated member only | sum of `bgp_peer_session_established` → CSV `established`; windows from `cycles.log` | Every trip flips the designated member 1→0→1; reload barriers fail the engine closed if any other session drops. |
+| Reload accounting exact | issued == barrier-verified complete; complete ≥ 0.9 × planned | `cycles.log` `reload N issued` (engine SIGHUP marker) / `reload N complete` (only after the engine's completion + marker barriers and integrity check pass) | Every reload cycle appends both lines; a reload whose barrier never completes stalls the engine's fail-closed watchdog. |
+| Trip accounting exact | executed == planned; per cycle the full evidence chain: breach counter reaches exactly N, hold-down countdown observed via `rbgp neighbor -j` (`max_prefix_restart_remaining_millis`, action `restart`), re-Established ≤ `max_prefix_restart_seconds` + 60 s after teardown, post-recovery `usage == routes`, `limit == max_prefixes`, `usage + headroom == limit`; zero unexpected latch-offs | `cycles.log` trip lines; `bgp_max_prefix_exceeded_total`, `bgp_max_prefix_usage/limit/headroom` (scope `aggregate`) | Each trip cycle drives breach → teardown → countdown → timed restart → compliant re-announce; the runner polls the CLI and metrics inside every window and fails closed on any missing link. |
+| Exceeded-counter exact | final `bgp_max_prefix_exceeded_total` == executed trips | CSV `max_prefix_exceeded_total` | Incremented once per deliberate breach; any spurious latch-off breaks the equality. |
+| Session-flap budget exact | flap delta over the run == executed trips (one per deliberate teardown) | sum of `bgp_session_flaps_total` → CSV `flaps_total` | Each trip teardown adds exactly one flap; reload cycles must add zero (the engine's per-reload `sessions_up` integrity check backs this). |
+| Peak RSS | < 3072 MB (rationale above) | daemon process-tree RSS → CSV `rss_mb` | Full-table re-advertisement on every reload; teardown/re-announce churn on every trip. |
+| RSS late-window slope | < 10 MB/h over the final 25 % of the run (evaluated only when that window ≥ 1 h; rationale above) | CSV `rss_mb` | Same. |
+| Intern-table late-window slope | < 100 entries/h over the same window (the scenario's attribute universe is fixed; reload re-interning must return to plateau) | `bgp_rib_attr_intern_global_size` → CSV `intern_size` | Every reload re-interns per-chain attributes; GC reclaims after transition. |
+| Counter monotonicity (no restart) | `bgp_messages_sent_total` never decreases between samples | CSV `msgs_sent_total` | Advances with every keepalive/UPDATE across 1000 sessions; a decrease means a daemon restart (abort criterion). |
+| readyz availability | HTTP 200 within 250 ms on every sample (the route-server-1000 receipt enforces this bound during reloads at this exact shape) | CSV `readyz_code`, `readyz_ms` | Probed every sample, including mid-reload and mid-trip. |
+| Minimum sample count | ≥ 0.9 × (`SOAK_SECONDS` ÷ `SAMPLE_INTERVAL`) | CSV row count | One row per interval; scrape failures skip the row (and ≥ 5 consecutive failures abort). |
+| No abort record | zero `ABORT:` lines | `cycles.log` | The runner writes one before any fail-closed exit (daemon death, blind sampler, evidence deadline, disk floor, watchdog). |
+
 ## Failure-injection inventory
 
 What each scenario actually injects (inventoried from the harness
@@ -228,6 +270,8 @@ scripts), mapped to the daemon guarantee it tests.
 | MAC mobility move | same MAC deleted on src PE, added on dst PE | 8 | RFC 7432 §15.1 sequence ratchet under concurrent ESI churn |
 | Link carrier down/up | AC interface down/up | 6 | ES drain trigger, DF failover, recovery hold-off, bounded blackout |
 | Tenant route add/del | `ip addr add/del` in VRF | 9 | L3 owned-state transactionality; route-wake path |
+| SIGHUP policy-file reload at scale | engine copies next `.rpol` generation over the live file + real SIGHUP, every 30 min under churn | 10 | Signal-driven reload path: barrier-verified full-fleet re-advertisement, no session impact, no reload-cycle leak |
+| Max-prefix trip + timed restart | designated member announces over its `max_prefixes` bound; daemon Cease teardown, hold-down, one timed restart; compliant re-announce | 10 | ADR-0108 enforcement + latch/restart cycle: exact breach accounting, countdown visibility, bounded recovery, headroom re-arm |
 
 ### Coverage gaps — guarantees with NO soak injection
 
@@ -240,9 +284,14 @@ coverage:
    the GR soak restarts the *peer*. Crash-recovery of the core BGP
    daemon (durable commit-confirm boot-revert included) has test
    coverage but no soak-duration injection.
-2. **SIGHUP file-reload path.** The daemon handles SIGHUP
+2. **SIGHUP file-reload path.** ~~The daemon handles SIGHUP
    (`src/main.rs`), but the hot-reload soak drives only the gRPC
-   transactional apply. The signal-driven reload path is unsoaked.
+   transactional apply. The signal-driven reload path is unsoaked.~~
+   **Closed by scenario 10**, which drives real SIGHUP policy-file
+   reloads every 30 minutes at the 1000-peer flagship shape, each
+   verified by the engine's completion barriers. (Config-file reload of
+   *neighbor* shape via SIGHUP remains uncovered — scenario 10 reloads
+   the policy file only.)
 3. **Listener kill.** No scenario kills or wedges the gRPC listener or
    the Prometheus exporter mid-soak; listener-death behavior (audit
    continuity, reconnect handling) is untested at duration.
@@ -252,8 +301,14 @@ coverage:
 5. **Rapid peer flap storm.** The fastest failure cadence in the suite
    is one event per 90 s (scenario 6). Sub-minute repeated flaps
    (damping/pending-delete pressure) have bench coverage but no soak.
-6. **Prefix-limit trip and timed restart.** No soak drives a peer over
-   a configured max-prefix bound and through the timed-restart cycle.
+6. **Prefix-limit trip and timed restart.** ~~No soak drives a peer over
+   a configured max-prefix bound and through the timed-restart cycle.~~
+   **Closed by scenario 10**, which trips the designated member's
+   aggregate `max_prefixes` bound every 4 hours and asserts the full
+   breach → countdown → timed-restart → compliant-recovery evidence
+   chain per cycle. (Per-family `max_prefixes_ipv4/ipv6` bounds and the
+   failed-restart indefinite latch remain soak-uncovered — they have
+   unit coverage only.)
 7. **Transport-level disturbance.** No packet loss / latency / MTU
    churn (netem) injection anywhere in the suite.
 8. **BMP / BFD subsystems.** No soak establishes a BMP station or BFD

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -858,3 +858,43 @@ per-cycle events recorded in `churn.log`.
 Each pairs a containerlab topology with a post-hoc analyzer and runs under the
 shared host mutex (see the top-of-file bench-vs-soak section); consult each
 script's header for the deploy step and its env vars.
+
+---
+
+# Route-server flagship soak (SIGHUP reload + max-prefix trip)
+
+`run-soak-rs-flagship.sh` drives the flagship shape — 1000 real eBGP
+route-server-client sessions × 400 routes each — against a bare-host
+daemon via the `bench/scale/reloadstall` engine (no containerlab), with
+the engine's steady churn running throughout. Two serialized injections:
+
+- a real SIGHUP policy-file reload every `RELOAD_INTERVAL_SEC`
+  (default 1800 s), each verified by the engine's generation-marker
+  completion barriers;
+- a max-prefix trip/timed-restart cycle every `TRIP_INTERVAL_SEC`
+  (default 14 400 s) on the designated member (stub 0), with the
+  runner asserting the daemon-side evidence chain per cycle:
+  `bgp_max_prefix_exceeded_total` reaches exactly N → hold-down
+  countdown visible in `rbgp neighbor -j` → re-Established within
+  `max_prefix_restart_seconds` + 60 s → headroom sane.
+
+```bash
+# Full 24 h flagship run (defaults):
+bash tests/soak/run-soak-rs-flagship.sh
+
+# ~7-minute smoke:
+SOAK_PEERS=12 SOAK_ROUTES_PER_PEER=50 SOAK_SECONDS=300 \
+RELOAD_INTERVAL_SEC=60 TRIP_INTERVAL_SEC=120 \
+TRIP_RESTART_SECONDS=20 WARMUP_SEC=30 SAMPLE_INTERVAL=10 \
+bash tests/soak/run-soak-rs-flagship.sh
+```
+
+Requires host ports 1790 (BGP) and 9179 (metrics) free — the runner
+refuses to start otherwise and never kills unknown processes. Output
+lands in `tests/soak/runs/soak-rs-flagship-<UTC>/` (`samples.csv`,
+`cycles.log`, `reloadstall.log`, `rustbgpd.log`, `run.json`,
+`verdict.json`); the analyzer is `analyze-soak-rs-flagship.py` and the
+precommitted gates are scenario 10 in
+`docs/soaks/soak-acceptance-gates.md`. Note the short scenario
+directory under `/tmp` is required by the gRPC UDS `sun_path` cap; the
+scenario is regenerated fresh per run and copied into the run dir.

--- a/tests/soak/analyze-soak-rs-flagship.py
+++ b/tests/soak/analyze-soak-rs-flagship.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Post-hoc analyzer for the route-server flagship soak.
+
+Reads samples.csv + cycles.log + run.json emitted by
+run-soak-rs-flagship.sh and emits a JSON verdict against the
+precommitted gates in docs/soaks/soak-acceptance-gates.md (scenario 10):
+
+  - minimum sample count (>= 0.9 x soak_seconds / sample_interval)
+  - session floor: every post-warmup sample fully Established, except the
+    designated member inside declared trip windows
+  - reload accounting exact: issued == barrier-verified complete,
+    complete >= 0.9 x planned
+  - trip accounting exact: executed == planned, full evidence chain per
+    cycle (breach counter, hold-down countdown, bounded re-establish,
+    headroom sanity), zero unexpected latch-offs
+  - exceeded-counter exact: final bgp_max_prefix_exceeded_total == trips
+  - flap budget exact: session-flap delta == trips (one per teardown)
+  - counter monotonicity: bgp_messages_sent_total never decreases
+  - readyz availability: 200 within 250 ms on every sample
+  - RSS peak ceiling; late-window RSS/intern slope (evaluated only when
+    the late window spans >= --min-slope-seconds)
+  - no ABORT record in cycles.log
+
+Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
+harness/input error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+REQUIRED = {
+    "timestamp", "elapsed_sec", "rss_mb", "intern_size", "established",
+    "flaps_total", "msgs_sent_total", "max_prefix_exceeded_total",
+    "readyz_code", "readyz_ms",
+}
+COUNTERS = {
+    "intern_size", "established", "flaps_total", "msgs_sent_total",
+    "max_prefix_exceeded_total", "readyz_code",
+}
+
+RSS_PEAK_LIMIT_MB = 3072.0
+RSS_LATE_SLOPE_LIMIT = 10.0     # MB/h over the late window
+INTERN_LATE_SLOPE_LIMIT = 100.0  # entries/h over the late window
+READYZ_MS_LIMIT = 250.0
+REESTABLISH_GRACE_SEC = 60
+
+CYCLE_RE = re.compile(
+    r"^\[(?P<ts>[0-9T:\-]+Z)\] (?P<body>.*)$"
+)
+
+
+def safe_float(value: str | None) -> Optional[float]:
+    if value is None or value in ("", "NaN", "nan"):
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def safe_int(value: str | None) -> Optional[int]:
+    f = safe_float(value)
+    if f is None or not f.is_integer():
+        return None
+    return int(f)
+
+
+def parse_ts(value: str) -> float:
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    ).timestamp()
+
+
+def linreg(xs: list[float], ys: list[float]) -> float:
+    if len(xs) < 2:
+        return float("nan")
+    mx = sum(xs) / len(xs)
+    my = sum(ys) / len(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    den = sum((x - mx) ** 2 for x in xs)
+    if den == 0:
+        return float("nan")
+    return num / den
+
+
+def parse_cycles(lines: list[str]) -> dict:
+    """Structured view of cycles.log: reload counts, per-trip evidence,
+    trip windows (epoch seconds), abort records."""
+    reload_issued: set[int] = set()
+    reload_complete: set[int] = set()
+    trips: dict[int, dict] = {}
+    aborts: list[str] = []
+    for raw in lines:
+        m = CYCLE_RE.match(raw.strip())
+        if not m:
+            continue
+        ts = parse_ts(m.group("ts"))
+        body = m.group("body")
+        if body.startswith("ABORT:"):
+            aborts.append(body)
+            continue
+        r = re.match(r"^reload (\d+) issued$", body)
+        if r:
+            reload_issued.add(int(r.group(1)))
+            continue
+        r = re.match(r"^reload (\d+) complete$", body)
+        if r:
+            reload_complete.add(int(r.group(1)))
+            continue
+        r = re.match(r"^trip (\d+) (.+)$", body)
+        if not r:
+            continue
+        n = int(r.group(1))
+        rest = r.group(2)
+        trip = trips.setdefault(n, {})
+        if rest == "announce_over":
+            trip["announce_over"] = ts
+        elif rest == "torn_down":
+            trip["torn_down"] = ts
+        elif rest == "reestablished":
+            trip["reestablished"] = ts
+        elif rest == "reannounced":
+            trip["reannounced"] = ts
+        else:
+            e = re.match(r"^exceeded_total=(\d+)$", rest)
+            if e:
+                trip["exceeded_total"] = int(e.group(1))
+                continue
+            e = re.match(r"^countdown_ms=(\d+) action=(\S+)$", rest)
+            if e:
+                trip["countdown_ms"] = int(e.group(1))
+                trip["countdown_action"] = e.group(2)
+                continue
+            e = re.match(r"^complete usage=(\d+) limit=(\d+) headroom=(\d+)$", rest)
+            if e:
+                trip["complete"] = ts
+                trip["usage"] = int(e.group(1))
+                trip["limit"] = int(e.group(2))
+                trip["headroom"] = int(e.group(3))
+    return {
+        "reload_issued": reload_issued,
+        "reload_complete": reload_complete,
+        "trips": trips,
+        "aborts": aborts,
+    }
+
+
+def check_trip(n: int, trip: dict, meta: dict) -> list[str]:
+    """Evidence-chain defects for one trip cycle (empty = clean)."""
+    defects = []
+    for key in ("announce_over", "torn_down", "reestablished", "reannounced",
+                "complete"):
+        if key not in trip:
+            defects.append(f"missing {key}")
+    if trip.get("exceeded_total") != n:
+        defects.append(
+            f"exceeded_total={trip.get('exceeded_total')} expected {n}"
+        )
+    if trip.get("countdown_action") != "restart":
+        defects.append(f"countdown action={trip.get('countdown_action')}")
+    countdown = trip.get("countdown_ms")
+    restart_ms = meta["trip_restart_seconds"] * 1000
+    if countdown is None or not 0 < countdown <= restart_ms:
+        defects.append(f"countdown_ms={countdown} outside (0, {restart_ms}]")
+    if "torn_down" in trip and "reestablished" in trip:
+        held = trip["reestablished"] - trip["torn_down"]
+        bound = meta["trip_restart_seconds"] + REESTABLISH_GRACE_SEC
+        if held > bound:
+            defects.append(f"re-establish took {held:.0f}s > {bound}s bound")
+    if "usage" in trip:
+        if trip["usage"] != meta["routes_per_peer"]:
+            defects.append(f"usage={trip['usage']} != routes_per_peer")
+        if trip["limit"] != meta["max_prefixes"]:
+            defects.append(f"limit={trip['limit']} != max_prefixes")
+        if trip["usage"] + trip["headroom"] != trip["limit"]:
+            defects.append("usage + headroom != limit")
+    return defects
+
+
+def analyze(rows: list[dict[str, str]], cycles: dict, meta: dict,
+            min_slope_seconds: float) -> dict:
+    peers = meta["peers"]
+    warmup = meta["warmup_sec"]
+    planned_reloads = meta["planned_reloads"]
+    planned_trips = meta["planned_trips"]
+    grace = meta["sample_interval_sec"]
+
+    trips = cycles["trips"]
+    executed_trips = sorted(n for n, t in trips.items() if "complete" in t)
+    trip_windows = [
+        (t["announce_over"] - grace, t["reestablished"] + grace)
+        for t in trips.values()
+        if "announce_over" in t and "reestablished" in t
+    ]
+
+    # Per-row series.
+    elapsed = [float(r["elapsed_sec"]) for r in rows]
+    rss = [float(r["rss_mb"]) for r in rows]
+    intern = [int(r["intern_size"]) for r in rows]
+    established = [int(r["established"]) for r in rows]
+    flaps = [int(r["flaps_total"]) for r in rows]
+    msgs = [int(r["msgs_sent_total"]) for r in rows]
+    exceeded = [int(r["max_prefix_exceeded_total"]) for r in rows]
+    readyz_code = [int(r["readyz_code"]) for r in rows]
+    readyz_ms = [float(r["readyz_ms"]) for r in rows]
+    stamps = [parse_ts(r["timestamp"]) for r in rows]
+
+    def in_trip_window(ts: float) -> bool:
+        return any(lo <= ts <= hi for lo, hi in trip_windows)
+
+    floor_violations = []
+    for i, row_elapsed in enumerate(elapsed):
+        if row_elapsed < warmup:
+            continue
+        if established[i] == peers:
+            continue
+        if established[i] == peers - 1 and in_trip_window(stamps[i]):
+            continue
+        floor_violations.append(
+            {"elapsed_sec": row_elapsed, "established": established[i]}
+        )
+
+    issued = len(cycles["reload_issued"])
+    complete = len(cycles["reload_complete"])
+
+    trip_defects = {
+        n: check_trip(n, trips.get(n, {}), meta)
+        for n in range(1, planned_trips + 1)
+    }
+    trip_defects = {n: d for n, d in trip_defects.items() if d}
+
+    monotone_breaks = sum(
+        1 for a, b in zip(msgs, msgs[1:]) if b < a
+    )
+    readyz_bad = sum(
+        1 for code, ms in zip(readyz_code, readyz_ms)
+        if code != 200 or ms > READYZ_MS_LIMIT
+    )
+
+    peak_rss = max(rss) if rss else float("nan")
+
+    # Late window: final 25 % of the elapsed span.
+    span = elapsed[-1] if elapsed else 0.0
+    late_start = 0.75 * span
+    late = [(e, r, i2) for e, r, i2 in zip(elapsed, rss, intern)
+            if e >= late_start]
+    late_span = late[-1][0] - late[0][0] if len(late) >= 2 else 0.0
+    slope_evaluated = late_span >= min_slope_seconds
+    rss_slope = linreg([e / 3600 for e, _, _ in late],
+                       [r for _, r, _ in late]) if slope_evaluated else None
+    intern_slope = linreg([e / 3600 for e, _, _ in late],
+                          [i2 for _, _, i2 in late]) if slope_evaluated else None
+
+    expected_samples = 0.9 * meta["soak_seconds"] / meta["sample_interval_sec"]
+
+    gates = {
+        "min_samples": {
+            "value": len(rows),
+            "limit": expected_samples,
+            "pass": len(rows) >= expected_samples,
+        },
+        "session_floor": {
+            "value": {"violations": len(floor_violations),
+                      "first": floor_violations[:5]},
+            "pass": not floor_violations,
+        },
+        "reload_accounting": {
+            "value": {"issued": issued, "complete": complete,
+                      "planned": planned_reloads},
+            "pass": issued == complete and complete >= 0.9 * planned_reloads,
+        },
+        "trip_accounting": {
+            "value": {"executed": len(executed_trips),
+                      "planned": planned_trips,
+                      "defects": trip_defects},
+            "pass": len(executed_trips) == planned_trips and not trip_defects,
+        },
+        "exceeded_exact": {
+            "value": exceeded[-1] if exceeded else None,
+            "limit": len(executed_trips),
+            "pass": bool(exceeded) and exceeded[-1] == len(executed_trips),
+        },
+        "flap_budget": {
+            "value": (flaps[-1] - flaps[0]) if flaps else None,
+            "limit": len(executed_trips),
+            "pass": bool(flaps) and flaps[-1] - flaps[0] == len(executed_trips),
+        },
+        "msgs_sent_monotone": {
+            "value": {"breaks": monotone_breaks},
+            "pass": monotone_breaks == 0,
+        },
+        "readyz": {
+            "value": {"bad_samples": readyz_bad,
+                      "limit_ms": READYZ_MS_LIMIT},
+            "pass": readyz_bad == 0,
+        },
+        "rss_peak_mb": {
+            "value": peak_rss if not math.isnan(peak_rss) else None,
+            "limit": RSS_PEAK_LIMIT_MB,
+            "pass": (not math.isnan(peak_rss)) and peak_rss < RSS_PEAK_LIMIT_MB,
+        },
+        "rss_late_slope_per_hour": {
+            "value": rss_slope,
+            "limit": RSS_LATE_SLOPE_LIMIT,
+            "pass": True if not slope_evaluated
+            else (rss_slope is not None and not math.isnan(rss_slope)
+                  and rss_slope < RSS_LATE_SLOPE_LIMIT),
+            "note": None if slope_evaluated else (
+                f"late window {late_span:.0f}s < {min_slope_seconds:.0f}s: "
+                "not evaluated (precommitted for >= 24 h windows)"
+            ),
+        },
+        "intern_late_slope_per_hour": {
+            "value": intern_slope,
+            "limit": INTERN_LATE_SLOPE_LIMIT,
+            "pass": True if not slope_evaluated
+            else (intern_slope is not None and not math.isnan(intern_slope)
+                  and intern_slope < INTERN_LATE_SLOPE_LIMIT),
+            "note": None if slope_evaluated else (
+                f"late window {late_span:.0f}s < {min_slope_seconds:.0f}s: "
+                "not evaluated (precommitted for >= 24 h windows)"
+            ),
+        },
+        "no_abort": {
+            "value": cycles["aborts"],
+            "pass": not cycles["aborts"],
+        },
+    }
+
+    all_pass = all(g["pass"] for g in gates.values())
+    return {
+        "verdict": "pass" if all_pass else "fail",
+        "samples": len(rows),
+        "reloads_issued": issued,
+        "reloads_complete": complete,
+        "trips_executed": len(executed_trips),
+        "trips_planned": planned_trips,
+        "peak_rss_mb": peak_rss if not math.isnan(peak_rss) else None,
+        "rss_late_slope_per_hour": rss_slope,
+        "intern_late_slope_per_hour": intern_slope,
+        "slope_window_evaluated": slope_evaluated,
+        "gates": gates,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Analyze the route-server flagship soak")
+    parser.add_argument("run_dir",
+                        help="Run directory (samples.csv, cycles.log, run.json)")
+    parser.add_argument("--output", help="Write verdict JSON to this path")
+    parser.add_argument("--min-slope-seconds", type=float, default=3600.0,
+                        help="Minimum late-window span before the slope gates "
+                             "are evaluated (default 3600)")
+    args = parser.parse_args()
+
+    try:
+        with open(f"{args.run_dir}/run.json", encoding="utf-8") as f:
+            meta = json.load(f)
+        with open(f"{args.run_dir}/samples.csv", newline="",
+                  encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            missing = REQUIRED - set(reader.fieldnames or [])
+            if missing:
+                print("error: missing required columns: "
+                      + ", ".join(sorted(missing)), file=sys.stderr)
+                return 2
+            rows = list(reader)
+        with open(f"{args.run_dir}/cycles.log", encoding="utf-8") as f:
+            cycle_lines = f.readlines()
+    except OSError as e:
+        print(f"error reading run dir: {e}", file=sys.stderr)
+        return 2
+
+    for key in ("peers", "routes_per_peer", "planned_reloads", "planned_trips",
+                "warmup_sec", "sample_interval_sec", "soak_seconds",
+                "trip_restart_seconds", "max_prefixes"):
+        if not isinstance(meta.get(key), int):
+            print(f"error: run.json missing integer {key}", file=sys.stderr)
+            return 2
+
+    if not rows:
+        print("error: samples.csv is empty", file=sys.stderr)
+        return 2
+    for line, row in enumerate(rows, 2):
+        for column in REQUIRED - {"timestamp"}:
+            value = safe_float(row.get(column))
+            if value is None:
+                print(f"error: row {line}: invalid {column}", file=sys.stderr)
+                return 2
+            if column in COUNTERS and (value < 0 or not value.is_integer()):
+                print(f"error: row {line}: invalid counter {column}",
+                      file=sys.stderr)
+                return 2
+        try:
+            parse_ts(row["timestamp"])
+        except ValueError:
+            print(f"error: row {line}: invalid timestamp", file=sys.stderr)
+            return 2
+
+    cycles = parse_cycles(cycle_lines)
+    result = analyze(rows, cycles, meta, args.min_slope_seconds)
+    out = json.dumps(result, indent=2)
+    print(out)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(out)
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/soak/run-soak-rs-flagship.sh
+++ b/tests/soak/run-soak-rs-flagship.sh
@@ -1,0 +1,505 @@
+#!/usr/bin/env bash
+# Soak: route-server flagship — 1000 real eBGP RS clients x 400 routes each
+# against a bare-host rustbgpd, driven by the bench/scale/reloadstall engine.
+#
+# Injections (both serialized by the engine, churn running throughout):
+#   - a real SIGHUP policy-file reload every RELOAD_INTERVAL_SEC, each one
+#     verified by the engine's generation-marker completion barriers;
+#   - a max-prefix trip/timed-restart cycle every TRIP_INTERVAL_SEC on the
+#     designated member (stub 0, 127.1.0.1): announce over the configured
+#     max_prefixes bound -> Cease teardown -> hold-down countdown -> the
+#     daemon's one timed restart -> re-establish -> compliant re-announce,
+#     with the runner asserting the daemon-side evidence chain per cycle
+#     (exceeded counter, countdown via rbgp neighbor -j, re-establish bound,
+#     headroom sanity).
+#
+# Precommitted gates: docs/soaks/soak-acceptance-gates.md (scenario 10).
+# Analyzer: tests/soak/analyze-soak-rs-flagship.py.
+#
+# Usage:
+#   bash tests/soak/run-soak-rs-flagship.sh                  # 24 h flagship
+#   SOAK_PEERS=12 SOAK_ROUTES_PER_PEER=50 SOAK_SECONDS=300 \
+#   RELOAD_INTERVAL_SEC=60 TRIP_INTERVAL_SEC=120 \
+#   TRIP_RESTART_SECONDS=20 WARMUP_SEC=30 SAMPLE_INTERVAL=10 \
+#   bash tests/soak/run-soak-rs-flagship.sh                  # smoke
+#
+# Output: tests/soak/runs/soak-rs-flagship-<UTC>/
+#   - samples.csv      one row per SAMPLE_INTERVAL
+#   - soak.log         runner stdout/stderr
+#   - cycles.log       reload + trip event/evidence lines
+#   - rustbgpd.log     daemon JSON logs
+#   - reloadstall.log  engine stdout/stderr (markers, csv records)
+#   - run.json         run metadata (analyzer input)
+#   - verdict.json     analyzer verdict
+
+set -euo pipefail
+
+SOAK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
+
+# --- Shape (flagship defaults; env-overridable for smokes) ---
+SOAK_PEERS="${SOAK_PEERS:-1000}"
+SOAK_ROUTES_PER_PEER="${SOAK_ROUTES_PER_PEER:-400}"
+SOAK_SECONDS="${SOAK_SECONDS:-86400}"
+RELOAD_INTERVAL_SEC="${RELOAD_INTERVAL_SEC:-1800}"
+TRIP_INTERVAL_SEC="${TRIP_INTERVAL_SEC:-14400}"
+SAMPLE_INTERVAL="${SAMPLE_INTERVAL:-30}"
+WARMUP_SEC="${WARMUP_SEC:-300}"
+CONTROL_SECS="${CONTROL_SECS:-30}"
+TRIP_LIMIT_MARGIN="${TRIP_LIMIT_MARGIN:-50}"
+TRIP_PREFIXES="${TRIP_PREFIXES:-64}"
+TRIP_RESTART_SECONDS="${TRIP_RESTART_SECONDS:-120}"
+TRIP_REESTABLISH_SEC="${TRIP_REESTABLISH_SEC:-300}"
+CONVERGE_CAP_SEC="${CONVERGE_CAP_SEC:-900}"
+LISTEN_PORT="${LISTEN_PORT:-1790}"
+# gen-scenario.py pins prometheus_addr to 127.0.0.1:9179.
+readonly METRICS_PORT=9179
+DESIGNATED_ADDR="127.1.0.1" # stub_addr(0) — the engine's designated member
+
+# --- Derived ---
+TOTAL_PREFIXES=$((SOAK_PEERS * SOAK_ROUTES_PER_PEER))
+RELOADS=$((SOAK_SECONDS / RELOAD_INTERVAL_SEC))
+if ((TRIP_INTERVAL_SEC % RELOAD_INTERVAL_SEC != 0)); then
+    echo "TRIP_INTERVAL_SEC must be a multiple of RELOAD_INTERVAL_SEC" >&2
+    exit 2
+fi
+TRIP_EVERY=$((TRIP_INTERVAL_SEC / RELOAD_INTERVAL_SEC))
+PLANNED_TRIPS=$((RELOADS / TRIP_EVERY))
+MAX_PREFIXES=$((SOAK_ROUTES_PER_PEER + TRIP_LIMIT_MARGIN))
+if ((TRIP_PREFIXES <= TRIP_LIMIT_MARGIN)); then
+    echo "TRIP_PREFIXES ($TRIP_PREFIXES) must exceed TRIP_LIMIT_MARGIN ($TRIP_LIMIT_MARGIN) to breach" >&2
+    exit 2
+fi
+if ((RELOADS < 1 || PLANNED_TRIPS < 1)); then
+    echo "shape yields no reloads or no trips (reloads=$RELOADS trips=$PLANNED_TRIPS)" >&2
+    exit 2
+fi
+if ((SOAK_PEERS <= 8)); then
+    echo "SOAK_PEERS must exceed 8 (the engine's churner count; stub 0 must not churn)" >&2
+    exit 2
+fi
+if ((TRIP_RESTART_SECONDS < 10)); then
+    echo "TRIP_RESTART_SECONDS must be >= 10 so the 1 s countdown poll can observe it" >&2
+    exit 2
+fi
+OVERALL_CAP_SEC="${OVERALL_CAP_SEC:-$((SOAK_SECONDS + RELOADS * 300 + PLANNED_TRIPS * (TRIP_RESTART_SECONDS + TRIP_REESTABLISH_SEC + 300) + 3600))}"
+
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-rs-flagship-$RUN_ID}"
+SAMPLES_CSV="$RUN_DIR/samples.csv"
+SOAK_LOG="$RUN_DIR/soak.log"
+CYCLES_LOG="$RUN_DIR/cycles.log"
+RUN_JSON="$RUN_DIR/run.json"
+RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
+RELOADSTALL_LOG="$RUN_DIR/reloadstall.log"
+PROM_TMP="$RUN_DIR/.metrics.prom"
+
+# shellcheck source=tests/soak/host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+
+log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+cycle_log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$CYCLES_LOG"
+}
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        log "ERROR: required tool '$1' not in PATH"
+        exit 2
+    fi
+}
+
+pid_running() {
+    [[ -n ${1:-} ]] && kill -0 "$1" 2>/dev/null
+}
+
+terminate() {
+    local pid=${1:-}
+    [[ -n $pid ]] || return 0
+    if pid_running "$pid"; then
+        kill -TERM "$pid" 2>/dev/null || true
+        for _ in $(seq 1 50); do pid_running "$pid" || break; sleep 0.1; done
+        if pid_running "$pid"; then kill -KILL "$pid" 2>/dev/null || true; fi
+    fi
+    wait "$pid" 2>/dev/null || true
+}
+
+H_PID=""
+DAEMON_PID=""
+SCEN=""
+cleanup() {
+    local rc=$?
+    trap - EXIT
+    set +e
+    terminate "$H_PID"
+    H_PID=""
+    terminate "$DAEMON_PID"
+    DAEMON_PID=""
+    [[ -n $SCEN && -d $SCEN ]] && rm -rf "$SCEN"
+    rm -f "$PROM_TMP"
+    if ((rc != 0)); then
+        log "FAILED rc=$rc — artifacts preserved in $RUN_DIR"
+    fi
+    exit "$rc"
+}
+
+abort() {
+    cycle_log "ABORT: $*"
+    log "ABORT: $*"
+    exit 1
+}
+
+ports_free() {
+    local listeners
+    listeners=$(ss -H -ltn) || return 1
+    ! awk -v a=":${LISTEN_PORT}" -v b=":${METRICS_PORT}" '
+        {if (substr($4,length($4)-length(a)+1)==a || substr($4,length($4)-length(b)+1)==b) used=1}
+        END{exit !used}' <<<"$listeners"
+}
+
+# --- Metric extraction (names verified against crates/telemetry/src/metrics.rs) ---
+prom_scrape() {
+    curl -fsS --max-time 5 "http://127.0.0.1:${METRICS_PORT}/metrics" >"$PROM_TMP"
+}
+
+# Sum every series of one metric family (0 when no series exists yet).
+prom_sum() {
+    awk -v n="$1" '$0 ~ "^"n"[{ ]" { s += $NF } END { printf "%.0f", s }' <"$PROM_TMP"
+}
+
+# Exact unlabeled gauge value (nan when absent).
+prom_get() {
+    awk -v n="$1" '$0 ~ "^"n"[{ ]" { print $NF; found=1; exit }
+        END { if (!found) print "nan" }' <"$PROM_TMP"
+}
+
+# One peer+scope-labeled gauge value (nan when absent).
+prom_peer_scope() {
+    awk -v m="$1" -v p="peer=\"$2\"" -v s="scope=\"$3\"" '
+        $0 ~ "^"m"\\{" && index($0, p) && index($0, s) { print $NF; found=1; exit }
+        END { if (!found) print "nan" }' <"$PROM_TMP"
+}
+
+tree_rss_mb() {
+    ps -eo pid=,ppid=,rss= --no-headers | awk -v root="$DAEMON_PID" '
+        {parent[$1]=$2; rss[$1]=$3} END {for (pid in parent) {p=pid
+        while (p in parent && p != root && parent[p] != p) p=parent[p]
+        if (p == root) total+=rss[pid]} printf "%.1f", total/1024}'
+}
+
+# Designated-member max-prefix state from the CLI: "<action> <remaining|null>".
+designated_max_prefix_state() {
+    timeout -k 1 5 "$RBGP" -s "unix://$SCEN/grpc.sock" -j neighbor "$DESIGNATED_ADDR" 2>/dev/null |
+        python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if isinstance(d, list):
+    if not d:
+        sys.exit(0)
+    d = d[0]
+r = d.get("max_prefix_restart_remaining_millis")
+print(d.get("max_prefix_action", ""), r if r is not None else "null")' || true
+}
+
+# --- Trip evidence state machine (driven off engine log markers) ---
+TRIP_N=""
+TRIP_EXCEEDED_SEEN=0
+TRIP_COUNTDOWN_SEEN=0
+TRIP_TORN_SEEN=0
+TRIP_REEST_SEEN=0
+TRIP_HEADROOM_PENDING=0
+TRIP_DEADLINE_EPOCH=0
+
+trip_begin() {
+    TRIP_N=$1
+    TRIP_EXCEEDED_SEEN=0
+    TRIP_COUNTDOWN_SEEN=0
+    TRIP_TORN_SEEN=0
+    TRIP_REEST_SEEN=0
+    TRIP_HEADROOM_PENDING=0
+    TRIP_DEADLINE_EPOCH=$(($(date +%s) + 60 + TRIP_RESTART_SECONDS + TRIP_REESTABLISH_SEC + 120))
+    cycle_log "trip $TRIP_N announce_over"
+}
+
+trip_evidence_tick() {
+    [[ -n $TRIP_N ]] || return 0
+    if (($(date +%s) > TRIP_DEADLINE_EPOCH)); then
+        abort "trip $TRIP_N evidence deadline exceeded (exceeded=$TRIP_EXCEEDED_SEEN countdown=$TRIP_COUNTDOWN_SEEN torn=$TRIP_TORN_SEEN reest=$TRIP_REEST_SEEN headroom_pending=$TRIP_HEADROOM_PENDING)"
+    fi
+    if ((TRIP_EXCEEDED_SEEN == 0)); then
+        if prom_scrape; then
+            local exceeded
+            exceeded=$(prom_sum bgp_max_prefix_exceeded_total)
+            if ((exceeded >= TRIP_N)); then
+                TRIP_EXCEEDED_SEEN=1
+                cycle_log "trip $TRIP_N exceeded_total=$exceeded"
+            fi
+        fi
+    fi
+    if ((TRIP_COUNTDOWN_SEEN == 0 && TRIP_REEST_SEEN == 0)); then
+        local state action remaining
+        state=$(designated_max_prefix_state)
+        if [[ -n $state ]]; then
+            read -r action remaining <<<"$state"
+            if [[ $remaining != null && -n $remaining ]]; then
+                TRIP_COUNTDOWN_SEEN=1
+                cycle_log "trip $TRIP_N countdown_ms=$remaining action=$action"
+            fi
+        fi
+    fi
+    if ((TRIP_HEADROOM_PENDING == 1)); then
+        if prom_scrape; then
+            local usage limit headroom
+            usage=$(prom_peer_scope bgp_max_prefix_usage "$DESIGNATED_ADDR" aggregate)
+            limit=$(prom_peer_scope bgp_max_prefix_limit "$DESIGNATED_ADDR" aggregate)
+            headroom=$(prom_peer_scope bgp_max_prefix_headroom "$DESIGNATED_ADDR" aggregate)
+            if [[ $usage == "$SOAK_ROUTES_PER_PEER" && $limit == "$MAX_PREFIXES" ]]; then
+                cycle_log "trip $TRIP_N complete usage=$usage limit=$limit headroom=$headroom"
+                TRIP_N=""
+                TRIP_HEADROOM_PENDING=0
+            fi
+        fi
+    fi
+}
+
+handle_line() {
+    local line=$1
+    if [[ $line =~ ^reload\ ([0-9]+)\ SIGHUP\  ]]; then
+        cycle_log "reload ${BASH_REMATCH[1]} issued"
+    elif [[ $line =~ ^reloadstall_csv,([0-9]+), ]]; then
+        cycle_log "reload ${BASH_REMATCH[1]} complete"
+    elif [[ $line =~ ^trip\ ([0-9]+)\ announce_over\  ]]; then
+        trip_begin "${BASH_REMATCH[1]}"
+    elif [[ $line =~ ^trip\ ([0-9]+)\ torn_down\  ]]; then
+        TRIP_TORN_SEEN=1
+        cycle_log "trip ${BASH_REMATCH[1]} torn_down"
+    elif [[ $line =~ ^trip\ ([0-9]+)\ reestablished\  ]]; then
+        TRIP_REEST_SEEN=1
+        cycle_log "trip ${BASH_REMATCH[1]} reestablished"
+        if ((TRIP_COUNTDOWN_SEEN == 0)); then
+            abort "trip ${BASH_REMATCH[1]} re-established before a hold-down countdown was observed"
+        fi
+    elif [[ $line =~ ^trip\ ([0-9]+)\ reannounced ]]; then
+        cycle_log "trip ${BASH_REMATCH[1]} reannounced"
+    elif [[ $line =~ ^trip\ ([0-9]+)\ complete\  ]]; then
+        if ((TRIP_TORN_SEEN == 0 || TRIP_REEST_SEEN == 0 || TRIP_COUNTDOWN_SEEN == 0 || TRIP_EXCEEDED_SEEN == 0)); then
+            abort "trip ${BASH_REMATCH[1]} completed with missing evidence (exceeded=$TRIP_EXCEEDED_SEEN countdown=$TRIP_COUNTDOWN_SEEN torn=$TRIP_TORN_SEEN reest=$TRIP_REEST_SEEN)"
+        fi
+        TRIP_HEADROOM_PENDING=1
+    fi
+}
+
+SEEN_LINES=0
+process_log() {
+    local total
+    total=$(wc -l <"$RELOADSTALL_LOG")
+    ((total > SEEN_LINES)) || return 0
+    local line
+    while IFS= read -r line; do
+        handle_line "$line"
+    done < <(sed -n "$((SEEN_LINES + 1)),${total}p" "$RELOADSTALL_LOG")
+    SEEN_LINES=$total
+}
+
+SCRAPE_FAILS=0
+sample_row() {
+    local elapsed=$1
+    # Sessions are held open by the engine; once it exits (or if it exits
+    # mid-scrape) a sample would record the harness's own teardown as
+    # daemon un-health. Record a row only when the engine was alive on
+    # both sides of the scrape.
+    pid_running "$H_PID" || return 0
+    local readyz code seconds ms
+    readyz=$(curl -sS -o /dev/null --max-time 5 -w '%{http_code} %{time_total}' \
+        "http://127.0.0.1:${METRICS_PORT}/readyz" 2>/dev/null) || readyz="000 0"
+    read -r code seconds <<<"$readyz"
+    ms=$(awk -v t="$seconds" 'BEGIN { printf "%.1f", t * 1000 }')
+    if ! prom_scrape; then
+        SCRAPE_FAILS=$((SCRAPE_FAILS + 1))
+        cycle_log "sample scrape failed (consecutive=$SCRAPE_FAILS)"
+        if ((SCRAPE_FAILS >= 5)); then
+            abort "metrics endpoint unreachable for $SCRAPE_FAILS consecutive samples"
+        fi
+        return 0
+    fi
+    SCRAPE_FAILS=0
+    pid_running "$H_PID" || return 0
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$elapsed" \
+        "$(tree_rss_mb)" \
+        "$(prom_get bgp_rib_attr_intern_global_size)" \
+        "$(prom_sum bgp_peer_session_established)" \
+        "$(prom_sum bgp_session_flaps_total)" \
+        "$(prom_sum bgp_messages_sent_total)" \
+        "$(prom_sum bgp_max_prefix_exceeded_total)" \
+        "$code" \
+        "$ms" \
+        >>"$SAMPLES_CSV"
+    local avail_kib
+    avail_kib=$(df -Pk "$RUN_DIR" | awk 'NR==2 {print $4}')
+    if ((avail_kib < 5 * 1024 * 1024)); then
+        abort "host disk below 5 GiB free (${avail_kib} KiB)"
+    fi
+}
+
+write_run_json() {
+    {
+        echo "{"
+        printf '  "run_id": "%s",\n' "$RUN_ID"
+        printf '  "git_head": "%s",\n' "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+        printf '  "peers": %d,\n' "$SOAK_PEERS"
+        printf '  "routes_per_peer": %d,\n' "$SOAK_ROUTES_PER_PEER"
+        printf '  "total_prefixes": %d,\n' "$TOTAL_PREFIXES"
+        printf '  "soak_seconds": %d,\n' "$SOAK_SECONDS"
+        printf '  "sample_interval_sec": %d,\n' "$SAMPLE_INTERVAL"
+        printf '  "warmup_sec": %d,\n' "$WARMUP_SEC"
+        printf '  "reload_interval_sec": %d,\n' "$RELOAD_INTERVAL_SEC"
+        printf '  "trip_interval_sec": %d,\n' "$TRIP_INTERVAL_SEC"
+        printf '  "planned_reloads": %d,\n' "$RELOADS"
+        printf '  "planned_trips": %d,\n' "$PLANNED_TRIPS"
+        printf '  "trip_every": %d,\n' "$TRIP_EVERY"
+        printf '  "max_prefixes": %d,\n' "$MAX_PREFIXES"
+        printf '  "trip_limit_margin": %d,\n' "$TRIP_LIMIT_MARGIN"
+        printf '  "trip_prefixes": %d,\n' "$TRIP_PREFIXES"
+        printf '  "trip_restart_seconds": %d,\n' "$TRIP_RESTART_SECONDS"
+        printf '  "trip_reestablish_sec": %d,\n' "$TRIP_REESTABLISH_SEC"
+        printf '  "listen_port": %d,\n' "$LISTEN_PORT"
+        printf '  "metrics_port": %d,\n' "$METRICS_PORT"
+        printf '  "designated_member": "%s"\n' "$DESIGNATED_ADDR"
+        echo "}"
+    } >"$RUN_JSON"
+}
+
+main() {
+    mkdir -p "$RUN_DIR"
+    exec > >(tee -a "$SOAK_LOG") 2>&1
+    acquire_rustbgpd_host_lock
+    trap cleanup EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    for tool in cargo curl awk python3 ss flock git ps df mktemp timeout; do
+        require_tool "$tool"
+    done
+
+    if ! ports_free; then
+        log "ERROR: port $LISTEN_PORT or $METRICS_PORT is already in use — refusing to start (not killing unknown processes)"
+        exit 75
+    fi
+
+    log "route-server flagship soak starting"
+    log "  shape:            ${SOAK_PEERS} peers x ${SOAK_ROUTES_PER_PEER} routes (${TOTAL_PREFIXES} total)"
+    log "  window:           ${SOAK_SECONDS}s nominal (${RELOADS} reloads @ ${RELOAD_INTERVAL_SEC}s, ${PLANNED_TRIPS} trips @ ${TRIP_INTERVAL_SEC}s)"
+    log "  trip member:      $DESIGNATED_ADDR max_prefixes=$MAX_PREFIXES restart=${TRIP_RESTART_SECONDS}s"
+    log "  output:           $RUN_DIR"
+
+    log "building daemon + rbgp + reloadstall (--release --locked)"
+    (cd "$REPO_ROOT" && cargo build --release --locked -p rustbgpd -p rustbgpctl) \
+        >"$RUN_DIR/build-root.log" 2>&1
+    (cd "$REPO_ROOT" && cargo build --release --locked \
+        --manifest-path bench/scale/reloadstall/Cargo.toml) \
+        >"$RUN_DIR/build-reloadstall.log" 2>&1
+    DAEMON="$REPO_ROOT/target/release/rustbgpd"
+    RBGP="$REPO_ROOT/target/release/rbgp"
+    HARNESS="$REPO_ROOT/bench/scale/target/release/reloadstall"
+    sha256sum "$DAEMON" "$RBGP" "$HARNESS" >"$RUN_DIR/binaries.sha256"
+
+    # Fresh scenario per run, never reused; /tmp keeps the gRPC UDS under
+    # the SUN_LEN path cap (see gen-scenario.py).
+    SCEN="$(mktemp -d /tmp/rsfs.XXXXXX)"
+    GEN_TRIP_MAX_PREFIXES=$MAX_PREFIXES GEN_TRIP_RESTART_SECONDS=$TRIP_RESTART_SECONDS \
+        python3 "$REPO_ROOT/bench/scale/reloadstall/gen-scenario.py" \
+        "$SOAK_PEERS" "$SCEN" "$LISTEN_PORT" "$SOAK_PEERS" >"$RUN_DIR/generator.log"
+    mkdir -p "$RUN_DIR/scenario"
+    cp "$SCEN/config.toml" "$SCEN"/*.rpol "$RUN_DIR/scenario/"
+    "$DAEMON" --check "$SCEN/config.toml" >"$RUN_DIR/daemon-check.log" 2>&1
+
+    write_run_json
+
+    "$DAEMON" "$SCEN/config.toml" >"$RUSTBGPD_LOG" 2>&1 &
+    DAEMON_PID=$!
+    log "daemon started pid=$DAEMON_PID"
+    local ready=0
+    for _ in $(seq 1 1200); do
+        if curl -fsS --max-time 0.25 "http://127.0.0.1:${METRICS_PORT}/readyz" >/dev/null 2>&1; then
+            ready=1
+            break
+        fi
+        pid_running "$DAEMON_PID" || abort "daemon exited during startup"
+        sleep 0.1
+    done
+    ((ready == 1)) || abort "daemon did not become ready within 120s"
+    log "daemon ready"
+
+    RELOADSTALL_CYCLE_QUIESCE_SECS=$RELOAD_INTERVAL_SEC \
+        RELOADSTALL_TRIP_EVERY=$TRIP_EVERY \
+        RELOADSTALL_TRIP_PREFIXES=$TRIP_PREFIXES \
+        RELOADSTALL_TRIP_REESTABLISH_SECS=$TRIP_REESTABLISH_SEC \
+        "$HARNESS" "$SOAK_PEERS" "$TOTAL_PREFIXES" "$LISTEN_PORT" "$DAEMON_PID" \
+        "$SCEN/member.rpol" "$SCEN/gen-a.rpol" "$SCEN/gen-b.rpol" \
+        "$RELOADS" "$CONTROL_SECS" "$SOAK_PEERS" >"$RELOADSTALL_LOG" 2>&1 &
+    H_PID=$!
+    log "engine started pid=$H_PID"
+
+    local converge_deadline=$(($(date +%s) + CONVERGE_CAP_SEC))
+    until grep -q '^converged (' "$RELOADSTALL_LOG" 2>/dev/null; do
+        pid_running "$H_PID" || abort "engine exited before convergence"
+        (($(date +%s) < converge_deadline)) || abort "convergence exceeded ${CONVERGE_CAP_SEC}s"
+        sleep 1
+    done
+    log "engine converged; sampling starts (interval=${SAMPLE_INTERVAL}s warmup=${WARMUP_SEC}s)"
+
+    echo "timestamp,elapsed_sec,rss_mb,intern_size,established,flaps_total,msgs_sent_total,max_prefix_exceeded_total,readyz_code,readyz_ms" >"$SAMPLES_CSV"
+    local start_epoch now next_sample overall_deadline
+    start_epoch=$(date +%s)
+    next_sample=$start_epoch
+    overall_deadline=$((start_epoch + OVERALL_CAP_SEC))
+
+    while :; do
+        now=$(date +%s)
+        if ! pid_running "$H_PID"; then
+            process_log
+            break
+        fi
+        pid_running "$DAEMON_PID" || abort "daemon died mid-soak"
+        process_log
+        trip_evidence_tick
+        if ((now >= next_sample)); then
+            sample_row $((now - start_epoch))
+            next_sample=$((now + SAMPLE_INTERVAL))
+        fi
+        ((now < overall_deadline)) || abort "overall watchdog cap ${OVERALL_CAP_SEC}s exceeded"
+        sleep 1
+    done
+
+    local hrc=0
+    wait "$H_PID" || hrc=$?
+    H_PID=""
+    ((hrc == 0)) || abort "engine exited non-zero: $hrc"
+    if [[ -n $TRIP_N ]]; then
+        # Drain the last trip's headroom evidence (bounded).
+        local drain_deadline=$(($(date +%s) + 60))
+        while [[ -n $TRIP_N ]]; do
+            (($(date +%s) < drain_deadline)) || abort "trip $TRIP_N headroom evidence never settled"
+            trip_evidence_tick
+            sleep 1
+        done
+    fi
+    log "engine completed cleanly; running analyzer"
+
+    terminate "$DAEMON_PID"
+    DAEMON_PID=""
+
+    python3 "$SOAK_SCRIPT_DIR/analyze-soak-rs-flagship.py" "$RUN_DIR" \
+        --output "$RUN_DIR/verdict.json"
+    log "soak complete: verdict in $RUN_DIR/verdict.json"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/soak/test_analyze_soak_rs_flagship.py
+++ b/tests/soak/test_analyze_soak_rs_flagship.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Load-bearing gate contracts for the route-server flagship soak analyzer."""
+
+import csv
+import json
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).parent
+ANALYZER = HERE / "analyze-soak-rs-flagship.py"
+T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+FIELDS = [
+    "timestamp", "elapsed_sec", "rss_mb", "intern_size", "established",
+    "flaps_total", "msgs_sent_total", "max_prefix_exceeded_total",
+    "readyz_code", "readyz_ms",
+]
+
+
+def ts(elapsed):
+    return (T0 + timedelta(seconds=elapsed)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def cline(elapsed, body):
+    return f"[{ts(elapsed)}] {body}"
+
+
+def smoke_meta(**over):
+    meta = {
+        "peers": 12, "routes_per_peer": 50, "total_prefixes": 600,
+        "soak_seconds": 240, "sample_interval_sec": 30, "warmup_sec": 30,
+        "planned_reloads": 4, "planned_trips": 2, "trip_every": 2,
+        "max_prefixes": 100, "trip_restart_seconds": 20,
+    }
+    meta.update(over)
+    return meta
+
+
+def trip_block(n, start, restart_sec=20, exceeded=None, holddown=None):
+    """Full evidence chain for one trip starting at `start` elapsed sec."""
+    exceeded = n if exceeded is None else exceeded
+    holddown = restart_sec if holddown is None else holddown
+    down = start + 1
+    up = down + holddown
+    return [
+        cline(start, f"trip {n} announce_over"),
+        cline(down, f"trip {n} torn_down"),
+        cline(down + 1, f"trip {n} exceeded_total={exceeded}"),
+        cline(down + 2, f"trip {n} countdown_ms={restart_sec * 1000 - 1000} "
+                        "action=restart"),
+        cline(up, f"trip {n} reestablished"),
+        cline(up + 1, f"trip {n} reannounced"),
+        cline(up + 4, f"trip {n} complete usage=50 limit=100 headroom=50"),
+    ]
+
+
+def smoke_cycles():
+    lines = []
+    for r, at in ((1, 40), (2, 55), (3, 130), (4, 200)):
+        lines.append(cline(at, f"reload {r} issued"))
+        lines.append(cline(at + 5, f"reload {r} complete"))
+    lines += trip_block(1, 60)
+    lines += trip_block(2, 150)
+    return lines
+
+
+def smoke_rows():
+    rows = []
+    for i, elapsed in enumerate(range(0, 241, 30)):
+        # Trip 1 window covers elapsed 60; trip 2 covers 150: the dip at 60
+        # is the designated member's declared teardown.
+        established = 11 if elapsed == 60 else 12
+        flaps = 0 if elapsed < 60 else (1 if elapsed < 150 else 2)
+        exceeded = 0 if elapsed < 60 else (1 if elapsed < 150 else 2)
+        rows.append({
+            "timestamp": ts(elapsed), "elapsed_sec": str(elapsed),
+            "rss_mb": "100.0", "intern_size": "1000",
+            "established": str(established), "flaps_total": str(flaps),
+            "msgs_sent_total": str(1000 + i * 500),
+            "max_prefix_exceeded_total": str(exceeded),
+            "readyz_code": "200", "readyz_ms": "5.0",
+        })
+    return rows
+
+
+def long_meta():
+    return smoke_meta(soak_seconds=86400, sample_interval_sec=3600,
+                      warmup_sec=300, planned_reloads=48, planned_trips=6,
+                      trip_every=8)
+
+
+def long_cycles():
+    lines = []
+    for r in range(1, 49):
+        at = r * 1700
+        lines.append(cline(at, f"reload {r} issued"))
+        lines.append(cline(at + 10, f"reload {r} complete"))
+    for n in range(1, 7):
+        lines += trip_block(n, n * 14000 + 100)
+    return lines
+
+
+def long_rows(rss_of=None):
+    rows = []
+    for i, elapsed in enumerate(range(0, 86401, 3600)):
+        rss = 1000.0 if rss_of is None else rss_of(elapsed)
+        trips_done = min(6, max(0, (elapsed - 100) // 14000))
+        rows.append({
+            "timestamp": ts(elapsed), "elapsed_sec": str(elapsed),
+            "rss_mb": f"{rss:.1f}", "intern_size": "1000",
+            "established": "12", "flaps_total": str(trips_done),
+            "msgs_sent_total": str(10_000 + i * 5000),
+            "max_prefix_exceeded_total": str(trips_done),
+            "readyz_code": "200", "readyz_ms": "5.0",
+        })
+    return rows
+
+
+def run_analyzer(rows, cycles, meta, fields=FIELDS):
+    with tempfile.TemporaryDirectory() as tmp:
+        run_dir = Path(tmp)
+        with (run_dir / "samples.csv").open("w", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=fields,
+                                    extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(rows)
+        (run_dir / "cycles.log").write_text("\n".join(cycles) + "\n")
+        (run_dir / "run.json").write_text(json.dumps(meta))
+        result = subprocess.run(
+            ["python3", str(ANALYZER), str(run_dir)],
+            text=True, capture_output=True, check=False,
+        )
+    payload = json.loads(result.stdout) if result.stdout else None
+    return result, payload
+
+
+class RsFlagshipAnalyzerContracts(unittest.TestCase):
+    def test_clean_smoke_run_passes_with_slope_gates_annotated(self):
+        result, payload = run_analyzer(smoke_rows(), smoke_cycles(),
+                                       smoke_meta())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(payload["verdict"], "pass")
+        # The in-window session dip is the declared trip teardown, not a
+        # floor violation.
+        self.assertTrue(payload["gates"]["session_floor"]["pass"])
+        # Short windows must not silently green-light the slope gates:
+        # they pass only with the explicit not-evaluated annotation.
+        self.assertFalse(payload["slope_window_evaluated"])
+        self.assertIn("not evaluated",
+                      payload["gates"]["rss_late_slope_per_hour"]["note"])
+
+    def test_session_dip_outside_trip_window_fails(self):
+        rows = smoke_rows()
+        rows[-1]["established"] = "11"
+        result, payload = run_analyzer(rows, smoke_cycles(), smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["session_floor"]["pass"])
+
+    def test_two_members_down_inside_trip_window_fails(self):
+        rows = smoke_rows()
+        rows[2]["established"] = "10"  # elapsed 60, inside trip 1's window
+        result, payload = run_analyzer(rows, smoke_cycles(), smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["session_floor"]["pass"])
+
+    def test_missing_countdown_evidence_fails(self):
+        cycles = [l for l in smoke_cycles() if "trip 2 countdown_ms" not in l]
+        result, payload = run_analyzer(smoke_rows(), cycles, smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        gate = payload["gates"]["trip_accounting"]
+        self.assertFalse(gate["pass"])
+        self.assertIn("2", gate["value"]["defects"])
+
+    def test_incomplete_reload_accounting_fails(self):
+        cycles = [l for l in smoke_cycles() if "reload 4 complete" not in l]
+        result, payload = run_analyzer(smoke_rows(), cycles, smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["reload_accounting"]["pass"])
+
+    def test_spurious_latch_off_breaks_exact_exceeded_accounting(self):
+        rows = smoke_rows()
+        rows[-1]["max_prefix_exceeded_total"] = "3"
+        result, payload = run_analyzer(rows, smoke_cycles(), smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["exceeded_exact"]["pass"])
+
+    def test_msgs_sent_regression_fails_as_restart_detection(self):
+        rows = smoke_rows()
+        rows[5]["msgs_sent_total"] = "1"
+        result, payload = run_analyzer(rows, smoke_cycles(), smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["msgs_sent_monotone"]["pass"])
+
+    def test_rss_over_ceiling_fails(self):
+        rows = smoke_rows()
+        rows[4]["rss_mb"] = "4000.0"
+        result, payload = run_analyzer(rows, smoke_cycles(), smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["rss_peak_mb"]["pass"])
+
+    def test_reestablish_over_bound_fails(self):
+        cycles = []
+        for r, at in ((1, 40), (2, 55), (3, 130), (4, 200)):
+            cycles.append(cline(at, f"reload {r} issued"))
+            cycles.append(cline(at + 5, f"reload {r} complete"))
+        cycles += trip_block(1, 60)
+        # Trip 2 re-establishes 200 s after teardown: past the
+        # restart_seconds + 60 s bound.
+        cycles += trip_block(2, 150, holddown=200)
+        result, payload = run_analyzer(smoke_rows(), cycles, smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["trip_accounting"]["pass"])
+
+    def test_abort_record_fails(self):
+        cycles = smoke_cycles() + [cline(230, "ABORT: daemon died mid-soak")]
+        result, payload = run_analyzer(smoke_rows(), cycles, smoke_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["no_abort"]["pass"])
+
+    def test_missing_column_is_input_error(self):
+        fields = [f for f in FIELDS if f != "max_prefix_exceeded_total"]
+        result, _ = run_analyzer(smoke_rows(), smoke_cycles(), smoke_meta(),
+                                 fields=fields)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("max_prefix_exceeded_total", result.stderr)
+
+    def test_long_window_evaluates_slopes_and_passes_when_flat(self):
+        result, payload = run_analyzer(long_rows(), long_cycles(), long_meta())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["slope_window_evaluated"])
+        self.assertTrue(payload["gates"]["rss_late_slope_per_hour"]["pass"])
+
+    def test_long_window_late_leak_fails_slope_gate(self):
+        def leaking(elapsed):
+            return 1000.0 + max(0, elapsed - 64800) / 3600 * 20.0
+
+        result, payload = run_analyzer(long_rows(rss_of=leaking),
+                                       long_cycles(), long_meta())
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["gates"]["rss_late_slope_per_hour"]["pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Builds the route-server flagship 24 h soak scenario (ADR-0125 E2): 1000 real eBGP route-server-client sessions × 400 routes each against a bare-host daemon, driven by the `bench/scale/reloadstall` engine with its steady churn running throughout, plus two serialized failure injections that close soak coverage gaps 2 and 6:

- **Real SIGHUP policy-file reload** every `RELOAD_INTERVAL_SEC` (default 1800 s → 48/24 h), each verified by the engine's generation-marker completion barriers and per-reload integrity checks.
- **Max-prefix trip / timed-restart cycle** every `TRIP_INTERVAL_SEC` (default 14 400 s → 6/24 h) on the designated member (stub 0, `max_prefixes = routes + 50`, `max_prefix_restart_seconds = 120`): announce over the bound → Cease teardown → withdraw propagation verified at every survivor → reconnect-retry through the hold-down → the daemon's one timed restart → compliant-base-only re-announce → re-announce propagation verified. The runner asserts the daemon-side evidence chain per cycle: `bgp_max_prefix_exceeded_total` reaches exactly N → hold-down countdown observed via `rbgp neighbor -j` (`max_prefix_restart_remaining_millis`, action `restart`) → re-Established within `max_prefix_restart_seconds` + 60 s → `usage`/`limit`/`headroom` sane.

### Pieces

- `tests/soak/run-soak-rs-flagship.sh` — fail-closed runner (host lock, port admission, fresh scenario per run, bare daemon with JSON logs, readiness gate, 30 s sampler, cycle watcher + trip evidence machine, abort-preserves-artifacts).
- `bench/scale/reloadstall` — additive soak env knobs only (`RELOADSTALL_CYCLE_QUIESCE_SECS`, `RELOADSTALL_TRIP_EVERY`, `RELOADSTALL_TRIP_PREFIXES`, `RELOADSTALL_TRIP_REESTABLISH_SECS`); every knob absent reproduces the frozen one-shot contract byte-for-byte (source-shape guard tests still pass unchanged). Trip verification reuses the flapstorm bitmap machinery with the K=1 window shape. `gen-scenario.py` gains `GEN_TRIP_MAX_PREFIXES` / `GEN_TRIP_RESTART_SECONDS`. README arg-contract section updated.
- `tests/soak/analyze-soak-rs-flagship.py` + `test_analyze_soak_rs_flagship.py` (13 gate-contract tests, wired into CI next to the existing soak analyzer tests, plus a CI shellcheck line for the runner).
- `docs/soaks/soak-acceptance-gates.md` — precommitted scenario 10 gate table (session floor with declared trip windows; exact reload/trip accounting; exact exceeded-counter and flap budgets; counter monotonicity; readyz 200/250 ms; 3 GiB RSS ceiling calibrated from the route-server-1000 receipt's 2 GiB one-shot bound + reload-cycle glibc-retention headroom; late-window-only slope bounds with stated rationale), failure-injection inventory rows, and honest annotation of coverage gaps 2 and 6 (numbering unchanged; residual sub-gaps stated).
- CHANGELOG entry. No manifest changes, so no lockfile changes.

### Smoke evidence (12 peers × 50 routes, 5 reloads @ 60 s, 2 trips @ 120 s, restart 20 s)

Analyzer verdict: **pass** — all 12 gates green (35 samples, reloads 5 issued == 5 barrier-verified, trips 2/2, peak RSS 35.2 MB; late-window slope gates correctly annotated "not evaluated" for the short window).

```
[00:09:17Z] trip 1 announce_over
[00:09:17Z] trip 1 torn_down
[00:09:17Z] trip 1 exceeded_total=1
[00:09:17Z] trip 1 countdown_ms=19121 action=restart
[00:09:37Z] trip 1 reestablished
[00:09:37Z] trip 1 reannounced
[00:09:37Z] trip 1 complete usage=50 limit=100 headroom=50
...
[00:11:38Z] trip 2 countdown_ms=19081 action=restart
[00:11:58Z] trip 2 complete usage=50 limit=100 headroom=50
```

```
trip_csv,1,12,0.050,0.000,20.134,0.030,33,12,0
trip_csv,2,12,0.051,0.000,20.130,0.034,34,12,0
reloadstall_csv,5,12,12,0,600,0.002493,...,34,35,0,12,0
final CSV row: established=12 flaps_total=2 max_prefix_exceeded_total=2 readyz=200
```

Clean teardown verified: no orphan `rustbgpd`/`reloadstall` processes, scenario tmp dirs removed. (Note: `trip_csv` `withdraw_s` can read 0.000 at smoke scale — withdraw propagation to survivors completes before the tripped stub's own close detection; the withdraw completion barrier itself is what gates.)

### Verification

- `cargo fmt --all -- --check` (root + bench/scale), `cargo clippy --workspace --all-targets -- -D warnings` (root + bench/scale), `cargo test --workspace`, `cargo doc --workspace --no-deps` — all green.
- bench/scale `--release --locked` build green; reloadstall unit tests 22/22 (including the new trip-schedule/trip-block/env-default contracts and the unchanged frozen-contract source-shape guards).
- `shellcheck -x` clean; `python3 -m pytest tests/soak/test_analyze_soak_rs_flagship.py` 13/13.
- End-to-end smoke above ran the real daemon on host ports 1790/9179 (checked free first).
