### PR TITLE
Prefilter incremental ASPA revalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Incremental ASPA cache updates now carry their exact changed customer-ASN
+  set into the RIB. The manager still scans every admitted route, but avoids
+  detailed ASPA verification for AS paths disjoint from that set; first,
+  full-snapshot, and server-loss updates retain full revalidation. Completion
+  logs distinguish full and delta modes and summarize invalid hops only among
+  routes actually revalidated. This is an avoided-work improvement with the
+  same route-selection outcomes, not an asymptotic or wall-clock claim.
+  (LAN-1059)
+
 - Make peer-scoped `rbgp rib --prefix … --explain --explain-peer …` mirror
   live ORR selection. ORR clients now show their per-vantage winner from the
   reflection-eligible candidate set instead of the global Loc-RIB best, so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ version = "0.65.0"
 dependencies = [
  "criterion",
  "rustbgpd-wire",
+ "rustc-hash 2.1.3",
  "smallvec",
  "thiserror 2.0.20",
  "tokio",

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1084,6 +1084,7 @@ name = "rustbgpd-rpki"
 version = "0.65.0"
 dependencies = [
  "rustbgpd-wire",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.20",
  "tokio",

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -385,7 +385,20 @@ impl RibManager {
         );
     }
 
-    pub(super) fn handle_aspa_cache_update(&mut self, table: Arc<rustbgpd_rpki::AspaTable>) {
+    pub(super) fn handle_aspa_cache_update(
+        &mut self,
+        table: Arc<rustbgpd_rpki::AspaTable>,
+        delta: Option<rustc_hash::FxHashSet<u32>>,
+    ) {
+        let started = std::time::Instant::now();
+        // Delta filtering requires a previously distributed state baseline.
+        // The first update must repair every route, even if tagged incremental.
+        let delta = if self.aspa_table.is_some() {
+            delta
+        } else {
+            None
+        };
+        let mode = if delta.is_some() { "delta" } else { "full" };
         self.aspa_table = Some(table);
         let Some(table) = self.aspa_table.as_ref() else {
             return;
@@ -395,11 +408,23 @@ impl RibManager {
 
         let mut affected = HashSet::new();
         let mut routes_scanned = 0_u64;
+        let mut routes_revalidated = 0_u64;
         let mut changed_routes = 0_u64;
         let mut invalid_hops = AspaInvalidHopSummary::default();
         for rib in self.ribs.values_mut() {
             for route in rib.iter_mut() {
                 routes_scanned += 1;
+                // A table update can affect a verdict only when its customer
+                // ASN occurs in the route's AS_SEQUENCE or AS_SET. We still
+                // scan every route; the delta avoids only detailed validation.
+                if delta.as_ref().is_some_and(|changed| {
+                    route
+                        .as_path()
+                        .is_none_or(|path| path.asns().all(|asn| !changed.contains(&asn)))
+                }) {
+                    continue;
+                }
+                routes_revalidated += 1;
                 let result = validate_route_aspa_detailed(route, table);
                 if let Some(hop) = result.invalid_hop {
                     invalid_hops.observe(hop);
@@ -418,12 +443,15 @@ impl RibManager {
         }
         info!(
             records,
+            mode,
             routes_scanned,
+            routes_revalidated,
             changed_routes,
             affected_prefixes = affected.len(),
             invalid_hop_routes = invalid_hops.routes,
             suppressed_routes = invalid_hops.suppressed_routes,
             invalid_hops = %invalid_hops.render(),
+            elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
             "ASPA cache update re-validation complete"
         );
     }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2368,7 +2368,12 @@ impl RibManager {
             RibUpdate::RpkiCacheUpdate { table, delta } => {
                 self.handle_rpki_cache_update(table, delta);
             }
-            RibUpdate::AspaTableUpdate { table } => self.handle_aspa_cache_update(table),
+            RibUpdate::AspaTableUpdate {
+                table,
+                changed_customer_asns,
+            } => {
+                self.handle_aspa_cache_update(table, changed_customer_asns);
+            }
             RibUpdate::InjectFlowSpec { route, reply } => self.handle_inject_flowspec(route, reply),
             RibUpdate::WithdrawFlowSpec { key, reply } => {
                 let retired = ExactExportKey::FlowSpec(key.clone());

--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -43,6 +43,10 @@ fn aspa_invalid_hop_summary_keeps_smallest_pairs_and_exact_suppression() {
 
 /// Red proof: deleting/splitting the event or skipping unchanged Invalid breaks exact fields.
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "single-subscriber event fixture asserts the complete bounded log contract"
+)]
 fn aspa_cache_update_emits_one_bounded_completion_event() {
     use std::collections::BTreeMap;
     use std::sync::{Arc as StdArc, Mutex};
@@ -56,6 +60,9 @@ fn aspa_cache_update_emits_one_bounded_completion_event() {
     struct Fields(BTreeMap<String, String>);
     impl Visit for Fields {
         fn record_u64(&mut self, field: &Field, value: u64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_str(&mut self, field: &Field, value: &str) {
             self.0.insert(field.name().to_string(), value.to_string());
         }
         fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
@@ -104,6 +111,7 @@ fn aspa_cache_update_emits_one_bounded_completion_event() {
     manager.ribs.insert(peer, rib);
 
     let captured = StdArc::new(Mutex::new(Vec::new()));
+    manager.aspa_table = Some(Arc::new(AspaTable::new(vec![])));
     let table = Arc::new(AspaTable::new(vec![
         AspaRecord {
             customer_asn: 65003,
@@ -127,11 +135,11 @@ fn aspa_cache_update_emits_one_bounded_completion_event() {
         // so the measured call cannot lose that race afterwards.
         let (_warm_tx, warm_rx) = mpsc::channel(1);
         let mut warm = RibManager::new(warm_rx, dummy_query_rx(), None, None, BgpMetrics::new());
-        warm.handle_aspa_cache_update(Arc::clone(&table));
+        warm.handle_aspa_cache_update(Arc::clone(&table), None);
         tracing::callsite::rebuild_interest_cache();
         captured.lock().unwrap().clear();
 
-        manager.handle_aspa_cache_update(table);
+        manager.handle_aspa_cache_update(table, Some(rustc_hash::FxHashSet::from_iter([65003])));
     });
 
     // Count *the* completion event, not this thread's global event volume.
@@ -149,18 +157,319 @@ fn aspa_cache_update_emits_one_bounded_completion_event() {
     let fields = &events[0].0;
     for (name, value) in [
         ("records", "2"),
+        ("mode", "delta"),
         ("routes_scanned", "2"),
+        ("routes_revalidated", "1"),
         ("changed_routes", "1"),
         ("affected_prefixes", "1"),
-        ("invalid_hop_routes", "2"),
+        ("invalid_hop_routes", "1"),
         ("suppressed_routes", "0"),
     ] {
         assert_eq!(fields.get(name).map(String::as_str), Some(value), "{name}");
     }
     assert_eq!(
         fields.get("invalid_hops").map(String::as_str),
-        Some("65003>65002:1, 65005>65004:1")
+        Some("65003>65002:1")
     );
+    assert!(fields.contains_key("elapsed_ms"));
+}
+
+#[test]
+fn aspa_delta_revalidates_only_intersecting_paths_across_segments() {
+    use rustbgpd_rpki::AspaTable;
+    use rustbgpd_wire::AspaValidation;
+
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let paths = [
+        vec![65010, 65100],
+        vec![65101, 65010, 65102],
+        vec![65103, 65010],
+        vec![65200, 65201],
+    ];
+    let mut rib = crate::adj_rib_in::AdjRibIn::new(peer);
+    for (octet, path) in (1_u8..).zip(paths) {
+        let mut route = make_route_with_as_path(
+            Ipv4Prefix::new(Ipv4Addr::new(10, 0, octet, 0), 24),
+            Ipv4Addr::new(192, 0, 2, 1),
+            path,
+        );
+        route.aspa_state = AspaValidation::Valid;
+        rib.insert(route);
+    }
+    let mut as_set = make_route_with_as_path(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 0, 5, 0), 24),
+        Ipv4Addr::new(192, 0, 2, 1),
+        vec![],
+    );
+    as_set.attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSet(vec![65010, 65300])],
+        }),
+    ]);
+    as_set.aspa_state = AspaValidation::Valid;
+    rib.insert(as_set);
+    manager.ribs.insert(peer, rib);
+    manager.aspa_table = Some(Arc::new(AspaTable::new(vec![])));
+
+    manager.handle_aspa_cache_update(
+        Arc::new(AspaTable::new(vec![])),
+        Some(rustc_hash::FxHashSet::from_iter([65010])),
+    );
+
+    let states: Vec<_> = manager.ribs[&peer]
+        .iter()
+        .map(|route| route.aspa_state)
+        .collect();
+    assert_eq!(
+        states
+            .iter()
+            .filter(|state| **state == AspaValidation::Unknown)
+            .count(),
+        3
+    );
+    assert_eq!(
+        states
+            .iter()
+            .filter(|state| **state == AspaValidation::Invalid)
+            .count(),
+        1
+    );
+    assert_eq!(
+        states
+            .iter()
+            .filter(|state| **state == AspaValidation::Valid)
+            .count(),
+        1
+    );
+    assert_eq!(
+        manager.ribs[&peer]
+            .iter()
+            .find(
+                |route| route.prefix == Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 4, 0), 24))
+            )
+            .unwrap()
+            .aspa_state,
+        AspaValidation::Valid,
+        "disjoint poison proves the route was scanned but not revalidated"
+    );
+}
+
+#[test]
+fn aspa_first_delta_forces_full_rescan() {
+    use rustbgpd_rpki::AspaTable;
+    use rustbgpd_wire::AspaValidation;
+
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+    let mut route = make_route_with_as_path(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 24),
+        Ipv4Addr::new(192, 0, 2, 2),
+        vec![65100, 65101],
+    );
+    route.aspa_state = AspaValidation::Valid;
+    let mut rib = crate::adj_rib_in::AdjRibIn::new(peer);
+    rib.insert(route);
+    manager.ribs.insert(peer, rib);
+
+    manager.handle_aspa_cache_update(
+        Arc::new(AspaTable::new(vec![])),
+        Some(rustc_hash::FxHashSet::from_iter([65010])),
+    );
+    assert_eq!(
+        manager.ribs[&peer].iter().next().unwrap().aspa_state,
+        AspaValidation::Unknown
+    );
+}
+
+#[test]
+fn aspa_none_forces_full_rescan() {
+    use rustbgpd_rpki::AspaTable;
+    use rustbgpd_wire::AspaValidation;
+
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 3));
+    let mut route = make_route_with_as_path(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 2, 0, 0), 24),
+        Ipv4Addr::new(192, 0, 2, 3),
+        vec![65100, 65101],
+    );
+    route.aspa_state = AspaValidation::Valid;
+    let mut rib = crate::adj_rib_in::AdjRibIn::new(peer);
+    rib.insert(route);
+    manager.ribs.insert(peer, rib);
+    manager.aspa_table = Some(Arc::new(AspaTable::new(vec![])));
+
+    manager.handle_aspa_cache_update(Arc::new(AspaTable::new(vec![])), None);
+    assert_eq!(
+        manager.ribs[&peer].iter().next().unwrap().aspa_state,
+        AspaValidation::Unknown
+    );
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one differential fixture keeps the 40-step state-machine oracle auditable"
+)]
+fn aspa_delta_matches_full_rescan_on_deterministic_sequences() {
+    use rustbgpd_rpki::{AspaRecord, AspaTable};
+
+    fn fixture_manager() -> RibManager {
+        let (_tx, rx) = mpsc::channel(1);
+        let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+        for peer_octet in [10_u8, 11] {
+            let peer = Ipv4Addr::new(192, 0, 2, peer_octet);
+            let mut routes = vec![
+                make_route_with_as_path(
+                    Ipv4Prefix::new(Ipv4Addr::new(10, 3, 1, 0), 24),
+                    peer,
+                    vec![65001, 65002],
+                ),
+                make_route_with_as_path(
+                    Ipv4Prefix::new(Ipv4Addr::new(10, 3, 2, 0), 24),
+                    peer,
+                    vec![65003, 65004, 65004],
+                ),
+                make_route_with_as_path(
+                    Ipv4Prefix::new(Ipv4Addr::new(10, 3, 3, 0), 24),
+                    peer,
+                    vec![],
+                ),
+                make_route_with_as_path(
+                    Ipv4Prefix::new(Ipv4Addr::new(10, 3, 4, 0), 24),
+                    peer,
+                    vec![],
+                ),
+                make_route_with_as_path(
+                    Ipv4Prefix::new(Ipv4Addr::new(10, 3, 5, 0), 24),
+                    peer,
+                    vec![65006, 65007],
+                ),
+                make_route_with_as_path(
+                    Ipv4Prefix::new(Ipv4Addr::new(10, 3, 6, 0), 24),
+                    peer,
+                    vec![65008, 65009, 65010],
+                ),
+            ];
+            routes[2].attributes = Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![
+                        AsPathSegment::AsSequence(vec![65005]),
+                        AsPathSegment::AsSet(vec![65006, 65007]),
+                    ],
+                }),
+            ]);
+            routes[3].attributes = Arc::new(vec![PathAttribute::Origin(Origin::Igp)]);
+            routes[4].origin_type = crate::route::RouteOrigin::Ibgp;
+            manager.handle_update(RibUpdate::RoutesReceived {
+                session_id: 0,
+                peer: IpAddr::V4(peer),
+                announced: routes,
+                withdrawn: vec![],
+                flowspec_announced: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_announced: vec![],
+                evpn_withdrawn: vec![],
+            });
+        }
+        manager
+    }
+
+    fn snapshot(manager: &RibManager) -> (Vec<String>, Vec<String>) {
+        let mut adj: Vec<_> = manager
+            .ribs
+            .iter()
+            .flat_map(|(peer, rib)| {
+                rib.iter().map(move |route| {
+                    format!(
+                        "{peer}|{}|{}|{:?}",
+                        route.prefix, route.path_id, route.aspa_state
+                    )
+                })
+            })
+            .collect();
+        let mut loc: Vec<_> = manager
+            .loc_rib
+            .iter()
+            .map(|route| {
+                format!(
+                    "{}|{}|{}|{:?}",
+                    route.prefix, route.peer, route.path_id, route.aspa_state
+                )
+            })
+            .collect();
+        adj.sort_unstable();
+        loc.sort_unstable();
+        (adj, loc)
+    }
+
+    fn table(records: &BTreeMap<u32, Vec<u32>>) -> Arc<AspaTable> {
+        Arc::new(AspaTable::new(
+            records
+                .iter()
+                .map(|(customer_asn, provider_asns)| AspaRecord {
+                    customer_asn: *customer_asn,
+                    provider_asns: provider_asns.clone(),
+                })
+                .collect(),
+        ))
+    }
+
+    let mut delta_manager = fixture_manager();
+    let mut full_manager = fixture_manager();
+    let mut records = BTreeMap::new();
+    records.insert(65002, vec![65001]);
+    let mut current = table(&records);
+    delta_manager.handle_aspa_cache_update(Arc::clone(&current), None);
+    full_manager.handle_aspa_cache_update(Arc::clone(&current), None);
+    assert_eq!(snapshot(&delta_manager), snapshot(&full_manager));
+
+    let mut distributed = 0;
+    let mut suppressed = 0;
+    for step in 0_u32..40 {
+        let customer = 65001 + (step % 10);
+        match step % 5 {
+            0 => {
+                records.insert(customer, vec![66000 + (step % 3)]);
+            }
+            1 => {
+                records.insert(customer, vec![66000, 66001]);
+            }
+            2 => {
+                records.remove(&customer);
+            }
+            3 => {
+                records.insert(customer, vec![66001, 66002]);
+            }
+            _ => {}
+        }
+        let next = table(&records);
+        if *next == *current {
+            suppressed += 1;
+            continue;
+        }
+        delta_manager.handle_aspa_cache_update(
+            Arc::clone(&next),
+            Some(rustc_hash::FxHashSet::from_iter([customer])),
+        );
+        full_manager.handle_aspa_cache_update(Arc::clone(&next), None);
+        current = next;
+        distributed += 1;
+        assert_eq!(
+            snapshot(&delta_manager),
+            snapshot(&full_manager),
+            "diverged at deterministic step {step}"
+        );
+    }
+    assert_eq!(distributed + suppressed, 40);
+    assert!(distributed > 0);
+    assert!(suppressed >= 4);
 }
 
 #[test]
