### PR TITLE
Export process start time and alert on restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Linux metrics registries now register the standard process collector, with a
+  tested generic restart alert whose ten-minute sampled-change boundary and
+  attribution limits are documented. Readable, usable `/proc` process data is
+  required for the collector to expose a nonzero start time. (LAN-1056)
+
 - v1-gating flagship soak receipts (ADR-0125 evidence bar E2): the 24 h
   route-server flagship run (`soak-rs-flagship-20260816T062037Z` — 48/48
   barrier-verified SIGHUP reloads, 6/6 max-prefix trip/timed-restart

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1613,6 +1613,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2338,6 +2344,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.13.0",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.13.0",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,8 +2374,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf",
  "thiserror 2.0.20",
 ]
@@ -3247,6 +3277,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3254,7 +3297,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3707,7 +3750,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3719,7 +3762,7 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "windows-sys 0.61.2",
 ]
@@ -4837,7 +4880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,9 +1212,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 prost = "0.14"
 prost-types = "0.14"
-prometheus = "0.14"
+prometheus = { version = "0.14", features = ["process"] }
 socket2 = { version = "0.6", features = ["all"] }
 # `uio` gates recvmsg / ControlMessageOwned / cmsg_space! used by the BFD actor
 # to read IP_RECVTTL / IPV6_RECVHOPLIMIT + IP_PKTINFO / IPV6_PKTINFO ancillary

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -486,6 +486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,7 +542,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -573,6 +579,12 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -677,7 +689,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -697,7 +709,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -820,6 +832,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.13.1",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.13.1",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,8 +862,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf",
  "thiserror 2.0.20",
 ]
