### PR TITLE
Automate the authenticated IXP Manager router lifecycle

### DIFF
--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -124,7 +124,8 @@ jobs:
             done
             for file in lib/systemd/system/rustbgpd.service \
                         usr/share/man/man1/rbgp.1.gz \
-                        usr/share/man/man8/rustbgpd.8.gz; do
+                        usr/share/man/man8/rustbgpd.8.gz \
+                        usr/share/doc/rustbgpd/LICENSES.md; do
               test -s "$tree/$file" || { echo "missing or empty: $tree/$file" >&2; exit 1; }
             done
             # The packaged daemon must accept the config its own package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           # install under /usr/share):
           #   rustbgpd, rbgp, rs-config-render        binaries
           #   birdwatcher-adapter                     Alice-LG birdwatcher shim
-          #   LICENSE-MIT, LICENSE-APACHE             licenses
+          #   LICENSE-MIT, LICENSE-APACHE, LICENSES.md licenses
           #   rustbgpd.schema.json                    config JSON Schema
           #   share/man/man1/rbgp.1                   CLI man page
           #   share/man/man8/rustbgpd.8               daemon man page
@@ -167,7 +167,7 @@ jobs:
           cp target/${{ matrix.target }}/release/rbgp staging/
           cp target/${{ matrix.target }}/release/rs-config-render staging/
           cp target/${{ matrix.target }}/release/birdwatcher-adapter staging/
-          cp LICENSE-MIT LICENSE-APACHE staging/
+          cp LICENSE-MIT LICENSE-APACHE LICENSES.md staging/
           cp docs/rustbgpd.schema.json staging/
           cp examples/systemd/rustbgpd.service \
             examples/systemd/rustbgpd-dataplane.conf staging/share/systemd/
@@ -190,7 +190,7 @@ jobs:
           done
           tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz \
             rustbgpd rbgp rs-config-render birdwatcher-adapter \
-            LICENSE-MIT LICENSE-APACHE rustbgpd.schema.json share
+            LICENSE-MIT LICENSE-APACHE LICENSES.md rustbgpd.schema.json share
           # Also publish the config JSON Schema as a standalone asset so
           # editors can reference the stable
           # `releases/latest/download/rustbgpd.schema.json` URL. Both
@@ -209,7 +209,7 @@ jobs:
           # present entry (LICENSE-MIT) even though it is there.
           entries="$(tar -tzf "dist/rustbgpd-${SUFFIX}.tar.gz")"
           for f in rustbgpd rbgp rs-config-render birdwatcher-adapter \
