### PR TITLE
fix: validate ORR peer-address vantages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply the existing ORR topology-address validity rules after resolving
+  `orr_vantage = "peer_address"`, so a derived unspecified, loopback, or local
+  reflector `router_id` is rejected. Empty human `rbgp orr` output now
+  describes the active registration state accurately. (LAN-1067)
+
 ## [0.65.0] — 2026-08-18
 
 ### Security

--- a/crates/cli/src/commands/orr.rs
+++ b/crates/cli/src/commands/orr.rs
@@ -9,6 +9,7 @@ use crate::proto::{
 };
 use serde::Serialize;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
+use std::io::Write;
 
 const NO_ACTIVE_VANTAGES: &str = "No active ORR vantages (none registered by live peers)";
 
@@ -39,11 +40,7 @@ fn print_orr_status(resp: &ListOrrStatusResponse, json: bool) -> Result<(), CliE
     if json {
         output::print_json_pretty(&JsonOrrStatus(resp))?;
     } else if resp.vantages.is_empty() {
-        println!("{NO_ACTIVE_VANTAGES}");
-        println!(
-            "Topology: {} nodes, {} links",
-            resp.topology_nodes, resp.topology_links
-        );
+        write_inactive_status(&mut std::io::stdout().lock(), resp)?;
     } else {
         println!(
             "{:<40} {:<10} {:<18} {:<8} Peers",
@@ -77,6 +74,18 @@ fn print_orr_status(resp: &ListOrrStatusResponse, json: bool) -> Result<(), CliE
         );
     }
     Ok(())
