### PR TITLE
Record the h2 RUSTSEC-2026-0258 fix in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- **`h2` 0.4.13 → 0.4.16 clears RUSTSEC-2026-0258** (unbounded empty DATA
+  frames). `h2` accepted and queued empty HTTP/2 DATA frames without limit,
+  so a stream that was not actively drained could grow memory without bound,
+  or panic once the length overflowed. The crate is transitive via
+  `hyper`/`tonic`, which makes the gRPC API listener the exposed surface.
+  Lockfile-only: no manifest constraint and no code change were needed.
+
 ### Added
 
 - Linux metrics registries now register the standard process collector, with a


### PR DESCRIPTION
RUSTSEC-2026-0258 (`h2` unbounded empty DATA frames, filed 2026-08-17) is
already cleared on `main`. `h2` moved 0.4.13 → 0.4.16 in #1705 as an
incidental lockfile refresh, and `cargo audit` at d7510d3a reports zero
vulnerabilities against a freshly fetched advisory database. The advisory is
present in that database and is not on the `.cargo/audit.toml` ignore list,
so the clean result is a real clearance rather than a suppression.

Nothing recorded the fix. #1705 is a metrics change and carries no changelog
note for the bump, so v0.65.0 would ship a security fix with no line in the
release notes. This adds a `### Security` entry under `[Unreleased]` naming
the advisory, the exposed surface (`h2` is transitive via `hyper`/`tonic`,
which puts the exposure on the gRPC API listener), and the version
transition.

## Scope

Documentation only — no dependency, manifest, or code change.

- `cargo update -p h2` is a no-op for `h2` at this base: it reports
  `Locking 0 packages`, and the resolved version is already 0.4.16 against
  the advisory's patched range of `>= 0.4.16`. There is exactly one `h2` in
  the tree.
- That invocation does drag an unrelated `windows-sys` 0.61.2 → 0.52.0
  downgrade across five Windows-only dependency edges, so no lockfile change
  is carried here.
- `bench/scale/Cargo.lock` does not depend on `h2` at all. It is the only
  other tracked lockfile since the seven per-harness lockfiles were
  consolidated in #1661; `tools/` and `tests/` have none of their own.
- No `[patch]` section and no `.cargo/audit.toml` entry were added.

## Gates

All run at this branch head; every exit code 0.

| Gate | Exit |
| --- | --- |
| `cargo audit` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `cargo build --workspace --release` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| standalone harness `cargo fmt` ×4 | 0 |
| standalone harness `cargo test --locked` ×4 | 0 |
| standalone harness `cargo clippy --locked` ×2 | 0 |

`cargo audit` reports zero vulnerabilities; `cargo test --workspace` ran 110
suites with no failures.
