### PR TITLE
docs: correct operator-facing accuracy defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Streamed config Plan/Apply now gives one bounded, nonpreemptive admission
+  waiter to operators and protects operator-issued plan tokens at capacity.
 - Rejected-route retention now installs its configured LRU bound on the lazily
   created empty store before retaining the first rejection. This removes
   rustbgpd’s explicit dependency on `lru`’s unbounded-capacity sentinel while

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -156,7 +156,7 @@ exact total; `--count` bounds response transfer, not server-side query work. It
 cannot be combined with the rejected-route or explain views.
 
 The full unary listings (`rib bgpls|vpn|labeled|rtc|blackholes|fib`,
-`flowspec`, `evpn list|diagnose`, `topology nodes|links`, `orr`) return the
+`flowspec`, `evpn|evpn diagnose`, `topology nodes|links`, `orr`) return the
 whole table in one response and decode up to a finite 64 MiB ceiling (roughly
 0.7-1.3 million rows). A response above the ceiling still fails closed,
 currently as `out of range`. The ceiling is client-side compatibility headroom

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2575,6 +2575,7 @@ same entry are ANDed.
 | `match_as_path`          | string   | no*      | AS_PATH regex (Cisco/Quagga style, `_` = boundary)    |
 | `match_neighbor_set`     | string   | no*      | Named neighbor set matched against the evaluation peer |
 | `match_route_type`       | string   | no*      | Route source type: `"local"`, `"internal"`, `"external"` |
+| `match_evpn_route_type`  | u8       | no*      | EVPN route type (RFC 7432 §7 / RFC 9136): 1 EAD, 2 MAC/IP, 3 IMET, 4 Ethernet Segment, 5 IP Prefix. Non-EVPN routes never match a set value |
 | `match_as_path_length_ge`| u32      | no*      | Minimum AS_PATH length to match (inclusive)           |
 | `match_as_path_length_le`| u32      | no*      | Maximum AS_PATH length to match (inclusive)           |
 | `match_local_pref_ge`    | u32      | no*      | Minimum `LOCAL_PREF` to match (inclusive)             |
@@ -2587,9 +2588,10 @@ same entry are ANDed.
 | `action`                 | string   | yes      | `"permit"` or `"deny"`                                |
 
 *At least one of `prefix`, `match_community`, `match_as_path`,
-`match_neighbor_set`, `match_route_type`, `match_as_path_length_ge`,
-`match_as_path_length_le`, `match_local_pref_ge`, `match_local_pref_le`,
-`match_med_ge`, `match_med_le`, `match_next_hop`, or
+`match_neighbor_set`, `match_route_type`, `match_evpn_route_type`,
+`match_as_path_length_ge`, `match_as_path_length_le`,
+`match_local_pref_ge`, `match_local_pref_le`, `match_med_ge`,
+`match_med_le`, `match_next_hop`, or
 `match_rpki_validation` / `match_aspa_validation` is required.
 
 ASPA verification is an IPv4/IPv6-unicast edge-ingress signal. eBGP routes
@@ -4143,14 +4145,12 @@ neighbor-reconcile step returns `None` on partial failure because
 live state is genuinely ambiguous after a delete-then-readd partial;
 earlier reload steps still land at the manager and remain in effect.
 
-Inline `policy.import` / `policy.export` (the legacy global-fallback
-statements), `[global]` ASN/router-id/families,
+`[global]` identity and daemon-wide flags (ASN, router-id, listen
+port, cluster-id, admission and multipath knobs),
 `[global.telemetry.grpc_*]` listener config, `[rpki]`, `[bmp]`,
 `[mrt]`, and `apply_bum_enforcement` are
 **restart-required** — they're surfaced under "Restart-required" in