@@ -1110,6 +1146,19 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1117,8 +1166,8 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1231,7 +1280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1315,8 +1364,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1413,7 +1462,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1662,12 +1711,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -453,6 +453,13 @@ impl BgpMetrics {
         reason = "the constructor keeps the complete metric inventory and registration wiring together"
     )]
     pub fn with_registry(registry: Registry) -> Self {
+        #[cfg(target_os = "linux")]
+        registry
+            .register(Box::new(
+                prometheus::process_collector::ProcessCollector::for_self(),
+            ))
+            .expect("process collector registration");
+
         let state_transitions = IntCounterVec::new(
             Opts::new(
                 "bgp_session_state_transitions_total",
@@ -4822,6 +4829,22 @@ mod tests {
         let mut buf = Vec::new();
         encoder.encode(&families, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn process_collector_is_registered_on_private_registry() {
+        let metrics = BgpMetrics::new();
+        let samples = metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .filter(|family| family.name() == "process_start_time_seconds")
+            .flat_map(|family| family.get_metric().to_vec())
+            .collect::<Vec<_>>();
+
+        assert_eq!(samples.len(), 1);
+        assert!(samples[0].get_gauge().value() > 0.0);
     }
 
     fn event_outbox_queue_depths(m: &BgpMetrics) -> Vec<(String, f64)> {

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -24,6 +24,17 @@ log_format = "json"
 The same listener serves `/metrics`, `/livez`, and `/readyz`. Omit
 `prometheus_addr` to disable it.
 
+On Linux, each private registry also registers the standard process collector.
+Readable, usable `/proc` process data is required: inaccessible data can omit
+`process_start_time_seconds`, while unusable boot or stat data can leave its
+value zero, preventing the alert from establishing a restart. The shipped
+`RustbgpdRestarted` rule reports a sampled start-time change for the stable
+`job="rustbgpd"` target over ten minutes. It is a generic restart signal:
+planned, manual, and package-driven restarts fire too. Missing pre- or
+post-restart samples or changing target labels can miss a restart, and the
+signal expires after ten minutes. It cannot attribute exit 70, a crash, or any
+other reason; logs and the service manager remain authoritative.
+
 ## Prometheus scrape config
 
 ```yaml

--- a/docs/settlement-watchdog.md
+++ b/docs/settlement-watchdog.md
@@ -222,6 +222,18 @@ The diagnostic deliberately carries no config contents, paths, tokens,
 confirm IDs, or raw error text; `kind` + `phase` + `fence_reason` are
 the complete classification.
 
+The Prometheus `RustbgpdRestarted` alert can reveal a sampled change in
+`process_start_time_seconds` for the stable rustbgpd scrape target. It covers
+the restart after the five-second supervised-recovery gap, but it is not proof
+of a settlement fail-stop: planned, manual, package, and crash restarts fire as
+well. The registered collector requires readable, usable Linux `/proc` process
+data; inaccessible data can omit the family, while unusable boot or stat data
+can leave start time zero and prevent the alert from establishing a restart.
+Missing samples on either side of the restart or a target-label change can
+also miss it, and it expires after the ten-minute lookback. The metric cannot
+attribute exit 70 or any restart reason; the settlement log above and systemd
+remain authoritative.
+
 ### 2. Let the restart happen — it is safe by design
 
 The shipped unit restarts the daemon after `RestartSec=5`. Restart is

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -36,6 +36,19 @@ groups:
             {{ $labels.instance }} for 2 minutes. The daemon is down,
             unreachable, or `prometheus_addr` is no longer configured.
 
+      - alert: RustbgpdRestarted
+        expr: changes(process_start_time_seconds{job="rustbgpd"}[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "rustbgpd restarted ({{ $labels.instance }})"
+          description: >-
+            The sampled process start time for rustbgpd at
+            {{ $labels.instance }} changed in the last 10 minutes. This is a
+            generic restart signal; inspect logs and the service manager for
+            the reason.
+
       - alert: BgpRuntimeConfigSettlementSlow
         # Early advisory: ten minutes of owned settlement is far past any
         # measured normal apply but leaves twenty minutes of the fixed

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -41,6 +41,38 @@ tests:
                 edge1:9179 for 2 minutes. The daemon is down,
                 unreachable, or `prometheus_addr` is no longer configured.
 
+  # ── RustbgpdRestarted ────────────────────────────────────────
+  # Pins a stable target, a sampled start-time change, job scoping, and
+  # expiry after the ten-minute lookback.
+  - interval: 1m
+    input_series:
+      - series: 'process_start_time_seconds{job="rustbgpd", instance="edge1:9179"}'
+        values: "100x10 200x12"
+      - series: 'process_start_time_seconds{job="rustbgpd", instance="edge2:9179"}'
+        values: "300x22"
+      - series: 'process_start_time_seconds{job="other", instance="edge3:9179"}'
+        values: "400x10 500x12"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: RustbgpdRestarted
+        exp_alerts: []
+      - eval_time: 11m
+        alertname: RustbgpdRestarted
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: rustbgpd
+              instance: edge1:9179
+            exp_annotations:
+              summary: "rustbgpd restarted (edge1:9179)"
+              description: >-
+                The sampled process start time for rustbgpd at edge1:9179
+                changed in the last 10 minutes. This is a generic restart
+                signal; inspect logs and the service manager for the reason.
+      - eval_time: 22m
+        alertname: RustbgpdRestarted
+        exp_alerts: []
+
   # ── BgpRuntimeConfigSettlementSlow ────────────────────────────
   # Label names and values mirror the daemon's closed metric surface in
   # crates/api/src/runtime_config_settlement.rs: labels kind/phase/


### PR DESCRIPTION
## Summary

- register Prometheus's standard process collector on each private Linux metrics registry
- add a tested `RustbgpdRestarted` alert based on sampled start-time changes over ten minutes
- document `/proc` availability, detection, expiry, and attribution boundaries

## Claim boundary

This is a generic sampled-restart signal for a stable `job="rustbgpd"` target. Planned, manual, package-driven, and crash restarts can all fire it. Missing samples, target-label changes, or unavailable/unusable `/proc` data can prevent detection. It cannot attribute exit 70, a crash, or any restart reason; logs and the service manager remain authoritative.

## Verification

- exact Linux telemetry test, exactly one test
- Prometheus 0.14 feature-tree check
- repository-pinned promtool 3.4.1 rule check and rule tests
- formatting and diff checks
- retained exact-hash T019 workspace Clippy, tests, rustdoc, and Rust 1.95 receipts
- hosted CI on the exact PR head

Linear: LAN-1056
