### PR TITLE
Fence IXP Manager handle lifecycles on shared hosts

### DIFF
--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -42,6 +42,8 @@ sudo -u rustbgpd /usr/bin/rs-config-render \
   --input-format ixp-manager-v1 \
   --context /var/lib/rustbgpd/ixp-manager/router.json \
   --out-dir /var/lib/rustbgpd/ixp-manager/candidate \
+  --router-handle rs1-ipv4 \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
   --max-prefix-restart-seconds 300 \
   --check-with /usr/bin/rustbgpd
 ```
@@ -56,7 +58,9 @@ suppressed so authentication values cannot escape through diagnostics.
 
 `render-receipt.json` is written last and only after the strict check passes.
 It records the source identity and hash, generated-file hashes and counts,
-refusal status, and the checked rustbgpd version without copying secrets. A
+refusal status, checked rustbgpd version, router handle, and exact runtime-state
+directory without copying secrets. The generated config fixes the gRPC UDS at
+`<runtime-state-dir>/grpc.sock`. A
 candidate without that receipt is incomplete and must not be deployed.
 
 After reviewing a complete candidate, install `config.toml` and its `policy/`
@@ -72,17 +76,22 @@ and literal arguments (never a shell command):
 
 ```console
 sudo -u rustbgpd /usr/bin/rs-config-render activate \
+  --router-handle rs1-ipv4 \
   --candidate /var/lib/rustbgpd/ixp-manager/candidate \
-  --state-dir /var/lib/rustbgpd/ixp-manager/activation \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
   --check-with /usr/bin/rustbgpd --rbgp /usr/bin/rbgp \
-  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
   --activation-command /usr/bin/sudo \
   --activation-arg=-n --activation-arg /usr/bin/systemctl \
   --activation-arg reload-or-restart --activation-arg rustbgpd
 ```
 
 The service must read
-`/var/lib/rustbgpd/ixp-manager/activation/current/config.toml`. The state path
+`/var/lib/rustbgpd/rs1-ipv4/activation/current/config.toml`. The runtime path
+basename must equal the router handle, and the activation path must be exactly
+`<runtime-state-dir>/activation`. The state path
 must be absolute, pre-created as a non-symlink mode-0700 directory, and owned by
 the `rustbgpd` account. Keep the candidate and state exclusively writable by
 that identity; do not run another publisher or reloader concurrently. Use
@@ -122,17 +131,20 @@ sudo -u rustbgpd /usr/bin/rs-config-render ixp-manager-lifecycle run \
   --router-handle rs1-ipv4 \
   --api-key-file /var/lib/rustbgpd/ixp-manager/api-key \
   --candidate-dir /var/lib/rustbgpd/ixp-manager/candidate-1 \
-  --state-dir /var/lib/rustbgpd/ixp-manager/lifecycle \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
   --max-prefix-restart-seconds 300 \
   --check-with /usr/bin/rustbgpd --rbgp /usr/bin/rbgp \
-  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
   --activation-command /usr/bin/sudo \
   --activation-arg=-n --activation-arg /usr/bin/systemctl \
   --activation-arg reload-or-restart --activation-arg rustbgpd
 ```
 
 Supply a new absent or empty mode-0700 candidate directory for each run. The
-absolute state directory must already exist at mode 0700 and remain owned by
+absolute runtime, activation, and shared host-state directories must already
+exist at mode 0700 and remain owned by
 the `rustbgpd` identity. The API-key path must be absolute, regular,
 non-symlink, mode 0600, and at most 4 KiB. The value appears only in the
 `X-IXP-Manager-API-Key` request header: it is not accepted in argv or the
@@ -151,14 +163,25 @@ means `updated` was delivered. Exit 2 means no lock was acquired or a definite
 pre-activation refusal was released. Exit 4 means the activation command never
 started, exact prior runtime was proven, and release was delivered. Exit 5
 does not issue a callback because lock acquisition or an activation effect is
-uncertain. Exit 6 leaves one durable `updated` or release callback pending;
-retry only that callback with the same identity:
+uncertain. Exit 6 leaves one durable `updated` or release callback pending.
+
+Every activation or lifecycle command also takes one advisory lock in the
+shared host-state directory. A synced owner fence remains after process death,
+ambiguous lock acquisition, activation recovery, or a pending callback. A new
+run returns exit 5 while any fence exists; only `resume` with the exact same
+handle, runtime, activation, host-state, and UDS binding may continue. A proven
+terminal journal cleanup is synced before that matching fence is removed.
+
+Retry only the pending callback with the same identity:
 
 ```console
 sudo -u rustbgpd /usr/bin/rs-config-render ixp-manager-lifecycle resume \
   --ixp-origin https://ixp.example.net --router-handle rs1-ipv4 \
   --api-key-file /var/lib/rustbgpd/ixp-manager/api-key \
-  --state-dir /var/lib/rustbgpd/ixp-manager/lifecycle
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock
 ```
 
 Callback delivery is at-least-once because IXP Manager v7.4 supplies no lease

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -2,6 +2,8 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::time::Duration;
 
+use crate::ixp_manager_host::Binding;
+
 #[derive(Debug)]
 pub struct Options<'a> {
     pub candidate: &'a Path,
@@ -13,6 +15,7 @@ pub struct Options<'a> {
     pub initial: bool,
     pub activation_command: &'a Path,
     pub activation_args: &'a [OsString],
