### PR TITLE
Fix reloadstall soak end-of-run: final-trip evidence hold + bounded events

### DIFF
--- a/bench/scale/reloadstall/README.md
+++ b/bench/scale/reloadstall/README.md
@@ -139,6 +139,12 @@ max-prefix trip cycles:
   the daemon's import path and session accounting.
 - `RELOADSTALL_TRIP_REESTABLISH_SECS` — teardown-to-re-established deadline
   (default 300); must exceed the daemon-side `max_prefix_restart_seconds`.
+- `RELOADSTALL_FINAL_QUIESCE_SECS` — post-run session hold in seconds
+  (default: the cycle quiesce), applied only when the LAST reload carries a
+  trip cycle: the engine sleeps with every stub session still up after
+  `trip N complete`, so an outer runner can drain the trip's daemon-side
+  evidence (`bgp_max_prefix_usage`/`limit`/`headroom`) from live metrics
+  before teardown. Never applies to the one-shot contract (no trips).
 
 `gen-scenario.py` grows a matching additive pair: setting both
 `GEN_TRIP_MAX_PREFIXES` and `GEN_TRIP_RESTART_SECONDS` adds

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -912,6 +912,19 @@ fn completion_us(ctx: &Ctx, i: usize) -> Option<u64> {
     ctx.obs[i].generation.lock().unwrap().completed_at_us
 }
 
+/// Per-cycle events drain (end of every reload cycle, after its CSV row).
+/// A cycle's gap stats consume only its own `[t_hup, reload_end]` window,
+/// so events from completed cycles are dead weight — without this the
+/// per-observer Vec grows for the entire soak window (the iBGP-RR hold
+/// bounds the same growth by disabling recording instead, since nothing
+/// consumes gap stats there). `clear()` keeps capacity, so memory stays
+/// bounded by the busiest single cycle.
+fn drain_cycle_events(obs: &[Obs]) {
+    for observer in obs {
+        observer.events.lock().unwrap().clear();
+    }
+}
+
 fn stable_marker_is_fresh(seen_at_us: u64, since_us: u64) -> bool {
     seen_at_us != 0 && seen_at_us >= since_us
 }
@@ -2289,6 +2302,7 @@ fn main() {
                 first_generation_update.p95,
                 first_generation_update.max,
             );
+            drain_cycle_events(&ctx.obs);
             // Quiesce between cycles (soak mode overrides the historical 20 s
             // to self-pace the whole window).
             tokio::time::sleep(Duration::from_secs(cycle_quiesce_secs)).await;
@@ -2740,6 +2754,52 @@ mod tests {
         // The smoke shape: 5 reloads, trip every 2nd -> 2 trips.
         let slots: Vec<u32> = (1..=5).filter(|&r| is_trip_slot(r, 2)).collect();
         assert_eq!(slots, vec![2, 4]);
+    }
+
+    #[test]
+    fn reload_cycle_drain_keeps_observer_events_bounded() {
+        let observer = || Obs {
+            events: Mutex::new(
+                (0..1000)
+                    .map(|t_us| Event {
+                        t_us,
+                        base_ann: 1,
+                        other: 0,
+                    })
+                    .collect(),
+            ),
+            base_ann_total: AtomicU64::new(0),
+            established: AtomicBool::new(true),
+            last_comms: Mutex::new(Vec::new()),
+            stable_marker_seen_at_us: AtomicU64::new(0),
+            expected_community: AtomicU32::new(0),
+            generation: Mutex::new(GenerationProgress::default()),
+            refresh_pending: AtomicBool::new(false),
+            flap_mode: AtomicU32::new(FLAP_OFF),
+        };
+        let obs = vec![observer(), observer()];
+        let capacity_before = obs[0].events.lock().unwrap().capacity();
+        drain_cycle_events(&obs);
+        for o in &obs {
+            let events = o.events.lock().unwrap();
+            assert!(events.is_empty(), "cycle drain must empty every observer");
+            assert_eq!(
+                events.capacity(),
+                capacity_before,
+                "drain keeps capacity: memory bound = busiest single cycle"
+            );
+        }
+        // The drain must run inside the reload loop, after the cycle's CSV
+        // row (its stats consumed the events) and before the quiesce.
+        let source = include_str!("main.rs");
+        let call = ["drain_cycle_events", "(&ctx.obs)"].concat();
+        assert_eq!(source.matches(&call).count(), 1);
+        let csv_needle = ["reloadstall_csv,", "{r}"].concat();
+        let csv = source.find(&csv_needle).unwrap();
+        let drain = source.find(&call).unwrap();
+        let quiesce_needle = ["from_secs(cycle_", "quiesce_secs)"].concat();
+        let quiesce = source.find(&quiesce_needle).unwrap();
+        assert!(csv < drain && drain < quiesce);
     }
 
     #[test]

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -61,6 +61,12 @@
 //! - `RELOADSTALL_TRIP_REESTABLISH_SECS`: teardown-to-re-established
 //!   deadline (default 300); must exceed the daemon's configured
 //!   `max_prefix_restart_seconds`.
