### PR TITLE
Release private VPN storage on update-group transfer

### DIFF
--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -217,12 +217,24 @@ impl AdjRibOut {
     }
 
     /// Remove only the VPN routes and their secondary key index, leaving
-    /// every other family untouched. The VPN sibling of
-    /// [`Self::clear_unicast`]: used when a peer's VPN advertised state
-    /// moves onto the update-group path.
+    /// every other family untouched. This keeps the backing allocations for
+    /// callers that expect the VPN table to refill. Use [`Self::release_vpn`]
+    /// when ownership moves to an update group.
     pub fn clear_vpn(&mut self) {
         self.vpn_routes.clear();
         self.vpn_key_path_ids.clear();
+    }
+
+    /// Remove only the VPN routes and their secondary key index, releasing
+    /// their backing allocations while leaving every other family untouched.
+    pub fn release_vpn(&mut self) {
+        self.vpn_routes = HashMap::default();
+        self.vpn_key_path_ids = HashMap::default();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn bench_vpn_capacities(&self) -> (usize, usize) {
+        (self.vpn_routes.capacity(), self.vpn_key_path_ids.capacity())
     }
 
     /// Remove every advertised route — unicast, `FlowSpec`, EVPN, BGP-LS,
@@ -875,6 +887,43 @@ mod tests {
         assert!(rib.is_empty());
         assert_eq!(rib.bench_route_capacity(), 0);
         assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.bgpls_len(), 1);
+    }
+
+    #[test]
+    fn clear_vpn_keeps_capacity_and_other_families() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        for octet in 1..=64 {
+            rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, octet, 0], 24, 100), 1));
+        }
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(17), 1));
+        let capacities = rib.bench_vpn_capacities();
+
+        rib.clear_vpn();
+
+        assert_eq!(rib.vpn_len(), 0);
+        assert_eq!(rib.bench_vpn_capacities(), capacities);
+        assert!(rib.get(&prefix_a(), 0).is_some());
+        assert_eq!(rib.bgpls_len(), 1);
+    }
+
+    #[test]
+    fn release_vpn_drops_capacity_and_keeps_other_families() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        for octet in 1..=64 {
+            rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, octet, 0], 24, 100), 1));
+        }
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(18), 1));
+        let capacities = rib.bench_vpn_capacities();
+        assert!(capacities.0 > 0 && capacities.1 > 0);
+
+        rib.release_vpn();
+
+        assert_eq!(rib.vpn_len(), 0);
+        assert_eq!(rib.bench_vpn_capacities(), (0, 0));
+        assert!(rib.get(&prefix_a(), 0).is_some());
         assert_eq!(rib.bgpls_len(), 1);
     }
 

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -941,6 +941,96 @@ fn grouped_peer_slow_round_trip_releases_private_unicast_without_wire_delta() {
     }
 }
 