@@ -596,9 +905,12 @@ async fn ibgp_aspa_stays_unknown_on_insert_and_cache_revalidation() {
         customer_asn: 65003,
         provider_asns: vec![65002],
     }]));
-    tx.send(RibUpdate::AspaTableUpdate { table: valid_table })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::AspaTableUpdate {
+        table: valid_table,
+        changed_customer_asns: None,
+    })
+    .await
+    .unwrap();
 
     let mut route = make_route_with_as_path(
         Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
@@ -646,6 +958,7 @@ async fn ibgp_aspa_stays_unknown_on_insert_and_cache_revalidation() {
     }]));
     tx.send(RibUpdate::AspaTableUpdate {
         table: invalid_table,
+        changed_customer_asns: None,
     })
     .await
     .unwrap();
@@ -706,7 +1019,12 @@ async fn aspa_cache_update_revalidates_with_stored_downstream_context() {
             provider_asns: vec![65001],
         },
     ]));
-    tx.send(RibUpdate::AspaTableUpdate { table }).await.unwrap();
+    tx.send(RibUpdate::AspaTableUpdate {
+        table,
+        changed_customer_asns: None,
+    })
+    .await
+    .unwrap();
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::QueryReceivedRoutes {

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2232,8 +2232,10 @@ pub enum RibUpdate {
     AspaTableUpdate {
         /// The new ASPA table snapshot.
         table: Arc<AspaTable>,
-        /// Customer ASNs changed by an incremental RTR update. `None` forces
-        /// a full revalidation, including the first table, full sync, and server loss.
+        /// Customer ASNs changed by an incremental RTR update. `Some` supplies
+        /// scope usable only when a prior distributed ASPA baseline exists.
+        /// `None` requests full revalidation. The first installed table always
+        /// revalidates fully regardless of this payload.
         changed_customer_asns: Option<rustc_hash::FxHashSet<u32>>,
     },
     /// Inject a locally-originated `FlowSpec` route.

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2232,6 +2232,9 @@ pub enum RibUpdate {
     AspaTableUpdate {
         /// The new ASPA table snapshot.
         table: Arc<AspaTable>,
+        /// Customer ASNs changed by an incremental RTR update. `None` forces
+        /// a full revalidation, including the first table, full sync, and server loss.
+        changed_customer_asns: Option<rustc_hash::FxHashSet<u32>>,
     },
     /// Inject a locally-originated `FlowSpec` route.
     InjectFlowSpec {

--- a/crates/rpki/Cargo.toml
+++ b/crates/rpki/Cargo.toml
@@ -17,6 +17,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+rustc-hash.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use rustc_hash::FxHashSet;
 use tokio::sync::mpsc;
 use tracing::{debug, info};
 
@@ -39,6 +40,9 @@ pub struct RpkiTableUpdate {
 pub struct AspaTableUpdate {
     /// The new merged ASPA table snapshot.
     pub table: Arc<AspaTable>,
+    /// Customer ASNs announced or withdrawn by an RTR incremental update.
+    /// `None` requires a full revalidation (full snapshot or server loss).
+    pub changed_customer_asns: Option<FxHashSet<u32>>,
 }
 
 /// Merges VRP and ASPA data from multiple RTR cache servers.
@@ -99,7 +103,7 @@ impl VrpManager {
     }
 
     async fn handle_update(&mut self, update: VrpUpdate) {
-        let vrp_delta = match update {
+        let (vrp_delta, changed_customer_asns) = match update {
             VrpUpdate::FullTable {
                 server,
                 entries,
@@ -124,7 +128,7 @@ impl VrpManager {
                 );
                 // A full snapshot replaces the server's whole set — there is
                 // no bounded changed-entry list, so downstream must rescan.
-                None
+                (None, None)
             }
             VrpUpdate::IncrementalUpdate {
                 server,
@@ -164,13 +168,18 @@ impl VrpManager {
                 // customer ASN; an announce replaces the customer's entire
                 // provider set.
                 let aspa_table = self.server_aspa_tables.entry(server).or_default();
+                let changed_customer_asns = aspa_announced
+                    .iter()
+                    .chain(&aspa_withdrawn)
+                    .map(|record| record.customer_asn)
+                    .collect();
                 for w in &aspa_withdrawn {
                     aspa_table.remove(&w.customer_asn);
                 }
                 for a in aspa_announced {
                     aspa_table.insert(a.customer_asn, a.provider_asns);
                 }
-                Some(delta)
+                (Some(delta), Some(changed_customer_asns))
             }
             VrpUpdate::ServerDown { server } => {
                 info!(%server, "cache server down — removing entries");
@@ -179,12 +188,13 @@ impl VrpManager {
                 // ponytail: the removed set IS the exact delta, but server
                 // loss is rare and multi-cache overlap makes it usually a
                 // no-op distribution; wire it through if it ever shows up.
-                None
+                (None, None)
             }
         };
 
         self.rebuild_and_distribute_vrp(vrp_delta).await;
-        self.rebuild_and_distribute_aspa().await;
+        self.rebuild_and_distribute_aspa(changed_customer_asns)
+            .await;
     }
 
     // Full rebuild (clone + sort of every entry) on every update, even a
@@ -226,7 +236,7 @@ impl VrpManager {
             .await;
     }
 
-    async fn rebuild_and_distribute_aspa(&mut self) {
+    async fn rebuild_and_distribute_aspa(&mut self, changed_customer_asns: Option<FxHashSet<u32>>) {
         let Some(ref aspa_tx) = self.aspa_rib_tx else {
             return;
         };
@@ -251,7 +261,12 @@ impl VrpManager {
 
         info!(records = new_table.len(), "ASPA table updated");
         self.current_aspa_table = Arc::clone(&new_table);
-        let _ = aspa_tx.send(AspaTableUpdate { table: new_table }).await;
+        let _ = aspa_tx
+            .send(AspaTableUpdate {
+                table: new_table,
+                changed_customer_asns,
+            })
+            .await;
     }
 
     /// Number of connected cache servers with data.
@@ -471,6 +486,54 @@ mod tests {
 
         let update = aspa_rx.try_recv().unwrap();
         assert_eq!(update.table.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn aspa_update_change_scope_follows_update_kind() {
+        let (_vrp_tx, vrp_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (aspa_tx, mut aspa_rx) = mpsc::channel(16);
+        let mut mgr = VrpManager::new(vrp_rx, rib_tx).with_aspa_tx(aspa_tx);
+
+        mgr.handle_update(VrpUpdate::FullTable {
+            server: server1(),
+            entries: vec![],
+            aspa_records: vec![
+                AspaRecord {
+                    customer_asn: 65001,
+                    provider_asns: vec![65101],
+                },
+                AspaRecord {
+                    customer_asn: 65002,
+                    provider_asns: vec![65102],
+                },
+            ],
+        })
+        .await;
+        assert!(aspa_rx.try_recv().unwrap().changed_customer_asns.is_none());
+
+        mgr.handle_update(VrpUpdate::IncrementalUpdate {
+            server: server1(),
+            announced: vec![],
+            withdrawn: vec![],
+            aspa_announced: vec![AspaRecord {
+                customer_asn: 65001,
+                provider_asns: vec![65111],
+            }],
+            aspa_withdrawn: vec![AspaRecord {
+                customer_asn: 65002,
+                provider_asns: vec![],
+            }],
+        })
+        .await;
+        assert_eq!(
+            aspa_rx.try_recv().unwrap().changed_customer_asns.unwrap(),
+            FxHashSet::from_iter([65001, 65002])
+        );
+
+        mgr.handle_update(VrpUpdate::ServerDown { server: server1() })
+            .await;
+        assert!(aspa_rx.try_recv().unwrap().changed_customer_asns.is_none());
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3620,6 +3620,7 @@ async fn run<T>(
                 let _ = aspa_rib_tx
                     .send(RibUpdate::AspaTableUpdate {
                         table: update.table,
+                        changed_customer_asns: update.changed_customer_asns,
                     })
                     .await;
                 trigger_import_validation_refresh(


### PR DESCRIPTION
## Summary

- carry the exact customer-ASN set from incremental ASPA updates into the RIB
- retain a full RIB scan while skipping detailed validation only for AS paths disjoint from that set
- force full revalidation for the first table, full snapshots, and server loss
- report scanned and revalidated route counts in the bounded completion log
- keep the standalone scale workspace lock in sync with the new direct dependency edge

The deterministic differential proof compares delta filtering with full revalidation and preserves identical Adj-RIB-In ASPA states and Loc-RIB identities across 40 announce, replace, and withdraw steps.

This makes no wall-clock, asymptotic-complexity, or memory-use claim.

## Verification

- focused ASPA update-kind, intersection, first-delta, full-fallback, bounded-log, and 40-step differential tests
- all four locked scale suites, rrtransport strict Clippy and smoke, and enhanced-route-refresh strict Clippy
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps --locked`
- `git diff --check`

LAN-1059
