### PR TITLE
docs(roadmap): match the memory-attribution receipt's published claims

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1468,15 +1468,20 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
     routes traced the whole settled-memory step introduced by the July 2026
     performance batch (all of it shipped in v0.61.0) to one change: #1189's
     coalesced neighbor RIB snapshots, taken deliberately to buy convergence at
-    the route-server shape. The same campaign shows roughly half that batch's
-    convergence gain — #1183, #1176, #1177 — cost no memory at all, and that
-    v0.63.0, ADR-0126, and v0.64.0 are flat there.
+    the route-server shape. The same campaign puts roughly half that batch's
+    convergence gain in the 22-commit interval ending at #1183 (which also
+    carries #1176 and #1177), measured as convergence down with memory down
+    alongside it — an interval result, with no per-PR resolution. Everything
+    after v0.63.0 — ADR-0126 and v0.64.0 — measured flat there; the 34-commit
+    v0.63.0 run-up is a minor contributor at +24.4 MiB, above the flat band
+    and published without an ownership claim.
     ADR-0126's shared-group machinery postdates #1189 and can hold the
     coalesced snapshot state once per update group rather than once per
     neighbor. Hard-gated: no more than a 2% convergence regression at the
     shape #1189 bought its speed-up at, or the trade stays as it is. The
-    narrative lives in `docs/BENCHMARKS.md`; the campaign receipt is not yet
-    published under `docs/perf/`, so no per-commit magnitudes are public.
+    narrative lives in `docs/BENCHMARKS.md`; the per-commit magnitudes and
+    the preregistered bands are in the
+    [August 2026 receipt](docs/perf/memory-attribution-2026-08.md).
   - General FIB runtime: investigate prefix-dirty reconcile so a single prefix
     change does not necessarily trigger full RIB query + full kernel dump +
     full projection. Design-gated because drift recovery, ECMP siblings,

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1163,24 +1163,25 @@ The history table above stops at v0.32.0. The step it does not show is the one
 the July 2026 performance batch introduced at route-server scale, and that
 bill is not spread across the batch: a single-commit attribution campaign at
 100 peers × 1,000 routes traced the whole settled-memory step to **one change
-— #1189, `perf(api): coalesce neighbor RIB snapshots`** (merged 2026-07-26,
-shipped in v0.61.0). Measured as a single-commit step against its immediate
-parent, it is **+106.6 MiB cgroup `memory.peak` and +101.1 MiB settled
-anonymous RSS, for −1.02 s of convergence**. It was taken deliberately as a
-memory-for-speed trade, and the campaign confirms it behaved exactly as
-designed: it is the single place where both the memory and the convergence
-moved.
+— #1189, `perf(api): coalesce neighbor RIB snapshots`** (merged
+2026-07-27T01:53Z, ~14 h before the v0.61.0 tagged commit and shipped in
+it). Measured as a single-commit step against its immediate parent, it is
+**+106.6 MiB cgroup `memory.peak` and +101.1 MiB settled anonymous RSS, for
+−1.02 s of convergence**. It was taken deliberately as a memory-for-speed
+trade, and the campaign confirms it behaved exactly as designed: it is the
+single place where both the memory and the convergence moved.
 
 The rest of that batch's convergence gain cost nothing. The 22 commits ending
 at #1183 (`perf: grow extended-message receive buffers on demand`), which also
 carry #1176 (`perf(rib): remove peer-multiplied fanout bookkeeping`) and #1177
