### PR TITLE
Degrade an upstream bird3 outage to a loud, non-blocking m43 skip

### DIFF
--- a/.github/scripts/install-bird3.sh
+++ b/.github/scripts/install-bird3.sh
@@ -7,6 +7,13 @@ readonly BIRD3_SHA256="d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45
 readonly BIRD3_ASSET="bird-${BIRD3_VERSION}.tar.gz"
 readonly BIRD3_URL="https://bird.nic.cz/download/${BIRD3_ASSET}"
 readonly BIRD3_ATTEMPTS=3
+# prepare_archive separates a third-party outage from a supply-chain signal so
+# callers can act on the difference. 3 = the archive bytes never arrived (every
+# attempt failed to fetch); 4 = bytes arrived and failed the pinned checksum or
+# source-version check. Only 3 is tolerated downstream; see the bird3_archive
+# job in .github/workflows/kernel-dataplane.yml.
+readonly BIRD3_RC_UNAVAILABLE=3
+readonly BIRD3_RC_CORRUPT=4
 
 verify_archive() {
     local sha256=${1:?sha256}
@@ -61,6 +68,26 @@ stage_archive() (
     printf 'staged verified bird %s source archive\n' "$BIRD3_VERSION"
 )
 
+# The upstream archive is a third party. When it will not serve the pinned
+# tarball at all, say so where a human reading the run will see it: an
+# annotation in the run UI plus a line in the job summary naming the scenario
+# that loses coverage, the reason, and the URL that refused. This is the only
+# site that holds the URL, so the loud text cannot drift from the real target.
+announce_unavailable() {
+    local url=${1:?url}
+    local message
+
+    message="M43 (TCP-AO interop vs BIRD ${BIRD3_VERSION}) skipped: the pinned"
+    message+=" bird ${BIRD3_VERSION} source archive is unavailable upstream"
+    message+=" after ${BIRD3_ATTEMPTS} attempts (${url})."
+    message+=" This is third-party unavailability, not a rustbgpd failure;"
+    message+=" re-run once upstream recovers."
+    echo "::warning::${message}" >&2
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        printf '%s\n' "$message" >>"$GITHUB_STEP_SUMMARY"
+    fi
+}
+
 download_archive_once() {
     local url=${1:?url}
     local destination=${2:?destination}
@@ -77,6 +104,7 @@ prepare_archive() {
     local url=${2:?url}
     local archive=${3:?archive}
     local attempt staged_archive
+    local fetched=0
 
     if verify_archive_contents "$sha256" "$archive" 2>/dev/null; then
         echo "using verified cached bird3 archive"
@@ -90,11 +118,13 @@ prepare_archive() {
     mkdir -p "$(dirname "$archive")"
     for ((attempt = 1; attempt <= BIRD3_ATTEMPTS; attempt++)); do
         staged_archive=$(mktemp "${archive}.download.XXXXXX")
-        if download_archive_once "$url" "$staged_archive" \
-            && verify_archive_contents "$sha256" "$staged_archive"; then
-            mv -f -- "$staged_archive" "$archive"
-            echo "downloaded and verified bird3 archive"
-            return 0
+        if download_archive_once "$url" "$staged_archive"; then
+            fetched=1
+            if verify_archive_contents "$sha256" "$staged_archive"; then
+                mv -f -- "$staged_archive" "$archive"
+                echo "downloaded and verified bird3 archive"
+                return 0
+            fi
         fi
         rm -f -- "$staged_archive"
         if ((attempt < BIRD3_ATTEMPTS)); then
@@ -103,8 +133,15 @@ prepare_archive() {
         fi
     done
 
-    echo "::error::bird3 download/verification failed after ${BIRD3_ATTEMPTS} attempts: ${url}" >&2
-    return 1
+    if ((fetched)); then
+        # Bytes arrived and did not match the pinned checksum or the pinned
+        # source version. That is a supply-chain signal, not an outage, and it
+        # stays hard-red no matter how many times it repeats.
+        echo "::error::bird3 archive failed verification after ${BIRD3_ATTEMPTS} attempts: ${url}" >&2
+        return "$BIRD3_RC_CORRUPT"
+    fi
+    announce_unavailable "$url"
+    return "$BIRD3_RC_UNAVAILABLE"
 }
 
 fail_self_test() {
@@ -115,6 +152,7 @@ fail_self_test() {
 self_test() (
     local fixture_dir source_dir valid_archive valid_checksum wrong_dir wrong_archive
     local wrong_checksum partial_archive expected_url staged_hash attempts
+    local summary_file rc
 
     fixture_dir=$(mktemp -d)
     trap 'rm -rf -- "$fixture_dir"' EXIT
@@ -209,19 +247,59 @@ self_test() (
         | grep -Fxq "using verified cached bird3 archive" \
         || fail_self_test "warm cache attempted an upstream fetch"
 
+    # Upstream refused to serve the bytes at all (a 403/5xx makes curl -f
+    # exit non-zero). That is third-party unavailability: distinct exit code,
+    # loud annotation, and a job-summary line naming scenario/reason/URL.
+    attempts=0
+    download_archive_once() {
+        ((attempts += 1))
+        return 22
+    }
+    summary_file="$fixture_dir/step-summary.md"
+    : >"$summary_file"
+    rc=0
+    GITHUB_STEP_SUMMARY="$summary_file" \
+        prepare_archive "$valid_checksum" "https://example.invalid/unavailable" \
+        "$fixture_dir/cold-cache.tar.gz" >/dev/null 2>"$fixture_dir/unavailable.err" \
+        || rc=$?
+    [[ "$rc" -eq "$BIRD3_RC_UNAVAILABLE" ]] \
+        || fail_self_test "unreachable upstream did not report BIRD3_RC_UNAVAILABLE"
+    [[ "$attempts" -eq "$BIRD3_ATTEMPTS" ]] \
+        || fail_self_test "cold-cache retry bound was not enforced"
+    [[ ! -e "$fixture_dir/cold-cache.tar.gz" ]] \
+        || fail_self_test "failed cold-cache fetch left an artifact"
+    grep -Fq '::warning::M43' "$fixture_dir/unavailable.err" \
+        || fail_self_test "unavailable upstream did not emit a warning annotation"
+    grep -Fq 'https://example.invalid/unavailable' "$summary_file" \
+        || fail_self_test "job summary did not name the upstream URL"
+    grep -Fq 'M43' "$summary_file" \
+        || fail_self_test "job summary did not name the skipped scenario"
+
+    # Bytes arrived and failed verification. A checksum mismatch on a file that
+    # DID download is a supply-chain signal, not an outage: separate exit code,
+    # no skip annotation, no job-summary excuse.
     attempts=0
     download_archive_once() {
         ((attempts += 1))
         printf '<html>503</html>\n' >"$2"
     }
-    if prepare_archive "$valid_checksum" "https://example.invalid/unavailable" \
-        "$fixture_dir/cold-cache.tar.gz" >/dev/null 2>&1; then
-        fail_self_test "cold-cache upstream failure was accepted"
-    fi
+    : >"$summary_file"
+    rc=0
+    GITHUB_STEP_SUMMARY="$summary_file" \
+        prepare_archive "$valid_checksum" "https://example.invalid/corrupt" \
+        "$fixture_dir/corrupt-cache.tar.gz" >/dev/null 2>"$fixture_dir/corrupt.err" \
+        || rc=$?
+    [[ "$rc" -eq "$BIRD3_RC_CORRUPT" ]] \
+        || fail_self_test "unverifiable download did not report BIRD3_RC_CORRUPT"
     [[ "$attempts" -eq "$BIRD3_ATTEMPTS" ]] \
-        || fail_self_test "cold-cache retry bound was not enforced"
-    [[ ! -e "$fixture_dir/cold-cache.tar.gz" ]] \
-        || fail_self_test "failed cold-cache fetch left an artifact"
+        || fail_self_test "corrupt-download retry bound was not enforced"
+    [[ ! -e "$fixture_dir/corrupt-cache.tar.gz" ]] \
+        || fail_self_test "failed corrupt download left an artifact"
+    [[ ! -s "$summary_file" ]] \
+        || fail_self_test "corrupt download wrote a skip excuse to the job summary"
+    if grep -Fq '::warning::M43' "$fixture_dir/corrupt.err"; then
+        fail_self_test "corrupt download emitted a skip annotation"
+    fi
 
     # shellcheck disable=SC2317
     curl() { fail_self_test "offline stage invoked curl"; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,13 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py
           python3 scripts/check_ci_scale_split_contract.py
+      # The Kernel Dataplane gate tolerates exactly one skip (m43, when the
+      # third-party bird3 archive is unavailable upstream). Execute the real
+      # aggregate body and the installer's outage/corruption split here so the
+      # tolerance cannot silently widen into a gate that no longer fails.
+      - name: Prove kernel-dataplane bird3 outage tolerance
+        run: |
+          python3 -m unittest -v scripts/test_kernel_dataplane_bird3_tolerance.py
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -113,12 +113,26 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  # This archive feeds exactly one scenario, m43. Its host is a third party:
+  # when it refuses to serve the pinned tarball (nic.cz returned 403 on all
+  # three attempts with a cold cache on 2026-08-18) the run is carrying
+  # evidence about somebody else's web server, not about rustbgpd, and it
+  # hard-failed a release gate. So a *fetch* outage degrades to a loud,
+  # non-blocking skip of m43; nothing else does. In particular bytes that DID
+  # download and then failed the pinned checksum or source-version check are a
+  # supply-chain signal, not an outage, and stay hard-red. install-bird3.sh
+  # separates the two by exit code (3 = never fetched, 4 = fetched but
+  # unverifiable) and this job republishes the call as bird3_status for the
+  # m43 job gate and the check aggregate to read, so neither has to infer
+  # intent from a bare job conclusion.
   bird3_archive:
     needs: classify_changes
     if: needs.classify_changes.outputs.run_labs == 'true'
     name: Prepare exact bird3 archive
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      bird3_status: ${{ steps.prepare.outputs.bird3_status }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -129,11 +143,25 @@ jobs:
           path: ${{ runner.temp }}/bird3-cache/bird-3.3.1.tar.gz
           key: bird3-v3.3.1-source-d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190
       - name: Prepare exact bird3 archive
+        id: prepare
         run: |
+          set -uo pipefail
+          rc=0
           .github/scripts/install-bird3.sh \
             --prepare-archive \
-            "$RUNNER_TEMP/bird3-cache/bird-3.3.1.tar.gz"
+            "$RUNNER_TEMP/bird3-cache/bird-3.3.1.tar.gz" || rc=$?
+          case "$rc" in
+            0) status=ok ;;
+            3) status=unavailable ;;
+            4) status=corrupt ;;
+            *) status=error ;;
+          esac
+          echo "bird3_status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" != ok ] && [ "$status" != unavailable ]; then
+            exit "$rc"
+          fi
       - name: Upload verified bird3 archive
+        if: steps.prepare.outputs.bird3_status == 'ok'
         uses: actions/upload-artifact@v7
         with:
           name: bird3-v3.3.1-source
@@ -447,6 +475,11 @@ jobs:
 
   m43:
     needs: [grpcurl_archive, bird3_archive, prime_dev_image]
+    # No archive means no BIRD 3.3.1 image, so nothing here can run. Skipping
+    # the whole job rather than letting it report success with its lab steps
+    # quietly disabled is what lets the check aggregate print the skip and name
+    # its cause: a success with a hole in it is invisible coverage loss.
+    if: needs.bird3_archive.outputs.bird3_status != 'unavailable'
     name: M43 — TCP-AO live rotation and crash recovery (BIRD 3.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -900,11 +933,35 @@ jobs:
           run_labs = classifier.get("outputs", {}).get("run_labs")
           failed = classifier.get("result") != "success" or run_labs not in {"true", "false"}
           expected_result = "success" if run_labs == "true" else "skipped"
+          # The only tolerated deviation: m43 reporting skipped because the
+          # bird3 producer succeeded and told us the pinned archive was
+          # unavailable upstream. A producer that failed, a corrupt archive, or
+          # an m43 that actually ran and failed all stay red. The excuse prints
+          # next to the roster entry so a tolerated skip never reads like a
+          # normal not-applicable one.
+          bird3 = needs["bird3_archive"]
+          excused = (
+              "m43"
+              if run_labs == "true"
+              and bird3.get("result") == "success"
+              and bird3.get("outputs", {}).get("bird3_status") == "unavailable"
+              and needs["m43"].get("result") == "skipped"
+              else ""
+          )
           for job in expected:
               result = needs[job].get("result")
-              print(f"{job}={result}")
-              if job != "classify_changes" and result != expected_result:
+              note = " (bird3 archive unavailable upstream)" if job == excused else ""
+              print(f"{job}={result}{note}")
+              if job in ("classify_changes", excused):
+                  continue
+              if result != expected_result:
                   failed = True
+          if excused:
+              print(
+                  "::warning::m43=skipped (bird3 archive unavailable upstream): "
+                  "TCP-AO interop against BIRD 3.3.1 did not run in this Kernel "
+                  "Dataplane run; this gate passed without that coverage"
+              )
           if failed:
               sys.exit(1)
           PY

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -111,6 +111,20 @@ receipt and a separate destructive crash-restart recovery receipt. The
 workflow still probes the selected runner kernel first; a future runner without
 TCP-AO support reports a warning and skips only that topology.
 
+M43 is also the only scenario fed by a third-party source archive
+(`bird-3.3.1.tar.gz`, fetched once per run by the `bird3_archive` job). When
+that host refuses to serve the pinned tarball, the `check` aggregate tolerates
+`m43=skipped` and prints it as `m43=skipped (bird3 archive unavailable
+upstream)` alongside a `::warning::` and a job-summary line naming the URL, so
+the outage never hard-fails a release gate on evidence about somebody else's
+web server. The tolerance is that narrow by construction: it is keyed on the
+producer publishing `bird3_status=unavailable`, which only happens when no
+bytes ever arrived. An archive that downloads and then fails its pinned
+checksum or source-version check is a supply-chain signal, reports
+`bird3_status=corrupt`, and stays hard-red; so does an M43 that actually runs
+and fails. `scripts/test_kernel_dataplane_bird3_tolerance.py` executes the real
+aggregate body against stubbed job results to keep those paths honest.
+
 #### M-series proof quality contract
 
 A `Tested (Mxx)` receipt is only as strong as the evidence its driver asserts.

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -22,7 +22,7 @@ TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
     "v064_validator": "b3f0ae8906bd28397a5f82bab0db5467e09a8e312aa24a8c8f2db8fd01c6310a",
-    "core": "b2afd36bb65640496181d311b2d528cf9e7de052c6299f93b0cc58e45be16abe",
+    "core": "962f91a26c1091edbae07341ef3b457f4d42d7cbbcf9ea5874359626fd1509cf",
     "core_tests": "c5d8ed560cd4e572f535bb4eabe065372fddfc1dbefe0c341a9c5af76ed6df0f",
     "scale_receipts": "57a201b5691dd08fecb49860deb942a74a4dcf4d2b3a77a18716b3fc9d981b85",
     "check": "736f69ca686c06e889962d5fb93d80ee848090718dcf63aeff695febc6cbfcc5",

--- a/scripts/test_kernel_dataplane_bird3_tolerance.py
+++ b/scripts/test_kernel_dataplane_bird3_tolerance.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Prove the kernel-dataplane bird3-outage tolerance is exactly one skip wide.
+
+The `check` aggregate in `.github/workflows/kernel-dataplane.yml` tolerates
+`m43=skipped` when — and only when — the bird3 producer succeeded and published
+`bird3_status=unavailable`. A gate that can no longer fail is worse than the
+problem it fixed, so the aggregate's real shell body is extracted from the
+workflow and executed here against stubbed `needs` contexts: every genuine
+failure must still exit non-zero.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "kernel-dataplane.yml"
+INSTALLER = ROOT / ".github" / "scripts" / "install-bird3.sh"
+
+EXPECTED_JOBS = """
+classify_changes grpcurl_archive gobgp_archive bird3_archive prime_dev_image
+m36 m37 m37-ip m38 m39
+m39b m48 m60 m61 m62 m40 m42 m50 m52 m58 m53 m51 m43 m47
+m69 m70 m65 m71 m72 m66 m67 m68 netns
+""".split()
+
+EXCUSE = "m43=skipped (bird3 archive unavailable upstream)"
+
+
+def aggregate_source() -> str:
+    """Return the aggregate's real Python body, as the workflow runs it."""
+    text = WORKFLOW.read_text()
+    body = text.split("\njobs:\n", 1)[1]
+    match = re.search(r"(?ms)^  check:\n(.*?)(?=^  [\w-]+:\n|\Z)", body)
+    assert match is not None, "check job not found"
+    inline = re.search(
+        r"(?ms)^          python3 - <<'PY'\n(.*?)^          PY$", match.group(1)
+    )
+    assert inline is not None, "inline aggregate script not found"
+    return textwrap.dedent(inline.group(1))
+
+
+def needs_context(
+    *,
+    run_labs: str = "true",
+    bird3_status: str | None = "ok",
+    bird3_result: str | None = None,
+    m43_result: str | None = None,
+) -> dict[str, dict]:
+    default = "success" if run_labs == "true" else "skipped"
+    needs = {job: {"result": default} for job in EXPECTED_JOBS}
+    needs["classify_changes"] = {
+        "result": "success",
+        "outputs": {"run_labs": run_labs},
+    }
+    needs["bird3_archive"] = {"result": bird3_result or default}
+    if bird3_status is not None:
+        needs["bird3_archive"]["outputs"] = {"bird3_status": bird3_status}
+    needs["m43"] = {"result": m43_result or default}
+    return needs
+
+
+def run_aggregate(needs: dict[str, dict]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", aggregate_source()],
+        env={
+            "NEEDS_CONTEXT": json.dumps(needs),
+            "EXPECTED_JOBS": " ".join(EXPECTED_JOBS),
+            "PATH": "/usr/bin:/bin",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class Bird3ToleranceTests(unittest.TestCase):
+    def test_all_green_passes_with_a_bare_roster(self) -> None:
+        result = run_aggregate(needs_context())
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("m43=success\n", result.stdout)
+        self.assertNotIn("unavailable", result.stdout)
+
+    def test_upstream_unavailable_passes_loudly(self) -> None:
+        result = run_aggregate(
+            needs_context(bird3_status="unavailable", m43_result="skipped")
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(f"{EXCUSE}\n", result.stdout)
+        self.assertIn(f"::warning::{EXCUSE}", result.stdout)
+        # Every other scenario keeps its ordinary roster entry.
+        self.assertIn("m47=success\n", result.stdout)
+
+    def test_m43_running_and_failing_still_fails(self) -> None:
+        result = run_aggregate(
+            needs_context(bird3_status="unavailable", m43_result="failure")
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        self.assertIn("m43=failure\n", result.stdout)
+        self.assertNotIn(EXCUSE, result.stdout)
+
+    def test_corrupt_archive_stays_red(self) -> None:
+        # A checksum/version failure on bytes that DID download is a
+        # supply-chain signal: the producer exits non-zero, so m43 skips
+        # without an excuse and the aggregate must fail.
+        result = run_aggregate(
+            needs_context(
+                bird3_status="corrupt",
+                bird3_result="failure",
+                m43_result="skipped",
+            )
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        self.assertIn("bird3_archive=failure\n", result.stdout)
+        self.assertNotIn(EXCUSE, result.stdout)
+
+    def test_bare_m43_skip_is_not_excused(self) -> None:
+        for status in ("ok", "corrupt", None):
+            with self.subTest(bird3_status=status):
+                result = run_aggregate(
+                    needs_context(bird3_status=status, m43_result="skipped")
+                )
+                self.assertEqual(1, result.returncode, result.stdout)
+                self.assertNotIn(EXCUSE, result.stdout)
+
+    def test_unavailable_excuses_only_m43(self) -> None:
+        needs = needs_context(bird3_status="unavailable", m43_result="skipped")
+        needs["m51"] = {"result": "skipped"}
+        result = run_aggregate(needs)
+        self.assertEqual(1, result.returncode, result.stdout)
+
+    def test_lab_free_run_still_requires_every_job_skipped(self) -> None:
+        self.assertEqual(
+            0, run_aggregate(needs_context(run_labs="false")).returncode
+        )
+        noisy = needs_context(run_labs="false")
+        noisy["m43"] = {"result": "failure"}
+        self.assertEqual(1, run_aggregate(noisy).returncode)
+
+    def test_workflow_wiring(self) -> None:
+        text = WORKFLOW.read_text()
+        for seam in (
+            "bird3_status: ${{ steps.prepare.outputs.bird3_status }}",
+            "if: needs.bird3_archive.outputs.bird3_status != 'unavailable'",
+            "if: steps.prepare.outputs.bird3_status == 'ok'",
+            "3) status=unavailable ;;",
+            "4) status=corrupt ;;",
+        ):
+            self.assertIn(seam, text, f"kernel-dataplane.yml missing {seam}")
+        # The tolerance must never be spelled with continue-on-error, which
+        # would swallow genuine m43 failures too.
+        self.assertNotIn("continue-on-error", text)
+
+    def test_installer_classifies_outage_apart_from_corruption(self) -> None:
+        result = subprocess.run(
+            ["bash", str(INSTALLER), "--self-test"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`bird3_archive` downloads `bird-3.3.1.tar.gz` from a third-party host and feeds
exactly one scenario, `m43`. On 2026-08-18 that host returned HTTP 403 on all
three attempts with a cold cache: the prep job failed, `m43` reported
`skipped`, and the `check` aggregate went red on a release commit. Every other
scenario (m36…m72, netns) passed, and a rerun ~15 minutes later was green with
no code change.

A third-party download failure was indistinguishable from a rustbgpd test
failure, so a release gate hard-failed on evidence about somebody else's web
server.

## Approach

Split the two failure modes at the source rather than letting the aggregate
infer intent from a bare job conclusion.

`install-bird3.sh --prepare-archive` now classifies by exit code:

| exit | meaning | disposition |
|---|---|---|
| 0 | verified archive in hand | normal run |
| 3 | bytes never arrived — every attempt failed to fetch | tolerated, loud skip |
| 4 | bytes arrived and failed the pinned checksum or source-version check | hard-red |

The prep step maps that to a machine-readable job output
`bird3_status=ok\|unavailable\|corrupt` and exits zero only for `ok` and
`unavailable`. `m43` carries a job-level
`if: needs.bird3_archive.outputs.bird3_status != 'unavailable'`, and the
aggregate excuses `m43=skipped` **only** when the producer succeeded *and*
published `bird3_status=unavailable`.

Retry count (3) and the cache key are unchanged.

### Corrupt-checksum decision: stays hard-red

A checksum or source-version mismatch on a file that *did* download is a
supply-chain signal, not an outage. It gets its own status (`corrupt`), its own
`::error::`, no `::warning::`, and no job-summary excuse; the producer exits
non-zero and the aggregate fails exactly as before.

### The skip is loud

The installer emits, on `unavailable` only, both a `::warning::` annotation and
a `$GITHUB_STEP_SUMMARY` line — it is the single site that holds the URL, so
the loud text cannot drift from the real target:

```
M43 (TCP-AO interop vs BIRD 3.3.1) skipped: the pinned bird 3.3.1 source
archive is unavailable upstream after 3 attempts
(https://bird.nic.cz/download/bird-3.3.1.tar.gz). This is third-party
unavailability, not a rustbgpd failure; re-run once upstream recovers.
```

The aggregate roster annotates the entry in place and adds its own warning:

```
m43=skipped (bird3 archive unavailable upstream)
::warning::m43=skipped (bird3 archive unavailable upstream): TCP-AO interop
against BIRD 3.3.1 did not run in this Kernel Dataplane run; this gate passed
without that coverage
```

`m43` skips as a whole job rather than reporting success with its lab steps
quietly disabled, because a success with a hole in it is invisible coverage
loss.

## Proof

A gate that can no longer fail is worse than the problem it fixed, so
`scripts/test_kernel_dataplane_bird3_tolerance.py` extracts the aggregate's
real body out of the workflow and executes it against stubbed `needs`
contexts. Observed aggregate output:

| case | exit | roster |
|---|---|---|
| `bird3_status=unavailable`, `m43=skipped` | **0** | `m43=skipped (bird3 archive unavailable upstream)` + `::warning::` |
| `m43=failure` (ran, assertions failed) | **1** | `m43=failure`, no excuse |
| corrupt archive (producer red), `m43=skipped` | **1** | `bird3_archive=failure`, no excuse |
| bare `m43=skipped` with `bird3_status=ok` | **1** | `m43=skipped`, no excuse |
| `unavailable` but another scenario also skipped | **1** | — |
| `run_labs=false` (all skipped) | **0** | — |

Installer classification, exercised against a stubbed upstream:

| stub | exit | annotation | summary |
|---|---|---|---|
| `curl` exits 22 (403) | **3** | `::warning::M43 …` | URL + scenario written |
| 200 with a non-archive body | **4** | `::error::…failed verification` | empty |

Mutation-checked — the test goes red when the tolerance is widened to any
`m43` skip, when the roster annotation is dropped, and when the excuse is
extended past `m43`; green unmutated.

The test is wired into the `core` CI job, which moves the pinned `core` job
body hash in `check_ci_scale_split_contract.py` (expected drift: one added
step). It also runs `install-bird3.sh --self-test`, whose new cases cover the
outage/corruption split — that self-test had never executed in CI before.

## Gates

`check_ci_scale_split_contract.py`, `check_public_tracker_ids.py`,
`check_ci_image_primer_contract.py`, `cargo fmt --all -- --check`, the three
contract unittest suites, `install-bird3.sh --self-test`, `shellcheck`,
`bash -n`, and YAML parse: all exit 0. `actionlint` on the two changed
workflows: clean (its findings elsewhere are pre-existing, in untouched
workflows).

## Docs

`docs/INTEROP.md` gains a paragraph in the M43 gating section covering the
tolerance, its narrowness, the corrupt-archive disposition, and where the proof
lives. The workflow carries the rationale inline at all three edit sites.