+//! - `RELOADSTALL_FINAL_QUIESCE_SECS`: post-run session hold (default:
+//!   the cycle quiesce), applied only when the LAST reload carries a
+//!   trip cycle: the engine keeps every stub session up after
+//!   `trip N complete` so an outer runner can drain the trip's
+//!   daemon-side evidence (usage/limit/headroom) from live metrics
+//!   before teardown. Never applies to the one-shot contract (no trips).
 //!
 //! iBGP-RR extensions (route-reflector flagship soak) — additive env
 //! vars; absent, the frozen eBGP route-server contract is untouched:
@@ -1161,6 +1167,21 @@ fn is_trip_slot(reload: u32, trip_every: u32) -> bool {
     trip_every != 0 && reload.is_multiple_of(trip_every)
 }
 
+/// Post-run session hold (seconds) before teardown. When the LAST reload
+/// carries a trip cycle, the outer runner still has to observe the settled
+/// post-recovery state (usage/limit/headroom) from the daemon's live
+/// metrics after `trip N complete`; exiting immediately drops every stub
+/// session and that peer-scoped state can never settle. Zero whenever the
+/// last cycle cannot leave evidence pending — including the frozen
+/// one-shot contract (`trip_every == 0`).
+fn final_quiesce_secs(reloads: u32, trip_every: u32, hold_secs: u64) -> u64 {
+    if is_trip_slot(reloads, trip_every) {
+        hold_secs
+    } else {
+        0
+    }
+}
+
 /// Over-limit trip block: base indexes `[total, total + count)`. Outside
 /// every observer's completion bitmap (`base_prefix_index` rejects
 /// `>= total`) and outside the churn space, but shaped exactly like base