-(`perf(wire): eliminate temporary codec allocation churn`) — all merged the
-same day, all in v0.61.0 — moved convergence down **−1.03 s with memory going
-down alongside it** (−7.4 MiB peak, −23.7 MiB settled anon). That half is
-resolved to the interval, not to individual PRs. #1188 (`perf(policy): share
-attribution labels through group staging`) reduced memory on its own, by
-**−21.4 MiB peak / −23.8 MiB settled anon**, and the two steps reconcile
-exactly: −21.4 + 106.6 = +85.2 MiB, the measured endpoint delta across them.
+(`perf(wire): eliminate temporary codec allocation churn`) — all merged
+2026-07-26 UTC, all in v0.61.0 — moved convergence down **−1.03 s with
+memory going down alongside it** (−7.4 MiB peak, −23.7 MiB settled anon).
+That half is resolved to the interval, not to individual PRs. #1188
+(`perf(policy): share attribution labels through group staging`) reduced
+memory on its own, by **−21.4 MiB peak / −23.8 MiB settled anon**, and the
+two steps reconcile exactly: −21.4 + 106.6 = +85.2 MiB, the measured
+endpoint delta across them.
 Roughly half the batch's speed-up was free; only #1189 was paid for.
 
 The later arcs the campaign covered measured flat or negative at this shape —

--- a/docs/perf/memory-attribution-2026-08.md
+++ b/docs/perf/memory-attribution-2026-08.md
@@ -35,8 +35,9 @@ endpoint delta because the step before it is negative.
 
 **#1189 is the sole owner of the memory step, and it is also where the
 speed came from.** #1188 is a memory *reducer* that owns none of the
-growth. Both merged 2026-07-26 and shipped in **v0.61.0** (tag cut
-2026-07-27) — not v0.62.0.
+growth. Both merged **2026-07-27T01:53Z** and shipped in **v0.61.0**,
+whose tagged commit landed 2026-07-27T16:17Z — ~14 h later, the same UTC
+day — not v0.62.0.
 
 † The #1184 arm's convergence is bimodal here (12.91/12.97 fast mode vs
 13.95/13.97/14.01 slow mode, 3 of 5 slow), so its 13.95 s median sits in
@@ -233,7 +234,7 @@ lower**. See the limits section on what that does and does not attribute.
 
 | Role | Commit(s) | Magnitude | Evidence |
 |---|---|---|---|
-| **Sole owner** | **#1189 `perf(api): coalesce neighbor RIB snapshots`** (merge `21aeba73`, 2026-07-26, v0.61.0) | **+106.6 MiB cg peak, +101.1 MiB settled anon, for −1.02 s convergence** | phase 6, single-commit step, n = 5/arm |
+| **Sole owner** | **#1189 `perf(api): coalesce neighbor RIB snapshots`** (merge `21aeba73`, 2026-07-27T01:53Z, v0.61.0) | **+106.6 MiB cg peak, +101.1 MiB settled anon, for −1.02 s convergence** | phase 6, single-commit step, n = 5/arm |
 | **Reducer** | #1188 `perf(policy): share attribution labels through group staging` (merge `9c1ebb12`) | **−21.4 MiB cg peak, −23.8 MiB settled anon** | phase 6, 5-commit step of which only #1188 touches runtime code |
 | **Free speed** | the 22-commit interval ending at merge #1183, whose perf-labeled landings are #1183 `perf: grow extended-message receive buffers on demand`, #1176 `perf(rib): remove peer-multiplied fanout bookkeeping`, #1177 `perf(wire): eliminate temporary codec allocation churn` | **−1.03 s with peak −7.4 MiB (flat) and settled anon −23.7 MiB** | phase 4, interval-level — **not** split per commit |
 | **Exonerated (measured, flat or negative)** | #1184 alone (−9.5 MiB peak, +0.02 s); the authz arc (−15.5 MiB over its 54-commit interval); the 48-commit interval that lands listener hardening and ADR-0126 phases 1–3 (−18.0 MiB); v0.64.0 (+4.5 MiB over 11 commits); the 145 commits from v0.64.0 to the anchor (+10.4 MiB) | inside the ±15 MiB flat band, or a reduction beyond it | phases 2 and 5 |


### PR DESCRIPTION
ROADMAP's neighbor-RIB-snapshot-coalescing entry carried two claims the
published campaign receipt (`docs/perf/memory-attribution-2026-08.md`, #1697)
does not support, and the surrounding write-ups dated the batch's merges in
local time rather than UTC.

## ROADMAP: match the receipt's published claims

- **The free half of the convergence gain was an interval result, not three
  PRs.** The campaign measured a 22-commit interval ending at merge #1183 —
  which also carries #1176 and #1177 — as convergence down with memory down.
  No commit inside it was measured alone, so "#1183, #1176, #1177 cost no
  memory at all" claimed a per-PR resolution that does not exist.
- **The v0.63.0 run-up is not flat.** Its 34-commit interval measured
  +24.4 MiB, inside the band the preregistration reserved for "minor
  contributor, no ownership claim" — above the ±15 MiB flat band. What is flat
  is everything *after* v0.63.0: ADR-0126 (−18.0 MiB) and v0.64.0 (+4.5 MiB).

Also drops the stale closing line saying the receipt is unpublished and no
per-commit magnitudes are public — #1697 published both — and links the
receipt instead.

## Receipt + BENCHMARKS: date the merges in UTC

The batch straddles two UTC days. Merge timestamps, from the API:

| PR | Merged (UTC) |
|---|---|
| #1176 | 2026-07-26T16:16:02Z |
| #1177 | 2026-07-26T17:50:24Z |
| #1183 | 2026-07-26T21:21:14Z |
| #1184 | 2026-07-26T21:55:46Z |
| #1188 | 2026-07-27T01:53:19Z |
| #1189 | 2026-07-27T01:53:30Z |

Both the receipt and BENCHMARKS dated #1188/#1189 to 2026-07-26, which is true
only in the bench host's local time; the project dates in UTC. That also left
the v0.61.0 containment argument resting on a merge date that appeared to
predate the tag by a full day. Both now carry the merge timestamp alongside
the v0.61.0 tagged commit's (2026-07-27T16:17Z, ~14 h later the same UTC day),
so containment is self-evident rather than inferred from a coarse date.

Dates only — no magnitude, ownership or band claim is restated or reopened.

Release label (v0.61.0) and every cited PR title were verified against the
receipt and the API; both were already correct.

Gates: `check_public_tracker_ids.py`, `check-v1-stable-surface.py`,
`check_ci_scale_split_contract.py`, `cargo fmt --all -- --check` — all pass.
