### PR TITLE
Narrow ambiguous IXP activation recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   no-transit policy, incomplete or ambiguous member data, and unsupported
   router modes fail closed. The local activation command rechecks and
   atomically publishes immutable generations, settles real health/config diff,
-  no-ops on equal content, and attempts to restore and re-settle the prior
-  generation on failure. Exit 4 proves restoration; exit 5 reports that
-  recovery or receipt durability is unproven. M96 proves the successful path
-  against MD5-authenticated FRR; authenticated fetch and IXP Manager callbacks
+  no-ops on equal content, and restores the prior link without a second
+  activation only when the command cannot start. Once started, failure or
+  unsettled state retains the candidate. Exit 4 proves pre-effect restoration;
+  exit 5 reports that recovery or receipt durability is unproven. M96 proves the
+  pre-effect path against MD5-authenticated FRR; focused tests prove the started
+  failure boundary. Authenticated fetch and IXP Manager callbacks
   remain external. (LAN-1105)
 - `birdwatcher-adapter` now serves IXP Manager v7.4.0's exact received and
   export route journeys for IPv4/IPv6 unicast. Every page carries the exact

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -614,9 +614,11 @@ an original Foil JSON export, fails closed on unsupported effective policy, and
 writes a private candidate, validates it with the selected rustbgpd binary's
 strict offline check, then writes the validated receipt last. Its local helper
 now rechecks, atomically publishes and settles immutable generations. Exit 4
-proves an exact prior-generation rollback; exit 5 leaves recovery or receipt
-durability unproven. M96 proves the successful rollback against an
-MD5-authenticated FRR member without a daemon restart or session flap. HTTP
+is limited to a command that could not start and proves exact prior-link/runtime
+restoration without a second activation. A started command that fails or does
+not settle leaves the candidate current; exit 5 requires explicit recovery.
+M96 proves the pre-effect restoration against an MD5-authenticated FRR member
+without a daemon restart or session flap. HTTP
 fetching, callbacks, active UI-filter
 translation, custom-skin migration, and multi-address ownership remain open
 under LAN-1105. The external adapter now also serves the IXP

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -64,10 +64,12 @@ template or GPL source enters the binary or packaged artifacts.
 The local activation helper consumes only a complete strict-check receipt; it
 does not fetch or call IXP Manager. M96 feeds the live pinned Foil capture into
 the real renderer/checker, then proves atomic initial, no-op, hot-reload, and
-restart-required rollback paths against MD5-authenticated FRR. It observes only
-complete old/new symlink targets and proves exact prior bytes, live diff zero,
-route/session continuity, unchanged daemon PID/flaps, private modes, literal
-arguments, and secret-free receipts/output. Fetch/callback lifecycle, filter
+pre-effect spawn-failure restoration against MD5-authenticated FRR. It proves
+exact prior bytes and runtime without a second activation. Focused tests prove
+that a started command's failure retains the candidate for explicit recovery.
+M96 also covers complete symlink targets, live diff zero, route/session
+continuity, unchanged daemon PID/flaps, private modes, literal arguments, and
+secret-free receipts/output. Fetch/callback lifecycle, filter
 translation, custom-skin migration, and multi-address parity remain open.
 
 ### CI coverage
@@ -112,7 +114,7 @@ dispatch always run.
   negative-completeness deployment (**M92**).
 - **Core RR against incumbents** — RFC 4456 reflection + RFC 4724 GR helper-truth against BIRD 2 clients and OpenBGPD 9.1 clients, plus required-family OPEN enforcement against BIRD: **M85**, **M86**, **M93**.
 - **Live policy-presence safety** — ADR-0112 RFC 8212 import-presence transitions qualified for Route Refresh, rejected whole when one peer cannot converge, and converged on the wire when it can: **M95**.
