### PR TITLE
Remove borrowed RIB event sink compatibility

### DIFF
--- a/crates/api/src/event_history_sinks.rs
+++ b/crates/api/src/event_history_sinks.rs
@@ -110,32 +110,14 @@ impl EhmRibSink {
 }
 
 impl RibEventSink for EhmRibSink {
-    fn publish_route_event(&self, event: &RouteEvent) {
-        let event = Arc::new(event.clone());
-        let timestamp_ns = timestamp_ns_now();
-        self.enqueue(RibEventSnapshot::Route {
-            event,
-            timestamp_ns,
-        });
-    }
-
-    fn publish_route_event_shared(&self, event: &Arc<RouteEvent>) {
+    fn publish_route_event(&self, event: &Arc<RouteEvent>) {
         self.enqueue(RibEventSnapshot::Route {
             event: Arc::clone(event),
             timestamp_ns: timestamp_ns_now(),
         });
     }
 
-    fn publish_evpn_event(&self, event: &EvpnRouteEvent) {
-        let event = Arc::new(event.clone());
-        let timestamp_ns = timestamp_ns_now();
-        self.enqueue(RibEventSnapshot::Evpn {
-            event,
-            timestamp_ns,
-        });
-    }
-
-    fn publish_evpn_event_shared(&self, event: &Arc<EvpnRouteEvent>) {
+    fn publish_evpn_event(&self, event: &Arc<EvpnRouteEvent>) {
         self.enqueue(RibEventSnapshot::Evpn {
             event: Arc::clone(event),
             timestamp_ns: timestamp_ns_now(),
@@ -634,12 +616,12 @@ mod tests {
             let event = sample_route_event(RouteEventType::Added, index);
             expected_payloads
                 .push(convert::route_event_to_bgp_event(event.clone()).encode_to_vec());
-            sink.publish_route_event(&event);
+            sink.publish_route_event(&Arc::new(event));
             if index == 3 {
                 let evpn = sample_evpn_event();
                 expected_payloads
                     .push(convert::evpn_event_to_bgp_event(evpn.clone()).encode_to_vec());
-                sink.publish_evpn_event(&evpn);
+                sink.publish_evpn_event(&Arc::new(evpn));
             }
         }
         let after_ns = timestamp_ns_now();
@@ -691,7 +673,7 @@ mod tests {
             metrics: metrics.clone(),
         };
         let before_ns = timestamp_ns_now();
-        sink.publish_route_event(&sample_route_event(RouteEventType::Added, 0));
+        sink.publish_route_event(&Arc::new(sample_route_event(RouteEventType::Added, 0)));
         let after_ns = timestamp_ns_now();
 
         tokio::time::sleep(Duration::from_millis(150)).await;
@@ -732,7 +714,7 @@ mod tests {
         };
         let event = Arc::new(sample_route_event(RouteEventType::Added, 0));
 
-        sink.publish_route_event_shared(&event);
+        sink.publish_route_event(&event);
 
         match snapshot_rx.try_recv().expect("snapshot accepted") {
             RibEventSnapshot::Route { event: queued, .. } => {
@@ -790,13 +772,13 @@ mod tests {
         };
 
         let first = Arc::new(sample_route_event(RouteEventType::Added, 0));
-        sink.publish_route_event_shared(&first);
+        sink.publish_route_event(&first);
         assert!(!state.degraded(), "accepted publish must not degrade");
         assert!(!losses.has_changed().unwrap());
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 0);
 
         let second = Arc::new(sample_route_event(RouteEventType::Added, 1));
-        sink.publish_route_event_shared(&second);
+        sink.publish_route_event(&second);
         assert!(state.degraded(), "queue-full drop must flip EHM state");
         assert!(losses.has_changed().unwrap());
         assert_eq!(*losses.borrow_and_update(), 1);
@@ -807,7 +789,7 @@ mod tests {
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 1);
 
         let third = Arc::new(sample_route_event(RouteEventType::Added, 2));
-        sink.publish_route_event_shared(&third);
+        sink.publish_route_event(&third);
         assert!(losses.has_changed().unwrap());
         assert_eq!(*losses.borrow_and_update(), 2);
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 2);
@@ -830,7 +812,7 @@ mod tests {
         };
 
         let event = Arc::new(sample_evpn_event());
-        sink.publish_evpn_event_shared(&event);
+        sink.publish_evpn_event(&event);
         assert!(!state.degraded(), "closed drop must not flip EHM state");
         assert!(!losses.has_changed().unwrap());
         assert!(
@@ -857,7 +839,7 @@ mod tests {
 
         for index in 0..16u32 {
             let event = Arc::new(sample_route_event(RouteEventType::Added, index));
-            sink.publish_route_event_shared(&event);
+            sink.publish_route_event(&event);
         }
         stage.shutdown().await;
 
@@ -870,7 +852,7 @@ mod tests {
         }
 
         let late = Arc::new(sample_route_event(RouteEventType::Added, 99));
-        sink.publish_route_event_shared(&late);
+        sink.publish_route_event(&late);
         assert_eq!(drop_counter(&metrics, "route", "closed"), 1);
         assert!(
             !handle.state().degraded(),

--- a/crates/rib/src/event_sink.rs
+++ b/crates/rib/src/event_sink.rs
@@ -30,42 +30,24 @@ use crate::event::{EvpnRouteEvent, RouteEvent};
 /// in the publish hot path; a panic here would unwind through the
 /// RIB actor.
 ///
-/// Trait methods take `&RouteEvent` / `&EvpnRouteEvent` rather than
-/// owned values so the existing `publish_*_event` paths can clone
-/// only when needed (EVPN events carry `Arc<EvpnRibRoute>` payloads
-/// that are cheap to clone, but the legacy ring already takes one
-/// clone for its `push_back` so passing by reference here saves
-/// another).
 pub trait RibEventSink: Send + Sync + 'static {
     /// Hand a route event to the sink. Called from
     /// `RibManager::publish_route_event` after the event has been
     /// stamped with its process-local `event_id`, appended to the
-    /// bounded ring; the shared sink callback (defaulting here) runs before
+    /// bounded ring; the sink callback runs before
     /// live broadcast on `route_events_tx`. Legacy
     /// `event_id` value is preserved as-is on the snapshot the sink
     /// sees; the durable cursor overwrites it from the EHM commit on
     /// the wire path.
-    fn publish_route_event(&self, event: &RouteEvent);
-
-    /// Hand a shared route event to the sink. Legacy implementors keep
-    /// working through the borrowed-event method; sinks that can retain the
-    /// existing allocation may override this additive path.
-    fn publish_route_event_shared(&self, event: &Arc<RouteEvent>) {
-        self.publish_route_event(event.as_ref());
-    }
+    fn publish_route_event(&self, event: &Arc<RouteEvent>);
 
     /// Hand an EVPN best-path event to the sink. Called from
-    /// `RibManager::publish_evpn_route_event` after ring insertion and through
-    /// the shared sink callback (defaulting here) before live broadcast. EVPN
+    /// `RibManager::publish_evpn_route_event` after ring insertion and before
+    /// live broadcast. EVPN
     /// events do not currently carry a
     /// process-local `event_id`; the durable envelope id is the only
     /// id surfaced on the EHM-backed wire path.
-    fn publish_evpn_event(&self, event: &EvpnRouteEvent);
-
-    /// Shared counterpart to [`Self::publish_evpn_event`].
-    fn publish_evpn_event_shared(&self, event: &Arc<EvpnRouteEvent>) {
-        self.publish_evpn_event(event.as_ref());
-    }
+    fn publish_evpn_event(&self, event: &Arc<EvpnRouteEvent>);
 }
 
 /// No-op sink used when `[event_history]` is disabled or EHM failed
@@ -77,8 +59,6 @@ pub trait RibEventSink: Send + Sync + 'static {
 pub struct NoopRibEventSink;
 
 impl RibEventSink for NoopRibEventSink {
-    fn publish_route_event(&self, _event: &RouteEvent) {}
-    fn publish_route_event_shared(&self, _event: &Arc<RouteEvent>) {}
-    fn publish_evpn_event(&self, _event: &EvpnRouteEvent) {}
-    fn publish_evpn_event_shared(&self, _event: &Arc<EvpnRouteEvent>) {}
+    fn publish_route_event(&self, _event: &Arc<RouteEvent>) {}
+    fn publish_evpn_event(&self, _event: &Arc<EvpnRouteEvent>) {}
 }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2633,7 +2633,7 @@ impl RibManager {
         // not load-bearing for correctness; pick the order that
         // avoids the second clone (sink first, then move into
         // broadcast).
-        self.event_sink.publish_route_event_shared(&event);
+        self.event_sink.publish_route_event(&event);
         let _ = self.route_events_tx.send(event);
     }
 
@@ -2694,7 +2694,7 @@ impl RibManager {
         self.evpn_route_event_history.push_back(Arc::clone(&event));
         // ADR-0072: durable outbox sink fires alongside the legacy
         // broadcast. See `publish_route_event` for the ordering note.
-        self.event_sink.publish_evpn_event_shared(&event);
+        self.event_sink.publish_evpn_event(&event);
         let _ = self.evpn_events_tx.send(event);
     }
 

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -5,26 +5,11 @@ use crate::event_sink::RibEventSink;
 struct SharedRouteCapture(std::sync::Mutex<Option<Arc<crate::event::RouteEvent>>>);
 
 impl RibEventSink for SharedRouteCapture {
-    fn publish_route_event(&self, _event: &crate::event::RouteEvent) {
-        panic!("manager must use the shared route-event path")
-    }
-
-    fn publish_route_event_shared(&self, event: &Arc<crate::event::RouteEvent>) {
+    fn publish_route_event(&self, event: &Arc<crate::event::RouteEvent>) {
         *self.0.lock().unwrap() = Some(Arc::clone(event));
     }
 
-    fn publish_evpn_event(&self, _event: &crate::event::EvpnRouteEvent) {}
-}
-
-#[derive(Default)]
-struct LegacyRouteSink(std::sync::atomic::AtomicUsize);
-
-impl RibEventSink for LegacyRouteSink {
-    fn publish_route_event(&self, _event: &crate::event::RouteEvent) {
-        self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn publish_evpn_event(&self, _event: &crate::event::EvpnRouteEvent) {}
+    fn publish_evpn_event(&self, _event: &Arc<crate::event::EvpnRouteEvent>) {}
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -78,28 +63,6 @@ async fn route_history_and_live_broadcast_share_arc_but_queries_are_owned() {
         manager.route_event_history.back().unwrap().reason,
         "original"
     );
-}
-
-#[test]
-fn shared_trait_default_preserves_legacy_sink_and_noop_is_empty() {
-    let event = Arc::new(crate::event::RouteEvent {
-        event_id: 0,
-        event_type: RouteEventType::Added,
-        prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
-        peer: None,
-        previous_peer: None,
-        target_peer: None,
-        timestamp: String::new(),
-        path_id: 0,
-        reason: String::new(),
-    });
-    let legacy = LegacyRouteSink::default();
-    legacy.publish_route_event_shared(&event);
-    assert_eq!(legacy.0.load(std::sync::atomic::Ordering::Relaxed), 1);
-
-    let before = Arc::strong_count(&event);
-    crate::event_sink::NoopRibEventSink.publish_route_event_shared(&event);
-    assert_eq!(Arc::strong_count(&event), before);
 }
 
 async fn subscribe_events(

--- a/crates/rib/src/manager/tests/evpn.rs
+++ b/crates/rib/src/manager/tests/evpn.rs
@@ -2043,13 +2043,9 @@ async fn subscribe_evpn_events(
 struct SharedEvpnCapture(std::sync::Mutex<Option<Arc<crate::event::EvpnRouteEvent>>>);
 
 impl crate::event_sink::RibEventSink for SharedEvpnCapture {
-    fn publish_route_event(&self, _event: &crate::event::RouteEvent) {}
+    fn publish_route_event(&self, _event: &Arc<crate::event::RouteEvent>) {}
 
-    fn publish_evpn_event(&self, _event: &crate::event::EvpnRouteEvent) {
-        panic!("manager must use the shared EVPN-event path")
-    }
-
-    fn publish_evpn_event_shared(&self, event: &Arc<crate::event::EvpnRouteEvent>) {
+    fn publish_evpn_event(&self, event: &Arc<crate::event::EvpnRouteEvent>) {
         *self.0.lock().unwrap() = Some(Arc::clone(event));
     }
 }


### PR DESCRIPTION
## Summary

- collapse the unpublished `RibEventSink` trait to the Arc-only contract already used by production
- remove borrowed-event clone adapters and duplicate no-op/EHM methods
- delete the synthetic legacy compatibility sink while retaining Arc-identity and event-history behavior coverage

This is an internal deletion-only simplification. Event ordering, broadcast, queue/drop/degraded metrics, conversion, and shutdown behavior are unchanged.

## Scope

- five files
- 25 additions, 104 deletions (net -79)
- no workflow, dependency, proto, metric, public operator behavior, documentation, changelog, or roadmap changes

Both affected crates are unpublished, and repository documentation refers only to the trait generically, so no compatibility or user-facing documentation update is required.

Closes LAN-1066.

## Verification

- `cargo test -p rustbgpd-rib manager::tests::events_metrics`
- `cargo test -p rustbgpd-rib manager::tests::evpn::evpn_history_and_live_broadcast_share_arc`
- `cargo test -p rustbgpd-api event_history_sinks`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo +1.95 check --workspace --all-targets --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- `git diff --check`