+#[test]
+fn grouped_peer_slow_round_trip_releases_private_vpn_without_wire_delta() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 63, 1, 5));
+    let mut outbound = register_direct_peer_with_families(&mut manager, peer, vpn_sendable());
+    assert_eq!(outbound.try_recv().unwrap().end_of_rib, vpn_sendable());
+    let mut route = make_vpn_rib_route(Ipv4Addr::new(192, 0, 2, 7), 31, 100, 100);
+    route.origin_type = crate::route::RouteOrigin::Ebgp;
+    let route_key = route.key();
+    manager.handle_update(RibUpdate::VpnRoutesReceived {
+        peer: route.peer,
+        session_id: 0,
+        announced: vec![route.clone()],
+        withdrawn: vec![],
+    });
+    while manager.process_next_route_chunk() {}
+    let announced = outbound.try_recv().unwrap();
+    assert_eq!(announced.vpn_announce.len(), 1);
+    assert_eq!(announced.vpn_announce[0].key(), route_key);
+    assert!(crate::manager::helpers::vpn_routes_equal(
+        &announced.vpn_announce[0],
+        &route
+    ));
+    let initial_gid = manager.grouped_member_of(peer).expect("initial group");
+    let initial_group = manager.group_ribs[&initial_gid]
+        .table
+        .get_vpn(&route_key)
+        .expect("initial grouped VPN route");
+    assert!(crate::manager::helpers::vpn_routes_equal(
+        initial_group,
+        &route
+    ));
+
+    manager.handle_update(RibUpdate::PeerSlowState {
+        peer,
+        session_id: 0,
+        slow: true,
+    });
+    while manager.process_next_route_chunk() {}
+
+    assert!(manager.grouped_member_of(peer).is_none());
+    let private = manager
+        .adj_ribs_out
+        .get(&peer)
+        .expect("private fallback state");
+    let retained = private.get_vpn(&route_key).expect("private VPN route");
+    assert!(crate::manager::helpers::vpn_routes_equal(retained, &route));
+    assert_eq!(retained.nlri, route.nlri);
+    assert_eq!(retained.next_hop, route.next_hop);
+    assert_eq!(retained.peer, route.peer);
+    assert_eq!(retained.attributes, route.attributes);
+    assert_eq!(retained.received_at, route.received_at);
+    assert_eq!(private.vpn_path_ids_for_key(&route_key.nlri_key), [0]);
+    let capacities = private.bench_vpn_capacities();
+    assert!(capacities.0 > 0 && capacities.1 > 0);
+    assert!(matches!(
+        outbound.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    manager.handle_update(RibUpdate::PeerSlowState {
+        peer,
+        session_id: 0,
+        slow: false,
+    });
+    while manager.process_next_route_chunk() {}
+
+    assert!(manager.grouped_member_of(peer).is_some());
+    let final_gid = manager.grouped_member_of(peer).expect("rebuilt group");
+    let final_group = manager.group_ribs[&final_gid]
+        .table
+        .get_vpn(&route_key)
+        .expect("rebuilt grouped VPN route");
+    assert!(crate::manager::helpers::vpn_routes_equal(
+        final_group,
+        &route
+    ));
+    let private = manager
+        .adj_ribs_out
+        .get(&peer)
+        .expect("private grouped state");
+    assert_eq!(private.vpn_len(), 0);
+    assert_eq!(private.bench_vpn_capacities(), (0, 0));
+    assert!(matches!(
+        outbound.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+}
+
 fn drive_exact_precommit_step(
     manager: &mut RibManager,
     peers: [IpAddr; 2],

--- a/crates/rib/src/manager/update_groups/membership.rs
+++ b/crates/rib/src/manager/update_groups/membership.rs
@@ -123,7 +123,7 @@ impl RibManager {
                 if let Some(rib_out) = self.adj_ribs_out.get_mut(&peer) {
                     rib_out.release_unicast();
                     if vpn_groupable {
-                        rib_out.clear_vpn();
+                        rib_out.release_vpn();
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- release both private VPN HashMap allocations when a VPN-groupable peer transfers advertised-state ownership to an update group
- retain `clear_vpn` allocation-preserving behavior for callers that expect refill
- pin exact group-to-private-to-group VPN content, path-ID, capacity, and zero-wire-delta behavior

## Verification

- `clear_vpn_keeps_capacity_and_other_families`
- `release_vpn_drops_capacity_and_keeps_other_families`
- `grouped_peer_slow_round_trip_releases_private_vpn_without_wire_delta`
- `grouped_peer_slow_round_trip_releases_private_unicast_without_wire_delta`
- `oracle_vpn_streams_identical_across_group_lifecycle`
- `cargo test --locked -p rustbgpd-rib --lib` — 1,161 passed, 2 ignored
- strict bench-internals Clippy
- warning-denied rustdoc
- fmt and diff checks

Repository commit and push hooks also passed formatting, Clippy, tests, and documentation checks.

## Scope boundary

This resets only the two private VPN HashMap capacities after the existing regroup baseline capture at the existing ownership-transfer seam. Other families, group construction, route selection, RTC filtering, dirty and tombstone handling, exact advertised VPN content, and wire output are unchanged.

This is a structural capacity-release claim only. It does not claim RSS, peak memory, allocator return, byte savings, latency, convergence, hot-path improvement, universal VPN savings, or any reduction in group-owned state. No public API, configuration, protocol, or operator contract changes, so external documentation and changelog are unchanged.

LAN-1057
