### PR TITLE
Complete exact IXP Manager route-detail journeys

### DIFF
--- a/.github/workflows/ixp-compat.yml
+++ b/.github/workflows/ixp-compat.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     paths:
       - "tests/compat/ixp-manager-birdseye/**"
+      - "examples/birdwatcher-adapter/**"
+      - "tests/birdwatcher_adapter_smoke.rs"
       - ".github/workflows/ixp-compat.yml"
       - "docs/INTEROP.md"
   push:
     branches: [main]
     paths:
       - "tests/compat/ixp-manager-birdseye/**"
+      - "examples/birdwatcher-adapter/**"
+      - "tests/birdwatcher_adapter_smoke.rs"
       - ".github/workflows/ixp-compat.yml"
       - "docs/INTEROP.md"
   workflow_dispatch:
@@ -23,5 +27,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/install-protobuf
       - name: Verify the pinned upstream contract
         run: tests/compat/ixp-manager-birdseye/run.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `birdwatcher-adapter` now serves IXP Manager v7.4.0's exact received and
+  export route journeys for IPv4/IPv6 unicast. Every page carries the exact
+  daemon-side prefix filter, all Add-Path candidates retain source alias and
+  order, and the route cap applies after exact filtering. The pinned oracle
+  drives both real IXP Manager consumer methods against a live adapter while
+  keeping `runtime_compatibility` false. (LAN-1118)
 - `birdwatcher-adapter` now supports immutable IXP Manager protocol aliases,
   Bird's Eye-shaped protocol detail and symbols, member received/export views,
   canonical lowercase API metadata alongside preserved Alice-LG keys, and an

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -26,15 +26,20 @@ against a deterministic fake `birdc`; upstream source is cloned temporarily and
 installed from its lockfiles. See
 [`tests/compat/ixp-manager-birdseye/README.md`](../tests/compat/ixp-manager-birdseye/README.md)
 for the pins, fixture provenance, and local reproduction command.
+The same gate also runs IXP Manager's exact protocol/export consumer methods
+against a live `birdwatcher-adapter` backed by a real rustbgpd process.
 
 This oracle is intentionally **not** a runtime compatibility claim. The
 example adapter now provides immutable protocol aliases plus the current
 consumer's status, BGP inventory/detail, symbols, member received-route, and
-member export-route seam with an enforced response maximum. This remains
-partial runtime support: complete rejected-route reasons, less-specific lookup,
-and an atomic all-candidate table snapshot are still unavailable. Global table,
-count, exact-prefix, and wildcard-community endpoints are not served, so the
-adapter is not described as fully IXP Manager / Bird's Eye compatible.
+member export-route seam with an enforced response maximum. Exact protocol and
+export prefix lookups are supported and preserve all Add-Path candidates in
+daemon order. This remains partial runtime support: complete rejected-route
+reasons, less-specific lookup, and an atomic all-candidate table snapshot are
+still unavailable. Global table, count, and wildcard-community endpoints are
+not served. The adapter's `api.version` is rustbgpd product identity, not a
+Bird's Eye version claim, and the adapter is not described as fully IXP Manager
+/ Bird's Eye compatible.
 
 ### CI coverage
 

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -84,6 +84,8 @@ listener beyond loopback only with the mTLS controls in `docs/SECURITY.md`.
 | `GET /symbols`               | Sorted live protocol identities; routing-table symbols stay empty      |
 | `GET /routes/protocol/{id}`  | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
 | `GET /routes/export/{id}`    | `RibService.ListAdvertisedRoutes` (paged, all unicast families) |
