### PR TITLE
Add manual IXP Manager render path

### DIFF
--- a/.github/workflows/ixp-compat.yml
+++ b/.github/workflows/ixp-compat.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "tests/compat/ixp-manager-birdseye/**"
       - "examples/birdwatcher-adapter/**"
+      - "tools/rs-config-render/**"
+      - "integrations/ixp-manager/**"
       - "tests/birdwatcher_adapter_smoke.rs"
       - ".github/workflows/ixp-compat.yml"
       - "docs/INTEROP.md"
@@ -13,6 +15,8 @@ on:
     paths:
       - "tests/compat/ixp-manager-birdseye/**"
       - "examples/birdwatcher-adapter/**"
+      - "tools/rs-config-render/**"
+      - "integrations/ixp-manager/**"
       - "tests/birdwatcher_adapter_smoke.rs"
       - ".github/workflows/ixp-compat.yml"
       - "docs/INTEROP.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rs-config-render` now accepts a strict IXP Manager v7.4 Foil JSON export,
+  writes a private route-server candidate, validates it with the selected
+  `rustbgpd` binary's version and `--check --strict` modes, then writes the
+  receipt last. Applicable UI filters, BIRD skin overrides, implicit
+  no-transit policy, incomplete or ambiguous member data, and unsupported
+  router modes fail closed. Fetch, activation, reload, and rollback remain an
+  explicit operator workflow. (LAN-1105)
 - `birdwatcher-adapter` now serves IXP Manager v7.4.0's exact received and
   export route journeys for IPv4/IPv6 unicast. Every page carries the exact
   daemon-side prefix filter, all Add-Path candidates retain source alias and

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,0 +1,15 @@
+# License map
+
+Unless a file says otherwise, rustbgpd is available under either the Apache
+License 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE)) or the MIT license
+([`LICENSE-MIT`](LICENSE-MIT)), at your option.
+
+The original IXP Manager Foil integration under
+`integrations/ixp-manager/gpl-2.0-only/` is GPL-2.0-only. Its complete license
+is included beside the source. That subtree is source-only: Cargo does not
+embed it, and rustbgpd release archives, binary packages, and final container
+images do not include it.
+
+The two parts communicate only through the documented versioned JSON/process
+boundary. Generated JSON and candidate configuration are data, not embedded
+integration source.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -609,7 +609,13 @@ refresh cadence, followed by the final semantic diff and support bundle,
 tested rollback, and a recorded feedback or explicit no-change outcome; the
 1,000-peer route-server scale receipt
 is [retained](docs/perf/route-server-1000-2026-07.md). The ARouteServer target
-ships as `tools/rs-config-render`. The external adapter now also serves the IXP
+ships as `tools/rs-config-render`. Its manual IXP Manager v7.4 seam now accepts
+an original Foil JSON export, fails closed on unsupported effective policy, and
+writes a private candidate, validates it with the selected rustbgpd binary's
+strict offline check, then writes the validated receipt last. HTTP fetching,
+activation, reload/settlement, callbacks, rollback, active UI-filter
+translation, custom-skin migration, and multi-address ownership remain open
+under LAN-1105. The external adapter now also serves the IXP
 Manager v7.4 status, live protocol inventory/detail, symbols, member received,
 and member export slice through immutable aliases with an enforced response
 maximum. Remaining Bird's Eye work is global table/count and exact/less-specific

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -41,6 +41,30 @@ not served. The adapter's `api.version` is rustbgpd product identity, not a
 Bird's Eye version claim, and the adapter is not described as fully IXP Manager
 / Bird's Eye compatible.
 
+### IXP Manager v7.4 manual configuration oracle
+
+The same pinned gate installs the repository's GPL-2.0-only Foil exporter into
+a temporary active IXP Manager v7.4 skin, loads upstream's own MySQL fixture,
+and invokes the real router configuration generator. Its supported
+single-session capture feeds the real `rs-config-render` binary, which must run
+the real `rustbgpd --version` and `rustbgpd --check --strict` before writing a
+receipt. The checked-in fixture is byte-identical to that live capture.
+
+This is a bounded export/render path, not full IXP Manager template or runtime
+compatibility. The renderer refuses applicable enabled production UI filters,
+active BIRD skin customizations, the implicit no-transit default, quarantine or
+non-route-server modes, protocols other than IPv4/IPv6, disabled large
+communities, IRR-disabled or empty clients, missing, malformed, or zero-port
+RPKI caches, wrong-family, duplicate or multi-address client data, unknown
+schema versions or fields, incomplete terminal markers, placeholder or overlong
+effective authentication, and symlink/public input or output paths.
+It renders only independently owned rustbgpd policy; no IXP Manager BIRD
+template or GPL source enters the binary or packaged artifacts.
+
+Fetching, activation, reload, callback, rollback, filter translation, custom
+skin migration, and multi-address next-hop parity remain outside this manual
+seam. A candidate without the final strict-check receipt is not deployable.
+
 ### CI coverage
 
 The hosted `.github/workflows/interop.yml` path gates the following

--- a/integrations/ixp-manager/gpl-2.0-only/LICENSE
+++ b/integrations/ixp-manager/gpl-2.0-only/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/integrations/ixp-manager/gpl-2.0-only/README.md
+++ b/integrations/ixp-manager/gpl-2.0-only/README.md
@@ -1,0 +1,24 @@
+# IXP Manager Foil exporter
+
+This directory contains original GPL-2.0-only integration source. It is not
+part of any rustbgpd binary, binary package, release archive, or final image.
+See [`LICENSE`](LICENSE).
+
+Install `api/v4/router/server/rustbgpd/json.foil.php` beneath the same path in
+the active IXP Manager `VIEW_SKIN`. IXP Manager v7.4 then renders the strict
+`rustbgpd.ixp-manager.router-config/v1` JSON document through its normal router
+configuration generator. The exporter reads IXP Manager's sanitized session,
+IRR, max-prefix, authentication, RPKI, and route-filter state; it does not copy
+or translate the upstream BIRD templates.
+
+Fetch that document separately through the authenticated IXP Manager API into
+a regular, non-symlink mode-0600 local file. Keep API keys in the fetcher's
+secret store or request header, never in a command line, JSON capture,
+candidate, or receipt. The Rust renderer has no HTTP client and does not handle
+IXP Manager credentials.
+
+The exporter deliberately reports unsupported production filters and active
+BIRD skin overrides so the Rust renderer can refuse instead of silently losing
+policy. It also distinguishes an unset no-transit override from an explicitly
+empty override. See `tools/rs-config-render/README.md` for the bounded manual
+render and strict-check workflow.

