### PR TITLE
Document ORR-aware peer explain behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Make peer-scoped `rbgp rib --prefix … --explain --explain-peer …` mirror
+  live ORR selection. ORR clients now show their per-vantage winner from the
+  reflection-eligible candidate set instead of the global Loc-RIB best, so
+  existing explain output can intentionally change; global and non-ORR scopes
+  retain their prior selection behavior. The effective vantage is exposed in
+  the additive `ExplainBestPathResponse.orr_vantage` field. (LAN-1068)
+
 - Apply the existing ORR topology-address validity rules after resolving
   `orr_vantage = "peer_address"`, so a derived unspecified, loopback, or local
   reflector `router_id` is rejected. Empty human `rbgp orr` output now


### PR DESCRIPTION
## Summary

- record that peer-scoped explain now selects an ORR client's per-vantage winner from reflection-eligible candidates
- call out that existing explain output can intentionally change for ORR clients
- preserve the documented compatibility boundary: global and non-ORR scopes retain their prior selection behavior, while the response field is additive

This is the release-note follow-up to #1721. The implementation and detailed operator guide are already merged.

## Verification

- `python3 scripts/check_public_tracker_ids.py`
- `python3 scripts/check-v1-stable-surface.py`
- `git diff --check`
- repository commit and push hooks

Linear: LAN-1068
