### PR TITLE
Activate IXP Manager candidates atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `rustbgpd` binary's version and `--check --strict` modes, then writes the
   receipt last. Applicable UI filters, BIRD skin overrides, implicit
   no-transit policy, incomplete or ambiguous member data, and unsupported
-  router modes fail closed. Fetch, activation, reload, and rollback remain an
-  explicit operator workflow. (LAN-1105)
+  router modes fail closed. The local activation command rechecks and
+  atomically publishes immutable generations, settles real health/config diff,
+  no-ops on equal content, and attempts to restore and re-settle the prior
+  generation on failure. Exit 4 proves restoration; exit 5 reports that
+  recovery or receipt durability is unproven. M96 proves the successful path
+  against MD5-authenticated FRR; authenticated fetch and IXP Manager callbacks
+  remain external. (LAN-1105)
 - `birdwatcher-adapter` now serves IXP Manager v7.4.0's exact received and
   export route journeys for IPv4/IPv6 unicast. Every page carries the exact
   daemon-side prefix filter, all Add-Path candidates retain source alias and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -612,8 +612,12 @@ is [retained](docs/perf/route-server-1000-2026-07.md). The ARouteServer target
 ships as `tools/rs-config-render`. Its manual IXP Manager v7.4 seam now accepts
 an original Foil JSON export, fails closed on unsupported effective policy, and
 writes a private candidate, validates it with the selected rustbgpd binary's
-strict offline check, then writes the validated receipt last. HTTP fetching,
-activation, reload/settlement, callbacks, rollback, active UI-filter
+strict offline check, then writes the validated receipt last. Its local helper
+now rechecks, atomically publishes and settles immutable generations. Exit 4
+proves an exact prior-generation rollback; exit 5 leaves recovery or receipt
+durability unproven. M96 proves the successful rollback against an
+MD5-authenticated FRR member without a daemon restart or session flap. HTTP
+fetching, callbacks, active UI-filter
 translation, custom-skin migration, and multi-address ownership remain open
 under LAN-1105. The external adapter now also serves the IXP
 Manager v7.4 status, live protocol inventory/detail, symbols, member received,

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -61,9 +61,14 @@ effective authentication, and symlink/public input or output paths.
 It renders only independently owned rustbgpd policy; no IXP Manager BIRD
 template or GPL source enters the binary or packaged artifacts.
 
-Fetching, activation, reload, callback, rollback, filter translation, custom
-skin migration, and multi-address next-hop parity remain outside this manual
-seam. A candidate without the final strict-check receipt is not deployable.
+The local activation helper consumes only a complete strict-check receipt; it
+does not fetch or call IXP Manager. M96 feeds the live pinned Foil capture into
+the real renderer/checker, then proves atomic initial, no-op, hot-reload, and
+restart-required rollback paths against MD5-authenticated FRR. It observes only
+complete old/new symlink targets and proves exact prior bytes, live diff zero,
+route/session continuity, unchanged daemon PID/flaps, private modes, literal
+arguments, and secret-free receipts/output. Fetch/callback lifecycle, filter
+translation, custom-skin migration, and multi-address parity remain open.
 
 ### CI coverage
 
@@ -107,6 +112,7 @@ dispatch always run.
   negative-completeness deployment (**M92**).
 - **Core RR against incumbents** — RFC 4456 reflection + RFC 4724 GR helper-truth against BIRD 2 clients and OpenBGPD 9.1 clients, plus required-family OPEN enforcement against BIRD: **M85**, **M86**, **M93**.
 - **Live policy-presence safety** — ADR-0112 RFC 8212 import-presence transitions qualified for Route Refresh, rejected whole when one peer cannot converge, and converged on the wire when it can: **M95**.
+- **IXP Manager local activation** — pinned v7.4 Foil render, atomic generation publication, live settlement, and exact rollback against MD5-authenticated FRR: **M96** (local).
 - **Graceful Shutdown** — receiver/initiator coverage across unicast, FlowSpec, and EVPN: **M35**, **M35b**, **M35c**.
 - **BLACKHOLE FIB discard** — RFC 7999 receiver scoping plus opt-in kernel discard install / withdraw: **M41**.
 - **gRPC/gNMI + EVPN injection** — ADR-0064 mTLS tier enforcement, ADR-0070 gNMI / OpenConfig telemetry + Set, gNMI Subscribe ON_CHANGE, and EVPN Type 5 control-plane injection: **M44**, **M54**, **M56**, **M45**.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -128,6 +128,32 @@ rs-config-render --version
 in the archive either way, so install it now rather than discovering it is
 missing from a cron refresh later.
 
+For an IXP Manager candidate, point the service at a stable activation symlink,
+then let the renderer publish and settle an immutable generation:
+
+```console
+sudo -u rustbgpd /usr/local/bin/rs-config-render activate \
+  --candidate /var/lib/rustbgpd/ixp-manager/candidate \
+  --state-dir /var/lib/rustbgpd/ixp-manager/activation \
+  --check-with /usr/local/bin/rustbgpd --rbgp /usr/local/bin/rbgp \
+  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --activation-command /usr/bin/sudo \
+  --activation-arg=-n --activation-arg /usr/bin/systemctl \
+  --activation-arg reload-or-restart --activation-arg rustbgpd
+```
+
+Render and activate as the `rustbgpd` service identity; it must own the private
+candidate and activation-state parent. Configure `ExecStart` to read
+`.../activation/current/config.toml`, and authorize that account in sudoers for
+only `/usr/bin/systemctl reload-or-restart rustbgpd`. The state path must be
+absolute and its immediate parent must exist. Add `--initial` only when both no
+current generation and no reachable daemon exist. Normalized comparison TOML
+is limited to 4,194,299 bytes (4 MiB minus five encoded-request bytes). Exit 4
+proves the prior link and runtime were restored. Exit 5 means recovery or
+receipt durability is unproven: leave retained state
+untouched and inspect the current private receipt if present. It may be absent
+or stale when its final write or directory sync failed.
+
 ### Debian / RPM packages
 
 Tagged releases also publish native packages built with

--- a/tests/interop/configs/frr-bgpd-m96-ixp-manager.conf
+++ b/tests/interop/configs/frr-bgpd-m96-ixp-manager.conf
@@ -1,0 +1,21 @@
+frr defaults traditional
+hostname m96-member
+service integrated-vtysh-config
+!
+ip route 31.135.128.0/19 Null0
+ip route 31.135.160.0/19 Null0
+!
+router bgp 42
+ bgp router-id 10.1.0.36
+ no bgp ebgp-requires-policy
+ neighbor 192.0.2.18 remote-as 65501
+ neighbor 192.0.2.18 password mcWsqMdzGwTKt67g
+ neighbor 192.0.2.18 timers 3 9
+ !
+ address-family ipv4 unicast
+  network 31.135.128.0/19
+  network 31.135.160.0/19
+  neighbor 192.0.2.18 activate
+ exit-address-family
+exit
+!

--- a/tests/interop/m96-ixp-manager-activation-frr.clab.yml
+++ b/tests/interop/m96-ixp-manager-activation-frr.clab.yml
@@ -1,0 +1,35 @@
+# Containerlab topology: a pinned IXP Manager v7.4 capture activated into
+# rustbgpd against a real MD5-authenticated FRR member.
+#
+# Usage:
+#   docker build --target dev -t rustbgpd:dev .
+#   containerlab deploy -t tests/interop/m96-ixp-manager-activation-frr.clab.yml
+#   bash tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
+#   containerlab destroy -t tests/interop/m96-ixp-manager-activation-frr.clab.yml --cleanup
+
+name: m96-ixp-manager-activation
+
+topology:
+  nodes:
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      exec:
+        - ip addr add 192.0.2.18/32 dev eth1
+        - ip route add 10.1.0.36/32 dev eth1
+        - ip link set eth1 up
+
+    frr:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+      binds:
+        - ./configs/frr-daemons:/etc/frr/daemons:ro
+        - ./configs/frr-bgpd-m96-ixp-manager.conf:/etc/frr/frr.conf:ro
+      exec:
+        - ip addr add 10.1.0.36/32 dev eth1
+        - ip route add 192.0.2.18/32 dev eth1
+        - ip link set eth1 up
+
+  links:
+    - endpoints: ["rustbgpd:eth1", "frr:eth1"]

