### PR TITLE
Serve IXP Manager filtered-prefix wildcard queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `birdwatcher-adapter` now serves IXP Manager v7.4.0's exact member
+  filtered-prefix wildcard journey from retained rejects. It accepts only the
+  daemon's `{ASN}:1101:*` namespace, removes wire-supplied values there before
+  synthesizing one conservative reason, preserves unrelated communities, and
+  keeps no-session empty and route-cap 403 behavior. The pinned real consumer
+  and populated live-BGP smoke cover the slice while `runtime_compatibility`
+  remains false. (LAN-1134)
 - `rs-config-render ixp-manager-lifecycle` now drives IXP Manager v7.4's
   authenticated router lock, Foil fetch, existing strict render/atomic
   activation, and updated/release callbacks. A private synced journal precedes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -625,8 +625,10 @@ transitions and MD5-FRR continuity. Active UI-filter translation, custom-skin
 migration, and multi-address ownership remain open. The external adapter now
 also serves the IXP Manager v7.4 status, live protocol inventory/detail,
 symbols, member received, and member export slice through immutable aliases
-with an enforced response maximum. Remaining Bird's Eye work is global
-table/count and exact/less-specific lookup, wildcard-community search, and the
+with an enforced response maximum. Its exact member filtered-prefix wildcard
+journey reads retained rejects, scrubs the daemon-owned reason namespace, and
+synthesizes only conservative reason ids. Remaining Bird's Eye work is global
+table/count, less-specific lookup, other wildcard-community searches, and the
 complete reject-reason inventory;
 no full compatibility claim is made.
 [ADR-0126](docs/adr/0126-shared-group-per-client-best.md) (Accepted) landed

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -26,17 +26,20 @@ against a deterministic fake `birdc`; upstream source is cloned temporarily and
 installed from its lockfiles. See
 [`tests/compat/ixp-manager-birdseye/README.md`](../tests/compat/ixp-manager-birdseye/README.md)
 for the pins, fixture provenance, and local reproduction command.
-The same gate also runs IXP Manager's exact protocol/export consumer methods
-against a live `birdwatcher-adapter` backed by a real rustbgpd process.
+The same gate also runs IXP Manager's exact protocol/export and member
+filtered-prefix consumer methods against a live `birdwatcher-adapter` backed
+by a real rustbgpd process.
 
 This oracle is intentionally **not** a runtime compatibility claim. The
 example adapter now provides immutable protocol aliases plus the current
 consumer's status, BGP inventory/detail, symbols, member received-route, and
 member export-route seam with an enforced response maximum. Exact protocol and
 export prefix lookups are supported and preserve all Add-Path candidates in