-- **IXP Manager local activation** — pinned v7.4 Foil render, atomic generation publication, live settlement, and exact rollback against MD5-authenticated FRR: **M96** (local).
+- **IXP Manager local activation** — pinned v7.4 Foil render, atomic publication, live settlement, and pre-effect restoration against MD5-authenticated FRR: **M96** (local).
 - **Graceful Shutdown** — receiver/initiator coverage across unicast, FlowSpec, and EVPN: **M35**, **M35b**, **M35c**.
 - **BLACKHOLE FIB discard** — RFC 7999 receiver scoping plus opt-in kernel discard install / withdraw: **M41**.
 - **gRPC/gNMI + EVPN injection** — ADR-0064 mTLS tier enforcement, ADR-0070 gNMI / OpenConfig telemetry + Set, gNMI Subscribe ON_CHANGE, and EVPN Type 5 control-plane injection: **M44**, **M54**, **M56**, **M45**.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -145,14 +145,19 @@ sudo -u rustbgpd /usr/local/bin/rs-config-render activate \
 Render and activate as the `rustbgpd` service identity; it must own the private
 candidate and activation-state parent. Configure `ExecStart` to read
 `.../activation/current/config.toml`, and authorize that account in sudoers for
-only `/usr/bin/systemctl reload-or-restart rustbgpd`. The state path must be
-absolute and its immediate parent must exist. Add `--initial` only when both no
-current generation and no reachable daemon exist. Normalized comparison TOML
-is limited to 4,194,299 bytes (4 MiB minus five encoded-request bytes). Exit 4
-proves the prior link and runtime were restored. Exit 5 means recovery or
-receipt durability is unproven: leave retained state
-untouched and inspect the current private receipt if present. It may be absent
-or stale when its final write or directory sync failed.
+only `/usr/bin/systemctl reload-or-restart rustbgpd`. Pre-create the absolute
+state directory as a non-symlink mode-0700 directory owned by `rustbgpd`; do not
+let another process publish or reload during the call. Add `--initial` only when
+both no current generation and no reachable daemon exist. Normalized comparison
+TOML is limited to 4,194,299 bytes (4 MiB minus five encoded-request bytes).
+
+The activation executable must be synchronous. Exit 4 occurs only when it could
+not start: the prior link is restored without another activation and the prior
+runtime is verified unchanged. Once it starts, a nonzero exit, timeout, or
+unsettled result leaves `current` on the candidate and returns exit 5. Leave
+retained state untouched and inspect the current private receipt if present;
+recovery or receipt durability is unproven, and the receipt may be absent or
+stale when its final write or directory sync failed.
 
 ### Debian / RPM packages
 

--- a/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
+++ b/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# M96: real IXP Manager v7.4 render -> atomic local activation -> rollback.
+# M96: real IXP Manager v7.4 render -> atomic local activation and refusal.
 
 set -euo pipefail
 
@@ -131,12 +131,12 @@ runtime_equal() {
 }
 
 private_state() {
-    docker exec "$RUST" bash -c \
-        "test \"\$(stat -c %a '$STATE')\" = 700
-         test \"\$(stat -c %a '$STATE/activation.lock')\" = 600
-         test \"\$(stat -c %a '$STATE/activation-receipt.json')\" = 600
-         test -L '$STATE/current'
-         ! find '$STATE/generations' -type d ! -perm 700 -print -quit | grep -q .
+    docker exec "$RUST" bash -ec \
+        "test \"\$(stat -c %a '$STATE')\" = 700 &&
+         test \"\$(stat -c %a '$STATE/activation.lock')\" = 600 &&
+         test \"\$(stat -c %a '$STATE/activation-receipt.json')\" = 600 &&
+         test -L '$STATE/current' &&
+         ! find '$STATE/generations' -type d ! -perm 700 -print -quit | grep -q . &&
          ! find '$STATE/generations' -type f ! -perm 600 -print -quit | grep -q ."
 }
 
@@ -186,6 +186,10 @@ jq -e '.status == "activated" and .initial == true and .activation_runs == 1
     "$WORK/initial-receipt.json" >/dev/null || fail "initial receipt is incomplete"
 ! grep -Fq "$SECRET" "$WORK/initial-receipt.json" || fail "initial receipt leaked MD5"
 private_state || fail "activation state or generation has a public or wrong file type/mode"