+| `GET /route/{prefix}/protocol/{id}` | `RibService.ListReceivedRoutes` (paged, exact IPv4/IPv6 unicast prefix) |
+| `GET /route/{prefix}/export/{id}` | `RibService.ListAdvertisedRoutes` (paged, exact IPv4/IPv6 unicast prefix) |
 | `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
 | `GET /routes/filtered/{id}`  | `PolicyService.ListRejectedRoutes` (unpaged — the store is bounded at the `[policy.reject_retention]` capacity, default 1024/peer) |
 | `GET /routes/noexport/{id}`  | `RibService.ListBestRoutes` − `RibService.ListAdvertisedRoutes` (both paged), each missing prefix explained by `RibService.ExplainAdvertisedRoute` |
@@ -113,14 +115,24 @@ bare peer-IP lookup remains accepted.
 
 Every successful response retains Alice-LG's `api.Version` and
 `api.result_from_cache` keys while also exposing Bird's Eye's lowercase
-`version`, `from_cache`, and enforced `max_routes`. A route-array request whose
-actual size exceeds that maximum returns HTTP 403 instead of truncating.
+`version`, `from_cache`, and enforced `max_routes`. Both version keys contain
+`rustbgpd <package-version>` as product identity; they are not a claim to
+implement Bird's Eye API version 2.1.0. A route-array request whose actual size
+exceeds that maximum returns HTTP 403 instead of truncating.
+
+IXP Manager's `protocolRoute()` and `exportRoute()` journeys use
+`/route/<prefix>%2F<mask>/protocol/{id}` and `/route/<prefix>%2F<mask>/export/{id}`.
+These views request an exact prefix on every gRPC page, retain every Add-Path
+candidate in daemon order, and apply `--max-routes` only after exact filtering.
+Malformed prefixes return HTTP 400, unknown identities return 404, and daemon
+failures return a sanitized 502.
 
 This is deliberately partial IXP Manager support: status, live BGP inventory
 and detail, protocol symbols, member received routes, and member exported
-routes are available. Global table views, counts, exact/less-specific search,
-large-community wildcard search, and the complete reject-reason inventory are
-not yet implemented; the adapter does not claim full Bird's Eye compatibility.
+routes, including exact protocol/export lookup, are available. Global table
+views, counts, less-specific search, large-community wildcard search, and the
+complete reject-reason inventory are not yet implemented; the adapter does not
+claim full Bird's Eye compatibility.
 
 ## Filtered routes and reject reasons
 
@@ -274,10 +286,10 @@ the adapter returns `502 Bad Gateway` (the in-daemon server returned
 ## Testing
 
 - Unit tests: `cargo test -p birdwatcher-adapter`
-- End-to-end smoke test of the status/peer/accepted/filtered/noexport
+- End-to-end smoke test of the status/peer/accepted/filtered/noexport/exact
   subset: `cargo test --test birdwatcher_adapter_smoke` (root package;
   spawns a real daemon plus this adapter, announces a clean route and a
   loop-poisoned one from one live peer plus an announce-nothing receiver
   peer, and asserts the accepted, filtered, and both sides of the noexport
-  views — suppressed route present for the announcer, exported route absent
-  for the receiver).
+  views — including received/exported Add-Path multiplicity, order, source
+  alias direction, exact-filter-before-cap, and stable 400/404/502 errors).

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -14,6 +14,8 @@
 //! - `GET /symbols` — sorted live protocol identities
 //! - `GET /routes/protocol/{id}` — received routes by neighbor address
 //! - `GET /routes/export/{id}` — routes advertised to a neighbor
+//! - `GET /route/{prefix}/protocol/{id}` — exact received-route candidates
+//! - `GET /route/{prefix}/export/{id}` — exact advertised-route candidates
 //! - `GET /routes/peer/{peer}` — received routes by peer IP
 //! - `GET /routes/filtered/{id}` — rejected routes retained by the peer's
 //!   session (`PolicyService.ListRejectedRoutes`), tagged with a synthesized
@@ -342,6 +344,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/symbols", get(symbols))
         .route("/routes/protocol/{id}", get(routes_protocol))
         .route("/routes/export/{id}", get(routes_export))
+        .route("/route/{prefix}/protocol/{id}", get(route_protocol))
+        .route("/route/{prefix}/export/{id}", get(route_export))
         .route("/routes/peer/{peer}", get(routes_peer))
         .route("/routes/filtered/{id}", get(routes_filtered))
         .route("/routes/noexport/{id}", get(routes_noexport))
@@ -695,6 +699,155 @@ async fn routes_export(
     Ok(Json(serde_json::json!({
         "api": api_block(state.max_routes),
         "routes": routes,
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// GET /route/{prefix}/protocol/{id} — exact received-route candidates
+// GET /route/{prefix}/export/{id}   — exact advertised-route candidates
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExactRouteSource {
+    Received,
+    Advertised,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ExactPrefix {
+    address: IpAddr,
+    length: u32,
+}
+
+impl ExactPrefix {
+    fn parse(value: &str) -> Result<Self, HttpError> {
+        let invalid = || json_error(StatusCode::BAD_REQUEST, "Invalid route prefix");
+        let (address, length) = value.split_once('/').ok_or_else(invalid)?;
+        if address.is_empty() || length.is_empty() || length.contains('/') {
+            return Err(invalid());
+        }
+        let address: IpAddr = address.parse().map_err(|_| invalid())?;
+        let length: u32 = length.parse().map_err(|_| invalid())?;
+        let width = if address.is_ipv4() { 32 } else { 128 };
+        if length > width || !network_aligned(address, length) {
+            return Err(invalid());
+        }
+        Ok(Self { address, length })
+    }
+
+    fn matches(self, route: &proto::Route) -> bool {
+        route.prefix == self.address.to_string() && route.prefix_length == self.length
+    }
+}
+
+fn network_aligned(address: IpAddr, length: u32) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            let mask = if length == 0 {
+                0
+            } else {
+                u32::MAX << (32 - length)
+            };
+            u32::from(address) & !mask == 0
+        }
+        IpAddr::V6(address) => {
+            let mask = if length == 0 {
+                0
+            } else {
+                u128::MAX << (128 - length)
+            };
+            u128::from(address) & !mask == 0
+        }
+    }
+}
+
+#[allow(
+    clippy::match_same_arms,
+    reason = "separate arms keep each exact IXP consumer journey mutation-testable"
+)]
+fn exact_route_request(
+    peer: IpAddr,
+    prefix: ExactPrefix,
+    page_token: String,
+    source: ExactRouteSource,
+) -> proto::ListRoutesRequest {
+    let prefix_filter = match source {
+        ExactRouteSource::Received => prefix.address.to_string(),
+        ExactRouteSource::Advertised => prefix.address.to_string(),
+    };
+    proto::ListRoutesRequest {
+        neighbor_address: peer.to_string(),
+        afi_safi: proto::AddressFamily::Unspecified as i32,
+        page_size: 1000,
+        page_token,
+        prefix_filter,
+        prefix_filter_length: prefix.length,
+        longer_prefixes: false,
+        ..Default::default()
+    }
+}
+
+fn append_exact_routes(
+    routes: &mut Vec<proto::Route>,
+    page: Vec<proto::Route>,
+    prefix: ExactPrefix,
+    max_routes: u64,
+) -> Result<(), HttpError> {
+    routes.extend(page.into_iter().filter(|route| prefix.matches(route)));
+    enforce_max(routes.len() as u64, max_routes)
+}
+
+async fn route_protocol(
+    State(state): State<AppState>,
+    Path((prefix, id)): Path<(String, String)>,
+) -> Result<Json<Value>, HttpError> {
+    serve_exact_route(&state, &prefix, &id, ExactRouteSource::Received).await
+}
+
+async fn route_export(
+    State(state): State<AppState>,
+    Path((prefix, id)): Path<(String, String)>,
+) -> Result<Json<Value>, HttpError> {
+    serve_exact_route(&state, &prefix, &id, ExactRouteSource::Advertised).await
+}
+
+async fn serve_exact_route(
+    state: &AppState,
+    raw_prefix: &str,
+    id: &str,
+    source: ExactRouteSource,
+) -> Result<Json<Value>, HttpError> {
+    let prefix = ExactPrefix::parse(raw_prefix)?;
+    let peer = state.identities.resolve(id)?;
+    let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
+    let mut routes = Vec::new();
+    let mut page_token = String::new();
+    loop {
+        let request = exact_route_request(peer, prefix, page_token, source);
+        let response = match source {
+            ExactRouteSource::Received => client
+                .list_received_routes(request)
+                .await
+                .map_err(|error| bad_gateway("ListReceivedRoutes", &error))?,
+            ExactRouteSource::Advertised => client
+                .list_advertised_routes(request)
+                .await
+                .map_err(|error| bad_gateway("ListAdvertisedRoutes", &error))?,
+        }
+        .into_inner();
+        append_exact_routes(&mut routes, response.routes, prefix, state.max_routes)?;
+        if response.next_page_token.is_empty() {
+            break;
+        }
+        page_token = response.next_page_token;
+    }
+
+    Ok(Json(serde_json::json!({
+        "api": api_block(state.max_routes),
+        "routes": routes
+            .iter()
+            .map(|route| route_to_birdwatcher(route, &state.identities))
+            .collect::<Vec<_>>(),
     })))
 }
 
@@ -1790,6 +1943,7 @@ mod tests {
             assert!(api.get(key).is_some(), "missing {key}: {api}");
         }
         assert_eq!(api["Version"], api["version"]);
+        assert!(api["version"].as_str().unwrap().starts_with("rustbgpd "));
 
         assert!(
             Args::try_parse_from([
@@ -1801,6 +1955,112 @@ mod tests {
             ])
             .is_err()
         );
+    }
+
+    #[test]
+    fn exact_prefix_parser_accepts_networks_and_rejects_malformed_or_host_values() {
+        for (input, address, length) in [
+            ("192.0.2.0/24", "192.0.2.0", 24),
+            ("0.0.0.0/0", "0.0.0.0", 0),
+            ("2001:db8::/32", "2001:db8::", 32),
+            ("::/0", "::", 0),
+        ] {
+            let parsed = ExactPrefix::parse(input).unwrap();
+            assert_eq!(parsed.address.to_string(), address);
+            assert_eq!(parsed.length, length);
+        }
+        for input in [
+            "192.0.2.0",
+            "192.0.2.0/",
+            "192.0.2.0/24/extra",
+            "not-an-ip/24",
+            "192.0.2.0/nope",
+            "192.0.2.0/33",
+            "192.0.2.1/24",
+            "2001:db8::/129",
+            "2001:db8::1/64",
+        ] {
+            let (status, Json(body)) = ExactPrefix::parse(input).unwrap_err();
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{input}");
+            assert_eq!(body, serde_json::json!({"message":"Invalid route prefix"}));
+            assert!(!body.to_string().contains(input));
+        }
+    }
+
+    #[test]
+    fn exact_route_requests_pin_every_filter_on_every_page_and_unknown_id_is_404() {
+        let peer: IpAddr = "192.0.2.1".parse().unwrap();
+        let prefix = ExactPrefix::parse("2001:db8::/32").unwrap();
+        for source in [ExactRouteSource::Received, ExactRouteSource::Advertised] {
+            for token in ["", "opaque-page-2"] {
+                let request = exact_route_request(peer, prefix, token.to_string(), source);
+                assert_eq!(request.neighbor_address, peer.to_string(), "{source:?}");
+                assert_eq!(request.prefix_filter, "2001:db8::", "{source:?}");
+                assert_eq!(request.prefix_filter_length, 32, "{source:?}");
+                assert!(!request.longer_prefixes, "{source:?}");
+                assert_eq!(
+                    request.afi_safi,
+                    proto::AddressFamily::Unspecified as i32,
+                    "{source:?}"
+                );
+                assert_eq!(request.page_token, token, "{source:?}");
+            }
+        }
+        let resolver = IdentityResolver::default();
+        let (status, Json(body)) = resolver.resolve("missing-alias").unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, serde_json::json!({"message":"Protocol not found"}));
+    }
+
+    #[test]
+    fn exact_route_pages_preserve_add_path_order_and_cap_only_exact_candidates() {
+        let prefix = ExactPrefix::parse("192.0.2.0/24").unwrap();
+        let route = |network: &str, path_id: u32, med: u32| proto::Route {
+            prefix: network.to_string(),
+            prefix_length: 24,
+            path_id,
+            med,
+            ..Default::default()
+        };
+        for source in [ExactRouteSource::Received, ExactRouteSource::Advertised] {
+            let mut routes = Vec::new();
+            append_exact_routes(
+                &mut routes,
+                vec![
+                    route("198.51.100.0", 1, 99),
+                    route("192.0.2.0", 11, 10),
+                    route("192.0.2.0", 22, 20),
+                ],
+                prefix,
+                2,
+            )
+            .unwrap();
+            assert_eq!(
+                routes.iter().map(|route| route.path_id).collect::<Vec<_>>(),
+                [11, 22],
+                "{source:?}"
+            );
+            let (status, Json(body)) =
+                append_exact_routes(&mut routes, vec![route("192.0.2.0", 33, 30)], prefix, 2)
+                    .unwrap_err();
+            assert_eq!(status, StatusCode::FORBIDDEN, "{source:?}");
+            assert_eq!(
+                body,
+                serde_json::json!({"message":"Number of routes exceeds maximum allowed (3/2)"})
+            );
+        }
+    }
+
+    #[test]
+    fn upstream_error_mapping_is_stable_and_sanitized() {
+        let status = tonic::Status::internal("secret upstream detail");
+        let (http_status, Json(body)) = bad_gateway("ListReceivedRoutes", &status);
+        assert_eq!(http_status, StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            body,
+            serde_json::json!({"message":"Upstream daemon request failed"})
+        );
+        assert!(!body.to_string().contains("secret"));
     }
 
     #[test]

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -18,6 +18,8 @@
 //! `/routes/filtered/{id}` view (reason token + synthesized reason
 //! community) and the real `routes.filtered` neighbor-summary count
 //! end-to-end.
+//! The clean prefix carries two Add-Path candidates so the exact-route
+//! views also prove multiplicity and order.
 //!
 //! A third neighbor (127.0.0.2, announce-nothing receiver) exercises the
 //! `/routes/noexport/{id}` view from both sides: the accepted route is
@@ -350,11 +352,19 @@ remote_asn = 65020
 description = "live peer"
 graceful_restart = false
 
+[neighbors.add_path]
+receive = true
+receive_max = 4
+
 [[neighbors]]
 address = "127.0.0.2"
 remote_asn = 65030
 description = "receiver peer"
 graceful_restart = false
+
+[neighbors.add_path]
+send = true
+send_max = 4
 "#,
         runtime_dir = runtime_dir.display(),
         grpc_socket = grpc_socket.display(),
@@ -411,6 +421,7 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
     use rustbgpd_wire::message::{Message, encode_message};
     use rustbgpd_wire::open::OpenMessage;
     use rustbgpd_wire::update::UpdateMessage;
+    use rustbgpd_wire::{AddPathFamily, AddPathMode, Afi, Capability, Safi};
 
     let mut stream = TcpStream::connect(("127.0.0.1", bgp_port)).expect("connect to BGP port");
     let open = Message::Open(OpenMessage {
@@ -418,9 +429,13 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
         my_as: 65020,
         hold_time: 90,
         bgp_identifier: "10.0.0.2".parse().unwrap(),
-        capabilities: Vec::new(),
+        capabilities: vec![Capability::AddPath(vec![AddPathFamily {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            send_receive: AddPathMode::Send,
+        }])],
     });
-    let encode_update = |as_sequence: Vec<u32>, nlri: &'static [u8]| {
+    let encode_update = |as_sequence: Vec<u32>, nlri: &'static [u8], med: u32| {
         let mut attrs = Vec::new();
         rustbgpd_wire::attribute::encode_path_attributes(
             &[
@@ -431,6 +446,7 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
                 // Non-loopback: the daemon's UPDATE validation rejects a
                 // loopback NEXT_HOP (subcode 8).
                 PathAttribute::NextHop("192.0.2.99".parse().unwrap()),
+                PathAttribute::Med(med),
             ],
             &mut attrs,
             false,
@@ -443,11 +459,18 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
             nlri: bytes::Bytes::from_static(nlri),
         })
     };
-    // 10.99.0.0/24, clean path → accepted.
-    let accepted = encode_update(vec![65020], &[24, 10, 99, 0]);
+    // RFC 7911 NLRI: four-byte path id, then the ordinary prefix encoding.
+    let accepted_11 = encode_update(vec![65020], &[0, 0, 0, 11, 24, 10, 99, 0], 10);
+    let accepted_22 = encode_update(vec![65020], &[0, 0, 0, 22, 24, 10, 99, 0], 20);
     // 10.98.0.0/24, daemon's own AS 65001 in path → as_path_loop reject.
-    let looped = encode_update(vec![65020, 65001], &[24, 10, 98, 0]);
-    for msg in [&open, &Message::Keepalive, &accepted, &looped] {
+    let looped = encode_update(vec![65020, 65001], &[0, 0, 0, 30, 24, 10, 98, 0], 30);
+    for msg in [
+        &open,
+        &Message::Keepalive,
+        &accepted_11,
+        &accepted_22,
+        &looped,
+    ] {
         let encoded = encode_message(msg).expect("encode BGP message");
         stream.write_all(&encoded).expect("write BGP message");
     }
@@ -467,6 +490,7 @@ fn announce_additional_route(stream: &mut TcpStream) {
                 segments: vec![AsPathSegment::AsSequence(vec![65020])],
             }),
             PathAttribute::NextHop("192.0.2.99".parse().unwrap()),
+            PathAttribute::Med(31),
         ],
         &mut attrs,
         false,
@@ -476,7 +500,7 @@ fn announce_additional_route(stream: &mut TcpStream) {
     let update = Message::Update(UpdateMessage {
         withdrawn_routes: bytes::Bytes::new(),
         path_attributes: attrs.into(),
-        nlri: bytes::Bytes::from_static(&[24, 10, 97, 0]),
+        nlri: bytes::Bytes::from_static(&[0, 0, 0, 31, 24, 10, 97, 0]),
     });
     stream
         .write_all(&encode_message(&update).expect("encode additional route"))
@@ -502,14 +526,18 @@ fn announce_additional_rejected_route(stream: &mut TcpStream) {
         false,
     )
     .expect("encode additional rejected route attributes");
-    let update = Message::Update(UpdateMessage {
-        withdrawn_routes: bytes::Bytes::new(),
-        path_attributes: attrs.into(),
-        nlri: bytes::Bytes::from_static(&[24, 10, 96, 0]),
-    });
-    stream
-        .write_all(&encode_message(&update).expect("encode additional rejected route"))
-        .expect("announce additional rejected route");
+    for (path_id, prefix) in [(32, [10, 96, 0]), (33, [10, 95, 0])] {
+        let mut nlri = vec![0, 0, 0, path_id, 24];
+        nlri.extend_from_slice(&prefix);
+        let update = Message::Update(UpdateMessage {
+            withdrawn_routes: bytes::Bytes::new(),
+            path_attributes: attrs.clone().into(),
+            nlri: nlri.into(),
+        });
+        stream
+            .write_all(&encode_message(&update).expect("encode additional rejected route"))
+            .expect("announce additional rejected route");
+    }
 }
 
 /// Second minimal speaker: complete the handshake as AS 65030 from
@@ -521,6 +549,7 @@ fn announce_additional_rejected_route(stream: &mut TcpStream) {
 fn establish_bgp_receiver(bgp_port: u16) -> TcpStream {
     use rustbgpd_wire::message::{Message, encode_message};
     use rustbgpd_wire::open::OpenMessage;
+    use rustbgpd_wire::{AddPathFamily, AddPathMode, Afi, Capability, Safi};
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
@@ -545,7 +574,11 @@ fn establish_bgp_receiver(bgp_port: u16) -> TcpStream {
         my_as: 65030,
         hold_time: 90,
         bgp_identifier: "10.0.0.3".parse().unwrap(),
-        capabilities: Vec::new(),
+        capabilities: vec![Capability::AddPath(vec![AddPathFamily {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            send_receive: AddPathMode::Receive,
+        }])],
     });
     let mut stream = stream;
     for msg in [&open, &Message::Keepalive] {
@@ -577,6 +610,26 @@ fn epoch_from_timestamp(s: &str) -> u64 {
 }
 
 #[test]
+fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
+    let workflow = include_str!("../.github/workflows/ixp-compat.yml");
+    for path in [
+        "examples/birdwatcher-adapter/**",
+        "tests/birdwatcher_adapter_smoke.rs",
+    ] {
+        let entry = format!("      - \"{path}\"");
+        assert_eq!(workflow.lines().filter(|line| *line == entry).count(), 2);
+    }
+    let installer = "      - uses: ./.github/actions/install-protobuf";
+    assert_eq!(workflow.matches(installer).count(), 1);
+    let checkout = workflow.find("actions/checkout@v7").unwrap();
+    let installer = workflow.find(installer).unwrap();
+    let oracle = workflow
+        .find("tests/compat/ixp-manager-birdseye/run.sh")
+        .unwrap();
+    assert!(checkout < installer && installer < oracle);
+}
+
+#[test]
 fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_subset() {
     let temp = tempfile::tempdir().expect("create temp dir");
     std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
@@ -605,7 +658,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
                 "--protocol-alias",
                 "pb_0002_as65030=127.0.0.2@master4",
                 "--max-routes",
-                "1",
+                "2",
             ])
             .stdout(Stdio::null())
             .stderr(Stdio::from(
@@ -635,6 +688,12 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         },
     );
     wait_for_http_status(adapter_port, "/status", 502, &mut adapter);
+    for path in [
+        "/route/10.99.0.0%2F24/protocol/pb_0001_as65020",
+        "/route/10.99.0.0%2F24/export/pb_0002_as65030",
+    ] {
+        wait_for_exact_json_error(adapter_port, path, 502, "Upstream daemon request failed");
+    }
 
     // Now start the daemon. The adapter's lazy UDS channel must reconnect on
     // a later request; replacing the adapter would make the PID assertion red.
@@ -673,7 +732,13 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         status["api"]["Version"], status["api"]["version"],
         "{status}"
     );
-    assert_eq!(status["api"]["max_routes"], 1, "{status}");
+    assert_eq!(status["api"]["max_routes"], 2, "{status}");
+    assert!(
+        status["api"]["version"]
+            .as_str()
+            .is_some_and(|version| version.starts_with("rustbgpd ")),
+        "api.version is product identity, not a Bird's Eye compatibility claim: {status}"
+    );
     for key in ["server_time", "last_reboot", "last_reconfig"] {
         assert!(
             status["status"][key]
@@ -748,6 +813,18 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         serde_json::from_str::<serde_json::Value>(&missing_body).unwrap(),
         serde_json::json!({"message":"Protocol not found"})
     );
+    wait_for_exact_json_error(
+        adapter_port,
+        "/route/not-a-prefix/protocol/pb_0001_as65020",
+        400,
+        "Invalid route prefix",
+    );
+    for path in [
+        "/route/10.99.0.0%2F24/protocol/does_not_exist",
+        "/route/10.99.0.0%2F24/export/does_not_exist",
+    ] {
+        wait_for_exact_json_error(adapter_port, path, 404, "Protocol not found");
+    }
 
     // /routes/peer/{peer} — empty route set still returns the full
     // envelope with an empty routes array.
@@ -766,11 +843,12 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     // Establish a real session from the in-test BGP speaker and
     // announce one route; the adapter must serve it with a non-empty
     // `age` receive timestamp.
+    // Its two Add-Path candidates must both survive in path-id order.
     let mut bgp_session = establish_bgp_and_announce(bgp_port);
     let deadline = Instant::now() + Duration::from_secs(60);
     let live = loop {
         let live = get_json(adapter_port, "/routes/peer/127.0.0.1", "adapter");
-        if live["routes"].as_array().is_some_and(|r| r.len() == 1) {
+        if live["routes"].as_array().is_some_and(|r| r.len() == 2) {
             break live;
         }
         assert!(
@@ -780,18 +858,33 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         );
         thread::sleep(Duration::from_millis(200));
     };
+    for route in live["routes"].as_array().unwrap() {
+        assert_eq!(route["network"], "10.99.0.0/24", "{live}");
+        assert_eq!(route["from_protocol"], "pb_0001_as65020", "{live}");
+    }
     assert_eq!(
-        live["routes"][0]["network"], "10.99.0.0/24",
-        "announced route must be served"
-    );
-    assert_eq!(
-        live["routes"][0]["from_protocol"], "pb_0001_as65020",
-        "{live}"
+        live["routes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|route| route["bgp"]["med"].as_u64().unwrap())
+            .collect::<Vec<_>>(),
+        [10, 20],
+        "Add-Path candidates must remain in daemon order: {live}"
     );
     let aliased_live = get_json(adapter_port, "/routes/protocol/pb_0001_as65020", "adapter");
     assert_eq!(
         aliased_live, live,
         "alias and bare peer must resolve identically"
+    );
+    let exact_received = get_json(
+        adapter_port,
+        "/route/10.99.0.0%2F24/protocol/pb_0001_as65020",
+        "adapter",
+    );
+    assert_eq!(
+        exact_received, live,
+        "exact protocol route must preserve every candidate and its order"
     );
     let age = live["routes"][0]["age"].as_str().unwrap_or_default();
     assert!(!age.is_empty(), "adapter age must be populated");
@@ -893,7 +986,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         let exported = &protocols["protocols"]["pb_0002_as65030"]["routes"]["exported"];
         let receiver_noexport =
             get_json(adapter_port, "/routes/noexport/pb_0002_as65030", "adapter");
-        if exported == 1 && receiver_noexport["routes"] == serde_json::json!([]) {
+        if exported == 2 && receiver_noexport["routes"] == serde_json::json!([]) {
             break;
         }
         assert!(
@@ -903,14 +996,43 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         );
         thread::sleep(Duration::from_millis(200));
     }
-    let exported = get_json(adapter_port, "/routes/export/pb_0002_as65030", "adapter");
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let exact_exported = loop {
+        let exported = get_json(
+            adapter_port,
+            "/route/10.99.0.0%2F24/export/pb_0002_as65030",
+            "adapter",
+        );
+        if exported["routes"]
+            .as_array()
+            .is_some_and(|routes| routes.len() == 2)
+        {
+            break exported;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "exact export did not retain both candidates: {exported}\ndaemon stderr:\n{}",
+            daemon.stderr()
+        );
+        thread::sleep(Duration::from_millis(200));
+    };
     assert_eq!(
-        exported["routes"][0]["network"], "10.99.0.0/24",
-        "{exported}"
+        exact_exported["routes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|route| route["bgp"]["med"].as_u64().unwrap())
+            .collect::<Vec<_>>(),
+        [10, 20],
+        "export candidates must preserve order: {exact_exported}"
     );
-    assert_eq!(
-        exported["routes"][0]["from_protocol"], "pb_0001_as65020",
-        "exported route must retain its source protocol identity: {exported}"
+    assert!(
+        exact_exported["routes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|route| route["from_protocol"] == "pb_0001_as65020"),
+        "export identity is the source alias, never the target id: {exact_exported}"
     );
 
     // A configured peer with no live session has no outbound export
@@ -923,7 +1045,21 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     );
 
     announce_additional_route(&mut bgp_session);
-    let over_limit = "Number of routes exceeds maximum allowed (2/1)";
+    let over_limit = "Number of routes exceeds maximum allowed (3/2)";
+    // The full route arrays now exceed the cap, but the exact result remains
+    // two candidates: nonmatching routes are filtered before limit checking.
+    let exact_received_after_nonmatch = get_json(
+        adapter_port,
+        "/route/10.99.0.0%2F24/protocol/pb_0001_as65020",
+        "adapter",
+    );
+    assert_eq!(exact_received_after_nonmatch, exact_received);
+    let exact_export_after_nonmatch = get_json(
+        adapter_port,
+        "/route/10.99.0.0%2F24/export/pb_0002_as65030",
+        "adapter",
+    );
+    assert_eq!(exact_export_after_nonmatch, exact_exported);
     wait_for_exact_json_error(
         adapter_port,
         "/routes/protocol/pb_0001_as65020",
@@ -936,13 +1072,6 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         403,
         over_limit,
     );
-    wait_for_exact_json_error(
-        adapter_port,
-        "/routes/noexport/pb_0001_as65020",
-        403,
-        over_limit,
-    );
-
     announce_additional_rejected_route(&mut bgp_session);
     wait_for_exact_json_error(
         adapter_port,

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -6,7 +6,10 @@ claim that rustbgpd or its example Birdwatcher adapter is Bird's Eye compatible.
 
 The gate clones and verifies these exact upstream commits, installs both
 projects from their committed Composer lockfiles, starts the real Bird's Eye
-Lumen server with `APP_DEBUG=false`, and invokes the real IXP Manager consumer:
+Lumen server with `APP_DEBUG=false`, and invokes the real IXP Manager consumer.
+It then starts a real rustbgpd plus `birdwatcher-adapter` and points that same
+pinned consumer's `protocolRoute()` and `exportRoute()` journeys at the live
+adapter:
 
 - Bird's Eye v2.1.0: `7f8c2375e610578bcf6ea5ceec630a180f945b89`
 - IXP Manager v7.4.0: `300b7e0ba9adb0aaac975899e45fc8bcbc0ca37d`
@@ -26,6 +29,13 @@ and body are all part of the reviewed fixture. Composer validation is strict;
 the harness permits only IXP Manager's pinned deprecated `GPL-2.0` identifier
 warning and rejects any additional warning.
 
+The live-adapter leg intentionally uses a configured, down peer, so the exact
+lookups return honest empty route arrays. The live BGP smoke test separately
+pins populated Add-Path candidate multiplicity, ordering, filtering, and source
+alias direction. `api.version` remains `rustbgpd <package-version>` product
+identity, not Bird's Eye semantic-version compatibility. No full compatibility
+claim is made and `runtime_compatibility` remains false.
+
 Run the gate from the repository root:
 
 ```console