-daemon order. This remains partial runtime support: complete rejected-route
-reasons, less-specific lookup, and an atomic all-candidate table snapshot are
-still unavailable. Global table, count, and wildcard-community endpoints are
+daemon order. The exact `{daemon ASN}:1101:*` filtered-prefix query reads only
+retained rejects, scrubs that reserved namespace, and adds one conservative
+reason. This remains partial runtime support: complete rejected-route reasons,
+less-specific lookup, and an atomic all-candidate table snapshot are still
+unavailable. Global table, count, and other wildcard-community endpoints are
 not served. The adapter's `api.version` is rustbgpd product identity, not a
 Bird's Eye version claim, and the adapter is not described as fully IXP Manager
 / Bird's Eye compatible.

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -88,6 +88,7 @@ listener beyond loopback only with the mTLS controls in `docs/SECURITY.md`.
 | `GET /route/{prefix}/export/{id}` | `RibService.ListAdvertisedRoutes` (paged, exact IPv4/IPv6 unicast prefix) |
 | `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
 | `GET /routes/filtered/{id}`  | `PolicyService.ListRejectedRoutes` (unpaged — the store is bounded at the `[policy.reject_retention]` capacity, default 1024/peer) |
+| `GET /routes/lc-zwild/protocol/{id}/{x}/{y}` | `GlobalService.GetGlobal` + `PolicyService.ListRejectedRoutes` for IXP Manager's `{daemon ASN}:1101:*` filtered-prefix query |
 | `GET /routes/noexport/{id}`  | `RibService.ListBestRoutes` − `RibService.ListAdvertisedRoutes` (both paged), each missing prefix explained by `RibService.ExplainAdvertisedRoute` |
 
 There are no placeholder 501 responses. Route `age` is served from the
@@ -129,10 +130,34 @@ failures return a sanitized 502.
 
 This is deliberately partial IXP Manager support: status, live BGP inventory
 and detail, protocol symbols, member received routes, and member exported
-routes, including exact protocol/export lookup, are available. Global table
-views, counts, less-specific search, large-community wildcard search, and the
-complete reject-reason inventory are not yet implemented; the adapter does not
-claim full Bird's Eye compatibility.
+routes, including exact protocol/export lookup, are available. The exact
+filtered-prefix wildcard journey described below is also available. Global
+table views, counts, less-specific search, other large-community wildcard
+queries, and the complete reject-reason inventory are not implemented; the
+adapter does not claim full Bird's Eye compatibility.
+
+IXP Manager v7.4 queries member-filtered prefixes through
+`/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`. The adapter answers only
+that exact daemon-owned namespace and returns an empty route array for other
+`x` or `y` values. It never scans accepted routes: the response comes only from
+the selected session's retained rejects, preserves the usual no-session empty
+answer, and returns HTTP 403 when the retained set exceeds `--max-routes`.
+
+Each returned route carries exactly one synthesized `{daemon ASN}:1101:<id>`
+reason. Before adding it, the adapter removes every wire-supplied community in
+that reserved namespace, preventing a member from forging the displayed
+reason while preserving unrelated large communities. Mapping is deliberately
+conservative:
+
+| Retained cause | IXP Manager reason id |
+|---|---:|
+| `.rpol` term `reject-too-specific` | 1 |
+| `.rpol` term `reject-non-global` | 3 |
+| first-AS mismatch | 7 |
+| strict next-hop ownership | 8 |
+| `.rpol` term `reject-rpki-invalid` with invalid RPKI state | 13 |
+| `.rpol` term `reject-transit-leak` | 14 |
+| any other or ambiguous cause | 0 |
 
 ## Filtered routes and reject reasons
 

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -20,6 +20,8 @@
 //! - `GET /routes/filtered/{id}` — rejected routes retained by the peer's
 //!   session (`PolicyService.ListRejectedRoutes`), tagged with a synthesized
 //!   reject-reason large community (see the README mapping table)
+//! - `GET /routes/lc-zwild/protocol/{id}/{x}/{y}` — the IXP Manager v7.4
+//!   filtered-prefix query for this daemon's `{asn}:1101:*` reason namespace
 //! - `GET /routes/noexport/{id}` — Loc-RIB best routes NOT advertised to the
 //!   peer (`ListBestRoutes` minus `ListAdvertisedRoutes`), each explained by
 //!   the live export gate ladder (`RibService.ExplainAdvertisedRoute`) and
@@ -348,6 +350,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/route/{prefix}/export/{id}", get(route_export))
         .route("/routes/peer/{peer}", get(routes_peer))
         .route("/routes/filtered/{id}", get(routes_filtered))
+        .route(
+            "/routes/lc-zwild/protocol/{id}/{x}/{y}",
+            get(routes_protocol_large_community_wild_xy),
+        )
         .route("/routes/noexport/{id}", get(routes_noexport))
         .with_state(state);
 
@@ -890,6 +896,66 @@ async fn routes_filtered(
     )))
 }
 
+const IXP_MANAGER_REJECT_FUNCTION: u64 = 1101;
+
+/// IXP Manager v7.4's member-facing filtered-prefix query. Only the daemon's
+/// own rejection namespace is meaningful; a different `(x, y)` is a valid
+/// query with no matches.
+async fn routes_protocol_large_community_wild_xy(
+    State(state): State<AppState>,
+    Path((id, x, y)): Path<(String, u64, u64)>,
+) -> Result<Json<Value>, HttpError> {
+    let peer = state.identities.resolve(&id)?;
+    if y != IXP_MANAGER_REJECT_FUNCTION {
+        return Ok(Json(empty_routes_body(state.max_routes)));
+    }
+    let mut global = proto::global_service_client::GlobalServiceClient::new(state.upstream.clone());
+    let daemon_asn = u64::from(
+        global
+            .get_global(proto::GetGlobalRequest {})
+            .await
+            .map_err(|error| bad_gateway("GetGlobal", &error))?
+            .into_inner()
+            .asn,
+    );
+    if !ixp_manager_reason_namespace_matches(daemon_asn, x, y) {
+        return Ok(Json(empty_routes_body(state.max_routes)));
+    }
+    let mut policy = proto::policy_service_client::PolicyServiceClient::new(state.upstream.clone());
+    let response = match policy
+        .list_rejected_routes(proto::ListRejectedRoutesRequest {
+            peer_address: peer.to_string(),
+        })
+        .await
+    {
+        Ok(response) => response.into_inner(),
+        Err(status) if status.code() == tonic::Code::NotFound => {
+            return Ok(Json(empty_routes_body(state.max_routes)));
+        }
+        Err(error) => return Err(bad_gateway("ListRejectedRoutes", &error)),
+    };
+    enforce_max(response.routes.len() as u64, state.max_routes)?;
+    let routes = response
+        .routes
+        .iter()
+        .map(|route| {
+            ixp_manager_rejected_route_to_birdwatcher(route, peer, &state.identities, daemon_asn)
+        })
+        .collect::<Vec<_>>();
+    Ok(Json(serde_json::json!({
+        "api": api_block(state.max_routes),
+        "routes": routes,
+    })))
+}
+
+fn empty_routes_body(max_routes: u64) -> Value {
+    serde_json::json!({ "api": api_block(max_routes), "routes": [] })
+}
+
+fn ixp_manager_reason_namespace_matches(daemon_asn: u64, x: u64, y: u64) -> bool {
+    x == daemon_asn && y == IXP_MANAGER_REJECT_FUNCTION
+}
+
 /// Build the filtered-view response body from a `ListRejectedRoutes`
 /// reply. The store is bounded (`[policy.reject_retention]` capacity,
 /// default 1024) and the RPC is unpaged — one call returns everything.
@@ -959,23 +1025,79 @@ fn rejected_route_to_birdwatcher(
     peer: IpAddr,
     identities: &IdentityResolver,
 ) -> Value {
+    render_rejected_route(
+        route,
+        peer,
+        identities,
+        reject_reason_community(&route.reason),
+        None,
+    )
+}
+
+fn ixp_manager_rejected_route_to_birdwatcher(
+    route: &proto::RejectedRoute,
+    peer: IpAddr,
+    identities: &IdentityResolver,
+    daemon_asn: u64,
+) -> Value {
+    render_rejected_route(
+        route,
+        peer,
+        identities,
+        [
+            daemon_asn,
+            IXP_MANAGER_REJECT_FUNCTION,
+            ixp_manager_reject_reason_id(route),
+        ],
+        Some([daemon_asn, IXP_MANAGER_REJECT_FUNCTION]),
+    )
+}
+
+fn ixp_manager_reject_reason_id(route: &proto::RejectedRoute) -> u64 {
+    match (route.reason.as_str(), route.reason_detail.as_str()) {
+        ("policy_reject", detail) if detail.ends_with(":reject-too-specific") => 1,
+        ("policy_reject", detail) if detail.ends_with(":reject-non-global") => 3,
+        ("treat_as_withdraw", "aspa_first_as_mismatch") => 7,
+        ("next_hop_ownership", _) => 8,
+        ("policy_reject", detail)
+            if detail.ends_with(":reject-rpki-invalid") && route.rpki_validation == "invalid" =>
+        {
+            13
+        }
+        ("policy_reject", detail) if detail.ends_with(":reject-transit-leak") => 14,
+        _ => 0,
+    }
+}
+
+fn render_rejected_route(
+    route: &proto::RejectedRoute,
+    peer: IpAddr,
+    identities: &IdentityResolver,
+    reason_community: [u64; 3],
+    reserved_namespace: Option<[u64; 2]>,
+) -> Value {
     let communities: Vec<Vec<u32>> = route
         .communities
         .iter()
         .map(|c| vec![(*c >> 16) & 0xffff, *c & 0xffff])
         .collect();
 
-    // Wire large communities the route carried, then the synthesized
-    // reason triplet appended last.
+    // Wire large communities the route carried, then the synthesized reason
+    // triplet appended last. IXP Manager's namespace is adapter-owned: scrub
+    // every wire-supplied value in it so a peer cannot forge the displayed
+    // rejection cause.
     let mut large_communities: Vec<Vec<u64>> = route
         .large_communities
         .iter()
         .filter_map(|lc| {
             let parts: Vec<u64> = lc.split(':').filter_map(|p| p.parse().ok()).collect();
-            (parts.len() == 3).then_some(parts)
+            (parts.len() == 3
+                && reserved_namespace
+                    .is_none_or(|reserved| parts[0] != reserved[0] || parts[1] != reserved[1]))
+            .then_some(parts)
         })
         .collect();
-    large_communities.push(reject_reason_community(&route.reason).to_vec());
+    large_communities.push(reason_community.to_vec());
 
     // The retained AS_PATH is a lossless display string ("65001 {65002
     // 65003}"); birdwatcher wants an ASN array, so flatten it (AS_SET
@@ -1709,6 +1831,96 @@ mod tests {
             json["bgp"]["large_communities"],
             serde_json::json!([[64496, 65520, 6]])
         );
+    }
+
+    #[test]
+    fn ixp_manager_reason_mapping_is_conservative_and_stable() {
+        let route = |reason: &str, detail: &str, rpki: &str| proto::RejectedRoute {
+            reason: reason.to_string(),
+            reason_detail: detail.to_string(),
+            rpki_validation: rpki.to_string(),
+            ..Default::default()
+        };
+        for (entry, id) in [
+            (
+                route("policy_reject", "ixp:reject-too-specific", "valid"),
+                1,
+            ),
+            (route("policy_reject", "ixp:reject-non-global", "valid"), 3),
+            (
+                route("treat_as_withdraw", "aspa_first_as_mismatch", "not_found"),
+                7,
+            ),
+            (route("next_hop_ownership", "strict_peer", "valid"), 8),
+            (
+                route("policy_reject", "ixp:reject-rpki-invalid", "invalid"),
+                13,
+            ),
+            (
+                route("policy_reject", "ixp:reject-transit-leak", "valid"),
+                14,
+            ),
+            (
+                route("policy_reject", "ixp:reject-rpki-invalid", "valid"),
+                0,
+            ),
+            (route("otc_route_leak", "ingress_from_peer", "valid"), 0),
+            (route("rr_loop", "cluster_list", "valid"), 0),
+            (route("policy_reject", "custom:unknown", "invalid"), 0),
+        ] {
+            assert_eq!(ixp_manager_reject_reason_id(&entry), id, "{entry:?}");
+        }
+    }
+
+    #[test]
+    fn ixp_manager_reason_namespace_is_scrubbed_and_replaced_once() {
+        let route = proto::RejectedRoute {
+            reason: "next_hop_ownership".to_string(),
+            large_communities: vec![
+                "65001:1101:99".to_string(),
+                "65001:1101:8".to_string(),
+                "65001:999:7".to_string(),
+                "64496:1101:4".to_string(),
+            ],
+            ..Default::default()
+        };
+        let peer = "192.0.2.1".parse().unwrap();
+        let json = ixp_manager_rejected_route_to_birdwatcher(
+            &route,
+            peer,
+            &IdentityResolver::default(),
+            65001,
+        );
+        assert_eq!(
+            json["bgp"]["large_communities"],
+            serde_json::json!([[65001, 999, 7], [64496, 1101, 4], [65001, 1101, 8]])
+        );
+    }
+
+    #[test]
+    fn ixp_manager_filtered_handler_uses_only_retained_rejects() {
+        let source = include_str!("main.rs");
+        assert!(source.contains(".route(\n            \"/routes/lc-zwild/protocol/{id}/{x}/{y}\""));
+        let body = source
+            .split_once("async fn routes_protocol_large_community_wild_xy(")
+            .unwrap()
+            .1
+            .split_once("fn empty_routes_body(")
+            .unwrap()
+            .0;
+        assert!(body.contains(".list_rejected_routes("), "{body}");
+        assert!(!body.contains("list_received_routes"), "{body}");
+        assert!(!body.contains("list_best_routes"), "{body}");
+        assert!(!body.contains("serve_routes_for_peer"), "{body}");
+        assert!(body.contains("enforce_max(response.routes.len() as u64, state.max_routes)?"));
+        assert!(
+            body.find("if y != IXP_MANAGER_REJECT_FUNCTION").unwrap()
+                < body.find(".get_global(").unwrap(),
+            "{body}"
+        );
+        assert!(ixp_manager_reason_namespace_matches(65001, 65001, 1101));
+        assert!(!ixp_manager_reason_namespace_matches(65001, 65002, 1101));
+        assert!(!ixp_manager_reason_namespace_matches(65001, 65001, 1102));
     }
 
     /// Retention disabled and enabled-but-empty both produce the full

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -421,7 +421,7 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
     use rustbgpd_wire::message::{Message, encode_message};
     use rustbgpd_wire::open::OpenMessage;
     use rustbgpd_wire::update::UpdateMessage;
-    use rustbgpd_wire::{AddPathFamily, AddPathMode, Afi, Capability, Safi};
+    use rustbgpd_wire::{AddPathFamily, AddPathMode, Afi, Capability, LargeCommunity, Safi};
 
     let mut stream = TcpStream::connect(("127.0.0.1", bgp_port)).expect("connect to BGP port");
     let open = Message::Open(OpenMessage {
@@ -435,10 +435,10 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
             send_receive: AddPathMode::Send,
         }])],
     });
-    let encode_update = |as_sequence: Vec<u32>, nlri: &'static [u8], med: u32| {
-        let mut attrs = Vec::new();
-        rustbgpd_wire::attribute::encode_path_attributes(
-            &[
+    let encode_update =
+        |as_sequence: Vec<u32>, nlri: &'static [u8], med: u32, forge_reason: bool| {
+            let mut attrs = Vec::new();
+            let mut attributes = vec![
                 PathAttribute::Origin(Origin::Igp),
                 PathAttribute::AsPath(AsPath {
                     segments: vec![AsPathSegment::AsSequence(as_sequence)],
@@ -447,23 +447,26 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
                 // loopback NEXT_HOP (subcode 8).
                 PathAttribute::NextHop("192.0.2.99".parse().unwrap()),
                 PathAttribute::Med(med),
-            ],
-            &mut attrs,
-            false,
-            false,
-        )
-        .expect("encode path attributes");
-        Message::Update(UpdateMessage {
-            withdrawn_routes: bytes::Bytes::new(),
-            path_attributes: attrs.into(),
-            nlri: bytes::Bytes::from_static(nlri),
-        })
-    };
+            ];
+            if forge_reason {
+                attributes.push(PathAttribute::LargeCommunities(vec![
+                    LargeCommunity::new(65001, 1101, 99),
+                    LargeCommunity::new(65001, 999, 7),
+                ]));
+            }
+            rustbgpd_wire::attribute::encode_path_attributes(&attributes, &mut attrs, false, false)
+                .expect("encode path attributes");
+            Message::Update(UpdateMessage {
+                withdrawn_routes: bytes::Bytes::new(),
+                path_attributes: attrs.into(),
+                nlri: bytes::Bytes::from_static(nlri),
+            })
+        };
     // RFC 7911 NLRI: four-byte path id, then the ordinary prefix encoding.
-    let accepted_11 = encode_update(vec![65020], &[0, 0, 0, 11, 24, 10, 99, 0], 10);
-    let accepted_22 = encode_update(vec![65020], &[0, 0, 0, 22, 24, 10, 99, 0], 20);
+    let accepted_11 = encode_update(vec![65020], &[0, 0, 0, 11, 24, 10, 99, 0], 10, false);
+    let accepted_22 = encode_update(vec![65020], &[0, 0, 0, 22, 24, 10, 99, 0], 20, false);
     // 10.98.0.0/24, daemon's own AS 65001 in path → as_path_loop reject.
-    let looped = encode_update(vec![65020, 65001], &[0, 0, 0, 30, 24, 10, 98, 0], 30);
+    let looped = encode_update(vec![65020, 65001], &[0, 0, 0, 30, 24, 10, 98, 0], 30, true);
     for msg in [
         &open,
         &Message::Keepalive,
@@ -920,6 +923,38 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         "filtered route must carry the synthesized as_path_loop community: {filtered}"
     );
 
+    // IXP Manager v7.4 asks for `{daemon ASN}:1101:*`. This view uses only
+    // retained rejects, strips the peer's forged value in that reserved
+    // namespace, preserves unrelated communities, and synthesizes one
+    // conservative reason (as_path_loop is deliberately generic here).
+    let ixp_filtered = get_json(
+        adapter_port,
+        "/routes/lc-zwild/protocol/pb_0001_as65020/65001/1101",
+        "adapter",
+    );
+    assert_eq!(ixp_filtered["routes"].as_array().unwrap().len(), 1);
+    assert_eq!(ixp_filtered["routes"][0]["network"], "10.98.0.0/24");
+    let ixp_communities = ixp_filtered["routes"][0]["bgp"]["large_communities"]
+        .as_array()
+        .unwrap();
+    assert!(ixp_communities.contains(&serde_json::json!([65001, 999, 7])));
+    assert_eq!(
+        ixp_communities
+            .iter()
+            .filter(|community| community[0] == 65001 && community[1] == 1101)
+            .collect::<Vec<_>>(),
+        [&serde_json::json!([65001, 1101, 0])]
+    );
+    for path in [
+        "/routes/lc-zwild/protocol/pb_0001_as65020/65002/1101",
+        "/routes/lc-zwild/protocol/pb_0001_as65020/65001/1102",
+    ] {
+        assert_eq!(
+            get_json(adapter_port, path, "adapter")["routes"],
+            serde_json::json!([])
+        );
+    }
+
     // /protocols/bgp — the neighbor summary serves the real filtered
     // count from the same retention store.
     let protocols = get_json(adapter_port, "/protocols/bgp", "adapter");
@@ -946,6 +981,12 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     // the filtered view is empty, not an error.
     let down = get_json(adapter_port, "/routes/filtered/bgp_192.0.2.10", "adapter");
     assert_eq!(down["routes"], serde_json::json!([]), "{down}");
+    let down_ixp = get_json(
+        adapter_port,
+        "/routes/lc-zwild/protocol/bgp_192.0.2.10/65001/1101",
+        "adapter",
+    );
+    assert_eq!(down_ixp["routes"], serde_json::json!([]), "{down_ixp}");
 
     // /routes/noexport/{id} — the accepted route is Loc-RIB best, but
     // split horizon suppresses it toward its own announcer: the
@@ -1076,6 +1117,12 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     wait_for_exact_json_error(
         adapter_port,
         "/routes/filtered/pb_0001_as65020",
+        403,
+        over_limit,
+    );
+    wait_for_exact_json_error(
+        adapter_port,
+        "/routes/lc-zwild/protocol/pb_0001_as65020/65001/1101",
         403,
         over_limit,
     );

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -8,8 +8,8 @@ The gate clones and verifies these exact upstream commits, installs both
 projects from their committed Composer lockfiles, starts the real Bird's Eye
 Lumen server with `APP_DEBUG=false`, and invokes the real IXP Manager consumer.
 It then starts a real rustbgpd plus `birdwatcher-adapter` and points that same
-pinned consumer's `protocolRoute()` and `exportRoute()` journeys at the live
-adapter:
+pinned consumer's `protocolRoute()`, `exportRoute()`, and
+`routesProtocolLargeCommunityWildXYRoutes()` journeys at the live adapter:
 
 - Bird's Eye v2.1.0: `7f8c2375e610578bcf6ea5ceec630a180f945b89`
 - IXP Manager v7.4.0: `300b7e0ba9adb0aaac975899e45fc8bcbc0ca37d`
@@ -30,9 +30,11 @@ the harness permits only IXP Manager's pinned deprecated `GPL-2.0` identifier
 warning and rejects any additional warning.
 
 The live-adapter leg intentionally uses a configured, down peer, so the exact
-lookups return honest empty route arrays. The live BGP smoke test separately
-pins populated Add-Path candidate multiplicity, ordering, filtering, and source
-alias direction. `api.version` remains `rustbgpd <package-version>` product
+lookups and filtered-prefix query return honest empty route arrays. The live
+BGP smoke test separately pins populated Add-Path candidate multiplicity,
+ordering, retained-reject sourcing, reserved-community scrubbing, reason
+fallback, filtering, and source alias direction. `api.version` remains
+`rustbgpd <package-version>` product
 identity, not Bird's Eye semantic-version compatibility. No full compatibility
 claim is made and `runtime_compatibility` remains false.
 
@@ -53,8 +55,9 @@ diff -u tests/compat/ixp-manager-birdseye/fixtures/birdseye-contract.json \
 ```
 
 `contract.json` deliberately keeps the unsupported runtime matrix executable.
