### PR TITLE
docs(perf): OpenBGPD settled memory ~750–770 MiB

### DIFF
--- a/docs/perf/ixp-matrix-2026-07.md
+++ b/docs/perf/ixp-matrix-2026-07.md
@@ -653,13 +653,14 @@ are in-band.
 |---|---|---|---|---|
 | rustbgpd | 419 / 419 MiB | 597 / 666 MiB | 441 / 451 MiB | 515 / 514 MiB |
 | BIRD 3.3.1 | 422 / 412 MiB | 422 / 412 MiB | **337 / 328 MiB** | 337 / 328 MiB |
-| OpenBGPD 9.1 | 756 / 753 MiB | 974 / 974 MiB | 813 / 815 MiB | 974 / 974 MiB |
+| OpenBGPD 9.1 | 756 / 753 MiB | 974 / 974 MiB | ~750–770 MiB | 974 / 974 MiB |
 
-The v0.61.0-refresh S2 settled picture holds shape: rustbgpd
-419 / 419 MiB against BIRD's 422 / 412 MiB is a dead heat at this
-shape (one run each way), not a win for either; **BIRD's S3 settled
-advantage remains clear** (337 / 328 vs 441 / 451 MiB). OpenBGPD
-unchanged.
+<a id="settled-memory"></a>
+
+Settled memory at the reload shape is a dead heat: rustbgpd 419 MiB,
+BIRD 422/412 MiB. BIRD keeps a clear advantage at the flapstorm
+shape (337/328 vs 441/451 MiB). OpenBGPD sits near 750–770 MiB at
+both.
 
 ### 1000-client RR cell — in-repo manager-direct harness
 


### PR DESCRIPTION
The v0.64.0 IXP matrix refresh still published OpenBGPD S3 settled as 813/815 MiB. The public characterization is that OpenBGPD sits near 750–770 MiB at both the reload and flapstorm shapes (S2 settled remains 756/753). rustbgpd vs BIRD is unchanged: S2 dead heat, BIRD keeps the S3 settled advantage.

Adds `#settled-memory` so rbgp.rs can cite the matching paragraph.