--- a/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
+++ b/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# M96: real IXP Manager v7.4 render -> atomic local activation -> rollback.
+
+set -euo pipefail
+
+STATE=/var/lib/m96-activation
+MARKER='m96 literal;touch /tmp/m96-shell-eval'
+
+# This exact executable is copied into the rustbgpd container. The activation
+# helper passes MARKER as one literal argv element; no shell command is parsed.
+if [ "${1:-}" = internal-activate ]; then
+    [ "$#" -eq 2 ] && [ "$2" = "$MARKER" ] || exit 64
+    if pid=$(pidof -s rustbgpd 2>/dev/null); then
+        kill -HUP "$pid"
+    else
+        mkdir -p /var/lib/rustbgpd
+        nohup /usr/local/bin/rustbgpd "$STATE/current/config.toml" \
+            >/dev/null 2>&1 </dev/null &
+    fi
+    exit 0
+fi
+
+TOPO=m96-ixp-manager-activation
+RUST=clab-${TOPO}-rustbgpd
+FRR=clab-${TOPO}-frr
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+TARGET=$ROOT/target/x86_64-unknown-linux-musl/debug/rs-config-render
+BIN=/usr/local/bin/rs-config-render
+ACT=/usr/local/bin/m96-activate
+ADDR=unix:///var/lib/rustbgpd/grpc.sock
+SECRET=mcWsqMdzGwTKt67g
+WORK=$(mktemp -d)
+cleanup() {
+    containerlab destroy -t "$ROOT/tests/interop/m96-ixp-manager-activation-frr.clab.yml" \
+        --cleanup >/dev/null 2>&1 || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+fail() { printf 'M96 FAIL: %s\n' "$*" >&2; exit 1; }
+ok() { printf 'M96 PASS: %s\n' "$*"; }
+
+for container in "$RUST" "$FRR"; do
+    docker inspect "$container" >/dev/null 2>&1 || fail "$container is not running"
+done
+
+CAPTURE_OUTPUT="$WORK/capture" \
+    "$ROOT/tests/compat/ixp-manager-birdseye/run.sh" >/dev/null
+FIXTURE=$WORK/capture/ixp-manager-v7.4-rustbgpd.json
+cargo +1.98.0 build --locked --target x86_64-unknown-linux-musl -p rs-config-render
+docker cp "$TARGET" "$RUST:$BIN"
+docker cp "$0" "$RUST:$ACT"
+cp "$FIXTURE" "$WORK/initial.json"
+jq '.clients[0].prefixes += ["31.135.160.0/19"]' "$FIXTURE" >"$WORK/hot.json"
+jq '.router.router_id = "192.0.2.99"' "$WORK/hot.json" >"$WORK/restart.json"
+for input in initial hot restart; do
+    docker cp "$WORK/$input.json" "$RUST:/var/lib/m96-$input.json"
+done
+docker exec "$RUST" sh -c \
+    "chmod 700 '$BIN' '$ACT'; chmod 600 /var/lib/m96-*.json; rm -rf '$STATE'; mkdir -m 700 '$STATE'"
+
+render() {
+    local name=$1
+    docker exec "$RUST" "$BIN" \
+        --input-format ixp-manager-v1 \
+        --context "/var/lib/m96-$name.json" \
+        --out-dir "/var/lib/m96-$name-candidate" \
+        --max-prefix-restart-seconds 300 \
+        --check-with /usr/local/bin/rustbgpd >/dev/null
+}
+
+activate() {
+    local candidate=$1 expected=$2 label=$3 initial=${4:-} command=${5:-$ACT}
+    local extra=() activation=(--activation-command "$command")
+    [ -n "$initial" ] && extra=("$initial")
+    if [ "$command" = "$ACT" ]; then
+        activation+=(--activation-arg internal-activate --activation-arg "$MARKER")
+    fi
+    set +e
+    docker exec "$RUST" "$BIN" activate \
+        --candidate "$candidate" --state-dir "$STATE" \
+        --check-with /usr/local/bin/rustbgpd \
+        --rbgp /usr/local/bin/rbgp --rbgp-addr "$ADDR" \
+        --settle-seconds 20 "${extra[@]}" \
+        "${activation[@]}" \
+        >"$WORK/$label.output" 2>&1
+    local status=$?
+    set -e
+    [ "$status" -eq "$expected" ] || {
+        cat "$WORK/$label.output" >&2
+        fail "$label exited $status, expected $expected"
+    }
+    ! grep -Fq "$SECRET" "$WORK/$label.output" || fail "$label leaked MD5 in output"
+}
+
+receipt() {
+    docker exec "$RUST" cat "$STATE/activation-receipt.json"
+}
+
+current() {
+    docker exec "$RUST" readlink "$STATE/current"
+}
+
+neighbor() {
+    docker exec "$RUST" /usr/local/bin/rbgp --addr "$ADDR" --json neighbor 10.1.0.36
+}
+
+has_route() {
+    docker exec "$RUST" /usr/local/bin/rbgp --addr "$ADDR" --json \
+        rib received 10.1.0.36 2>/dev/null \
+        | jq -e --arg prefix "$1" '[.[] | select(.prefix == $prefix)] | length == 1' >/dev/null
+}
+
+wait_for() {
+    local label=$1
+    shift
+    for _ in $(seq 1 40); do
+        if "$@"; then ok "$label"; return; fi
+        sleep 1
+    done
+    fail "$label did not converge"
+}
+
+session_ready() {
+    neighbor 2>/dev/null | jq -e '.state == "Established"' >/dev/null
+}
+
+runtime_equal() {
+    docker exec "$RUST" bash -c \
+        "sed 's#\"policy/#\"$STATE/current/policy/#g' '$STATE/current/config.toml' >'$STATE/.m96-compare.toml'; chmod 600 '$STATE/.m96-compare.toml'; /usr/local/bin/rbgp --addr '$ADDR' config diff '$STATE/.m96-compare.toml' >/dev/null 2>&1"
+}
+
+private_state() {
+    docker exec "$RUST" bash -c \
+        "test \"\$(stat -c %a '$STATE')\" = 700
+         test \"\$(stat -c %a '$STATE/activation.lock')\" = 600
+         test \"\$(stat -c %a '$STATE/activation-receipt.json')\" = 600
+         test -L '$STATE/current'
+         ! find '$STATE/generations' -type d ! -perm 700 -print -quit | grep -q .
+         ! find '$STATE/generations' -type f ! -perm 600 -print -quit | grep -q ."
+}
+
+start_observer() {
+    docker exec "$RUST" rm -f /tmp/m96-observer.stop /tmp/m96-observer.log
+    docker exec -d "$RUST" bash -c \
+        "while [ ! -e /tmp/m96-observer.stop ]; do readlink '$STATE/current' 2>/dev/null || echo MISSING; done >/tmp/m96-observer.log"
+}
+
+stop_observer() {
+    local output=$1 restored=${2:-}
+    if [ -n "$restored" ]; then
+        for _ in $(seq 1 20); do
+            docker exec "$RUST" tail -n 1 /tmp/m96-observer.log | grep -Fxq "$restored" && break
+            sleep 0.1
+        done
+    fi
+    docker exec "$RUST" touch /tmp/m96-observer.stop
+    sleep 1
+    docker exec "$RUST" cat /tmp/m96-observer.log >"$output"
+}
+
+assert_rollback_order() {
+    awk -v old="$2" -v bad="$3" '
+        $0 == old && phase == 0 { phase = 1 }
+        $0 == bad && phase == 1 { phase = 2 }
+        $0 == old && phase == 2 { phase = 3 }
+        END { exit phase == 3 ? 0 : 1 }
+    ' "$1" || fail "observer missed ordered prior -> candidate -> prior transition"
+}
+
+assert_observer() {
+    local log=$1 old=$2 new=$3
+    grep -Fxq "$old" "$log" || fail "observer missed $old"
+    grep -Fxq "$new" "$log" || fail "observer missed $new"
+    if grep -Fvx -e "$old" -e "$new" "$log" >/dev/null; then
+        fail "observer saw absent or unknown current target"
+    fi
+}
+
+render initial
+activate /var/lib/m96-initial-candidate 0 initial --initial
+[ "$(cat "$WORK/initial.output")" = 'activation activated' ] || fail "initial output changed"
+receipt >"$WORK/initial-receipt.json"
+jq -e '.status == "activated" and .initial == true and .activation_runs == 1
+    and .phases.candidate_link.durable == true and .phases.runtime_equal == true' \
+    "$WORK/initial-receipt.json" >/dev/null || fail "initial receipt is incomplete"
+! grep -Fq "$SECRET" "$WORK/initial-receipt.json" || fail "initial receipt leaked MD5"
+private_state || fail "activation state or generation has a public or wrong file type/mode"
+docker exec "$RUST" test ! -e /tmp/m96-shell-eval || fail "literal activation argument was shell-evaluated"
+wait_for "MD5 FRR session Established" session_ready
+wait_for "pinned IXP prefix accepted" has_route 31.135.128.0/19
+runtime_equal || fail "initial live config differs from current"
+
+initial_target=$(current)
+activation_receipt=$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")
+activate /var/lib/m96-initial-candidate 0 noop "" /bin/false
+[ "$(cat "$WORK/noop.output")" = 'activation noop' ] || fail "no-op output changed"
+[ "$(current)" = "$initial_target" ] || fail "no-op moved current"
+receipt | jq -e '.status == "noop" and .activation_runs == 0' >/dev/null \
+    || fail "no-op receipt is false"
+[ "$activation_receipt" != "$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")" ] \
+    || fail "no-op did not write its receipt last"
+ok "identical content is a no-op and /bin/false was not executed"
+
+render hot
+start_observer
+activate /var/lib/m96-hot-candidate 0 hot
+stop_observer "$WORK/hot-observer"
+hot_target=$(current)
+assert_observer "$WORK/hot-observer" "$initial_target" "$hot_target"
+wait_for "hot-added prefix accepted" has_route 31.135.160.0/19
+runtime_equal || fail "hot live config differs from current"
+ok "changed policy candidate activated through an atomic current transition"
+
+docker exec "$RUST" sh -c "printf '\n# tampered\n' >>/var/lib/m96-hot-candidate/config.toml"
+before_tamper=$(current)
+receipt_before=$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")
+activate /var/lib/m96-hot-candidate 2 tamper
+[ "$(current)" = "$before_tamper" ] || fail "tamper refusal moved current"
+[ "$receipt_before" = "$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")" ] \
+    || fail "tamper refusal rewrote the last truthful receipt"
+ok "tampered rendered candidate refused before publication"
+
+render restart
+prior_link=$(current)
+docker exec "$RUST" bash -c \
+    "find -L '$STATE/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
+    >"$WORK/prior-files"
+pid_before=$(docker exec "$RUST" pidof -s rustbgpd)
+state_before=$(neighbor)
+start_observer
+activate /var/lib/m96-restart-candidate 4 rollback
+stop_observer "$WORK/rollback-observer" "$prior_link"
+receipt >"$WORK/rollback-receipt.json"
+bad_target="generations/$(jq -r .candidate_sha256 "$WORK/rollback-receipt.json")"
+assert_observer "$WORK/rollback-observer" "$prior_link" "$bad_target"
+assert_rollback_order "$WORK/rollback-observer" "$prior_link" "$bad_target"
+[ "$(current)" = "$prior_link" ] || fail "rollback did not restore exact prior link"
+docker exec "$RUST" bash -c \
+    "find -L '$STATE/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
+    >"$WORK/restored-files"
+cmp -s "$WORK/prior-files" "$WORK/restored-files" || fail "rollback changed prior bytes"
+runtime_equal || fail "rolled-back runtime differs from prior"
+pid_after=$(docker exec "$RUST" pidof -s rustbgpd)
+state_after=$(neighbor)
+[ "$pid_after" = "$pid_before" ] || fail "daemon PID changed across failed activation"
+jq -n --argjson before "$state_before" --argjson after "$state_after" \
+    '$before.state == "Established" and (($before.uptime_seconds // 0) > 0)
+     and $after.state == "Established"
+     and (($before.flap_count // 0) == ($after.flap_count // 0))
+     and (($after.uptime_seconds // 0) >= ($before.uptime_seconds // 0))' \
+    >/dev/null || fail "FRR session flapped or its handle was replaced"
+jq -e '.status == "rolled_back" and .activation_runs == 2
+    and .phases.rollback_link.durable == true
+    and .phases.rollback_activation_ran == true and .phases.runtime_equal == true' \
+    "$WORK/rollback-receipt.json" >/dev/null || fail "rollback receipt is incomplete"
+! grep -Fq "$SECRET" "$WORK/rollback-receipt.json" || fail "rollback receipt leaked MD5"
+wait_for "route remains accepted after exact rollback" has_route 31.135.128.0/19
+wait_for "hot-added route remains accepted after exact rollback" has_route 31.135.160.0/19
+private_state || fail "rollback left unsafe state modes"
+ok "restart-required SIGHUP candidate rolled back with exact bytes, PID, and session continuity"
+
+docker exec "$FRR" vtysh -c 'show bgp neighbors 192.0.2.18 json' \
+    | jq -e '.["192.0.2.18"].bgpState == "Established"' >/dev/null \
+    || fail "FRR does not report the authenticated session Established"
+if find "$WORK" \( -name '*.output' -o -name '*receipt.json' \) \
+    -exec grep -Fl "$SECRET" {} + | grep -q .; then
+    fail "MD5 escaped into helper output or receipts"
+fi
+ok "M96 real-process activation and rollback contract complete"

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -38,7 +38,7 @@ The supported render command is:
 
 ```console
 umask 077
-rs-config-render \
+sudo -u rustbgpd /usr/bin/rs-config-render \
   --input-format ixp-manager-v1 \
   --context /var/lib/rustbgpd/ixp-manager/router.json \
   --out-dir /var/lib/rustbgpd/ixp-manager/candidate \
@@ -48,7 +48,8 @@ rs-config-render \
 
 The input must be a regular, non-symlink mode-0600 file. The output directory
 must be absent or an empty, non-symlink mode-0700 directory; generated
-configuration and policy files are mode 0600.
+configuration and policy files are mode 0600. Keep the input, candidate, and
+activation-state parent owned by the `rustbgpd` service identity shown here.
 IXP Manager mode always runs the selected binary first as `rustbgpd --version`
 and then as `rustbgpd --check --strict <candidate>/config.toml`. Child output is
 suppressed so authentication values cannot escape through diagnostics.
@@ -61,8 +62,45 @@ candidate without that receipt is incomplete and must not be deployed.
 After reviewing a complete candidate, install `config.toml` and its `policy/`
 directory together using the existing coordinated-file procedure, then SIGHUP
 rustbgpd. A failed export, refusal, render, or check leaves the running daemon
-untouched. This mode does not fetch, install, activate, reload, poll, roll back,
-or call IXP Manager update/release callbacks.
+untouched. This render mode does not fetch or call IXP Manager update/release
+callbacks.
+
+### Atomic local activation
+
+After review, activate a complete private candidate with an exact executable
+and literal arguments (never a shell command):
+
+```console
+sudo -u rustbgpd /usr/bin/rs-config-render activate \
+  --candidate /var/lib/rustbgpd/ixp-manager/candidate \
+  --state-dir /var/lib/rustbgpd/ixp-manager/activation \
+  --check-with /usr/bin/rustbgpd --rbgp /usr/bin/rbgp \
+  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --activation-command /usr/bin/sudo \
+  --activation-arg=-n --activation-arg /usr/bin/systemctl \
+  --activation-arg reload-or-restart --activation-arg rustbgpd
+```
+
+The service must read
+`/var/lib/rustbgpd/ixp-manager/activation/current/config.toml`. The state path
+must be absolute and its immediate parent must exist. Use `--initial` only for
+the first publication, when no current generation and no reachable daemon
+exist. Normalized comparison TOML is capped at 4,194,299 bytes so its encoded
+request, including five bytes of protobuf overhead, remains within 4 MiB. The
+helper rechecks a private immutable generation, atomically
+renames the relative `current` symlink, runs the command once, and requires both
+`rbgp health` and `rbgp config diff` to settle. Equal content is a no-op. A
+failed replacement attempts to restore the prior link and settle it again;
+exit 4 proves that link and runtime were restored.
+
+Authorize the `rustbgpd` account in sudoers for only the exact
+`/usr/bin/systemctl reload-or-restart rustbgpd` command. The private
+`activation-receipt.json` is written last; generations are retained for
+operator inspection. Exit 0 means activated or no-op, 2 refusal, 4 a proven
+rollback, and 5 means recovery or receipt durability is unproven. A receipt may
+therefore be absent or stale after exit 5. The helper does not deploy services,
+prune generations, retry indefinitely, or call IXP Manager. These examples use
+package paths; release archives install the three binaries under `/usr/local/bin`.
 
 Release tarballs (`rustbgpd-<arch>.tar.gz` on the [releases
 page](https://github.com/lance0/rustbgpd/releases)) ship the

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -1,0 +1,876 @@
+use std::ffi::OsString;
+use std::path::Path;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct Options<'a> {
+    pub candidate: &'a Path,
+    pub state_dir: &'a Path,
+    pub checker: &'a Path,
+    pub rbgp: &'a Path,
+    pub rbgp_addr: &'a str,
+    pub settle: Duration,
+    pub initial: bool,
+    pub activation_command: &'a Path,
+    pub activation_args: &'a [OsString],
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Status {
+    Activated,
+    Noop,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    Refused(&'static str),
+    RolledBack,
+    RecoveryRequired,
+}
+
+#[cfg(not(unix))]
+pub fn activate(_: &Options<'_>) -> Result<Status, Error> {
+    Err(Error::Refused("activation is supported only on Unix"))
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::{Error, Options, Status};
+    use serde_json::{Value, json};
+    use sha2::{Digest, Sha256};
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::fmt::Write as _;
+    use std::fs::{self, File, OpenOptions};
+    use std::io::Write as _;
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt, symlink};
+    use std::path::{Component, Path, PathBuf};
+    use std::process::{Child, Command, Output, Stdio};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    const RECEIPT: &str = "render-receipt.json";
+    const ACTIVATION_RECEIPT: &str = "activation-receipt.json";
+    const GENERATED: &str = "generated_files";
+    const ROOT_KEYS: &[&str] = &["input", "counts", "refusals", GENERATED, "strict_check"];
+    const COUNT_KEYS: &[&str] = &["clients", "prefixes", "origins"];
+    const SKINS: &str = "route_server_skin_files";
+    const MULTI: &str = "multi_address_clients";
+    const MAX_DIFF_TOML_BYTES: usize = 4_194_299;
+    const REFUSAL_KEYS: &[&str] = &["status", "active_ui_filters", SKINS, MULTI];
+    type AResult<T> = Result<T, Error>;
+
+    struct Verified {
+        digest: String,
+        files: BTreeMap<String, String>,
+        directories: Vec<String>,
+        checker_version: String,
+        config: Vec<u8>,
+    }
+
+    fn private(path: &Path, directory: bool, mode: u32) -> bool {
+        fs::symlink_metadata(path).is_ok_and(|metadata| {
+            let kind = metadata.file_type();
+            let exact_kind = kind.is_dir() == directory
+                && (directory || (kind.is_file() && metadata.nlink() == 1));
+            exact_kind && metadata.permissions().mode() & 0o777 == mode
+        })
+    }
+
+    fn digest(bytes: &[u8]) -> String {
+        Sha256::digest(bytes)
+            .iter()
+            .fold(String::with_capacity(64), |mut output, byte| {
+                write!(output, "{byte:02x}").expect("String writes cannot fail");
+                output
+            })
+    }
+
+    fn valid_digest(value: &str) -> bool {
+        value.len() == 64
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    }
+
+    fn exact_keys(value: &Value, expected: &[&str]) -> bool {
+        let Some(object) = value.as_object() else {
+            return false;
+        };
+        object.len() == expected.len() && expected.iter().all(|key| object.contains_key(*key))
+    }
+
+    fn safe_relative(value: &str) -> bool {
+        !value.is_empty()
+            && Path::new(value)
+                .components()
+                .all(|component| matches!(component, Component::Normal(_)))
+    }
+
+    fn walk(
+        root: &Path,
+        directory: &Path,
+        files: &mut BTreeSet<String>,
+        dirs: &mut BTreeSet<String>,
+    ) -> AResult<()> {
+        for entry in
+            fs::read_dir(directory).map_err(|_| Error::Refused("candidate tree is unreadable"))?
+        {
+            let entry = entry.map_err(|_| Error::Refused("candidate tree is unreadable"))?;
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| Error::Refused("candidate tree escaped"))?;
+            let name = relative
+                .to_str()
+                .ok_or(Error::Refused("candidate path is not UTF-8"))?
+                .replace('\\', "/");
+            let metadata = fs::symlink_metadata(&path)
+                .map_err(|_| Error::Refused("candidate tree is unreadable"))?;
+            if metadata.file_type().is_dir() && private(&path, true, 0o700) {
+                dirs.insert(name);
+                walk(root, &path, files, dirs)?;
+            } else if metadata.file_type().is_file() && private(&path, false, 0o600) {
+                files.insert(name);
+            } else {
+                return Err(Error::Refused(
+                    "candidate entries must be private regular files or directories",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn verify_candidate(root: &Path) -> AResult<Verified> {
+        if !private(root, true, 0o700) || !private(&root.join(RECEIPT), false, 0o600) {
+            return Err(Error::Refused(
+                "candidate and receipt must be private regular paths",
+            ));
+        }
+        let receipt_bytes = fs::read(root.join(RECEIPT))
+            .map_err(|_| Error::Refused("render receipt is unreadable"))?;
+        if receipt_bytes.len() > 1024 * 1024 {
+            return Err(Error::Refused("render receipt is oversized"));
+        }
+        let receipt: Value = serde_json::from_slice(&receipt_bytes)
+            .map_err(|_| Error::Refused("render receipt is invalid"))?;
+        if !exact_keys(&receipt, ROOT_KEYS)
+            || !exact_keys(
+                &receipt["input"],
+                &["schema", "ixp_manager_version", "router_handle", "sha256"],
+            )
+            || !exact_keys(&receipt["counts"], COUNT_KEYS)
+            || !exact_keys(&receipt["refusals"], REFUSAL_KEYS)
+            || !exact_keys(&receipt["strict_check"], &["binary_version", "passed"])
+            || receipt["input"]["schema"] != "rustbgpd.ixp-manager.router-config/v1"
+            || receipt["input"]["ixp_manager_version"] != "7.4.0"
+            || receipt["input"]["router_handle"]
+                .as_str()
+                .is_none_or(str::is_empty)
+            || !receipt["input"]["sha256"]
+                .as_str()
+                .is_some_and(valid_digest)
+            || !COUNT_KEYS.iter().all(|key| {
+                receipt["counts"][key]
+                    .as_u64()
+                    .is_some_and(|count| count > 0)
+            })
+            || receipt["refusals"]["status"] != "passed"
+            || !REFUSAL_KEYS[1..]
+                .iter()
+                .all(|key| receipt["refusals"][key] == 0)
+            || receipt["strict_check"]["passed"] != true
+            || !receipt["strict_check"]["binary_version"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("rustbgpd "))
+        {
+            return Err(Error::Refused("render receipt contract does not match"));
+        }
+        let generated = receipt["generated_files"]
+            .as_object()
+            .ok_or(Error::Refused("render receipt file map is invalid"))?;
+        let mut expected_dirs = BTreeSet::new();
+        let mut hashes = BTreeMap::new();
+        for (name, value) in generated {
+            let hash = value
+                .as_str()
+                .filter(|value| valid_digest(value))
+                .ok_or(Error::Refused("render receipt file hash is invalid"))?;
+            if !safe_relative(name) || name == RECEIPT {
+                return Err(Error::Refused("render receipt file path is unsafe"));
+            }
+            let mut parent = Path::new(name).parent();
+            while let Some(path) = parent.filter(|path| !path.as_os_str().is_empty()) {
+                expected_dirs.insert(path.to_string_lossy().replace('\\', "/"));
+                parent = path.parent();
+            }
+            hashes.insert(name.clone(), hash.to_owned());
+        }
+        if !hashes.contains_key("config.toml") || hashes.is_empty() {
+            return Err(Error::Refused("render receipt omits config.toml"));
+        }
+        let mut actual_files = BTreeSet::new();
+        let mut actual_dirs = BTreeSet::new();
+        walk(root, root, &mut actual_files, &mut actual_dirs)?;
+        let mut expected_files = hashes.keys().cloned().collect::<BTreeSet<_>>();
+        expected_files.insert(RECEIPT.to_owned());
+        if actual_files != expected_files || actual_dirs != expected_dirs {
+            return Err(Error::Refused(
+                "candidate tree differs from the render receipt",
+            ));
+        }
+        let mut identity = Sha256::new();
+        let mut config = Vec::new();
+        for (name, expected) in &hashes {
+            let bytes = fs::read(root.join(name))
+                .map_err(|_| Error::Refused("candidate file is unreadable"))?;
+            if digest(&bytes) != *expected {
+                return Err(Error::Refused("candidate file hash mismatch"));
+            }
+            identity.update(name.as_bytes());
+            identity.update([0]);
+            identity.update(expected.as_bytes());
+            identity.update([0]);
+            if name == "config.toml" {
+                config = bytes;
+            }
+        }
+        let mut directories = actual_dirs.into_iter().collect::<Vec<_>>();
+        directories.sort_by_key(|path| std::cmp::Reverse(Path::new(path).components().count()));
+        Ok(Verified {
+            digest: digest(&identity.finalize()),
+            files: hashes,
+            directories,
+            checker_version: receipt["strict_check"]["binary_version"]
+                .as_str()
+                .expect("validated above")
+                .to_owned(),
+            config,
+        })
+    }
+
+    fn create_private_dir(path: &Path) -> AResult<()> {
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+            .map_err(|_| Error::Refused("cannot create private state directory"))?;
+        private(path, true, 0o700)
+            .then_some(())
+            .ok_or(Error::Refused("state directories must be mode 0700"))
+    }
+
+    fn state_lock(state: &Path) -> AResult<File> {
+        let path = state.join("activation.lock");
+        let file = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .map_err(|_| Error::Refused("state lock is unsafe"))?,
+            Err(_) => return Err(Error::Refused("cannot create state lock")),
+        };
+        let opened = file
+            .metadata()
+            .map_err(|_| Error::Refused("state lock is unsafe"))?;
+        let named =
+            fs::symlink_metadata(&path).map_err(|_| Error::Refused("state lock is unsafe"))?;
+        if !named.file_type().is_file()
+            || named.permissions().mode() & 0o777 != 0o600
+            || opened.dev() != named.dev()
+            || opened.ino() != named.ino()
+            || opened.nlink() != 1
+        {
+            return Err(Error::Refused("state lock is unsafe"));
+        }
+        match file.try_lock() {
+            Ok(()) => Ok(file),
+            Err(fs::TryLockError::WouldBlock) => {
+                Err(Error::Refused("another activation holds the state lock"))
+            }
+            Err(fs::TryLockError::Error(_)) => Err(Error::Refused("state lock failed")),
+        }
+    }
+
+    fn sync_dir(path: &Path) -> AResult<()> {
+        File::open(path)
+            .and_then(|file| file.sync_all())
+            .map_err(|_| Error::RecoveryRequired)
+    }
+
+    struct Staging(Option<PathBuf>);
+
+    impl Drop for Staging {
+        fn drop(&mut self) {
+            if let Some(path) = self.0.take() {
+                let _ = fs::remove_dir_all(path);
+            }
+        }
+    }
+
+    fn copy_generation(candidate: &Path, state: &Path, verified: &Verified) -> AResult<PathBuf> {
+        let generations = state.join("generations");
+        create_private_dir(&generations)?;
+        let final_path = generations.join(&verified.digest);
+        if final_path.exists() {
+            let existing = verify_candidate(&final_path)?;
+            if existing.digest != verified.digest {
+                return Err(Error::Refused("immutable generation content mismatch"));
+            }
+            sync_dir(&generations)?;
+            return Ok(final_path);
+        }
+        let temporary = generations.join(unique_name(&format!(".{}", verified.digest)));
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&temporary)
+            .map_err(|_| Error::Refused("cannot stage generation"))?;
+        let mut staging = Staging(Some(temporary.clone()));
+        for name in verified
+            .files
+            .keys()
+            .map(String::as_str)
+            .chain(std::iter::once(RECEIPT))
+        {
+            let destination = temporary.join(name);
+            if let Some(parent) = destination.parent() {
+                create_private_dir(parent)?;
+            }
+            let mut output = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&destination)
+                .map_err(|_| Error::Refused("cannot stage generation"))?;
+            output
+                .write_all(
+                    &fs::read(candidate.join(name))
+                        .map_err(|_| Error::Refused("candidate file is unreadable"))?,
+                )
+                .map_err(|_| Error::Refused("cannot stage generation"))?;
+            output
+                .sync_all()
+                .map_err(|_| Error::Refused("cannot sync generation"))?;
+        }
+        for directory in &verified.directories {
+            sync_dir(&temporary.join(directory))
+                .map_err(|_| Error::Refused("cannot sync generation"))?;
+        }
+        sync_dir(&temporary).map_err(|_| Error::Refused("cannot sync generation"))?;
+        let staged = verify_candidate(&temporary)?;
+        if staged.digest != verified.digest {
+            return Err(Error::Refused("staged generation changed during copy"));
+        }
+        fs::rename(&temporary, &final_path)
+            .map_err(|_| Error::Refused("cannot publish generation"))?;
+        staging.0.take();
+        sync_dir(&generations)?;
+        Ok(final_path)
+    }
+
+    fn current_target(state: &Path) -> AResult<Option<String>> {
+        let current = state.join("current");
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(Error::Refused("current generation is unreadable")),
+        };
+        if !metadata.file_type().is_symlink() {
+            return Err(Error::Refused(
+                "current must be a relative generation symlink",
+            ));
+        }
+        let target = fs::read_link(current)
+            .map_err(|_| Error::Refused("current generation is unreadable"))?;
+        let text = target
+            .to_str()
+            .ok_or(Error::Refused("current generation target is invalid"))?;
+        let parts = target.components().collect::<Vec<_>>();
+        if parts.len() != 2
+            || parts[0] != Component::Normal("generations".as_ref())
+            || !matches!(parts[1], Component::Normal(_))
+        {
+            return Err(Error::Refused(
+                "current must be a relative generation symlink",
+            ));
+        }
+        let hash = text
+            .strip_prefix("generations/")
+            .ok_or(Error::Refused("current generation target is invalid"))?;
+        if !valid_digest(hash) || verify_candidate(&state.join(&target))?.digest != hash {
+            return Err(Error::Refused(
+                "current generation is not immutable content",
+            ));
+        }
+        Ok(Some(text.to_owned()))
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Publication {
+        Durable,
+        RenamedUnsynced,
+        UnchangedError,
+    }
+
+    fn unique_name(prefix: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |value| value.as_nanos());
+        format!("{prefix}.{}.{nanos}", std::process::id())
+    }
+
+    fn publish_current(state: &Path, target: &str) -> Publication {
+        let temporary = state.join(unique_name(".current"));
+        if symlink(target, &temporary).is_err() {
+            return Publication::UnchangedError;
+        }
+        if fs::rename(&temporary, state.join("current")).is_err() {
+            let _ = fs::remove_file(temporary);
+            return Publication::UnchangedError;
+        }
+        if sync_dir(state).is_ok() {
+            Publication::Durable
+        } else {
+            Publication::RenamedUnsynced
+        }
+    }
+
+    fn normalized_toml(config: &[u8], state: &Path) -> AResult<Vec<u8>> {
+        let current = fs::canonicalize(state)
+            .map_err(|_| Error::Refused("state path is invalid"))?
+            .join("current");
+        current
+            .to_str()
+            .ok_or(Error::Refused("state path is not UTF-8"))?;
+        let input = std::str::from_utf8(config)
+            .map_err(|_| Error::Refused("generation config is invalid"))?;
+        let mut document: toml::Value =
+            toml::from_str(input).map_err(|_| Error::Refused("generation config is invalid"))?;
+        if let Some(policy) = document
+            .get_mut("policy")
+            .and_then(toml::Value::as_table_mut)
+        {
+            for key in ["rpol_files", "rpol_roots"] {
+                if let Some(paths) = policy.get_mut(key).and_then(toml::Value::as_array_mut) {
+                    for path in paths {
+                        let relative = path.as_str().filter(|value| safe_relative(value)).ok_or(
+                            Error::Refused("policy paths must stay inside the generation"),
+                        )?;
+                        *path = toml::Value::String(
+                            current
+                                .join(relative)
+                                .to_str()
+                                .ok_or(Error::Refused("state path is not UTF-8"))?
+                                .to_owned(),
+                        );
+                    }
+                }
+            }
+        }
+        let bytes = toml::to_string(&document)
+            .map_err(|_| Error::Refused("cannot normalize runtime comparison"))?
+            .into_bytes();
+        if bytes.len() > MAX_DIFF_TOML_BYTES {
+            return Err(Error::Refused(
+                "normalized config exceeds rbgp diff request limit",
+            ));
+        }
+        Ok(bytes)
+    }
+
+    fn comparison_file(bytes: &[u8], state: &Path, label: &str) -> AResult<PathBuf> {
+        let path = state.join(unique_name(&format!(".compare-{label}")));
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|_| Error::Refused("cannot stage runtime comparison"))?;
+        file.write_all(bytes)
+            .and_then(|_| file.sync_all())
+            .map_err(|_| Error::Refused("cannot stage runtime comparison"))?;
+        Ok(path)
+    }
+
+    fn wait_output(mut child: Child, deadline: Instant) -> Option<Output> {
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => return child.wait_with_output().ok(),
+                Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(25)),
+                Ok(None) | Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+            }
+        }
+    }
+
+    #[derive(PartialEq, Eq)]
+    enum Health {
+        Reachable(bool),
+        Unreachable,
+        Invalid,
+    }
+
+    fn health_probe(options: &Options<'_>, deadline: Instant) -> Health {
+        let Ok(child) = Command::new(options.rbgp)
+            .args(["--json", "--addr", options.rbgp_addr, "health"])
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+        else {
+            return Health::Invalid;
+        };
+        let Some(output) = wait_output(child, deadline) else {
+            return Health::Invalid;
+        };
+        if output.status.success() {
+            return serde_json::from_slice::<Value>(&output.stdout)
+                .ok()
+                .and_then(|value| value.get("healthy")?.as_bool())
+                .map_or(Health::Invalid, Health::Reachable);
+        }
+        let error = String::from_utf8_lossy(&output.stderr);
+        if output.status.code() == Some(1)
+            && (error.contains("cannot reach rustbgpd at ")
+                || error.contains("daemon is not running or unreachable"))
+        {
+            Health::Unreachable
+        } else {
+            Health::Invalid
+        }
+    }
+
+    fn equal_runtime(options: &Options<'_>, comparison: &Path, deadline: Instant) -> bool {
+        let Ok(child) = Command::new(options.rbgp)
+            .args(["--addr", options.rbgp_addr, "config", "diff"])
+            .arg(comparison)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            return false;
+        };
+        wait_output(child, deadline).is_some_and(|output| output.status.code() == Some(0))
+    }
+
+    fn settle(options: &Options<'_>, comparison: &Path, deadline: Instant) -> bool {
+        loop {
+            if health_probe(options, deadline) == Health::Reachable(true)
+                && equal_runtime(options, comparison, deadline)
+            {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    #[derive(Clone, Copy, Default)]
+    struct Attempt {
+        ran: bool,
+        health_checked: bool,
+        settled: bool,
+    }
+
+    fn activate_and_settle(options: &Options<'_>, comparison: &Path) -> Attempt {
+        let deadline = Instant::now() + options.settle;
+        let Ok(child) = Command::new(options.activation_command)
+            .args(options.activation_args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            return Attempt::default();
+        };
+        if !wait_output(child, deadline).is_some_and(|output| output.status.success()) {
+            return Attempt {
+                ran: true,
+                ..Attempt::default()
+            };
+        }
+        Attempt {
+            ran: true,
+            health_checked: true,
+            settled: settle(options, comparison, deadline),
+        }
+    }
+
+    #[derive(Clone, Copy, Default)]
+    struct Phases {
+        initial: bool,
+        candidate_publication: Option<Publication>,
+        rollback_publication: Option<Publication>,
+        candidate: Attempt,
+        rollback: Attempt,
+        runtime_equal: bool,
+    }
+
+    fn write_receipt(
+        state: &Path,
+        status: &str,
+        candidate: &str,
+        previous: Option<&str>,
+        phases: Phases,
+        checker_version: &str,
+    ) -> AResult<()> {
+        let receipt = json!({
+            "schema": "rustbgpd.ixp-manager.activation/v1",
+            "status": status,
+            "candidate_sha256": candidate,
+            "previous_generation": previous,
+            "initial": phases.initial,
+            "activation_runs": u8::from(phases.candidate.ran) + u8::from(phases.rollback.ran),
+            "strict_check": {"passed": true, "binary_version": checker_version},
+            "phases": {
+                "candidate_link": {"published": phases.candidate_publication.is_some(), "durable": phases.candidate_publication == Some(Publication::Durable)},
+                "candidate_activation_ran": phases.candidate.ran,
+                "initial_unreachable_checked": phases.initial,
+                "rollback_link": {"published": phases.rollback_publication.is_some(), "durable": phases.rollback_publication == Some(Publication::Durable)},
+                "rollback_activation_ran": phases.rollback.ran,
+                "health_checked": !phases.initial || phases.candidate.health_checked || phases.rollback.health_checked,
+                "runtime_equal": phases.runtime_equal
+            }
+        });
+        let temporary = state.join(unique_name(&format!(".{ACTIVATION_RECEIPT}")));
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)
+            .map_err(|_| Error::RecoveryRequired)?;
+        let mut bytes = serde_json::to_vec_pretty(&receipt).expect("receipt serializes");
+        bytes.push(b'\n');
+        file.write_all(&bytes)
+            .and_then(|_| file.sync_all())
+            .map_err(|_| Error::RecoveryRequired)?;
+        fs::rename(&temporary, state.join(ACTIVATION_RECEIPT))
+            .map_err(|_| Error::RecoveryRequired)?;
+        sync_dir(state)
+    }
+
+    fn disjoint(candidate: &Path, state: &Path) -> bool {
+        let Ok(candidate) = fs::canonicalize(candidate) else {
+            return false;
+        };
+        let state = if state.exists() {
+            fs::canonicalize(state).ok()
+        } else {
+            state
+                .parent()
+                .and_then(|parent| fs::canonicalize(parent).ok())
+                .and_then(|parent| state.file_name().map(|name| parent.join(name)))
+        };
+        state.is_some_and(|state| !candidate.starts_with(&state) && !state.starts_with(candidate))
+    }
+
+    fn cleanup(paths: &[&Path]) {
+        for path in paths {
+            let _ = fs::remove_file(path);
+        }
+    }
+
+    pub fn activate(options: &Options<'_>) -> AResult<Status> {
+        if options.settle < Duration::from_secs(1)
+            || options.settle > Duration::from_secs(120)
+            || options.rbgp_addr.is_empty()
+        {
+            return Err(Error::Refused(
+                "settlement must be 1..=120 seconds and address nonempty",
+            ));
+        }
+        if !options.state_dir.is_absolute()
+            || (!options.state_dir.exists()
+                && options
+                    .state_dir
+                    .parent()
+                    .and_then(|parent| fs::canonicalize(parent).ok())
+                    .is_none())
+        {
+            return Err(Error::Refused(
+                "state directory must be absolute with an existing immediate parent",
+            ));
+        }
+        let candidate = verify_candidate(options.candidate)?;
+        if !disjoint(options.candidate, options.state_dir) {
+            return Err(Error::Refused(
+                "candidate and state directory must not overlap",
+            ));
+        }
+        create_private_dir(options.state_dir)?;
+        let _lock = state_lock(options.state_dir)?;
+        let checker_deadline = Instant::now() + options.settle;
+        let version_child = Command::new(options.checker)
+            .arg("--version")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| Error::Refused("strict checker could not run"))?;
+        let version_output = wait_output(version_child, checker_deadline)
+            .ok_or(Error::Refused("strict checker timed out"))?;
+        let version_text = std::str::from_utf8(&version_output.stdout)
+            .map_err(|_| Error::Refused("strict checker version is invalid"))?;
+        let mut version_words = version_text
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .split_ascii_whitespace();
+        let (Some(name), Some(number)) = (version_words.next(), version_words.next()) else {
+            return Err(Error::Refused("strict checker version is invalid"));
+        };
+        if !version_output.status.success()
+            || name != "rustbgpd"
+            || !number
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b".+-_".contains(&byte))
+        {
+            return Err(Error::Refused("strict checker version is invalid"));
+        }
+        let checker_version = format!("rustbgpd {number}");
+        if checker_version != candidate.checker_version {
+            return Err(Error::Refused("strict checker version changed"));
+        }
+        let previous = current_target(options.state_dir)?;
+        if options.initial == previous.is_some() {
+            return Err(Error::Refused(
+                "--initial requires exactly an empty current state",
+            ));
+        }
+        if options.initial
+            && health_probe(options, Instant::now() + options.settle) != Health::Unreachable
+        {
+            return Err(Error::Refused("--initial requires no reachable daemon"));
+        }
+        let candidate_runtime = normalized_toml(&candidate.config, options.state_dir)?;
+        let prior_runtime = previous
+            .as_deref()
+            .map(|target| {
+                verify_candidate(&options.state_dir.join(target))
+                    .and_then(|verified| normalized_toml(&verified.config, options.state_dir))
+            })
+            .transpose()?;
+        let mut phases = Phases {
+            initial: options.initial,
+            ..Phases::default()
+        };
+        let generation = copy_generation(options.candidate, options.state_dir, &candidate)?;
+        let check_child = Command::new(options.checker)
+            .args(["--check", "--strict"])
+            .arg(generation.join("config.toml"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| Error::Refused("strict checker could not run"))?;
+        let checked = wait_output(check_child, Instant::now() + options.settle)
+            .ok_or(Error::Refused("strict checker timed out"))?;
+        if !checked.status.success() {
+            return Err(Error::Refused("strict candidate check failed"));
+        }
+        let candidate_target = format!("generations/{}", candidate.digest);
+        let candidate_comparison =
+            comparison_file(&candidate_runtime, options.state_dir, "candidate")?;
+        let finish = |status: &str, phases: Phases, paths: &[&Path]| {
+            cleanup(paths);
+            write_receipt(
+                options.state_dir,
+                status,
+                &candidate.digest,
+                previous.as_deref(),
+                phases,
+                &checker_version,
+            )
+        };
+        if let Some(previous_target) = previous.as_deref() {
+            let prior_comparison = comparison_file(
+                prior_runtime
+                    .as_deref()
+                    .expect("present with previous target"),
+                options.state_dir,
+                "prior",
+            )?;
+            let known_good_deadline = Instant::now() + options.settle;
+            if health_probe(options, known_good_deadline) != Health::Reachable(true)
+                || !equal_runtime(options, &prior_comparison, known_good_deadline)
+            {
+                cleanup(&[&candidate_comparison, &prior_comparison]);
+                return Err(Error::Refused("current runtime is not known-good"));
+            }
+            if previous_target == candidate_target {
+                phases.runtime_equal = true;
+                finish("noop", phases, &[&candidate_comparison, &prior_comparison])?;
+                return Ok(Status::Noop);
+            }
+            let publication = publish_current(options.state_dir, &candidate_target);
+            if publication == Publication::UnchangedError {
+                cleanup(&[&candidate_comparison, &prior_comparison]);
+                return Err(Error::Refused(
+                    "atomic current publication failed before rename",
+                ));
+            }
+            phases.candidate_publication = Some(publication);
+            if publication == Publication::Durable {
+                phases.candidate = activate_and_settle(options, &candidate_comparison);
+                if phases.candidate.settled {
+                    phases.runtime_equal = true;
+                    finish(
+                        "activated",
+                        phases,
+                        &[&candidate_comparison, &prior_comparison],
+                    )?;
+                    return Ok(Status::Activated);
+                }
+            }
+            let rollback_publication = publish_current(options.state_dir, previous_target);
+            if rollback_publication != Publication::UnchangedError {
+                phases.rollback_publication = Some(rollback_publication);
+                phases.rollback = activate_and_settle(options, &prior_comparison);
+                phases.runtime_equal |= phases.rollback.settled;
+                if rollback_publication == Publication::Durable && phases.rollback.settled {
+                    phases.runtime_equal = true;
+                    finish(
+                        "rolled_back",
+                        phases,
+                        &[&candidate_comparison, &prior_comparison],
+                    )?;
+                    return Err(Error::RolledBack);
+                }
+            }
+            finish(
+                "recovery_required",
+                phases,
+                &[&candidate_comparison, &prior_comparison],
+            )?;
+            return Err(Error::RecoveryRequired);
+        }
+        let publication = publish_current(options.state_dir, &candidate_target);
+        if publication == Publication::UnchangedError {
+            cleanup(&[&candidate_comparison]);
+            return Err(Error::Refused(
+                "atomic current publication failed before rename",
+            ));
+        }
+        phases.candidate_publication = Some(publication);
+        if publication == Publication::Durable {
+            phases.candidate = activate_and_settle(options, &candidate_comparison);
+            phases.runtime_equal = phases.candidate.settled;
+            if phases.candidate.settled {
+                finish("activated", phases, &[&candidate_comparison])?;
+                return Ok(Status::Activated);
+            }
+        }
+        finish("recovery_required", phases, &[&candidate_comparison])?;
+        Err(Error::RecoveryRequired)
+    }
+}
+
+#[cfg(unix)]
+pub use unix::activate;

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -43,6 +43,7 @@ use std::fmt::Write as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+pub mod activation;
 pub mod ixp_manager;
 
 /// Top-level keys of the supported `template-context` shape, sorted.

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -3,8 +3,10 @@
 
 #![deny(unsafe_code)]
 
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::time::Duration;
 
 use clap::{Parser, ValueEnum};
 
@@ -16,6 +18,41 @@ use rs_config_render::{
 enum InputFormat {
     Arouteserver,
     IxpManagerV1,
+}
+
+#[derive(Parser)]
+#[command(
+    name = "rs-config-render activate",
+    about = "Atomically publish and settle a validated local candidate"
+)]
+struct ActivateArgs {
+    /// Private rendered candidate directory
+    #[arg(long)]
+    candidate: PathBuf,
+    /// Private activation state directory
+    #[arg(long)]
+    state_dir: PathBuf,
+    /// rustbgpd binary used for version and strict candidate checks
+    #[arg(long)]
+    check_with: PathBuf,
+    /// Exact rbgp executable used for health and live config comparison
+    #[arg(long)]
+    rbgp: PathBuf,
+    /// Running rustbgpd gRPC address
+    #[arg(long)]
+    rbgp_addr: String,
+    /// Maximum seconds for each activation or rollback settlement
+    #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=120))]
+    settle_seconds: u64,
+    /// Permit publication only when no current generation or daemon exists
+    #[arg(long)]
+    initial: bool,
+    /// Exact activation executable; never evaluated by a shell
+    #[arg(long)]
+    activation_command: PathBuf,
+    /// Literal activation argument; repeatable and never shell-evaluated
+    #[arg(long, allow_hyphen_values = true)]
+    activation_arg: Vec<OsString>,
 }
 
 #[derive(Parser)]
@@ -110,7 +147,51 @@ fn stdout_exit(result: Result<(), StdoutWriteError>) -> ExitCode {
     stdout_exit_with(result, &mut stderr.lock())
 }
 
+fn parse_activation() -> Option<ActivateArgs> {
+    let mut args = std::env::args_os();
+    let binary = args.next()?;
+    (args.next().as_deref() == Some(OsStr::new("activate")))
+        .then(|| ActivateArgs::parse_from(std::iter::once(binary).chain(args)))
+}
+
 fn main() -> ExitCode {
+    if let Some(args) = parse_activation() {
+        let options = rs_config_render::activation::Options {
+            candidate: &args.candidate,
+            state_dir: &args.state_dir,
+            checker: &args.check_with,
+            rbgp: &args.rbgp,
+            rbgp_addr: &args.rbgp_addr,
+            settle: Duration::from_secs(args.settle_seconds),
+            initial: args.initial,
+            activation_command: &args.activation_command,
+            activation_args: &args.activation_arg,
+        };
+        return match rs_config_render::activation::activate(&options) {
+            Ok(status) => {
+                let status = match status {
+                    rs_config_render::activation::Status::Activated => "activated",
+                    rs_config_render::activation::Status::Noop => "noop",
+                };
+                stdout_exit(write_stdout(|writer| {
+                    writeln!(writer, "activation {status}")
+                }))
+            }
+            Err(error) => {
+                let (code, message) = match error {
+                    rs_config_render::activation::Error::Refused(reason) => (2, reason),
+                    rs_config_render::activation::Error::RolledBack => {
+                        (4, "candidate failed settlement; prior generation restored")
+                    }
+                    rs_config_render::activation::Error::RecoveryRequired => {
+                        (5, "recovery required; inspect private activation state")
+                    }
+                };
+                eprintln!("rs-config-render: activation: {message}");
+                ExitCode::from(code)
+            }
+        };
+    }
     let cli = Cli::parse();
     let customized = !cli.extra_rpol.is_empty() || !cli.merge_toml.is_empty();
     if matches!(cli.input_format, InputFormat::IxpManagerV1) {

--- a/tools/rs-config-render/tests/activation.rs
+++ b/tools/rs-config-render/tests/activation.rs
@@ -1,0 +1,450 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use rs_config_render::activation::{Error, Options, Status, activate};
+use sha2::{Digest, Sha256};
+
+const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
+const SECRET: &str = "activation-secret-must-not-escape";
+
+fn mode(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+}
+
+fn assert_mode(path: &Path, want: u32) {
+    assert_eq!(
+        fs::metadata(path).unwrap().permissions().mode() & 0o777,
+        want
+    );
+}
+
+fn executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    mode(path, 0o700);
+}
+
+fn assert_refused(result: Result<Status, Error>) {
+    assert!(matches!(result, Err(Error::Refused(_))));
+}
+
+struct Rig {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    state: PathBuf,
+    checker: PathBuf,
+    rbgp: PathBuf,
+    activation: PathBuf,
+}
+
+impl Rig {
+    fn new() -> Self {
+        let current = std::env::current_dir().unwrap();
+        let temp = tempfile::Builder::new()
+            .prefix("activation-")
+            .tempdir_in(&current)
+            .unwrap();
+        let root = temp.path().to_path_buf();
+        for (name, value) in [
+            ("version", "0.65.0"),
+            ("checker-mode", "ok"),
+            ("health-mode", "ok"),
+            ("activation-mode", "ok"),
+        ] {
+            fs::write(root.join(name), value).unwrap();
+        }
+        let checker = root.join("checker.sh");
+        executable(
+            &checker,
+            &format!(
+                r#"#!/bin/sh
+root=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+printf '%s\n' "$*" >> "$root/checker.log"
+if [ "$1" = --version ]; then
+  printf 'rustbgpd %s {SECRET}\n' "$(cat "$root/version")"
+  printf '{SECRET}\n' >&2
+  exit 0
+fi
+[ "$(cat "$root/checker-mode")" = ok ] || exit 9
+printf '{SECRET}\n' >&2
+exit 0
+"#
+            ),
+        );
+        let rbgp = root.join("rbgp.sh");
+        executable(
+            &rbgp,
+            r#"#!/bin/sh
+root=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+printf '%s\n' "$*" >> "$root/rbgp.log"
+case "$*" in
+  *" health")
+    case "$(cat "$root/health-mode")" in
+      malformed) printf 'not-json\n'; exit 0 ;;
+      auth) printf 'Error: permission denied\n' >&2; exit 1 ;;
+    esac
+    if [ ! -f "$root/runtime" ]; then
+      printf 'Error: cannot reach rustbgpd at test (connection refused)\n' >&2
+      exit 1
+    fi
+    [ "$(cat "$root/health-mode")" = unhealthy ] && healthy=false || healthy=true
+    printf '{"healthy":%s}\n' "$healthy"
+    exit 0
+    ;;
+esac
+for arg do candidate=$arg; done
+target=$(cat "$root/runtime")
+current=$(CDPATH= cd -- "$root/state" && pwd -P)/current
+grep -F "\"$current/policy/ixp-hygiene.rpol\"" "$candidate" >/dev/null || exit 8
+printf 'ABSOLUTE_CURRENT_OK\n' >> "$root/rbgp.log"
+if [ -f "$root/reject" ] && [ "$target" = "$(cat "$root/reject")" ]; then exit 2; fi
+exit 0
+"#,
+        );
+        let activation = root.join("activate.sh");
+        executable(
+            &activation,
+            &format!(
+                r#"#!/bin/sh
+root=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+target=$(readlink "$root/state/current") || exit 7
+printf '%s\n' "$target" >> "$root/activation.log"
+printf '%s\n' "$target" > "$root/runtime"
+case "$(cat "$root/activation-mode")" in
+  fail-once)
+    if [ ! -f "$root/failed-once" ]; then touch "$root/failed-once"; printf '{SECRET}\n'; exit 9; fi ;;
+  hang-once)
+    if [ ! -f "$root/hung-once" ]; then touch "$root/hung-once"; sleep 30; fi ;;
+  reject-current)
+    [ -f "$root/reject" ] || printf '%s\n' "$target" > "$root/reject" ;;
+esac
+printf '{SECRET}\n' >&2
+exit 0
+"#
+            ),
+        );
+        let state = root.join("state");
+        Self {
+            _temp: temp,
+            root,
+            state,
+            checker,
+            rbgp,
+            activation,
+        }
+    }
+
+    fn candidate(&self, name: &str, max_prefix: u64) -> PathBuf {
+        let mut input: serde_json::Value = serde_json::from_slice(FIXTURE).unwrap();
+        input["clients"][0]["max_prefix"] = max_prefix.into();
+        let context = self.root.join(format!("{name}.json"));
+        fs::write(&context, serde_json::to_vec(&input).unwrap()).unwrap();
+        mode(&context, 0o600);
+        let out = self.root.join(name);
+        rs_config_render::ixp_manager::write_checked_candidate(&context, &out, 300, &self.checker)
+            .unwrap();
+        out
+    }
+
+    fn run(&self, candidate: &Path, initial: bool, command: &Path) -> Result<Status, Error> {
+        let args = Vec::new();
+        activate(&Options {
+            candidate,
+            state_dir: &self.state,
+            checker: &self.checker,
+            rbgp: &self.rbgp,
+            rbgp_addr: "test:50051",
+            settle: Duration::from_secs(1),
+            initial,
+            activation_command: command,
+            activation_args: &args,
+        })
+    }
+
+    fn current(&self) -> String {
+        fs::read_link(self.root.join("state/current"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn set(&self, name: &str, value: &str) {
+        fs::write(self.root.join(name), value).unwrap();
+    }
+
+    fn receipt(&self) -> serde_json::Value {
+        serde_json::from_slice(&fs::read(self.root.join("state/activation-receipt.json")).unwrap())
+            .unwrap()
+    }
+}
+
+#[test]
+fn initial_activation_and_noop_are_private_exact_and_secret_free() {
+    let rig = Rig::new();
+    let candidate = rig.candidate("candidate-a", 100);
+    assert_eq!(
+        rig.run(&candidate, true, &rig.activation),
+        Ok(Status::Activated)
+    );
+    let target = rig.current();
+    assert!(target.starts_with("generations/"));
+    assert_eq!(
+        target,
+        fs::read_to_string(rig.root.join("runtime")).unwrap().trim()
+    );
+    assert!(
+        fs::read_to_string(rig.root.join("rbgp.log"))
+            .unwrap()
+            .contains("ABSOLUTE_CURRENT_OK")
+    );
+    let receipt = rig.receipt();
+    assert_eq!(receipt["status"], "activated");
+    assert_eq!(receipt["initial"], true);
+    assert_eq!(receipt["strict_check"]["binary_version"], "rustbgpd 0.65.0");
+    assert_eq!(receipt["phases"]["initial_unreachable_checked"], true);
+    assert_eq!(receipt["phases"]["runtime_equal"], true);
+    assert!(!serde_json::to_string(&receipt).unwrap().contains(SECRET));
+    assert_mode(&rig.root.join("state"), 0o700);
+    assert_mode(&rig.root.join("state/activation.lock"), 0o600);
+    let check_log = fs::read_to_string(rig.root.join("checker.log")).unwrap();
+    assert!(
+        check_log
+            .lines()
+            .last()
+            .unwrap()
+            .contains("state/generations/")
+    );
+
+    let activations = fs::read_to_string(rig.root.join("activation.log")).unwrap();
+    assert_eq!(
+        rig.run(&candidate, false, Path::new("/bin/false")),
+        Ok(Status::Noop)
+    );
+    assert_eq!(
+        fs::read_to_string(rig.root.join("activation.log")).unwrap(),
+        activations
+    );
+    assert_eq!(rig.receipt()["status"], "noop");
+
+    rig.set("version", "0.66.0");
+    assert_refused(rig.run(&candidate, false, &rig.activation));
+    rig.set("version", "0.65.0");
+    let second_state = rig.root.join("state-2");
+    rig.set("health-mode", "malformed");
+    let args = Vec::new();
+    let result = activate(&Options {
+        candidate: &candidate,
+        state_dir: &second_state,
+        checker: &rig.checker,
+        rbgp: &rig.rbgp,
+        rbgp_addr: "test:50051",
+        settle: Duration::from_secs(1),
+        initial: true,
+        activation_command: &rig.activation,
+        activation_args: &args,
+    });
+    assert_refused(result);
+    assert!(!second_state.join("current").exists());
+}
+
+#[test]
+fn changed_candidate_rolls_back_exactly_and_refuses_mutable_aliases() {
+    let rig = Rig::new();
+    let first = rig.candidate("candidate-a", 100);
+    rig.run(&first, true, &rig.activation).unwrap();
+    let second = rig.candidate("candidate-b", 101);
+    rig.run(&second, false, &rig.activation).unwrap();
+    let prior = rig.current();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let observed_bad = Arc::new(AtomicBool::new(false));
+    let state = rig.root.join("state");
+    let watcher = {
+        let stop = Arc::clone(&stop);
+        let observed_bad = Arc::clone(&observed_bad);
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                if fs::read_link(state.join("current")).is_err() {
+                    observed_bad.store(true, Ordering::Relaxed);
+                }
+            }
+        })
+    };
+    let third = rig.candidate("candidate-c", 102);
+    rig.set("activation-mode", "reject-current");
+    assert_eq!(
+        rig.run(&third, false, &rig.activation),
+        Err(Error::RolledBack)
+    );
+    stop.store(true, Ordering::Relaxed);
+    watcher.join().unwrap();
+    assert!(!observed_bad.load(Ordering::Relaxed));
+    assert_eq!(rig.current(), prior);
+    assert_eq!(
+        fs::read_to_string(rig.root.join("runtime")).unwrap().trim(),
+        prior
+    );
+    let receipt = rig.receipt();
+    assert_eq!(receipt["status"], "rolled_back");
+    assert_eq!(receipt["activation_runs"], 2);
+    assert_eq!(receipt["phases"]["rollback_activation_ran"], true);
+    assert_eq!(receipt["phases"]["runtime_equal"], true);
+
+    fs::write(third.join("config.toml"), "tampered").unwrap();
+    assert_refused(rig.run(&third, false, &rig.activation));
+    let linked = rig.candidate("candidate-linked", 103);
+    let policy = linked.join("policy/client-3.rpol");
+    fs::hard_link(&policy, rig.root.join("mutable-alias.rpol")).unwrap();
+    assert_refused(rig.run(&linked, false, &rig.activation));
+
+    let hanging = rig.candidate("candidate-hang", 104);
+    rig.set("activation-mode", "hang-once");
+    let started = Instant::now();
+    assert_eq!(
+        rig.run(&hanging, false, &rig.activation),
+        Err(Error::RolledBack)
+    );
+    assert!(started.elapsed() < Duration::from_secs(4));
+}
+
+#[test]
+fn initial_failed_command_exits_five_with_last_recovery_receipt() {
+    let rig = Rig::new();
+    let candidate = rig.candidate("candidate-recovery", 105);
+    rig.set("activation-mode", "fail-once");
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args(["activate", "--candidate"])
+        .arg(&candidate)
+        .arg("--state-dir")
+        .arg(&rig.state)
+        .arg("--check-with")
+        .arg(&rig.checker)
+        .arg("--rbgp")
+        .arg(&rig.rbgp)
+        .args(["--rbgp-addr", "test:50051", "--initial"])
+        .arg("--activation-command")
+        .arg(&rig.activation)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(5), "{output:?}");
+    assert!(!String::from_utf8_lossy(&output.stdout).contains(SECRET));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains(SECRET));
+    let receipt = rig.receipt();
+    assert_eq!(receipt["status"], "recovery_required");
+    assert_eq!(receipt["activation_runs"], 1);
+    let candidate_hash = receipt["candidate_sha256"].as_str().unwrap();
+    assert!(rig.current().ends_with(candidate_hash));
+    assert_eq!(receipt["phases"]["runtime_equal"], false);
+    assert!(!serde_json::to_string(&receipt).unwrap().contains(SECRET));
+}
+
+#[test]
+fn cli_help_pins_the_additive_literal_command_contract() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args(["activate", "--help"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let help = String::from_utf8(output.stdout).unwrap();
+    for flag in "--candidate --state-dir --check-with --rbgp --rbgp-addr --settle-seconds --initial --activation-command --activation-arg".split_whitespace() {
+        assert!(help.contains(flag), "missing {flag}: {help}");
+    }
+    assert!(help.contains("[default: 30]"));
+
+    let missing = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .output()
+        .unwrap();
+    let error = String::from_utf8(missing.stderr).unwrap();
+    assert_eq!(missing.status.code(), Some(2));
+    assert!(error.contains("--context <CONTEXT>\n  --out-dir <OUT_DIR>"));
+}
+
+#[test]
+fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
+    let rig = Rig::new();
+    let candidate = rig.candidate("candidate-boundaries", 106);
+    let args = Vec::new();
+    let run = |state: &Path, settle| {
+        activate(&Options {
+            candidate: &candidate,
+            state_dir: state,
+            checker: &rig.checker,
+            rbgp: &rig.rbgp,
+            rbgp_addr: "test:50051",
+            settle,
+            initial: true,
+            activation_command: &rig.activation,
+            activation_args: &args,
+        })
+    };
+    let subsecond = rig.root.join("subsecond-state");
+    assert_refused(run(&subsecond, Duration::from_millis(999)));
+    assert!(!subsecond.exists());
+    assert_refused(run(Path::new("relative-state"), Duration::from_secs(1)));
+    assert_refused(run(&rig.root.join("missing/state"), Duration::from_secs(1)));
+
+    let config = format!("[oversized]\nvalue = \"{}\"\n", "x".repeat(4_194_300));
+    fs::write(candidate.join("config.toml"), &config).unwrap();
+    let mut receipt: serde_json::Value =
+        serde_json::from_slice(&fs::read(candidate.join("render-receipt.json")).unwrap()).unwrap();
+    let hash = Sha256::digest(config.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    receipt["generated_files"]["config.toml"] = hash.into();
+    fs::write(
+        candidate.join("render-receipt.json"),
+        serde_json::to_vec_pretty(&receipt).unwrap(),
+    )
+    .unwrap();
+    let oversized = rig.root.join("oversized-state");
+    assert_refused(run(&oversized, Duration::from_secs(1)));
+    assert!(!oversized.join("generations").exists());
+    assert!(!oversized.join("current").exists());
+    assert!(!rig.root.join("activation.log").exists());
+
+    let partial = rig.candidate("candidate-partial", 107);
+    let delayed = rig.root.join("delayed-checker.sh");
+    executable(
+        &delayed,
+        "#!/bin/sh\nroot=$(CDPATH= cd -- \"$(dirname \"$0\")\" && pwd)\n[ \"$1\" = --version ] && { touch \"$root/version-started\"; sleep 1; }\nexec \"$root/checker.sh\" \"$@\"\n",
+    );
+    let state = rig.root.join("partial-state");
+    let rbgp = rig.rbgp.clone();
+    let activation = rig.activation.clone();
+    let paths = [partial.clone(), state.clone(), delayed, rbgp, activation];
+    let worker = std::thread::spawn(move || {
+        let args = Vec::new();
+        activate(&Options {
+            candidate: &paths[0],
+            state_dir: &paths[1],
+            checker: &paths[2],
+            rbgp: &paths[3],
+            rbgp_addr: "test:50051",
+            settle: Duration::from_secs(2),
+            initial: true,
+            activation_command: &paths[4],
+            activation_args: &args,
+        })
+    });
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !rig.root.join("version-started").exists() {
+        assert!(Instant::now() < deadline, "delayed checker did not start");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    fs::write(partial.join("policy/client-3.rpol"), "changed after verify").unwrap();
+    assert_refused(worker.join().unwrap());
+    assert_eq!(fs::read_dir(state.join("generations")).unwrap().count(), 0);
+    let source = include_str!("../src/activation.rs");
+    assert_eq!(source.matches("sync_dir(&generations)?;").count(), 2);
+    assert!(source.contains("staging.0.take();\n        sync_dir(&generations)?;"));
+    assert!(source.contains(
+        ".and_then(|file| file.sync_all())\n            .map_err(|_| Error::RecoveryRequired)"
+    ));
+}


### PR DESCRIPTION
## Summary

- add a local `rs-config-render activate` path for validated IXP Manager candidates
- publish private immutable generations through one atomic `current` symlink
- settle health and effective-config equality, no-op equal content, and attempt exact previous-generation recovery when replacement settlement fails; exit 4 proves rollback and exit 5 reports recovery or receipt durability as unproven
- add M96, which drives a fresh pinned IXP Manager v7.4 Foil capture through the real renderer and rustbgpd against an MD5-authenticated FRR member

## Validation

- focused activation, renderer, and CLI tests
- six destructive mutation proofs for hashes, atomic publication, no-op, diff handling, rollback activation, and output redaction
- Rust 1.95 package check
- Rust 1.98 strict workspace Clippy, workspace tests, and warning-denied docs
- real M96 initial, no-op, hot reload, tamper refusal, and restart-required rollback rehearsal
- format, ShellCheck, tracker, clippy-reasons, diff, roster, and cap checks

## Boundary

This is a local activation and rollback seam. Authenticated IXP Manager fetch, update/release callbacks, UI-filter translation, custom-skin migration, pruning, and multi-address ownership remain outside this change.

LAN-1105