### PR TITLE
Restore Rust 1.98 strict-Clippy compatibility

### DIFF
--- a/crates/api/src/config_service/stream.rs
+++ b/crates/api/src/config_service/stream.rs
@@ -707,7 +707,7 @@ mod tests {
     use std::path::Path;
     use std::sync::atomic::AtomicUsize;
 
-    use sha2::{Digest as _, Sha256};
+    use sha2::Sha256;
     use tempfile::TempDir;
     use tokio::net::TcpListener;
     use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};

--- a/crates/cli/src/commands/ribsnap.rs
+++ b/crates/cli/src/commands/ribsnap.rs
@@ -419,8 +419,11 @@ fn parse_attributes(mut buf: &[u8]) -> Result<SnapRoute, String> {
                         value.len()
                     ));
                 }
-                route.communities = value
-                    .chunks_exact(4)
+                let (chunks, []) = value.as_chunks::<4>() else {
+                    unreachable!("COMMUNITIES length was validated")
+                };
+                route.communities = chunks
+                    .iter()
                     .map(|c| u32::from_be_bytes([c[0], c[1], c[2], c[3]]))
                     .collect();
             }
@@ -431,10 +434,11 @@ fn parse_attributes(mut buf: &[u8]) -> Result<SnapRoute, String> {
                         value.len()
                     ));
                 }
-                route.extended_communities = value
-                    .chunks_exact(8)
-                    .map(|c| u64::from_be_bytes(c.try_into().expect("chunk of 8")))
-                    .collect();
+                let (chunks, []) = value.as_chunks::<8>() else {
+                    unreachable!("EXTENDED_COMMUNITIES length was validated")
+                };
+                route.extended_communities =
+                    chunks.iter().map(|c| u64::from_be_bytes(*c)).collect();
             }
             attr_type::LARGE_COMMUNITIES => {
                 if !value.len().is_multiple_of(12) {
@@ -443,8 +447,11 @@ fn parse_attributes(mut buf: &[u8]) -> Result<SnapRoute, String> {
                         value.len()
                     ));
                 }
