### PR TITLE
Batch event-history commit metrics

### DIFF
--- a/crates/api/src/event_history_sinks.rs
+++ b/crates/api/src/event_history_sinks.rs
@@ -430,7 +430,13 @@ fn event_type_label(e: &proto::BgpEvent) -> String {
 fn afi_safi_label(v: i32) -> Option<String> {
     match proto::AddressFamily::try_from(v).ok()? {
         proto::AddressFamily::Unspecified => None,
-        af => Some(af.as_str_name().to_lowercase()),
+        proto::AddressFamily::Ipv4Unicast => Some("address_family_ipv4_unicast".to_string()),
+        proto::AddressFamily::Ipv6Unicast => Some("address_family_ipv6_unicast".to_string()),
+        proto::AddressFamily::Ipv4Flowspec => Some("address_family_ipv4_flowspec".to_string()),
+        proto::AddressFamily::Ipv6Flowspec => Some("address_family_ipv6_flowspec".to_string()),
+        proto::AddressFamily::L2vpnEvpn => Some("address_family_l2vpn_evpn".to_string()),
+        proto::AddressFamily::BgpLs => Some("address_family_bgp_ls".to_string()),
+        proto::AddressFamily::BgpLsVpn => Some("address_family_bgp_ls_vpn".to_string()),
     }
 }
 
@@ -540,6 +546,40 @@ mod tests {
             .map_or(0, |value| {
                 value.trim().parse().expect("drop counter is integral")
             })
+    }
+
+    #[test]
+    fn afi_safi_labels_preserve_exact_stored_values() {
+        let cases = [
+            (
+                proto::AddressFamily::Ipv4Unicast,
+                "address_family_ipv4_unicast",
+            ),
+            (
+                proto::AddressFamily::Ipv6Unicast,
+                "address_family_ipv6_unicast",
+            ),
+            (
+                proto::AddressFamily::Ipv4Flowspec,
+                "address_family_ipv4_flowspec",
+            ),
+            (
+                proto::AddressFamily::Ipv6Flowspec,
+                "address_family_ipv6_flowspec",
+            ),
+            (proto::AddressFamily::L2vpnEvpn, "address_family_l2vpn_evpn"),
+            (proto::AddressFamily::BgpLs, "address_family_bgp_ls"),
+            (proto::AddressFamily::BgpLsVpn, "address_family_bgp_ls_vpn"),
+        ];
+
+        for (family, expected) in cases {
+            assert_eq!(afi_safi_label(family as i32).as_deref(), Some(expected));
+        }
+        assert_eq!(
+            afi_safi_label(proto::AddressFamily::Unspecified as i32),
+            None
+        );
+        assert_eq!(afi_safi_label(i32::MAX), None);
     }
 
     /// Payload-byte stability pin (LAN-393): the off-actor envelope

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -465,8 +465,22 @@ fn record_append_metrics(
     outcome: &storage::AppendOutcome,
 ) {
     if let Some(metrics) = metrics {
+        let mut committed_by_category = [0_u64; Category::ALL.len()];
         for env in envelopes {
-            metrics.record_event_outbox_committed(env.category.as_str());
+            let index = match env.category {
+                Category::Route => 0,
+                Category::Evpn => 1,
+                Category::Session => 2,
+                Category::Policy => 3,
+                Category::Bfd => 4,
+                Category::Dataplane => 5,
+            };
+            committed_by_category[index] += 1;
+        }
+        for (category, count) in Category::ALL.into_iter().zip(committed_by_category) {
+            if count > 0 {
+                metrics.record_event_outbox_committed_by(category.as_str(), count);
+            }
         }
         metrics.set_event_outbox_latest_event_id(
             i64::try_from(outcome.new_high_water).unwrap_or(i64::MAX),
@@ -1362,6 +1376,119 @@ mod tests {
             payload_codec: PayloadCodec::Opaque,
             payload: vec![value],
         }
+    }
+
+    fn metric_value(metrics: &BgpMetrics, family_name: &str, category: &str) -> Option<f64> {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == family_name)?
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "category" && label.value() == category)
+            })
+            .map(|metric| metric.get_counter().value())
+    }
+
+    fn gauge_value(metrics: &BgpMetrics, family_name: &str) -> f64 {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == family_name)
+            .unwrap()
+            .get_metric()[0]
+            .get_gauge()
+            .value()
+    }
+
+    #[test]
+    fn append_metrics_batch_committed_counts_by_category() {
+        let metrics = BgpMetrics::new();
+        let empty_outcome = storage::AppendOutcome {
+            assigned_ids: Vec::new(),
+            new_high_water: 7,
+            daemon_boot_id: Arc::from("test-boot"),
+            db_size_bytes: 800,
+        };
+        record_append_metrics(Some(&metrics), &[], &empty_outcome);
+        assert_eq!(
+            metric_value(&metrics, "bgp_event_outbox_committed_total", "route"),
+            None
+        );
+        assert_eq!(
+            gauge_value(&metrics, "bgp_event_outbox_latest_event_id"),
+            7.0
+        );
+        assert_eq!(
+            gauge_value(&metrics, "bgp_event_outbox_db_size_bytes"),
+            800.0
+        );
+
+        let envelopes = [
+            Arc::new(event(Category::Route, 1)),
+            Arc::new(event(Category::Policy, 2)),
+            Arc::new(event(Category::Route, 3)),
+            Arc::new(event(Category::Evpn, 4)),
+            Arc::new(event(Category::Policy, 5)),
+            Arc::new(event(Category::Policy, 6)),
+        ];
+        let first_outcome = storage::AppendOutcome {
+            assigned_ids: vec![8, 9, 10, 11, 12, 13],
+            new_high_water: 13,
+            daemon_boot_id: Arc::from("test-boot"),
+            db_size_bytes: 1_600,
+        };
+        record_append_metrics(Some(&metrics), &envelopes, &first_outcome);
+        assert_eq!(
+            metric_value(&metrics, "bgp_event_outbox_committed_total", "route"),
+            Some(2.0)
+        );
+        assert_eq!(
+            metric_value(&metrics, "bgp_event_outbox_committed_total", "evpn"),
+            Some(1.0)
+        );
+        assert_eq!(
+            metric_value(&metrics, "bgp_event_outbox_committed_total", "policy"),
+            Some(3.0)
+        );
+        assert_eq!(
+            metric_value(&metrics, "bgp_event_outbox_committed_total", "bfd"),
+            None
+        );
+
+        let repeated = [
+            Arc::new(event(Category::Route, 7)),
+            Arc::new(event(Category::Session, 8)),
+        ];
+        let repeated_outcome = storage::AppendOutcome {
+            assigned_ids: vec![14, 15],
+            new_high_water: 15,
+            daemon_boot_id: Arc::from("test-boot"),
+            db_size_bytes: 2_400,
+        };
+        record_append_metrics(Some(&metrics), &repeated, &repeated_outcome);
+        assert_eq!(
+            metric_value(&metrics, "bgp_event_outbox_committed_total", "route"),
+            Some(3.0)
+        );
+        assert_eq!(
+            metric_value(&metrics, "bgp_event_outbox_committed_total", "session"),
+            Some(1.0)
+        );
+        assert_eq!(
+            gauge_value(&metrics, "bgp_event_outbox_latest_event_id"),
+            15.0
+        );
+        assert_eq!(
+            gauge_value(&metrics, "bgp_event_outbox_db_size_bytes"),
+            2_400.0
+        );
     }
 
     async fn wait_for_store(store: &storage::StoreHandle, op: storage::TestStoreOp) {

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -203,6 +203,17 @@ impl Category {
         Self::Dataplane,
     ];
 
+    const fn index(self) -> usize {
+        match self {
+            Self::Route => 0,
+            Self::Evpn => 1,
+            Self::Session => 2,
+            Self::Policy => 3,
+            Self::Bfd => 4,
+            Self::Dataplane => 5,
+        }
+    }
+
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -467,17 +478,10 @@ fn record_append_metrics(
     if let Some(metrics) = metrics {
         let mut committed_by_category = [0_u64; Category::ALL.len()];
         for env in envelopes {
-            let index = match env.category {
-                Category::Route => 0,
-                Category::Evpn => 1,
-                Category::Session => 2,
-                Category::Policy => 3,
-                Category::Bfd => 4,
-                Category::Dataplane => 5,
-            };
-            committed_by_category[index] += 1;
+            committed_by_category[env.category.index()] += 1;
         }
-        for (category, count) in Category::ALL.into_iter().zip(committed_by_category) {
+        for category in Category::ALL {
+            let count = committed_by_category[category.index()];
             if count > 0 {
                 metrics.record_event_outbox_committed_by(category.as_str(), count);
             }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -4604,6 +4604,9 @@ impl BgpMetrics {
     /// Bulk version of [`Self::record_event_outbox_committed`] for a
     /// committed batch containing `count` events in the same category.
     pub fn record_event_outbox_committed_by(&self, category: &str, count: u64) {
+        if count == 0 {
+            return;
+        }
         self.0
             .event_outbox_committed
             .with_label_values(&[category])
@@ -4823,7 +4826,7 @@ mod jemalloc_stats {
 mod tests {
     use std::net::Ipv4Addr;
 
-    use prometheus::Encoder;
+    use prometheus::{Encoder, core::Collector};
 
     use super::*;
 
@@ -4965,6 +4968,7 @@ mod tests {
     fn event_outbox_committed_single_and_bulk_paths_are_additive() {
         let metrics = BgpMetrics::new();
 
+        metrics.record_event_outbox_committed_by("session", 0);
         metrics.record_event_outbox_committed("route");
         metrics.record_event_outbox_committed_by("route", 4);
         metrics.record_event_outbox_committed_by("evpn", 3);
@@ -4984,6 +4988,18 @@ mod tests {
                 .with_label_values(&["evpn"])
                 .get(),
             3
+        );
+        assert!(
+            !metrics
+                .0
+                .event_outbox_committed
+                .collect()
+                .iter()
+                .any(|family| family
+                    .get_metric()
+                    .iter()
+                    .flat_map(prometheus::proto::Metric::get_label)
+                    .any(|label| label.value() == "session"))
         );
 
         let isolated = BgpMetrics::new();

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -4596,13 +4596,18 @@ impl BgpMetrics {
 
     // ── Event history outbox (ADR-0072) ─────────────────────────
 
-    /// Record a successful durable commit. Called by EHM after each
-    /// committed batch, once per event in the batch.
+    /// Record one successful durable commit.
     pub fn record_event_outbox_committed(&self, category: &str) {
+        self.record_event_outbox_committed_by(category, 1);
+    }
+
+    /// Bulk version of [`Self::record_event_outbox_committed`] for a
+    /// committed batch containing `count` events in the same category.
+    pub fn record_event_outbox_committed_by(&self, category: &str, count: u64) {
         self.0
             .event_outbox_committed
             .with_label_values(&[category])
-            .inc();
+            .inc_by(count);
     }
 
     /// Record an outbox drop or cursor-delivery skip. `reason` is
@@ -4631,8 +4636,8 @@ impl BgpMetrics {
             .inc_by(count);
     }
 
-    /// Update the per-category queue depth gauge. EHM calls this
-    /// from the actor loop after each batch drain.
+    /// Update the per-category queue depth gauge. EHM calls this on
+    /// enqueue/dequeue and when initializing or reconciling lifecycle state.
     pub fn set_event_outbox_queue_depth(&self, category: &str, depth: i64) {
         let Some(index) = EVENT_OUTBOX_QUEUE_DEPTH_CATEGORIES
             .iter()
@@ -4954,6 +4959,42 @@ mod tests {
         let metrics = BgpMetrics::new();
         assert!(metrics.0.event_outbox_queue_depth_fixed.get().is_none());
         assert!(event_outbox_queue_depths(&metrics).is_empty());
+    }
+
+    #[test]
+    fn event_outbox_committed_single_and_bulk_paths_are_additive() {
+        let metrics = BgpMetrics::new();
+
+        metrics.record_event_outbox_committed("route");
+        metrics.record_event_outbox_committed_by("route", 4);
+        metrics.record_event_outbox_committed_by("evpn", 3);
+
+        assert_eq!(
+            metrics
+                .0
+                .event_outbox_committed
+                .with_label_values(&["route"])
+                .get(),
+            5
+        );
+        assert_eq!(
+            metrics
+                .0
+                .event_outbox_committed
+                .with_label_values(&["evpn"])
+                .get(),
+            3
+        );
+
+        let isolated = BgpMetrics::new();
+        assert_eq!(
+            isolated
+                .0
+                .event_outbox_committed
+                .with_label_values(&["route"])
+                .get(),
+            0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace per-event protobuf enum lowercasing with an exhaustive exact label mapping
- tally durable commits by category and increment each metric child once per nonempty category in a batch
- retain the single-event telemetry method as a compatibility delegator
- correct the queue-depth setter comment to cover enqueue, dequeue, initialization, and lifecycle reconciliation

Persisted labels, metric names, and metric totals are unchanged. This makes no daemon RSS or latency claim.

## Verification

- focused API, event-history, and telemetry tests
- strict workspace Clippy
- locked full workspace tests
- Rust 1.95 all-target/all-feature check
- warning-denied workspace library docs
- fmt and diff checks

Linear: LAN-1060