### PR TITLE
Fix rejected-route lazy-bound sentinel dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Rejected-route retention now installs its configured LRU bound on the lazily
+  created empty store before retaining the first rejection. This removes
+  rustbgpd’s explicit dependency on `lru`’s unbounded-capacity sentinel while
+  preserving incremental index growth and eviction behavior. (LAN-1048)
+
 - A confirmed apply whose v3 pending-authority publication fails before the
   locator rename — no authority retained, candidate and runtime untouched —
   now returns `FAILED_PRECONDITION` instead of `INTERNAL`, matching the

--- a/crates/transport/src/session/rejected_routes.rs
+++ b/crates/transport/src/session/rejected_routes.rs
@@ -246,11 +246,17 @@ impl RejectedRouteStore {
         }
     }
 
-    /// The backing LRU, built without reserving the configured maximum.
-    /// [`Self::insert`] converts it to the configured bound exactly when it
-    /// first fills, before any later insertion can overflow that bound.
+    /// The backing LRU, built without reserving the configured maximum. Its
+    /// bound is installed while the lazily created cache is still empty, before
+    /// the first retained rejection is pushed.
     fn storage(&mut self) -> &mut LruCache<ImportDecisionKey, RejectedRouteEntry> {
-        self.entries.get_or_insert_with(LruCache::unbounded)
+        self.entries.get_or_insert_with(|| {
+            let mut entries = LruCache::unbounded();
+            let capacity =
+                NonZeroUsize::new(self.capacity).expect("capacity is clamped to at least 1");
+            entries.resize(capacity);
+            entries
+        })
     }
 
     /// Insert or refresh a rejection. On overflow the least-recently
@@ -261,13 +267,10 @@ impl RejectedRouteStore {
     /// can exceed the documented per-entry budget.
     pub fn insert(&mut self, key: ImportDecisionKey, mut entry: RejectedRouteEntry) {
         entry.enforce_bounds();
-        let capacity = NonZeroUsize::new(self.capacity).expect("capacity is clamped to at least 1");
+        let capacity = self.capacity;
         let entries = self.storage();
         entries.push(key, entry);
-        if entries.cap() == NonZeroUsize::MAX && entries.len() == capacity.get() {
-            entries.resize(capacity);
-        }
-        debug_assert!(entries.len() <= capacity.get());
+        debug_assert!(entries.len() <= capacity);
     }
 
     /// Remove the entry for an identity that was subsequently accepted
@@ -370,6 +373,7 @@ mod tests {
     fn insert_then_snapshot_returns_entry() {
         let mut store = RejectedRouteStore::with_capacity(4);
         store.insert(key(1), entry(ImportRejectReason::PolicyReject));
+        assert_eq!(store.entries.as_ref().unwrap().cap().get(), 4);
         let snap = store.snapshot();
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].0, key(1));


### PR DESCRIPTION
## Summary

- install the configured rejected-route LRU bound on the lazily created empty store before its first push
- remove rustbgpd logic that depends on the unbounded-capacity sentinel from `lru`
- preserve lazy allocation, incremental index growth, exact eviction behavior, and existing configuration semantics

## Verification

- `cargo test --locked -p rustbgpd-transport --lib rejected_routes`
- `cargo test --locked -p rustbgpd-transport --lib reject_retention`
- `cargo run --locked -p rustbgpd-transport --bin rejected-route-store-allocation`
- `cargo test --locked -p rustbgpd-transport --lib`
- `cargo clippy --locked -p rustbgpd-transport --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The repository commit and push hooks also passed formatting, Clippy, tests, and documentation checks.

## Allocation and behavior boundary

The existing manual allocation/oracle target still verifies at least 24,576 requested-live bytes saved for the first retained entry at the default capacity versus eager `LruCache::new`, saturated retained requested-live bytes no greater than the eager oracle for its tested capacities, zero allocation requests for the prepared first overflow, and exact exercised LRU behavior.

This is not an RSS, peak-memory, allocator-overhead, CPU, latency, universal-platform, future-`lru`, or general memory-reduction claim. The first retained rejection is not allocation-free, and the manual proof target is not automatically executed by `cargo test`.

LAN-1048