### PR TITLE
Record the project site in workspace metadata and the README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ version = "0.64.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
+homepage = "https://rbgp.rs"
 repository = "https://github.com/lance0/rustbgpd"
 keywords = ["bgp", "networking", "routing", "grpc"]
 categories = ["network-programming"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Rust](https://img.shields.io/badge/rust-1.95+-orange.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
 
+Project site: <https://rbgp.rs>
+
 An API-first BGP daemon in Rust for IXP route servers, route reflectors, and
 automation-heavy control planes. gRPC is the primary interface for all peer
 lifecycle, routing, and policy operations — the config file bootstraps initial

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true


### PR DESCRIPTION
The project now has a landing page at https://rbgp.rs, and nothing in the repo pointed at it.

- Root `Cargo.toml` gains `homepage = "https://rbgp.rs"` under `[workspace.package]`.
- `rustbgpd-wire` and `rustbgpd-fsm` — the only workspace members without `publish = false` — declare `homepage.workspace = true`. Cargo does not inherit workspace metadata implicitly, so without the per-crate opt-in the field would never reach crates.io on the next publish. Every other member is `publish = false`, where the field would be dead metadata.
- `README.md` gains one line under the badge row.

`repository` is unchanged and still points at GitHub; the two fields are distinct and both correct.

Gates: `cargo fmt --all -- --check`, `cargo build --workspace`, `scripts/check-v1-stable-surface.py`, `scripts/check_public_tracker_ids.py` all pass. Neither `Cargo.lock` nor `bench/scale/Cargo.lock` changed, and both still resolve under `--locked`.