+docker exec "$RUST" chmod 0644 "$STATE/activation-receipt.json"
+if private_state; then fail "private-state probe accepted a public receipt"; fi
+docker exec "$RUST" chmod 0600 "$STATE/activation-receipt.json"
+private_state || fail "private-state probe did not recover after mode restoration"
 docker exec "$RUST" test ! -e /tmp/m96-shell-eval || fail "literal activation argument was shell-evaluated"
 wait_for "MD5 FRR session Established" session_ready
 wait_for "pinned IXP prefix accepted" has_route 31.135.128.0/19
@@ -229,7 +233,7 @@ docker exec "$RUST" bash -c \
 pid_before=$(docker exec "$RUST" pidof -s rustbgpd)
 state_before=$(neighbor)
 start_observer
-activate /var/lib/m96-restart-candidate 4 rollback
+activate /var/lib/m96-restart-candidate 4 rollback "" /definitely/missing/m96-activation
 stop_observer "$WORK/rollback-observer" "$prior_link"
 receipt >"$WORK/rollback-receipt.json"
 bad_target="generations/$(jq -r .candidate_sha256 "$WORK/rollback-receipt.json")"
@@ -250,15 +254,16 @@ jq -n --argjson before "$state_before" --argjson after "$state_after" \
      and (($before.flap_count // 0) == ($after.flap_count // 0))
      and (($after.uptime_seconds // 0) >= ($before.uptime_seconds // 0))' \
     >/dev/null || fail "FRR session flapped or its handle was replaced"
-jq -e '.status == "rolled_back" and .activation_runs == 2
+jq -e '.status == "rolled_back" and .activation_runs == 0
     and .phases.rollback_link.durable == true
-    and .phases.rollback_activation_ran == true and .phases.runtime_equal == true' \
+    and .phases.candidate_activation_ran == false
+    and .phases.rollback_activation_ran == false and .phases.runtime_equal == true' \
     "$WORK/rollback-receipt.json" >/dev/null || fail "rollback receipt is incomplete"
 ! grep -Fq "$SECRET" "$WORK/rollback-receipt.json" || fail "rollback receipt leaked MD5"
 wait_for "route remains accepted after exact rollback" has_route 31.135.128.0/19
 wait_for "hot-added route remains accepted after exact rollback" has_route 31.135.160.0/19
 private_state || fail "rollback left unsafe state modes"
-ok "restart-required SIGHUP candidate rolled back with exact bytes, PID, and session continuity"
+ok "unspawnable activation restored exact bytes, PID, runtime, and session continuity"
 
 docker exec "$FRR" vtysh -c 'show bgp neighbors 192.0.2.18 json' \
     | jq -e '.["192.0.2.18"].bgpState == "Established"' >/dev/null \
@@ -267,4 +272,4 @@ if find "$WORK" \( -name '*.output' -o -name '*receipt.json' \) \
     -exec grep -Fl "$SECRET" {} + | grep -q .; then
     fail "MD5 escaped into helper output or receipts"
 fi
-ok "M96 real-process activation and rollback contract complete"
+ok "M96 real-process activation and pre-effect restoration contract complete"

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -83,21 +83,27 @@ sudo -u rustbgpd /usr/bin/rs-config-render activate \
 
 The service must read
 `/var/lib/rustbgpd/ixp-manager/activation/current/config.toml`. The state path
-must be absolute and its immediate parent must exist. Use `--initial` only for
-the first publication, when no current generation and no reachable daemon
-exist. Normalized comparison TOML is capped at 4,194,299 bytes so its encoded
-request, including five bytes of protobuf overhead, remains within 4 MiB. The
-helper rechecks a private immutable generation, atomically
-renames the relative `current` symlink, runs the command once, and requires both
-`rbgp health` and `rbgp config diff` to settle. Equal content is a no-op. A
-failed replacement attempts to restore the prior link and settle it again;
-exit 4 proves that link and runtime were restored.
+must be absolute, pre-created as a non-symlink mode-0700 directory, and owned by
+the `rustbgpd` account. Keep the candidate and state exclusively writable by
+that identity; do not run another publisher or reloader concurrently. Use
+`--initial` only when no current generation and no reachable daemon exist.
+Normalized comparison TOML is capped at 4,194,299 bytes so its encoded request,
+including five bytes of protobuf overhead, remains within 4 MiB.
+
+The helper rechecks a private immutable generation, atomically renames the
+relative `current` symlink, runs one synchronous executable, and requires both
+`rbgp health` and `rbgp config diff` to settle. Equal content is a no-op. Exit 4
+is limited to a command that could not start: the helper restores the prior
+link without a second activation and verifies the unchanged prior runtime. Once
+the command starts, a nonzero exit, timeout, or unsettled runtime leaves
+`current` on the candidate and returns exit 5 for explicit operator recovery.
 
 Authorize the `rustbgpd` account in sudoers for only the exact
 `/usr/bin/systemctl reload-or-restart rustbgpd` command. The private
 `activation-receipt.json` is written last; generations are retained for
-operator inspection. Exit 0 means activated or no-op, 2 refusal, 4 a proven
-rollback, and 5 means recovery or receipt durability is unproven. A receipt may
+operator inspection. Exit 0 means activated or no-op, 2 refusal, 4 proven
+pre-effect restoration, and 5 means recovery or receipt durability is
+unproven. A receipt may
 therefore be absent or stale after exit 5. The helper does not deploy services,
 prune generations, retry indefinitely, or call IXP Manager. These examples use
 package paths; release archives install the three binaries under `/usr/local/bin`.

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -314,6 +314,20 @@ mod unix {
         }
     }
 
+    struct Comparison(PathBuf);
+
+    impl AsRef<Path> for Comparison {
+        fn as_ref(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for Comparison {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+
     fn copy_generation(candidate: &Path, state: &Path, verified: &Verified) -> AResult<PathBuf> {
         let generations = state.join("generations");
         create_private_dir(&generations)?;
@@ -484,7 +498,7 @@ mod unix {
         Ok(bytes)
     }
 
-    fn comparison_file(bytes: &[u8], state: &Path, label: &str) -> AResult<PathBuf> {
+    fn comparison_file(bytes: &[u8], state: &Path, label: &str) -> AResult<Comparison> {
         let path = state.join(unique_name(&format!(".compare-{label}")));
         let mut file = OpenOptions::new()
             .write(true)
@@ -492,10 +506,11 @@ mod unix {
             .mode(0o600)
             .open(&path)
             .map_err(|_| Error::Refused("cannot stage runtime comparison"))?;
+        let comparison = Comparison(path);
         file.write_all(bytes)
             .and_then(|_| file.sync_all())
             .map_err(|_| Error::Refused("cannot stage runtime comparison"))?;
-        Ok(path)
+        Ok(comparison)
     }
 
     fn wait_output(mut child: Child, deadline: Instant) -> Option<Output> {
@@ -662,21 +677,10 @@ mod unix {
         let Ok(candidate) = fs::canonicalize(candidate) else {
             return false;
         };
-        let state = if state.exists() {
-            fs::canonicalize(state).ok()
-        } else {
-            state
-                .parent()
-                .and_then(|parent| fs::canonicalize(parent).ok())
-                .and_then(|parent| state.file_name().map(|name| parent.join(name)))
+        let Ok(state) = fs::canonicalize(state) else {
+            return false;
         };
-        state.is_some_and(|state| !candidate.starts_with(&state) && !state.starts_with(candidate))
-    }
-
-    fn cleanup(paths: &[&Path]) {
-        for path in paths {
-            let _ = fs::remove_file(path);
-        }
+        !candidate.starts_with(&state) && !state.starts_with(candidate)
     }
 
     pub fn activate(options: &Options<'_>) -> AResult<Status> {
@@ -688,16 +692,9 @@ mod unix {
                 "settlement must be 1..=120 seconds and address nonempty",
             ));
         }
-        if !options.state_dir.is_absolute()
-            || (!options.state_dir.exists()
-                && options
-                    .state_dir
-                    .parent()
-                    .and_then(|parent| fs::canonicalize(parent).ok())
-                    .is_none())
-        {
+        if !options.state_dir.is_absolute() || !private(options.state_dir, true, 0o700) {
             return Err(Error::Refused(
-                "state directory must be absolute with an existing immediate parent",
+                "state directory must be a pre-created absolute mode-0700 directory",
             ));
         }
         let candidate = verify_candidate(options.candidate)?;
@@ -706,18 +703,19 @@ mod unix {
                 "candidate and state directory must not overlap",
             ));
         }
-        create_private_dir(options.state_dir)?;
         let _lock = state_lock(options.state_dir)?;
         let checker_deadline = Instant::now() + options.settle;
         let version_child = Command::new(options.checker)
             .arg("--version")
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .map_err(|_| Error::Refused("strict checker could not run"))?;
         let version_output = wait_output(version_child, checker_deadline)
             .ok_or(Error::Refused("strict checker timed out"))?;
-        let version_text = std::str::from_utf8(&version_output.stdout)
+        let mut version_bytes = version_output.stdout;
+        version_bytes.extend(version_output.stderr);
+        let version_text = std::str::from_utf8(&version_bytes)
             .map_err(|_| Error::Refused("strict checker version is invalid"))?;
         let mut version_words = version_text
             .lines()
@@ -778,8 +776,7 @@ mod unix {
         let candidate_target = format!("generations/{}", candidate.digest);
         let candidate_comparison =
             comparison_file(&candidate_runtime, options.state_dir, "candidate")?;
-        let finish = |status: &str, phases: Phases, paths: &[&Path]| {
-            cleanup(paths);
+        let finish = |status: &str, phases: Phases| {
             write_receipt(
                 options.state_dir,
                 status,
@@ -799,75 +796,74 @@ mod unix {
             )?;
             let known_good_deadline = Instant::now() + options.settle;
             if health_probe(options, known_good_deadline) != Health::Reachable(true)
-                || !equal_runtime(options, &prior_comparison, known_good_deadline)
+                || !equal_runtime(options, prior_comparison.as_ref(), known_good_deadline)
             {
-                cleanup(&[&candidate_comparison, &prior_comparison]);
                 return Err(Error::Refused("current runtime is not known-good"));
             }
             if previous_target == candidate_target {
                 phases.runtime_equal = true;
-                finish("noop", phases, &[&candidate_comparison, &prior_comparison])?;
+                drop(prior_comparison);
+                drop(candidate_comparison);
+                finish("noop", phases)?;
                 return Ok(Status::Noop);
             }
             let publication = publish_current(options.state_dir, &candidate_target);
             if publication == Publication::UnchangedError {
-                cleanup(&[&candidate_comparison, &prior_comparison]);
                 return Err(Error::Refused(
                     "atomic current publication failed before rename",
                 ));
             }
             phases.candidate_publication = Some(publication);
             if publication == Publication::Durable {
-                phases.candidate = activate_and_settle(options, &candidate_comparison);
+                phases.candidate = activate_and_settle(options, candidate_comparison.as_ref());
                 if phases.candidate.settled {
                     phases.runtime_equal = true;
-                    finish(
-                        "activated",
-                        phases,
-                        &[&candidate_comparison, &prior_comparison],
-                    )?;
+                    drop(prior_comparison);
+                    drop(candidate_comparison);
+                    finish("activated", phases)?;
                     return Ok(Status::Activated);
                 }
-            }
-            let rollback_publication = publish_current(options.state_dir, previous_target);
-            if rollback_publication != Publication::UnchangedError {
-                phases.rollback_publication = Some(rollback_publication);
-                phases.rollback = activate_and_settle(options, &prior_comparison);
-                phases.runtime_equal |= phases.rollback.settled;
-                if rollback_publication == Publication::Durable && phases.rollback.settled {
-                    phases.runtime_equal = true;
-                    finish(
-                        "rolled_back",
-                        phases,
-                        &[&candidate_comparison, &prior_comparison],
-                    )?;
-                    return Err(Error::RolledBack);
+                if !phases.candidate.ran {
+                    let rollback = publish_current(options.state_dir, previous_target);
+                    if rollback != Publication::UnchangedError {
+                        phases.rollback_publication = Some(rollback);
+                    }
+                    let deadline = Instant::now() + options.settle;
+                    if rollback == Publication::Durable
+                        && health_probe(options, deadline) == Health::Reachable(true)
+                        && equal_runtime(options, prior_comparison.as_ref(), deadline)
+                    {
+                        phases.runtime_equal = true;
+                        drop(prior_comparison);
+                        drop(candidate_comparison);
+                        finish("rolled_back", phases)?;
+                        return Err(Error::RolledBack);
+                    }
                 }
             }
-            finish(
-                "recovery_required",
-                phases,
-                &[&candidate_comparison, &prior_comparison],
-            )?;
+            drop(prior_comparison);
+            drop(candidate_comparison);
+            finish("recovery_required", phases)?;
             return Err(Error::RecoveryRequired);
         }
         let publication = publish_current(options.state_dir, &candidate_target);
         if publication == Publication::UnchangedError {
-            cleanup(&[&candidate_comparison]);
             return Err(Error::Refused(
                 "atomic current publication failed before rename",
             ));
         }
         phases.candidate_publication = Some(publication);
         if publication == Publication::Durable {
-            phases.candidate = activate_and_settle(options, &candidate_comparison);
+            phases.candidate = activate_and_settle(options, candidate_comparison.as_ref());
             phases.runtime_equal = phases.candidate.settled;
             if phases.candidate.settled {
-                finish("activated", phases, &[&candidate_comparison])?;
+                drop(candidate_comparison);
+                finish("activated", phases)?;
                 return Ok(Status::Activated);
             }
         }
-        finish("recovery_required", phases, &[&candidate_comparison])?;
+        drop(candidate_comparison);
+        finish("recovery_required", phases)?;
         Err(Error::RecoveryRequired)
     }
 }

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -180,9 +180,10 @@ fn main() -> ExitCode {
             Err(error) => {
                 let (code, message) = match error {
                     rs_config_render::activation::Error::Refused(reason) => (2, reason),
-                    rs_config_render::activation::Error::RolledBack => {
-                        (4, "candidate failed settlement; prior generation restored")
-                    }
+                    rs_config_render::activation::Error::RolledBack => (
+                        4,
+                        "activation command did not start; prior generation restored",
+                    ),
                     rs_config_render::activation::Error::RecoveryRequired => {
                         (5, "recovery required; inspect private activation state")
                     }

--- a/tools/rs-config-render/tests/activation.rs
+++ b/tools/rs-config-render/tests/activation.rs
@@ -1,7 +1,7 @@
 #![cfg(unix)]
 
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -67,8 +67,12 @@ impl Rig {
 root=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 printf '%s\n' "$*" >> "$root/checker.log"
 if [ "$1" = --version ]; then
-  printf 'rustbgpd %s {SECRET}\n' "$(cat "$root/version")"
-  printf '{SECRET}\n' >&2
+  if [ -f "$root/version-stderr" ]; then
+    printf 'rustbgpd %s\n' "$(cat "$root/version")" >&2
+  else
+    printf 'rustbgpd %s {SECRET}\n' "$(cat "$root/version")"
+    printf '{SECRET}\n' >&2
+  fi
   exit 0
 fi
 [ "$(cat "$root/checker-mode")" = ok ] || exit 9
@@ -130,6 +134,8 @@ exit 0
             ),
         );
         let state = root.join("state");
+        fs::create_dir(&state).unwrap();
+        mode(&state, 0o700);
         Self {
             _temp: temp,
             root,
@@ -188,6 +194,7 @@ exit 0
 fn initial_activation_and_noop_are_private_exact_and_secret_free() {
     let rig = Rig::new();
     let candidate = rig.candidate("candidate-a", 100);
+    fs::write(rig.root.join("version-stderr"), "").unwrap();
     assert_eq!(
         rig.run(&candidate, true, &rig.activation),
         Ok(Status::Activated)
@@ -232,10 +239,36 @@ fn initial_activation_and_noop_are_private_exact_and_secret_free() {
     );
     assert_eq!(rig.receipt()["status"], "noop");
 
+    let limited = Command::new("/bin/sh")
+        .args(["-c", "trap '' XFSZ; ulimit -f 0; exec \"$@\"", "sh"])
+        .arg(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args(["activate", "--candidate"])
+        .arg(&candidate)
+        .arg("--state-dir")
+        .arg(&rig.state)
+        .arg("--check-with")
+        .arg(&rig.checker)
+        .arg("--rbgp")
+        .arg(&rig.rbgp)
+        .args(["--rbgp-addr", "test:50051", "--activation-command"])
+        .arg("/bin/false")
+        .output()
+        .unwrap();
+    assert_eq!(limited.status.code(), Some(2));
+    assert!(fs::read_dir(&rig.state).unwrap().all(|entry| {
+        !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".compare-")
+    }));
+
     rig.set("version", "0.66.0");
     assert_refused(rig.run(&candidate, false, &rig.activation));
     rig.set("version", "0.65.0");
     let second_state = rig.root.join("state-2");
+    fs::create_dir(&second_state).unwrap();
+    mode(&second_state, 0o700);
     rig.set("health-mode", "malformed");
     let args = Vec::new();
     let result = activate(&Options {
@@ -276,10 +309,18 @@ fn changed_candidate_rolls_back_exactly_and_refuses_mutable_aliases() {
             }
         })
     };
-    let third = rig.candidate("candidate-c", 102);
-    rig.set("activation-mode", "reject-current");
+    let tampered = rig.candidate("candidate-c", 102);
+    fs::write(tampered.join("config.toml"), "tampered").unwrap();
+    assert_refused(rig.run(&tampered, false, &rig.activation));
+    let linked = rig.candidate("candidate-linked", 103);
+    let policy = linked.join("policy/client-3.rpol");
+    fs::hard_link(&policy, rig.root.join("mutable-alias.rpol")).unwrap();
+    assert_refused(rig.run(&linked, false, &rig.activation));
+
+    let third = rig.candidate("candidate-d", 104);
+    let activations = fs::read_to_string(rig.root.join("activation.log")).unwrap();
     assert_eq!(
-        rig.run(&third, false, &rig.activation),
+        rig.run(&third, false, &rig.root.join("missing-command")),
         Err(Error::RolledBack)
     );
     stop.store(true, Ordering::Relaxed);
@@ -292,24 +333,49 @@ fn changed_candidate_rolls_back_exactly_and_refuses_mutable_aliases() {
     );
     let receipt = rig.receipt();
     assert_eq!(receipt["status"], "rolled_back");
-    assert_eq!(receipt["activation_runs"], 2);
-    assert_eq!(receipt["phases"]["rollback_activation_ran"], true);
+    assert_eq!(receipt["activation_runs"], 0);
+    assert_eq!(receipt["phases"]["candidate_activation_ran"], false);
+    assert_eq!(receipt["phases"]["rollback_activation_ran"], false);
     assert_eq!(receipt["phases"]["runtime_equal"], true);
-
-    fs::write(third.join("config.toml"), "tampered").unwrap();
-    assert_refused(rig.run(&third, false, &rig.activation));
-    let linked = rig.candidate("candidate-linked", 103);
-    let policy = linked.join("policy/client-3.rpol");
-    fs::hard_link(&policy, rig.root.join("mutable-alias.rpol")).unwrap();
-    assert_refused(rig.run(&linked, false, &rig.activation));
-
-    let hanging = rig.candidate("candidate-hang", 104);
-    rig.set("activation-mode", "hang-once");
-    let started = Instant::now();
     assert_eq!(
-        rig.run(&hanging, false, &rig.activation),
-        Err(Error::RolledBack)
+        fs::read_to_string(rig.root.join("activation.log")).unwrap(),
+        activations
     );
+}
+
+#[test]
+fn started_failure_timeout_and_unsettled_retain_candidate_without_rollback() {
+    let started = Instant::now();
+    for mode_name in ["fail-once", "hang-once", "reject-current"] {
+        let rig = Rig::new();
+        let first = rig.candidate("candidate-a", 110);
+        rig.run(&first, true, &rig.activation).unwrap();
+        let candidate = rig.candidate("candidate-ambiguous", 111);
+        let prior = rig.current();
+        let activations = fs::read_to_string(rig.root.join("activation.log")).unwrap();
+        rig.set("activation-mode", mode_name);
+        assert_eq!(
+            rig.run(&candidate, false, &rig.activation),
+            Err(Error::RecoveryRequired)
+        );
+        let receipt = rig.receipt();
+        assert_ne!(rig.current(), prior);
+        assert!(
+            rig.current()
+                .ends_with(receipt["candidate_sha256"].as_str().unwrap())
+        );
+        assert_eq!(receipt["status"], "recovery_required");
+        assert_eq!(receipt["activation_runs"], 1);
+        assert_eq!(receipt["phases"]["rollback_link"]["published"], false);
+        assert_eq!(receipt["phases"]["rollback_activation_ran"], false);
+        assert_eq!(
+            fs::read_to_string(rig.root.join("activation.log"))
+                .unwrap()
+                .lines()
+                .count(),
+            activations.lines().count() + 1
+        );
+    }
     assert!(started.elapsed() < Duration::from_secs(4));
 }
 
@@ -384,10 +450,25 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
         })
     };
     let subsecond = rig.root.join("subsecond-state");
+    fs::create_dir(&subsecond).unwrap();
+    mode(&subsecond, 0o700);
     assert_refused(run(&subsecond, Duration::from_millis(999)));
-    assert!(!subsecond.exists());
-    assert_refused(run(Path::new("relative-state"), Duration::from_secs(1)));
-    assert_refused(run(&rig.root.join("missing/state"), Duration::from_secs(1)));
+    assert_eq!(fs::read_dir(&subsecond).unwrap().count(), 0);
+    let relative = rig
+        .state
+        .strip_prefix(std::env::current_dir().unwrap())
+        .unwrap();
+    assert_refused(run(relative, Duration::from_secs(1)));
+    let absent = rig.root.join("absent-state");
+    assert_refused(run(&absent, Duration::from_secs(1)));
+    assert!(!absent.exists());
+    let linked_state = rig.root.join("linked-state");
+    symlink(&rig.state, &linked_state).unwrap();
+    assert_refused(run(&linked_state, Duration::from_secs(1)));
+    let wrong_mode = rig.root.join("wrong-mode-state");
+    fs::create_dir(&wrong_mode).unwrap();
+    mode(&wrong_mode, 0o755);
+    assert_refused(run(&wrong_mode, Duration::from_secs(1)));
 
     let config = format!("[oversized]\nvalue = \"{}\"\n", "x".repeat(4_194_300));
     fs::write(candidate.join("config.toml"), &config).unwrap();
@@ -404,10 +485,12 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
     )
     .unwrap();
     let oversized = rig.root.join("oversized-state");
+    fs::create_dir(&oversized).unwrap();
+    mode(&oversized, 0o700);
     assert_refused(run(&oversized, Duration::from_secs(1)));
     assert!(!oversized.join("generations").exists());
     assert!(!oversized.join("current").exists());
-    assert!(!rig.root.join("activation.log").exists());
+    assert!(oversized.join("activation.lock").is_file());
 
     let partial = rig.candidate("candidate-partial", 107);
     let delayed = rig.root.join("delayed-checker.sh");
@@ -416,6 +499,8 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
         "#!/bin/sh\nroot=$(CDPATH= cd -- \"$(dirname \"$0\")\" && pwd)\n[ \"$1\" = --version ] && { touch \"$root/version-started\"; sleep 1; }\nexec \"$root/checker.sh\" \"$@\"\n",
     );
     let state = rig.root.join("partial-state");
+    fs::create_dir(&state).unwrap();
+    mode(&state, 0o700);
     let rbgp = rig.rbgp.clone();
     let activation = rig.activation.clone();
     let paths = [partial.clone(), state.clone(), delayed, rbgp, activation];


### PR DESCRIPTION
## Summary

- restrict proven rollback to activation commands that fail before spawning
- retain the candidate and return recovery-required after any started command with an uncertain outcome
- require a pre-created private activation state directory, clean comparison temporaries, and align checker version parsing
- strengthen M96 around private-state enforcement and the pre-effect rollback boundary

## Validation

- repository pre-push hooks: fmt, Clippy, workspace tests, and docs
- Rust 1.95 locked package check and Rust 1.98 strict package/workspace Clippy
- rs-config-render package suite and five destructive mutation probes
- pinned IXP Manager v7.4 / Foil / rustbgpd / FRR M96 activation lifecycle
- independent final diff audit

Follow-up hardening for #1745.