### PR TITLE
Pin protoc archive in shared CI installer

### DIFF
--- a/.github/actions/install-protobuf/action.yml
+++ b/.github/actions/install-protobuf/action.yml
@@ -1,8 +1,7 @@
-name: "Install protobuf compiler (hardened)"
+name: "Install pinned protobuf compiler"
 description: >-
-  Install protoc from the Ubuntu archive while tolerating transient failures
-  from preinstalled third-party apt repositories. The package install and
-  protoc sanity check remain hard failures.
+  Install the official protoc 25.3 archive after verifying its checksum and
+  architecture.
 runs:
   using: "composite"
   steps:
@@ -10,11 +9,30 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        if command -v protoc >/dev/null 2>&1; then
-          protoc --version
-          exit 0
+
+        if [[ "$(uname -m)" != "x86_64" ]]; then
+          echo "::error::the pinned protoc archive supports only x86_64 runners"
+          exit 1
         fi
-        sudo apt-get update -o Acquire::Retries=3 || \
-          echo "::warning::apt-get update reported repo errors; installing protobuf-compiler using existing package lists"
-        sudo apt-get install -y protobuf-compiler
-        protoc --version
+
+        version="25.3"
+        sha256="f853e691868d0557425ea290bf7ba6384eef2fa9b04c323afab49a770ba9da80"
+        install_root="$(mktemp -d "${RUNNER_TEMP}/protoc-${version}.XXXXXX")"
+        archive="${install_root}/protoc.zip"
+
+        curl -sSfL \
+          -o "$archive" \
+          "https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-linux-x86_64.zip"
+        printf '%s  %s\n' "$sha256" "$archive" | sha256sum -c -
+        unzip -q "$archive" -d "$install_root" 'bin/protoc' 'include/*'
+        rm -f "$archive"
+        chmod 0755 "${install_root}/bin/protoc"
+
+        echo "${install_root}/bin" >> "$GITHUB_PATH"
+        export PATH="${install_root}/bin:${PATH}"
+        actual_version="$(protoc --version)"
+        if [[ "$actual_version" != "libprotoc ${version}" ]]; then
+          echo "::error::expected libprotoc ${version}, got ${actual_version}"
+          exit 1
+        fi
+        echo "$actual_version"


### PR DESCRIPTION
## Summary

- replace the apt-based shared protobuf installer with the official protoc v25.3 archive
- verify the pinned SHA-256 digest and x86_64 runner architecture before use
- install the compiler and well-known proto includes under `RUNNER_TEMP`, then require the exact `libprotoc 25.3` identity

## Why

The apt update fallback only handles repository errors that return. On #1731, Ubuntu archive mirror requests hung for roughly 30 minutes in four jobs; the scale job reached its timeout before the package install began. A direct, checksum-verified upstream archive removes that mirror dependency without adding a cache, retry, matrix, job, or third-party action.

## Impact

The seven shared Ubuntu CI consumers use a deterministic compiler instead of the runner package mirror. Unsupported runner architectures fail closed. Runtime and release behavior are unchanged.

## Validation

- live archive download, SHA-256 verification, extraction, well-known include inventory, and exact version assertion
- CI image-primer contract suite and production checker
- CI scale-split contract suite and production checker
- release-install contract suite and production checker
- `cargo check --workspace --all-targets --locked`
- `cargo test --workspace --locked`
- `cargo fmt --all -- --check`
- commit-hook clippy and pre-push docs gates

Linear: LAN-1100