+    pub binding: &'a Binding,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -36,6 +39,7 @@ pub fn activate(_: &Options<'_>) -> Result<Status, Error> {
 #[cfg(unix)]
 mod unix {
     use super::{Error, Options, Status};
+    use crate::ixp_manager_host::{self, Binding, Guard, RenderBinding};
     use serde_json::{Value, json};
     use sha2::{Digest, Sha256};
     use std::collections::{BTreeMap, BTreeSet};
@@ -51,7 +55,14 @@ mod unix {
     const RECEIPT: &str = "render-receipt.json";
     const ACTIVATION_RECEIPT: &str = "activation-receipt.json";
     const GENERATED: &str = "generated_files";
-    const ROOT_KEYS: &[&str] = &["input", "counts", "refusals", GENERATED, "strict_check"];
+    const ROOT_KEYS: &[&str] = &[
+        "input",
+        "counts",
+        "refusals",
+        "host",
+        GENERATED,
+        "strict_check",
+    ];
     const COUNT_KEYS: &[&str] = &["clients", "prefixes", "origins"];
     const SKINS: &str = "route_server_skin_files";
     const MULTI: &str = "multi_address_clients";
@@ -140,7 +151,7 @@ mod unix {
         Ok(())
     }
 
-    fn verify_candidate(root: &Path) -> AResult<Verified> {
+    fn verify_candidate(root: &Path, binding: &Binding) -> AResult<Verified> {
         if !private(root, true, 0o700) || !private(&root.join(RECEIPT), false, 0o600) {
             return Err(Error::Refused(
                 "candidate and receipt must be private regular paths",
@@ -184,6 +195,13 @@ mod unix {
                 .is_some_and(|value| value.starts_with("rustbgpd "))
         {
             return Err(Error::Refused("render receipt contract does not match"));
+        }
+        let receipt_binding: RenderBinding = serde_json::from_value(receipt["host"].clone())
+            .map_err(|_| Error::Refused("render receipt host binding is invalid"))?;
+        if receipt_binding != binding.render_binding()
+            || receipt["input"]["router_handle"] != binding.router_handle
+        {
+            return Err(Error::Refused("render receipt host binding does not match"));
         }
         let generated = receipt["generated_files"]
             .as_object()
@@ -233,6 +251,28 @@ mod unix {
             if name == "config.toml" {
                 config = bytes;
             }
+        }
+        let config_text = std::str::from_utf8(&config)
+            .map_err(|_| Error::Refused("candidate config is not UTF-8"))?;
+        let parsed: toml::Value = toml::from_str(config_text)
+            .map_err(|_| Error::Refused("candidate config is invalid TOML"))?;
+        let global = parsed.get("global").and_then(toml::Value::as_table);
+        let runtime = global
+            .and_then(|global| global.get("runtime_state_dir"))
+            .and_then(toml::Value::as_str);
+        let uds = global
+            .and_then(|global| global.get("telemetry"))
+            .and_then(toml::Value::as_table)
+            .and_then(|telemetry| telemetry.get("grpc_uds"))
+            .and_then(toml::Value::as_table)
+            .and_then(|uds| uds.get("path"))
+            .and_then(toml::Value::as_str);
+        if runtime != binding.runtime_state_dir.to_str()
+            || uds != binding.runtime_state_dir.join("grpc.sock").to_str()
+        {
+            return Err(Error::Refused(
+                "candidate runtime binding does not match receipt",
+            ));
         }
         let mut directories = actual_dirs.into_iter().collect::<Vec<_>>();
         directories.sort_by_key(|path| std::cmp::Reverse(Path::new(path).components().count()));
@@ -328,12 +368,17 @@ mod unix {
         }
     }
 
-    fn copy_generation(candidate: &Path, state: &Path, verified: &Verified) -> AResult<PathBuf> {
+    fn copy_generation(
+        candidate: &Path,
+        state: &Path,
+        verified: &Verified,
+        binding: &Binding,
+    ) -> AResult<PathBuf> {
         let generations = state.join("generations");
         create_private_dir(&generations)?;
         let final_path = generations.join(&verified.digest);
         if final_path.exists() {
-            let existing = verify_candidate(&final_path)?;
+            let existing = verify_candidate(&final_path, binding)?;
             if existing.digest != verified.digest {
                 return Err(Error::Refused("immutable generation content mismatch"));
             }
@@ -377,7 +422,7 @@ mod unix {
                 .map_err(|_| Error::Refused("cannot sync generation"))?;
         }
         sync_dir(&temporary).map_err(|_| Error::Refused("cannot sync generation"))?;
-        let staged = verify_candidate(&temporary)?;
+        let staged = verify_candidate(&temporary, binding)?;
         if staged.digest != verified.digest {
             return Err(Error::Refused("staged generation changed during copy"));
         }
@@ -388,7 +433,7 @@ mod unix {
         Ok(final_path)
     }
 
-    fn current_target(state: &Path) -> AResult<Option<String>> {
+    fn current_target(state: &Path, binding: &Binding) -> AResult<Option<String>> {
         let current = state.join("current");
         let metadata = match fs::symlink_metadata(&current) {
             Ok(metadata) => metadata,
@@ -417,7 +462,7 @@ mod unix {
         let hash = text
             .strip_prefix("generations/")
             .ok_or(Error::Refused("current generation target is invalid"))?;
-        if !valid_digest(hash) || verify_candidate(&state.join(&target))?.digest != hash {
+        if !valid_digest(hash) || verify_candidate(&state.join(&target), binding)?.digest != hash {
             return Err(Error::Refused(
                 "current generation is not immutable content",
             ));
@@ -637,6 +682,7 @@ mod unix {
         previous: Option<&str>,
         phases: Phases,
         checker_version: &str,
+        binding: &Binding,
     ) -> AResult<()> {
         let receipt = json!({
             "schema": "rustbgpd.ixp-manager.activation/v1",
@@ -646,6 +692,7 @@ mod unix {
             "initial": phases.initial,
             "activation_runs": u8::from(phases.candidate.ran) + u8::from(phases.rollback.ran),
             "strict_check": {"passed": true, "binary_version": checker_version},
+            "host": binding,
             "phases": {
                 "candidate_link": {"published": phases.candidate_publication.is_some(), "durable": phases.candidate_publication == Some(Publication::Durable)},
                 "candidate_activation_ran": phases.candidate.ran,
@@ -683,13 +730,14 @@ mod unix {
         !candidate.starts_with(&state) && !state.starts_with(candidate)
     }
 
-    pub fn activate(options: &Options<'_>) -> AResult<Status> {
+    fn activate_inner(options: &Options<'_>) -> AResult<Status> {
         if options.settle < Duration::from_secs(1)
             || options.settle > Duration::from_secs(120)
-            || options.rbgp_addr.is_empty()
+            || options.rbgp_addr != options.binding.rbgp_addr
+            || options.state_dir != options.binding.activation_state_dir
         {
             return Err(Error::Refused(
-                "settlement must be 1..=120 seconds and address nonempty",
+                "activation state and rbgp address must match host binding",
             ));
         }
         if !options.state_dir.is_absolute() || !private(options.state_dir, true, 0o700) {
@@ -697,7 +745,7 @@ mod unix {
                 "state directory must be a pre-created absolute mode-0700 directory",
             ));
         }
-        let candidate = verify_candidate(options.candidate)?;
+        let candidate = verify_candidate(options.candidate, options.binding)?;
         if !disjoint(options.candidate, options.state_dir) {
             return Err(Error::Refused(
                 "candidate and state directory must not overlap",
@@ -737,7 +785,7 @@ mod unix {
         if checker_version != candidate.checker_version {
             return Err(Error::Refused("strict checker version changed"));
         }
-        let previous = current_target(options.state_dir)?;
+        let previous = current_target(options.state_dir, options.binding)?;
         if options.initial == previous.is_some() {
             return Err(Error::Refused(
                 "--initial requires exactly an empty current state",
@@ -752,7 +800,7 @@ mod unix {
         let prior_runtime = previous
             .as_deref()
             .map(|target| {
-                verify_candidate(&options.state_dir.join(target))
+                verify_candidate(&options.state_dir.join(target), options.binding)
                     .and_then(|verified| normalized_toml(&verified.config, options.state_dir))
             })
             .transpose()?;
@@ -760,7 +808,12 @@ mod unix {
             initial: options.initial,
             ..Phases::default()
         };
-        let generation = copy_generation(options.candidate, options.state_dir, &candidate)?;
+        let generation = copy_generation(
+            options.candidate,
+            options.state_dir,
+            &candidate,
+            options.binding,
+        )?;
         let check_child = Command::new(options.checker)
             .args(["--check", "--strict"])
             .arg(generation.join("config.toml"))
@@ -784,6 +837,7 @@ mod unix {
                 previous.as_deref(),
                 phases,
                 &checker_version,
+                options.binding,
             )
         };
         if let Some(previous_target) = previous.as_deref() {
@@ -866,7 +920,33 @@ mod unix {
         finish("recovery_required", phases)?;
         Err(Error::RecoveryRequired)
     }
+
+    fn host_error(error: ixp_manager_host::Error) -> Error {
+        match error {
+            ixp_manager_host::Error::Refused(reason) => Error::Refused(reason),
+            ixp_manager_host::Error::RecoveryRequired => Error::RecoveryRequired,
+        }
+    }
+
+    pub(crate) fn activate_guarded(options: &Options<'_>, guard: &Guard) -> AResult<Status> {
+        if !guard.owns(options.binding) {
+            return Err(Error::Refused("host guard does not own activation binding"));
+        }
+        activate_inner(options)
+    }
+
+    pub fn activate(options: &Options<'_>) -> AResult<Status> {
+        let guard = Guard::claim_new(options.binding).map_err(host_error)?;
+        let result = activate_guarded(options, &guard);
+        if result == Err(Error::RecoveryRequired) {
+            return result;
+        }
+        guard.clear().map_err(host_error)?;
+        result
+    }
 }
 
 #[cfg(unix)]
 pub use unix::activate;
+#[cfg(unix)]
+pub(crate) use unix::activate_guarded;

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -11,6 +11,8 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
+use crate::ixp_manager_host::RenderBinding;
+
 #[cfg(unix)]
 use std::fs::OpenOptions;
 #[cfg(unix)]
@@ -357,12 +359,26 @@ fn is_placeholder(secret: &str) -> bool {
     )
 }
 
-pub fn render_document(input: &[u8], restart_seconds: u32) -> Result<Candidate, Error> {
+pub fn render_document(
+    input: &[u8],
+    restart_seconds: u32,
+    binding: &RenderBinding,
+) -> Result<Candidate, Error> {
+    if !binding.valid() {
+        return Err(Error::Refused("invalid router host binding"));
+    }
     if restart_seconds == 0 {
         return Err(Error::Refused("max-prefix restart must be positive"));
     }
     let document: Document = serde_json::from_slice(input).map_err(|_| Error::Input)?;
     let effective = validate(&document)?;
+    if document.router.handle != binding.router_handle {
+        return Err(Error::Refused("router handle does not match host binding"));
+    }
+    let runtime = binding
+        .runtime_state_dir
+        .to_str()
+        .ok_or(Error::Refused("runtime state directory must be UTF-8"))?;
     let mut files = BTreeMap::new();
     files.insert("policy/ixp-hygiene.rpol".into(), render_hygiene(&document));
     for (client, prefixes) in document.clients.iter().zip(&effective) {
@@ -373,7 +389,7 @@ pub fn render_document(input: &[u8], restart_seconds: u32) -> Result<Candidate, 
     }
     files.insert(
         "config.toml".into(),
-        render_config(&document, restart_seconds),
+        render_config(&document, restart_seconds, runtime),
     );
     let metadata = json!({
         "input": {"schema": SCHEMA, "ixp_manager_version": IXP_VERSION,
@@ -382,19 +398,22 @@ pub fn render_document(input: &[u8], restart_seconds: u32) -> Result<Candidate, 
             "prefixes": effective.iter().map(Vec::len).sum::<usize>(),
             "origins": document.clients.iter().map(|c| c.origins.len()).sum::<usize>()},
         "refusals": {"status": "passed", "active_ui_filters": 0,
-            "route_server_skin_files": 0, "multi_address_clients": 0}
+            "route_server_skin_files": 0, "multi_address_clients": 0},
+        "host": binding
     });
     Ok(Candidate { files, metadata })
 }
 
-fn render_config(document: &Document, restart_seconds: u32) -> String {
+fn render_config(document: &Document, restart_seconds: u32, runtime: &str) -> String {
     let router = &document.router;
     let mut out = format!(
-        "# GENERATED candidate from IXP Manager {}.\n[global]\nasn = {}\nrouter_id = {}\nlisten_port = 179\nlisten_addresses = [{}]\nebgp_requires_policy = true\n\n[global.telemetry]\nlog_format = \"json\"\n",
+        "# GENERATED candidate from IXP Manager {}.\n[global]\nasn = {}\nrouter_id = {}\nruntime_state_dir = {}\nlisten_port = 179\nlisten_addresses = [{}]\nebgp_requires_policy = true\n\n[global.telemetry]\nlog_format = \"json\"\n\n[global.telemetry.grpc_uds]\npath = {}\nmode = 0o600\n",
         document.ixp_manager.version,
         router.asn,
         quoted(&router.router_id),
-        quoted(&router.peering_ip)
+        quoted(runtime),
+        quoted(&router.peering_ip),
+        quoted(&format!("{runtime}/grpc.sock"))
     );
     if router.rpki {
         out.push_str("\n[rpki]\n");
@@ -602,12 +621,13 @@ pub fn write_checked_candidate(
     out: &Path,
     restart_seconds: u32,
     checker: &Path,
+    binding: &RenderBinding,
 ) -> Result<usize, Error> {
     if !private_file(context, 0o600) {
         return Err(Error::Refused("input capture must be mode 0600"));
     }
     let input = fs::read(context).map_err(|_| Error::Input)?;
-    write_checked_candidate_bytes(&input, out, restart_seconds, checker)
+    write_checked_candidate_bytes(&input, out, restart_seconds, checker, binding)
 }
 
 /// Render and strictly validate a private in-memory IXP Manager capture.
@@ -619,8 +639,9 @@ pub fn write_checked_candidate_bytes(
     out: &Path,
     restart_seconds: u32,
     checker: &Path,
+    binding: &RenderBinding,
 ) -> Result<usize, Error> {
-    let candidate = render_document(input, restart_seconds)?;
+    let candidate = render_document(input, restart_seconds, binding)?;
     prepare_output(out)?;
     for (relative, contents) in &candidate.files {
         let path = out.join(relative);

--- a/tools/rs-config-render/src/ixp_manager_host.rs
+++ b/tools/rs-config-render/src/ixp_manager_host.rs
@@ -1,0 +1,220 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Component, Path, PathBuf};
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Binding {
+    pub(crate) router_handle: String,
+    pub(crate) runtime_state_dir: PathBuf,
+    pub(crate) activation_state_dir: PathBuf,
+    pub(crate) host_state_dir: PathBuf,
+    pub(crate) rbgp_addr: String,
+}
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RenderBinding {
+    pub(crate) router_handle: String,
+    pub(crate) runtime_state_dir: PathBuf,
+}
+fn valid_handle(handle: &str) -> bool {
+    (1..=128).contains(&handle.len())
+        && handle
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte))
+}
+fn valid_path(path: &Path) -> bool {
+    path.is_absolute()
+        && path.to_str().is_some()
+        && path
+            .components()
+            .all(|part| matches!(part, Component::RootDir | Component::Normal(_)))
+}
+fn valid_render(handle: &str, runtime: &Path) -> bool {
+    valid_handle(handle) && valid_path(runtime) && runtime.file_name() == Some(handle.as_ref())
+}
+impl RenderBinding {
+    pub fn new(router_handle: &str, runtime_state_dir: &Path) -> Result<Self, &'static str> {
+        let binding = Self {
+            router_handle: router_handle.to_owned(),
+            runtime_state_dir: runtime_state_dir.to_owned(),
+        };
+        binding
+            .valid()
+            .then_some(binding)
+            .ok_or("runtime state directory basename must equal valid router handle")
+    }
+    pub(crate) fn valid(&self) -> bool {
+        valid_render(&self.router_handle, &self.runtime_state_dir)
+    }
+}
+impl Binding {
+    pub fn new(
+        router_handle: &str,
+        runtime: &Path,
+        activation: &Path,
+        host: &Path,
+        rbgp_addr: &str,
+    ) -> Result<Self, &'static str> {
+        let binding = Self {
+            router_handle: router_handle.to_owned(),
+            runtime_state_dir: runtime.to_owned(),
+            activation_state_dir: activation.to_owned(),
+            host_state_dir: host.to_owned(),
+            rbgp_addr: rbgp_addr.to_owned(),
+        };
+        binding
+            .valid()
+            .then_some(binding)
+            .ok_or("invalid router host binding")
+    }
+    pub(crate) fn valid(&self) -> bool {
+        valid_render(&self.router_handle, &self.runtime_state_dir)
+            && valid_path(&self.activation_state_dir)
+            && valid_path(&self.host_state_dir)
+            && self.activation_state_dir == self.runtime_state_dir.join("activation")
+            && self.rbgp_addr == format!("unix://{}/grpc.sock", self.runtime_state_dir.display())
+    }
+    pub fn render_binding(&self) -> RenderBinding {
+        RenderBinding {
+            router_handle: self.router_handle.clone(),
+            runtime_state_dir: self.runtime_state_dir.clone(),
+        }
+    }
+    pub fn rbgp_addr(&self) -> &str {
+        &self.rbgp_addr
+    }
+}
+#[cfg(unix)]
+fn private_dir(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| {
+        metadata.file_type().is_dir() && metadata.permissions().mode() & 0o777 == 0o700
+    })
+}
+#[derive(Debug, Eq, PartialEq)]
+pub enum Error {
+    Refused(&'static str),
+    RecoveryRequired,
+}
+#[cfg(unix)]
+mod unix {
+    use super::{Binding, Error};
+    use std::fs::{self, File, OpenOptions};
+    use std::io::Write;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::path::Path;
+    const FENCE: &str = "ixp-manager-host-fence.json";
+    pub struct Guard(#[allow(dead_code)] File, Binding);
+    fn sync_dir(path: &Path) -> Result<(), Error> {
+        File::open(path)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|_| Error::RecoveryRequired)
+    }
+    fn host_lock(state: &Path) -> Result<File, Error> {
+        let path = state.join("ixp-manager-host.lock");
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|_| Error::Refused("host lock is unavailable"))?;
+        let opened = file
+            .metadata()
+            .map_err(|_| Error::Refused("unsafe host lock"))?;
+        let named = fs::symlink_metadata(path).map_err(|_| Error::Refused("unsafe host lock"))?;
+        if !named.file_type().is_file()
+            || named.nlink() != 1
+            || named.permissions().mode() & 0o777 != 0o600
+            || (named.dev(), named.ino()) != (opened.dev(), opened.ino())
+        {
+            return Err(Error::Refused("host lock is not private"));
+        }
+        file.try_lock()
+            .map_err(|_| Error::Refused("another host command is active"))?;
+        Ok(file)
+    }
+    fn read_fence(state: &Path) -> Result<Option<Binding>, Error> {
+        let path = state.join(FENCE);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(Error::RecoveryRequired),
+        };
+        if !metadata.file_type().is_file()
+            || metadata.nlink() != 1
+            || metadata.permissions().mode() & 0o777 != 0o600
+            || !(1..=64 * 1024).contains(&metadata.len())
+        {
+            return Err(Error::RecoveryRequired);
+        }
+        let bytes = fs::read(path).map_err(|_| Error::RecoveryRequired)?;
+        let binding: Binding =
+            serde_json::from_slice(&bytes).map_err(|_| Error::RecoveryRequired)?;
+        binding
+            .valid()
+            .then_some(Some(binding))
+            .ok_or(Error::RecoveryRequired)
+    }
+    fn write_fence(state: &Path, binding: &Binding) -> Result<(), Error> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(state.join(FENCE))
+            .map_err(|_| Error::RecoveryRequired)?;
+        serde_json::to_writer_pretty(&mut file, binding).map_err(|_| Error::RecoveryRequired)?;
+        file.write_all(b"\n")
+            .and_then(|_| file.sync_all())
+            .map_err(|_| Error::RecoveryRequired)?;
+        sync_dir(state)
+    }
+    impl Guard {
+        pub fn claim_new(binding: &Binding) -> Result<Self, Error> {
+            Self::claim(binding, false)
+        }
+        pub fn claim_existing(binding: &Binding) -> Result<Self, Error> {
+            Self::claim(binding, true)
+        }
+        fn claim(binding: &Binding, existing: bool) -> Result<Self, Error> {
+            if !binding.valid()
+                || ![
+                    &binding.runtime_state_dir,
+                    &binding.activation_state_dir,
+                    &binding.host_state_dir,
+                ]
+                .into_iter()
+                .all(|path| {
+                    super::private_dir(path) && fs::canonicalize(path).ok().as_deref() == Some(path)
+                })
+            {
+                return Err(Error::Refused("host binding directories are not private"));
+            }
+            let lock = host_lock(&binding.host_state_dir)?;
+            match (existing, read_fence(&binding.host_state_dir)?) {
+                (false, None) => write_fence(&binding.host_state_dir, binding)?,
+                (false, Some(_)) => return Err(Error::RecoveryRequired),
+                (true, Some(owner)) if owner == *binding => {}
+                (true, Some(_)) => return Err(Error::Refused("foreign host fence")),
+                (true, None) => return Err(Error::Refused("no pending host fence exists")),
+            }
+            Ok(Self(lock, binding.clone()))
+        }
+        pub fn clear(&self) -> Result<(), Error> {
+            let binding = &self.1;
+            match read_fence(&binding.host_state_dir)? {
+                Some(owner) if owner == *binding => {}
+                Some(_) => return Err(Error::Refused("foreign host fence cannot be cleared")),
+                None => return Err(Error::RecoveryRequired),
+            }
+            fs::remove_file(binding.host_state_dir.join(FENCE))
+                .map_err(|_| Error::RecoveryRequired)?;
+            sync_dir(&binding.host_state_dir)
+        }
+        pub(crate) fn owns(&self, binding: &Binding) -> bool {
+            self.1 == *binding
+        }
+    }
+}
+#[cfg(unix)]
+pub use unix::Guard;

--- a/tools/rs-config-render/src/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/src/ixp_manager_lifecycle.rs
@@ -4,6 +4,8 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::time::Duration;
 
+use crate::ixp_manager_host::Binding;
+
 #[derive(Debug)]
 pub struct Options<'a> {
     pub ixp_origin: &'a str,
@@ -21,6 +23,7 @@ pub struct Options<'a> {
     pub timeout: Duration,
     pub initial: bool,
     pub allow_http_loopback: bool,
+    pub binding: &'a Binding,
 }
 
 #[derive(Debug)]
@@ -31,6 +34,7 @@ pub struct ResumeOptions<'a> {
     pub state_dir: &'a Path,
     pub timeout: Duration,
     pub allow_http_loopback: bool,
+    pub binding: &'a Binding,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -91,6 +95,7 @@ pub fn resume(_: &ResumeOptions<'_>) -> Result<Status, Error> {
 #[cfg(unix)]
 mod unix {
     use super::{Error, Options, ResumeOptions, Status};
+    use crate::ixp_manager_host::{self, Binding, Guard};
     use crate::{activation, ixp_manager};
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
@@ -144,6 +149,7 @@ mod unix {
         ixp_manager_version: String,
         origin: String,
         router_handle: String,
+        host: Binding,
         phase: Phase,
         callback: Option<Callback>,
         callback_attempts: u32,
@@ -541,12 +547,13 @@ mod unix {
         sync_dir(state)
     }
 
-    fn new_journal(origin: &str, handle: &str) -> Journal {
+    fn new_journal(origin: &str, handle: &str, binding: &Binding) -> Journal {
         Journal {
             schema: JOURNAL_SCHEMA.to_owned(),
             ixp_manager_version: "7.4.0".to_owned(),
             origin: origin.to_owned(),
             router_handle: handle.to_owned(),
+            host: binding.clone(),
             phase: Phase::LockRequestPending,
             callback: None,
             callback_attempts: 0,
@@ -574,6 +581,7 @@ mod unix {
         client: &Client,
         journal: &mut Journal,
         callback: Callback,
+        guard: &Guard,
     ) -> Result<()> {
         journal.phase = match callback {
             Callback::Updated => Phase::UpdatedPending,
@@ -584,13 +592,39 @@ mod unix {
         journal.callback_attempts = journal.callback_attempts.saturating_add(1);
         write_journal(state, journal)?;
         match client.callback(callback) {
-            Ok(()) => remove_journal(state),
+            Ok(()) => {
+                remove_journal(state)?;
+                guard.clear().map_err(host_error)
+            }
             Err(_) => Err(Error::CallbackPending),
         }
     }
 
+    fn host_error(error: ixp_manager_host::Error) -> Error {
+        match error {
+            ixp_manager_host::Error::Refused(reason) => Error::Refused(reason),
+            ixp_manager_host::Error::RecoveryRequired => Error::ManualRecovery,
+        }
+    }
+
     pub fn run(options: &Options<'_>) -> Result<Status> {
+        if options.router_handle != options.binding.router_handle
+            || options.state_dir != options.binding.activation_state_dir
+            || options.rbgp_addr != options.binding.rbgp_addr
+        {
+            return Err(Error::Refused(
+                "lifecycle options do not match host binding",
+            ));
+        }
+        let client = Client::new(
+            options.ixp_origin,
+            options.router_handle,
+            options.api_key_file,
+            options.timeout,
+            options.allow_http_loopback,
+        )?;
         let _lock = state_lock(options.state_dir)?;
+        let guard = Guard::claim_new(options.binding).map_err(host_error)?;
         let path = journal_path(options.state_dir);
         match fs::symlink_metadata(&path) {
             Ok(_) if private(&path, false, 0o600) => {
@@ -600,14 +634,10 @@ mod unix {
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(_) => return Err(Error::ManualRecovery),
         }
-        let client = Client::new(
-            options.ixp_origin,
-            options.router_handle,
-            options.api_key_file,
-            options.timeout,
-            options.allow_http_loopback,
-        )?;
-        let mut journal = new_journal(&client.origin, &client.handle);
+        let mut journal = new_journal(&client.origin, &client.handle, options.binding);
+        let finish = |journal: &mut Journal, callback| {
+            callback_pending(options.state_dir, &client, journal, callback, &guard)
+        };
         write_journal(options.state_dir, &journal)?;
         match client.acquire() {
             LockResult::Acquired => {
@@ -616,6 +646,7 @@ mod unix {
             }
             LockResult::NotAcquired => {
                 remove_journal(options.state_dir)?;
+                guard.clear().map_err(host_error)?;
                 return Err(Error::Refused("IXP Manager update lock was not acquired"));
             }
             LockResult::Ambiguous(class) => {
@@ -630,21 +661,23 @@ mod unix {
             Err(_) => {
                 journal.activation_outcome = Some("refused".to_owned());
                 journal.error_class = Some("configuration_fetch".to_owned());
-                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                finish(&mut journal, Callback::Release)?;
                 return Err(Error::Refused("IXP Manager configuration fetch failed"));
             }
         };
+        let render_binding = options.binding.render_binding();
         if ixp_manager::write_checked_candidate_bytes(
             &input,
             options.candidate_dir,
             options.max_prefix_restart_seconds,
             options.checker,
+            &render_binding,
         )
         .is_err()
         {
             journal.activation_outcome = Some("refused".to_owned());
             journal.error_class = Some("candidate_render".to_owned());
-            callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+            finish(&mut journal, Callback::Release)?;
             return Err(Error::Refused("IXP Manager candidate was refused"));
         }
         journal.candidate_sha256 = candidate_digest(options.candidate_dir);
@@ -660,8 +693,9 @@ mod unix {
             initial: options.initial,
             activation_command: options.activation_command,
             activation_args: options.activation_args,
+            binding: options.binding,
         };
-        match activation::activate(&activation_args) {
+        match activation::activate_guarded(&activation_args, &guard) {
             Ok(status) => {
                 journal.activation_outcome = Some(
                     match status {
@@ -670,7 +704,7 @@ mod unix {
                     }
                     .to_owned(),
                 );
-                callback_pending(options.state_dir, &client, &mut journal, Callback::Updated)?;
+                finish(&mut journal, Callback::Updated)?;
                 Ok(match status {
                     activation::Status::Activated => Status::Activated,
                     activation::Status::Noop => Status::Noop,
@@ -678,12 +712,12 @@ mod unix {
             }
             Err(activation::Error::Refused(_)) => {
                 journal.activation_outcome = Some("refused".to_owned());
-                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                finish(&mut journal, Callback::Release)?;
                 Err(Error::Refused("candidate activation was refused"))
             }
             Err(activation::Error::RolledBack) => {
                 journal.activation_outcome = Some("rolled_back".to_owned());
-                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                finish(&mut journal, Callback::Release)?;
                 Err(Error::RolledBack)
             }
             Err(activation::Error::RecoveryRequired) => {
@@ -697,6 +731,14 @@ mod unix {
     }
 
     pub fn resume(options: &ResumeOptions<'_>) -> Result<Status> {
+        if options.router_handle != options.binding.router_handle
+            || options.state_dir != options.binding.activation_state_dir
+        {
+            return Err(Error::Refused(
+                "lifecycle options do not match host binding",
+            ));
+        }
+        let guard = Guard::claim_existing(options.binding).map_err(host_error)?;
         let _lock = state_lock(options.state_dir)?;
         let client = Client::new(
             options.ixp_origin,
@@ -706,9 +748,15 @@ mod unix {
             options.allow_http_loopback,
         )?;
         let mut journal = read_journal(options.state_dir)?;
-        if journal.origin != client.origin || journal.router_handle != client.handle {
+        if journal.origin != client.origin
+            || journal.router_handle != client.handle
+            || journal.host != *options.binding
+        {
             return Err(Error::Refused("lifecycle journal identity does not match"));
         }
+        let finish = |journal: &mut Journal, callback| {
+            callback_pending(options.state_dir, &client, journal, callback, &guard)
+        };
         match journal.phase {
             Phase::UpdatedPending
                 if journal.callback == Some(Callback::Updated)
@@ -717,7 +765,7 @@ mod unix {
                         Some("activated" | "noop")
                     ) =>
             {
-                callback_pending(options.state_dir, &client, &mut journal, Callback::Updated)?;
+                finish(&mut journal, Callback::Updated)?;
                 Ok(Status::Updated)
             }
             Phase::ReleasePending
@@ -728,7 +776,7 @@ mod unix {
                     ) =>
             {
                 let rolled_back = journal.activation_outcome.as_deref() == Some("rolled_back");
-                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                finish(&mut journal, Callback::Release)?;
                 if rolled_back {
                     Err(Error::RolledBack)
                 } else {
@@ -736,7 +784,7 @@ mod unix {
                 }
             }
             Phase::Locked if journal.callback.is_none() && journal.activation_outcome.is_none() => {
-                callback_pending(options.state_dir, &client, &mut journal, Callback::Release)?;
+                finish(&mut journal, Callback::Release)?;
                 Err(Error::Refused("lock released before activation"))
             }
             Phase::LockRequestPending | Phase::ActivationStarted | Phase::ManualRecovery => {

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -45,6 +45,7 @@ use sha2::{Digest, Sha256};
 
 pub mod activation;
 pub mod ixp_manager;
+pub mod ixp_manager_host;
 pub mod ixp_manager_lifecycle;
 
 /// Top-level keys of the supported `template-context` shape, sorted.

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -26,21 +26,17 @@ enum InputFormat {
     about = "Atomically publish and settle a validated local candidate"
 )]
 struct ActivateArgs {
+    #[command(flatten)]
+    host: HostBindingArgs,
     /// Private rendered candidate directory
     #[arg(long)]
     candidate: PathBuf,
-    /// Private activation state directory
-    #[arg(long)]
-    state_dir: PathBuf,
     /// rustbgpd binary used for version and strict candidate checks
     #[arg(long)]
     check_with: PathBuf,
     /// Exact rbgp executable used for health and live config comparison
     #[arg(long)]
     rbgp: PathBuf,
-    /// Running rustbgpd gRPC address
-    #[arg(long)]
-    rbgp_addr: String,
     /// Maximum seconds for each activation or rollback settlement
     #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=120))]
     settle_seconds: u64,
@@ -53,6 +49,32 @@ struct ActivateArgs {
     /// Literal activation argument; repeatable and never shell-evaluated
     #[arg(long, allow_hyphen_values = true)]
     activation_arg: Vec<OsString>,
+}
+
+#[derive(clap::Args)]
+struct HostBindingArgs {
+    #[arg(long)]
+    router_handle: String,
+    #[arg(long)]
+    runtime_state_dir: PathBuf,
+    #[arg(long)]
+    state_dir: PathBuf,
+    #[arg(long)]
+    host_state_dir: PathBuf,
+    #[arg(long)]
+    rbgp_addr: String,
+}
+
+impl HostBindingArgs {
+    fn binding(&self) -> Result<rs_config_render::ixp_manager_host::Binding, &'static str> {
+        rs_config_render::ixp_manager_host::Binding::new(
+            &self.router_handle,
+            &self.runtime_state_dir,
+            &self.state_dir,
+            &self.host_state_dir,
+            &self.rbgp_addr,
+        )
+    }
 }
 
 #[derive(Parser)]
@@ -75,18 +97,14 @@ enum LifecycleCommand {
 
 #[derive(clap::Args)]
 struct LifecycleConnectionArgs {
+    #[command(flatten)]
+    host: HostBindingArgs,
     /// IXP Manager root origin; HTTPS is required by default
     #[arg(long)]
     ixp_origin: String,
-    /// Exact IXP Manager router handle
-    #[arg(long)]
-    router_handle: String,
     /// Absolute mode-0600 file containing the API key
     #[arg(long)]
     api_key_file: PathBuf,
-    /// Pre-created absolute mode-0700 lifecycle/activation state directory
-    #[arg(long)]
-    state_dir: PathBuf,
     /// Whole-request deadline in seconds
     #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=300))]
     request_timeout_seconds: u64,
@@ -111,9 +129,6 @@ struct LifecycleRunArgs {
     /// Exact rbgp executable used for health and live config comparison
     #[arg(long)]
     rbgp: PathBuf,
-    /// Running rustbgpd gRPC address
-    #[arg(long)]
-    rbgp_addr: String,
     /// Maximum seconds for activation settlement
     #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=120))]
     settle_seconds: u64,
@@ -175,6 +190,10 @@ struct Cli {
     /// rustbgpd binary used for mandatory version and strict candidate checks
     #[arg(long)]
     check_with: Option<PathBuf>,
+    #[arg(long)]
+    router_handle: Option<String>,
+    #[arg(long)]
+    runtime_state_dir: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -269,52 +288,76 @@ fn main() -> ExitCode {
         return match args.command {
             LifecycleCommand::Run(args) => {
                 let connection = args.connection;
+                let binding = match connection.host.binding() {
+                    Ok(binding) => binding,
+                    Err(reason) => {
+                        eprintln!("rs-config-render: IXP Manager lifecycle: {reason}");
+                        return ExitCode::from(2);
+                    }
+                };
                 lifecycle_exit(rs_config_render::ixp_manager_lifecycle::run(
                     &rs_config_render::ixp_manager_lifecycle::Options {
                         ixp_origin: &connection.ixp_origin,
-                        router_handle: &connection.router_handle,
+                        router_handle: &connection.host.router_handle,
                         api_key_file: &connection.api_key_file,
                         candidate_dir: &args.candidate_dir,
-                        state_dir: &connection.state_dir,
+                        state_dir: &connection.host.state_dir,
                         checker: &args.check_with,
                         max_prefix_restart_seconds: args.max_prefix_restart_seconds,
                         rbgp: &args.rbgp,
-                        rbgp_addr: &args.rbgp_addr,
+                        rbgp_addr: &connection.host.rbgp_addr,
                         activation_command: &args.activation_command,
                         activation_args: &args.activation_arg,
                         settle: Duration::from_secs(args.settle_seconds),
                         timeout: Duration::from_secs(connection.request_timeout_seconds),
                         initial: args.initial,
                         allow_http_loopback: connection.allow_http_loopback,
+                        binding: &binding,
                     },
                 ))
             }
             LifecycleCommand::Resume(args) => {
                 let connection = args.connection;
+                let binding = match connection.host.binding() {
+                    Ok(binding) => binding,
+                    Err(reason) => {
+                        eprintln!("rs-config-render: IXP Manager lifecycle: {reason}");
+                        return ExitCode::from(2);
+                    }
+                };
                 lifecycle_exit(rs_config_render::ixp_manager_lifecycle::resume(
                     &rs_config_render::ixp_manager_lifecycle::ResumeOptions {
                         ixp_origin: &connection.ixp_origin,
-                        router_handle: &connection.router_handle,
+                        router_handle: &connection.host.router_handle,
                         api_key_file: &connection.api_key_file,
-                        state_dir: &connection.state_dir,
+                        state_dir: &connection.host.state_dir,
                         timeout: Duration::from_secs(connection.request_timeout_seconds),
                         allow_http_loopback: connection.allow_http_loopback,
+                        binding: &binding,
                     },
                 ))
             }
         };
     }
     if let Some(args) = parse_activation() {
+        let binding = match args.host.binding() {
+            Ok(binding) => binding,
+            Err(reason) => {
+                eprintln!("rs-config-render: activation: {reason}");
+                return ExitCode::from(2);
+            }
+        };
         let options = rs_config_render::activation::Options {
             candidate: &args.candidate,
-            state_dir: &args.state_dir,
+            state_dir: &args.host.state_dir,
             checker: &args.check_with,
             rbgp: &args.rbgp,
-            rbgp_addr: &args.rbgp_addr,
+            rbgp_addr: &args.host.rbgp_addr,
             settle: Duration::from_secs(args.settle_seconds),
             initial: args.initial,
             activation_command: &args.activation_command,
             activation_args: &args.activation_arg,
+            binding: &binding,
         };
         return match rs_config_render::activation::activate(&options) {
             Ok(status) => {
@@ -362,11 +405,29 @@ fn main() -> ExitCode {
             );
             return ExitCode::from(2);
         };
+        let (Some(handle), Some(runtime)) = (
+            cli.router_handle.as_deref(),
+            cli.runtime_state_dir.as_deref(),
+        ) else {
+            eprintln!(
+                "rs-config-render: IXP Manager mode requires --router-handle and --runtime-state-dir"
+            );
+            return ExitCode::from(2);
+        };
+        let binding = match rs_config_render::ixp_manager_host::RenderBinding::new(handle, runtime)
+        {
+            Ok(binding) => binding,
+            Err(reason) => {
+                eprintln!("rs-config-render: {reason}");
+                return ExitCode::from(2);
+            }
+        };
         return match rs_config_render::ixp_manager::write_checked_candidate(
             &cli.context,
             &cli.out_dir,
             restart,
             checker,
+            &binding,
         ) {
             Ok(files) => stdout_exit(write_stdout(|writer| {
                 writeln!(
@@ -381,7 +442,11 @@ fn main() -> ExitCode {
             }
         };
     }
-    if cli.max_prefix_restart_seconds.is_some() || cli.check_with.is_some() {
+    if cli.max_prefix_restart_seconds.is_some()
+        || cli.check_with.is_some()
+        || cli.router_handle.is_some()
+        || cli.runtime_state_dir.is_some()
+    {
         eprintln!("rs-config-render: IXP Manager options require --input-format ixp-manager-v1");
         return ExitCode::from(2);
     }

--- a/tools/rs-config-render/tests/activation.rs
+++ b/tools/rs-config-render/tests/activation.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use rs_config_render::activation::{Error, Options, Status, activate};
+use rs_config_render::ixp_manager_host::Binding;
 use sha2::{Digest, Sha256};
 
 const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
@@ -38,6 +39,8 @@ struct Rig {
     _temp: tempfile::TempDir,
     root: PathBuf,
     state: PathBuf,
+    runtime: PathBuf,
+    host: PathBuf,
     checker: PathBuf,
     rbgp: PathBuf,
     activation: PathBuf,
@@ -104,7 +107,7 @@ case "$*" in
 esac
 for arg do candidate=$arg; done
 target=$(cat "$root/runtime")
-current=$(CDPATH= cd -- "$root/state" && pwd -P)/current
+current=$(CDPATH= cd -- "$root/b2-rs1-lan1-ipv4/activation" && pwd -P)/current
 grep -F "\"$current/policy/ixp-hygiene.rpol\"" "$candidate" >/dev/null || exit 8
 printf 'ABSOLUTE_CURRENT_OK\n' >> "$root/rbgp.log"
 if [ -f "$root/reject" ] && [ "$target" = "$(cat "$root/reject")" ]; then exit 2; fi
@@ -117,7 +120,7 @@ exit 0
             &format!(
                 r#"#!/bin/sh
 root=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
-target=$(readlink "$root/state/current") || exit 7
+target=$(readlink "$root/b2-rs1-lan1-ipv4/activation/current") || exit 7
 printf '%s\n' "$target" >> "$root/activation.log"
 printf '%s\n' "$target" > "$root/runtime"
 case "$(cat "$root/activation-mode")" in
@@ -133,13 +136,21 @@ exit 0
 "#
             ),
         );
-        let state = root.join("state");
-        fs::create_dir(&state).unwrap();
-        mode(&state, 0o700);
+        let runtime = root.join("b2-rs1-lan1-ipv4");
+        fs::create_dir(&runtime).unwrap();
+        mode(&runtime, 0o700);
+        let state = runtime.join("activation");
+        let host = root.join("host-state");
+        for path in [&state, &host] {
+            fs::create_dir(path).unwrap();
+            mode(path, 0o700);
+        }
         Self {
             _temp: temp,
             root,
             state,
+            runtime,
+            host,
             checker,
             rbgp,
             activation,
@@ -147,15 +158,36 @@ exit 0
     }
 
     fn candidate(&self, name: &str, max_prefix: u64) -> PathBuf {
+        self.candidate_for(name, max_prefix, &self.state)
+    }
+
+    fn candidate_for(&self, name: &str, max_prefix: u64, _state: &Path) -> PathBuf {
         let mut input: serde_json::Value = serde_json::from_slice(FIXTURE).unwrap();
         input["clients"][0]["max_prefix"] = max_prefix.into();
         let context = self.root.join(format!("{name}.json"));
         fs::write(&context, serde_json::to_vec(&input).unwrap()).unwrap();
         mode(&context, 0o600);
         let out = self.root.join(name);
-        rs_config_render::ixp_manager::write_checked_candidate(&context, &out, 300, &self.checker)
-            .unwrap();
+        rs_config_render::ixp_manager::write_checked_candidate(
+            &context,
+            &out,
+            300,
+            &self.checker,
+            &self.binding(&self.state).render_binding(),
+        )
+        .unwrap();
         out
+    }
+
+    fn binding(&self, state: &Path) -> Binding {
+        Binding::new(
+            "b2-rs1-lan1-ipv4",
+            &self.runtime,
+            state,
+            &self.host,
+            &format!("unix://{}", self.runtime.join("grpc.sock").display()),
+        )
+        .unwrap()
     }
 
     fn run(&self, candidate: &Path, initial: bool, command: &Path) -> Result<Status, Error> {
@@ -165,16 +197,17 @@ exit 0
             state_dir: &self.state,
             checker: &self.checker,
             rbgp: &self.rbgp,
-            rbgp_addr: "test:50051",
+            rbgp_addr: self.binding(&self.state).rbgp_addr(),
             settle: Duration::from_secs(1),
             initial,
             activation_command: command,
             activation_args: &args,
+            binding: &self.binding(&self.state),
         })
     }
 
     fn current(&self) -> String {
-        fs::read_link(self.root.join("state/current"))
+        fs::read_link(self.state.join("current"))
             .unwrap()
             .to_string_lossy()
             .into_owned()
@@ -185,7 +218,7 @@ exit 0
     }
 
     fn receipt(&self) -> serde_json::Value {
-        serde_json::from_slice(&fs::read(self.root.join("state/activation-receipt.json")).unwrap())
+        serde_json::from_slice(&fs::read(self.state.join("activation-receipt.json")).unwrap())
             .unwrap()
     }
 }
@@ -216,16 +249,20 @@ fn initial_activation_and_noop_are_private_exact_and_secret_free() {
     assert_eq!(receipt["strict_check"]["binary_version"], "rustbgpd 0.65.0");
     assert_eq!(receipt["phases"]["initial_unreachable_checked"], true);
     assert_eq!(receipt["phases"]["runtime_equal"], true);
+    assert_eq!(
+        receipt["host"],
+        serde_json::to_value(rig.binding(&rig.state)).unwrap()
+    );
     assert!(!serde_json::to_string(&receipt).unwrap().contains(SECRET));
-    assert_mode(&rig.root.join("state"), 0o700);
-    assert_mode(&rig.root.join("state/activation.lock"), 0o600);
+    assert_mode(&rig.state, 0o700);
+    assert_mode(&rig.state.join("activation.lock"), 0o600);
     let check_log = fs::read_to_string(rig.root.join("checker.log")).unwrap();
     assert!(
         check_log
             .lines()
             .last()
             .unwrap()
-            .contains("state/generations/")
+            .contains("activation/generations/")
     );
 
     let activations = fs::read_to_string(rig.root.join("activation.log")).unwrap();
@@ -239,23 +276,32 @@ fn initial_activation_and_noop_are_private_exact_and_secret_free() {
     );
     assert_eq!(rig.receipt()["status"], "noop");
 
+    let limited_rig = Rig::new();
+    let limited_candidate = limited_rig.candidate("candidate-limited", 100);
     let limited = Command::new("/bin/sh")
         .args(["-c", "trap '' XFSZ; ulimit -f 0; exec \"$@\"", "sh"])
         .arg(env!("CARGO_BIN_EXE_rs-config-render"))
         .args(["activate", "--candidate"])
-        .arg(&candidate)
+        .arg(&limited_candidate)
         .arg("--state-dir")
-        .arg(&rig.state)
+        .arg(&limited_rig.state)
+        .args(["--router-handle", "b2-rs1-lan1-ipv4"])
+        .arg("--runtime-state-dir")
+        .arg(&limited_rig.runtime)
+        .arg("--host-state-dir")
+        .arg(&limited_rig.host)
         .arg("--check-with")
-        .arg(&rig.checker)
+        .arg(&limited_rig.checker)
         .arg("--rbgp")
-        .arg(&rig.rbgp)
-        .args(["--rbgp-addr", "test:50051", "--activation-command"])
+        .arg(&limited_rig.rbgp)
+        .arg("--rbgp-addr")
+        .arg(limited_rig.binding(&limited_rig.state).rbgp_addr())
+        .arg("--activation-command")
         .arg("/bin/false")
         .output()
         .unwrap();
-    assert_eq!(limited.status.code(), Some(2));
-    assert!(fs::read_dir(&rig.state).unwrap().all(|entry| {
+    assert_eq!(limited.status.code(), Some(5));
+    assert!(fs::read_dir(&limited_rig.state).unwrap().all(|entry| {
         !entry
             .unwrap()
             .file_name()
@@ -276,14 +322,46 @@ fn initial_activation_and_noop_are_private_exact_and_secret_free() {
         state_dir: &second_state,
         checker: &rig.checker,
         rbgp: &rig.rbgp,
-        rbgp_addr: "test:50051",
+        rbgp_addr: rig.binding(&rig.state).rbgp_addr(),
         settle: Duration::from_secs(1),
         initial: true,
         activation_command: &rig.activation,
         activation_args: &args,
+        binding: &rig.binding(&rig.state),
     });
     assert_refused(result);
     assert!(!second_state.join("current").exists());
+}
+
+#[test]
+fn receipt_and_toml_runtime_bindings_are_independently_enforced() {
+    let rig = Rig::new();
+    let receipt_mismatch = rig.candidate("candidate-receipt-mismatch", 120);
+    let receipt_path = receipt_mismatch.join("render-receipt.json");
+    let mut receipt: serde_json::Value =
+        serde_json::from_slice(&fs::read(&receipt_path).unwrap()).unwrap();
+    receipt["host"]["runtime_state_dir"] = "/tmp/foreign".into();
+    fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).unwrap()).unwrap();
+    assert_refused(rig.run(&receipt_mismatch, true, &rig.activation));
+    assert!(!rig.host.join("ixp-manager-host-fence.json").exists());
+
+    let toml_mismatch = rig.candidate("candidate-toml-mismatch", 121);
+    let config_path = toml_mismatch.join("config.toml");
+    let config = fs::read_to_string(&config_path)
+        .unwrap()
+        .replace(rig.runtime.to_str().unwrap(), "/tmp/b2-rs1-lan1-ipv4");
+    fs::write(&config_path, &config).unwrap();
+    let receipt_path = toml_mismatch.join("render-receipt.json");
+    let mut receipt: serde_json::Value =
+        serde_json::from_slice(&fs::read(&receipt_path).unwrap()).unwrap();
+    receipt["generated_files"]["config.toml"] = Sha256::digest(config.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+        .into();
+    fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).unwrap()).unwrap();
+    assert_refused(rig.run(&toml_mismatch, true, &rig.activation));
+    assert!(!rig.state.join("current").exists());
 }
 
 #[test]
@@ -297,7 +375,7 @@ fn changed_candidate_rolls_back_exactly_and_refuses_mutable_aliases() {
 
     let stop = Arc::new(AtomicBool::new(false));
     let observed_bad = Arc::new(AtomicBool::new(false));
-    let state = rig.root.join("state");
+    let state = rig.state.clone();
     let watcher = {
         let stop = Arc::clone(&stop);
         let observed_bad = Arc::clone(&observed_bad);
@@ -389,11 +467,18 @@ fn initial_failed_command_exits_five_with_last_recovery_receipt() {
         .arg(&candidate)
         .arg("--state-dir")
         .arg(&rig.state)
+        .args(["--router-handle", "b2-rs1-lan1-ipv4"])
+        .arg("--runtime-state-dir")
+        .arg(&rig.runtime)
+        .arg("--host-state-dir")
+        .arg(&rig.host)
         .arg("--check-with")
         .arg(&rig.checker)
         .arg("--rbgp")
         .arg(&rig.rbgp)
-        .args(["--rbgp-addr", "test:50051", "--initial"])
+        .arg("--rbgp-addr")
+        .arg(rig.binding(&rig.state).rbgp_addr())
+        .arg("--initial")
         .arg("--activation-command")
         .arg(&rig.activation)
         .output()
@@ -408,6 +493,7 @@ fn initial_failed_command_exits_five_with_last_recovery_receipt() {
     assert!(rig.current().ends_with(candidate_hash));
     assert_eq!(receipt["phases"]["runtime_equal"], false);
     assert!(!serde_json::to_string(&receipt).unwrap().contains(SECRET));
+    assert!(rig.host.join("ixp-manager-host-fence.json").exists());
 }
 
 #[test]
@@ -437,16 +523,19 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
     let candidate = rig.candidate("candidate-boundaries", 106);
     let args = Vec::new();
     let run = |state: &Path, settle| {
+        let binding = rig.binding(&rig.state);
+        let address = binding.rbgp_addr();
         activate(&Options {
             candidate: &candidate,
             state_dir: state,
             checker: &rig.checker,
             rbgp: &rig.rbgp,
-            rbgp_addr: "test:50051",
+            rbgp_addr: address,
             settle,
             initial: true,
             activation_command: &rig.activation,
             activation_args: &args,
+            binding: &binding,
         })
     };
     let subsecond = rig.root.join("subsecond-state");
@@ -470,6 +559,7 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
     mode(&wrong_mode, 0o755);
     assert_refused(run(&wrong_mode, Duration::from_secs(1)));
 
+    let candidate = rig.candidate("candidate-oversized", 106);
     let config = format!("[oversized]\nvalue = \"{}\"\n", "x".repeat(4_194_300));
     fs::write(candidate.join("config.toml"), &config).unwrap();
     let mut receipt: serde_json::Value =
@@ -484,13 +574,10 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
         serde_json::to_vec_pretty(&receipt).unwrap(),
     )
     .unwrap();
-    let oversized = rig.root.join("oversized-state");
-    fs::create_dir(&oversized).unwrap();
-    mode(&oversized, 0o700);
-    assert_refused(run(&oversized, Duration::from_secs(1)));
-    assert!(!oversized.join("generations").exists());
-    assert!(!oversized.join("current").exists());
-    assert!(oversized.join("activation.lock").is_file());
+    assert_refused(rig.run(&candidate, true, &rig.activation));
+    assert!(!rig.state.join("generations").exists());
+    assert!(!rig.state.join("current").exists());
+    assert!(!rig.state.join("activation.lock").exists());
 
     let partial = rig.candidate("candidate-partial", 107);
     let delayed = rig.root.join("delayed-checker.sh");
@@ -498,11 +585,10 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
         &delayed,
         "#!/bin/sh\nroot=$(CDPATH= cd -- \"$(dirname \"$0\")\" && pwd)\n[ \"$1\" = --version ] && { touch \"$root/version-started\"; sleep 1; }\nexec \"$root/checker.sh\" \"$@\"\n",
     );
-    let state = rig.root.join("partial-state");
-    fs::create_dir(&state).unwrap();
-    mode(&state, 0o700);
+    let state = rig.state.clone();
     let rbgp = rig.rbgp.clone();
     let activation = rig.activation.clone();
+    let binding = rig.binding(&state);
     let paths = [partial.clone(), state.clone(), delayed, rbgp, activation];
     let worker = std::thread::spawn(move || {
         let args = Vec::new();
@@ -511,11 +597,12 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
             state_dir: &paths[1],
             checker: &paths[2],
             rbgp: &paths[3],
-            rbgp_addr: "test:50051",
+            rbgp_addr: binding.rbgp_addr(),
             settle: Duration::from_secs(2),
             initial: true,
             activation_command: &paths[4],
             activation_args: &args,
+            binding: &binding,
         })
     });
     let deadline = Instant::now() + Duration::from_secs(2);

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use rs_config_render::ixp_manager::{Error, render_document};
+use rs_config_render::ixp_manager_host::RenderBinding;
 
 const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
 const SECRET: &str = "mcWsqMdzGwTKt67g";
@@ -19,18 +20,31 @@ fn value() -> serde_json::Value {
     serde_json::from_slice(FIXTURE).unwrap()
 }
 
+fn binding() -> RenderBinding {
+    RenderBinding::new(
+        "b2-rs1-lan1-ipv4",
+        std::path::Path::new("/var/lib/rustbgpd/b2-rs1-lan1-ipv4"),
+    )
+    .unwrap()
+}
+
 fn rendered(input: &serde_json::Value) -> Result<rs_config_render::ixp_manager::Candidate, Error> {
-    render_document(&serde_json::to_vec(input).unwrap(), 300)
+    render_document(&serde_json::to_vec(input).unwrap(), 300, &binding())
 }
 
 #[test]
 fn supported_render_is_deterministic_and_explicit() {
-    let first = render_document(FIXTURE, 300).unwrap();
-    assert_eq!(first.files, render_document(FIXTURE, 300).unwrap().files);
+    let first = render_document(FIXTURE, 300, &binding()).unwrap();
+    assert_eq!(
+        first.files,
+        render_document(FIXTURE, 300, &binding()).unwrap().files
+    );
     assert_eq!(first.files.len(), 3);
     let config = &first.files["config.toml"];
     for expected in [
         "listen_addresses = [\"192.0.2.18\"]",
+        "runtime_state_dir = \"/var/lib/rustbgpd/b2-rs1-lan1-ipv4\"",
+        "path = \"/var/lib/rustbgpd/b2-rs1-lan1-ipv4/grpc.sock\"",
         "next_hop_ownership = \"strict_peer\"",
         "per_client_best = true",
         "rs_control_communities = true",
@@ -64,6 +78,15 @@ fn supported_render_is_deterministic_and_explicit() {
 
 #[test]
 fn strict_schema_completion_and_refusal_matrix_fail_closed() {
+    let forged: RenderBinding = serde_json::from_value(serde_json::json!({
+        "router_handle": "b2-rs1-lan1-ipv4",
+        "runtime_state_dir": "/var/lib/rustbgpd/foreign"
+    }))
+    .unwrap();
+    assert!(matches!(
+        render_document(FIXTURE, 300, &forged),
+        Err(Error::Refused("invalid router host binding"))
+    ));
     let refuses = |pointer: &str, replacement: serde_json::Value| {
         let mut input = value();
         *input.pointer_mut(pointer).unwrap() = replacement;
@@ -153,6 +176,7 @@ fn run_cli(
     let checker = temp.path().join("checker.sh");
     fs::write(&checker, "#!/bin/sh\n[ ! -e \"$OUT/render-receipt.json\" ] || exit 90\nprintf '%s\\n' \"$*\" >> \"$LOG\"\nif [ \"$1\" = --version ]; then echo \"rustbgpd 0.65.0 $SECRET\"; echo \"$SECRET\" >&2; exit 0; fi\n[ \"$FAIL\" = 0 ] || exit 91\n").unwrap();
     set_mode(&checker, 0o700);
+    let runtime = temp.path().join("b2-rs1-lan1-ipv4");
     Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
         .args(["--input-format", "ixp-manager-v1", "--context"])
         .arg(&input)
@@ -160,6 +184,9 @@ fn run_cli(
         .arg(out)
         .args(["--max-prefix-restart-seconds", "300", "--check-with"])
         .arg(&checker)
+        .args(["--router-handle", "b2-rs1-lan1-ipv4"])
+        .arg("--runtime-state-dir")
+        .arg(&runtime)
         .env("OUT", out)
         .env("LOG", log)
         .env("SECRET", SECRET)
@@ -193,6 +220,13 @@ fn cli_enforces_private_checker_order_receipt_last_and_redaction() {
     assert_eq!(receipt["counts"]["clients"], 1);
     assert_eq!(receipt["counts"]["prefixes"], 1);
     assert_eq!(receipt["counts"]["origins"], 1);
+    assert_eq!(
+        receipt["host"],
+        serde_json::to_value(
+            RenderBinding::new("b2-rs1-lan1-ipv4", &temp.path().join("b2-rs1-lan1-ipv4")).unwrap()
+        )
+        .unwrap()
+    );
     assert_eq!(
         receipt["input"]["sha256"],
         digest(&temp.path().join("input.json"))

--- a/tools/rs-config-render/tests/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/tests/ixp_manager_lifecycle.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use rs_config_render::activation;
 use rs_config_render::ixp_manager;
+use rs_config_render::ixp_manager_host::{Binding, Guard, RenderBinding};
 use rs_config_render::ixp_manager_lifecycle::{self as lifecycle, Error, Status};
 
 const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
@@ -39,6 +40,7 @@ struct Response {
     location: Option<String>,
     expected_state: Option<(PathBuf, &'static str)>,
     delay: Option<Duration>,
+    chmod_before_reply: Option<(PathBuf, u32)>,
 }
 
 impl Response {
@@ -50,6 +52,7 @@ impl Response {
             location: None,
             expected_state: None,
             delay: None,
+            chmod_before_reply: None,
         }
     }
 
@@ -61,6 +64,7 @@ impl Response {
             location: None,
             expected_state: None,
             delay: None,
+            chmod_before_reply: None,
         }
     }
 
@@ -71,6 +75,11 @@ impl Response {
 
     fn after_delay(mut self, delay: Duration) -> Self {
         self.delay = Some(delay);
+        self
+    }
+
+    fn after_chmod(mut self, path: PathBuf, permissions: u32) -> Self {
+        self.chmod_before_reply = Some((path, permissions));
         self
     }
 }
@@ -114,6 +123,9 @@ impl Server {
                         state.contains(expected),
                         "request arrived before durable state {expected}: {state}"
                     );
+                }
+                if let Some((path, permissions)) = &response.chmod_before_reply {
+                    mode(path, *permissions);
                 }
                 writers.push(thread::spawn(move || {
                     let mut stream = stream;
@@ -168,11 +180,14 @@ struct Rig {
     _temp: tempfile::TempDir,
     root: PathBuf,
     state: PathBuf,
+    runtime: PathBuf,
+    host: PathBuf,
     candidate: PathBuf,
     key: PathBuf,
     checker: PathBuf,
     rbgp: PathBuf,
     activation: PathBuf,
+    binding: Binding,
 }
 
 impl Rig {
@@ -183,10 +198,14 @@ impl Rig {
             .tempdir_in(current)
             .unwrap();
         let root = temp.path().to_path_buf();
-        let state = root.join("state");
+        let runtime = root.join("b2-rs1-lan1-ipv4");
+        let state = runtime.join("activation");
         let candidate = root.join("candidate");
+        let host = root.join("host-state");
+        private_dir(&runtime);
         private_dir(&state);
         private_dir(&candidate);
+        private_dir(&host);
         let key = root.join("api-key");
         fs::write(&key, format!("{API_KEY}\n")).unwrap();
         mode(&key, 0o600);
@@ -205,15 +224,26 @@ impl Rig {
         );
         let activation = root.join("activate");
         executable(&activation, "#!/bin/sh\nexit 0\n");
+        let binding = Binding::new(
+            "b2-rs1-lan1-ipv4",
+            &runtime,
+            &state,
+            &host,
+            &format!("unix://{}", runtime.join("grpc.sock").display()),
+        )
+        .unwrap();
         let rig = Self {
             _temp: temp,
             root,
             state,
+            runtime,
+            host,
             candidate,
             key,
             checker,
             rbgp,
             activation,
+            binding,
         };
         rig.bootstrap();
         rig
@@ -222,61 +252,109 @@ impl Rig {
     fn bootstrap(&self) {
         let candidate = self.root.join("bootstrap");
         private_dir(&candidate);
-        ixp_manager::write_checked_candidate_bytes(FIXTURE, &candidate, 300, &self.checker)
-            .unwrap();
+        let binding = self.binding();
+        let render_binding = binding.render_binding();
+        ixp_manager::write_checked_candidate_bytes(
+            FIXTURE,
+            &candidate,
+            300,
+            &self.checker,
+            &render_binding,
+        )
+        .unwrap();
         assert_eq!(
             activation::activate(&activation::Options {
                 candidate: &candidate,
                 state_dir: &self.state,
                 checker: &self.checker,
                 rbgp: &self.rbgp,
-                rbgp_addr: "test",
+                rbgp_addr: binding.rbgp_addr(),
                 settle: Duration::from_secs(2),
                 initial: true,
                 activation_command: &self.activation,
                 activation_args: &[],
+                binding,
             }),
             Ok(activation::Status::Activated)
         );
     }
 
+    fn binding(&self) -> &Binding {
+        &self.binding
+    }
+
     fn options<'a>(&'a self, origin: &'a str) -> lifecycle::Options<'a> {
         lifecycle::Options {
             ixp_origin: origin,
-            router_handle: "rs1-ipv4",
+            router_handle: "b2-rs1-lan1-ipv4",
             api_key_file: &self.key,
             candidate_dir: &self.candidate,
             state_dir: &self.state,
             checker: &self.checker,
             max_prefix_restart_seconds: 300,
             rbgp: &self.rbgp,
-            rbgp_addr: "test",
+            rbgp_addr: self.binding.rbgp_addr(),
             activation_command: &self.activation,
             activation_args: &[],
             settle: Duration::from_secs(2),
             timeout: Duration::from_secs(2),
             initial: false,
             allow_http_loopback: true,
+            binding: &self.binding,
         }
     }
 
     fn resume_options<'a>(&'a self, origin: &'a str) -> lifecycle::ResumeOptions<'a> {
         lifecycle::ResumeOptions {
             ixp_origin: origin,
-            router_handle: "rs1-ipv4",
+            router_handle: "b2-rs1-lan1-ipv4",
             api_key_file: &self.key,
             state_dir: &self.state,
             timeout: Duration::from_secs(2),
             allow_http_loopback: true,
+            binding: &self.binding,
         }
     }
+}
+
+fn run_cli(rig: &Rig, origin: &str) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rs-config-render"));
+    command
+        .args([
+            "ixp-manager-lifecycle",
+            "run",
+            "--ixp-origin",
+            origin,
+            "--router-handle",
+            "b2-rs1-lan1-ipv4",
+            "--api-key-file",
+        ])
+        .arg(&rig.key)
+        .arg("--state-dir")
+        .arg(&rig.state)
+        .arg("--runtime-state-dir")
+        .arg(&rig.runtime)
+        .arg("--host-state-dir")
+        .arg(&rig.host)
+        .arg("--rbgp-addr")
+        .arg(rig.binding.rbgp_addr())
+        .arg("--candidate-dir")
+        .arg(&rig.candidate)
+        .arg("--check-with")
+        .arg(&rig.checker)
+        .args(["--max-prefix-restart-seconds", "300", "--rbgp"])
+        .arg(&rig.rbgp)
+        .args(["--settle-seconds", "2", "--activation-command"])
+        .arg(&rig.activation)
+        .args(["--request-timeout-seconds", "30", "--allow-http-loopback"]);
+    command
 }
 
 fn assert_request(request: &str, method: &str, action: &str) {
     let lower = request.to_ascii_lowercase();
     assert!(
         request.starts_with(&format!(
-            "{method} /admin/api/v4/router/{action}/rs1-ipv4 HTTP/1.1\r\n"
+            "{method} /admin/api/v4/router/{action}/b2-rs1-lan1-ipv4 HTTP/1.1\r\n"
         )),
         "unexpected request: {request}"
     );
@@ -321,6 +399,7 @@ fn noop_lifecycle_uses_exact_authenticated_order_and_acknowledges() {
     assert_request(&requests[1], "GET", "gen-config");
     assert_request(&requests[2], "POST", "updated");
     assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+    assert!(!rig.host.join("ixp-manager-host-fence.json").exists());
     assert_no_key(&rig.state);
     assert_no_key(&rig.candidate);
 }
@@ -337,6 +416,7 @@ fn definite_lock_and_render_failures_have_bounded_release_semantics() {
     assert_eq!(requests.len(), 1);
     assert_request(&requests[0], "POST", "get-update-lock");
     assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+    assert!(!rig.host.join("ixp-manager-host-fence.json").exists());
 
     let rejected = Server::start(vec![
         Response::json(200),
@@ -375,6 +455,7 @@ fn failed_callback_is_durable_and_resume_never_refetches_or_activates() {
     );
     let journal = fs::read_to_string(rig.state.join("ixp-manager-lifecycle.json")).unwrap();
     assert!(journal.contains("updated_pending"));
+    assert!(rig.host.join("ixp-manager-host-fence.json").exists());
     assert!(!journal.contains(API_KEY));
     assert_eq!(
         lifecycle::resume(&rig.resume_options(&server.origin)),
@@ -385,6 +466,7 @@ fn failed_callback_is_durable_and_resume_never_refetches_or_activates() {
     assert_request(&requests[2], "POST", "updated");
     assert_request(&requests[3], "POST", "updated");
     assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+    assert!(!rig.host.join("ixp-manager-host-fence.json").exists());
 }
 
 #[test]
@@ -401,6 +483,7 @@ fn started_activation_uncertainty_retains_remote_lock_for_manual_recovery() {
     let journal = fs::read_to_string(rig.state.join("ixp-manager-lifecycle.json")).unwrap();
     assert!(journal.contains("manual_recovery"));
     assert!(journal.contains("recovery_required"));
+    assert!(rig.host.join("ixp-manager-host-fence.json").exists());
     assert_eq!(
         lifecycle::resume(&rig.resume_options(&origin)),
         Err(Error::ManualRecovery)
@@ -439,6 +522,7 @@ fn redirects_and_unsafe_origins_or_key_files_are_refused_without_key_forwarding(
         location: Some(format!("http://{}/stolen", sink.local_addr().unwrap())),
         expected_state: None,
         delay: None,
+        chmod_before_reply: None,
     }]);
     assert_eq!(
         lifecycle::run(&rig.options(&redirected.origin)),
@@ -506,6 +590,7 @@ fn control_and_configuration_body_caps_fail_closed() {
         location: None,
         expected_state: None,
         delay: None,
+        chmod_before_reply: None,
     }]);
     assert_eq!(
         lifecycle::run(&rig.options(&control.origin)),
@@ -521,6 +606,7 @@ fn control_and_configuration_body_caps_fail_closed() {
         location: None,
         expected_state: None,
         delay: None,
+        chmod_before_reply: None,
     }]);
     assert_eq!(
         lifecycle::run(&rig.options(&malformed.origin)),
@@ -559,9 +645,11 @@ fn in_memory_renderer_is_byte_identical_to_private_file_entry_point() {
         &checker,
         "#!/bin/sh\n[ \"$1\" = --version ] && echo 'rustbgpd 0.65.0'\nexit 0\n",
     );
+    let binding =
+        RenderBinding::new("b2-rs1-lan1-ipv4", &temp.path().join("b2-rs1-lan1-ipv4")).unwrap();
     assert_eq!(
-        ixp_manager::write_checked_candidate(&input, &from_file, 300, &checker),
-        ixp_manager::write_checked_candidate_bytes(FIXTURE, &from_memory, 300, &checker)
+        ixp_manager::write_checked_candidate(&input, &from_file, 300, &checker, &binding),
+        ixp_manager::write_checked_candidate_bytes(FIXTURE, &from_memory, 300, &checker, &binding,)
     );
     for relative in [
         "config.toml",
@@ -578,13 +666,9 @@ fn in_memory_renderer_is_byte_identical_to_private_file_entry_point() {
 }
 
 #[test]
-fn lifecycle_state_lock_is_exclusive_before_any_network_request() {
+fn host_lock_is_exclusive_before_any_network_request() {
     let rig = Rig::new();
-    let lock = rig.state.join("ixp-manager-lifecycle.lock");
-    fs::write(&lock, []).unwrap();
-    mode(&lock, 0o600);
-    let held = File::options().read(true).write(true).open(lock).unwrap();
-    held.try_lock().unwrap();
+    let _held = Guard::claim_new(rig.binding()).unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
         .args([
             "ixp-manager-lifecycle",
@@ -592,12 +676,18 @@ fn lifecycle_state_lock_is_exclusive_before_any_network_request() {
             "--ixp-origin",
             "http://127.0.0.1:9",
             "--router-handle",
-            "rs1-ipv4",
+            "b2-rs1-lan1-ipv4",
             "--api-key-file",
         ])
         .arg(&rig.key)
         .arg("--state-dir")
         .arg(&rig.state)
+        .arg("--runtime-state-dir")
+        .arg(&rig.runtime)
+        .arg("--host-state-dir")
+        .arg(&rig.host)
+        .arg("--rbgp-addr")
+        .arg(rig.binding.rbgp_addr())
         .args(["--request-timeout-seconds", "1", "--allow-http-loopback"])
         .output()
         .unwrap();
@@ -605,8 +695,176 @@ fn lifecycle_state_lock_is_exclusive_before_any_network_request() {
     assert!(
         String::from_utf8(output.stderr)
             .unwrap()
-            .contains("another lifecycle command is active")
+            .contains("another host command is active")
     );
+}
+
+#[test]
+fn guard_clear_is_bound_to_the_claimed_host() {
+    let first = Rig::new();
+    let second = Rig::new();
+    let first_guard = Guard::claim_new(first.binding()).unwrap();
+    let second_guard = Guard::claim_new(second.binding()).unwrap();
+    first_guard.clear().unwrap();
+    assert!(!first.host.join("ixp-manager-host-fence.json").exists());
+    assert!(second.host.join("ixp-manager-host-fence.json").exists());
+    second_guard.clear().unwrap();
+}
+
+#[test]
+fn per_handle_state_lock_refuses_before_publishing_host_fence() {
+    let rig = Rig::new();
+    let lock = rig.state.join("ixp-manager-lifecycle.lock");
+    fs::write(&lock, []).unwrap();
+    mode(&lock, 0o600);
+    let held = File::options().read(true).write(true).open(lock).unwrap();
+    held.try_lock().unwrap();
+    assert_eq!(
+        lifecycle::run(&rig.options("http://127.0.0.1:9")),
+        Err(Error::Refused("another lifecycle command is active"))
+    );
+    assert!(!rig.host.join("ixp-manager-host-fence.json").exists());
+}
+
+#[test]
+fn topology_mismatches_are_refused_before_network_effects() {
+    let rig = Rig::new();
+    let forged: Binding = serde_json::from_value(serde_json::json!({
+        "router_handle": "foreign",
+        "runtime_state_dir": rig.runtime,
+        "activation_state_dir": rig.state,
+        "host_state_dir": rig.host,
+        "rbgp_addr": rig.binding.rbgp_addr()
+    }))
+    .unwrap();
+    assert!(matches!(
+        Guard::claim_new(&forged),
+        Err(rs_config_render::ixp_manager_host::Error::Refused(_))
+    ));
+    let wrong_runtime = rig.root.join("wrong-basename");
+    assert!(
+        Binding::new(
+            "b2-rs1-lan1-ipv4",
+            &wrong_runtime,
+            &wrong_runtime.join("activation"),
+            &rig.host,
+            &format!("unix://{}/grpc.sock", wrong_runtime.display()),
+        )
+        .is_err()
+    );
+    assert!(
+        Binding::new(
+            "b2-rs1-lan1-ipv4",
+            &rig.runtime,
+            &rig.root.join("other-state"),
+            &rig.host,
+            rig.binding.rbgp_addr(),
+        )
+        .is_err()
+    );
+    assert!(
+        Binding::new(
+            "b2-rs1-lan1-ipv4",
+            &rig.runtime,
+            &rig.state,
+            &rig.host,
+            "unix:///wrong/grpc.sock",
+        )
+        .is_err()
+    );
+
+    let wrong_state = rig.root.join("other-state");
+    private_dir(&wrong_state);
+    let mut options = rig.options("http://127.0.0.1:9");
+    options.state_dir = &wrong_state;
+    assert!(matches!(lifecycle::run(&options), Err(Error::Refused(_))));
+    let mut options = rig.options("http://127.0.0.1:9");
+    options.rbgp_addr = "unix:///wrong/grpc.sock";
+    assert!(matches!(lifecycle::run(&options), Err(Error::Refused(_))));
+}
+
+#[test]
+fn killed_run_retains_owner_fence_and_foreign_resume_cannot_bypass_it() {
+    let rig = Rig::new();
+    let server = Server::start(vec![
+        Response::json(200).after_delay(Duration::from_secs(30)),
+    ]);
+    let mut child = run_cli(&rig, &server.origin)
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while server.requests.lock().unwrap().is_empty() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "lock request was not observed"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+    child.kill().unwrap();
+    child.wait().unwrap();
+    assert!(rig.host.join("ixp-manager-host-fence.json").exists());
+    assert!(rig.state.join("ixp-manager-lifecycle.json").exists());
+
+    let foreign_runtime = rig.root.join("foreign-ipv4");
+    private_dir(&foreign_runtime);
+    let foreign_state = foreign_runtime.join("activation");
+    private_dir(&foreign_state);
+    let foreign = Binding::new(
+        "foreign-ipv4",
+        &foreign_runtime,
+        &foreign_state,
+        &rig.host,
+        &format!("unix://{}/grpc.sock", foreign_runtime.display()),
+    )
+    .unwrap();
+    let foreign_resume = lifecycle::ResumeOptions {
+        ixp_origin: &server.origin,
+        router_handle: "foreign-ipv4",
+        api_key_file: &rig.key,
+        state_dir: &foreign_state,
+        timeout: Duration::from_secs(1),
+        allow_http_loopback: true,
+        binding: &foreign,
+    };
+    assert_eq!(
+        lifecycle::resume(&foreign_resume),
+        Err(Error::Refused("foreign host fence"))
+    );
+    assert_eq!(
+        lifecycle::run(&rig.options(&server.origin)),
+        Err(Error::ManualRecovery)
+    );
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&server.origin)),
+        Err(Error::ManualRecovery)
+    );
+    assert_eq!(server.requests.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn callback_cleanup_failure_retains_fence_until_matching_resume() {
+    let rig = Rig::new();
+    let server = Server::start(vec![
+        Response::json(200),
+        Response::config(FIXTURE),
+        Response::json(200).after_chmod(rig.state.clone(), 0o500),
+        Response::json(200),
+    ]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&server.origin)),
+        Err(Error::ManualRecovery)
+    );
+    assert!(rig.state.join("ixp-manager-lifecycle.json").exists());
+    assert!(rig.host.join("ixp-manager-host-fence.json").exists());
+    mode(&rig.state, 0o700);
+    assert_eq!(
+        lifecycle::resume(&rig.resume_options(&server.origin)),
+        Ok(Status::Updated)
+    );
+    server.finish();
+    assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
+    assert!(!rig.host.join("ixp-manager-host-fence.json").exists());
 }
 
 #[test]
@@ -630,11 +888,14 @@ fn additive_cli_help_pins_run_and_callback_only_resume() {
         "--router-handle",
         "--api-key-file",
         "--state-dir",
+        "--runtime-state-dir",
+        "--host-state-dir",
+        "--rbgp-addr",
         "--request-timeout-seconds",
     ] {
         assert!(resume.contains(flag), "missing {flag}: {resume}");
     }
-    for forbidden in ["--candidate-dir", "--rbgp", "--activation-command"] {
+    for forbidden in ["--candidate-dir", "--rbgp <", "--activation-command"] {
         assert!(!resume.contains(forbidden), "resume exposed {forbidden}");
     }
 }
@@ -657,12 +918,16 @@ fn poisoned_proxy_is_ignored_and_cli_reports_the_exact_terminal_status() {
             "--ixp-origin",
             &server.origin,
             "--router-handle",
-            "rs1-ipv4",
+            "b2-rs1-lan1-ipv4",
             "--api-key-file",
         ])
         .arg(&rig.key)
         .arg("--state-dir")
         .arg(&rig.state)
+        .arg("--runtime-state-dir")
+        .arg(&rig.runtime)
+        .arg("--host-state-dir")
+        .arg(&rig.host)
         .arg("--candidate-dir")
         .arg(&rig.candidate)
         .arg("--check-with")
@@ -671,7 +936,7 @@ fn poisoned_proxy_is_ignored_and_cli_reports_the_exact_terminal_status() {
         .arg(&rig.rbgp)
         .args([
             "--rbgp-addr",
-            "test",
+            rig.binding.rbgp_addr(),
             "--settle-seconds",
             "2",
             "--request-timeout-seconds",
@@ -700,8 +965,8 @@ fn poisoned_proxy_is_ignored_and_cli_reports_the_exact_terminal_status() {
 
 #[test]
 fn only_the_pinned_definite_lock_statuses_clear_the_intent() {
-    let rig = Rig::new();
     for status in [401, 403, 404, 405, 422, 423] {
+        let rig = Rig::new();
         let server = Server::start(vec![Response::json(status)]);
         assert!(matches!(
             lifecycle::run(&rig.options(&server.origin)),
@@ -711,6 +976,7 @@ fn only_the_pinned_definite_lock_statuses_clear_the_intent() {
         assert!(!rig.state.join("ixp-manager-lifecycle.json").exists());
     }
     for status in [302, 400, 429, 500] {
+        let rig = Rig::new();
         let server = Server::start(vec![Response::json(status)]);
         assert_eq!(
             lifecycle::run(&rig.options(&server.origin)),
@@ -718,7 +984,7 @@ fn only_the_pinned_definite_lock_statuses_clear_the_intent() {
         );
         server.finish();
         assert!(rig.state.join("ixp-manager-lifecycle.json").exists());
-        fs::remove_file(rig.state.join("ixp-manager-lifecycle.json")).unwrap();
+        assert!(rig.host.join("ixp-manager-host-fence.json").exists());
     }
 }
 


### PR DESCRIPTION
## Summary

- bind rendered and activated configuration to one exact per-handle runtime directory, activation state, router handle, and gRPC socket
- serialize co-resident lifecycle commands with a shared advisory lock and retain a durable owner fence across process death, callback-pending, and ambiguous outcomes
- clear only a matching fence after durable terminal journal cleanup; foreign handles cannot clear or bypass uncertain state

## Verification

- focused render 4/4, activation 7/7, lifecycle 18/18
- package serial suite and full workspace all-feature tests
- strict package and workspace all-target/all-feature Clippy
- warning-denied workspace docs and v1-surface checker
- eight destructive mutations, all red and restored
- direct process-kill, callback cleanup failure/replay, foreign guard, and serde-forged binding proofs
- independent exact-diff audit

Package/systemd payloads and the real dual-stack two-handle M97 proof remain in LAN-1144.