### PR TITLE
build: exclude GPL integrations from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ target/
 **/target/
 .git/
 .claude/
+integrations/
 clab-*/
 bench/scale/matrix/artifacts-*/
 


### PR DESCRIPTION
Exclude the source-only GPL integration subtree from Docker build contexts so the final-image boundary is enforced before any build stage runs.