-`rustbgpd --diff` and logged at reload time with a one-line migration
-hint to named definitions plus `import_chain` / `export_chain` where
-applicable. EVPN tables (`[[evpn_instances]]`, `[[ethernet_segments]]`,
+`rustbgpd --diff`. EVPN tables (`[[evpn_instances]]`, `[[ethernet_segments]]`,
 and `[[evpn_ip_vrfs]]`) are coordinator-gated instead: SIGHUP and the
 whole-model `EvpnService.ApplyEvpnRuntime` RPC validate a full candidate,
 converge the daemon actors in order, and advance the committed runtime
@@ -4209,7 +4209,7 @@ starting:
 | `gr_peer_restart_time_max` must be <= 4095 | `gr_peer_restart_time_max <value> exceeds 4095 (12-bit max)` |
 | `gr_stale_routes_time` must be > 0 and <= 3600 | `invalid gr_stale_routes_time` |
 | Policy prefix length must not exceed AFI max (32 for IPv4, 128 for IPv6) | `invalid prefix length` |
-| Policy entry must have at least one match condition (`prefix`, `match_community`, `match_as_path`, `match_as_path_length_ge`, `match_as_path_length_le`, `match_rpki_validation`, or `match_aspa_validation`) | `must have at least one match condition` |
+| Policy entry must have at least one match condition (see [Match conditions](#match-conditions)) | `must have at least one match condition` |
 | Import `match_rpki_validation`/`match_aspa_validation` evaluates against the current snapshot — routes arriving before the first VRP/ASPA table loads see `not_found`/`unknown`; later cache updates trigger inbound Route Refresh for established peers whose import policy depends on validation state | *(informational — no error)* |
 | `match_as_path_length_ge` must not exceed `match_as_path_length_le` | `match_as_path_length_ge (...) exceeds match_as_path_length_le (...)` |
 | `set_*` fields cannot be used with `action = "deny"` | `set_* fields cannot be used with action = "deny"` |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -60,12 +60,12 @@ For crate dependency graph, runtime model, ownership model, data flow, lifecycle
 **RIB snapshot model:** Snapshots are generation-based, not deep copies. The RIB stores immutable per-prefix route sets behind `Arc`. Paginated gRPC queries iterate a snapshot handle while the active RIB advances generations without blocking readers. This avoids O(n) cloning on every query.
 
 **Redesign triggers (instrumented from day one):**
-- `rib_update_latency_p99` — if p99 exceeds 10ms under sustained load, evaluate sharding or batch coalescing.
-- `rib_channel_backpressure_total` — any non-zero sustained rate means session tasks are stalling.
-- `adjribout_channel_drops_total` — non-zero means a peer is falling behind.
-- `rib_snapshot_generation_lag` — high lag means a slow consumer is pinning old state.
+- `bgp_rib_ingest_channel_depth` — queued `RibUpdate` messages sampled once per manager loop. Pegged at the channel capacity means producers are parked; evaluate sharding or batch coalescing. The `bgp_rib_outbound_prefix_limit_actor_duration_seconds` and `bgp_rib_route_refresh_actor_duration_seconds` histograms time the actor operations that hold the loop.
+- `bgp_inbound_rib_backpressure_total` — any non-zero sustained rate means session tasks are stalling on a full RIB channel (ADR-0078).
+- `bgp_outbound_route_drops_total` — non-zero means a peer's writer channel was full or closed and outbound work was dropped.
+- `bgp_event_stream_lagged_total` — non-zero means a live event-stream subscriber is too slow to keep up and is missing events.
 
-The threshold for triggering a redesign conversation is: sustained p99 RIB latency above 10ms, or any backpressure-induced session flap in the interop test suite.
+The threshold for triggering a redesign conversation is: sustained ingest-channel depth at capacity, or any backpressure-induced session flap in the interop test suite.
 
 ---
 
@@ -349,25 +349,27 @@ Implement OPEN, KEEPALIVE, NOTIFICATION. FSM transitions and timer handling. Ses
 
 UPDATE processing is where most BGP implementations accumulate subtle bugs. rustbgpd validates every attribute against RFC 4271 with explicit, auditable checks.
 
+Dispositions follow RFC 7606, not RFC 4271's blanket session reset: `wire::validate::ErrorDisposition` classifies each error as attribute-discard, treat-as-withdraw, or session-reset, and the session applies the strongest disposition in the message (§3 (h)). Treat-as-withdraw and attribute-discard keep the session Established. See [RFC_NOTES.md — RFC 7606](RFC_NOTES.md#rfc-7606--revised-bgp-update-error-handling) for the authoritative per-attribute table.
+
 | Validation | RFC Reference | Behavior on Failure |
 |---|---|---|
-| Mandatory attributes present (ORIGIN, AS_PATH, NEXT_HOP for eBGP) | RFC 4271 §5.1.2 | NOTIFICATION (3, 3) — Missing Well-known Attribute |
-| No duplicate attributes in a single UPDATE | RFC 4271 §5 | NOTIFICATION (3, 1) — Malformed Attribute List |
-| Attribute flags match type (well-known, transitive, etc.) | RFC 4271 §4.3 | NOTIFICATION (3, 4) — Attribute Flags Error |
-| Attribute ordering (well-known before optional) | RFC 4271 §4.3 | Accept out-of-order but log; strict mode configurable |
-| AS_PATH segment type valid (AS_SET, AS_SEQUENCE) | RFC 4271 §4.3 | NOTIFICATION (3, 11) — Malformed AS_PATH |
-| AS_PATH length consistent with segment encoding | RFC 4271 §4.3 | NOTIFICATION (3, 11) — Malformed AS_PATH |
+| Mandatory attributes present (ORIGIN, AS_PATH, NEXT_HOP for eBGP) | RFC 4271 §5.1.2, RFC 7606 §3 (d) | Treat-as-withdraw; subcode (3, 3) travels on the §5.2 escalation only |
+| No duplicate attributes in a single UPDATE | RFC 7606 §3 (g) | Attribute-discard, keeping the first occurrence — except a duplicate MP_REACH_NLRI / MP_UNREACH_NLRI, which is session-reset with NOTIFICATION (3, 1) |
+| Attribute flags match type (well-known, transitive, etc.) | RFC 4271 §4.3, RFC 7606 §3 (c) | Treat-as-withdraw; session-reset on MP_REACH_NLRI / MP_UNREACH_NLRI (§5.3) |
+| Attribute ordering (well-known before optional) | RFC 4271 §4.3 | Accepted out of order; ordering is not enforced |
+| AS_PATH segment type valid (AS_SET, AS_SEQUENCE) | RFC 4271 §4.3, RFC 7606 §7.2 | Treat-as-withdraw; subcode (3, 11) |
+| AS_PATH length consistent with segment encoding | RFC 4271 §4.3, RFC 7606 §7.2 | Treat-as-withdraw; subcode (3, 11) |
 | 4-byte ASN handling (AS_TRANS mapping) | RFC 6793 | Reconstruct valid AS4 compatibility attributes; discard or ignore inconsistent sidecars per RFC 6793 |
-| NEXT_HOP is valid IP, not 0.0.0.0, not multicast | RFC 4271 §5.1.3 | NOTIFICATION (3, 8) — Invalid NEXT_HOP Attribute |
-| ORIGIN value is valid (IGP, EGP, INCOMPLETE) | RFC 4271 §4.3 | NOTIFICATION (3, 6) — Invalid ORIGIN Attribute |
-| Attribute length does not exceed UPDATE length | RFC 4271 §4.3 | NOTIFICATION (3, 1) — Malformed Attribute List |
-| Total path attributes length consistent with UPDATE length | RFC 4271 §4.3 | NOTIFICATION (3, 1) — Malformed Attribute List |
-| Unrecognized well-known attribute | RFC 4271 §5 | NOTIFICATION (2, 7) — Unrecognized Well-known Attribute |
-| Unrecognized optional non-transitive attribute | RFC 4271 §5 | Silently ignore (do NOT drop silently — emit structured event) |
+| NEXT_HOP is valid IP, not 0.0.0.0, not multicast | RFC 4271 §5.1.3, RFC 7606 §7.3 | Treat-as-withdraw; subcode (3, 8) |
+| ORIGIN value is valid (IGP, EGP, INCOMPLETE) | RFC 4271 §4.3, RFC 7606 §7.1 | Treat-as-withdraw; subcode (3, 6) |
+| Attribute length does not exceed the attribute section | RFC 7606 §4 | Treat-as-withdraw; subcode (3, 1) |
+| Total path attributes length consistent with UPDATE length | RFC 7606 §3 (b) | Session-reset — NOTIFICATION (3, 1), the NLRI field boundaries cannot be trusted |
+| Unrecognized well-known attribute | RFC 4271 §5, RFC 7606 §3 (c) | Treat-as-withdraw; subcode (3, 2) |
+| Unrecognized optional non-transitive attribute | RFC 4271 §5 | Not a failure — accepted and ignored |
 | Unrecognized optional transitive attribute | RFC 4271 §5 | Pass through, set Partial bit (see policy below) |
-| Attribute exceeds configured max size | rustbgpd limit | NOTIFICATION (3, 1) + structured event |
+| Message exceeds the negotiated maximum length | RFC 4271 §4.1, RFC 8654 | NOTIFICATION (1, 2) — Bad Message Length + structured event |
 
-Every validation failure produces a structured log event with the peer address, attribute type code, raw bytes (truncated), and the RFC section violated. No silent drops.
+Every validation failure produces a structured log event with the peer address, attribute type code, raw bytes (truncated), and the RFC section violated, and increments `bgp_update_malformed_total{peer,disposition}`. No silent drops.
 
 #### Partial Bit Policy
 
@@ -473,7 +475,7 @@ Added 2026-04 per ADR-0050. Extends the RIB / transport / gRPC stack with a para
 
 **Best-path: type-specific head + shared BGP body.** `evpn_tiebreak_simple` runs a Type-2-specific MAC Mobility head (sticky flag + sequence per RFC 7432 §15.1), then falls through to the standard BGP chain (LocalPref → AS_PATH → MED → eBGP>iBGP → peer). Type 1/4 DF-election tiebreaks are not implemented — the RR reflects, downstream VTEPs elect. Types 3/5 have no type-specific head.
 
-**Policy uses placeholder prefix.** EVPN `RouteContext` carries a synthesized `0.0.0.0/0` prefix — the existing context fields (extended communities, communities, AS_PATH, peer metadata) are what operators actually filter on. RT-based filtering works through the existing `match_community` clause. A dedicated `match_evpn_route_type` clause is a Phase 1.5 item if operators need it.
+**Policy uses placeholder prefix.** EVPN `RouteContext` carries a synthesized `0.0.0.0/0` prefix — the existing context fields (extended communities, communities, AS_PATH, peer metadata) are what operators actually filter on. RT-based filtering works through the existing `match_community` clause. A dedicated `match_evpn_route_type` clause shipped in v0.11.0 and matches the RFC 7432 §7 / RFC 9136 route type directly.
 
 **Next-hop preserved across reflection.** Outbound EVPN MP_REACH_NLRI carries the originating VTEP's loopback IP as next-hop, not the RR's address. This is what lets downstream VTEPs build VXLAN tunnels correctly — the RR is a control-plane waypoint, not a data-plane middlebox.
 
@@ -651,7 +653,7 @@ key edits/reordering remain restart-required.
 ### Malformed Message Handling Philosophy
 
 - **Never panic on malformed input.** Any input from the network is untrusted. Panics on malformed BGP messages are security vulnerabilities.
-- **Always NOTIFICATION.** Every malformed message produces the correct NOTIFICATION error code per RFC 4271, followed by session teardown. No silent drops, no "log and ignore."
+- **Never silently ignore.** Malformed framing — header, message length, NLRI or Withdrawn Routes fields — produces the RFC 4271 NOTIFICATION and tears the session down. Malformed path attributes follow RFC 7606: attribute-discard or treat-as-withdraw keeps the session Established, and session-reset is retained only where the NLRI cannot be trusted. Every case emits a structured event and increments `bgp_update_malformed_total{peer,disposition}`.
 - **Always log.** Every malformed message produces a structured event with peer address, message type, error description, and truncated raw bytes for forensic analysis.
 - **Fuzz everything.** The wire decoder is the attack surface. It runs under continuous fuzzing in CI.
 

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -939,8 +939,10 @@ did not take on:
 - PBB-EVPN (RFC 7623)
 - Multicast EVPN / MVPN (including RFC 9251 IGMP/MLD proxy routes)
 - MPLS encapsulation
-- `match_evpn_route_type` / `match_vni` / `match_mac` policy clauses
-  (Phase 1.5 nicety, not blocking)
+- `match_evpn_route_type` policy clause (shipped in v0.11.0 — see
+  [CONFIGURATION.md — Match conditions](CONFIGURATION.md#match-conditions))
+- `match_vni` / `match_mac` policy clauses (Phase 1.5 nicety, not
+  blocking)
 - EVPN MRT dump
 - EVPN BMP export (wire records already pass through, but no typed
   extraction in BMP message generation)

--- a/examples/envoy-mtls/README.md
+++ b/examples/envoy-mtls/README.md
@@ -84,12 +84,14 @@ grpcurl \
   default UDS is owner-only, so the daemon authorizes its clients by filesystem
   ownership; the client certificate identity stops at Envoy and never reaches
   the authorization layer. mTLS is an admission gate here, not per-client RBAC
-  — a monitoring-only certificate gets full mutating control. For tier
-  separation, either cap the backend with an explicit
-  `[global.telemetry.grpc_uds] max_tier` and run a second socket for mutating
-  access, or use the native mTLS TCP listener, which derives a per-certificate
-  principal that `[security.grpc.roles]` maps to `observer` / `automation` /
-  `operator`.
+  — a monitoring-only certificate gets full mutating control. A daemon has at
+  most one UDS listener and one TCP listener, so tier separation needs two
+  different listeners: either cap the Envoy-facing UDS with an explicit
+  `[global.telemetry.grpc_uds] max_tier` and do mutating work over a separate
+  authenticated loopback TCP listener (`token_file` + `principal`, mapped in
+  `[security.grpc.roles]`), or use the native mTLS TCP listener, which derives
+  a per-certificate principal that `[security.grpc.roles]` maps to `observer` /
+  `automation` / `operator`.
 - Firewall the exposed Envoy listener to known management hosts even when mTLS
   is enabled.
 - Prefer a dedicated management VLAN/interface instead of `0.0.0.0` where


### PR DESCRIPTION
Documentation audit follow-up for the operator-facing accuracy cluster. Every
claim below was re-verified against HEAD before editing.

## `crates/cli/README.md`

The unary-listing sentence still named `evpn list`. `EvpnAction` has no `List`
variant — only the nested `Es { List }` — so the documented command fails clap
parsing. The bare `rbgp evpn` form carries the same `--route-type` /
`--neighbor` / `--rd` filters, and the command list further down the same file
already uses it.

## `match_evpn_route_type`: the tree contradicted itself

`docs/CONFIGURATION.md` omitted the field from the match-condition table — the
only discovery surface for policy-statement fields — while
`docs/evpn-enablement.md` listed it among clauses that never shipped. The field
is wired end to end (`src/config/schema.rs`, `src/config/parse.rs`,
`crates/policy/src/compile.rs`, `crates/policy/src/engine.rs`, its explain
rendering, and `docs/rustbgpd.schema.json`), so editor completion offered a
field the reference denied existed.

Resolved toward the code: add the table row and the at-least-one-condition
list entry, split the evpn-enablement bullet so only `match_vni` / `match_mac`
remain in the not-implemented list, and drop the matching "Phase 1.5 item"
framing from `docs/DESIGN.md`. `docs/adr/0050` keeps its original wording — an
ADR is a historical record.

The validation-rules row at the bottom of `CONFIGURATION.md` carried a third,
shorter copy of the same list (seven conditions against the parser's fifteen);
it now points at the table instead.

## SIGHUP reload classification

The reload section classified inline `policy.import` / `policy.export` as
restart-required and promised "a one-line migration hint" at reload time.
`PolicyConfig` has only `import_chain` / `export_chain` and is
`#[serde(deny_unknown_fields)]`, so a config setting those keys fails to load
and never reaches a reload class; no migration-hint string exists in
`src/reload.rs` or `src/config/mod.rs`. The "Inline policy (removed)" section
earlier in the same file already said so. The same sentence named a `[global]
families` key that does not exist — `families` is per-neighbor and
per-peer-group only.

## `docs/DESIGN.md`

**Redesign-trigger metrics.** All four prescribed metrics were unqueryable:
`rib_update_latency_p99` and `rib_snapshot_generation_lag` appear nowhere but
this document, and the other two were misnamed. The triggers now name
`bgp_rib_ingest_channel_depth` (plus the two `bgp_rib_*_actor_duration_seconds`
histograms), `bgp_inbound_rib_backpressure_total`,
`bgp_outbound_route_drops_total`, and `bgp_event_stream_lagged_total`.

**RFC 7606.** The attribute validation matrix gave RFC 4271 NOTIFICATION codes
for errors the wire crate handles as treat-as-withdraw or attribute-discard
with the session left Established, and the "Always NOTIFICATION" philosophy
bullet asserted teardown on every malformed message. Both restate the shipped
dispositions and point at `RFC_NOTES.md`, which already had the authoritative
table.

Two adjacent cells in the same column were also wrong and are corrected in
place: attribute ordering claimed a configurable strict mode that does not
exist, and a "configured max size" row described a knob with no
implementation — the real ceiling is the negotiated message length, which
produces NOTIFICATION (1, 2).

## `examples/envoy-mtls/README.md`

The tier-separation note told operators to "run a second socket for mutating
access". `TelemetryConfig` declares exactly one optional UDS listener and one
optional TCP listener under `deny_unknown_fields`, and declaring
`[global.telemetry.grpc_uds]` replaces the implicit owner-only default rather
than adding to it — so the instruction cost an operator their only local
socket. The remaining path is one capped UDS plus an authenticated loopback
TCP listener.

## `CHANGELOG.md`

Restore the `[Unreleased]` / Fixed bullet for the streamed-config operator
admission waiter. It was added with the feature and deleted by an unrelated
commit that inserted its own entry at the same position. The feature is live
(`crates/api/src/config_service/stream.rs`, `operator_waiter: Arc<AtomicBool>`,
with a bounded-priority test), and `docs/API.md` and `docs/SECURITY.md` both
document it.

## Refuted

The audit reported duplicate attributes as treat-as-withdraw. They are not:
`check_duplicate_types` returns `SessionReset`, but it is unreachable for
non-MP attributes because `decode_path_attributes_revised` already applied RFC
7606 §3 (g) — keep the first occurrence, discard the rest as attribute-discard
— before validation runs. Duplicate `MP_REACH_NLRI` / `MP_UNREACH_NLRI` is the
session-reset case. The table row documents that split rather than the
suggested blanket treat-as-withdraw.

## Gates

`check_public_tracker_ids.py`, `check-v1-stable-surface.py`, `cargo fmt --all
-- --check`, and relative-link plus anchor resolution across all six touched
files. Documentation only; no test asserts on the content of any file in this
diff.