+}
+
+fn write_inactive_status(
+    writer: &mut impl Write,
+    resp: &ListOrrStatusResponse,
+) -> std::io::Result<()> {
+    writeln!(writer, "{NO_ACTIVE_VANTAGES}")?;
+    writeln!(
+        writer,
+        "Topology: {} nodes, {} links",
+        resp.topology_nodes, resp.topology_links
+    )
 }
 
 fn input_diagnostics(resp: &ListOrrStatusResponse) -> OrrInputDiagnostics {
@@ -219,10 +228,19 @@ mod tests {
             false,
         )
         .unwrap();
-        print_orr_status(&ListOrrStatusResponse::default(), false).unwrap();
+        let mut inactive_output = Vec::new();
+        write_inactive_status(
+            &mut inactive_output,
+            &ListOrrStatusResponse {
+                topology_nodes: 3,
+                topology_links: 2,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(
-            NO_ACTIVE_VANTAGES,
-            "No active ORR vantages (none registered by live peers)"
+            String::from_utf8(inactive_output).unwrap(),
+            "No active ORR vantages (none registered by live peers)\nTopology: 3 nodes, 2 links\n"
         );
     }
 

--- a/crates/cli/src/commands/orr.rs
+++ b/crates/cli/src/commands/orr.rs
@@ -10,6 +10,8 @@ use crate::proto::{
 use serde::Serialize;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 
+const NO_ACTIVE_VANTAGES: &str = "No active ORR vantages (none registered by live peers)";
+
 pub async fn status(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
     let resp = client
@@ -37,7 +39,7 @@ fn print_orr_status(resp: &ListOrrStatusResponse, json: bool) -> Result<(), CliE
     if json {
         output::print_json_pretty(&JsonOrrStatus(resp))?;
     } else if resp.vantages.is_empty() {
-        println!("No ORR vantages configured");
+        println!("{NO_ACTIVE_VANTAGES}");
         println!(
             "Topology: {} nodes, {} links",
             resp.topology_nodes, resp.topology_links
@@ -218,6 +220,10 @@ mod tests {
         )
         .unwrap();
         print_orr_status(&ListOrrStatusResponse::default(), false).unwrap();
+        assert_eq!(
+            NO_ACTIVE_VANTAGES,
+            "No active ORR vantages (none registered by live peers)"
+        );
     }
 
     // The ORR JSON output is produced by hand-rolled `Serialize` impls

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -904,7 +904,9 @@ complete atomic block. There is no probe or automatic legacy fallback.
 > need that loopback advertised as a prefix NLRI. A vantage that does not
 > resolve is not an error: the peer falls back to the standard best path,
 > counts in the `bgp_orr_unresolved_vantages` gauge, and is listed by
-> `rbgp orr`. Because ORR peers are never grouped into shared update groups,
+> `rbgp orr`. The derived address is rejected if it is unspecified, loopback,
+> or equal to the reflector's own `router_id`. Because ORR peers are never
+> grouped into shared update groups,
 > a range using this value produces one update group per peer.
 
 Use `rbgp neighbor <addr>` to inspect the actor's current aggregate

--- a/docs/cookbook/route-reflector.md
+++ b/docs/cookbook/route-reflector.md
@@ -108,6 +108,17 @@ remote_asn = 65000
 description = "client-region-b"
 peer_group = "rr-clients"
 orr_vantage = "10.0.8.1"
+
+# Give every established client in a dynamic range its own peering address as
+# the ORR vantage. The address must not equal this reflector's router_id.
+[peer_groups.dynamic-rr-clients]
+route_reflector_client = true
+orr_vantage = "peer_address"
+
+[[dynamic_neighbors]]
+prefix = "10.0.1.0/24"
+peer_group = "dynamic-rr-clients"
+remote_asn = 65000
 ```
 
 ## Verify
@@ -143,7 +154,7 @@ ORR (if configured):
 
 ```console
 $ rbgp topology nodes        # BGP-LS-sourced graph is populated
-$ rbgp orr                   # each vantage: resolved, SPF reach, bound peers
+$ rbgp orr                   # each live vantage: resolved, SPF reach, bound peers
 ```
 
 An unresolved vantage row means that client is silently getting the

--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -19,7 +19,7 @@ use super::parse::{
 };
 use super::schema::{
     BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_DYNAMIC_NEIGHBOR_LIMIT, DEFAULT_HOLD_TIME,
-    OrrVantage, parse_orr_vantage,
+    OrrVantage, parse_orr_vantage, validate_orr_vantage_address,
 };
 use super::{
     AddPathConfig, BgpRoleConfig, Config, ConfigError, Neighbor, NextHopOwnershipConfig,
@@ -864,15 +864,19 @@ impl Config {
             .as_deref()
             .or_else(|| group.and_then(|g| g.orr_vantage.as_deref()))
             .map(|raw| {
-                parse_orr_vantage(raw).map(|vantage| match vantage {
+                let vantage =
+                    parse_orr_vantage(raw).map_err(|reason| ConfigError::InvalidOrrVantage {
+                        reason: format!("neighbor {}: {reason}", neighbor.address),
+                    })?;
+                let vantage = match vantage {
                     OrrVantage::PeerAddress => peer_addr,
                     OrrVantage::Address(addr) => addr,
-                })
+                };
+                validate_orr_vantage_address(vantage, &self.global.router_id, &neighbor.address)
+                    .map_err(|reason| ConfigError::InvalidOrrVantage { reason })?;
+                Ok::<IpAddr, ConfigError>(vantage)
             })
-            .transpose()
-            .map_err(|reason| ConfigError::InvalidOrrVantage {
-                reason: format!("neighbor {}: {reason}", neighbor.address),
-            })?;
+            .transpose()?;
         transport.remove_private_as = Self::resolved_remove_private_as(neighbor, group);
         // RFC 4456: thread the local cluster-id just like
         // `PeerManager::build_transport_config`. Without it a runtime-added

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1653,6 +1653,30 @@ pub(crate) fn parse_orr_vantage(raw: &str) -> Result<OrrVantage, String> {
     }
 }
 
+/// Validate a resolved RFC 9107 ORR vantage address.
+///
+/// Both literal addresses and the per-peer selector pass through this helper
+/// so they cannot diverge on degenerate topology locations.
+pub(crate) fn validate_orr_vantage_address(
+    vantage: IpAddr,
+    local_router_id: &str,
+    subject: &str,
+) -> Result<(), String> {
+    if local_router_id.parse::<IpAddr>().ok() == Some(vantage) {
+        return Err(format!(
+            "orr_vantage {vantage} on neighbor {subject} must not equal the \
+             reflector's local router_id {local_router_id}"
+        ));
+    }
+    if vantage.is_unspecified() || vantage.is_loopback() {
+        return Err(format!(
+            "orr_vantage {vantage} on neighbor {subject} must be a real topology \
+             address, not an unspecified or loopback address"
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BgpRoleConfig {

--- a/src/config/tests/dynamic_neighbors.rs
+++ b/src/config/tests/dynamic_neighbors.rs
@@ -100,6 +100,39 @@ fn valid_dynamic_peer_modes_resolve_cluster_and_transport() {
 }
 
 #[test]
+fn dynamic_peer_address_orr_rejects_degenerate_derived_vantages() {
+    let config = parse(&dynamic_modes_toml(
+        "route_reflector_client = true\norr_vantage = \"peer_address\"",
+        65001,
+    ))
+    .unwrap();
+    let group = &config.peer_groups["modes"];
+    for (peer, expected) in [
+        ("10.0.0.1", "router_id"),
+        ("0.0.0.0", "unspecified or loopback"),
+        ("127.0.0.1", "unspecified or loopback"),
+    ] {
+        let err = config
+            .resolve_dynamic_neighbor(
+                peer.parse().unwrap(),
+                65001,
+                "dynamic",
+                group,
+                "modes",
+                false,
+            )
+            .err()
+            .expect("a degenerate derived vantage must fail");
+        assert!(
+            matches!(err, ConfigError::InvalidOrrVantage { .. })
+                && err.to_string().contains(peer)
+                && err.to_string().contains(expected),
+            "unexpected diagnostic for {peer}: {err}"
+        );
+    }
+}
+
+#[test]
 fn dynamic_neighbor_parses() {
     let toml = r#"
 [global]

--- a/src/config/tests/route_server.rs
+++ b/src/config/tests/route_server.rs
@@ -996,6 +996,25 @@ fn orr_vantage_peer_address_resolves_for_a_static_neighbor() {
 }
 
 #[test]
+fn orr_vantage_peer_address_rejects_static_peer_equal_to_local_router_id() {
+    let toml = orr_toml(
+        "",
+        "route_reflector_client = true\norr_vantage = \"peer_address\"",
+    )
+    .replace("address = \"10.0.0.2\"", "address = \"10.0.0.1\"");
+    let config = parse(&toml).unwrap();
+    let Err(err) = config.resolved_neighbors() else {
+        panic!("a peer-derived vantage equal to the reflector router_id must fail");
+    };
+    assert!(
+        matches!(err, ConfigError::InvalidOrrVantage { .. })
+            && err.to_string().contains("10.0.0.1")
+            && err.to_string().contains("router_id"),
+        "unexpected diagnostic: {err}"
+    );
+}
+
+#[test]
 fn orr_vantage_peer_address_alias_and_bad_values_are_classified() {
     // The kebab alias loads and resolves identically.
     let toml = orr_toml(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -15,7 +15,7 @@ use super::schema::{
     ManagedSvdVxlanNetdevConfig, ManagedVlanUpperNetdevConfig, ManagedVrfNetdevConfig,
     ManagedVxlanNetdevConfig, Rfc8212PolicySource,
 };
-use super::schema::{OrrVantage, parse_orr_vantage};
+use super::schema::{OrrVantage, parse_orr_vantage, validate_orr_vantage_address};
 use super::{
     Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, InboundAdmissionConfig, Neighbor,
     PeerGroupConfig, SecurityConfig, TcpAoConfig, TcpAoKeyringConfig, dynamic_prefixes_intersect,
@@ -233,18 +233,8 @@ fn validate_effective_peer_modes(
             // and it is exactly what `"peer_address"` derives. Only a vantage
             // equal to the reflector's own router_id degenerates to plain
             // non-ORR reflection.
-            if local_router_id.parse::<IpAddr>().ok() == Some(vantage) {
-                return Err(PeerModeViolation::RouteReflector(format!(
-                    "orr_vantage {vantage} on neighbor {subject} must not equal the \
-                     reflector's local router_id {local_router_id}"
-                )));
-            }
-            if vantage.is_unspecified() || vantage.is_loopback() {
-                return Err(PeerModeViolation::RouteReflector(format!(
-                    "orr_vantage {vantage} on neighbor {subject} must be a real topology \
-                     address, not an unspecified or loopback address"
-                )));
-            }
+            validate_orr_vantage_address(vantage, local_router_id, subject)
+                .map_err(PeerModeViolation::RouteReflector)?;
         }
     }
 


### PR DESCRIPTION
## Summary

- make literal and `peer_address` ORR vantages share one resolved-address validity rule
- reject a derived vantage that is unspecified, loopback, or equal to the reflector `router_id` through the existing fallible config-resolution path
- preserve valid IPv4/IPv6 per-peer vantages and the released `peer-address` alias
- make empty human `rbgp orr` output describe inactive registrations rather than configuration absence; JSON remains unchanged
- document the dynamic-range configuration and released validation boundary

This closes LAN-1067 without adding a protocol, API, metric, RIB, transport, interop, workflow, dependency, or topology surface.

## Verification

- `cargo test --bin rustbgpd config::tests::route_server` (44 passed)
- `cargo test --bin rustbgpd config::tests::dynamic_neighbors` (28 passed)
- `cargo test -p rustbgpctl commands::orr` (3 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo +1.95 check --workspace --all-targets --locked`
- warning-denied workspace rustdoc
- v1 stable-surface and public-doc checks
- repository commit and push hooks