-Only exact protocol-route and exact export-route journeys are runtime-supported.
-Complete rejected-route reasons, less-specific lookup, and atomic all-candidate
+Only exact protocol-route, exact export-route, and the filtered-prefix wildcard
+journeys are runtime-supported. Complete rejected-route reasons,
+less-specific lookup, and atomic all-candidate
 snapshots remain blockers. Protocol aliases are immutable after sidecar startup,
 so changing one requires a sidecar restart. Promoting any blocker, weakening the
 explicit alias or product-version posture, enabling debug mode, skipping a case,

--- a/tests/compat/ixp-manager-birdseye/adapter-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/adapter-consumer.php
@@ -17,7 +17,12 @@ $manifest = json_decode(
 );
 $protocol = $manifest['protocol_aliases']['member-v4'] ?? null;
 $versionPrefix = $manifest['adapter_api_version']['prefix'] ?? null;
-if ($protocol !== 'pb_as64496' || $versionPrefix !== 'rustbgpd ') {
+$filtered = $manifest['filtered_prefix_query'] ?? [];
+if (
+    $protocol !== 'pb_as64496'
+    || $versionPrefix !== 'rustbgpd '
+    || $filtered !== ['global_admin' => 65001, 'function' => 1101]
+) {
     throw new RuntimeException('adapter consumer contract drifted');
 }
 
@@ -32,6 +37,11 @@ $consumer = new BirdsEye($router);
 $responses = [
     'exact-protocol-route' => $consumer->protocolRoute($protocol, '192.0.2.0', 24),
     'exact-export-route' => $consumer->exportRoute($protocol, '192.0.2.0', 24),
+    'filtered-prefix-wildcard' => $consumer->routesProtocolLargeCommunityWildXYRoutes(
+        $protocol,
+        $filtered['global_admin'],
+        $filtered['function'],
+    ),
 ];
 
 foreach ($responses as $journey => $response) {

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -8,6 +8,10 @@
     "kind": "product-identity",
     "prefix": "rustbgpd "
   },
+  "filtered_prefix_query": {
+    "global_admin": 65001,
+    "function": 1101
+  },
   "runtime_compatibility": false,
   "manual_config_export": {
     "schema": "rustbgpd.ixp-manager.router-config/v1",
@@ -17,7 +21,8 @@
   },
   "runtime_supported": [
     "exact-protocol-route",
-    "exact-export-route"
+    "exact-export-route",
+    "filtered-prefix-wildcard"
   ],
   "unsupported": [
     "complete-rejected-route-reason-inventory",

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -31,8 +31,13 @@ UNSUPPORTED = {
     "atomic-all-candidate-table-snapshot",
     "runtime-protocol-alias-reconfiguration",
 }
-RUNTIME_SUPPORTED = {"exact-protocol-route", "exact-export-route"}
+RUNTIME_SUPPORTED = {
+    "exact-protocol-route",
+    "exact-export-route",
+    "filtered-prefix-wildcard",
+}
 ADAPTER_API_VERSION = {"kind": "product-identity", "prefix": "rustbgpd "}
+FILTERED_PREFIX_QUERY = {"global_admin": 65001, "function": 1101}
 
 
 def fail(message: str) -> None:
@@ -50,6 +55,8 @@ if set(manifest.get("runtime_supported", [])) != RUNTIME_SUPPORTED:
     fail("supported runtime matrix drifted")
 if manifest.get("adapter_api_version") != ADAPTER_API_VERSION:
     fail("adapter api.version must remain an honest product identity")
+if manifest.get("filtered_prefix_query") != FILTERED_PREFIX_QUERY:
+    fail("filtered-prefix namespace drifted")
 if manifest.get("protocol_aliases") != {"member-v4": "pb_as64496"}:
     fail("explicit protocol alias matrix drifted")
 


### PR DESCRIPTION
## Summary

- serve the exact pinned IXP Manager v7.4 filtered-prefix wildcard journey from retained rejected routes
- scrub wire-supplied daemon-ASN reason communities and synthesize one conservative mapped reason
- preserve aliases, empty results, route-cap refusal, and the explicit partial-compatibility boundary

## Verification

- adapter unit suite: 31/31
- populated live daemon/BGP smoke: 2/2
- pinned Bird Eye and real IXP Manager v7.4 consumer harness
- seven destructive mutations, all red and restored
- strict workspace all-target/all-feature Clippy
- warning-denied workspace docs and repository contract checkers
- independent exact-diff audit

The broad workspace run encountered two unchanged test-harness issues: the rs-config-render lifecycle parallel hang and the one-second smoke timestamp race. The changed smoke passed twice in isolation without code changes.