### PR TITLE
Skip canceled VPN and best-route materialization

### DIFF
--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2393,6 +2393,10 @@ impl RibManager {
                 queries::send_filtered_rows(self.loc_rib.iter_labeled(), filter.as_ref(), reply);
             }
             RibUpdate::QueryVpnRoutes { filter, reply } => {
+                if reply.is_closed() {
+                    debug!("VPN route listing canceled before materialization");
+                    return;
+                }
                 #[cfg(feature = "bench-internals")]
                 let started = std::time::Instant::now();
                 let routes = queries::filter_rows(self.loc_rib.iter_vpn(), filter.as_ref());

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -48,6 +48,19 @@ pub(super) fn filter_rows<'a, T: Clone + 'a>(
     }
 }
 
+fn send_materialized_rows<T>(
+    reply: tokio::sync::oneshot::Sender<Vec<T>>,
+    materialize: impl FnOnce() -> Vec<T>,
+) {
+    if reply.is_closed() {
+        debug!("route query canceled before materialization");
+        return;
+    }
+    if reply.send(materialize()).is_err() {
+        warn!("query caller dropped before receiving response");
+    }
+}
+
 /// [`filter_rows`] plus the reply, sharing `send_mrt_snapshot`'s cancellation
 /// rule: an abandoned caller (dropped receiver — e.g. a canceled gRPC request
 /// whose query was already queued behind other work) skips the copy entirely.
@@ -643,10 +656,7 @@ impl RibManager {
         &mut self,
         reply: tokio::sync::oneshot::Sender<Vec<crate::route::Route>>,
     ) {
-        let routes: Vec<_> = self.loc_rib.iter().cloned().collect();
-        if reply.send(routes).is_err() {
-            warn!("query caller dropped before receiving response");
-        }
+        send_materialized_rows(reply, || self.loc_rib.iter().cloned().collect());
     }
     /// Build the per-prefix FIB install-candidate view: each Loc-RIB best plus
     /// the equal-cost (ECMP) next-hop set, bounded by `max_paths`. Loc-RIB holds
@@ -2128,6 +2138,13 @@ impl RibManager {
 #[cfg(test)]
 mod cancellation_tests {
     use super::*;
+
+    #[test]
+    fn canceled_materialized_rows_does_not_invoke_builder() {
+        let (reply, receiver) = tokio::sync::oneshot::channel::<Vec<crate::route::Route>>();
+        drop(receiver);
+        send_materialized_rows(reply, || panic!("canceled query materialized"));
+    }
 
     #[test]
     fn canceled_neighbor_rib_snapshot_does_not_invoke_builder() {

--- a/crates/rib/src/manager/tests/non_unicast_pushdown.rs
+++ b/crates/rib/src/manager/tests/non_unicast_pushdown.rs
@@ -173,3 +173,17 @@ fn canceled_listing_skips_the_scan() {
         "a dropped receiver must skip the scan entirely"
     );
 }
+
+#[test]
+fn canceled_vpn_listing_skips_materialization() {
+    let (mut manager, _kept, _dropped) = manager_with_two_peers_per_family();
+    let (reply, receiver) = oneshot::channel();
+    drop(receiver);
+
+    manager.handle_update(RibUpdate::QueryVpnRoutes {
+        filter: Some(Box::new(|_: &VpnRibRoute| {
+            panic!("canceled VPN query invoked its filter")
+        })),
+        reply,
+    });
+}


### PR DESCRIPTION
## Summary

- skip VPN route listing before timing, filtering, table walking, cloning, or benchmark receipt work when its reply receiver is already closed
- skip live best-route materialization through a shared pre-builder cancellation helper
- add poison tests that fail if either canceled path invokes its materializer or VPN filter

## Verification

- both focused cancellation poison tests
- `cargo test --locked -p rustbgpd-rib --lib non_unicast_pushdown` — 4/4 passed
- `cargo test --locked -p rustbgpd-rib --lib cancellation_tests` — 5/5 passed
- `cargo test --locked -p rustbgpd-rib --lib` — 1,160 passed, 2 ignored
- `cargo clippy --locked -p rustbgpd-rib --all-targets --features bench-internals -- -D warnings`
- `bash bench/tests/test-vpn-query-receipt.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

Repository commit and push hooks also passed formatting, Clippy, tests, and documentation checks.

## Scope boundary

Successful VPN and best-route query rows, filtering, ordering, timing, capacity receipts, dispatch numbering, checksums, and logging are unchanged. The VPN receipt nesting contract remains green.

This only skips work when the receiver is already closed at dispatch. It does not provide mid-materialization cancellation, paging, bounded live-query size, quantified latency or memory savings, EVPN mirroring improvements, dead-query removal, or complete cancellation coverage across every RIB query. EVPN and dead-variant follow-ups remain separate.

LAN-1055