### PR TITLE
Follow rust-toolchain v1 release line

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           fetch-depth: 0 # full history + tags for `git describe` and the A/B worktrees
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
 
         with:
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
 
         with:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Prove kernel-dataplane bird3 outage tolerance
         run: |
           python3 -m unittest -v scripts/test_kernel_dataplane_bird3_tolerance.py
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -307,7 +307,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
@@ -340,7 +340,7 @@ jobs:
           # test-rrharness-driver resolves a retained pin commit and creates a
           # detached worktree at that exact revision.
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -456,7 +456,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95
+      - uses: dtolnay/rust-toolchain@v1 # 1.95
         with:
           toolchain: "1.95"
       - uses: ./.github/actions/install-protobuf

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,10 +28,9 @@ jobs:
           fi
           echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
           echo "RUSTUP_TOOLCHAIN=$toolchain" >> "$GITHUB_ENV"
-      # `@master` (not a SHA pin like every other action here) is the
-      # form scripts/check_fuzz_toolchain_pin.py sanctions for passing
-      # the reviewed-nightly `toolchain:` input.
-      - uses: dtolnay/rust-toolchain@master
+      # The action implementation follows its `v1` release line; the
+      # independently reviewed nightly is still passed through `toolchain:`.
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ steps.nightly.outputs.toolchain }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -517,7 +517,7 @@ jobs:
 
       - name: Install Rust 1.95 for the direct GET_KEYS receipt
         if: steps.tcp_ao.outputs.supported == 'true'
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95
+        uses: dtolnay/rust-toolchain@v1 # 1.95
         with:
           toolchain: "1.95"
 

--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf

--- a/.github/workflows/update-group-fault.yml
+++ b/.github/workflows/update-group-fault.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -99,9 +99,9 @@ CALL_HASHES = {
 PINS = collections.Counter(
     {
         "actions/checkout@v7": 87,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
+        "dtolnay/rust-toolchain@v1 # stable": 3,
         "Swatinem/rust-cache@v2": 5,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
+        "dtolnay/rust-toolchain@v1 # 1.95": 2,
         "docker/setup-buildx-action@v4": 45,
         "docker/build-push-action@v7": 46,
         "actions/cache@v6": 7,

--- a/scripts/check_fuzz_toolchain_pin.py
+++ b/scripts/check_fuzz_toolchain_pin.py
@@ -55,7 +55,7 @@ TOOLCHAIN_MARKERS = (
 # the sanctioned workflow form; `cargo "+$var"` is a pin-derived selector.
 VIOLATION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (
-        re.compile(r"dtolnay/rust-toolchain@(?!v1(?:\b|$))\S+"),
+        re.compile(r"dtolnay/rust-toolchain@(?!v1(?:\s|$))\S+"),
         "selects a toolchain in the action ref; use "
         "dtolnay/rust-toolchain@v1 and pass the pinned value as its "
         "toolchain input",

--- a/scripts/check_fuzz_toolchain_pin.py
+++ b/scripts/check_fuzz_toolchain_pin.py
@@ -51,13 +51,13 @@ TOOLCHAIN_MARKERS = (
 )
 
 # Each rule matches a toolchain selection that does not come from the pin.
-# `dtolnay/rust-toolchain@master` plus an expression-valued `toolchain:` input
-# is the sanctioned workflow form; `cargo "+$var"` is a pin-derived selector.
+# `dtolnay/rust-toolchain@v1` plus an expression-valued `toolchain:` input is
+# the sanctioned workflow form; `cargo "+$var"` is a pin-derived selector.
 VIOLATION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (
-        re.compile(r"dtolnay/rust-toolchain@(?!master(?:\b|$))\S+"),
+        re.compile(r"dtolnay/rust-toolchain@(?!v1(?:\b|$))\S+"),
         "selects a toolchain in the action ref; use "
-        "dtolnay/rust-toolchain@master and pass the pinned value as its "
+        "dtolnay/rust-toolchain@v1 and pass the pinned value as its "
         "toolchain input",
     ),
     (

--- a/scripts/test_check_fuzz_toolchain_pin.py
+++ b/scripts/test_check_fuzz_toolchain_pin.py
@@ -14,6 +14,8 @@ import check_fuzz_toolchain_pin as guard
 PIN_LINE = f'toolchain="$(cat {guard.PIN_PATH})"'
 
 FLOATING_SELECTIONS = (
+    "      - uses: dtolnay/rust-toolchain@master",
+    "      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c",
     "      - uses: dtolnay/rust-toolchain@nightly",
     "      - uses: dtolnay/rust-toolchain@stable",
     "      - uses: dtolnay/rust-toolchain@beta",
@@ -26,7 +28,7 @@ FLOATING_SELECTIONS = (
 )
 
 PIN_DERIVED_SELECTIONS = (
-    "      - uses: dtolnay/rust-toolchain@master",
+    "      - uses: dtolnay/rust-toolchain@v1",
     "          toolchain: ${{ steps.nightly.outputs.toolchain }}",
     '    && cargo "+$toolchain" install cargo-fuzz --version 0.13.2 --locked',
     '        cargo +"$TOOLCHAIN" fuzz build',

--- a/scripts/test_check_fuzz_toolchain_pin.py
+++ b/scripts/test_check_fuzz_toolchain_pin.py
@@ -16,6 +16,7 @@ PIN_LINE = f'toolchain="$(cat {guard.PIN_PATH})"'
 FLOATING_SELECTIONS = (
     "      - uses: dtolnay/rust-toolchain@master",
     "      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c",
+    "      - uses: dtolnay/rust-toolchain@v1.2.3",
     "      - uses: dtolnay/rust-toolchain@nightly",
     "      - uses: dtolnay/rust-toolchain@stable",
     "      - uses: dtolnay/rust-toolchain@beta",


### PR DESCRIPTION
## Summary

- follow the maintained `dtolnay/rust-toolchain@v1` release line across all workflows
- remove the fuzz workflow's lone `@master` exception while keeping its independently reviewed nightly input
- update the existing semantic guards so only the exact `@v1` ref is accepted and master, versioned-v1, channel, and legacy SHA refs are rejected

This removes a repository-local pin exception and its special-case explanation without adding a workflow, job, or check. The toolchain versions passed to the action remain unchanged.

Immediately before publication, upstream `v1` resolved to `6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772`; its action interface still declared the `toolchain` input and `RUSTUP_PERMIT_COPY_RENAME` behavior.

## Verification

- fuzz toolchain guard tests and production checker
- image-primer contract tests and production checker
- scale-split contract tests and production checker
- exact inventory of 12 `@v1` uses and zero old-SHA or `@master` uses
- destructive mutations proving master, versioned-v1, legacy SHA, and channel refs are rejected
- `git diff --check`

LAN-909