@@ -1586,6 +1607,7 @@ fn main() {
     let trip_every = u32::try_from(env_u64("RELOADSTALL_TRIP_EVERY", 0)).unwrap();
     let trip_prefix_count = u32::try_from(env_u64("RELOADSTALL_TRIP_PREFIXES", 64)).unwrap();
     let trip_reestablish = Duration::from_secs(env_u64("RELOADSTALL_TRIP_REESTABLISH_SECS", 300));
+    let final_quiesce = env_u64("RELOADSTALL_FINAL_QUIESCE_SECS", cycle_quiesce_secs);
     // iBGP-RR soak knobs; both absent reproduces the frozen eBGP contract.
     let ibgp_rr = ibgp_rr_mode(env_u64("RELOADSTALL_IBGP_RR_ASN", 0)).unwrap_or_else(|error| {
         eprintln!("{error}");
@@ -2283,6 +2305,15 @@ fn main() {
             }
         }
 
+        // Hold every session up after a final-cycle trip so the outer
+        // runner can drain the trip's daemon-side evidence from live
+        // metrics before teardown (see final_quiesce_secs).
+        let hold = final_quiesce_secs(reloads, trip_every, final_quiesce);
+        if hold > 0 {
+            println!("final quiesce {hold}s");
+            tokio::time::sleep(Duration::from_secs(hold)).await;
+        }
+
         let parse_errors = ctx.parse_errors.load(Ordering::Relaxed);
         let Some(evidence_dir) = evidence_dir.as_deref() else {
             println!("done rss_mib={}", rss_mib(pid));
@@ -2709,6 +2740,18 @@ mod tests {
         // The smoke shape: 5 reloads, trip every 2nd -> 2 trips.
         let slots: Vec<u32> = (1..=5).filter(|&r| is_trip_slot(r, 2)).collect();
         assert_eq!(slots, vec![2, 4]);
+    }
+
+    #[test]
+    fn final_quiesce_applies_only_when_the_last_reload_trips() {
+        // Flagship: 48 reloads, trip every 8th -> trip 6 rides reload 48,
+        // so the engine must hold sessions for the runner's evidence drain.
+        assert_eq!(final_quiesce_secs(48, 8, 120), 120);
+        // Masked smoke shape: last trip on reload 4 of 5 settles while the
+        // engine is still alive; no hold.
+        assert_eq!(final_quiesce_secs(5, 2, 120), 0);
+        // The frozen one-shot contract (no trips) never holds.
+        assert_eq!(final_quiesce_secs(4, 0, 120), 0);
     }
 
     #[test]

--- a/tests/soak/run-soak-rs-flagship.sh
+++ b/tests/soak/run-soak-rs-flagship.sh
@@ -50,6 +50,9 @@ TRIP_LIMIT_MARGIN="${TRIP_LIMIT_MARGIN:-50}"
 TRIP_PREFIXES="${TRIP_PREFIXES:-64}"
 TRIP_RESTART_SECONDS="${TRIP_RESTART_SECONDS:-120}"
 TRIP_REESTABLISH_SEC="${TRIP_REESTABLISH_SEC:-300}"
+# Engine-side session hold after a final-cycle trip; the runner's final
+# evidence drain window is half of it, so the sessions always outlive it.
+TRIP_FINAL_QUIESCE_SEC="${TRIP_FINAL_QUIESCE_SEC:-120}"
 CONVERGE_CAP_SEC="${CONVERGE_CAP_SEC:-900}"
 LISTEN_PORT="${LISTEN_PORT:-1790}"
 # gen-scenario.py pins prometheus_addr to 127.0.0.1:9179.
@@ -80,6 +83,10 @@ if ((SOAK_PEERS <= 8)); then
 fi
 if ((TRIP_RESTART_SECONDS < 10)); then
     echo "TRIP_RESTART_SECONDS must be >= 10 so the 1 s countdown poll can observe it" >&2
+    exit 2
+fi
+if ((TRIP_FINAL_QUIESCE_SEC < 30)); then
+    echo "TRIP_FINAL_QUIESCE_SEC must be >= 30 (the final-trip evidence drain runs inside it)" >&2
     exit 2
 fi
 OVERALL_CAP_SEC="${OVERALL_CAP_SEC:-$((SOAK_SECONDS + RELOADS * 300 + PLANNED_TRIPS * (TRIP_RESTART_SECONDS + TRIP_REESTABLISH_SEC + 300) + 3600))}"
@@ -369,6 +376,7 @@ write_run_json() {
         printf '  "trip_prefixes": %d,\n' "$TRIP_PREFIXES"
         printf '  "trip_restart_seconds": %d,\n' "$TRIP_RESTART_SECONDS"
         printf '  "trip_reestablish_sec": %d,\n' "$TRIP_REESTABLISH_SEC"
+        printf '  "trip_final_quiesce_sec": %d,\n' "$TRIP_FINAL_QUIESCE_SEC"
         printf '  "listen_port": %d,\n' "$LISTEN_PORT"
         printf '  "metrics_port": %d,\n' "$METRICS_PORT"
         printf '  "designated_member": "%s"\n' "$DESIGNATED_ADDR"
@@ -440,6 +448,7 @@ main() {
         RELOADSTALL_TRIP_EVERY=$TRIP_EVERY \
         RELOADSTALL_TRIP_PREFIXES=$TRIP_PREFIXES \
         RELOADSTALL_TRIP_REESTABLISH_SECS=$TRIP_REESTABLISH_SEC \
+        RELOADSTALL_FINAL_QUIESCE_SECS=$TRIP_FINAL_QUIESCE_SEC \
         "$HARNESS" "$SOAK_PEERS" "$TOTAL_PREFIXES" "$LISTEN_PORT" "$DAEMON_PID" \
         "$SCEN/member.rpol" "$SCEN/gen-a.rpol" "$SCEN/gen-b.rpol" \
         "$RELOADS" "$CONTROL_SECS" "$SOAK_PEERS" >"$RELOADSTALL_LOG" 2>&1 &
@@ -482,8 +491,12 @@ main() {
     H_PID=""
     ((hrc == 0)) || abort "engine exited non-zero: $hrc"
     if [[ -n $TRIP_N ]]; then
-        # Drain the last trip's headroom evidence (bounded).
-        local drain_deadline=$(($(date +%s) + 60))
+        # Drain the last trip's headroom evidence (bounded). When the last
+        # trip rides the last reload, the engine holds every session up for
+        # TRIP_FINAL_QUIESCE_SEC after `trip N complete`, so the live loop
+        # above normally settles this before the engine exits; this drain
+        # (half the hold) is the fail-closed backstop.
+        local drain_deadline=$(($(date +%s) + TRIP_FINAL_QUIESCE_SEC / 2))
         while [[ -n $TRIP_N ]]; do
             (($(date +%s) < drain_deadline)) || abort "trip $TRIP_N headroom evidence never settled"
             trip_evidence_tick


### PR DESCRIPTION
Two flagship-soak defects in the `bench/scale/reloadstall` engine's reload-paced (RS soak) path, both end-of-run/duration-shaped. Rebased on the iBGP-RR flagship soak (#1691); both features preserved.

## 1. Final-cycle trip evidence was unobservable (deterministic 24 h abort)

The soak mode injects a max-prefix trip after every K-th reload. When the trip rides the LAST reload — the 24 h flagship defaults do exactly this (48 reloads, trip every 8th → trip 6 on reload 48) — the engine completed the trip's internal verification (re-establish, re-announce, bitmap) and exited immediately, closing every stub TCP session. The runner's trip-evidence machine still has to observe the settled post-recovery state for the designated member from the daemon's live metrics (`bgp_max_prefix_usage == routes`, `usage + headroom == limit`); for a final-cycle trip that happened in the runner's bounded post-engine drain, by which time the peer-scoped state could never settle:

```
ABORT: trip N headroom evidence never settled
```

Non-final trips were unaffected — the engine stays alive through their settle.

Fix:

- **Engine**: new additive env knob `RELOADSTALL_FINAL_QUIESCE_SECS` (default: the cycle quiesce). After the reload loop, when the LAST reload carried a trip cycle, the engine prints `final quiesce Ns` and holds every stub session up for that window before teardown. The hold applies only to that shape: a run whose last reload has no trip, and the frozen one-shot no-knobs contract, behave exactly as before (source-shape guard tests pass unchanged; `final_quiesce_applies_only_when_the_last_reload_trips` pins the gating).
- **Runner** (`tests/soak/run-soak-rs-flagship.sh`): passes `TRIP_FINAL_QUIESCE_SEC` (default 120 s) as the engine hold and derives its fail-closed drain deadline as half of it, so the sessions always comfortably outlive the drain window. The evidence now settles in the live sampling loop while the engine holds; the post-exit drain remains as the fail-closed backstop (abort unchanged). `trip_final_quiesce_sec` recorded in `run.json`; knob documented in the reloadstall README and engine header.

## 2. Per-observer `events` Vec grew unbounded across soak cycles

Each reload cycle's gap stats (`max_gap_ms`) consume only that cycle's `[t_hup, reload_end]` window, but recorded events were never released — the per-observer Vec grew for the entire run, unbounded at the 24 h shape (churn cadence across 1000 observers). #1691's iBGP-RR hold bounds the same growth by disabling recording (nothing consumes gap stats there); the reload path must keep recording because every cycle's CSV row consumes its window.

Fix: `drain_cycle_events` clears every observer's events at the end of each reload cycle, after the cycle's `reloadstall_csv` row (its stats have consumed them) and before the quiesce. `clear()` keeps capacity, so memory stays bounded by the busiest single cycle and there is no per-cycle realloc churn. One-shot output is byte-for-byte unchanged (stats are computed before the drain). `reload_cycle_drain_keeps_observer_events_bounded` pins the drain behavior, capacity retention, and the call-site ordering (CSV → drain → quiesce).

## Proof (rebased head)

Exposed shape (last trip rides last reload — previously a deterministic end-of-run abort): `SOAK_PEERS=12 SOAK_ROUTES_PER_PEER=50 SOAK_SECONDS=240 RELOAD_INTERVAL_SEC=60 TRIP_INTERVAL_SEC=120 TRIP_RESTART_SECONDS=20 WARMUP_SEC=30 SAMPLE_INTERVAL=10` → 4 reloads, trip 2 on reload 4:

- engine log: `trip 2 complete` → `final quiesce 120s` → `done`; per-cycle `rss_mib` flat (29→33 MiB across all reloads and trips)
- cycles.log: `trip 2 complete usage=50 limit=100 headroom=50` — settled via live metrics during the hold
- analyzer verdict: **pass** — 44 samples, 2/2 trips, all 12 gates green; clean teardown, no orphan processes

Masked shape (the documented ~7-minute smoke: 5 reloads, trips on 2 and 4, last reload carries no trip): zero `final quiesce` lines (pre-fix path taken), verdict **pass**, 2/2 trips, all gates green, clean teardown.

## Gates (rebased head)

Root `cargo fmt` / `clippy --workspace --all-targets` / `test --workspace` / `doc` green; reloadstall `--release --locked` build + 26 unit tests green (all #1690/#1691 guard tests unchanged); `shellcheck -x` on both flagship runners green; RS + RR analyzer pytest suites (27) green unchanged.