--- a/integrations/ixp-manager/gpl-2.0-only/api/v4/router/server/rustbgpd/json.foil.php
+++ b/integrations/ixp-manager/gpl-2.0-only/api/v4/router/server/rustbgpd/json.foil.php
@@ -1,0 +1,158 @@
+<?php
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 Lance McKee
+// Original rustbgpd integration code. No upstream router template is copied.
+
+use IXP\Models\Aggregators\IrrdbAggregator;
+use IXP\Models\RouteServerFilterProd;
+use IXP\Models\Router;
+
+$router = $t->router;
+$protocol = (int)$router->protocol;
+$ipSort = static function( array &$values ): void {
+    usort( $values, static function( $left, $right ): int {
+        [ $leftIp, $leftMask ] = array_pad( explode( '/', (string)$left, 2 ), 2, '0' );
+        [ $rightIp, $rightMask ] = array_pad( explode( '/', (string)$right, 2 ), 2, '0' );
+        return strcmp( (string)inet_pton( $leftIp ), (string)inet_pton( $rightIp ) )
+            ?: ( (int)$leftMask <=> (int)$rightMask );
+    } );
+};
+
+$skinFiles = [];
+$skin = (string)env( 'VIEW_SKIN', '' );
+if( $skin !== '' ) {
+    $skinRoot = base_path( 'resources/skins/' . $skin );
+    foreach( [ 'bird', 'bird2', 'bird2-2025' ] as $tree ) {
+        $root = $skinRoot . '/api/v4/router/server/' . $tree;
+        if( !is_dir( $root ) ) {
+            continue;
+        }
+        $walk = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS )
+        );
+        foreach( $walk as $file ) {
+            if( $file->isFile() ) {
+                $skinFiles[] = substr( $file->getPathname(), strlen( $skinRoot ) + 1 );
+            }
+        }
+    }
+}
+sort( $skinFiles, SORT_STRING );
+
+$caches = [];
+if( (bool)$router->rpki ) {
+    foreach( [ 1, 2 ] as $number ) {
+        $host = config( "ixp.rpki.rtr{$number}.host" );
+        $port = config( "ixp.rpki.rtr{$number}.port" );
+        if( $host ) {
+            $host = filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 )
+                ? '[' . $host . ']' : $host;
+            $caches[] = $host . ':' . (int)$port;
+        }
+    }
+}
+sort( $caches, SORT_STRING );
+
+$override = config( 'ixp.no_transit_asns.override' );
+$noTransitSource = $override === false
+    ? 'IXP_MANAGER_IMPLICIT_DEFAULT' : 'IXP_NO_TRANSIT_ASNS_OVERRIDE';
+$noTransit = $override === false ? [] : array_map( 'intval', $override );
+sort( $noTransit, SORT_NUMERIC );
+
+$clients = [];
+$activeFilters = [];
+foreach( $t->ints as $int ) {
+    if( (int)$int['autsys'] === (int)$router->asn ) {
+        continue;
+    }
+    $customer = (int)$int['cid'];
+    $filters = RouteServerFilterProd::whereCustomerId( $customer )
+        ->where( 'enabled', 1 )
+        ->where( static function( $query ) use ( $int ): void {
+            $query->whereNull( 'vlan_id' )->orWhere( 'vlan_id', $int['vlanid'] );
+        } )
+        ->where( static function( $query ) use ( $router ): void {
+            $query->whereNull( 'protocol' )->orWhere( 'protocol', $router->protocol );
+        } )
+        ->orderBy( 'order_by' )->get();
+    if( $filters->isNotEmpty() ) {
+        $ids = array_map( 'intval', $filters->pluck( 'id' )->all() );
+        sort( $ids, SORT_NUMERIC );
+        $activeFilters[] = [ 'customer_id' => $customer, 'filter_ids' => $ids ];
+    }
+
+    $origins = array_map( 'intval', IrrdbAggregator::asnsForRouterConfiguration(
+        $customer, $protocol, true
+    ) );
+    sort( $origins, SORT_NUMERIC );
+    $prefixes = array_values( IrrdbAggregator::prefixesForRouterConfiguration(
+        $customer, $protocol, true
+    ) );
+    $ipSort( $prefixes );
+    $peeringIps = array_values( $int['allpeeringips'] );
+    $ipSort( $peeringIps );
+
+    $secret = $int['bgpmd5secret'];
+    $auth = (bool)$router->skip_md5 || !$secret
+        ? [ 'type' => 'none' ]
+        : [ 'type' => 'md5', 'value' => (string)$secret ];
+    $clients[] = [
+        'customer_id' => $customer,
+        'vlan_interface_id' => (int)$int['vliid'],
+        'name' => (string)$int['cname'],
+        'asn' => (int)$int['autsys'],
+        'address' => (string)$int['address'],
+        'peering_ips' => $peeringIps,
+        'max_prefix' => (int)$int['maxprefixes'],
+        'auth' => $auth,
+        'irr_filter' => (bool)$int['irrdbfilter'],
+        'more_specifics' => (bool)$int['rsmorespecifics'],
+        'origins' => $origins,
+        'prefixes' => $prefixes,
+    ];
+}
+usort( $clients, static fn( $a, $b ) => $a['vlan_interface_id'] <=> $b['vlan_interface_id'] );
+usort( $activeFilters, static fn( $a, $b ) => $a['customer_id'] <=> $b['customer_id'] );
+
+$types = [
+    Router::TYPE_ROUTE_SERVER => 'route-server',
+    Router::TYPE_ROUTE_COLLECTOR => 'collector',
+    Router::TYPE_AS112 => 'as112',
+];
+$document = [
+    'schema' => 'rustbgpd.ixp-manager.router-config/v1',
+    'ixp_manager' => [ 'version' => APPLICATION_VERSION ],
+    'router' => [
+        'handle' => (string)$router->handle,
+        'type' => $types[$router->type] ?? 'other',
+        'protocol' => $protocol,
+        'asn' => (int)$router->asn,
+        'router_id' => (string)$router->router_id,
+        'peering_ip' => (string)$router->peering_ip,
+        'vlan_id' => (int)$router->vlan_id,
+        'quarantine' => (bool)$router->quarantine,
+        'bgp_lc' => (bool)$router->bgp_lc,
+        'rfc1997_passthru' => (bool)$router->rfc1997_passthru,
+        'rpki' => (bool)$router->rpki,
+        'skip_md5' => (bool)$router->skip_md5,
+    ],
+    'policy' => [
+        'minimum_prefix_length' => (int)config(
+            'ixp.irrdb.min_v' . $protocol . '_subnet_size'
+        ),
+        'rtr_caches' => $caches,
+        'no_transit' => [ 'source' => $noTransitSource, 'asns' => $noTransit ],
+    ],
+    'clients' => $clients,
+    'unsupported' => [
+        'active_ui_filters' => $activeFilters,
+        'route_server_skin_files' => $skinFiles,
+    ],
+    'complete' => [
+        'handle' => (string)$router->handle,
+        'client_count' => count( $clients ),
+        'marker' => 'END_OF_RUSTBGPD_IXP_MANAGER_CONFIG_' . $router->handle,
+    ],
+];
+echo json_encode( $document, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR );
+echo "\n";

--- a/tests/compat/ixp-manager-birdseye/Dockerfile
+++ b/tests/compat/ixp-manager-birdseye/Dockerfile
@@ -1,3 +1,3 @@
 FROM composer:2.8.12@sha256:5248900ab8b5f7f880c2d62180e40960cd87f60149ec9a1abfd62ac72a02577c
 
-RUN docker-php-ext-install bcmath pcntl
+RUN docker-php-ext-install bcmath pcntl pdo_mysql

--- a/tests/compat/ixp-manager-birdseye/config-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/config-consumer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\DB;
+use IXP\Models\Router;
+use IXP\Tasks\Router\ConfigurationGenerator;
+
+$ixp = getenv('IXP_MANAGER_ROOT');
+require $ixp . '/vendor/autoload.php';
+$app = require $ixp . '/bootstrap/app.php';
+require_once $ixp . '/version.php';
+$app->make(Kernel::class)->bootstrap();
+
+$output = rtrim((string)getenv('CAPTURE_OUTPUT'), '/');
+$router = Router::whereHandle('b2-rs1-lan1-ipv4')->firstOrFail();
+$router->template = 'api/v4/router/server/rustbgpd/json';
+$fail = static function (string $message): never {
+    fwrite(STDERR, $message . "\n");
+    exit(1);
+};
+
+$render = static function (string $name) use ($router, $output): string {
+    $json = (new ConfigurationGenerator($router))->render()->render();
+    json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    $path = $output . '/' . $name;
+    file_put_contents($path, $json, LOCK_EX);
+    chmod($path, 0600);
+    return $json;
+};
+
+config(['ixp.no_transit_asns.override' => false]);
+$render('config-implicit.json');
+config(['ixp.no_transit_asns.override' => []]);
+$ui = json_decode($render('config-ui-filter.json'), true, 512, JSON_THROW_ON_ERROR);
+$filters = $ui['unsupported']['active_ui_filters'];
+if ($filters !== [['customer_id' => 2, 'filter_ids' => [31, 33, 35]]]) {
+    $fail('seeded applicable UI filters were not surfaced exactly');
+}
+
+DB::table('route_server_filters_prod')->update(['enabled' => 0]);
+$skin = $ixp . '/resources/skins/' . getenv('VIEW_SKIN')
+    . '/api/v4/router/server/bird2/contract.foil.php';
+if (!is_dir(dirname($skin))) {
+    mkdir(dirname($skin), 0700, true);
+}
+file_put_contents($skin, "<?php // contract-only override\n");
+$skinned = json_decode($render('config-skin.json'), true, 512, JSON_THROW_ON_ERROR);
+unlink($skin);
+if ($skinned['unsupported']['route_server_skin_files'] !== [
+    'api/v4/router/server/bird2/contract.foil.php',
+]) {
+    $fail('active BIRD skin file was not surfaced');
+}
+
+DB::table('vlaninterface')->where('id', '<>', 3)->update(['rsclient' => 0]);
+DB::table('irrdb_asn')->where('customer_id', 3)->where('protocol', 4)
+    ->where('asn', '<>', 42)->delete();
+DB::table('irrdb_prefix')->where('customer_id', 3)->where('protocol', 4)
+    ->where('prefix', '<>', '31.135.128.0/19')->delete();
+$first = $render('ixp-manager-v7.4-rustbgpd.json');
+$second = (new ConfigurationGenerator($router))->render()->render();
+if ($first !== $second) {
+    $fail('supported exporter output is nondeterministic');
+}

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -9,6 +9,12 @@
     "prefix": "rustbgpd "
   },
   "runtime_compatibility": false,
