### PR TITLE
ci: replace mirrors with semantic contracts

### DIFF
--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
-"""Fail closed when the CI core/scale split contract drifts."""
+"""Fail closed when the load-bearing CI split contract drifts."""
 
 from __future__ import annotations
 
-import collections
-import hashlib
 import re
 import sys
 from pathlib import Path
 
-ROSTER = [
+ROSTER = {
     "v064_validator",
     "core",
     "core_tests",
@@ -17,47 +15,8 @@ ROSTER = [
     "check",
     "msrv",
     "evpn_bum_filter_kernel",
-]
-TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8"
-PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
-JOB_HASHES = {
-    "v064_validator": "b3f0ae8906bd28397a5f82bab0db5467e09a8e312aa24a8c8f2db8fd01c6310a",
-    "core": "962f91a26c1091edbae07341ef3b457f4d42d7cbbcf9ea5874359626fd1509cf",
-    "core_tests": "c5d8ed560cd4e572f535bb4eabe065372fddfc1dbefe0c341a9c5af76ed6df0f",
-    "scale_receipts": "57a201b5691dd08fecb49860deb942a74a4dcf4d2b3a77a18716b3fc9d981b85",
-    "check": "736f69ca686c06e889962d5fb93d80ee848090718dcf63aeff695febc6cbfcc5",
-    "msrv": "273de02a6a1e67e17913b50023326214261b8f4d6399f8f8867188e7e3d2acb9",
-    "evpn_bum_filter_kernel": "d427ed2c650d619d926cad0a4cbb6b558dd013ace9b18ba48757be529420863a",
 }
-COMMAND_BODY_HASH = "bfd8b9d4e3553cb9a5b46d633bfcb4544a6076c2c0ec9874523af7bfb16224e2"
-STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
-CHECKOUT = "uses: actions/checkout@v7"
-TOOLCHAIN = (
-    "uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable"
-)
-RUST_CACHE = "uses: Swatinem/rust-cache@v2"
-PINS = collections.Counter(
-    {
-        "actions/checkout@v7": 6,
-        "actions/cache@v6": 1,
-        "actions/upload-artifact@v7": 1,
-        "actions/download-artifact@v8": 2,
-        "Swatinem/rust-cache@v2": 4,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 1,
-        "docker/setup-buildx-action@v4": 1,
-        "docker/build-push-action@v7": 1,
-    }
-)
-
-
-def _hash(text: str) -> str:
-    return hashlib.sha256(text.encode()).hexdigest()
-
-
-def _top_block(text: str, key: str) -> str:
-    match = re.search(rf"(?ms)^{re.escape(key)}:\n.*?(?=^[A-Za-z][\w-]*:|\Z)", text)
-    return match.group(0).rstrip() if match else ""
+RESULTS = ("V064_VALIDATOR", "CORE", "CORE_TESTS", "SCALE_RECEIPTS")
 
 
 def _jobs(text: str) -> dict[str, str]:
@@ -65,9 +24,9 @@ def _jobs(text: str) -> dict[str, str]:
     matches = list(re.finditer(r"(?m)^  ([\w-]+):\n", body))
     return {
         match.group(1): body[
-            match.end() : (
-                matches[index + 1].start() if index + 1 < len(matches) else len(body)
-            )
+            match.end() : matches[index + 1].start()
+            if index + 1 < len(matches)
+            else len(body)
         ]
         for index, match in enumerate(matches)
     }
@@ -75,128 +34,43 @@ def _jobs(text: str) -> dict[str, str]:
 
 def aggregate_shell(job: str) -> str:
     match = re.search(
-        r"(?ms)^      - name: Aggregate required CI result\n        run: \|\n(.*?)(?=^      - |\Z)",
+        r"(?ms)^      - name: Aggregate required CI result\n"
+        r"        run: \|\n(.*?)(?=^      - |\Z)",
         job,
     )
     return "" if match is None else re.sub(r"(?m)^          ", "", match.group(1))
 
 
 def check(root: Path) -> list[str]:
-    errors: list[str] = []
-    text = (root / ".github" / "workflows" / "ci.yml").read_text()
+    text = (root / ".github/workflows/ci.yml").read_text()
     jobs = _jobs(text)
-    if list(jobs) != ROSTER:
-        errors.append("exact CI job roster/order drifted")
-    if _hash(_top_block(text, "on")) != TRIGGER_HASH:
-        errors.append("CI triggers drifted")
-    if _hash(_top_block(text, "permissions")) != PERMISSION_HASH:
-        errors.append("CI permissions drifted")
-    for name, expected in JOB_HASHES.items():
-        if _hash(jobs.get(name, "")) != expected:
-            errors.append(f"{name} job body drifted")
-
-    producer = jobs.get("v064_validator", "")
-    for seam in (
-        "name: prepare exact v0.64 config migration validator",
-        "runs-on: ubuntu-latest",
-        "timeout-minutes: 10",
-        CHECKOUT,
-        "uses: actions/cache@v6",
-        "key: rustbgpd-v0.64.0-linux-amd64-bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137",
-        "--self-test",
-        "--prepare-archive",
-        "uses: actions/upload-artifact@v7",
-        "name: rustbgpd-v0.64.0-linux-amd64",
-        "if-no-files-found: error",
-    ):
-        if seam not in producer:
-            errors.append(f"v064_validator missing {seam}")
-    for forbidden in ("restore-keys:", "continue-on-error:"):
-        if forbidden in producer:
-            errors.append(f"v064_validator permits {forbidden}")
+    errors: list[str] = []
+    if set(jobs) != ROSTER:
+        errors.append("exact CI job roster drifted")
 
     core_tests = jobs.get("core_tests", "")
-    for seam in (
-        "name: core tests / rustdoc",
-        "needs: v064_validator",
-        "runs-on: ubuntu-latest",
-        "timeout-minutes: 30",
-        CHECKOUT,
-        "fetch-depth: 0",
-        TOOLCHAIN,
-        "toolchain: stable",
-        "uses: ./.github/actions/install-protobuf",
-        RUST_CACHE,
-        "- run: cargo test --workspace",
-        "- run: cargo doc --workspace --lib --no-deps",
-        'RUSTDOCFLAGS: "-D warnings"',
-    ):
-        if seam not in core_tests:
-            errors.append(f"core_tests missing {seam}")
-    for command in (
-        "- run: cargo test --workspace",
-        "- run: cargo doc --workspace --lib --no-deps",
-    ):
-        if text.count(command) != 1 or command in jobs.get("core", ""):
-            errors.append(f"{command} must exist only in core_tests")
-
-    if text.count(f"- name: {STEP_NAME}") != 1:
-        errors.append("extracted scale/receipt step must appear exactly once")
-    scale = jobs.get("scale_receipts", "")
-    command_match = re.search(
-        rf"(?ms)^      - name: {re.escape(STEP_NAME)}\n        run: \|\n(.*?)(?=^      - |\Z)",
-        scale,
-    )
-    if command_match is None or _hash(command_match.group(1)) != COMMAND_BODY_HASH:
-        errors.append("extracted command body/order drifted")
-    for seam in (
-        "name: scale / receipt checks",
-        "runs-on: ubuntu-latest",
-        "timeout-minutes: 30",
-        CHECKOUT,
-        "fetch-depth: 0",
-        TOOLCHAIN,
-        "toolchain: stable",
-        "components: rustfmt, clippy",
-        "uses: ./.github/actions/install-protobuf",
-        RUST_CACHE,
-        "sudo apt-get update",
-        "sudo apt-get install -y ripgrep",
-    ):
-        if seam not in scale:
-            errors.append(f"scale_receipts missing {seam}")
+    for command in ("cargo test --workspace", "cargo doc --workspace --lib --no-deps"):
+        if text.count(command) != 1 or command not in core_tests:
+            errors.append(f"{command} must exist exactly once in core_tests")
+    if 'RUSTDOCFLAGS: "-D warnings"' not in core_tests:
+        errors.append("core_tests rustdoc warnings contract drifted")
 
     aggregate = jobs.get("check", "")
-    for seam in (
-        "name: check",
-        "runs-on: ubuntu-latest",
-        "timeout-minutes: 5",
-        "if: ${{ always() }}",
-        "needs: [v064_validator, core, core_tests, scale_receipts]",
-        "V064_VALIDATOR_RESULT: ${{ needs.v064_validator.result }}",
-        "CORE_RESULT: ${{ needs.core.result }}",
-        "CORE_TESTS_RESULT: ${{ needs.core_tests.result }}",
-        "SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}",
-        "printf 'v064_validator=%s\\n' \"$V064_VALIDATOR_RESULT\"",
-        "printf 'core=%s\\n' \"$CORE_RESULT\"",
-        "printf 'core_tests=%s\\n' \"$CORE_TESTS_RESULT\"",
-        "printf 'scale_receipts=%s\\n' \"$SCALE_RECEIPTS_RESULT\"",
-        '[[ "$V064_VALIDATOR_RESULT" != "success" || "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
-    ):
+    if "if: ${{ always() }}" not in aggregate:
+        errors.append("aggregate check must run with always()")
+    needs = "needs: [v064_validator, core, core_tests, scale_receipts]"
+    if needs not in aggregate:
+        errors.append("aggregate check needs drifted")
+    for name in RESULTS:
+        job = name.lower()
+        seam = f"{name}_RESULT: ${{{{ needs.{job}.result }}}}"
         if seam not in aggregate:
-            errors.append(f"aggregate check missing {seam}")
-    if "actions/checkout@" in aggregate:
-        errors.append("aggregate check must not checkout source")
+            errors.append(f"aggregate check missing {job} result wiring")
+    disjunction = " || ".join(f'\"${name}_RESULT\" != \"success\"' for name in RESULTS)
+    if f"[[ {disjunction} ]]" not in aggregate:
+        errors.append("aggregate non-success disjunction drifted")
     if not aggregate_shell(aggregate):
         errors.append("aggregate check shell missing")
-
-    pins = collections.Counter(
-        value.strip()
-        for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE)
-        if not value.strip().startswith("./")
-    )
-    if pins != PINS:
-        errors.append("CI external action pins/counts drifted")
     return errors
 
 

--- a/scripts/check_public_tracker_ids.py
+++ b/scripts/check_public_tracker_ids.py
@@ -23,8 +23,10 @@ by editing this guard.
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import re
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -62,6 +64,7 @@ SCANNED_FILES = frozenset(
 SKIPPED_SUFFIXES = frozenset({".gz", ".png", ".svg", ".zst", ".bin"})
 
 TRACKER_ID = re.compile(r"\bLAN-\d+\b")
+HOME_PATH = re.compile(rb"/(?:home|Users)/(?![<$\{])[^/\s\"'<>]+")
 
 SEAL_NAME = "SHA256SUMS"
 SEAL_ROOT = Path("docs/perf/artifacts")
@@ -233,6 +236,47 @@ def audit_document(relative: str, text: str) -> list[str]:
     return failures
 
 
+def audit_artifact_home_paths(
+    paths: list[Path] | None = None, root: Path | None = None
+) -> list[str]:
+    """Reject literal absolute home paths in tracked performance artifacts."""
+    root = (root or ROOT).resolve()
+    artifacts = []
+    for path in paths if paths is not None else tracked_files():
+        try:
+            relative = path.relative_to(root).as_posix()
+        except ValueError as error:
+            raise TrackerIdGuardError(
+                f"tracked path escapes the repository root: {path}"
+            ) from error
+        if relative.startswith("docs/perf/artifacts/"):
+            artifacts.append((relative, path))
+    if not artifacts:
+        raise TrackerIdGuardError("no tracked performance artifacts were discovered")
+
+    failures: list[str] = []
+    for relative, path in artifacts:
+        if path.is_symlink():
+            raise TrackerIdGuardError(f"tracked artifact {relative} is a symlink")
+        try:
+            mode = path.stat().st_mode
+            if not stat.S_ISREG(mode) or mode & 0o444 == 0:
+                raise OSError("not a readable regular file")
+            opener = gzip.open if path.suffix == ".gz" else Path.open
+            with opener(path, "rb") as handle:
+                for number, line in enumerate(handle, start=1):
+                    if match := HOME_PATH.search(line):
+                        failures.append(
+                            f"{relative}:{number} contains literal absolute home path "
+                            f"{match.group(0).decode(errors='replace')!r}"
+                        )
+        except (OSError, EOFError) as error:
+            raise TrackerIdGuardError(
+                f"cannot read tracked artifact {relative}: {error}"
+            ) from error
+    return failures
+
+
 def main() -> int:
     try:
         documents = discover_documents()
@@ -245,6 +289,11 @@ def main() -> int:
         for relative, text in documents.items()
         for failure in audit_document(relative, text)
     ]
+    try:
+        failures.extend(audit_artifact_home_paths())
+    except TrackerIdGuardError as error:
+        print(f"public tracker ID check failed: {error}", file=sys.stderr)
+        return 1
     if failures:
         for failure in failures:
             print(f"public tracker ID check failed: {failure}", file=sys.stderr)

--- a/scripts/check_public_tracker_ids.py
+++ b/scripts/check_public_tracker_ids.py
@@ -65,6 +65,7 @@ SKIPPED_SUFFIXES = frozenset({".gz", ".png", ".svg", ".zst", ".bin"})
 
 TRACKER_ID = re.compile(r"\bLAN-\d+\b")
 HOME_PATH = re.compile(rb"/(?:home|Users)/(?![<$\{])[^/\s\"'<>]+")
+READ_SIZE, OVERLAP, EXCERPT_SIZE = 64 * 1024, 8, 160
 
 SEAL_NAME = "SHA256SUMS"
 SEAL_ROOT = Path("docs/perf/artifacts")
@@ -73,6 +74,29 @@ SEAL_LINE = re.compile(r"([0-9a-f]{64})  (.+)")
 
 class TrackerIdGuardError(RuntimeError):
     """The public documentation surface could not be enumerated."""
+
+
+def _audit_artifact_stream(relative: str, handle: object) -> list[str]:
+    failures: list[str] = []
+    carry = b""
+    line = 1
+    reported_line = 0
+    while chunk := handle.read(READ_SIZE):
+        window = carry + chunk
+        window_line = line - carry.count(b"\n")
+        for match in HOME_PATH.finditer(window):
+            number = window_line + window[: match.start()].count(b"\n")
+            if match.end() <= len(carry) or number == reported_line:
+                continue
+            excerpt = window[match.start() : match.start() + EXCERPT_SIZE]
+            failures.append(
+                f"{relative}:{number} contains literal absolute home path "
+                f"{excerpt.decode(errors='replace')!r}"
+            )
+            reported_line = number
+        line += chunk.count(b"\n")
+        carry = window[-OVERLAP:]
+    return failures
 
 
 def tracked_files() -> list[Path]:
@@ -264,12 +288,7 @@ def audit_artifact_home_paths(
                 raise OSError("not a readable regular file")
             opener = gzip.open if path.suffix == ".gz" else Path.open
             with opener(path, "rb") as handle:
-                for number, line in enumerate(handle, start=1):
-                    if match := HOME_PATH.search(line):
-                        failures.append(
-                            f"{relative}:{number} contains literal absolute home path "
-                            f"{match.group(0).decode(errors='replace')!r}"
-                        )
+                failures.extend(_audit_artifact_stream(relative, handle))
         except (OSError, EOFError) as error:
             raise TrackerIdGuardError(
                 f"cannot read tracked artifact {relative}: {error}"

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -190,6 +190,27 @@ class PrimerContractTests(unittest.TestCase):
     def test_live_contract(self):
         self.assertEqual([], check(ROOT))
 
+    def test_v064_producer_is_load_bearing(self):
+        cache_key = (
+            "key: rustbgpd-v0.64.0-linux-amd64-"
+            "bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137"
+        )
+        cases = (
+            ("  v064_validator:\n", "  renamed_validator:\n"),
+            ("uses: actions/cache@v6", "uses: actions/cache@main"),
+            (cache_key, f"{cache_key}\n          restore-keys: rustbgpd-v0.64"),
+            ("--self-test", "--skipped-self-test"),
+            ("--prepare-archive", "--skipped-prepare-archive"),
+            (
+                "uses: actions/upload-artifact@v7",
+                "uses: actions/upload-artifact@main",
+            ),
+            ("if-no-files-found: error", "if-no-files-found: ignore"),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(".github/workflows/ci.yml", old, new)
+
     def test_empty_flow_needs_is_empty(self):
         self.assertEqual([], _list_needs("    needs: []\n"))
         self.assertEqual(

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from scripts.check_ci_scale_split_contract import _jobs, aggregate_shell, check
 
-
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ".github/workflows/ci.yml"
 
@@ -25,9 +24,7 @@ class ScaleSplitContractTests(unittest.TestCase):
             start = 0
             for _ in range(occurrence + 1):
                 index = text.find(old, start)
-                self.assertNotEqual(
-                    -1, index, f"missing occurrence {occurrence}: {old}"
-                )
+                self.assertNotEqual(-1, index, f"missing occurrence: {old}")
                 start = index + len(old)
             target.write_text(text[:index] + new + text[index + len(old) :])
             self.assertTrue(check(root), f"mutation stayed green: {old}")
@@ -35,7 +32,7 @@ class ScaleSplitContractTests(unittest.TestCase):
     def test_live_contract(self) -> None:
         self.assertEqual([], check(ROOT))
 
-    def test_destructive_roster_and_preserved_bodies(self) -> None:
+    def test_semantic_mutations_fail_closed(self) -> None:
         cases = (
             ("  v064_validator:\n", "  renamed_validator:\n"),
             ("  core:\n", "  renamed_core:\n"),
@@ -44,134 +41,13 @@ class ScaleSplitContractTests(unittest.TestCase):
             ("  check:\n", "  renamed_check:\n"),
             ("  msrv:\n", "  renamed_msrv:\n"),
             ("  evpn_bum_filter_kernel:\n", "  renamed_evpn:\n"),
-            ("timeout-minutes: 45", "timeout-minutes: 44"),
-            ("Wire crate README freshness gate", "changed final core step"),
-            ("key: msrv-1.95", "key: msrv-drift"),
-            ("IMAGE_TAG: rustbgpd-netns-tests:latest", "IMAGE_TAG: drift"),
-            ("branches: [main]", "branches: [other]"),
-            ("permissions:\n  contents: read", "permissions:\n  contents: write"),
-        )
-        for old, new in cases:
-            with self.subTest(seam=old):
-                self.mutate(old, new)
-
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            target = root / WORKFLOW
-            target.parent.mkdir(parents=True)
-            shutil.copy2(ROOT / WORKFLOW, target)
-            text = target.read_text()
-            core_start = text.index("  core:\n")
-            scale_start = text.index("  scale_receipts:\n")
-            check_start = text.index("  check:\n", scale_start)
-            core = text[core_start:scale_start]
-            scale = text[scale_start:check_start]
-            target.write_text(text[:core_start] + scale + core + text[check_start:])
-            self.assertTrue(check(root), "job-order mutation stayed green")
-
-    def test_destructive_validator_producer(self) -> None:
-        cache_key = (
-            "key: rustbgpd-v0.64.0-linux-amd64-"
-            "bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137"
-        )
-        cases = (
-            (
-                "name: prepare exact v0.64 config migration validator",
-                "name: changed validator producer",
-            ),
-            ("uses: actions/cache@v6", "uses: actions/cache@main"),
-            (cache_key, f"{cache_key}\n          restore-keys: rustbgpd-v0.64"),
-            ("--self-test", "--skipped-self-test"),
-            ("--prepare-archive", "--changed-prepare"),
-            ("uses: actions/upload-artifact@v7", "uses: actions/upload-artifact@main"),
-            ("if-no-files-found: error", "if-no-files-found: ignore"),
-        )
-        for old, new in cases:
-            with self.subTest(seam=old):
-                self.mutate(old, new)
-
-    def test_destructive_extracted_step_and_setup(self) -> None:
-        step_name = "- name: Check standalone scale harnesses and receipt classifiers"
-        cases = (
-            ("name: scale / receipt checks", "name: changed"),
-            ("timeout-minutes: 30", "timeout-minutes: 29"),
-            ("fetch-depth: 0", "fetch-depth: 1", 2),
-            ("components: rustfmt, clippy", "components: rustfmt"),
-            ("uses: ./.github/actions/install-protobuf", "uses: ./changed", 2),
-            ("sudo apt-get install -y ripgrep", "sudo apt-get install -y grep"),
-            (
-                "cargo fmt --manifest-path bench/scale/rrharness/Cargo.toml -- --check",
-                "true",
-            ),
-            (
-                "cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked",
-                "true",
-            ),
-            ("python3 bench/tests/test_verify_mrt_growth_campaign.py", "true"),
-            (step_name, f"{step_name}\n      {step_name}"),
-        )
-        for case in cases:
-            old, new, *occurrence = case
-            with self.subTest(seam=old):
-                self.mutate(old, new, occurrence[0] if occurrence else 0)
-        for pin, occurrence in (
-            ("actions/checkout@v7", 3),
-            ("dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c", 2),
-            ("Swatinem/rust-cache@v2", 2),
-        ):
-            with self.subTest(pin=pin):
-                self.mutate(pin, "changed@main", occurrence)
-
-    def test_destructive_core_tests_extraction_and_setup(self) -> None:
-        cases = (
-            ("name: core tests / rustdoc", "name: changed"),
-            ("timeout-minutes: 30", "timeout-minutes: 29"),
-            ("fetch-depth: 0", "fetch-depth: 1", 1),
-            ("uses: ./.github/actions/install-protobuf", "uses: ./changed", 1),
             ("- run: cargo test --workspace", "- run: true"),
             ("- run: cargo doc --workspace --lib --no-deps", "- run: true"),
             ('RUSTDOCFLAGS: "-D warnings"', 'RUSTDOCFLAGS: ""'),
-        )
-        for case in cases:
-            old, new, *occurrence = case
-            with self.subTest(seam=old):
-                self.mutate(old, new, occurrence[0] if occurrence else 0)
-        for pin in (
-            "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c",
-            "Swatinem/rust-cache@v2",
-        ):
-            with self.subTest(pin=pin):
-                self.mutate(pin, "changed@main", 1)
-        self.mutate("actions/checkout@v7", "changed@main", 2)
-        self.mutate(
-            "      - name: Wire crate README freshness gate",
-            "      - run: cargo test --workspace\n"
-            "      - run: cargo doc --workspace --lib --no-deps\n"
-            "        env:\n"
-            '          RUSTDOCFLAGS: "-D warnings"\n'
-            "      - name: Wire crate README freshness gate",
-        )
-
-    def test_destructive_aggregate_seams(self) -> None:
-        cases = (
-            ("name: check", "name: changed"),
-            ("timeout-minutes: 5", "timeout-minutes: 6"),
             ("if: ${{ always() }}", "if: ${{ success() }}"),
             (
                 "needs: [v064_validator, core, core_tests, scale_receipts]",
-                "needs: [core, core_tests, scale_receipts]",
-            ),
-            (
-                "needs: [v064_validator, core, core_tests, scale_receipts]",
-                "needs: [v064_validator, core_tests, scale_receipts]",
-            ),
-            (
-                "needs: [v064_validator, core, core_tests, scale_receipts]",
-                "needs: [v064_validator, core, scale_receipts]",
-            ),
-            (
-                "needs: [v064_validator, core, core_tests, scale_receipts]",
-                "needs: [v064_validator, core, core_tests]",
+                "needs: [core]",
             ),
             (
                 "V064_VALIDATOR_RESULT: ${{ needs.v064_validator.result }}",
@@ -186,10 +62,10 @@ class ScaleSplitContractTests(unittest.TestCase):
                 "SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}",
                 "SCALE_RECEIPTS_RESULT: success",
             ),
-            ("printf 'core=%s\\n' \"$CORE_RESULT\"", "true"),
-            ("printf 'core_tests=%s\\n' \"$CORE_TESTS_RESULT\"", "true"),
             (
-                '[[ "$V064_VALIDATOR_RESULT" != "success" || "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
+                '[[ "$V064_VALIDATOR_RESULT" != "success" || "$CORE_RESULT" != '
+                '"success" || "$CORE_TESTS_RESULT" != "success" || '
+                '"$SCALE_RECEIPTS_RESULT" != "success" ]]',
                 "[[ false ]]",
             ),
         )
@@ -198,50 +74,26 @@ class ScaleSplitContractTests(unittest.TestCase):
                 self.mutate(old, new)
 
     def test_aggregate_shell_truth_table(self) -> None:
-        workflow = (ROOT / WORKFLOW).read_text()
-        shell = aggregate_shell(_jobs(workflow)["check"])
+        shell = aggregate_shell(_jobs((ROOT / WORKFLOW).read_text())["check"])
         self.assertTrue(shell)
 
-        def run(validator=None, core=None, core_tests=None, scale=None):
+        def run(values):
             env = os.environ.copy()
-            env.pop("V064_VALIDATOR_RESULT", None)
-            env.pop("CORE_RESULT", None)
-            env.pop("CORE_TESTS_RESULT", None)
-            env.pop("SCALE_RECEIPTS_RESULT", None)
-            if validator is not None:
-                env["V064_VALIDATOR_RESULT"] = validator
-            if core is not None:
-                env["CORE_RESULT"] = core
-            if core_tests is not None:
-                env["CORE_TESTS_RESULT"] = core_tests
-            if scale is not None:
-                env["SCALE_RECEIPTS_RESULT"] = scale
-            return subprocess.run(
-                ["bash", "-c", shell], env=env, capture_output=True, text=True
-            )
+            for name in ("V064_VALIDATOR", "CORE", "CORE_TESTS", "SCALE_RECEIPTS"):
+                env.pop(f"{name}_RESULT", None)
+            for name, value in values.items():
+                if value is not None:
+                    env[f"{name}_RESULT"] = value
+            return subprocess.run(["bash", "-c", shell], env=env, capture_output=True)
 
-        self.assertEqual(0, run("success", "success", "success", "success").returncode)
-        for bad in ("failure", "cancelled", "skipped", ""):
-            with self.subTest(child="v064_validator", result=bad):
-                self.assertNotEqual(
-                    0, run(bad, "success", "success", "success").returncode
-                )
-            with self.subTest(child="core", result=bad):
-                self.assertNotEqual(
-                    0, run("success", bad, "success", "success").returncode
-                )
-            with self.subTest(child="core_tests", result=bad):
-                self.assertNotEqual(
-                    0, run("success", "success", bad, "success").returncode
-                )
-            with self.subTest(child="scale_receipts", result=bad):
-                self.assertNotEqual(
-                    0, run("success", "success", "success", bad).returncode
-                )
-        self.assertNotEqual(0, run(None, "success", "success", "success").returncode)
-        self.assertNotEqual(0, run("success", None, "success", "success").returncode)
-        self.assertNotEqual(0, run("success", "success", None, "success").returncode)
-        self.assertNotEqual(0, run("success", "success", "success", None).returncode)
+        names = ("V064_VALIDATOR", "CORE", "CORE_TESTS", "SCALE_RECEIPTS")
+        good = {name: "success" for name in names}
+        self.assertEqual(0, run(good).returncode)
+        for name in good:
+            for bad in ("failure", "cancelled", "skipped", "", None):
+                values = good | {name: bad}
+                with self.subTest(child=name, result=bad):
+                    self.assertNotEqual(0, run(values).returncode)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_public_tracker_ids.py
+++ b/scripts/test_check_public_tracker_ids.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import sys
 import tempfile
@@ -66,6 +67,58 @@ class PublicTrackerIdTests(unittest.TestCase):
             with self.subTest(line=line):
                 failures = guard.audit_document("docs/example.md", f"{line}\n")
                 self.assertEqual(failures, [], f"{line!r} must be accepted")
+
+    def test_artifact_home_paths_cover_plain_gzip_and_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            clean = write_fixture(
+                root,
+                "docs/perf/artifacts/example/clean.txt",
+                "/home/<user>/run $HOME/run ${HOME}/run\n",
+            )
+            linux = write_fixture(root, "docs/perf/artifacts/linux.txt", "/home/alice/run\n")
+            mac = root / "docs/perf/artifacts/example/mac.txt.gz"
+            with gzip.open(mac, "wb") as handle:
+                handle.write(b"/Users/bob/run\n")
+            failures = guard.audit_artifact_home_paths([clean, linux, mac], root)
+            self.assertTrue(any("/home/alice" in failure for failure in failures))
+            self.assertTrue(any("/Users/bob" in failure for failure in failures))
+
+    def test_artifact_walk_failures_are_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "no tracked"):
+                guard.audit_artifact_home_paths([], root)
+
+            corrupt = write_fixture(root, "docs/perf/artifacts/corrupt.gz", b"not gzip")
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "cannot read"):
+                guard.audit_artifact_home_paths([corrupt], root)
+
+            unreadable = write_fixture(root, "docs/perf/artifacts/unreadable", "clean\n")
+            unreadable.chmod(0)
+            try:
+                with self.assertRaisesRegex(guard.TrackerIdGuardError, "cannot read"):
+                    guard.audit_artifact_home_paths([unreadable], root)
+            finally:
+                unreadable.chmod(0o600)
+
+            target = write_fixture(root, "target.txt", "clean\n")
+            symlink = root / "docs/perf/artifacts/example/link.txt"
+            symlink.parent.mkdir(parents=True)
+            symlink.symlink_to(target)
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "symlink"):
+                guard.audit_artifact_home_paths([symlink], root)
+
+    def test_artifact_git_enumeration_failure_is_closed(self) -> None:
+        original = guard.tracked_files
+        guard.tracked_files = lambda: (_ for _ in ()).throw(
+            guard.TrackerIdGuardError("cannot list tracked files: synthetic failure")
+        )
+        try:
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "synthetic failure"):
+                guard.audit_artifact_home_paths()
+        finally:
+            guard.tracked_files = original
 
     def test_failure_reports_the_line_number(self) -> None:
         failures = guard.audit_document("docs/example.md", "clean\nLAN-931 here\n")

--- a/scripts/test_check_public_tracker_ids.py
+++ b/scripts/test_check_public_tracker_ids.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import gzip
 import hashlib
+import io
 import sys
 import tempfile
 import unittest
@@ -83,6 +84,25 @@ class PublicTrackerIdTests(unittest.TestCase):
             failures = guard.audit_artifact_home_paths([clean, linux, mac], root)
             self.assertTrue(any("/home/alice" in failure for failure in failures))
             self.assertTrue(any("/Users/bob" in failure for failure in failures))
+
+    def test_artifact_scan_is_chunk_bounded_and_boundary_safe(self) -> None:
+        class RecordingStream(io.BytesIO):
+            def read(self, size: int = -1) -> bytes:
+                if not 0 < size <= guard.READ_SIZE:
+                    raise AssertionError(f"unbounded read request: {size}")
+                return super().read(size)
+            def readline(self, _size: int = -1) -> bytes:
+                raise AssertionError("readline must not be used")
+
+        prefix = b"x\n" * (guard.READ_SIZE // 2) + b"x" * (guard.READ_SIZE - 10)
+        payload = prefix + b"/home/alice/" + b"z" * (guard.READ_SIZE * 2)
+        failures = guard._audit_artifact_stream("artifact", RecordingStream(payload))
+        self.assertEqual(len(failures), 1)
+        self.assertIn(f"artifact:{guard.READ_SIZE // 2 + 1}", failures[0])
+        self.assertLess(len(failures[0]), guard.EXCERPT_SIZE + 100)
+        placeholder = b"x" * (guard.READ_SIZE - 3) + b"/home/<user>/run"
+        failures = guard._audit_artifact_stream("artifact", RecordingStream(placeholder))
+        self.assertEqual(failures, [])
 
     def test_artifact_walk_failures_are_closed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- replace LAN-960 byte hashes, roster ordering, setup mirrors, action counters, and prose anchors with executable semantic checks
- preserve exact CI job membership, workspace test/rustdoc placement, warning denial, and aggregate failure propagation
- move all seven v0.64 producer mutation proofs into the load-bearing image-primer suite
- implement LAN-1063 in the existing public-docs invocation by streaming tracked performance artifacts, including gzip captures, and rejecting literal Linux/macOS home paths
- fail closed on corrupt gzip, unreadable files, tracked symlinks, git enumeration failure, and empty artifact discovery

## Maintenance budget

- scale-split checker and tests: 458 lines to 184
- full change: 214 insertions, 326 deletions; net 112 lines removed
- no workflow, job, required check, matrix, path trigger, dependency, or new invocation

The artifact check is deliberately narrow: it scans only tracked `docs/perf/artifacts/**` content and rejects literal `/home/<segment>` and `/Users/<segment>` paths. Placeholder forms such as `/home/<user>`, `$HOME`, and `${HOME}` remain valid. It does not infer hostnames, handles, standalone usernames, or other identities and has no allowlist.

Plain and gzip streams are read in explicit 64 KiB chunks with an 8-byte boundary overlap and bounded diagnostics. The scanner does not accumulate a decompressed line or an input-sized scan buffer. Regression coverage includes a literal split across a chunk boundary, a newline-free payload larger than two chunks, bounded read requests, boundary-split placeholders, exact later line reporting, and a path segment longer than one chunk.

## Verification

- `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py` (33 passed)
- `python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py` (3 passed)
- `python3 -m unittest -v scripts/test_check_public_tracker_ids.py` (15 passed)
- `python3 scripts/check_ci_image_primer_contract.py`
- `python3 scripts/check_ci_scale_split_contract.py`
- `python3 scripts/check_public_tracker_ids.py`
- `git diff --check`
- repository commit and push hooks
