### PR TITLE
docs: attribute the July 2026 memory step to a single commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ architecture decision record for every protocol and design choice.
 | Workspace tests | Unit, integration, and property tests (`cargo test --workspace`) |
 | Wire fuzzing | libFuzzer harnesses on message and attribute decoders, run nightly in CI |
 | Interop suites | Automated interop suite (see [docs/INTEROP.md](docs/INTEROP.md) for the full matrix), primarily against FRR 10.3.1 plus GoBGP 3.37.0–4.6.0 across labs and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.3.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
-| Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md). |
+| Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md) — including the 1,000-session flagship 24 h runs for the [route server](docs/soaks/soak-rs-flagship-24h.md) and the [route reflector](docs/soaks/soak-rr-flagship-24h.md). |
 | Protocol coverage | [Supported standards at a glance](docs/RFC_NOTES.md#supported-standards-at-a-glance) plus per-RFC conformance notes in [docs/RFC_NOTES.md](docs/RFC_NOTES.md); interop matrix in [docs/INTEROP.md](docs/INTEROP.md) and receipts in [docs/RECEIPTS.md](docs/RECEIPTS.md). |
 | Architecture decisions | ADRs documenting every protocol and design choice ([docs/adr/](docs/adr/)) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1463,6 +1463,20 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
     isolated attribution and repeat the full typical/rich/unique insert,
     bulk-load, and churn measurement matrix. Only a measurement GO may proceed
     to a prototype's collision and memory gates.
+  - Neighbor RIB snapshot coalescing — thin the memory-for-speed trade
+    (LAN-1050). The single-commit attribution campaign at 100 peers × 1,000
+    routes traced the whole settled-memory step introduced by the July 2026
+    performance batch (all of it shipped in v0.61.0) to one change: #1189's
+    coalesced neighbor RIB snapshots, taken deliberately to buy convergence at
+    the route-server shape. The same campaign shows roughly half that batch's
+    convergence gain — #1183, #1176, #1177 — cost no memory at all, and that
+    v0.63.0, ADR-0126, and v0.64.0 are flat there.
+    ADR-0126's shared-group machinery postdates #1189 and can hold the
+    coalesced snapshot state once per update group rather than once per
+    neighbor. Hard-gated: no more than a 2% convergence regression at the
+    shape #1189 bought its speed-up at, or the trade stays as it is. The
+    narrative lives in `docs/BENCHMARKS.md`; the campaign receipt is not yet
+    published under `docs/perf/`, so no per-commit magnitudes are public.
   - General FIB runtime: investigate prefix-dirty reconcile so a single prefix
     change does not necessarily trigger full RIB query + full kernel dump +
     full projection. Design-gated because drift recovery, ECMP siblings,

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1157,6 +1157,83 @@ HashMap overhead is structural (power-of-2 rounding), not rehash churn.
 Remaining memory is HashMap bucket arrays (~78%) and actual Route data (~19%).
 No obvious accidental overhead remains.
 
+### Where the July 2026 memory step went — single-commit attribution
+
+The history table above stops at v0.32.0. The step it does not show is the one
+the July 2026 performance batch introduced at route-server scale, and that
+bill is not spread across the batch: a single-commit attribution campaign at
+100 peers × 1,000 routes traced the whole settled-memory step to **one change
+— #1189, `perf(api): coalesce neighbor RIB snapshots`** (merged 2026-07-26,
+shipped in v0.61.0). It was taken deliberately as a memory-for-speed trade,
+and the campaign confirms it behaved exactly as designed: it is the single
+place where both the memory and the convergence moved.
+
+The rest of that batch's convergence gain cost nothing. #1183 (lazy inbound
+receive buffer), #1176 (`perf(rib): remove peer-multiplied fanout
+bookkeeping`), and #1177 (`perf(wire): eliminate temporary codec allocation
+churn`) — all merged the same day, all in v0.61.0 — each moved convergence
+down with memory going down alongside it, and #1188 (`perf(policy): share
+attribution names across evaluations`) reduced memory on its own. Roughly half
+the batch's speed-up was free; only #1189 was paid for.
+
+The later arcs the campaign covered all measured flat at this shape — the
+authz work, v0.63.0, ADR-0126's grouped per-client-best, and v0.64.0. The
+#1678–#1689 hardening tranche is a separate case worth stating plainly: its
+structural reclaims
+(private unicast storage released after regrouping, unused group route-slab
+tails trimmed, read-buffer storage released on disconnect, rejected-route
+retention grown incrementally) are **lifecycle-conditional**. They pay back on
+isolate/rejoin, oversized messages, and flood-then-adopt — not on a daemon
+sitting at steady state, which is why a settled-memory number does not move
+when they land.
+
+**Method, and why the per-commit deltas are not quoted here.** The campaign
+ran interleaved round-robin A/B arms with medians over five runs per arm,
+reproducible builds byte-identical across campaigns, cgroup `memory.peak` as
+the primary surface (not process-tree RSS, and not the raw container
+`memory_stats.usage` counter the bgperf2 rows above report), and bands
+preregistered before the runs. Settled memory at 100 peers × 1,000 routes
+carries a **±30–50 MiB allocator-arena residency noise floor** — the same
+figure the soak gates are calibrated against, see
+[`soaks/soak-acceptance-gates.md`](soaks/soak-acceptance-gates.md) — so any
+figure at this shape is a band, never a point. This page quotes only numbers
+with a checked-in artifact behind them, and the campaign's receipt is not yet
+published under [`perf/`](perf/); the attribution above is therefore stated as
+which commit and which direction, without magnitudes, until that receipt
+lands.
+
+**Open follow-up: thin the #1189 trade.** ADR-0126's shared-group machinery
+did not exist when #1189 landed — it can hold coalesced snapshot state once
+per update group instead of once per neighbor, which is the shape of the
+retention #1189 introduced. Reworking it that way is planned, and hard-gated:
+no more than a 2% convergence regression at the shape #1189 bought its
+speed-up at. The trade is only worth undoing if the speed survives.
+
+### Steady-state memory at flagship scale — 24 h soak observations
+
+The two archived v1-gating flagship soaks are the current published
+steady-state observations at 1,000 sessions. They are **stability evidence,
+not comparisons**: no control daemon ran alongside either run, so neither
+licenses a performance claim, and their surface is daemon process-tree RSS —
+a third surface again, distinct from both cgroup `memory.peak` and the raw
+container counter used by bgperf2.
+
+| Shape | Steady band | Peak | Late-window slope |
+|---|---|---|---|
+| Route server — 1000 eBGP RS-client sessions × 400 routes (400,000), 24 h under churn with 48 SIGHUP reloads and 6 max-prefix trip/restart cycles | **432–449 MB** between injections | 581.7 MB (reload re-advertisement and trip re-announce bursts, settling back into the band each time) | 0.0724 MB/h |
+| Route reflector — 1000 iBGP RR-client sessions × 100 routes (100,000), 24 h under 5,486,092 churn cycles | **~220–235 MB** for the whole hold | 342.5 MB, in the terminal 1,000-way full-table refresh | 0.2958 MB/h |
+
+Receipts, gates, and artifacts:
+[`soaks/soak-rs-flagship-24h.md`](soaks/soak-rs-flagship-24h.md) and
+[`soaks/soak-rr-flagship-24h.md`](soaks/soak-rr-flagship-24h.md); both are
+indexed with the rest of the operational evidence in
+[`OPERATIONAL_PROOF.md`](OPERATIONAL_PROOF.md) and
+[`RECEIPTS.md`](RECEIPTS.md). The intern gauge
+(`bgp_rib_attr_intern_global_size`) was pinned across both runs, and the RR
+run closed on an exact terminal reflected-delivery receipt — 99,900 non-self
+prefixes to every observer, zero parse errors, zero session flaps — so those
+flat bands were held while the daemon was demonstrably still doing the work.
+
 ### Shared `RouteData` — measured and rejected
 
 Splitting `Route` into a shared immutable `RouteData` (referenced from each RIB)


### PR DESCRIPTION
## What this changes

`docs/BENCHMARKS.md` gains two sections in the memory/convergence history
area, plus a cross-reference from `README.md` and a planned item in
`ROADMAP.md`.

### 1. Single-commit attribution for the July 2026 memory step

The end-to-end optimization-history table stops at v0.32.0, so the
route-server-scale memory step that arrived with the July 2026 performance
batch has never been explained on this page. A single-commit attribution
campaign at 100 peers × 1,000 routes traces the whole settled-memory step to
one change — #1189, `perf(api): coalesce neighbor RIB snapshots` — taken
deliberately as a memory-for-speed trade. The rest of that batch's convergence
gain cost nothing: #1183, #1176 and #1177 moved convergence down with memory
going down alongside, and #1188 reduced memory on its own. Roughly half the
batch's speed-up was free; only #1189 was paid for. The later arcs the
campaign covered measured flat at this shape, and the #1678–#1689 hardening
tranche's reclaims are lifecycle-conditional (isolate/rejoin, oversized
messages, flood-then-adopt) rather than steady-state.

**Per-commit magnitudes are deliberately not published.** The campaign's
receipt is not yet checked in under `docs/perf/`, and this page quotes only
figures with an in-repo artifact behind them, so the attribution is stated as
which commit and which direction only. The section says so in as many words.

Release framing is taken from git rather than from the working note that
prompted this write-up: `git merge-base --is-ancestor` puts all five cited
PRs (#1176, #1177, #1183, #1188, #1189) inside the `v0.61.0` tag, so the text
says "the July 2026 performance batch … shipped in v0.61.0" rather than
naming a later release.

### 2. Steady-state memory at flagship scale

The two archived v1-gating flagship 24 h soaks are surfaced as the current
published steady-state observations at 1,000 sessions, quoted as bands with
their peaks and late-window slopes, and explicitly labeled stability evidence
— no control daemon ran alongside either, so neither licenses a performance
claim. Every figure is quoted from the receipt it links to.

The section also keeps the three memory surfaces distinct, because they are
easy to conflate across this page: cgroup `memory.peak` (the attribution
campaign), daemon process-tree RSS (the soaks), and the raw container
`memory_stats.usage` counter (the historical bgperf2 rows). The ±30–50 MiB
allocator-arena residency noise floor at this shape is cited to
`docs/soaks/soak-acceptance-gates.md`, where the soak ceilings are calibrated
against it.

### 3. The planned follow-up

ADR-0126's shared-group machinery postdates #1189 and can hold the coalesced
snapshot state once per update group rather than once per neighbor. Thinning
that trade is recorded in the ROADMAP performance backlog, hard-gated on no
more than a 2% convergence regression at the shape #1189 bought its speed-up
at. `docs/BENCHMARKS.md` names the follow-up without a tracker reference.

## Numbers published, and their sources

| Figure | Source |
|---|---|
| RS: 432–449 MB steady band, 581.7 MB peak, 0.0724 MB/h late slope, 48 SIGHUP reloads, 6 trip/restart cycles | `docs/soaks/soak-rs-flagship-24h.md` |
| RR: ~220–235 MB hold band, 342.5 MB peak, 0.2958 MB/h late slope, 5,486,092 churn cycles, 99,900 non-self prefixes per observer, 0 parse errors, 0 flaps | `docs/soaks/soak-rr-flagship-24h.md` |
| ±30–50 MiB allocator-arena noise floor at 100p × 1k | `docs/soaks/soak-acceptance-gates.md` |
| PR identities, subjects, merge dates, and `v0.61.0` containment | git history |

No other numbers are added. No existing claim is restated, refreshed, or
reworded — the diff is purely additive apart from the one README table cell.

## Gates

- `python3 scripts/check_public_tracker_ids.py` — pass (601 documents)
- `python3 -m unittest scripts/test_check_public_tracker_ids.py` — 11 tests, OK
- `python3 scripts/check-v1-stable-surface.py` — pass
- `python3 scripts/check_ci_scale_split_contract.py` — pass
- `cargo fmt --all -- --check` — pass (no Rust changes)
- Relative-link resolution across the three changed files — 0 broken

No CHANGELOG entry: recent docs-only precedent is split, and the closest
analogue (#1644, a published-claim correction sweep) edited historical entries
rather than adding an Unreleased one.
