### PR TITLE
Re-pin CI scale split contract to the soak-test wiring

### DIFF
--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -24,12 +24,12 @@ JOB_HASHES = {
     "v064_validator": "b3f0ae8906bd28397a5f82bab0db5467e09a8e312aa24a8c8f2db8fd01c6310a",
     "core": "b2afd36bb65640496181d311b2d528cf9e7de052c6299f93b0cc58e45be16abe",
     "core_tests": "c5d8ed560cd4e572f535bb4eabe065372fddfc1dbefe0c341a9c5af76ed6df0f",
-    "scale_receipts": "7f6daffbf3451a5cc9f135f5d6774d6c19ec1e9c6ac66407834ef0f655837fc3",
+    "scale_receipts": "57a201b5691dd08fecb49860deb942a74a4dcf4d2b3a77a18716b3fc9d981b85",
     "check": "736f69ca686c06e889962d5fb93d80ee848090718dcf63aeff695febc6cbfcc5",
     "msrv": "273de02a6a1e67e17913b50023326214261b8f4d6399f8f8867188e7e3d2acb9",
     "evpn_bum_filter_kernel": "d427ed2c650d619d926cad0a4cbb6b558dd013ace9b18ba48757be529420863a",
 }
-COMMAND_BODY_HASH = "5ce94e3ab2d57649218de2495ed08bdf73878249c0b21f032f9a2c847f38a14f"
+COMMAND_BODY_HASH = "bfd8b9d4e3553cb9a5b46d633bfcb4544a6076c2c0ec9874523af7bfb16224e2"
 STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
 CHECKOUT = "uses: actions/checkout@v7"
 TOOLCHAIN = (


### PR DESCRIPTION
Main's `core` job is red at "Prove CI scale split contract": #1690 and #1691 added the rs/rr flagship soak analyzer unittest invocations and shellcheck lines to the extracted scale/receipt step, intentionally changing the `scale_receipts` job body that `scripts/check_ci_scale_split_contract.py` pins.

This catches the pin up to the intended state at 60d173bc by updating the two affected hashes (`scale_receipts` job body, extracted command body). The drift between the last pin (026af293) and 60d173bc is exactly the four lines below and nothing else; #1692 did not touch `ci.yml`.

From #1690:
```
python3 -m unittest -v tests/soak/test_analyze_soak_rs_flagship.py
shellcheck -x tests/soak/run-soak-rs-flagship.sh
```

From #1691:
```
python3 -m unittest -v tests/soak/test_analyze_soak_rr_flagship.py
shellcheck -x tests/soak/run-soak-rr-flagship.sh
```

No workflow or contract-logic changes; the contract still proves the same seams.

Gates:
- `python3 scripts/check_ci_scale_split_contract.py` — OK, rc=0
- `python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py` — 7/7
- `cargo fmt --all -- --check` — clean