@@ -43,11 +53,12 @@ diff -u tests/compat/ixp-manager-birdseye/fixtures/birdseye-contract.json \
 ```
 
 `contract.json` deliberately keeps the unsupported runtime matrix executable.
+Only exact protocol-route and exact export-route journeys are runtime-supported.
 Complete rejected-route reasons, less-specific lookup, and atomic all-candidate
 snapshots remain blockers. Protocol aliases are immutable after sidecar startup,
 so changing one requires a sidecar restart. Promoting any blocker, weakening the
-explicit alias, enabling debug mode, skipping a case, or drifting a pin or
-response makes the gate fail.
+explicit alias or product-version posture, enabling debug mode, skipping a case,
+or drifting a pin or response makes the gate fail.
 
 ## Provenance and licensing
 

--- a/tests/compat/ixp-manager-birdseye/adapter-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/adapter-consumer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use IXP\Models\Router;
+use IXP\Services\LookingGlass\BirdsEye;
+
+require getenv('IXP_MANAGER_ROOT') . '/vendor/autoload.php';
+
+$manifest = json_decode(
+    file_get_contents(__DIR__ . '/contract.json'),
+    true,
+    512,
+    JSON_THROW_ON_ERROR,
+);
+$protocol = $manifest['protocol_aliases']['member-v4'] ?? null;
+$versionPrefix = $manifest['adapter_api_version']['prefix'] ?? null;
+if ($protocol !== 'pb_as64496' || $versionPrefix !== 'rustbgpd ') {
+    throw new RuntimeException('adapter consumer contract drifted');
+}
+
+$container = new Container();
+Container::setInstance($container);
+$container->instance('config', new Repository([
+    'ixp_fe' => ['frontend' => ['disabled' => ['logs' => true]]],
+]));
+$router = new Router();
+$router->api = getenv('BIRDSEYE_API');
+$consumer = new BirdsEye($router);
+$responses = [
+    'exact-protocol-route' => $consumer->protocolRoute($protocol, '192.0.2.0', 24),
+    'exact-export-route' => $consumer->exportRoute($protocol, '192.0.2.0', 24),
+];
+
+foreach ($responses as $journey => $response) {
+    if (!is_string($response)) {
+        throw new RuntimeException("$journey did not return adapter JSON");
+    }
+    $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+    if (($decoded['routes'] ?? null) !== []) {
+        throw new RuntimeException("$journey expected the configured down peer to be empty");
+    }
+    $version = $decoded['api']['version'] ?? '';
+    if (!is_string($version) || !str_starts_with($version, $versionPrefix)) {
+        throw new RuntimeException("$journey api.version is not rustbgpd product identity");
+    }
+}
+
+echo json_encode($responses, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES) . "\n";

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -4,7 +4,15 @@
   "protocol_aliases": {
     "member-v4": "pb_as64496"
   },
+  "adapter_api_version": {
+    "kind": "product-identity",
+    "prefix": "rustbgpd "
+  },
   "runtime_compatibility": false,
+  "runtime_supported": [
+    "exact-protocol-route",
+    "exact-export-route"
+  ],
   "unsupported": [
     "complete-rejected-route-reason-inventory",
     "less-specific-longest-prefix-match",

--- a/tests/compat/ixp-manager-birdseye/run-adapter-consumer.sh
+++ b/tests/compat/ixp-manager-birdseye/run-adapter-consumer.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo=$(CDPATH='' cd -- "$root/../../.." && pwd)
+ixp_manager=${1:?IXP Manager checkout is required}
+image=${2:?PHP contract image is required}
+tmp=$(mktemp -d)
+daemon_pid=
+adapter_pid=
+cleanup() {
+  [ -z "$adapter_pid" ] || kill "$adapter_pid" 2>/dev/null || true
+  [ -z "$daemon_pid" ] || kill "$daemon_pid" 2>/dev/null || true
+  rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
+
+cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" --bin rustbgpd
+cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" -p birdwatcher-adapter
+socket=$tmp/rustbgpd.sock
+mkdir -p "$tmp/runtime"
+cat >"$tmp/rustbgpd.toml" <<EOF
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 0
+runtime_state_dir = "$tmp/runtime"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "$socket"
+mode = 0o600
+
+[[neighbors]]
+address = "192.0.2.1"
+remote_asn = 64496
+graceful_restart = false
+EOF
+
+"$repo/target/debug/rustbgpd" "$tmp/rustbgpd.toml" >"$tmp/daemon.log" 2>&1 &
+daemon_pid=$!
+for _ in $(seq 1 120); do
+  [ -S "$socket" ] && break
+  kill -0 "$daemon_pid" 2>/dev/null || { cat "$tmp/daemon.log" >&2; exit 1; }
+  sleep 0.1
+done
+[ -S "$socket" ] || { cat "$tmp/daemon.log" >&2; exit 1; }
+
+NO_COLOR=1 "$repo/target/debug/birdwatcher-adapter" \
+  --grpc-addr "unix://$socket" --listen 127.0.0.1:0 \
+  --protocol-alias pb_as64496=192.0.2.1@master4 --max-routes 2 \
+  >"$tmp/adapter.out" 2>"$tmp/adapter.log" &
+adapter_pid=$!
+port=
+for _ in $(seq 1 120); do
+  port=$(grep -o '127\.0\.0\.1:[0-9][0-9]*' "$tmp/adapter.log" | tail -1 | cut -d: -f2 || true)
+  [ -z "$port" ] || break
+  kill -0 "$adapter_pid" 2>/dev/null || { cat "$tmp/adapter.log" >&2; exit 1; }
+  sleep 0.1
+done
+[ -n "$port" ] || { cat "$tmp/adapter.log" >&2; exit 1; }
+curl --silent --fail "http://127.0.0.1:$port/route/192.0.2.0%2F24/protocol/pb_as64496" >/dev/null
+docker run --rm --network host --user "$(id -u):$(id -g)" \
+  --env IXP_MANAGER_ROOT=/upstreams/ixp-manager \
+  --env BIRDSEYE_API="http://127.0.0.1:$port" \
+  --volume "$root:/harness:ro" \
+  --volume "$ixp_manager:/upstreams/ixp-manager:ro" \
+  "$image" php /harness/adapter-consumer.php

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -49,3 +49,5 @@ docker run --rm --user "$(id -u):$(id -g)" \
   --volume "$composer_cache:/composer-cache" \
   --volume "$capture_output:/capture-output" \
   "$image" /harness/run-in-container.sh
+
+"$root/run-adapter-consumer.sh" "$tmp/ixp-manager" "$image" >/dev/null

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -31,6 +31,8 @@ UNSUPPORTED = {
     "atomic-all-candidate-table-snapshot",
     "runtime-protocol-alias-reconfiguration",
 }
+RUNTIME_SUPPORTED = {"exact-protocol-route", "exact-export-route"}
+ADAPTER_API_VERSION = {"kind": "product-identity", "prefix": "rustbgpd "}
 
 
 def fail(message: str) -> None:
@@ -44,6 +46,10 @@ if manifest.get("runtime_compatibility") is not False:
     fail("contract oracle must not promote a runtime compatibility claim")
 if set(manifest.get("unsupported", [])) != UNSUPPORTED:
     fail("unsupported compatibility matrix drifted")
+if set(manifest.get("runtime_supported", [])) != RUNTIME_SUPPORTED:
+    fail("supported runtime matrix drifted")
+if manifest.get("adapter_api_version") != ADAPTER_API_VERSION:
+    fail("adapter api.version must remain an honest product identity")
 if manifest.get("protocol_aliases") != {"member-v4": "pb_as64496"}:
     fail("explicit protocol alias matrix drifted")
 


### PR DESCRIPTION
## Summary

- add exact received-route and exported-route detail endpoints to the Birdwatcher-compatible sidecar
- preserve all Add-Path candidates, pagination order, and source/target alias direction while applying exact filtering before the configured cap
- exercise IXP Manager v7.4.0's real `protocolRoute()` and `exportRoute()` consumers against a live rustbgpd adapter
- make adapter and live-smoke changes trigger the existing pinned compatibility oracle

The adapter continues to report its rustbgpd product version, and `runtime_compatibility` remains false. Global tables, search, longest-prefix match, wildcard queries, complete rejection taxonomy, and runtime alias reconfiguration remain explicitly unsupported.

## Verification

- adapter unit tests and real BGP/Add-Path smoke
- pinned IXP Manager v7.4.0 and Bird's Eye oracle with the live-adapter consumer leg
- nine destructive filter, pagination, cap, candidate, alias, version, and workflow-trigger proofs
- Rust 1.98 strict workspace Clippy and locked workspace tests
- Rust 1.95 locked workspace all-target check
- warning-denied workspace docs
- v1 surface, public tracker, scale-split, and Clippy-reasons contracts

Linear: LAN-1118