-                route.large_communities = value
-                    .chunks_exact(12)
+                let (chunks, []) = value.as_chunks::<12>() else {
+                    unreachable!("LARGE_COMMUNITIES length was validated")
+                };
+                route.large_communities = chunks
+                    .iter()
                     .map(|c| {
                         [
                             u32::from_be_bytes([c[0], c[1], c[2], c[3]]),
@@ -476,7 +483,10 @@ fn parse_as_path(mut value: &[u8]) -> Result<Vec<u32>, String> {
         if value.len() < segment_len {
             return Err("truncated AS_PATH segment".to_string());
         }
-        for chunk in value[2..segment_len].chunks_exact(4) {
+        let (chunks, []) = value[2..segment_len].as_chunks::<4>() else {
+            unreachable!("AS_PATH segment length was validated")
+        };
+        for chunk in chunks {
             path.push(u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
         }
         value = &value[segment_len..];

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -1075,6 +1075,11 @@ fn take_universal_failure(state: &mut State) -> Option<DataplaneError> {
     Some(f.error.realize())
 }
 
+#[allow(unknown_lints, reason = "Clippy 1.97 predates this lint")]
+#[expect(
+    clippy::unused_async_trait_impl,
+    reason = "async trait methods must defer state mutation until the returned future is polled"
+)]
 impl NexthopOps for InMemoryDataplane {
     async fn add_nexthop_member(
         &mut self,
@@ -1999,6 +2004,18 @@ mod tests {
             dst: ip("10.0.0.2"),
         };
         assert!(dp.apply(&op).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn nexthop_ops_remain_lazy_until_polled() {
+        let mut dp = InMemoryDataplane::new();
+        let h = dp.handle();
+        h.inject_failure_io(None);
+
+        let future = dp.add_nexthop_member(1, ip("192.0.2.1"));
+        assert_eq!(h.state.lock().expect("poisoned").failures.len(), 1);
+        assert!(matches!(future.await, Err(DataplaneError::Io(_))));
+        assert!(h.nexthop_ops().is_empty());
     }
 
     #[tokio::test]

--- a/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
@@ -601,8 +601,8 @@ fn parse_dump_message_for_class(
             },
             NHA_GROUP => {
                 // Payload is an array of `nexthop_grp` (8 bytes each).
-                let chunks = payload.chunks_exact(8);
-                if !chunks.remainder().is_empty() {
+                let (chunks, remainder) = payload.as_chunks::<8>();
+                if !remainder.is_empty() {
                     return Err(NexthopError::Truncated);
                 }
                 let mut ids = Vec::with_capacity(payload.len() / 8);

--- a/crates/rib/src/orr.rs
+++ b/crates/rib/src/orr.rs
@@ -160,8 +160,11 @@ fn decode_mt_ids(protocol_id: u8, value: &[u8]) -> Result<Vec<u16>, ()> {
     if value.is_empty() || !value.len().is_multiple_of(2) {
         return Err(());
     }
-    value
-        .chunks_exact(2)
+    let (chunks, []) = value.as_chunks::<2>() else {
+        unreachable!("MT-ID length was validated")
+    };
+    chunks
+        .iter()
         .map(|raw| {
             let raw = u16::from_be_bytes([raw[0], raw[1]]);
             match protocol_id {

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -813,8 +813,10 @@ impl BgpListener {
     /// # Errors
     ///
     /// Returns an error if binding or pre-listen option installation fails.
+    #[allow(unknown_lints, reason = "Clippy 1.97 predates this lint")]
     #[allow(
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "preserve the existing async public API for callers"
     )]
     pub async fn bind_with_options(
@@ -842,8 +844,10 @@ impl BgpListener {
     ///
     /// Returns `InvalidInput` for an empty endpoint set, or the first socket
     /// creation, option, bind, or listen error.
+    #[allow(unknown_lints, reason = "Clippy 1.97 predates this lint")]
     #[allow(
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "match the async bind API of the other listener constructors"
     )]
     pub async fn bind_strict_with_options(
@@ -884,8 +888,10 @@ impl BgpListener {
     ///
     /// Returns an error only when neither family can be bound, or when
     /// pre-listen option installation fails on a bindable socket.
+    #[allow(unknown_lints, reason = "Clippy 1.97 predates this lint")]
     #[allow(
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "match the async bind API of the single-family constructors"
     )]
     pub async fn bind_dual_with_options(

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1257,8 +1257,11 @@ fn decode_as4_path(raw: &RawAttribute) -> Result<(AsPath, bool), DecodeError> {
                 value.len()
             )));
         }
-        let asns = value[..needed]
-            .chunks_exact(4)
+        let (chunks, []) = value[..needed].as_chunks::<4>() else {
+            unreachable!("AS4_PATH length was validated")
+        };
+        let asns = chunks
+            .iter()
             .map(|asn| u32::from_be_bytes([asn[0], asn[1], asn[2], asn[3]]))
             .collect();
         value = &value[needed..];
@@ -1513,8 +1516,11 @@ fn decode_attribute_value(
                     ),
                 });
             }
-            let communities = value
-                .chunks_exact(4)
+            let (chunks, []) = value.as_chunks::<4>() else {
+                unreachable!("COMMUNITIES length was validated")
+            };
+            let communities = chunks
+                .iter()
                 .map(|c| u32::from_be_bytes([c[0], c[1], c[2], c[3]]))
                 .collect();
             Ok(PathAttribute::Communities(communities))
@@ -1531,8 +1537,11 @@ fn decode_attribute_value(
                     ),
                 });
             }
-            let communities = value
-                .chunks_exact(8)
+            let (chunks, []) = value.as_chunks::<8>() else {
+                unreachable!("EXTENDED_COMMUNITIES length was validated")
+            };
+            let communities = chunks
+                .iter()
                 .map(|c| {
                     ExtendedCommunity::new(u64::from_be_bytes([
                         c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7],
@@ -1560,8 +1569,11 @@ fn decode_attribute_value(
                     detail: format!("CLUSTER_LIST length {} not a multiple of 4", value.len()),
                 });
             }
-            let ids = value
-                .chunks_exact(4)
+            let (chunks, []) = value.as_chunks::<4>() else {
+                unreachable!("CLUSTER_LIST length was validated")
+            };
+            let ids = chunks
+                .iter()
                 .map(|c| Ipv4Addr::new(c[0], c[1], c[2], c[3]))
                 .collect();
             Ok(PathAttribute::ClusterList(ids))
@@ -1578,8 +1590,11 @@ fn decode_attribute_value(
                 });
             }
             let mut seen = std::collections::HashSet::with_capacity(value.len() / 12);
-            let communities = value
-                .chunks_exact(12)
+            let (chunks, []) = value.as_chunks::<12>() else {
+                unreachable!("LARGE_COMMUNITIES length was validated")
+            };
+            let communities = chunks
+                .iter()
                 .filter_map(|c| {
                     let community = LargeCommunity::new(
                         u32::from_be_bytes([c[0], c[1], c[2], c[3]]),

--- a/src/config_history/v2.rs
+++ b/src/config_history/v2.rs
@@ -808,9 +808,11 @@ fn decode_hex(value: &str) -> Result<Vec<u8>, &'static str> {
     {
         return Err("hex must be lowercase and even-length");
     }
-    value
-        .as_bytes()
-        .chunks_exact(2)
+    let (pairs, []) = value.as_bytes().as_chunks::<2>() else {
+        unreachable!("hex length was validated")
+    };
+    pairs
+        .iter()
         .map(|pair| {
             let digit = |byte| {
                 if byte <= b'9' {

--- a/src/confirm_journal/v3.rs
+++ b/src/confirm_journal/v3.rs
@@ -1494,7 +1494,10 @@ mod history_digest {
             ));
         }
         let mut digest = [0u8; 32];
-        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        let (pairs, []) = value.as_bytes().as_chunks::<2>() else {
+            unreachable!("digest length was validated")
+        };
+        for (index, pair) in pairs.iter().enumerate() {
             let digit = |byte| {
                 if byte <= b'9' {
                     byte - b'0'


### PR DESCRIPTION
## Summary

- migrate all constant-size `chunks_exact` parsing sites to explicit `as_chunks` remainder handling
- preserve malformed-tail rejection and the in-memory dataplane's lazy poll-time behavior
- keep the public async listener API compatible with both Clippy 1.97 and 1.98

## Verification

- Rust 1.95 locked workspace all-target check
- default strict workspace Clippy
- Rust 1.98 keep-going strict workspace Clippy
- Rust 1.98 locked full workspace tests
- focused malformed attribute, EVPN remainder, lazy-future, listener, and config-stream tests
- clippy-reasons contract and repository commit hooks

No runtime, API, config, dependency, workflow, or documentation behavior changes.

Linear: LAN-1117
