### PR TITLE
Clarify Birdwatcher snapshot consistency

### DIFF
--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -170,11 +170,11 @@ the real decision. Precisely what the view contains:
 makes one `ExplainAdvertisedRoute` call per suppressed prefix. Each paged
 snapshot is version-fenced independently: concurrent churn within either walk
 can fail the request rather than mix generations in that snapshot, so clients
-should retry a 502. The two snapshots are not fenced to the same generation,
-however, so churn between them can make the diff incomplete. The per-prefix
-`ExplainAdvertisedRoute` re-check drops candidates that would be advertised,
-so the race cannot fabricate a "not exported" claim; the re-check cannot
-recover a route omitted by the cross-snapshot diff.
+should retry the request when it returns a 502. The two snapshots are not fenced
+to the same generation, however, so churn between them can make the diff
+incomplete. The per-prefix `ExplainAdvertisedRoute` re-check drops candidates
+that would be advertised, so the race cannot fabricate a "not exported" claim;
+the re-check cannot recover a route omitted by the cross-snapshot diff.
 Alice-LG's `[noexport] load_on_demand` (its default) fits this — the view is
 only computed when an operator opens it. Do not poll it as a metrics endpoint;
 for very large or fast-changing Loc-RIBs, use a caching proxy and expect the

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -167,9 +167,14 @@ the real decision. Precisely what the view contains:
   it never fabricates a "not exported" claim.
 
 **Cost:** each request pages the complete Loc-RIB and peer Adj-RIB-Out, then
-makes one `ExplainAdvertisedRoute` call per suppressed prefix. Both paged
-snapshots are version-fenced: concurrent table churn can fail the request
-rather than return a mixed-generation answer, so clients should retry a 502.
+makes one `ExplainAdvertisedRoute` call per suppressed prefix. Each paged
+snapshot is version-fenced independently: concurrent churn within either walk
+can fail the request rather than mix generations in that snapshot, so clients
+should retry a 502. The two snapshots are not fenced to the same generation,
+however, so churn between them can make the diff incomplete. The per-prefix
+`ExplainAdvertisedRoute` re-check drops candidates that would be advertised,
+so the race cannot fabricate a "not exported" claim; the re-check cannot
+recover a route omitted by the cross-snapshot diff.
 Alice-LG's `[noexport] load_on_demand` (its default) fits this — the view is
 only computed when an operator opens it. Do not poll it as a metrics endpoint;
 for very large or fast-changing Loc-RIBs, use a caching proxy and expect the


### PR DESCRIPTION
## Summary

- clarify that each paged snapshot used by the Birdwatcher noexport view is independently generation-fenced
- document that the two snapshots are not fenced to the same generation, so churn between them can make the diff incomplete
- explain that the per-prefix `ExplainAdvertisedRoute` re-check prevents a false "not exported" claim but cannot recover a route omitted by the diff

## Impact

Documentation only. Runtime behavior, APIs, CI, the changelog, and the roadmap are unchanged.

Tracks LAN-953.

## Validation

- `git diff --check`
- `python3 scripts/test_check_release_install_contract.py` (13 tests passed)
- `python3 scripts/check_release_install_contract.py`
- repository commit and pre-push hooks
