### PR TITLE
Refresh GoBGP v4.8 parity evidence

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -106,10 +106,11 @@ IPv4/IPv6 `Prefix` routes.
     EVPN, iBGP roles, AS-confederation sub-AS roles, and operator overrides of
     OTC behavior are intentionally out of scope for v1.
 
-[^gobgp-extmsg]: GoBGP upstream support was added in the exact `v4.7.0` tag,
-    verified 2026-07-12 from the tagged
-    [release notes](https://github.com/osrg/gobgp/releases/tag/v4.7.0). This
-    records upstream support, not a rustbgpd/GoBGP interoperability receipt.
+[^gobgp-extmsg]: GoBGP upstream support was added in the exact `v4.7.0` tag
+    and is retained in the exact `v4.8.0` tagged
+    [capability definitions](https://github.com/osrg/gobgp/blob/v4.8.0/pkg/packet/bgp/bgp.go#L406-L438),
+    verified 2026-08-19. This records upstream support, not a rustbgpd/GoBGP
+    interoperability receipt.
 
 ## Policy Engine
 
@@ -145,7 +146,7 @@ IPv4/IPv6 `Prefix` routes.
     and export policy for external BGP; this claim is limited to those release
     lines.
 [^rfc8212-gobgp]: GoBGP
-    [v4.7.0 policy documentation](https://raw.githubusercontent.com/osrg/gobgp/v4.7.0/docs/sources/policy.md)
+    [v4.8.0 policy documentation](https://github.com/osrg/gobgp/blob/v4.8.0/docs/sources/policy.md#L886-L899)
     says unmatched import and export policy defaults to `accept-route`.
 [^rfc8212-openbgpd]: The
     [OpenBSD-current `bgpd.conf(5)` filter documentation](https://man.openbsd.org/bgpd.conf#FILTER)

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -4,13 +4,15 @@ For release-by-release feature history, see [CHANGELOG.md](../CHANGELOG.md).
 
 This document is the canonical source for GoBGP capability claims in the
 project docs (the [comparison matrix](COMPARISON.md) defers to it). GoBGP
-cells are verified against the exact GoBGP `v4.7.0` tag and its
-[release notes](https://github.com/osrg/gobgp/releases/tag/v4.7.0): Enhanced
-Route Refresh is present (`BGP_CAP_ENHANCED_ROUTE_REFRESH = 70`); no ORF
-capability is defined (no code 3 in the constant block); no BGP Role
-capability is defined (RFC 9234, tracked upstream as the still-open feature
-request [osrg/gobgp#3244](https://github.com/osrg/gobgp/issues/3244)); and
-Extended Messages support was added in v4.7.0. Verified 2026-07-12. These are
+cells are verified against the exact GoBGP `v4.8.0` tag, its
+[release notes](https://github.com/osrg/gobgp/releases/tag/v4.8.0), and the
+tagged [capability definitions](https://github.com/osrg/gobgp/blob/v4.8.0/pkg/packet/bgp/bgp.go#L406-L438):
+Extended Messages (code 6, added in v4.7.0) and Enhanced Route Refresh (code
+70) are present; ORF (code 3), BGP Role (code 9), and Add-Path Paths-Limit
+(code 76) are absent. The latter two remain open upstream as
+[osrg/gobgp#3244](https://github.com/osrg/gobgp/issues/3244) and
+[osrg/gobgp#2786](https://github.com/osrg/gobgp/issues/2786), respectively,
+and the tag contains no ASPA implementation. Verified 2026-08-19. These are
 upstream capability claims, not rustbgpd interoperability receipts; receipts
 are identified explicitly where they exist.
 
@@ -106,7 +108,7 @@ releases rather than carried forward from older measurements.
 | Next-hop set/self | Yes | Yes | set_next_hop = "self" or IP |
 | Named policy definitions | Yes | Yes | TOML definitions with configurable default_action |
 | Policy chaining | Yes | Yes | GoBGP-style: permit=continue, deny=stop, implicit permit |
-| Default eBGP policy (RFC 8212) | No | Opt-in | GoBGP v4.7.0 defaults unmatched import/export policy to `accept-route`; rustbgpd requires explicit `ebgp_requires_policy = true` |
+| Default eBGP policy (RFC 8212) | No | Opt-in | GoBGP [v4.8.0 policy documentation](https://github.com/osrg/gobgp/blob/v4.8.0/docs/sources/policy.md#L886-L899) defaults unmatched import/export policy to `accept-route`; rustbgpd requires explicit `ebgp_requires_policy = true` |
 | Scriptable policy language | No | Yes | `.rpol` (ADR-0096): typed + compiled, named prefix/community sets as indexed matchers, parameterized policies, `apply()` composition, in-language unit tests via `rbgp policy check`; route-for-route parity vs FRR route-maps proven in M80 |
 | Policy dry-run against the live RIB | No | Yes | `rbgp policy test` / `TestPolicy` RPC — a candidate `.rpol` policy evaluated read-only over an Adj-RIB-In / Loc-RIB snapshot: counts, per-term hits, before/after diffs |
 | Live per-term policy hit counters | No | Yes | `rbgp policy stats --direction import\|export\|both` / `GetPolicyStats` — since-chain-install counters on installed import and export chains; import rows also carry the session-local policy generation |


### PR DESCRIPTION
## Summary

- repin GoBGP capability evidence to the official v4.8.0 tagged source
- record that capability codes 6 and 70 remain present while ORF, Role, Paths-Limit, and ASPA remain absent
- refresh the RFC 8212 source while preserving the historical v4.7 Extended Messages statement

No comparison-matrix cells change. GoBGP's new internal TCP-AO helpers are not exposed through BGP configuration, API, or server wiring, so the operator-facing TCP-AO result remains unchanged.

## Verification

- official v4.8.0 release, tagged capability source, and policy documentation
- upstream Role and Paths-Limit issues remain open
- public tracker-ID mutation tests and production checker
- explicit assertions for unchanged TCP-AO, GoBGP 4.3.0 performance, and v3 fixture references
- `git diff --check`

LAN-956