-                   LICENSE-MIT LICENSE-APACHE \
+                   LICENSE-MIT LICENSE-APACHE LICENSES.md \
                    share/man/man1/rbgp.1 share/man/man8/rustbgpd.8 \
                    share/completions/rbgp.bash share/completions/rbgp.zsh \
                    share/completions/rbgp.fish \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rs-config-render ixp-manager-lifecycle` now drives IXP Manager v7.4's
+  authenticated router lock, Foil fetch, existing strict render/atomic
+  activation, and updated/release callbacks. A private synced journal precedes
+  every remote effect, callback-only resume is at-least-once, and no uncertain
+  acquisition or activation is released or acknowledged automatically.
+  HTTPS platform trust, disabled redirects/proxies, bounded bodies, header-only
+  credentials, and M97's real v7.4/MySQL/MD5-FRR receipt close the operational
+  loop without expanding the daemon API. (LAN-1126)
 - `rs-config-render` now accepts a strict IXP Manager v7.4 Foil JSON export,
   writes a private route-server candidate, validates it with the selected
   `rustbgpd` binary's version and `--check --strict` modes, then writes the
@@ -23,8 +31,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   unsettled state retains the candidate. Exit 4 proves pre-effect restoration;
   exit 5 reports that recovery or receipt durability is unproven. M96 proves the
   pre-effect path against MD5-authenticated FRR; focused tests prove the started
-  failure boundary. Authenticated fetch and IXP Manager callbacks
-  remain external. (LAN-1105)
+  failure boundary. (LAN-1105)
 - `birdwatcher-adapter` now serves IXP Manager v7.4.0's exact received and
   export route journeys for IPv4/IPv6 unicast. Every page carries the exact
   daemon-side prefix filter, all Add-Path candidates retain source alias and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bgpkit-parser"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +573,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +609,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1541,6 +1567,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2081,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,7 +2180,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2857,6 +2938,8 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "toml",
+ "ureq",
+ "zeroize",
 ]
 
 [[package]]
@@ -3318,6 +3401,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3420,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3371,6 +3493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,6 +3531,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3579,6 +3733,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3796,7 +3966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
@@ -4085,7 +4255,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4330,6 +4500,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,6 +4718,24 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 # Daemon boot ID stamping for restart detection (ADR-0072).
 uuid = { version = "1", features = ["v4"] }
 zeroize = "1"
+ureq = { version = "=3.4.0", default-features = false, features = ["rustls", "platform-verifier"] }
 
 [package]
 name = "rustbgpd"

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -13,3 +13,70 @@ images do not include it.
 The two parts communicate only through the documented versioned JSON/process
 boundary. Generated JSON and candidate configuration are data, not embedded
 integration source.
+
+## CDLA-Permissive-2.0 root certificate data
+
+The `webpki-roots` and `webpki-root-certs` dependencies provide Mozilla root
+certificate data under the following agreement.
+
+# Community Data License Agreement - Permissive - Version 2.0
+
+This is the Community Data License Agreement - Permissive, Version
+2.0 (the "agreement"). Data Provider(s) and Data Recipient(s) agree
+as follows:
+
+## 1. Provision of the Data
+
+1.1. A Data Recipient may use, modify, and share the Data made
+available by Data Provider(s) under this agreement if that Data
+Recipient follows the terms of this agreement.
+
+1.2. This agreement does not impose any restriction on a Data
+Recipient's use, modification, or sharing of any portions of the
+Data that are in the public domain or that may be used, modified,
+or shared under any other legal exception or limitation.
+
+## 2. Conditions for Sharing Data
+
+2.1. A Data Recipient may share Data, with or without modifications, so
+long as the Data Recipient makes available the text of this agreement
+with the shared Data.
+
+## 3. No Restrictions on Results
+
+3.1. This agreement does not impose any restriction or obligations
+with respect to the use, modification, or sharing of Results.
+
+## 4. No Warranty; Limitation of Liability
+
+4.1. All Data Recipients receive the Data subject to the following
+terms:
+
+THE DATA IS PROVIDED ON AN "AS IS" BASIS, WITHOUT REPRESENTATIONS,
+WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED
+INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+NO DATA PROVIDER SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE DATA OR RESULTS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+## 5. Definitions
+
+5.1. "Data" means the material received by a Data Recipient under
+this agreement.
+
+5.2. "Data Provider" means any person who is the source of Data
+provided under this agreement and in reliance on a Data Recipient's
+agreement to its terms.
+
+5.3. "Data Recipient" means any person who receives Data directly
+or indirectly from a Data Provider and agrees to the terms of this
+agreement.
+
+5.4. "Results" means any outcome obtained by computational analysis
+of Data, including for example machine learning models and models'
+insights.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -618,14 +618,16 @@ is limited to a command that could not start and proves exact prior-link/runtime
 restoration without a second activation. A started command that fails or does
 not settle leaves the candidate current; exit 5 requires explicit recovery.
 M96 proves the pre-effect restoration against an MD5-authenticated FRR member
-without a daemon restart or session flap. HTTP
-fetching, callbacks, active UI-filter
-translation, custom-skin migration, and multi-address ownership remain open
-under LAN-1105. The external adapter now also serves the IXP
-Manager v7.4 status, live protocol inventory/detail, symbols, member received,
-and member export slice through immutable aliases with an enforced response
-maximum. Remaining Bird's Eye work is global table/count and exact/less-specific
-lookup, wildcard-community search, and the complete reject-reason inventory;
+without a daemon restart or session flap. The authenticated v7.4 lifecycle now
+journals lock intent, fetches the real Foil boundary, drives that activation,
+and delivers explicit updated/release callbacks; M97 proves the real database
+transitions and MD5-FRR continuity. Active UI-filter translation, custom-skin
+migration, and multi-address ownership remain open. The external adapter now
+also serves the IXP Manager v7.4 status, live protocol inventory/detail,
+symbols, member received, and member export slice through immutable aliases
+with an enforced response maximum. Remaining Bird's Eye work is global
+table/count and exact/less-specific lookup, wildcard-community search, and the
+complete reject-reason inventory;
 no full compatibility claim is made.
 [ADR-0126](docs/adr/0126-shared-group-per-client-best.md) (Accepted) landed
 shared-group per-client best-path: the `per_client_best` path-hiding

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,13 @@ allow = [
     "Unlicense",
 ]
 confidence-threshold = 0.8
+exceptions = [
+    # ureq 3.4.0's Rustls platform-verifier path carries the Mozilla root
+    # data under CDLA-Permissive-2.0. Keep this approval version-scoped;
+    # LICENSES.md accompanies the data in release archives.
+    { crate = "webpki-root-certs@1.0.9", allow = ["CDLA-Permissive-2.0"] },
+    { crate = "webpki-roots@1.0.9", allow = ["CDLA-Permissive-2.0"] },
+]
 
 [bans]
 # Duplicate-version entries are expected churn in a tree this size

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -61,16 +61,20 @@ effective authentication, and symlink/public input or output paths.
 It renders only independently owned rustbgpd policy; no IXP Manager BIRD
 template or GPL source enters the binary or packaged artifacts.
 
-The local activation helper consumes only a complete strict-check receipt; it
-does not fetch or call IXP Manager. M96 feeds the live pinned Foil capture into
-the real renderer/checker, then proves atomic initial, no-op, hot-reload, and
+The local activation helper consumes only a complete strict-check receipt. M96
+feeds the live pinned Foil capture into the real renderer/checker, then proves
+atomic initial, no-op, hot-reload, and
 pre-effect spawn-failure restoration against MD5-authenticated FRR. It proves
 exact prior bytes and runtime without a second activation. Focused tests prove
 that a started command's failure retains the candidate for explicit recovery.
 M96 also covers complete symlink targets, live diff zero, route/session
 continuity, unchanged daemon PID/flaps, private modes, literal arguments, and
-secret-free receipts/output. Fetch/callback lifecycle, filter
-translation, custom-skin migration, and multi-address parity remain open.
+secret-free receipts/output. M97 adds the authenticated IXP Manager v7.4
+lifecycle: real API-key rejection, router lock and competing-423 behavior,
+Foil fetch/render, database-visible updated/release callbacks, and the same
+MD5-FRR continuity. Ambiguous remote or activation effects remain operator
+owned. Filter translation, custom-skin migration, and multi-address parity
+remain open.
 
 ### CI coverage
 
@@ -115,6 +119,7 @@ dispatch always run.
 - **Core RR against incumbents** — RFC 4456 reflection + RFC 4724 GR helper-truth against BIRD 2 clients and OpenBGPD 9.1 clients, plus required-family OPEN enforcement against BIRD: **M85**, **M86**, **M93**.
 - **Live policy-presence safety** — ADR-0112 RFC 8212 import-presence transitions qualified for Route Refresh, rejected whole when one peer cannot converge, and converged on the wire when it can: **M95**.
 - **IXP Manager local activation** — pinned v7.4 Foil render, atomic publication, live settlement, and pre-effect restoration against MD5-authenticated FRR: **M96** (local).
+- **IXP Manager authenticated lifecycle** — pinned v7.4 API lock/fetch/callback state around the M96 activation seam, with database and MD5-FRR proof: **M97** (local).
 - **Graceful Shutdown** — receiver/initiator coverage across unicast, FlowSpec, and EVPN: **M35**, **M35b**, **M35c**.
 - **BLACKHOLE FIB discard** — RFC 7999 receiver scoping plus opt-in kernel discard install / withdraw: **M41**.
 - **gRPC/gNMI + EVPN injection** — ADR-0064 mTLS tier enforcement, ADR-0070 gNMI / OpenConfig telemetry + Set, gNMI Subscribe ON_CHANGE, and EVPN Type 5 control-plane injection: **M44**, **M54**, **M56**, **M45**.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -159,6 +159,32 @@ retained state untouched and inspect the current private receipt if present;
 recovery or receipt durability is unproven, and the receipt may be absent or
 stale when its final write or directory sync failed.
 
+To drive the same path directly from IXP Manager v7.4, create a separate
+mode-0700 candidate directory for the run and store the API key in an absolute
+mode-0600 regular file owned by `rustbgpd`:
+
+```console
+sudo -u rustbgpd /usr/local/bin/rs-config-render ixp-manager-lifecycle run \
+  --ixp-origin https://ixp.example.net --router-handle rs1-ipv4 \
+  --api-key-file /var/lib/rustbgpd/ixp-manager/api-key \
+  --candidate-dir /var/lib/rustbgpd/ixp-manager/candidate-1 \
+  --state-dir /var/lib/rustbgpd/ixp-manager/activation \
+  --max-prefix-restart-seconds 300 \
+  --check-with /usr/local/bin/rustbgpd --rbgp /usr/local/bin/rbgp \
+  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --activation-command /usr/bin/sudo \
+  --activation-arg=-n --activation-arg /usr/bin/systemctl \
+  --activation-arg reload-or-restart --activation-arg rustbgpd
+```
+
+The helper uses the exact v7.4 lock, Foil configuration, updated, and release
+endpoints. HTTPS platform roots are required; redirects, proxies, URL
+credentials, and path-prefixed origins are disabled. Requests send the API key
+only in the credential header. A synced private journal precedes each remote
+effect. Exit 6 means one callback is pending and may be retried with
+`ixp-manager-lifecycle resume`; exit 5 means acquisition or activation remains
+uncertain and no callback is attempted automatically. Delivery is at-least-once.
+
 ### Debian / RPM packages
 
 Tagged releases also publish native packages built with

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -88,6 +88,10 @@ contents:
     dst: /usr/share/doc/rustbgpd/LICENSE-APACHE
     file_info:
       mode: 0644
+  - src: LICENSES.md
+    dst: /usr/share/doc/rustbgpd/LICENSES.md
+    file_info:
+      mode: 0644
   - src: docs/rustbgpd.schema.json
     dst: /usr/share/doc/rustbgpd/rustbgpd.schema.json
     file_info:

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 BINARIES = ("rustbgpd", "rbgp", "rs-config-render", "birdwatcher-adapter")
+LICENSES = ("LICENSE-MIT", "LICENSE-APACHE", "LICENSES.md")
 SYSTEMD = (
     "share/systemd/rustbgpd.service",
     "share/systemd/rustbgpd-dataplane.conf",
@@ -32,6 +33,7 @@ MONITORING = (
 )
 SYSTEMD_UNIT = "examples/systemd/rustbgpd.service"
 COMPOSE_FILE = "examples/docker-compose/docker-compose.yml"
+LICENSE_MAP = "LICENSES.md"
 SYSTEMD_DIRECTIVES = {
     ("Unit", "StartLimitIntervalSec"): "10min",
     ("Unit", "StartLimitBurst"): "5",
@@ -218,16 +220,25 @@ def check(root: Path) -> list[str]:
     try:
         check_systemd_unit(errors, read(SYSTEMD_UNIT))
         check_compose(errors, read(COMPOSE_FILE))
+        license_map = read(LICENSE_MAP)
+        for clause in (
+            "# Community Data License Agreement - Permissive - Version 2.0",
+            "## 2. Conditions for Sharing Data",
+            '5.4. "Results" means any outcome obtained by computational analysis',
+        ):
+            if clause not in license_map:
+                errors.append(f"license map: missing CDLA clause {clause!r}")
         release = read(".github/workflows/release.yml")
         package_tar = (
             "tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz rustbgpd rbgp "
-            "rs-config-render birdwatcher-adapter LICENSE-MIT LICENSE-APACHE rustbgpd.schema.json share"
+            "rs-config-render birdwatcher-adapter LICENSE-MIT LICENSE-APACHE LICENSES.md rustbgpd.schema.json share"
         )
         package = select_script(release, "tarball package commands", package_tar)
         package_patterns = tuple(
             rf"^cp target/\$\{{\{{ matrix\.target \}}\}}/release/{binary} staging/$"
             for binary in BINARIES
         ) + (
+            r"^cp LICENSE-MIT LICENSE-APACHE LICENSES\.md staging/$",
             r"^cp examples/systemd/rustbgpd\.service examples/systemd/rustbgpd-dataplane\.conf staging/share/systemd/$",
             r"^cp docs/grafana/rustbgpd-overview\.json staging/share/monitoring/$",
             r"^cp examples/prometheus/rustbgpd-alerts\.yml examples/prometheus/rustbgpd-alerts_test\.yml staging/share/monitoring/$",
@@ -240,7 +251,7 @@ def check(root: Path) -> list[str]:
             "tarball payload assertions",
             'entries="$(tar -tzf "dist/rustbgpd-${SUFFIX}.tar.gz")"',
         )
-        payloads = BINARIES + SYSTEMD + tuple(tar for _, tar, _ in MONITORING)
+        payloads = BINARIES + LICENSES + SYSTEMD + tuple(tar for _, tar, _ in MONITORING)
         inventory = re.search(r"(?m)^for f in (.+); do$", assertion)
         asserted = set(inventory.group(1).split()) if inventory else set()
         missing_payloads = set(payloads) - asserted
@@ -276,6 +287,9 @@ def check(root: Path) -> list[str]:
         for source, _, _ in MONITORING:
             if not (root / source).is_file() or (root / source).stat().st_size == 0:
                 errors.append(f"monitoring source missing or empty: {source}")
+        license_mapping = (LICENSE_MAP, "/usr/share/doc/rustbgpd/LICENSES.md")
+        if license_mapping not in mappings:
+            errors.append(f"native license mapping missing {license_mapping!r}")
 
         contract = read(".github/workflows/release-install-contract.yml")
         native = select_script(
@@ -296,6 +310,8 @@ def check(root: Path) -> list[str]:
                 r"^for tree in extracted/deb extracted/rpm; do$",
                 r"^for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do$",
                 r'^test -x "\$tree/usr/bin/\$exe" ',
+                r"^for file in lib/systemd/system/rustbgpd\.service usr/share/man/man1/rbgp\.1\.gz usr/share/man/man8/rustbgpd\.8\.gz usr/share/doc/rustbgpd/LICENSES\.md; do$",
+                r'^test -s "\$tree/\$file" ',
                 r'^"\$tree/usr/bin/rustbgpd" --check "\$tree/etc/rustbgpd/config\.toml"$',
                 r'^unit="\$tree/lib/systemd/system/rustbgpd\.service"$',
                 r"^for directive in StartLimitIntervalSec=10min StartLimitBurst=5 Restart=on-failure RestartSec=5 TimeoutStopSec=32min; do$",

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -31,8 +31,21 @@ INPUTS = (
     "examples/prometheus/rustbgpd-alerts_test.yml",
     contract.SYSTEMD_UNIT,
     contract.COMPOSE_FILE,
+    contract.LICENSE_MAP,
 )
 MUTATIONS = (
+    (
+        contract.LICENSE_MAP,
+        '5.4. "Results" means any outcome obtained by computational analysis',
+        '5.4. "Results" means an omitted agreement clause',
+        "license map",
+    ),
+    (
+        "packaging/nfpm.yaml",
+        "  - src: LICENSES.md\n    dst: /usr/share/doc/rustbgpd/LICENSES.md",
+        "  - src: omitted-license-map\n    dst: /usr/share/doc/rustbgpd/omitted",
+        "native license mapping",
+    ),
     (
         RELEASE,
         "                   share/monitoring/rustbgpd-alerts_test.yml; do",

--- a/tests/interop/m97-ixp-manager-authenticated-lifecycle.clab.yml
+++ b/tests/interop/m97-ixp-manager-authenticated-lifecycle.clab.yml
@@ -1,0 +1,63 @@
+# Containerlab topology: pinned IXP Manager v7.4 lifecycle API, real MySQL,
+# rustbgpd, and the M96 MD5-authenticated FRR member.
+#
+# Build prerequisites:
+#   docker build --target dev -t rustbgpd:dev .
+#   docker build -t rustbgpd-ixp-manager-v7.4:300b7e0 \
+#     tests/compat/ixp-manager-birdseye
+#
+# Usage:
+#   containerlab deploy -t tests/interop/m97-ixp-manager-authenticated-lifecycle.clab.yml
+#   bash tests/interop/scripts/test-m97-ixp-manager-authenticated-lifecycle.sh
+
+name: m97-ixp-manager-lifecycle
+
+topology:
+  nodes:
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      exec:
+        - ip addr add 192.0.2.18/32 dev eth1
+        - ip route add 10.1.0.36/32 dev eth1
+        - ip link set eth1 up
+
+    ixp-manager:
+      kind: linux
+      image: rustbgpd-ixp-manager-v7.4:300b7e0
+      network-mode: container:clab-m97-ixp-manager-lifecycle-rustbgpd
+      cmd: sleep infinity
+      env:
+        APP_DEBUG: "false"
+        DB_HOST: clab-m97-ixp-manager-lifecycle-mysql
+        DB_PORT: "3306"
+        DB_DATABASE: ixp_ci
+        DB_USERNAME: root
+        DB_PASSWORD: ""
+        VIEW_SKIN: rustbgpd-lifecycle
+        IXP_NO_TRANSIT_ASNS_OVERRIDE: ""
+        IXP_RPKI_RTR1_HOST: 127.0.0.1
+        IXP_RPKI_RTR1_PORT: "3323"
+        IXP_RPKI_RTR2_HOST: ""
+
+    mysql:
+      kind: linux
+      image: mysql:8.4.11@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb
+      env:
+        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        MYSQL_DATABASE: ixp_ci
+
+    frr:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+      binds:
+        - ./configs/frr-daemons:/etc/frr/daemons:ro
+        - ./configs/frr-bgpd-m96-ixp-manager.conf:/etc/frr/frr.conf:ro
+      exec:
+        - ip addr add 10.1.0.36/32 dev eth1
+        - ip route add 192.0.2.18/32 dev eth1
+        - ip link set eth1 up
+
+  links:
+    - endpoints: ["rustbgpd:eth1", "frr:eth1"]

--- a/tests/interop/scripts/test-m97-ixp-manager-authenticated-lifecycle.sh
+++ b/tests/interop/scripts/test-m97-ixp-manager-authenticated-lifecycle.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# M97: pinned IXP Manager v7.4 authenticated lifecycle and MD5 FRR continuity.
+
+set -euo pipefail
+umask 077
+
+STATE=/var/lib/m97-lifecycle
+
+# This file is copied into the rustbgpd container as the activation helper.
+if [ "${1:-}" = internal-activate ]; then
+    [ "$#" -eq 2 ] && [ "$2" = barrier ] || exit 64
+    touch /tmp/m97-activation-entered
+    sleep 4
+    if pid=$(pidof -s rustbgpd 2>/dev/null); then
+        kill -HUP "$pid"
+    else
+        mkdir -p /var/lib/rustbgpd
+        nohup /usr/local/bin/rustbgpd "$STATE/current/config.toml" \
+            >/dev/null 2>&1 </dev/null &
+    fi
+    exit 0
+fi
+
+TOPO=m97-ixp-manager-lifecycle
+RUST=clab-${TOPO}-rustbgpd
+IXP=clab-${TOPO}-ixp-manager
+MYSQL=clab-${TOPO}-mysql
+FRR=clab-${TOPO}-frr
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+TOPOLOGY=$ROOT/tests/interop/m97-ixp-manager-authenticated-lifecycle.clab.yml
+ORIGIN=http://127.0.0.1:18080
+HANDLE=b2-rs1-lan1-ipv4
+EXPECTED_COMMIT=300b7e0ba9adb0aaac975899e45fc8bcbc0ca37d
+TARGET=$ROOT/target/x86_64-unknown-linux-musl/debug/rs-config-render
+BIN=/usr/local/bin/rs-config-render
+ACT=/usr/local/bin/m97-activate
+KEY_FILE=/var/lib/m97-api-key
+WRONG_KEY_FILE=/var/lib/m97-wrong-api-key
+ADDR=unix:///var/lib/rustbgpd/grpc.sock
+MD5=mcWsqMdzGwTKt67g
+WORK=$(mktemp -d)
+LIFECYCLE_PID=
+
+cleanup() {
+    if [ -n "$LIFECYCLE_PID" ]; then
+        kill "$LIFECYCLE_PID" >/dev/null 2>&1 || true
+    fi
+    containerlab destroy -t "$TOPOLOGY" --cleanup >/dev/null 2>&1 || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+fail() { printf 'M97 FAIL: %s\n' "$*" >&2; exit 1; }
+ok() { printf 'M97 PASS: %s\n' "$*"; }
+
+for container in "$RUST" "$IXP" "$MYSQL" "$FRR"; do
+    docker inspect "$container" >/dev/null 2>&1 || fail "$container is not running"
+done
+
+for _ in $(seq 1 90); do
+    if docker exec "$MYSQL" mysqladmin ping --host 127.0.0.1 --silent \
+        >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+docker exec "$MYSQL" mysqladmin ping --host 127.0.0.1 --silent >/dev/null \
+    || fail "MySQL did not become ready"
+
+manifest=$ROOT/tests/compat/ixp-manager-birdseye/contract.json
+commit=$(jq -r .ixp_manager_commit "$manifest")
+[ "$commit" = "$EXPECTED_COMMIT" ] || fail "pinned IXP Manager commit drifted"
+git clone --quiet --filter=blob:none --no-checkout \
+    https://github.com/inex/IXP-Manager.git "$WORK/ixp-manager"
+git -C "$WORK/ixp-manager" fetch --quiet --depth=1 origin "$commit"
+git -C "$WORK/ixp-manager" checkout --quiet --detach FETCH_HEAD
+[ "$(git -C "$WORK/ixp-manager" rev-parse HEAD)" = "$EXPECTED_COMMIT" ] \
+    || fail "IXP Manager checkout is not v7.4.0 commit 300b7e0"
+
+docker exec "$IXP" mkdir -p /opt/ixp-manager
+docker cp "$WORK/ixp-manager/." "$IXP:/opt/ixp-manager"
+if ! docker exec "$IXP" composer install --working-dir=/opt/ixp-manager \
+    --no-dev --no-interaction --no-progress --prefer-dist --no-scripts \
+    >"$WORK/composer.output" 2>&1; then
+    cat "$WORK/composer.output" >&2
+    fail "pinned IXP Manager Composer install failed"
+fi
+docker exec "$IXP" cp /opt/ixp-manager/.env.ci /opt/ixp-manager/.env
+skin=/opt/ixp-manager/resources/skins/rustbgpd-lifecycle/api/v4/router/server/rustbgpd
+docker exec "$IXP" mkdir -p "$skin"
+docker cp \
+    "$ROOT/integrations/ixp-manager/gpl-2.0-only/api/v4/router/server/rustbgpd/json.foil.php" \
+    "$IXP:$skin/json.foil.php"
+
+docker exec -i "$MYSQL" mysql --user root ixp_ci \
+    <"$WORK/ixp-manager/data/ci/ci_test_db.sql"
+docker exec -i "$MYSQL" mysql --user root ixp_ci <<'SQL'
+UPDATE routers SET template='api/v4/router/server/rustbgpd/json',
+  last_update_started=NULL, last_updated=NULL, pause_updates=0
+  WHERE handle='b2-rs1-lan1-ipv4';
+UPDATE route_server_filters_prod SET enabled=0;
+UPDATE vlaninterface SET rsclient=0 WHERE id<>3;
+DELETE FROM irrdb_asn WHERE customer_id=3 AND protocol=4 AND asn<>42;
+DELETE FROM irrdb_prefix
+  WHERE customer_id=3 AND protocol=4 AND prefix<>'31.135.128.0/19';
+SQL
+
+docker exec "$RUST" sh -ec \
+    "umask 077; od -An -N32 -tx1 /dev/urandom | tr -d ' \n' >'$KEY_FILE';
+     printf '%s' definitely-wrong-m97-key >'$WRONG_KEY_FILE';
+     chmod 600 '$KEY_FILE' '$WRONG_KEY_FILE'"
+{
+    printf "UPDATE api_keys SET api_key='"
+    docker exec "$RUST" cat "$KEY_FILE"
+    printf "', expires='2099-12-31 23:59:59' WHERE id=1;\n"
+} | docker exec -i "$MYSQL" mysql --user root ixp_ci
+docker exec "$RUST" cat "$KEY_FILE" | docker exec -i "$IXP" sh -ec \
+    'umask 077; cat >/tmp/m97-api-key; chmod 600 /tmp/m97-api-key'
+
+docker exec -d "$IXP" sh -c \
+    'cd /opt/ixp-manager && exec php -d display_errors=0 -d log_errors=1 \
+      -S 127.0.0.1:18080 -t public public/index.php \
+      >/tmp/m97-server.log 2>&1'
+for _ in $(seq 1 60); do
+    if docker exec "$IXP" php -r \
+        '$s=@fsockopen("127.0.0.1",18080); exit($s ? 0 : 1);' \
+        >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+docker exec "$IXP" php -r \
+    '$s=@fsockopen("127.0.0.1",18080); exit($s ? 0 : 1);' \
+    || { docker exec "$IXP" cat /tmp/m97-server.log >&2; fail "IXP Manager API did not start"; }
+
+api() {
+    docker exec "$IXP" php -d display_errors=0 -r '
+        $method = $argv[1]; $url = $argv[2]; $keyMode = $argv[3]; $output = $argv[4];
+        $header = "";
+        if ($keyMode === "valid") {
+            $key = trim(file_get_contents("/tmp/m97-api-key"));
+            $header = "X-IXP-Manager-API-Key: " . $key . "\r\n";
+        } elseif ($keyMode === "wrong") {
+            $header = "X-IXP-Manager-API-Key: definitely-wrong-m97-key\r\n";
+        }
+        $context = stream_context_create(["http" => [
+            "method" => $method, "header" => $header, "ignore_errors" => true,
+        ]]);
+        $body = @file_get_contents($url, false, $context);
+        $line = $http_response_header[0] ?? "";
+        if (!preg_match("/ ([0-9]{3}) /", $line, $match)) { exit(70); }
+        if ($output === "body") {
+            if ($match[1] !== "200" || $body === false) { exit(71); }
+            fwrite(STDOUT, $body);
+        } else { fwrite(STDOUT, $match[1]); }
+    ' "$1" "$ORIGIN/admin/api/v4/router/$2/$HANDLE" "$3" "$4"
+}
+
+[ "$(api POST get-update-lock none status)" = 401 ] \
+    || fail "real IXP Manager accepted a request without an API key"
+[ "$(api POST get-update-lock wrong status)" = 401 ] \
+    || fail "real IXP Manager accepted a wrong API key"
+api GET gen-config valid body >"$WORK/foil.json"
+cmp -s "$WORK/foil.json" \
+    "$ROOT/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json" \
+    || fail "real v7.4 Foil API capture drifted from the pinned oracle"
+ok "pinned v7.4 API authentication and exact Foil capture"
+
+cargo +1.98.0 build --locked --target x86_64-unknown-linux-musl \
+    -p rs-config-render
+docker cp "$TARGET" "$RUST:$BIN"
+docker cp "$0" "$RUST:$ACT"
+docker exec "$RUST" sh -ec \
+    "chmod 700 '$BIN' '$ACT'; rm -rf '$STATE' /var/lib/m97-wrong-state \
+       /var/lib/m97-initial-candidate /var/lib/m97-refused-candidate;
+     mkdir -m 700 '$STATE' /var/lib/m97-wrong-state"
+
+lifecycle() {
+    local candidate=$1 state=$2 key=$3
+    shift 3
+    docker exec "$RUST" "$BIN" ixp-manager-lifecycle run \
+        --ixp-origin "$ORIGIN" --allow-http-loopback \
+        --router-handle "$HANDLE" --api-key-file "$key" \
+        --candidate-dir "$candidate" --state-dir "$state" \
+        --check-with /usr/local/bin/rustbgpd \
+        --max-prefix-restart-seconds 300 \
+        --rbgp /usr/local/bin/rbgp --rbgp-addr "$ADDR" \
+        --settle-seconds 20 --request-timeout-seconds 30 \
+        --activation-command "$ACT" --activation-arg internal-activate \
+        --activation-arg barrier "$@"
+}
+
+set +e
+lifecycle /var/lib/m97-wrong-candidate /var/lib/m97-wrong-state \
+    "$WRONG_KEY_FILE" --initial >"$WORK/wrong.output" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || fail "wrong-key lifecycle exited $status, expected 2"
+docker exec "$RUST" test ! -e /var/lib/m97-wrong-state/ixp-manager-lifecycle.json \
+    || fail "wrong-key refusal retained a lifecycle journal"
+[ "$(docker exec "$MYSQL" mysql --batch --skip-column-names --user root ixp_ci \
+    -e "SELECT IF(last_update_started IS NULL AND last_updated IS NULL,1,0) FROM routers WHERE handle='$HANDLE'")" = 1 ] \
+    || fail "wrong-key request changed router timestamps"
+ok "wrong API key was definitely refused without acquiring a lock"
+
+sql() {
+    docker exec "$MYSQL" mysql --batch --skip-column-names --user root ixp_ci \
+        -e "$1"
+}
+neighbor() {
+    docker exec "$RUST" /usr/local/bin/rbgp --addr "$ADDR" --json \
+        neighbor 10.1.0.36
+}
+has_route() {
+    docker exec "$RUST" /usr/local/bin/rbgp --addr "$ADDR" --json \
+        rib received 10.1.0.36 2>/dev/null \
+        | jq -e --arg prefix "$1" \
+            '[.[] | select(.prefix == $prefix)] | length == 1' >/dev/null
+}
+wait_for() {
+    local label=$1
+    shift
+    for _ in $(seq 1 40); do
+        if "$@"; then ok "$label"; return; fi
+        sleep 1
+    done
+    fail "$label did not converge"
+}
+session_ready() {
+    neighbor 2>/dev/null | jq -e '.state == "Established"' >/dev/null
+}
+
+docker exec "$RUST" rm -f /tmp/m97-activation-entered
+lifecycle /var/lib/m97-initial-candidate "$STATE" "$KEY_FILE" --initial \
+    >"$WORK/initial.output" 2>&1 &
+LIFECYCLE_PID=$!
+wait_for "activation barrier entered while the upstream lock is held" \
+    docker exec "$RUST" test -e /tmp/m97-activation-entered
+[ "$(sql "SELECT IF(last_update_started IS NOT NULL AND last_updated IS NULL,1,0) FROM routers WHERE handle='$HANDLE'")" = 1 ] \
+    || fail "database did not expose the acquired update lock"
+[ "$(api POST get-update-lock valid status)" = 423 ] \
+    || fail "a competing authenticated update was not refused with HTTP 423"
+set +e
+wait "$LIFECYCLE_PID"
+status=$?
+set -e
+LIFECYCLE_PID=
+[ "$status" -eq 0 ] || { cat "$WORK/initial.output" >&2; fail "initial lifecycle exited $status"; }
+[ "$(cat "$WORK/initial.output")" = 'IXP Manager lifecycle activated' ] \
+    || fail "initial lifecycle output changed"
+[ "$(sql "SELECT IF(last_update_started IS NOT NULL AND last_updated>=last_update_started,1,0) FROM routers WHERE handle='$HANDLE'")" = 1 ] \
+    || fail "updated callback was not visible in the real database"
+docker exec "$RUST" test ! -e "$STATE/ixp-manager-lifecycle.json" \
+    || fail "successful updated callback retained a lifecycle journal"
+docker exec "$RUST" test -s /var/lib/m97-initial-candidate/render-receipt.json \
+    || fail "real Foil capture was not rendered and checked"
+wait_for "MD5 FRR session Established" session_ready
+wait_for "pinned IXP prefix accepted" has_route 31.135.128.0/19
+ok "real lock transition, competing 423, activation, and updated callback"
+
+prior_link=$(docker exec "$RUST" readlink "$STATE/current")
+docker exec "$RUST" sh -c \
+    "find -L '$STATE/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
+    >"$WORK/prior-files"
+docker exec "$RUST" cat "$STATE/activation-receipt.json" \
+    >"$WORK/activation-receipt.json"
+receipt_before=$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")
+pid_before=$(docker exec "$RUST" pidof -s rustbgpd)
+session_before=$(neighbor)
+last_updated=$(sql "SELECT DATE_FORMAT(last_updated,'%Y-%m-%d %H:%i:%s') FROM routers WHERE handle='$HANDLE'")
+[ -n "$last_updated" ] || fail "updated timestamp was empty"
+sql "UPDATE route_server_filters_prod SET customer_id=3, enabled=1 WHERE id=31" \
+    >/dev/null
+docker exec "$RUST" rm -f /tmp/m97-activation-entered
+set +e
+lifecycle /var/lib/m97-refused-candidate "$STATE" "$KEY_FILE" \
+    >"$WORK/refused.output" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || { cat "$WORK/refused.output" >&2; fail "refusal exited $status"; }
+docker exec "$RUST" test ! -e /tmp/m97-activation-entered \
+    || fail "pre-activation refusal invoked the activation command"
+[ "$(docker exec "$RUST" readlink "$STATE/current")" = "$prior_link" ] \
+    || fail "pre-activation refusal moved current"
+docker exec "$RUST" sh -c \
+    "find -L '$STATE/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
+    >"$WORK/after-refusal-files"
+cmp -s "$WORK/prior-files" "$WORK/after-refusal-files" \
+    || fail "pre-activation refusal changed prior runtime bytes"
+[ "$receipt_before" = "$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")" ] \
+    || fail "pre-activation refusal rewrote the activation receipt"
+[ "$(docker exec "$RUST" pidof -s rustbgpd)" = "$pid_before" ] \
+    || fail "rustbgpd PID changed across pre-activation refusal"
+release_pair=$(sql "SELECT CONCAT(DATE_FORMAT(last_update_started,'%Y-%m-%d %H:%i:%s'),'|',DATE_FORMAT(last_updated,'%Y-%m-%d %H:%i:%s')) FROM routers WHERE handle='$HANDLE'")
+[ "$release_pair" = "$last_updated|$last_updated" ] \
+    || fail "release callback did not restore the prior database timestamp"
+docker exec "$RUST" test ! -e "$STATE/ixp-manager-lifecycle.json" \
+    || fail "delivered release callback retained a lifecycle journal"
+session_after=$(neighbor)
+jq -n --argjson before "$session_before" --argjson after "$session_after" '
+    $before.state == "Established" and $after.state == "Established"
+    and (($before.flap_count // 0) == ($after.flap_count // 0))
+    and (($after.uptime_seconds // 0) >= ($before.uptime_seconds // 0))' \
+    >/dev/null || fail "MD5 session flapped across pre-activation refusal"
+wait_for "route preserved after release" has_route 31.135.128.0/19
+ok "pre-activation refusal released the DB lock and preserved prior runtime/session"
+
+docker exec "$RUST" bash -ec \
+    "test \"\$(stat -c %a '$STATE')\" = 700;
+     test \"\$(stat -c %a '$STATE/ixp-manager-lifecycle.lock')\" = 600;
+     test \"\$(stat -c %a '$STATE/activation.lock')\" = 600;
+     test \"\$(stat -c %a '$STATE/activation-receipt.json')\" = 600;
+     test \"\$(stat -c %a '$KEY_FILE')\" = 600;
+     test -L '$STATE/current';
+     ! find '$STATE/generations' -type d ! -perm 700 -print -quit | grep -q .;
+     ! find '$STATE/generations' -type f ! -perm 600 -print -quit | grep -q ."
+if docker exec "$RUST" cat "$KEY_FILE" \
+    | grep -RFl -f - "$WORK" >/dev/null 2>&1; then
+    fail "API key escaped into retained host artifacts"
+fi
+docker exec "$RUST" sh -ec \
+    "! grep -RFl -f '$KEY_FILE' '$STATE' /var/lib/m97-initial-candidate \
+       /var/lib/m97-refused-candidate >/dev/null 2>&1"
+docker exec "$IXP" sh -ec \
+    '! grep -F -f /tmp/m97-api-key /tmp/m97-server.log >/dev/null 2>&1'
+if printf '%s' "$MD5" | grep -Fl -f - "$WORK/initial.output" \
+    "$WORK/refused.output" "$WORK/activation-receipt.json" >/dev/null; then
+    fail "MD5 secret escaped into lifecycle output or receipt"
+fi
+docker exec "$FRR" vtysh -c 'show bgp neighbors 192.0.2.18 json' \
+    | jq -e '.["192.0.2.18"].bgpState == "Established"' >/dev/null \
+    || fail "FRR does not report the authenticated session Established"
+ok "M97 authenticated lifecycle, private modes, cleanup, and redaction complete"

--- a/tools/rs-config-render/Cargo.toml
+++ b/tools/rs-config-render/Cargo.toml
@@ -16,6 +16,8 @@ clap = { workspace = true }
 sha2 = { workspace = true }
 toml = { workspace = true }
 rustbgpd-policy = { workspace = true }
+ureq = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -108,6 +108,64 @@ therefore be absent or stale after exit 5. The helper does not deploy services,
 prune generations, retry indefinitely, or call IXP Manager. These examples use
 package paths; release archives install the three binaries under `/usr/local/bin`.
 
+### Authenticated IXP Manager lifecycle
+
+`ixp-manager-lifecycle run` wraps the pinned IXP Manager v7.4 router API around
+the same renderer and atomic activation path. It acquires the upstream router
+lock, fetches the real Foil JSON over HTTPS, renders and strictly checks a fresh
+private candidate, activates it, then delivers `updated` or
+`release-update-lock` as appropriate:
+
+```console
+sudo -u rustbgpd /usr/bin/rs-config-render ixp-manager-lifecycle run \
+  --ixp-origin https://ixp.example.net \
+  --router-handle rs1-ipv4 \
+  --api-key-file /var/lib/rustbgpd/ixp-manager/api-key \
+  --candidate-dir /var/lib/rustbgpd/ixp-manager/candidate-1 \
+  --state-dir /var/lib/rustbgpd/ixp-manager/lifecycle \
+  --max-prefix-restart-seconds 300 \
+  --check-with /usr/bin/rustbgpd --rbgp /usr/bin/rbgp \
+  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --activation-command /usr/bin/sudo \
+  --activation-arg=-n --activation-arg /usr/bin/systemctl \
+  --activation-arg reload-or-restart --activation-arg rustbgpd
+```
+
+Supply a new absent or empty mode-0700 candidate directory for each run. The
+absolute state directory must already exist at mode 0700 and remain owned by
+the `rustbgpd` identity. The API-key path must be absolute, regular,
+non-symlink, mode 0600, and at most 4 KiB. The value appears only in the
+`X-IXP-Manager-API-Key` request header: it is not accepted in argv or the
+environment and is not retained in the lifecycle journal, render receipt,
+capture, output, or diagnostics.
+
+HTTPS with platform trust roots is mandatory. Redirects and environment
+proxies are disabled. `--allow-http-loopback` exists only for a numeric
+loopback test origin; hostname HTTP, `localhost`, URL credentials, query
+strings, fragments, and path-prefixed origins are refused. Requests use a
+bounded 1–300 second deadline, 32 KiB response-header ceiling, 64 KiB control
+body ceiling, and 4 MiB configuration ceiling.
+
+Lifecycle intent is written and synced before every upstream request. Exit 0
+means `updated` was delivered. Exit 2 means no lock was acquired or a definite
+pre-activation refusal was released. Exit 4 means the activation command never
+started, exact prior runtime was proven, and release was delivered. Exit 5
+does not issue a callback because lock acquisition or an activation effect is
+uncertain. Exit 6 leaves one durable `updated` or release callback pending;
+retry only that callback with the same identity:
+
+```console
+sudo -u rustbgpd /usr/bin/rs-config-render ixp-manager-lifecycle resume \
+  --ixp-origin https://ixp.example.net --router-handle rs1-ipv4 \
+  --api-key-file /var/lib/rustbgpd/ixp-manager/api-key \
+  --state-dir /var/lib/rustbgpd/ixp-manager/lifecycle
+```
+
+Callback delivery is at-least-once because IXP Manager v7.4 supplies no lease
+or idempotency token. `resume` never refetches, rerenders, or activates. It has
+no automatic action for exit 5; inspect retained activation/lifecycle state and
+the live daemon before explicitly resolving the upstream router lock.
+
 Release tarballs (`rustbgpd-<arch>.tar.gz` on the [releases
 page](https://github.com/lance0/rustbgpd/releases)) ship the
 `rs-config-render` binary alongside `rustbgpd` and `rbgp`; from

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -607,7 +607,20 @@ pub fn write_checked_candidate(
         return Err(Error::Refused("input capture must be mode 0600"));
     }
     let input = fs::read(context).map_err(|_| Error::Input)?;
-    let candidate = render_document(&input, restart_seconds)?;
+    write_checked_candidate_bytes(&input, out, restart_seconds, checker)
+}
+
+/// Render and strictly validate a private in-memory IXP Manager capture.
+///
+/// This is the authenticated-lifecycle entry point: callers retain ownership
+/// of the fetched secret-bearing bytes and never need to persist a raw capture.
+pub fn write_checked_candidate_bytes(
+    input: &[u8],
+    out: &Path,
+    restart_seconds: u32,
+    checker: &Path,
+) -> Result<usize, Error> {
+    let candidate = render_document(input, restart_seconds)?;
     prepare_output(out)?;
     for (relative, contents) in &candidate.files {
         let path = out.join(relative);

--- a/tools/rs-config-render/src/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/src/ixp_manager_lifecycle.rs
@@ -1,0 +1,753 @@
+//! Authenticated IXP Manager v7.4 lock, render, activation, and callback lifecycle.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct Options<'a> {
+    pub ixp_origin: &'a str,
+    pub router_handle: &'a str,
+    pub api_key_file: &'a Path,
+    pub candidate_dir: &'a Path,
+    pub state_dir: &'a Path,
+    pub checker: &'a Path,
+    pub max_prefix_restart_seconds: u32,
+    pub rbgp: &'a Path,
+    pub rbgp_addr: &'a str,
+    pub activation_command: &'a Path,
+    pub activation_args: &'a [OsString],
+    pub settle: Duration,
+    pub timeout: Duration,
+    pub initial: bool,
+    pub allow_http_loopback: bool,
+}
+
+#[derive(Debug)]
+pub struct ResumeOptions<'a> {
+    pub ixp_origin: &'a str,
+    pub router_handle: &'a str,
+    pub api_key_file: &'a Path,
+    pub state_dir: &'a Path,
+    pub timeout: Duration,
+    pub allow_http_loopback: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Status {
+    Activated,
+    Noop,
+    Updated,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    Refused(&'static str),
+    RolledBack,
+    ManualRecovery,
+    CallbackPending,
+}
+
+impl Error {
+    pub const fn exit_code(&self) -> u8 {
+        match self {
+            Self::Refused(_) => 2,
+            Self::RolledBack => 4,
+            Self::ManualRecovery => 5,
+            Self::CallbackPending => 6,
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Refused(reason) => formatter.write_str(reason),
+            Self::RolledBack => formatter.write_str("activation did not start; lock released"),
+            Self::ManualRecovery => {
+                formatter.write_str("manual recovery required; upstream lock retained")
+            }
+            Self::CallbackPending => formatter.write_str("callback pending; run resume"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[cfg(not(unix))]
+pub fn run(_: &Options<'_>) -> Result<Status, Error> {
+    Err(Error::Refused(
+        "IXP Manager lifecycle is supported only on Unix",
+    ))
+}
+
+#[cfg(not(unix))]
+pub fn resume(_: &ResumeOptions<'_>) -> Result<Status, Error> {
+    Err(Error::Refused(
+        "IXP Manager lifecycle is supported only on Unix",
+    ))
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::{Error, Options, ResumeOptions, Status};
+    use crate::{activation, ixp_manager};
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+    use sha2::{Digest, Sha256};
+    use std::fs::{self, File, OpenOptions};
+    use std::io::{self, Read, Write};
+    use std::net::IpAddr;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use ureq::Agent;
+    use ureq::http::{HeaderMap, Uri};
+    use ureq::tls::{RootCerts, TlsConfig, TlsProvider};
+    use zeroize::Zeroizing;
+
+    const KEY_HEADER: &str = "X-IXP-Manager-API-Key";
+    const JOURNAL: &str = "ixp-manager-lifecycle.json";
+    const JOURNAL_SCHEMA: &str = "rustbgpd.ixp-manager.lifecycle/v1";
+    const LOCK: &str = "ixp-manager-lifecycle.lock";
+    const MAX_KEY: u64 = 4 * 1024;
+    const MAX_CONTROL: u64 = 64 * 1024;
+    const MAX_CONFIG: u64 = 4 * 1024 * 1024;
+    const MAX_JOURNAL: u64 = 64 * 1024;
+    static TEMPORARY_NONCE: AtomicU64 = AtomicU64::new(0);
+
+    type Result<T> = std::result::Result<T, Error>;
+
+    #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    enum Phase {
+        LockRequestPending,
+        Locked,
+        ActivationStarted,
+        UpdatedPending,
+        ReleasePending,
+        ManualRecovery,
+    }
+
+    #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    enum Callback {
+        Updated,
+        Release,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[serde(deny_unknown_fields)]
+    struct Journal {
+        schema: String,
+        ixp_manager_version: String,
+        origin: String,
+        router_handle: String,
+        phase: Phase,
+        callback: Option<Callback>,
+        callback_attempts: u32,
+        candidate_sha256: Option<String>,
+        activation_outcome: Option<String>,
+        error_class: Option<String>,
+    }
+
+    struct Client {
+        agent: Agent,
+        origin: String,
+        handle: String,
+        key: Zeroizing<String>,
+    }
+
+    enum LockResult {
+        Acquired,
+        NotAcquired,
+        Ambiguous(&'static str),
+    }
+
+    enum RequestError {
+        Definite,
+        Ambiguous(&'static str),
+    }
+
+    struct StateLock {
+        _file: File,
+    }
+
+    fn private(path: &Path, directory: bool, mode: u32) -> bool {
+        fs::symlink_metadata(path).is_ok_and(|metadata| {
+            let kind = metadata.file_type();
+            let expected = if directory {
+                kind.is_dir()
+            } else {
+                kind.is_file() && metadata.nlink() == 1
+            };
+            expected && metadata.permissions().mode() & 0o777 == mode
+        })
+    }
+
+    fn same_private_file(path: &Path, file: &File, mode: u32) -> bool {
+        let Ok(named) = fs::symlink_metadata(path) else {
+            return false;
+        };
+        let Ok(opened) = file.metadata() else {
+            return false;
+        };
+        named.file_type().is_file()
+            && opened.file_type().is_file()
+            && named.nlink() == 1
+            && opened.nlink() == 1
+            && named.permissions().mode() & 0o777 == mode
+            && opened.permissions().mode() & 0o777 == mode
+            && named.dev() == opened.dev()
+            && named.ino() == opened.ino()
+    }
+
+    fn sync_dir(path: &Path) -> Result<()> {
+        File::open(path)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|_| Error::ManualRecovery)
+    }
+
+    fn state_lock(state: &Path) -> Result<StateLock> {
+        if !state.is_absolute() || !private(state, true, 0o700) {
+            return Err(Error::Refused(
+                "state directory must be a pre-created absolute mode-0700 directory",
+            ));
+        }
+        let path = state.join(LOCK);
+        let file = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+        {
+            Ok(file) => {
+                file.sync_all().map_err(|_| Error::ManualRecovery)?;
+                sync_dir(state)?;
+                file
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&path)
+                    .map_err(|_| Error::Refused("lifecycle lock is unavailable"))?;
+                if !same_private_file(&path, &file, 0o600) {
+                    return Err(Error::Refused("lifecycle lock is not private"));
+                }
+                file
+            }
+            Err(_) => return Err(Error::Refused("lifecycle lock is unavailable")),
+        };
+        file.try_lock()
+            .map_err(|_| Error::Refused("another lifecycle command is active"))?;
+        Ok(StateLock { _file: file })
+    }
+
+    fn validate_handle(handle: &str) -> Result<()> {
+        if handle.is_empty()
+            || handle.len() > 128
+            || !handle
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte))
+        {
+            return Err(Error::Refused("router handle is invalid"));
+        }
+        Ok(())
+    }
+
+    fn normalized_origin(origin: &str, allow_http_loopback: bool) -> Result<String> {
+        let uri: Uri = origin
+            .parse()
+            .map_err(|_| Error::Refused("IXP origin is invalid"))?;
+        let scheme = uri
+            .scheme_str()
+            .ok_or(Error::Refused("IXP origin is invalid"))?;
+        let authority = uri
+            .authority()
+            .ok_or(Error::Refused("IXP origin is invalid"))?;
+        if authority.as_str().contains('@')
+            || uri.query().is_some()
+            || !matches!(uri.path(), "" | "/")
+            || authority
+                .host()
+                .trim_end_matches('.')
+                .eq_ignore_ascii_case("localhost")
+        {
+            return Err(Error::Refused("IXP origin must be a root origin"));
+        }
+        match scheme {
+            "https" => {}
+            "http"
+                if allow_http_loopback
+                    && authority
+                        .host()
+                        .parse::<IpAddr>()
+                        .is_ok_and(|address| address.is_loopback()) => {}
+            "http" => {
+                return Err(Error::Refused(
+                    "HTTP requires an explicit numeric-loopback allowance",
+                ));
+            }
+            _ => return Err(Error::Refused("IXP origin must use HTTPS")),
+        }
+        Ok(format!("{scheme}://{authority}"))
+    }
+
+    fn api_key(path: &Path) -> Result<Zeroizing<String>> {
+        if !path.is_absolute() || !private(path, false, 0o600) {
+            return Err(Error::Refused(
+                "API key must be an absolute private mode-0600 regular file",
+            ));
+        }
+        let file = File::open(path).map_err(|_| Error::Refused("API key is unreadable"))?;
+        if !same_private_file(path, &file, 0o600) {
+            return Err(Error::Refused(
+                "API key must be an absolute private mode-0600 regular file",
+            ));
+        }
+        let metadata = file
+            .metadata()
+            .map_err(|_| Error::Refused("API key is unreadable"))?;
+        if metadata.len() == 0 || metadata.len() > MAX_KEY {
+            return Err(Error::Refused("API key size is invalid"));
+        }
+        let mut bytes = Zeroizing::new(Vec::with_capacity(metadata.len() as usize));
+        file.take(MAX_KEY + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| Error::Refused("API key is unreadable"))?;
+        if bytes.len() as u64 > MAX_KEY {
+            return Err(Error::Refused("API key size is invalid"));
+        }
+        let text = std::str::from_utf8(&bytes)
+            .map_err(|_| Error::Refused("API key is invalid UTF-8"))?
+            .trim_end_matches(['\r', '\n']);
+        if text.is_empty() || !text.bytes().all(|byte| byte.is_ascii_graphic()) {
+            return Err(Error::Refused("API key is invalid"));
+        }
+        Ok(Zeroizing::new(text.to_owned()))
+    }
+
+    fn agent(timeout: Duration) -> Result<Agent> {
+        if !(Duration::from_secs(1)..=Duration::from_secs(300)).contains(&timeout) {
+            return Err(Error::Refused("request timeout must be 1..=300 seconds"));
+        }
+        Ok(Agent::config_builder()
+            .proxy(None)
+            .max_redirects(0)
+            .http_status_as_error(false)
+            .max_response_header_size(32 * 1024)
+            .timeout_global(Some(timeout))
+            .tls_config(
+                TlsConfig::builder()
+                    .provider(TlsProvider::Rustls)
+                    .root_certs(RootCerts::PlatformVerifier)
+                    .build(),
+            )
+            .build()
+            .new_agent())
+    }
+
+    impl Client {
+        fn new(
+            origin: &str,
+            handle: &str,
+            key_file: &Path,
+            timeout: Duration,
+            allow_http_loopback: bool,
+        ) -> Result<Self> {
+            validate_handle(handle)?;
+            Ok(Self {
+                agent: agent(timeout)?,
+                origin: normalized_origin(origin, allow_http_loopback)?,
+                handle: handle.to_owned(),
+                key: api_key(key_file)?,
+            })
+        }
+
+        fn url(&self, action: &str) -> String {
+            format!(
+                "{}/admin/api/v4/router/{action}/{}",
+                self.origin, self.handle
+            )
+        }
+
+        fn control(&self, action: &str) -> std::result::Result<(), RequestError> {
+            let mut response = self
+                .agent
+                .post(&self.url(action))
+                .header(KEY_HEADER, self.key.as_str())
+                .send_empty()
+                .map_err(|_| RequestError::Ambiguous("transport"))?;
+            let status = response.status();
+            if !status.is_success() {
+                return match status.as_u16() {
+                    401 | 403 | 404 | 405 | 422 | 423 => Err(RequestError::Definite),
+                    _ => Err(RequestError::Ambiguous("status")),
+                };
+            }
+            let body = response
+                .body_mut()
+                .with_config()
+                .limit(MAX_CONTROL + 1)
+                .read_to_vec()
+                .map_err(|_| RequestError::Ambiguous("control_body"))?;
+            if body.len() as u64 > MAX_CONTROL || !valid_control_response(response.headers(), &body)
+            {
+                return Err(RequestError::Ambiguous("control_body"));
+            }
+            Ok(())
+        }
+
+        fn acquire(&self) -> LockResult {
+            match self.control("get-update-lock") {
+                Ok(()) => LockResult::Acquired,
+                Err(RequestError::Definite) => LockResult::NotAcquired,
+                Err(RequestError::Ambiguous(class)) => LockResult::Ambiguous(class),
+            }
+        }
+
+        fn configuration(&self) -> std::result::Result<Zeroizing<Vec<u8>>, RequestError> {
+            let mut response = self
+                .agent
+                .get(&self.url("gen-config"))
+                .header(KEY_HEADER, self.key.as_str())
+                .call()
+                .map_err(|_| RequestError::Ambiguous("transport"))?;
+            if !response.status().is_success() {
+                return Err(RequestError::Definite);
+            }
+            let content_type = response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default();
+            if !content_type
+                .split(';')
+                .next()
+                .is_some_and(|value| value.trim().eq_ignore_ascii_case("text/plain"))
+            {
+                return Err(RequestError::Definite);
+            }
+            let body = response
+                .body_mut()
+                .with_config()
+                .limit(MAX_CONFIG + 1)
+                .read_to_vec()
+                .map_err(|_| RequestError::Ambiguous("config_body"))?;
+            if body.len() as u64 > MAX_CONFIG {
+                return Err(RequestError::Definite);
+            }
+            Ok(Zeroizing::new(body))
+        }
+
+        fn callback(&self, callback: Callback) -> std::result::Result<(), RequestError> {
+            self.control(match callback {
+                Callback::Updated => "updated",
+                Callback::Release => "release-update-lock",
+            })
+        }
+    }
+
+    fn valid_control_response(headers: &HeaderMap, body: &[u8]) -> bool {
+        let content_type = headers
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.split(';').next())
+            .is_some_and(|value| value.trim().eq_ignore_ascii_case("application/json"));
+        let Ok(Value::Object(object)) = serde_json::from_slice(body) else {
+            return false;
+        };
+        let valid_pair = |text: &str, unix: &str| match (object.get(text), object.get(unix)) {
+            (Some(Value::Null), Some(Value::Null)) => true,
+            (Some(Value::String(text)), Some(Value::Number(unix))) => {
+                !text.is_empty() && unix.as_i64().is_some()
+            }
+            _ => false,
+        };
+        content_type
+            && object.len() == 4
+            && valid_pair("last_update_started", "last_update_started_unix")
+            && valid_pair("last_updated", "last_updated_unix")
+    }
+
+    fn journal_path(state: &Path) -> PathBuf {
+        state.join(JOURNAL)
+    }
+
+    fn write_journal(state: &Path, journal: &Journal) -> Result<()> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let nonce = TEMPORARY_NONCE.fetch_add(1, Ordering::Relaxed);
+        let temporary = state.join(format!(
+            ".{JOURNAL}.{}.{}.{}.tmp",
+            std::process::id(),
+            timestamp,
+            nonce
+        ));
+        let bytes = serde_json::to_vec_pretty(journal).expect("journal serializes");
+        let result = (|| -> io::Result<()> {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&temporary)?;
+            file.write_all(&bytes)?;
+            file.write_all(b"\n")?;
+            file.sync_all()?;
+            fs::rename(&temporary, journal_path(state))?;
+            File::open(state)?.sync_all()
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temporary);
+            return Err(Error::ManualRecovery);
+        }
+        Ok(())
+    }
+
+    fn read_journal(state: &Path) -> Result<Journal> {
+        let path = journal_path(state);
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Err(Error::Refused("no pending lifecycle callback exists"));
+            }
+            Err(_) => return Err(Error::ManualRecovery),
+        }
+        if !private(&path, false, 0o600) {
+            return Err(Error::ManualRecovery);
+        }
+        let metadata = fs::metadata(&path).map_err(|_| Error::ManualRecovery)?;
+        if metadata.len() == 0 || metadata.len() > MAX_JOURNAL {
+            return Err(Error::ManualRecovery);
+        }
+        let mut bytes = Vec::new();
+        File::open(path)
+            .and_then(|file| file.take(MAX_JOURNAL + 1).read_to_end(&mut bytes))
+            .map_err(|_| Error::ManualRecovery)?;
+        let journal: Journal = serde_json::from_slice(&bytes).map_err(|_| Error::ManualRecovery)?;
+        if journal.schema != JOURNAL_SCHEMA || journal.ixp_manager_version != "7.4.0" {
+            return Err(Error::ManualRecovery);
+        }
+        Ok(journal)
+    }
+
+    fn remove_journal(state: &Path) -> Result<()> {
+        fs::remove_file(journal_path(state)).map_err(|_| Error::ManualRecovery)?;
+        sync_dir(state)
+    }
+
+    fn new_journal(origin: &str, handle: &str) -> Journal {
+        Journal {
+            schema: JOURNAL_SCHEMA.to_owned(),
+            ixp_manager_version: "7.4.0".to_owned(),
+            origin: origin.to_owned(),
+            router_handle: handle.to_owned(),
+            phase: Phase::LockRequestPending,
+            callback: None,
+            callback_attempts: 0,
+            candidate_sha256: None,
+            activation_outcome: None,
+            error_class: None,
+        }
+    }
+
+    fn candidate_digest(path: &Path) -> Option<String> {
+        let bytes = fs::read(path.join("render-receipt.json")).ok()?;
+        Some(
+            Sha256::digest(bytes)
+                .iter()
+                .fold(String::with_capacity(64), |mut output, byte| {
+                    use std::fmt::Write as _;
+                    write!(output, "{byte:02x}").expect("String writes cannot fail");
+                    output
+                }),
+        )
+    }
+
+    fn callback_pending(
+        state: &Path,
+        client: &Client,
+        journal: &mut Journal,
+        callback: Callback,
+    ) -> Result<()> {
+        journal.phase = match callback {
+            Callback::Updated => Phase::UpdatedPending,
+            Callback::Release => Phase::ReleasePending,
+        };
+        journal.callback = Some(callback);
+        write_journal(state, journal)?;
+        journal.callback_attempts = journal.callback_attempts.saturating_add(1);
+        write_journal(state, journal)?;
+        match client.callback(callback) {
+            Ok(()) => remove_journal(state),
+            Err(_) => Err(Error::CallbackPending),
+        }
+    }
+
+    pub fn run(options: &Options<'_>) -> Result<Status> {
+        let _lock = state_lock(options.state_dir)?;
+        let path = journal_path(options.state_dir);
+        match fs::symlink_metadata(&path) {
+            Ok(_) if private(&path, false, 0o600) => {
+                return Err(Error::Refused("pending lifecycle state requires resume"));
+            }
+            Ok(_) => return Err(Error::ManualRecovery),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(_) => return Err(Error::ManualRecovery),
+        }
+        let client = Client::new(
+            options.ixp_origin,
+            options.router_handle,
+            options.api_key_file,
+            options.timeout,
+            options.allow_http_loopback,
+        )?;
+        let mut journal = new_journal(&client.origin, &client.handle);
+        write_journal(options.state_dir, &journal)?;
+        match client.acquire() {
+            LockResult::Acquired => {
+                journal.phase = Phase::Locked;
+                write_journal(options.state_dir, &journal)?;
+            }
+            LockResult::NotAcquired => {
+                remove_journal(options.state_dir)?;
+                return Err(Error::Refused("IXP Manager update lock was not acquired"));
+            }
+            LockResult::Ambiguous(class) => {
+                journal.phase = Phase::ManualRecovery;
+                journal.error_class = Some(class.to_owned());
+                write_journal(options.state_dir, &journal)?;
+                return Err(Error::ManualRecovery);
+            }
+        }
+        let input = match client.configuration() {
+            Ok(input) => input,
+            Err(_) => {
+                journal.activation_outcome = Some("refused".to_owned());
+                journal.error_class = Some("configuration_fetch".to_owned());
+                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                return Err(Error::Refused("IXP Manager configuration fetch failed"));
+            }
+        };
+        if ixp_manager::write_checked_candidate_bytes(
+            &input,
+            options.candidate_dir,
+            options.max_prefix_restart_seconds,
+            options.checker,
+        )
+        .is_err()
+        {
+            journal.activation_outcome = Some("refused".to_owned());
+            journal.error_class = Some("candidate_render".to_owned());
+            callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+            return Err(Error::Refused("IXP Manager candidate was refused"));
+        }
+        journal.candidate_sha256 = candidate_digest(options.candidate_dir);
+        journal.phase = Phase::ActivationStarted;
+        write_journal(options.state_dir, &journal)?;
+        let activation_args = activation::Options {
+            candidate: options.candidate_dir,
+            state_dir: options.state_dir,
+            checker: options.checker,
+            rbgp: options.rbgp,
+            rbgp_addr: options.rbgp_addr,
+            settle: options.settle,
+            initial: options.initial,
+            activation_command: options.activation_command,
+            activation_args: options.activation_args,
+        };
+        match activation::activate(&activation_args) {
+            Ok(status) => {
+                journal.activation_outcome = Some(
+                    match status {
+                        activation::Status::Activated => "activated",
+                        activation::Status::Noop => "noop",
+                    }
+                    .to_owned(),
+                );
+                callback_pending(options.state_dir, &client, &mut journal, Callback::Updated)?;
+                Ok(match status {
+                    activation::Status::Activated => Status::Activated,
+                    activation::Status::Noop => Status::Noop,
+                })
+            }
+            Err(activation::Error::Refused(_)) => {
+                journal.activation_outcome = Some("refused".to_owned());
+                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                Err(Error::Refused("candidate activation was refused"))
+            }
+            Err(activation::Error::RolledBack) => {
+                journal.activation_outcome = Some("rolled_back".to_owned());
+                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                Err(Error::RolledBack)
+            }
+            Err(activation::Error::RecoveryRequired) => {
+                journal.phase = Phase::ManualRecovery;
+                journal.activation_outcome = Some("recovery_required".to_owned());
+                journal.error_class = Some("activation".to_owned());
+                write_journal(options.state_dir, &journal)?;
+                Err(Error::ManualRecovery)
+            }
+        }
+    }
+
+    pub fn resume(options: &ResumeOptions<'_>) -> Result<Status> {
+        let _lock = state_lock(options.state_dir)?;
+        let client = Client::new(
+            options.ixp_origin,
+            options.router_handle,
+            options.api_key_file,
+            options.timeout,
+            options.allow_http_loopback,
+        )?;
+        let mut journal = read_journal(options.state_dir)?;
+        if journal.origin != client.origin || journal.router_handle != client.handle {
+            return Err(Error::Refused("lifecycle journal identity does not match"));
+        }
+        match journal.phase {
+            Phase::UpdatedPending
+                if journal.callback == Some(Callback::Updated)
+                    && matches!(
+                        journal.activation_outcome.as_deref(),
+                        Some("activated" | "noop")
+                    ) =>
+            {
+                callback_pending(options.state_dir, &client, &mut journal, Callback::Updated)?;
+                Ok(Status::Updated)
+            }
+            Phase::ReleasePending
+                if journal.callback == Some(Callback::Release)
+                    && matches!(
+                        journal.activation_outcome.as_deref(),
+                        Some("refused" | "rolled_back")
+                    ) =>
+            {
+                let rolled_back = journal.activation_outcome.as_deref() == Some("rolled_back");
+                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                if rolled_back {
+                    Err(Error::RolledBack)
+                } else {
+                    Err(Error::Refused("lock released without activation"))
+                }
+            }
+            Phase::Locked if journal.callback.is_none() && journal.activation_outcome.is_none() => {
+                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                Err(Error::Refused("lock released before activation"))
+            }
+            Phase::LockRequestPending | Phase::ActivationStarted | Phase::ManualRecovery => {
+                Err(Error::ManualRecovery)
+            }
+            Phase::UpdatedPending | Phase::ReleasePending | Phase::Locked => {
+                Err(Error::ManualRecovery)
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+pub use unix::{resume, run};

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -45,6 +45,7 @@ use sha2::{Digest, Sha256};
 
 pub mod activation;
 pub mod ixp_manager;
+pub mod ixp_manager_lifecycle;
 
 /// Top-level keys of the supported `template-context` shape, sorted.
 ///

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Duration;
 
-use clap::{Parser, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use rs_config_render::{
     Options, RenderError, SiteLocalFile, SiteLocalInput, render, render_site_local,
@@ -53,6 +53,85 @@ struct ActivateArgs {
     /// Literal activation argument; repeatable and never shell-evaluated
     #[arg(long, allow_hyphen_values = true)]
     activation_arg: Vec<OsString>,
+}
+
+#[derive(Parser)]
+#[command(
+    name = "rs-config-render ixp-manager-lifecycle",
+    about = "Run the authenticated IXP Manager v7.4 router lifecycle"
+)]
+struct LifecycleArgs {
+    #[command(subcommand)]
+    command: LifecycleCommand,
+}
+
+#[derive(Subcommand)]
+enum LifecycleCommand {
+    /// Lock, fetch, render, activate, and acknowledge one router configuration
+    Run(LifecycleRunArgs),
+    /// Replay one durable pending callback without fetching or activating
+    Resume(LifecycleResumeArgs),
+}
+
+#[derive(clap::Args)]
+struct LifecycleConnectionArgs {
+    /// IXP Manager root origin; HTTPS is required by default
+    #[arg(long)]
+    ixp_origin: String,
+    /// Exact IXP Manager router handle
+    #[arg(long)]
+    router_handle: String,
+    /// Absolute mode-0600 file containing the API key
+    #[arg(long)]
+    api_key_file: PathBuf,
+    /// Pre-created absolute mode-0700 lifecycle/activation state directory
+    #[arg(long)]
+    state_dir: PathBuf,
+    /// Whole-request deadline in seconds
+    #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=300))]
+    request_timeout_seconds: u64,
+    /// Permit plaintext HTTP only to a numeric loopback origin
+    #[arg(long)]
+    allow_http_loopback: bool,
+}
+
+#[derive(clap::Args)]
+struct LifecycleRunArgs {
+    #[command(flatten)]
+    connection: LifecycleConnectionArgs,
+    /// Empty private directory for the fetched, rendered candidate
+    #[arg(long)]
+    candidate_dir: PathBuf,
+    /// rustbgpd binary used for mandatory strict candidate checks
+    #[arg(long)]
+    check_with: PathBuf,
+    /// Positive automatic restart delay for IXP Manager max-prefix
+    #[arg(long)]
+    max_prefix_restart_seconds: u32,
+    /// Exact rbgp executable used for health and live config comparison
+    #[arg(long)]
+    rbgp: PathBuf,
+    /// Running rustbgpd gRPC address
+    #[arg(long)]
+    rbgp_addr: String,
+    /// Maximum seconds for activation settlement
+    #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=120))]
+    settle_seconds: u64,
+    /// Permit initial publication only when no current generation or daemon exists
+    #[arg(long)]
+    initial: bool,
+    /// Exact activation executable; never evaluated by a shell
+    #[arg(long)]
+    activation_command: PathBuf,
+    /// Literal activation argument; repeatable and never shell-evaluated
+    #[arg(long, allow_hyphen_values = true)]
+    activation_arg: Vec<OsString>,
+}
+
+#[derive(clap::Args)]
+struct LifecycleResumeArgs {
+    #[command(flatten)]
+    connection: LifecycleConnectionArgs,
 }
 
 #[derive(Parser)]
@@ -154,7 +233,77 @@ fn parse_activation() -> Option<ActivateArgs> {
         .then(|| ActivateArgs::parse_from(std::iter::once(binary).chain(args)))
 }
 
+fn parse_lifecycle() -> Option<LifecycleArgs> {
+    let mut args = std::env::args_os();
+    let binary = args.next()?;
+    (args.next().as_deref() == Some(OsStr::new("ixp-manager-lifecycle")))
+        .then(|| LifecycleArgs::parse_from(std::iter::once(binary).chain(args)))
+}
+
+fn lifecycle_exit(
+    result: Result<
+        rs_config_render::ixp_manager_lifecycle::Status,
+        rs_config_render::ixp_manager_lifecycle::Error,
+    >,
+) -> ExitCode {
+    match result {
+        Ok(status) => {
+            let status = match status {
+                rs_config_render::ixp_manager_lifecycle::Status::Activated => "activated",
+                rs_config_render::ixp_manager_lifecycle::Status::Noop => "noop",
+                rs_config_render::ixp_manager_lifecycle::Status::Updated => "updated",
+            };
+            stdout_exit(write_stdout(|writer| {
+                writeln!(writer, "IXP Manager lifecycle {status}")
+            }))
+        }
+        Err(error) => {
+            eprintln!("rs-config-render: IXP Manager lifecycle: {error}");
+            ExitCode::from(error.exit_code())
+        }
+    }
+}
+
 fn main() -> ExitCode {
+    if let Some(args) = parse_lifecycle() {
+        return match args.command {
+            LifecycleCommand::Run(args) => {
+                let connection = args.connection;
+                lifecycle_exit(rs_config_render::ixp_manager_lifecycle::run(
+                    &rs_config_render::ixp_manager_lifecycle::Options {
+                        ixp_origin: &connection.ixp_origin,
+                        router_handle: &connection.router_handle,
+                        api_key_file: &connection.api_key_file,
+                        candidate_dir: &args.candidate_dir,
+                        state_dir: &connection.state_dir,
+                        checker: &args.check_with,
+                        max_prefix_restart_seconds: args.max_prefix_restart_seconds,
+                        rbgp: &args.rbgp,
+                        rbgp_addr: &args.rbgp_addr,
+                        activation_command: &args.activation_command,
+                        activation_args: &args.activation_arg,
+                        settle: Duration::from_secs(args.settle_seconds),
+                        timeout: Duration::from_secs(connection.request_timeout_seconds),
+                        initial: args.initial,
+                        allow_http_loopback: connection.allow_http_loopback,
+                    },
+                ))
+            }
+            LifecycleCommand::Resume(args) => {
+                let connection = args.connection;
+                lifecycle_exit(rs_config_render::ixp_manager_lifecycle::resume(
+                    &rs_config_render::ixp_manager_lifecycle::ResumeOptions {
+                        ixp_origin: &connection.ixp_origin,
+                        router_handle: &connection.router_handle,
+                        api_key_file: &connection.api_key_file,
+                        state_dir: &connection.state_dir,
+                        timeout: Duration::from_secs(connection.request_timeout_seconds),
+                        allow_http_loopback: connection.allow_http_loopback,
+                    },
+                ))
+            }
+        };
+    }
     if let Some(args) = parse_activation() {
         let options = rs_config_render::activation::Options {
             candidate: &args.candidate,

--- a/tools/rs-config-render/tests/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/tests/ixp_manager_lifecycle.rs
@@ -1,0 +1,810 @@
+#![cfg(unix)]
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use rs_config_render::activation;
+use rs_config_render::ixp_manager;
+use rs_config_render::ixp_manager_lifecycle::{self as lifecycle, Error, Status};
+
+const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
+const API_KEY: &str = "lifecycle-api-key-must-not-leak";
+
+fn mode(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+}
+
+fn private_dir(path: &Path) {
+    fs::create_dir(path).unwrap();
+    mode(path, 0o700);
+}
+
+fn executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    mode(path, 0o700);
+}
+
+#[derive(Clone)]
+struct Response {
+    status: u16,
+    content_type: &'static str,
+    body: Vec<u8>,
+    location: Option<String>,
+    expected_state: Option<(PathBuf, &'static str)>,
+    delay: Option<Duration>,
+}
+
+impl Response {
+    fn json(status: u16) -> Self {
+        Self {
+            status,
+            content_type: "application/json",
+            body: br#"{"last_update_started":"2026-08-20T00:00:00+00:00","last_update_started_unix":1787184000,"last_updated":null,"last_updated_unix":null}"#.to_vec(),
+            location: None,
+            expected_state: None,
+            delay: None,
+        }
+    }
+
+    fn config(body: &[u8]) -> Self {
+        Self {
+            status: 200,
+            content_type: "text/plain; charset=UTF-8",
+            body: body.to_vec(),
+            location: None,
+            expected_state: None,
+            delay: None,
+        }
+    }
+
+    fn after_state_contains(mut self, path: PathBuf, expected: &'static str) -> Self {
+        self.expected_state = Some((path, expected));
+        self
+    }
+
+    fn after_delay(mut self, delay: Duration) -> Self {
+        self.delay = Some(delay);
+        self
+    }
+}
+
+struct Server {
+    origin: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    join: thread::JoinHandle<()>,
+}
+
+fn read_request(mut stream: &TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .unwrap();
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 2048];
+    while !bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+        let count = stream.read(&mut chunk).unwrap();
+        assert_ne!(count, 0, "HTTP request ended before its headers");
+        bytes.extend_from_slice(&chunk[..count]);
+        assert!(bytes.len() <= 32 * 1024, "test request headers too large");
+    }
+    String::from_utf8(bytes).unwrap()
+}
+
+impl Server {
+    fn start(responses: Vec<Response>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let origin = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&requests);
+        let join = thread::spawn(move || {
+            let mut writers = Vec::new();
+            for response in responses {
+                let (stream, _) = listener.accept().unwrap();
+                let request = read_request(&stream);
+                captured.lock().unwrap().push(request);
+                if let Some((path, expected)) = &response.expected_state {
+                    let state = fs::read_to_string(path).unwrap();
+                    assert!(
+                        state.contains(expected),
+                        "request arrived before durable state {expected}: {state}"
+                    );
+                }
+                writers.push(thread::spawn(move || {
+                    let mut stream = stream;
+                    if let Some(delay) = response.delay {
+                        thread::sleep(delay);
+                    }
+                    stream
+                        .set_write_timeout(Some(Duration::from_secs(3)))
+                        .unwrap();
+                    let reason = match response.status {
+                        200 => "OK",
+                        302 => "Found",
+                        423 => "Locked",
+                        500 => "Server Error",
+                        _ => "Error",
+                    };
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 {} {reason}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n",
+                        response.status,
+                        response.content_type,
+                        response.body.len()
+                    );
+                    if let Some(location) = response.location {
+                        let _ = write!(stream, "Location: {location}\r\n");
+                    }
+                    let _ = write!(stream, "\r\n");
+                    let _ = stream.write_all(&response.body);
+                }));
+            }
+            for writer in writers {
+                writer.join().unwrap();
+            }
+        });
+        Self {
+            origin,
+            requests,
+            join,
+        }
+    }
+
+    fn finish(self) -> Vec<String> {
+        self.join.join().unwrap();
+        Arc::try_unwrap(self.requests)
+            .unwrap()
+            .into_inner()
+            .unwrap()
+    }
+}
+
+struct Rig {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    state: PathBuf,
+    candidate: PathBuf,
+    key: PathBuf,
+    checker: PathBuf,
+    rbgp: PathBuf,
+    activation: PathBuf,
+}
+
+impl Rig {
+    fn new() -> Self {
+        let current = std::env::current_dir().unwrap();
+        let temp = tempfile::Builder::new()
+            .prefix("ixp-lifecycle-")
+            .tempdir_in(current)
+            .unwrap();
+        let root = temp.path().to_path_buf();
+        let state = root.join("state");
+        let candidate = root.join("candidate");
+        private_dir(&state);
+        private_dir(&candidate);
+        let key = root.join("api-key");
+        fs::write(&key, format!("{API_KEY}\n")).unwrap();
+        mode(&key, 0o600);
+        let checker = root.join("rustbgpd");
+        executable(
+            &checker,
+            "#!/bin/sh\n[ \"$1\" = --version ] && { echo 'rustbgpd 0.65.0'; exit 0; }\nexit 0\n",
+        );
+        let rbgp = root.join("rbgp");
+        executable(
+            &rbgp,
+            &format!(
+                "#!/bin/sh\ncase \"$*\" in\n  *' health')\n    if [ -L {state}/current ]; then echo '{{\"healthy\":true}}'; exit 0; fi\n    echo 'Error: cannot reach rustbgpd at test (connection refused)' >&2; exit 1;;\nesac\nexit 0\n",
+                state = state.display()
+            ),
+        );
+        let activation = root.join("activate");
+        executable(&activation, "#!/bin/sh\nexit 0\n");
+        let rig = Self {
+            _temp: temp,
+            root,
+            state,
+            candidate,
+            key,
+            checker,
+            rbgp,
+            activation,
+        };
+        rig.bootstrap();
+        rig
+    }
+
+    fn bootstrap(&self) {
+        let candidate = self.root.join("bootstrap");
+        private_dir(&candidate);
+        ixp_manager::write_checked_candidate_bytes(FIXTURE, &candidate, 300, &self.checker)
+            .unwrap();
+        assert_eq!(
+            activation::activate(&activation::Options {
+                candidate: &candidate,
+                state_dir: &self.state,
+                checker: &self.checker,
+                rbgp: &self.rbgp,
+                rbgp_addr: "test",
+                settle: Duration::from_secs(2),
+                initial: true,
+                activation_command: &self.activation,
+                activation_args: &[],
+            }),
+            Ok(activation::Status::Activated)
+        );
+    }
+
+    fn options<'a>(&'a self, origin: &'a str) -> lifecycle::Options<'a> {
+        lifecycle::Options {
+            ixp_origin: origin,
+            router_handle: "rs1-ipv4",
+            api_key_file: &self.key,
+            candidate_dir: &self.candidate,
+            state_dir: &self.state,
+            checker: &self.checker,
+            max_prefix_restart_seconds: 300,
+            rbgp: &self.rbgp,
+            rbgp_addr: "test",
+            activation_command: &self.activation,
+            activation_args: &[],
+            settle: Duration::from_secs(2),
+            timeout: Duration::from_secs(2),
+            initial: false,
+            allow_http_loopback: true,
+        }
+    }
+
+    fn resume_options<'a>(&'a self, origin: &'a str) -> lifecycle::ResumeOptions<'a> {
+        lifecycle::ResumeOptions {
+            ixp_origin: origin,
+            router_handle: "rs1-ipv4",
+            api_key_file: &self.key,
+            state_dir: &self.state,
+            timeout: Duration::from_secs(2),
+            allow_http_loopback: true,
+        }
+    }
+}
+
+fn assert_request(request: &str, method: &str, action: &str) {
+    let lower = request.to_ascii_lowercase();
+    assert!(
+        request.starts_with(&format!(
+            "{method} /admin/api/v4/router/{action}/rs1-ipv4 HTTP/1.1\r\n"
+        )),
+        "unexpected request: {request}"
+    );
+    assert!(lower.contains(&format!(
+        "\r\nx-ixp-manager-api-key: {}\r\n",
+        API_KEY.to_ascii_lowercase()
+    )));
+}
+
+fn assert_no_key(path: &Path) {
+    if path.is_dir() {
+        for entry in fs::read_dir(path).unwrap() {
+            assert_no_key(&entry.unwrap().path());
+        }
+    } else if path.is_file() {
+        assert!(
+            !fs::read(path)
+                .unwrap()
+                .windows(API_KEY.len())
+                .any(|window| window == API_KEY.as_bytes()),
+            "API key leaked to {}",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn noop_lifecycle_uses_exact_authenticated_order_and_acknowledges() {
+    let rig = Rig::new();
+    let server = Server::start(vec![
+        Response::json(200),
+        Response::config(FIXTURE),
+        Response::json(200),
+    ]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&server.origin)),
+        Ok(Status::Noop)
+    );
+    let requests = server.finish();
+    assert_eq!(requests.len(), 3);
+    assert_request(&requests[0], "POST", "get-update-lock");
+    assert_request(&requests[1], "GET", "gen-config");
+    assert_request(&requests[2], "POST", "updated");
+    assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+    assert_no_key(&rig.state);
+    assert_no_key(&rig.candidate);
+}
+
+#[test]
+fn definite_lock_and_render_failures_have_bounded_release_semantics() {
+    let rig = Rig::new();
+    let unavailable = Server::start(vec![Response::json(423)]);
+    assert!(matches!(
+        lifecycle::run(&rig.options(&unavailable.origin)),
+        Err(Error::Refused(_))
+    ));
+    let requests = unavailable.finish();
+    assert_eq!(requests.len(), 1);
+    assert_request(&requests[0], "POST", "get-update-lock");
+    assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+
+    let rejected = Server::start(vec![
+        Response::json(200),
+        Response::config(br#"{}"#),
+        Response::json(200).after_state_contains(
+            rig.state.join("ixp-manager-lifecycle.json"),
+            "release_pending",
+        ),
+    ]);
+    assert!(matches!(
+        lifecycle::run(&rig.options(&rejected.origin)),
+        Err(Error::Refused(_))
+    ));
+    let requests = rejected.finish();
+    assert_request(&requests[0], "POST", "get-update-lock");
+    assert_request(&requests[1], "GET", "gen-config");
+    assert_request(&requests[2], "POST", "release-update-lock");
+    assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+}
+
+#[test]
+fn failed_callback_is_durable_and_resume_never_refetches_or_activates() {
+    let rig = Rig::new();
+    let server = Server::start(vec![
+        Response::json(200),
+        Response::config(FIXTURE),
+        Response::json(500).after_state_contains(
+            rig.state.join("ixp-manager-lifecycle.json"),
+            "updated_pending",
+        ),
+        Response::json(200),
+    ]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&server.origin)),
+        Err(Error::CallbackPending)
+    );
+    let journal = fs::read_to_string(rig.state.join("ixp-manager-lifecycle.json")).unwrap();
+    assert!(journal.contains("updated_pending"));
+    assert!(!journal.contains(API_KEY));
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&server.origin)),
+        Ok(Status::Updated)
+    );
+    let requests = server.finish();
+    assert_eq!(requests.len(), 4);
+    assert_request(&requests[2], "POST", "updated");
+    assert_request(&requests[3], "POST", "updated");
+    assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+}
+
+#[test]
+fn started_activation_uncertainty_retains_remote_lock_for_manual_recovery() {
+    let rig = Rig::new();
+    executable(&rig.activation, "#!/bin/sh\nexit 9\n");
+    let server = Server::start(vec![Response::json(200), Response::config(FIXTURE)]);
+    let mut options = rig.options(&server.origin);
+    options.max_prefix_restart_seconds = 301;
+    assert_eq!(lifecycle::run(&options), Err(Error::ManualRecovery));
+    let origin = server.origin.clone();
+    let requests = server.finish();
+    assert_eq!(requests.len(), 2, "manual recovery must not callback");
+    let journal = fs::read_to_string(rig.state.join("ixp-manager-lifecycle.json")).unwrap();
+    assert!(journal.contains("manual_recovery"));
+    assert!(journal.contains("recovery_required"));
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+    let path = rig.state.join("ixp-manager-lifecycle.json");
+    let mut started: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    started["phase"] = "activation_started".into();
+    fs::write(&path, serde_json::to_vec(&started).unwrap()).unwrap();
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+    fs::remove_file(&path).unwrap();
+    let missing = rig.state.join("missing-journal-target");
+    std::os::unix::fs::symlink(&missing, &path).unwrap();
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+    assert_eq!(
+        lifecycle::run(&rig.options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+    assert_eq!(fs::read_link(&path).unwrap(), missing);
+}
+
+#[test]
+fn redirects_and_unsafe_origins_or_key_files_are_refused_without_key_forwarding() {
+    let rig = Rig::new();
+    let sink = TcpListener::bind("127.0.0.1:0").unwrap();
+    sink.set_nonblocking(true).unwrap();
+    let redirected = Server::start(vec![Response {
+        status: 302,
+        content_type: "application/json",
+        body: b"{}".to_vec(),
+        location: Some(format!("http://{}/stolen", sink.local_addr().unwrap())),
+        expected_state: None,
+        delay: None,
+    }]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&redirected.origin)),
+        Err(Error::ManualRecovery)
+    );
+    let requests = redirected.finish();
+    assert_eq!(requests.len(), 1);
+    assert!(matches!(
+        sink.accept(),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+    ));
+    fs::remove_file(rig.state.join("ixp-manager-lifecycle.json")).unwrap();
+
+    for origin in [
+        "http://example.com",
+        "http://localhost:80",
+        "https://LOCALHOST.",
+        "https://user@example.com",
+        "https://example.com/path",
+        "https://example.com?query=1",
+    ] {
+        assert!(matches!(
+            lifecycle::run(&rig.options(origin)),
+            Err(Error::Refused(_))
+        ));
+    }
+    mode(&rig.key, 0o644);
+    assert!(matches!(
+        lifecycle::run(&rig.options("https://127.0.0.1")),
+        Err(Error::Refused(_))
+    ));
+    mode(&rig.key, 0o600);
+    fs::write(&rig.key, "non-ascii-é").unwrap();
+    assert!(matches!(
+        lifecycle::run(&rig.options("https://127.0.0.1")),
+        Err(Error::Refused(_))
+    ));
+    let target = rig.root.join("real-key");
+    fs::write(&target, API_KEY).unwrap();
+    mode(&target, 0o600);
+    fs::remove_file(&rig.key).unwrap();
+    std::os::unix::fs::symlink(target, &rig.key).unwrap();
+    assert!(matches!(
+        lifecycle::run(&rig.options("https://127.0.0.1")),
+        Err(Error::Refused(_))
+    ));
+}
+
+#[test]
+fn control_and_configuration_body_caps_fail_closed() {
+    let rig = Rig::new();
+    let slow = Server::start(vec![
+        Response::json(200).after_delay(Duration::from_millis(1_500)),
+    ]);
+    let mut options = rig.options(&slow.origin);
+    options.timeout = Duration::from_secs(1);
+    assert_eq!(lifecycle::run(&options), Err(Error::ManualRecovery));
+    slow.finish();
+
+    let rig = Rig::new();
+    let control = Server::start(vec![Response {
+        status: 200,
+        content_type: "application/json",
+        body: vec![b'x'; 64 * 1024 + 1],
+        location: None,
+        expected_state: None,
+        delay: None,
+    }]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&control.origin)),
+        Err(Error::ManualRecovery)
+    );
+    control.finish();
+
+    let rig = Rig::new();
+    let malformed = Server::start(vec![Response {
+        status: 200,
+        content_type: "application/json",
+        body: b"{}".to_vec(),
+        location: None,
+        expected_state: None,
+        delay: None,
+    }]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&malformed.origin)),
+        Err(Error::ManualRecovery)
+    );
+    malformed.finish();
+
+    let rig = Rig::new();
+    let mut oversized = FIXTURE.to_vec();
+    oversized.resize(4 * 1024 * 1024 + 1, b' ');
+    let config = Server::start(vec![
+        Response::json(200),
+        Response::config(&oversized),
+        Response::json(200),
+    ]);
+    assert!(matches!(
+        lifecycle::run(&rig.options(&config.origin)),
+        Err(Error::Refused(_))
+    ));
+    let requests = config.finish();
+    assert_request(&requests[2], "POST", "release-update-lock");
+}
+
+#[test]
+fn in_memory_renderer_is_byte_identical_to_private_file_entry_point() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("input.json");
+    fs::write(&input, FIXTURE).unwrap();
+    mode(&input, 0o600);
+    let from_file = temp.path().join("from-file");
+    let from_memory = temp.path().join("from-memory");
+    private_dir(&from_file);
+    private_dir(&from_memory);
+    let checker = temp.path().join("rustbgpd");
+    executable(
+        &checker,
+        "#!/bin/sh\n[ \"$1\" = --version ] && echo 'rustbgpd 0.65.0'\nexit 0\n",
+    );
+    assert_eq!(
+        ixp_manager::write_checked_candidate(&input, &from_file, 300, &checker),
+        ixp_manager::write_checked_candidate_bytes(FIXTURE, &from_memory, 300, &checker)
+    );
+    for relative in [
+        "config.toml",
+        "policy/ixp-hygiene.rpol",
+        "policy/client-3.rpol",
+        "render-receipt.json",
+    ] {
+        assert_eq!(
+            fs::read(from_file.join(relative)).unwrap(),
+            fs::read(from_memory.join(relative)).unwrap(),
+            "{relative} changed between entry points"
+        );
+    }
+}
+
+#[test]
+fn lifecycle_state_lock_is_exclusive_before_any_network_request() {
+    let rig = Rig::new();
+    let lock = rig.state.join("ixp-manager-lifecycle.lock");
+    fs::write(&lock, []).unwrap();
+    mode(&lock, 0o600);
+    let held = File::options().read(true).write(true).open(lock).unwrap();
+    held.try_lock().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args([
+            "ixp-manager-lifecycle",
+            "resume",
+            "--ixp-origin",
+            "http://127.0.0.1:9",
+            "--router-handle",
+            "rs1-ipv4",
+            "--api-key-file",
+        ])
+        .arg(&rig.key)
+        .arg("--state-dir")
+        .arg(&rig.state)
+        .args(["--request-timeout-seconds", "1", "--allow-http-loopback"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("another lifecycle command is active")
+    );
+}
+
+#[test]
+fn additive_cli_help_pins_run_and_callback_only_resume() {
+    let binary = env!("CARGO_BIN_EXE_rs-config-render");
+    let root = Command::new(binary)
+        .args(["ixp-manager-lifecycle", "--help"])
+        .output()
+        .unwrap();
+    assert!(root.status.success());
+    let root = String::from_utf8(root.stdout).unwrap();
+    assert!(root.contains("run") && root.contains("resume"));
+    let resume = Command::new(binary)
+        .args(["ixp-manager-lifecycle", "resume", "--help"])
+        .output()
+        .unwrap();
+    assert!(resume.status.success());
+    let resume = String::from_utf8(resume.stdout).unwrap();
+    for flag in [
+        "--ixp-origin",
+        "--router-handle",
+        "--api-key-file",
+        "--state-dir",
+        "--request-timeout-seconds",
+    ] {
+        assert!(resume.contains(flag), "missing {flag}: {resume}");
+    }
+    for forbidden in ["--candidate-dir", "--rbgp", "--activation-command"] {
+        assert!(!resume.contains(forbidden), "resume exposed {forbidden}");
+    }
+}
+
+#[test]
+fn poisoned_proxy_is_ignored_and_cli_reports_the_exact_terminal_status() {
+    let rig = Rig::new();
+    let server = Server::start(vec![
+        Response::json(200),
+        Response::config(FIXTURE),
+        Response::json(200),
+    ]);
+    let sink = TcpListener::bind("127.0.0.1:0").unwrap();
+    sink.set_nonblocking(true).unwrap();
+    let proxy = format!("http://{}", sink.local_addr().unwrap());
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args([
+            "ixp-manager-lifecycle",
+            "run",
+            "--ixp-origin",
+            &server.origin,
+            "--router-handle",
+            "rs1-ipv4",
+            "--api-key-file",
+        ])
+        .arg(&rig.key)
+        .arg("--state-dir")
+        .arg(&rig.state)
+        .arg("--candidate-dir")
+        .arg(&rig.candidate)
+        .arg("--check-with")
+        .arg(&rig.checker)
+        .args(["--max-prefix-restart-seconds", "300", "--rbgp"])
+        .arg(&rig.rbgp)
+        .args([
+            "--rbgp-addr",
+            "test",
+            "--settle-seconds",
+            "2",
+            "--request-timeout-seconds",
+            "2",
+            "--activation-command",
+        ])
+        .arg(&rig.activation)
+        .arg("--allow-http-loopback")
+        .env("HTTP_PROXY", &proxy)
+        .env("HTTPS_PROXY", &proxy)
+        .env("ALL_PROXY", &proxy)
+        .env("NO_PROXY", "")
+        .env("no_proxy", "")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stdout, b"IXP Manager lifecycle noop\n");
+    assert!(!String::from_utf8(output.stderr).unwrap().contains(API_KEY));
+    let requests = server.finish();
+    assert_eq!(requests.len(), 3);
+    assert!(matches!(
+        sink.accept(),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+    ));
+}
+
+#[test]
+fn only_the_pinned_definite_lock_statuses_clear_the_intent() {
+    let rig = Rig::new();
+    for status in [401, 403, 404, 405, 422, 423] {
+        let server = Server::start(vec![Response::json(status)]);
+        assert!(matches!(
+            lifecycle::run(&rig.options(&server.origin)),
+            Err(Error::Refused(_))
+        ));
+        server.finish();
+        assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+    }
+    for status in [302, 400, 429, 500] {
+        let server = Server::start(vec![Response::json(status)]);
+        assert_eq!(
+            lifecycle::run(&rig.options(&server.origin)),
+            Err(Error::ManualRecovery)
+        );
+        server.finish();
+        assert!(rig.state.join("ixp-manager-lifecycle.json").exists());
+        fs::remove_file(rig.state.join("ixp-manager-lifecycle.json")).unwrap();
+    }
+}
+
+#[test]
+fn corrupt_or_contradictory_durable_state_never_sends_a_callback() {
+    let rig = Rig::new();
+    let server = Server::start(vec![
+        Response::json(200),
+        Response::config(FIXTURE),
+        Response::json(500),
+    ]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&server.origin)),
+        Err(Error::CallbackPending)
+    );
+    let origin = server.origin.clone();
+    server.finish();
+    let journal_path = rig.state.join("ixp-manager-lifecycle.json");
+    let mut journal: serde_json::Value =
+        serde_json::from_slice(&fs::read(&journal_path).unwrap()).unwrap();
+    journal["callback"] = "release".into();
+    fs::write(&journal_path, serde_json::to_vec(&journal).unwrap()).unwrap();
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+    journal["callback"] = "updated".into();
+    journal["activation_outcome"] = "refused".into();
+    fs::write(&journal_path, serde_json::to_vec(&journal).unwrap()).unwrap();
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+    journal["phase"] = "release_pending".into();
+    journal["callback"] = "release".into();
+    journal["activation_outcome"] = "activated".into();
+    fs::write(&journal_path, serde_json::to_vec(&journal).unwrap()).unwrap();
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+    fs::write(&journal_path, b"{}\n").unwrap();
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&origin)),
+        Err(Error::ManualRecovery)
+    );
+}
+
+#[test]
+fn release_resume_preserves_the_original_refusal_or_rollback_exit() {
+    let rig = Rig::new();
+    let refused = Server::start(vec![
+        Response::json(200),
+        Response::config(b"{}"),
+        Response::json(500),
+        Response::json(200),
+    ]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&refused.origin)),
+        Err(Error::CallbackPending)
+    );
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&refused.origin)),
+        Err(Error::Refused("lock released without activation"))
+    );
+    let requests = refused.finish();
+    assert_request(&requests[2], "POST", "release-update-lock");
+    assert_request(&requests[3], "POST", "release-update-lock");
+
+    let rig = Rig::new();
+    let rolled_back = Server::start(vec![
+        Response::json(200),
+        Response::config(FIXTURE),
+        Response::json(500),
+        Response::json(200),
+    ]);
+    let mut options = rig.options(&rolled_back.origin);
+    options.max_prefix_restart_seconds = 301;
+    let missing = rig.root.join("missing-activation-command");
+    options.activation_command = &missing;
+    assert_eq!(lifecycle::run(&options), Err(Error::CallbackPending));
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&rolled_back.origin)),
+        Err(Error::RolledBack)
+    );
+    let requests = rolled_back.finish();
+    assert_request(&requests[2], "POST", "release-update-lock");
+    assert_request(&requests[3], "POST", "release-update-lock");
+}


### PR DESCRIPTION
## Summary

- authenticate to the exact IXP Manager v7.4 router API, acquire its update lock, fetch the Foil configuration, render and activate it, then deliver the correct callback
- persist a private synced lifecycle journal before every remote effect, with callback-only replay and manual recovery for ambiguous acquisition or activation
- disable redirects and proxies, bound deadlines and response bodies, keep API keys out of argv, environment, URLs, captures, receipts, and diagnostics
- add the real pinned-v7.4 M97 MySQL/Foil/MD5-FRR lifecycle receipt and preserve the existing M96 activation receipt
- ship the platform trust-store data license in tarball and native package payloads with version-scoped cargo-deny exceptions

## Verification

- `cargo +1.98.0 test --locked -p rs-config-render -- --test-threads=1`
- `cargo +1.98.0 clippy --locked --workspace --all-targets --all-features -- -D warnings`
- Rust 1.95 locked native and musl package checks
- warning-denied workspace docs
- seven destructive lifecycle mutation proofs
- M96 and M97 real topology receipts
- `cargo deny check licenses bans sources`
- release-install, public-tracker, scale-split, and Clippy-reason contract gates

The broad workspace run reached the existing `quickstart_dynamic_neighbor` five-second shutdown flake after all preceding targets passed; the exact unchanged test passed isolated in 0.51 seconds.