### PR TITLE
Restore wire README freshness contract

### DIFF
--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -41,6 +41,14 @@ def aggregate_shell(job: str) -> str:
     return "" if match is None else re.sub(r"(?m)^          ", "", match.group(1))
 
 
+def named_step(job: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^      - name: {re.escape(name)}\n(.*?)(?=^      - |\Z)",
+        job,
+    )
+    return "" if match is None else match.group(1)
+
+
 def check(root: Path) -> list[str]:
     text = (root / ".github/workflows/ci.yml").read_text()
     jobs = _jobs(text)
@@ -54,6 +62,20 @@ def check(root: Path) -> list[str]:
             errors.append(f"{command} must exist exactly once in core_tests")
     if 'RUSTDOCFLAGS: "-D warnings"' not in core_tests:
         errors.append("core_tests rustdoc warnings contract drifted")
+
+    wire_step_name = "Wire crate README freshness gate"
+    wire_step = named_step(jobs.get("core", ""), wire_step_name)
+    if text.count(f"- name: {wire_step_name}") != 1 or not wire_step:
+        errors.append("wire README freshness gate must exist exactly once in core")
+    else:
+        for seam in (
+            'git diff "$base"...HEAD -- crates/wire/Cargo.toml \\',
+            'git diff "$base"...HEAD -- crates/wire/README.md \\',
+            r"'^\+version\s*='",
+            "exit 1",
+        ):
+            if seam not in wire_step:
+                errors.append(f"wire README freshness gate missing {seam}")
 
     aggregate = jobs.get("check", "")
     if "if: ${{ always() }}" not in aggregate:

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -44,6 +44,20 @@ class ScaleSplitContractTests(unittest.TestCase):
             ("- run: cargo test --workspace", "- run: true"),
             ("- run: cargo doc --workspace --lib --no-deps", "- run: true"),
             ('RUSTDOCFLAGS: "-D warnings"', 'RUSTDOCFLAGS: ""'),
+            (
+                "- name: Wire crate README freshness gate",
+                "- name: Unchecked wire README",
+            ),
+            (
+                'git diff "$base"...HEAD -- crates/wire/Cargo.toml',
+                'git diff "$base"...HEAD -- crates/wire/README.md',
+            ),
+            (
+                'git diff "$base"...HEAD -- crates/wire/README.md',
+                'git diff "$base"...HEAD -- crates/wire/NOTES.md',
+            ),
+            (r"'^\+version\s*='", r"'^version\s*='"),
+            ("              exit 1", "              true"),
             ("if: ${{ always() }}", "if: ${{ success() }}"),
             (
                 "needs: [v064_validator, core, core_tests, scale_receipts]",


### PR DESCRIPTION
## Summary

- restore a semantic contract for the existing wire crate README freshness gate
- require the gate exactly once in `core`, including the wire version diff, README diff, version-line trigger, and fail-closed exit
- prove each seam is load-bearing with destructive mutation tests

## Verification

- `python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py`
- `python3 scripts/check_ci_scale_split_contract.py`
- adjacent image-primer and public-tracker contract suites and production checkers
- `git diff --check`
- repository commit and push hooks

## Scope

This adds no workflow, job, dependency, body hash, or step-name prose mirror beyond the existing operational step name. It restores the semantic coverage lost when the old hash-based checker was simplified.

Linear: LAN-1069