+  "manual_config_export": {
+    "schema": "rustbgpd.ixp-manager.router-config/v1",
+    "ixp_manager_version": "7.4.0",
+    "router_handle": "b2-rs1-lan1-ipv4",
+    "strict_receipt_required": true
+  },
   "runtime_supported": [
     "exact-protocol-route",
     "exact-export-route"

--- a/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json
@@ -1,0 +1,64 @@
+{
+    "schema": "rustbgpd.ixp-manager.router-config/v1",
+    "ixp_manager": {
+        "version": "7.4.0"
+    },
+    "router": {
+        "handle": "b2-rs1-lan1-ipv4",
+        "type": "route-server",
+        "protocol": 4,
+        "asn": 65501,
+        "router_id": "192.0.2.18",
+        "peering_ip": "192.0.2.18",
+        "vlan_id": 1,
+        "quarantine": false,
+        "bgp_lc": true,
+        "rfc1997_passthru": false,
+        "rpki": true,
+        "skip_md5": false
+    },
+    "policy": {
+        "minimum_prefix_length": 24,
+        "rtr_caches": [
+            "127.0.0.1:3323"
+        ],
+        "no_transit": {
+            "source": "IXP_NO_TRANSIT_ASNS_OVERRIDE",
+            "asns": []
+        }
+    },
+    "clients": [
+        {
+            "customer_id": 3,
+            "vlan_interface_id": 3,
+            "name": "PCH DNS",
+            "asn": 42,
+            "address": "10.1.0.36",
+            "peering_ips": [
+                "10.1.0.36"
+            ],
+            "max_prefix": 2000,
+            "auth": {
+                "type": "md5",
+                "value": "mcWsqMdzGwTKt67g"
+            },
+            "irr_filter": true,
+            "more_specifics": false,
+            "origins": [
+                42
+            ],
+            "prefixes": [
+                "31.135.128.0/19"
+            ]
+        }
+    ],
+    "unsupported": {
+        "active_ui_filters": [],
+        "route_server_skin_files": []
+    },
+    "complete": {
+        "handle": "b2-rs1-lan1-ipv4",
+        "client_count": 1,
+        "marker": "END_OF_RUSTBGPD_IXP_MANAGER_CONFIG_b2-rs1-lan1-ipv4"
+    }
+}

--- a/tests/compat/ixp-manager-birdseye/run-in-container.sh
+++ b/tests/compat/ixp-manager-birdseye/run-in-container.sh
@@ -80,6 +80,14 @@ CAPTURE_FIXTURES=${CAPTURE_FIXTURES:-0} CAPTURE_OUTPUT=${CAPTURE_OUTPUT:-/captur
 
 validate_composer "$ixp_manager" ixp-gpl-warning
 composer install --working-dir="$ixp_manager" --no-dev --no-interaction --no-progress --prefer-dist --no-scripts
+cp "$ixp_manager/.env.ci" "$ixp_manager/.env"
+exporter="$ixp_manager/resources/skins/${VIEW_SKIN}/api/v4/router/server/rustbgpd"
+mkdir -p "$exporter"
+cp /exporter/json.foil.php "$exporter/json.foil.php"
+IXP_MANAGER_ROOT="$ixp_manager" php "$root/config-consumer.php"
+for config_capture in config-implicit.json config-ui-filter.json config-skin.json ixp-manager-v7.4-rustbgpd.json; do
+  [ -s "${CAPTURE_OUTPUT}/$config_capture" ] || { echo "IXP Manager config capture failed: $config_capture" >&2; exit 1; }
+done
 IXP_MANAGER_ROOT="$ixp_manager" BIRDSEYE_API=http://127.0.0.1:18080/api \
   php "$root/consumer.php" >"$capture/ixp-manager-consumer.json"
 consumer_fixture="$root/fixtures/ixp-manager-consumer.json"

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -2,8 +2,16 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo=$(CDPATH='' cd -- "$root/../../.." && pwd)
 tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT INT TERM
+network=rustbgpd-ixp-contract-$$
+mysql=rustbgpd-ixp-mysql-$$
+cleanup() {
+  docker rm --force "$mysql" >/dev/null 2>&1 || true
+  docker network rm "$network" >/dev/null 2>&1 || true
+  rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
 
 if [ "${CAPTURE_FIXTURES:-0}" = 1 ] && [ -z "${CAPTURE_OUTPUT:-}" ]; then
   echo "CAPTURE_OUTPUT is required when CAPTURE_FIXTURES=1" >&2
@@ -39,15 +47,62 @@ clone_pin https://github.com/inex/birdseye.git "$birdseye_commit" "$tmp/birdseye
 clone_pin https://github.com/inex/IXP-Manager.git "$ixp_manager_commit" "$tmp/ixp-manager"
 
 image=$(docker build --quiet --file "$root/Dockerfile" "$root")
+docker network create "$network" >/dev/null
+docker run --detach --name "$mysql" --network "$network" \
+  --env MYSQL_ALLOW_EMPTY_PASSWORD=yes --env MYSQL_DATABASE=ixp_ci \
+  'mysql:8.4.11@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb' >/dev/null
+for _ in $(seq 1 90); do
+  if docker exec "$mysql" mysqladmin ping --host 127.0.0.1 --silent; then break; fi
+  sleep 1
+done
+docker exec "$mysql" mysqladmin ping --host 127.0.0.1 --silent
+docker exec -i "$mysql" mysql --user root ixp_ci <"$tmp/ixp-manager/data/ci/ci_test_db.sql"
 docker run --rm --user "$(id -u):$(id -g)" \
+  --network "$network" \
   --env CAPTURE_FIXTURES="${CAPTURE_FIXTURES:-0}" \
   --env CAPTURE_OUTPUT=/capture-output \
   --env COMPOSER_CACHE_DIR=/composer-cache \
+  --env DB_HOST="$mysql" --env DB_PORT=3306 --env DB_DATABASE=ixp_ci \
+  --env DB_USERNAME=root --env DB_PASSWORD= \
+  --env VIEW_SKIN=rustbgpd-contract --env IXP_NO_TRANSIT_ASNS_OVERRIDE= \
+  --env IXP_RPKI_RTR1_HOST=127.0.0.1 --env IXP_RPKI_RTR1_PORT=3323 \
+  --env IXP_RPKI_RTR2_HOST= \
   --volume "$root:/harness:ro" \
+  --volume "$repo/integrations/ixp-manager/gpl-2.0-only/api/v4/router/server/rustbgpd/json.foil.php:/exporter/json.foil.php:ro" \
   --volume "$tmp/birdseye:/upstreams/birdseye" \
   --volume "$tmp/ixp-manager:/upstreams/ixp-manager" \
   --volume "$composer_cache:/composer-cache" \
   --volume "$capture_output:/capture-output" \
   "$image" /harness/run-in-container.sh
+
+supported="$capture_output/ixp-manager-v7.4-rustbgpd.json"
+for capture in config-implicit.json config-ui-filter.json config-skin.json "$supported"; do
+  [ -f "$capture_output/$(basename "$capture")" ] || { echo "missing real IXP Manager capture: $capture" >&2; exit 1; }
+  chmod 600 "$capture_output/$(basename "$capture")"
+done
+cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" -p rs-config-render --bin rs-config-render
+cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" --bin rustbgpd
+for refused in config-implicit.json config-ui-filter.json config-skin.json; do
+  out="$tmp/refused-${refused%.json}"
+  if "$repo/target/debug/rs-config-render" --input-format ixp-manager-v1 \
+    --context "$capture_output/$refused" --out-dir "$out" \
+    --max-prefix-restart-seconds 300 --check-with "$repo/target/debug/rustbgpd"; then
+    echo "unsupported real IXP Manager capture rendered: $refused" >&2
+    exit 1
+  fi
+  [ ! -e "$out/render-receipt.json" ]
+done
+candidate="$tmp/candidate"
+"$repo/target/debug/rs-config-render" --input-format ixp-manager-v1 \
+  --context "$supported" --out-dir "$candidate" \
+  --max-prefix-restart-seconds 300 --check-with "$repo/target/debug/rustbgpd" >/dev/null
+[ -f "$candidate/render-receipt.json" ]
+fixture="$root/fixtures/ixp-manager-v7.4-rustbgpd.json"
+if [ "${CAPTURE_FIXTURES:-0}" = 1 ]; then
+  : # The real capture already has the fixture's canonical basename.
+else
+  diff -u "$fixture" "$supported"
+fi
+cmp "$supported" "$repo/tools/rs-config-render/tests/fixtures/ixp-manager-v1-supported.json"
 
 "$root/run-adapter-consumer.sh" "$tmp/ixp-manager" "$image" >/dev/null

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -26,6 +26,44 @@ the refresh loop can gate on warnings, not just on rejection.
 
 [arouteserver]: https://github.com/pierky/arouteserver
 
+## IXP Manager v7.4 manual candidate
+
+The GPL-2.0-only Foil exporter under
+[`integrations/ixp-manager`](../../integrations/ixp-manager/gpl-2.0-only/README.md)
+runs inside IXP Manager and emits the versioned JSON boundary. Fetch that JSON
+separately with authenticated `curl` into a mode-0600 file; the renderer does
+not fetch URLs or handle API keys.
+
+The supported render command is:
+
+```console
+umask 077
+rs-config-render \
+  --input-format ixp-manager-v1 \
+  --context /var/lib/rustbgpd/ixp-manager/router.json \
+  --out-dir /var/lib/rustbgpd/ixp-manager/candidate \
+  --max-prefix-restart-seconds 300 \
+  --check-with /usr/bin/rustbgpd
+```
+
+The input must be a regular, non-symlink mode-0600 file. The output directory
+must be absent or an empty, non-symlink mode-0700 directory; generated
+configuration and policy files are mode 0600.
+IXP Manager mode always runs the selected binary first as `rustbgpd --version`
+and then as `rustbgpd --check --strict <candidate>/config.toml`. Child output is
+suppressed so authentication values cannot escape through diagnostics.
+
+`render-receipt.json` is written last and only after the strict check passes.
+It records the source identity and hash, generated-file hashes and counts,
+refusal status, and the checked rustbgpd version without copying secrets. A
+candidate without that receipt is incomplete and must not be deployed.
+
+After reviewing a complete candidate, install `config.toml` and its `policy/`
+directory together using the existing coordinated-file procedure, then SIGHUP
+rustbgpd. A failed export, refusal, render, or check leaves the running daemon
+untouched. This mode does not fetch, install, activate, reload, poll, roll back,
+or call IXP Manager update/release callbacks.
+
 Release tarballs (`rustbgpd-<arch>.tar.gz` on the [releases
 page](https://github.com/lance0/rustbgpd/releases)) ship the
 `rs-config-render` binary alongside `rustbgpd` and `rbgp`; from

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -1,0 +1,650 @@
+//! Strict, manual IXP Manager v7.4 candidate rendering.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::fs;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::Path;
+use std::process::Command;
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+#[cfg(unix)]
+use std::fs::OpenOptions;
+#[cfg(unix)]
+use std::io::Write as _;
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+
+const SCHEMA: &str = "rustbgpd.ixp-manager.router-config/v1";
+const IXP_VERSION: &str = "7.4.0";
+const BASE_HYGIENE: &str = include_str!("../../../examples/route-server/hygiene.rpol");
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    Refused(&'static str),
+    Input,
+    Output,
+    Checker,
+}
+
+impl Error {
+    pub const fn exit_code(&self) -> u8 {
+        match self {
+            Self::Input => 1,
+            Self::Refused(_) => 2,
+            Self::Output | Self::Checker => 3,
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Refused(reason) => write!(f, "IXP Manager input refused: {reason}"),
+            Self::Input => f.write_str("IXP Manager input is invalid or has an unknown field"),
+            Self::Output => {
+                f.write_str("candidate output must be an absent or empty private directory")
+            }
+            Self::Checker => f.write_str("strict checker failed; candidate has no receipt"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Document {
+    schema: String,
+    ixp_manager: IxpManager,
+    router: Router,
+    policy: Policy,
+    clients: Vec<Client>,
+    unsupported: Unsupported,
+    complete: Complete,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IxpManager {
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Router {
+    handle: String,
+    #[serde(rename = "type")]
+    kind: String,
+    protocol: u8,
+    asn: u32,
+    router_id: String,
+    peering_ip: String,
+    vlan_id: u64,
+    quarantine: bool,
+    bgp_lc: bool,
+    rfc1997_passthru: bool,
+    rpki: bool,
+    skip_md5: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Policy {
+    minimum_prefix_length: u8,
+    rtr_caches: Vec<String>,
+    no_transit: NoTransit,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NoTransit {
+    source: String,
+    asns: Vec<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Client {
+    customer_id: u64,
+    vlan_interface_id: u64,
+    name: String,
+    asn: u32,
+    address: String,
+    peering_ips: Vec<String>,
+    max_prefix: u32,
+    auth: Auth,
+    irr_filter: bool,
+    more_specifics: bool,
+    origins: Vec<u32>,
+    prefixes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
+enum Auth {
+    None,
+    Md5 { value: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Unsupported {
+    active_ui_filters: Vec<ActiveFilter>,
+    route_server_skin_files: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ActiveFilter {
+    customer_id: u64,
+    filter_ids: Vec<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Complete {
+    handle: String,
+    client_count: usize,
+    marker: String,
+}
+
+#[derive(Debug)]
+pub struct Candidate {
+    pub files: BTreeMap<String, String>,
+    metadata: Value,
+}
+
+fn quoted(value: &str) -> String {
+    serde_json::to_string(value).expect("string serialization cannot fail")
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .fold(String::with_capacity(64), |mut out, byte| {
+            write!(out, "{byte:02x}").expect("String writes cannot fail");
+            out
+        })
+}
+
+fn strictly_sorted<T: Ord>(items: &[T]) -> bool {
+    items.windows(2).all(|pair| pair[0] < pair[1])
+}
+
+fn prefix_key(raw: &str, family: u8) -> Option<(u128, u8)> {
+    let (address, length) = raw.split_once('/')?;
+    if address.contains('/') {
+        return None;
+    }
+    let address: IpAddr = address.parse().ok()?;
+    let length: u8 = length.parse().ok()?;
+    let (bits, width) = match (family, address) {
+        (4, IpAddr::V4(ip)) => Some((u128::from(u32::from(ip)), 32)),
+        (6, IpAddr::V6(ip)) => Some((u128::from(ip), 128)),
+        _ => None,
+    }?;
+    if length > width {
+        return None;
+    }
+    let host = width - length;
+    let host_mask = if host == 128 {
+        u128::MAX
+    } else {
+        (1u128 << host) - 1
+    };
+    (bits & host_mask == 0).then_some((bits, length))
+}
+
+fn valid_handle(handle: &str) -> bool {
+    !handle.is_empty()
+        && handle.len() <= 128
+        && handle
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"-_.".contains(&b))
+}
+
+fn validate(document: &Document) -> Result<Vec<Vec<String>>, Error> {
+    if document.schema != SCHEMA || document.ixp_manager.version != IXP_VERSION {
+        return Err(Error::Refused("unsupported schema or IXP Manager version"));
+    }
+    let router = &document.router;
+    if !valid_handle(&router.handle)
+        || router.kind != "route-server"
+        || !matches!(router.protocol, 4 | 6)
+        || router.asn == 0
+        || router.vlan_id == 0
+        || router.router_id.parse::<Ipv4Addr>().is_err()
+    {
+        return Err(Error::Refused("invalid route-server identity"));
+    }
+    if router.quarantine || !router.bgp_lc {
+        return Err(Error::Refused("unsupported route-server mode"));
+    }
+    let local: IpAddr = router
+        .peering_ip
+        .parse()
+        .map_err(|_| Error::Refused("invalid addressing"))?;
+    if (router.protocol == 4) != local.is_ipv4() {
+        return Err(Error::Refused("invalid addressing"));
+    }
+    if document.policy.no_transit.source != "IXP_NO_TRANSIT_ASNS_OVERRIDE" {
+        return Err(Error::Refused("explicit no-transit override required"));
+    }
+    if !strictly_sorted(&document.policy.no_transit.asns)
+        || document.policy.no_transit.asns.contains(&0)
+    {
+        return Err(Error::Refused("invalid no-transit data"));
+    }
+    if let Some(filter) = document.unsupported.active_ui_filters.first() {
+        let _validated_shape = (filter.customer_id, &filter.filter_ids);
+        return Err(Error::Refused(
+            "active production UI filters are unsupported",
+        ));
+    }
+    if !document.unsupported.route_server_skin_files.is_empty() {
+        return Err(Error::Refused(
+            "active BIRD skin customization is unsupported",
+        ));
+    }
+    let maximum = if router.protocol == 4 { 32 } else { 128 };
+    if document.policy.minimum_prefix_length == 0
+        || document.policy.minimum_prefix_length > maximum
+        || !strictly_sorted(&document.policy.rtr_caches)
+        || document
+            .policy
+            .rtr_caches
+            .iter()
+            .any(|cache| match cache.parse::<SocketAddr>() {
+                Ok(address) => address.port() == 0,
+                Err(_) => true,
+            })
+        || (router.rpki && document.policy.rtr_caches.is_empty())
+    {
+        return Err(Error::Refused("invalid RPKI or prefix-length policy"));
+    }
+    if document.complete.handle != router.handle
+        || document.complete.client_count != document.clients.len()
+        || document.complete.marker
+            != format!("END_OF_RUSTBGPD_IXP_MANAGER_CONFIG_{}", router.handle)
+    {
+        return Err(Error::Refused("incomplete export marker"));
+    }
+    let mut customers = BTreeSet::new();
+    let mut vlis = BTreeSet::new();
+    let mut asns = BTreeSet::new();
+    let mut addresses = BTreeSet::new();
+    let mut effective = Vec::new();
+    for client in &document.clients {
+        let address: IpAddr = client
+            .address
+            .parse()
+            .map_err(|_| Error::Refused("invalid addressing"))?;
+        if client.customer_id == 0
+            || client.vlan_interface_id == 0
+            || client.asn == 0
+            || client.max_prefix == 0
+            || (router.protocol == 4) != address.is_ipv4()
+            || !customers.insert(client.customer_id)
+            || !vlis.insert(client.vlan_interface_id)
+            || !asns.insert(client.asn)
+            || !addresses.insert(address)
+            || client.peering_ips.len() != 1
+            || client.peering_ips[0] != client.address
+        {
+            return Err(Error::Refused("invalid or duplicate client data"));
+        }
+        if !client.irr_filter
+            || client.origins.is_empty()
+            || client.origins.contains(&0)
+            || !strictly_sorted(&client.origins)
+        {
+            return Err(Error::Refused("effective IRR origins are unavailable"));
+        }
+        let keys = client
+            .prefixes
+            .iter()
+            .map(|prefix| prefix_key(prefix, router.protocol))
+            .collect::<Option<Vec<_>>>()
+            .ok_or(Error::Refused("invalid addressing"))?;
+        if keys.is_empty() || !strictly_sorted(&keys) {
+            return Err(Error::Refused("effective IRR prefixes are unavailable"));
+        }
+        let prefixes = client
+            .prefixes
+            .iter()
+            .zip(keys)
+            .filter_map(|(prefix, (_, length))| {
+                if client.more_specifics && length > document.policy.minimum_prefix_length {
+                    None
+                } else if client.more_specifics && length < document.policy.minimum_prefix_length {
+                    Some(format!(
+                        "{prefix} le {}",
+                        document.policy.minimum_prefix_length
+                    ))
+                } else {
+                    Some(prefix.clone())
+                }
+            })
+            .collect::<Vec<_>>();
+        if prefixes.is_empty() {
+            return Err(Error::Refused("effective IRR prefixes are unavailable"));
+        }
+        match &client.auth {
+            Auth::None => {}
+            Auth::Md5 { .. } if router.skip_md5 => {
+                return Err(Error::Refused("MD5 present while skip_md5 is active"));
+            }
+            Auth::Md5 { value }
+                if value.is_empty() || value.len() > 80 || is_placeholder(value) =>
+            {
+                return Err(Error::Refused("invalid MD5 secret"));
+            }
+            Auth::Md5 { .. } => {}
+        }
+        effective.push(prefixes);
+    }
+    Ok(effective)
+}
+
+fn is_placeholder(secret: &str) -> bool {
+    matches!(
+        secret.trim().to_ascii_lowercase().as_str(),
+        "changeme" | "placeholder" | "<redacted>" | "redacted" | "todo"
+    )
+}
+
+pub fn render_document(input: &[u8], restart_seconds: u32) -> Result<Candidate, Error> {
+    if restart_seconds == 0 {
+        return Err(Error::Refused("max-prefix restart must be positive"));
+    }
+    let document: Document = serde_json::from_slice(input).map_err(|_| Error::Input)?;
+    let effective = validate(&document)?;
+    let mut files = BTreeMap::new();
+    files.insert("policy/ixp-hygiene.rpol".into(), render_hygiene(&document));
+    for (client, prefixes) in document.clients.iter().zip(&effective) {
+        files.insert(
+            format!("policy/client-{}.rpol", client.vlan_interface_id),
+            render_client(client, prefixes),
+        );
+    }
+    files.insert(
+        "config.toml".into(),
+        render_config(&document, restart_seconds),
+    );
+    let metadata = json!({
+        "input": {"schema": SCHEMA, "ixp_manager_version": IXP_VERSION,
+            "router_handle": document.router.handle, "sha256": sha256(input)},
+        "counts": {"clients": document.clients.len(),
+            "prefixes": effective.iter().map(Vec::len).sum::<usize>(),
+            "origins": document.clients.iter().map(|c| c.origins.len()).sum::<usize>()},
+        "refusals": {"status": "passed", "active_ui_filters": 0,
+            "route_server_skin_files": 0, "multi_address_clients": 0}
+    });
+    Ok(Candidate { files, metadata })
+}
+
+fn render_config(document: &Document, restart_seconds: u32) -> String {
+    let router = &document.router;
+    let mut out = format!(
+        "# GENERATED candidate from IXP Manager {}.\n[global]\nasn = {}\nrouter_id = {}\nlisten_port = 179\nlisten_addresses = [{}]\nebgp_requires_policy = true\n\n[global.telemetry]\nlog_format = \"json\"\n",
+        document.ixp_manager.version,
+        router.asn,
+        quoted(&router.router_id),
+        quoted(&router.peering_ip)
+    );
+    if router.rpki {
+        out.push_str("\n[rpki]\n");
+        for cache in &document.policy.rtr_caches {
+            let _ = writeln!(out, "[[rpki.cache_servers]]\naddress = {}", quoted(cache));
+        }
+    }
+    out.push_str("\n[policy.definitions.ixp-transparent-export]\ndefault_action = \"permit\"\n\n[policy]\nrpol_files = [\n    \"policy/ixp-hygiene.rpol\",\n");
+    for client in &document.clients {
+        let _ = writeln!(
+            out,
+            "    \"policy/client-{}.rpol\",",
+            client.vlan_interface_id
+        );
+    }
+    out.push_str("]\nexport_chain = [\"ixp-transparent-export\"]\n");
+    for client in &document.clients {
+        let family = if router.protocol == 4 {
+            "ipv4_unicast"
+        } else {
+            "ipv6_unicast"
+        };
+        let _ = write!(
+            out,
+            "\n[[neighbors]]\naddress = {}\nremote_asn = {}\ndescription = {}\nfamilies = [{}]\nroute_server_client = true\nrole = \"route_server\"\nnext_hop_ownership = \"strict_peer\"\nper_client_best = true\nrs_control_communities = true\ninterpret_rfc1997 = {}\nmax_prefixes_{} = {}\nmax_prefix_restart_seconds = {}\nimport_policy_chain = [\"reject-special-purpose\", \"ixp-hygiene\", \"ixp-manager-hygiene\", \"client-{}\"]\n",
+            quoted(&client.address),
+            client.asn,
+            quoted(&client.name),
+            quoted(family),
+            !router.rfc1997_passthru,
+            if router.protocol == 4 { "ipv4" } else { "ipv6" },
+            client.max_prefix,
+            restart_seconds,
+            client.vlan_interface_id
+        );
+        if let Auth::Md5 { value } = &client.auth {
+            let _ = writeln!(out, "md5_password = {}", quoted(value));
+        }
+    }
+    out
+}
+
+fn render_hygiene(document: &Document) -> String {
+    let mut out = BASE_HYGIENE.to_owned();
+    out.push_str("\n# IXP Manager effective policy additions.\n");
+    let no_transit = &document.policy.no_transit.asns;
+    if !no_transit.is_empty() {
+        let values = no_transit
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let regex = no_transit
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join("|");
+        let _ = writeln!(out, "asn-set ixp-manager-no-transit-asns {{ {values} }}");
+        let _ = writeln!(
+            out,
+            "policy ixp-manager-hygiene {{\n    term reject-transit-leak {{ if route.as-path matches \"_({regex})_\" {{ reject }} }}"
+        );
+    } else {
+        out.push_str("policy ixp-manager-hygiene {\n");
+    }
+    let root = if document.router.protocol == 4 {
+        "0.0.0.0/0"
+    } else {
+        "::/0"
+    };
+    let maximum = if document.router.protocol == 4 {
+        32
+    } else {
+        128
+    };
+    if document.policy.minimum_prefix_length < maximum {
+        let _ = writeln!(
+            out,
+            "    term reject-too-specific {{ if route.prefix in ixp-manager-too-specific {{ reject }} }}"
+        );
+    }
+    if document.router.rpki {
+        out.push_str("    term reject-rpki-invalid { if route.rpki == invalid { reject } }\n");
+    }
+    out.push_str("}\n");
+    if document.policy.minimum_prefix_length < maximum {
+        let _ = writeln!(
+            out,
+            "prefix-set ixp-manager-too-specific {{ {root} ge {} }}",
+            document.policy.minimum_prefix_length + 1
+        );
+    }
+    out
+}
+
+fn render_client(client: &Client, prefixes: &[String]) -> String {
+    let slug = client.vlan_interface_id;
+    let origins = client
+        .origins
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut out = format!(
+        "# GENERATED IXP Manager IRR policy.\nasn-set client-{slug}-origins {{ {origins} }}\nprefix-set client-{slug}-prefixes {{\n"
+    );
+    for prefix in prefixes {
+        let _ = writeln!(out, "    {prefix},");
+    }
+    let _ = write!(
+        out,
+        "}}\npolicy client-{slug} {{\n    term accept-authorized {{ if route.origin-as in client-{slug}-origins && route.prefix in client-{slug}-prefixes {{ accept }} }}\n    term rest {{ reject }}\n}}\n"
+    );
+    out
+}
+
+#[cfg(unix)]
+fn private_file(path: &Path, mode: u32) -> bool {
+    fs::symlink_metadata(path)
+        .is_ok_and(|m| m.file_type().is_file() && m.permissions().mode() & 0o777 == mode)
+}
+
+#[cfg(not(unix))]
+fn private_file(_: &Path, _: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn private_dir(path: &Path, mode: u32) -> bool {
+    fs::symlink_metadata(path)
+        .is_ok_and(|m| m.file_type().is_dir() && m.permissions().mode() & 0o777 == mode)
+}
+
+#[cfg(not(unix))]
+fn private_dir(_: &Path, _: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn create_private_dir(path: &Path) -> std::io::Result<()> {
+    fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(path)
+}
+
+#[cfg(not(unix))]
+fn create_private_dir(_: &Path) -> std::io::Result<()> {
+    Err(std::io::ErrorKind::Unsupported.into())
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(contents)
+}
+
+#[cfg(not(unix))]
+fn write_private(_: &Path, _: &[u8]) -> std::io::Result<()> {
+    Err(std::io::ErrorKind::Unsupported.into())
+}
+
+fn prepare_output(out: &Path) -> Result<(), Error> {
+    if out.exists() {
+        if !out.is_dir()
+            || !private_dir(out, 0o700)
+            || fs::read_dir(out)
+                .map_err(|_| Error::Output)?
+                .next()
+                .is_some()
+        {
+            return Err(Error::Output);
+        }
+    } else {
+        create_private_dir(out).map_err(|_| Error::Output)?;
+    }
+    Ok(())
+}
+
+fn safe_version(output: &[u8]) -> Result<String, Error> {
+    let text = std::str::from_utf8(output).map_err(|_| Error::Checker)?;
+    let mut words = text
+        .lines()
+        .next()
+        .ok_or(Error::Checker)?
+        .split_ascii_whitespace();
+    let name = words.next().ok_or(Error::Checker)?;
+    let version = words.next().ok_or(Error::Checker)?;
+    if name != "rustbgpd"
+        || !version
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b".+-_".contains(&b))
+    {
+        return Err(Error::Checker);
+    }
+    Ok(format!("rustbgpd {version}"))
+}
+
+pub fn write_checked_candidate(
+    context: &Path,
+    out: &Path,
+    restart_seconds: u32,
+    checker: &Path,
+) -> Result<usize, Error> {
+    if !private_file(context, 0o600) {
+        return Err(Error::Refused("input capture must be mode 0600"));
+    }
+    let input = fs::read(context).map_err(|_| Error::Input)?;
+    let candidate = render_document(&input, restart_seconds)?;
+    prepare_output(out)?;
+    for (relative, contents) in &candidate.files {
+        let path = out.join(relative);
+        if let Some(parent) = path.parent() {
+            create_private_dir(parent).map_err(|_| Error::Output)?;
+        }
+        write_private(&path, contents.as_bytes()).map_err(|_| Error::Output)?;
+    }
+    let version = Command::new(checker)
+        .arg("--version")
+        .output()
+        .map_err(|_| Error::Checker)?;
+    if !version.status.success() {
+        return Err(Error::Checker);
+    }
+    let mut version_bytes = version.stdout;
+    version_bytes.extend(version.stderr);
+    let version = safe_version(&version_bytes)?;
+    let checked = Command::new(checker)
+        .arg("--check")
+        .arg("--strict")
+        .arg(out.join("config.toml"))
+        .output()
+        .map_err(|_| Error::Checker)?;
+    if !checked.status.success() {
+        return Err(Error::Checker);
+    }
+    let hashes = candidate
+        .files
+        .iter()
+        .map(|(path, contents)| (path.clone(), sha256(contents.as_bytes())))
+        .collect::<BTreeMap<_, _>>();
+    let mut receipt = candidate.metadata;
+    receipt["generated_files"] = serde_json::to_value(hashes).expect("hash map serializes");
+    receipt["strict_check"] = json!({"binary_version": version, "passed": true});
+    let mut encoded = serde_json::to_vec_pretty(&receipt).expect("receipt serializes");
+    encoded.push(b'\n');
+    write_private(&out.join("render-receipt.json"), &encoded).map_err(|_| Error::Output)?;
+    Ok(candidate.files.len())
+}

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -43,6 +43,8 @@ use std::fmt::Write as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+pub mod ixp_manager;
+
 /// Top-level keys of the supported `template-context` shape, sorted.
 ///
 /// Pinned against arouteserver's builder render context (the dict the

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -6,31 +6,40 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 use rs_config_render::{
     Options, RenderError, SiteLocalFile, SiteLocalInput, render, render_site_local,
 };
 
+#[derive(Clone, Copy, ValueEnum)]
+enum InputFormat {
+    Arouteserver,
+    IxpManagerV1,
+}
+
 #[derive(Parser)]
 #[command(
     name = "rs-config-render",
     version,
-    about = "Render rustbgpd route-server configuration from `arouteserver template-context` output"
+    about = "Render rustbgpd route-server configuration from supported upstream exports"
 )]
 struct Cli {
-    /// Path to `arouteserver template-context` output (YAML; JSON also parses)
+    /// Input document format
+    #[arg(long, value_enum, default_value = "arouteserver")]
+    input_format: InputFormat,
+    /// Path to the selected input document (arouteserver YAML/JSON or IXP Manager JSON)
     #[arg(long)]
     context: PathBuf,
     /// Output directory (created if missing)
     #[arg(long)]
     out_dir: PathBuf,
     /// Abort when a client's generated prefix-set has fewer members
-    #[arg(long, default_value_t = 1)]
-    min_prefixes: u32,
+    #[arg(long)]
+    min_prefixes: Option<u32>,
     /// Abort when a client's generated origin asn-set has fewer members
-    #[arg(long, default_value_t = 1)]
-    min_origins: u32,
+    #[arg(long)]
+    min_origins: Option<u32>,
     /// RTR cache endpoint (host:port) for [[rpki.cache_servers]]; repeatable.
     /// Required when the context enables RPKI origin validation.
     #[arg(long = "rtr-cache")]
@@ -44,6 +53,12 @@ struct Cli {
     /// Strict site-local hook TOML; exactly one when --extra-rpol is used
     #[arg(long = "merge-toml")]
     merge_toml: Vec<PathBuf>,
+    /// Required positive automatic restart delay for IXP Manager max-prefix
+    #[arg(long)]
+    max_prefix_restart_seconds: Option<u32>,
+    /// rustbgpd binary used for mandatory version and strict candidate checks
+    #[arg(long)]
+    check_with: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -98,6 +113,47 @@ fn stdout_exit(result: Result<(), StdoutWriteError>) -> ExitCode {
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let customized = !cli.extra_rpol.is_empty() || !cli.merge_toml.is_empty();
+    if matches!(cli.input_format, InputFormat::IxpManagerV1) {
+        if customized
+            || cli.min_prefixes.is_some()
+            || cli.min_origins.is_some()
+            || !cli.rtr_cache.is_empty()
+            || cli.allow_shape_drift
+        {
+            eprintln!("rs-config-render: IXP Manager mode does not accept arouteserver options");
+            return ExitCode::from(2);
+        }
+        let (Some(restart), Some(checker)) =
+            (cli.max_prefix_restart_seconds, cli.check_with.as_deref())
+        else {
+            eprintln!(
+                "rs-config-render: IXP Manager mode requires --max-prefix-restart-seconds and --check-with"
+            );
+            return ExitCode::from(2);
+        };
+        return match rs_config_render::ixp_manager::write_checked_candidate(
+            &cli.context,
+            &cli.out_dir,
+            restart,
+            checker,
+        ) {
+            Ok(files) => stdout_exit(write_stdout(|writer| {
+                writeln!(
+                    writer,
+                    "validated {files} candidate file(s) + receipt into {}",
+                    cli.out_dir.display()
+                )
+            })),
+            Err(error) => {
+                eprintln!("rs-config-render: {error}");
+                ExitCode::from(error.exit_code())
+            }
+        };
+    }
+    if cli.max_prefix_restart_seconds.is_some() || cli.check_with.is_some() {
+        eprintln!("rs-config-render: IXP Manager options require --input-format ixp-manager-v1");
+        return ExitCode::from(2);
+    }
     if customized && (cli.extra_rpol.is_empty() || cli.merge_toml.len() != 1) {
         eprintln!(
             "rs-config-render: {}",
@@ -119,8 +175,8 @@ fn main() -> ExitCode {
         }
     };
     let opts = Options {
-        min_prefixes: cli.min_prefixes,
-        min_origins: cli.min_origins,
+        min_prefixes: cli.min_prefixes.unwrap_or(1),
+        min_origins: cli.min_origins.unwrap_or(1),
         rtr_caches: cli.rtr_cache,
         allow_shape_drift: cli.allow_shape_drift,
     };

--- a/tools/rs-config-render/tests/fixtures/ixp-manager-v1-supported.json
+++ b/tools/rs-config-render/tests/fixtures/ixp-manager-v1-supported.json
@@ -1,0 +1,64 @@
+{
+    "schema": "rustbgpd.ixp-manager.router-config/v1",
+    "ixp_manager": {
+        "version": "7.4.0"
+    },
+    "router": {
+        "handle": "b2-rs1-lan1-ipv4",
+        "type": "route-server",
+        "protocol": 4,
+        "asn": 65501,
+        "router_id": "192.0.2.18",
+        "peering_ip": "192.0.2.18",
+        "vlan_id": 1,
+        "quarantine": false,
+        "bgp_lc": true,
+        "rfc1997_passthru": false,
+        "rpki": true,
+        "skip_md5": false
+    },
+    "policy": {
+        "minimum_prefix_length": 24,
+        "rtr_caches": [
+            "127.0.0.1:3323"
+        ],
+        "no_transit": {
+            "source": "IXP_NO_TRANSIT_ASNS_OVERRIDE",
+            "asns": []
+        }
+    },
+    "clients": [
+        {
+            "customer_id": 3,
+            "vlan_interface_id": 3,
+            "name": "PCH DNS",
+            "asn": 42,
+            "address": "10.1.0.36",
+            "peering_ips": [
+                "10.1.0.36"
+            ],
+            "max_prefix": 2000,
+            "auth": {
+                "type": "md5",
+                "value": "mcWsqMdzGwTKt67g"
+            },
+            "irr_filter": true,
+            "more_specifics": false,
+            "origins": [
+                42
+            ],
+            "prefixes": [
+                "31.135.128.0/19"
+            ]
+        }
+    ],
+    "unsupported": {
+        "active_ui_filters": [],
+        "route_server_skin_files": []
+    },
+    "complete": {
+        "handle": "b2-rs1-lan1-ipv4",
+        "client_count": 1,
+        "marker": "END_OF_RUSTBGPD_IXP_MANAGER_CONFIG_b2-rs1-lan1-ipv4"
+    }
+}

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -1,0 +1,320 @@
+use std::fs;
+
+use rs_config_render::ixp_manager::{Error, render_document};
+
+const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
+const SECRET: &str = "mcWsqMdzGwTKt67g";
+
+fn digest(path: &std::path::Path) -> String {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(fs::read(path).unwrap())
+        .iter()
+        .fold(String::new(), |mut out, byte| {
+            std::fmt::Write::write_fmt(&mut out, format_args!("{byte:02x}")).unwrap();
+            out
+        })
+}
+
+fn value() -> serde_json::Value {
+    serde_json::from_slice(FIXTURE).unwrap()
+}
+
+fn rendered(input: &serde_json::Value) -> Result<rs_config_render::ixp_manager::Candidate, Error> {
+    render_document(&serde_json::to_vec(input).unwrap(), 300)
+}
+
+#[test]
+fn supported_render_is_deterministic_and_explicit() {
+    let first = render_document(FIXTURE, 300).unwrap();
+    assert_eq!(first.files, render_document(FIXTURE, 300).unwrap().files);
+    assert_eq!(first.files.len(), 3);
+    let config = &first.files["config.toml"];
+    for expected in [
+        "listen_addresses = [\"192.0.2.18\"]",
+        "next_hop_ownership = \"strict_peer\"",
+        "per_client_best = true",
+        "rs_control_communities = true",
+        "interpret_rfc1997 = true",
+        "max_prefix_restart_seconds = 300",
+        "md5_password = \"mcWsqMdzGwTKt67g\"",
+    ] {
+        assert!(config.contains(expected), "missing {expected}");
+    }
+    let client = &first.files["policy/client-3.rpol"];
+    assert!(client.contains("asn-set client-3-origins { 42 }"));
+    assert!(client.contains("31.135.128.0/19"));
+    assert!(client.contains("term rest { reject }"));
+    let mut loose = value();
+    loose["clients"][0]["more_specifics"] = true.into();
+    assert!(
+        rendered(&loose).unwrap().files["policy/client-3.rpol"].contains("31.135.128.0/19 le 24")
+    );
+    let mut transit = value();
+    transit["policy"]["no_transit"]["asns"] = serde_json::json!([42]);
+    let hygiene = &rendered(&transit).unwrap().files["policy/ixp-hygiene.rpol"];
+    assert!(hygiene.contains("if route.as-path matches \"_(42)_\""));
+    assert!(!hygiene.contains("peer.asn in ixp-manager-no-transit"));
+    let mut maximum = value();
+    maximum["policy"]["minimum_prefix_length"] = 32.into();
+    assert!(
+        !rendered(&maximum).unwrap().files["policy/ixp-hygiene.rpol"]
+            .contains("ixp-manager-too-specific")
+    );
+}
+
+#[test]
+fn strict_schema_completion_and_refusal_matrix_fail_closed() {
+    let refuses = |pointer: &str, replacement: serde_json::Value| {
+        let mut input = value();
+        *input.pointer_mut(pointer).unwrap() = replacement;
+        assert!(rendered(&input).is_err(), "{pointer} unexpectedly rendered");
+    };
+    refuses("/schema", serde_json::json!("wrong"));
+    refuses("/ixp_manager/version", serde_json::json!("7.5.0"));
+    refuses("/router/type", serde_json::json!("collector"));
+    refuses("/router/protocol", serde_json::json!(5));
+    refuses("/router/quarantine", serde_json::json!(true));
+    refuses("/router/bgp_lc", serde_json::json!(false));
+    refuses("/policy/no_transit/source", serde_json::json!("default"));
+    refuses(
+        "/unsupported/active_ui_filters",
+        serde_json::json!([{"customer_id":3,"filter_ids":[]}]),
+    );
+    refuses(
+        "/unsupported/route_server_skin_files",
+        serde_json::json!(["bird2/standard.foil.php"]),
+    );
+    refuses("/clients/0/irr_filter", serde_json::json!(false));
+    refuses("/clients/0/origins", serde_json::json!([]));
+    refuses("/clients/0/origins/0", serde_json::json!(0));
+    refuses("/clients/0/prefixes", serde_json::json!([]));
+    refuses("/clients/0/address", serde_json::json!("not-an-ip"));
+    refuses("/clients/0/address", serde_json::json!("2001:db8::1"));
+    refuses(
+        "/clients/0/peering_ips",
+        serde_json::json!(["10.1.0.36", "10.1.0.37"]),
+    );
+    refuses("/clients/0/auth/value", serde_json::json!("changeme"));
+    refuses("/clients/0/auth/value", serde_json::json!("x".repeat(81)));
+    refuses("/policy/rtr_caches", serde_json::json!(["127.0.0.1:0"]));
+    refuses("/policy/rtr_caches", serde_json::json!([]));
+    refuses("/complete/marker", serde_json::json!("END"));
+    refuses("/complete/handle", serde_json::json!("other"));
+    refuses("/complete/client_count", serde_json::json!(2));
+    refuses("/router/skip_md5", serde_json::json!(true));
+    let mut unknown = value();
+    unknown["router"]["mystery"] = true.into();
+    assert_eq!(rendered(&unknown).unwrap_err(), Error::Input);
+    let mut dropped = value();
+    dropped["clients"][0]["more_specifics"] = true.into();
+    dropped["clients"][0]["prefixes"] = serde_json::json!(["31.135.128.0/25"]);
+    assert!(rendered(&dropped).is_err());
+    let mut repeated = value();
+    let mut client = repeated["clients"][0].clone();
+    client["customer_id"] = 4.into();
+    client["vlan_interface_id"] = 4.into();
+    client["address"] = "10.1.0.37".into();
+    client["peering_ips"] = serde_json::json!(["10.1.0.37"]);
+    repeated["clients"].as_array_mut().unwrap().push(client);
+    repeated["complete"]["client_count"] = 2.into();
+    assert!(rendered(&repeated).is_err());
+    let mut no_auth = value();
+    no_auth["clients"][0]["auth"] = serde_json::json!({"type":"none"});
+    assert!(rendered(&no_auth).is_ok());
+    no_auth["router"]["skip_md5"] = true.into();
+    assert!(rendered(&no_auth).is_ok());
+}
+
+#[cfg(unix)]
+fn set_mode(path: &std::path::Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+}
+
+#[cfg(unix)]
+fn mode(path: &std::path::Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
+#[cfg(unix)]
+fn run_cli(
+    temp: &tempfile::TempDir,
+    out: &std::path::Path,
+    fail: bool,
+    input_mode: u32,
+    extra: &[&str],
+) -> std::process::Output {
+    use std::process::Command;
+    let input = temp.path().join("input.json");
+    fs::write(&input, FIXTURE).unwrap();
+    set_mode(&input, input_mode);
+    let log = temp.path().join("checker.log");
+    let checker = temp.path().join("checker.sh");
+    fs::write(&checker, "#!/bin/sh\n[ ! -e \"$OUT/render-receipt.json\" ] || exit 90\nprintf '%s\\n' \"$*\" >> \"$LOG\"\nif [ \"$1\" = --version ]; then echo \"rustbgpd 0.65.0 $SECRET\"; echo \"$SECRET\" >&2; exit 0; fi\n[ \"$FAIL\" = 0 ] || exit 91\n").unwrap();
+    set_mode(&checker, 0o700);
+    Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args(["--input-format", "ixp-manager-v1", "--context"])
+        .arg(&input)
+        .arg("--out-dir")
+        .arg(out)
+        .args(["--max-prefix-restart-seconds", "300", "--check-with"])
+        .arg(&checker)
+        .env("OUT", out)
+        .env("LOG", log)
+        .env("SECRET", SECRET)
+        .env("FAIL", if fail { "1" } else { "0" })
+        .args(extra)
+        .output()
+        .unwrap()
+}
+
+#[cfg(unix)]
+#[test]
+fn cli_enforces_private_checker_order_receipt_last_and_redaction() {
+    use std::os::unix::fs::symlink;
+    let temp = tempfile::tempdir().unwrap();
+    let out = temp.path().join("candidate");
+    fs::create_dir(&out).unwrap();
+    set_mode(&out, 0o700);
+    let result = run_cli(&temp, &out, false, 0o600, &[]);
+    assert!(result.status.success(), "{result:?}");
+    assert!(!String::from_utf8_lossy(&result.stdout).contains(SECRET));
+    assert!(!String::from_utf8_lossy(&result.stderr).contains(SECRET));
+    let receipt = fs::read(out.join("render-receipt.json")).unwrap();
+    assert!(
+        !receipt
+            .windows(SECRET.len())
+            .any(|w| w == SECRET.as_bytes())
+    );
+    let receipt: serde_json::Value = serde_json::from_slice(&receipt).unwrap();
+    assert_eq!(receipt["strict_check"]["binary_version"], "rustbgpd 0.65.0");
+    assert_eq!(receipt["strict_check"]["passed"], true);
+    assert_eq!(receipt["counts"]["clients"], 1);
+    assert_eq!(receipt["counts"]["prefixes"], 1);
+    assert_eq!(receipt["counts"]["origins"], 1);
+    assert_eq!(
+        receipt["input"]["sha256"],
+        digest(&temp.path().join("input.json"))
+    );
+    assert_eq!(mode(&out), 0o700);
+    assert_eq!(mode(&out.join("policy")), 0o700);
+    for path in [
+        "config.toml",
+        "policy/ixp-hygiene.rpol",
+        "policy/client-3.rpol",
+        "render-receipt.json",
+    ] {
+        assert_eq!(mode(&out.join(path)), 0o600);
+        if path != "render-receipt.json" {
+            assert_eq!(receipt["generated_files"][path], digest(&out.join(path)));
+        }
+    }
+    let log = fs::read_to_string(temp.path().join("checker.log")).unwrap();
+    let lines = log.lines().collect::<Vec<_>>();
+    assert_eq!(lines[0], "--version");
+    assert_eq!(
+        lines[1],
+        format!("--check --strict {}", out.join("config.toml").display())
+    );
+
+    let failed = temp.path().join("failed");
+    let result = run_cli(&temp, &failed, true, 0o600, &[]);
+    assert_eq!(result.status.code(), Some(3));
+    assert!(failed.join("config.toml").is_file());
+    assert!(!failed.join("render-receipt.json").exists());
+    assert!(!String::from_utf8_lossy(&result.stderr).contains(SECRET));
+    let nonempty = temp.path().join("nonempty");
+    fs::create_dir(&nonempty).unwrap();
+    set_mode(&nonempty, 0o700);
+    fs::write(nonempty.join("old"), b"stale").unwrap();
+    assert_eq!(
+        run_cli(&temp, &nonempty, false, 0o600, &[]).status.code(),
+        Some(3)
+    );
+    let public = temp.path().join("public");
+    fs::create_dir(&public).unwrap();
+    set_mode(&public, 0o755);
+    assert_eq!(
+        run_cli(&temp, &public, false, 0o600, &[]).status.code(),
+        Some(3)
+    );
+    assert_eq!(
+        run_cli(&temp, &temp.path().join("public-input"), false, 0o644, &[])
+            .status
+            .code(),
+        Some(2)
+    );
+    let legacy = temp.path().join("legacy");
+    assert_eq!(
+        run_cli(&temp, &legacy, false, 0o600, &["--min-prefixes", "1"])
+            .status
+            .code(),
+        Some(2)
+    );
+    let empty = temp.path().join("empty");
+    fs::create_dir(&empty).unwrap();
+    set_mode(&empty, 0o700);
+    let out_link = temp.path().join("output-link");
+    symlink(&empty, &out_link).unwrap();
+    assert_eq!(
+        run_cli(&temp, &out_link, false, 0o600, &[]).status.code(),
+        Some(3)
+    );
+    fs::remove_file(temp.path().join("input.json")).unwrap();
+    let input_target = temp.path().join("input-target.json");
+    fs::write(&input_target, FIXTURE).unwrap();
+    set_mode(&input_target, 0o600);
+    symlink(&input_target, temp.path().join("input.json")).unwrap();
+    assert_eq!(
+        run_cli(&temp, &temp.path().join("linked-input"), false, 0o600, &[])
+            .status
+            .code(),
+        Some(2)
+    );
+}
+
+#[test]
+fn workflow_and_gpl_source_only_boundaries_are_pinned() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let workflow = fs::read_to_string(root.join(".github/workflows/ixp-compat.yml")).unwrap();
+    for path in ["tools/rs-config-render/**", "integrations/ixp-manager/**"] {
+        assert_eq!(workflow.matches(&format!("- \"{path}\"")).count(), 2);
+    }
+    for source in [
+        "tools/rs-config-render/src/ixp_manager.rs",
+        "tools/rs-config-render/src/lib.rs",
+        "tools/rs-config-render/src/main.rs",
+    ] {
+        let text = fs::read_to_string(root.join(source)).unwrap();
+        assert!(!text.contains("include_str!(\"../../../integrations/"));
+        assert!(!text.contains("include_bytes!(\"../../../integrations/"));
+    }
+    let binary = fs::read(env!("CARGO_BIN_EXE_rs-config-render")).unwrap();
+    assert!(
+        !binary
+            .windows(b"integrations/ixp-manager/gpl-2.0-only".len())
+            .any(|w| w == b"integrations/ixp-manager/gpl-2.0-only")
+    );
+    for manifest in [
+        ".github/workflows/release.yml",
+        "scripts/build-packages.sh",
+        "Dockerfile",
+    ] {
+        assert!(
+            !fs::read_to_string(root.join(manifest))
+                .unwrap()
+                .contains("integrations/ixp-manager")
+        );
+    }
+    let allowed = |entries: &[&str]| {
+        entries
+            .iter()
+            .all(|path| !path.starts_with("integrations/"))
+    };
+    assert!(allowed(&["rustbgpd", "share/rustbgpd/config.toml"]));
+    assert!(!allowed(&[
+        "rustbgpd",
+        "integrations/ixp-manager/gpl-2.0-only/LICENSE"
+    ]));
+}


### PR DESCRIPTION
## Summary

- add an original GPL-2.0-only IXP Manager v7.4 Foil exporter that emits a strict versioned JSON boundary
- extend \`rs-config-render\` with a manual, private candidate path and explicit fail-closed refusals for unsupported effective policy
- require the selected \`rustbgpd\` binary to pass version discovery and \`--check --strict\` before writing the validated receipt last
- prove the supported and refused paths against the real pinned IXP Manager v7.4/MySQL harness

This is a bounded manual export/render/check seam. It does not fetch remotely, activate configuration, reload a daemon, roll back, translate UI filters, or claim full IXP Manager template/runtime compatibility.

## Verification

- \`cargo test --locked -p rs-config-render\`
- \`cargo test --locked --test rs_config_render_emitted_check\`
- pinned IXP Manager v7.4/MySQL/Foil, Bird’s Eye, and live-adapter oracle
- eleven destructive mutation classes, restored after each proof
- Rust 1.98 strict workspace Clippy and Rust 1.95 locked all-target check
- workspace unit/integration targets plus isolated Rust 1.98 API doctest after clearing a shared cross-toolchain artifact collision
- warning-denied workspace docs in a fresh target directory
- exact roster, line caps, private modes, secret redaction, GPL package boundary, and diff seals

Linear: LAN-1105