### PR TITLE
Ship paired IXP route-server instances

### DIFF
--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -20,6 +20,7 @@ on:
       - examples/docker-compose/docker-compose.yml
       - examples/docker-compose/README.md
       - examples/systemd/rustbgpd.service
+      - examples/systemd/rustbgpd@.service
       - examples/prometheus/rustbgpd-alerts.yml
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
@@ -50,6 +51,7 @@ on:
       - examples/docker-compose/docker-compose.yml
       - examples/docker-compose/README.md
       - examples/systemd/rustbgpd.service
+      - examples/systemd/rustbgpd@.service
       - examples/prometheus/rustbgpd-alerts.yml
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
@@ -123,6 +125,7 @@ jobs:
                 || { echo "missing or not executable: $tree/usr/bin/$exe" >&2; exit 1; }
             done
             for file in lib/systemd/system/rustbgpd.service \
+                        lib/systemd/system/rustbgpd@.service \
                         usr/share/man/man1/rbgp.1.gz \
                         usr/share/man/man8/rustbgpd.8.gz \
                         usr/share/doc/rustbgpd/LICENSES.md; do
@@ -136,16 +139,23 @@ jobs:
             for directive in StartLimitIntervalSec=10min StartLimitBurst=5 Restart=on-failure RestartSec=5 TimeoutStopSec=32min; do
               grep -qxF "$directive" "$unit"
             done
-          python3 - "$unit" <<'PY'
+            template="$tree/lib/systemd/system/rustbgpd@.service"
+            grep -qxF 'ExecStart=/usr/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml' "$template"
+            grep -qxF 'StateDirectory=rustbgpd/%i rustbgpd/%i/activation' "$template"
+            grep -qxF 'ReadWritePaths=/var/lib/rustbgpd/%i' "$template"
+          python3 - "$unit" "$template" <<'PY'
           import sys
           from pathlib import Path
-          from scripts.check_release_install_contract import systemd_assignments, systemd_status_is_70
+          from scripts.check_release_install_contract import check_systemd_template, systemd_assignments, systemd_status_is_70
 
           for _, key, value in systemd_assignments(Path(sys.argv[1]).read_text()):
               if key in {"SuccessExitStatus", "RestartPreventExitStatus"} and any(
                   systemd_status_is_70(token) for token in value.split()
               ):
                   raise SystemExit(f"exit 70/SOFTWARE must remain restartable: {sys.argv[1]}")
+          template_errors = []
+          check_systemd_template(template_errors, Path(sys.argv[2]).read_text(), packaged=True)
+          if template_errors: raise SystemExit("; ".join(template_errors))
           PY
           done
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           #   share/man/man1/rbgp.1                   CLI man page
           #   share/man/man8/rustbgpd.8               daemon man page
           #   share/completions/rbgp.{bash,zsh,fish}  shell completions
-          #   share/systemd/rustbgpd.service          hardened systemd unit
+          #   share/systemd/rustbgpd{,@}.service      hardened systemd units
           #   share/systemd/rustbgpd-dataplane.conf   opt-in CAP_NET_ADMIN drop-in
           #   share/monitoring/rustbgpd-overview.json Grafana dashboard
           #   share/monitoring/rustbgpd-alerts.yml    Prometheus alert rules
@@ -169,7 +169,7 @@ jobs:
           cp target/${{ matrix.target }}/release/birdwatcher-adapter staging/
           cp LICENSE-MIT LICENSE-APACHE LICENSES.md staging/
           cp docs/rustbgpd.schema.json staging/
-          cp examples/systemd/rustbgpd.service \
+          cp examples/systemd/rustbgpd.service examples/systemd/rustbgpd@.service \
             examples/systemd/rustbgpd-dataplane.conf staging/share/systemd/
           cp docs/grafana/rustbgpd-overview.json staging/share/monitoring/
           cp examples/prometheus/rustbgpd-alerts.yml \
@@ -214,6 +214,7 @@ jobs:
                    share/completions/rbgp.bash share/completions/rbgp.zsh \
                    share/completions/rbgp.fish \
                    share/systemd/rustbgpd.service \
+                   share/systemd/rustbgpd@.service \
                    share/systemd/rustbgpd-dataplane.conf \
                    share/monitoring/rustbgpd-overview.json \
                    share/monitoring/rustbgpd-alerts.yml \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Release tarballs, Debian packages, and RPMs now ship an opt-in
+  `rustbgpd@.service` with exact per-handle IXP Manager state and UDS binding.
+  M97 proves two pinned IPv4/IPv6 handles share one host namespace and host
+  fence while retaining distinct PIDs, TCP/179 listeners, state, sessions, and
+  failure domains. (LAN-1144)
 - `birdwatcher-adapter` now serves IXP Manager v7.4.0's exact member
   filtered-prefix wildcard journey from retained rejects. It accepts only the
   daemon's `{ASN}:1101:*` namespace, removes wire-supplied values there before

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -620,9 +620,11 @@ not settle leaves the candidate current; exit 5 requires explicit recovery.
 M96 proves the pre-effect restoration against an MD5-authenticated FRR member
 without a daemon restart or session flap. The authenticated v7.4 lifecycle now
 journals lock intent, fetches the real Foil boundary, drives that activation,
-and delivers explicit updated/release callbacks; M97 proves the real database
-transitions and MD5-FRR continuity. Active UI-filter translation, custom-skin
-migration, and multi-address ownership remain open. The external adapter now
+and delivers explicit updated/release callbacks. The packaged opt-in
+`rustbgpd@.service` and M97 prove two exact IPv4/IPv6 handles in one host
+namespace with shared-fence serialization and independent MD5-BGP continuity.
+Active UI-filter translation, custom-skin migration, and multi-address
+ownership remain open. The external adapter now
 also serves the IXP Manager v7.4 status, live protocol inventory/detail,
 symbols, member received, and member export slice through immutable aliases
 with an enforced response maximum. Its exact member filtered-prefix wildcard

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -72,10 +72,11 @@ exact prior bytes and runtime without a second activation. Focused tests prove
 that a started command's failure retains the candidate for explicit recovery.
 M96 also covers complete symlink targets, live diff zero, route/session
 continuity, unchanged daemon PID/flaps, private modes, literal arguments, and
-secret-free receipts/output. M97 adds the authenticated IXP Manager v7.4
-lifecycle: real API-key rejection, router lock and competing-423 behavior,
-Foil fetch/render, database-visible updated/release callbacks, and the same
-MD5-FRR continuity. Ambiguous remote or activation effects remain operator
+secret-free receipts/output. M97 adds two exact IPv4/IPv6 handles in one host
+namespace: distinct PIDs, state/UDS endpoints, TCP/179 listeners, and real
+MD5-FRR sessions, plus a shared durable host fence, paired competing-423
+behavior, sequential callbacks, and cross-handle failure containment.
+Ambiguous remote or activation effects remain operator
 owned. Filter translation, custom-skin migration, and multi-address parity
 remain open.
 
@@ -122,7 +123,7 @@ dispatch always run.
 - **Core RR against incumbents** — RFC 4456 reflection + RFC 4724 GR helper-truth against BIRD 2 clients and OpenBGPD 9.1 clients, plus required-family OPEN enforcement against BIRD: **M85**, **M86**, **M93**.
 - **Live policy-presence safety** — ADR-0112 RFC 8212 import-presence transitions qualified for Route Refresh, rejected whole when one peer cannot converge, and converged on the wire when it can: **M95**.
 - **IXP Manager local activation** — pinned v7.4 Foil render, atomic publication, live settlement, and pre-effect restoration against MD5-authenticated FRR: **M96** (local).
-- **IXP Manager authenticated lifecycle** — pinned v7.4 API lock/fetch/callback state around the M96 activation seam, with database and MD5-FRR proof: **M97** (local).
+- **IXP Manager authenticated lifecycle** — pinned v7.4 API lock/fetch/callback state for two same-host IPv4/IPv6 handles, with shared-fence, database, and MD5-FRR proof: **M97** (local).
 - **Graceful Shutdown** — receiver/initiator coverage across unicast, FlowSpec, and EVPN: **M35**, **M35b**, **M35c**.
 - **BLACKHOLE FIB discard** — RFC 7999 receiver scoping plus opt-in kernel discard install / withdraw: **M41**.
 - **gRPC/gNMI + EVPN injection** — ADR-0064 mTLS tier enforcement, ADR-0070 gNMI / OpenConfig telemetry + Set, gNMI Subscribe ON_CHANGE, and EVPN Type 5 control-plane injection: **M44**, **M54**, **M56**, **M45**.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,6 +55,7 @@ share/man/man1/rbgp.1                   CLI man page
 share/man/man8/rustbgpd.8               daemon man page
 share/completions/rbgp.{bash,zsh,fish}  shell completions
 share/systemd/rustbgpd.service          hardened systemd unit
+share/systemd/rustbgpd@.service         opt-in per-handle systemd unit
 share/systemd/rustbgpd-dataplane.conf   opt-in CAP_NET_ADMIN drop-in
 share/monitoring/rustbgpd-overview.json Grafana dashboard
 share/monitoring/rustbgpd-alerts.yml    Prometheus alert rules
@@ -90,7 +91,7 @@ sudo install -m 0644 share/completions/rbgp.bash \
 sudo useradd --system --home-dir /var/lib/rustbgpd \
   --shell /usr/sbin/nologin rustbgpd 2>/dev/null || true
 sudo install -m 0644 share/systemd/rustbgpd.service \
-  /etc/systemd/system/rustbgpd.service
+  share/systemd/rustbgpd@.service /etc/systemd/system/
 sudo install -d -m 0755 /etc/rustbgpd
 rustbgpd --init-config edge | \
   sudo tee /etc/rustbgpd/config.toml >/dev/null
@@ -207,8 +208,9 @@ sudo dnf install -y \
 <!-- release-install-contract:native-package:start -->
 The package installs the four binaries (`rustbgpd`, `rbgp`,
 `rs-config-render`, and `birdwatcher-adapter`) to `/usr/bin`, the hardened
-systemd unit (see [systemd](#systemd) below — same unit, `ExecStart`
-pointed at `/usr/bin`), man pages and shell completions, and creates
+systemd singleton and opt-in per-handle template units (see
+[systemd](#systemd) below — `ExecStart` pointed at `/usr/bin`), man pages and
+shell completions, and creates
 the `rustbgpd` system user (imperatively at install time, plus a
 declarative `sysusers.d` file). A starter config lands at
 `/etc/rustbgpd/config.toml` (mode `0640 root:rustbgpd`, never
@@ -375,6 +377,25 @@ system user, the standard sandbox set (`NoNewPrivileges`,
 `RuntimeDirectory`), and a capability set of exactly
 `CAP_NET_BIND_SERVICE` (bind port 179 as non-root). That is everything
 a route-reflector / control-plane-only deployment needs.
+
+Releases also ship the opt-in
+[`rustbgpd@.service`](../examples/systemd/rustbgpd@.service) for IXP Manager.
+Literal `%i` is the exact router handle: it selects
+`/var/lib/rustbgpd/%i/activation/current/config.toml`, a private per-handle
+runtime/UDS, and no writable access to the shared lifecycle fence. Pre-create
+each exact handle and the one shared fence directory before the first lifecycle
+run; authorize and invoke only literal instances, never a wildcard sudoers rule:
+
+```sh
+handle=rs1-ipv4
+sudo install -d -m 0700 -o rustbgpd -g rustbgpd \
+  "/var/lib/rustbgpd/$handle" "/var/lib/rustbgpd/$handle/activation" \
+  /var/lib/rustbgpd/ixp-manager-host
+sudo systemctl enable "rustbgpd@$handle"
+```
+
+Use distinct runtime/activation/UDS paths for every handle and the same
+`/var/lib/rustbgpd/ixp-manager-host` for all lifecycle commands on that host.
 
 Notes on the sandbox:
 

--- a/examples/systemd/rustbgpd@.service
+++ b/examples/systemd/rustbgpd@.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=rustbgpd BGP daemon (%i)
+Documentation=https://github.com/lance0/rustbgpd
+After=network-online.target
+Wants=network-online.target
+# Bound repeated fail-stop recovery: five starts per ten-minute window.
+StartLimitIntervalSec=10min
+StartLimitBurst=5
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml
+ExecReload=/bin/kill -HUP $MAINPID
+
+User=rustbgpd
+Group=rustbgpd
+
+# Keep each IXP Manager handle's daemon and activation state private.
+StateDirectory=rustbgpd/%i rustbgpd/%i/activation
+StateDirectoryMode=0700
+RuntimeDirectory=rustbgpd/%i
+RuntimeDirectoryMode=0700
+UMask=0077
+
+# Security hardening. The shared lifecycle host fence is intentionally
+# outside this daemon's writable namespace.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/rustbgpd/%i
+PrivateTmp=yes
+
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=32min
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -43,6 +43,10 @@ contents:
     dst: /lib/systemd/system/rustbgpd.service
     file_info:
       mode: 0644
+  - src: ${PKGROOT}/lib/systemd/system/rustbgpd@.service
+    dst: /lib/systemd/system/rustbgpd@.service
+    file_info:
+      mode: 0644
   - src: packaging/sysusers.conf
     dst: /usr/lib/sysusers.d/rustbgpd.conf
     file_info:

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -56,15 +56,23 @@ install -D -m 0755 "$staging/rbgp" "$pkgroot/usr/bin/rbgp"
 install -D -m 0755 "$staging/rs-config-render" "$pkgroot/usr/bin/rs-config-render"
 install -D -m 0755 "$staging/birdwatcher-adapter" "$pkgroot/usr/bin/birdwatcher-adapter"
 
-# systemd unit: packages install binaries to /usr/bin, the example unit
-# points at /usr/local/bin (the tarball install path).
-grep -q '^ExecStart=/usr/local/bin/rustbgpd ' examples/systemd/rustbgpd.service || {
-    echo "error: examples/systemd/rustbgpd.service ExecStart no longer matches the expected /usr/local/bin path; update this script" >&2
+# systemd units: packages install binaries to /usr/bin; the examples point at
+# /usr/local/bin (the tarball install path). Rewrite only that binary path.
+mkdir -p "$pkgroot/lib/systemd/system"
+for unit in rustbgpd.service 'rustbgpd@.service'; do
+    source="examples/systemd/$unit"
+    grep -q '^ExecStart=/usr/local/bin/rustbgpd ' "$source" || {
+        echo "error: $source ExecStart no longer matches the expected /usr/local/bin path; update this script" >&2
+        exit 1
+    }
+    sed 's|^ExecStart=/usr/local/bin/rustbgpd |ExecStart=/usr/bin/rustbgpd |' \
+        "$source" > "$pkgroot/lib/systemd/system/$unit"
+done
+grep -qxF 'ExecStart=/usr/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml' \
+    "$pkgroot/lib/systemd/system/rustbgpd@.service" || {
+    echo "error: packaged template changed the per-handle activation config path" >&2
     exit 1
 }
-mkdir -p "$pkgroot/lib/systemd/system"
-sed 's|^ExecStart=/usr/local/bin/rustbgpd |ExecStart=/usr/bin/rustbgpd |' \
-    examples/systemd/rustbgpd.service > "$pkgroot/lib/systemd/system/rustbgpd.service"
 
 # Config skeleton: the minimal example with its dev-friendly /tmp state
 # dir rewritten to the production path the systemd unit provides.

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -12,6 +12,7 @@ BINARIES = ("rustbgpd", "rbgp", "rs-config-render", "birdwatcher-adapter")
 LICENSES = ("LICENSE-MIT", "LICENSE-APACHE", "LICENSES.md")
 SYSTEMD = (
     "share/systemd/rustbgpd.service",
+    "share/systemd/rustbgpd@.service",
     "share/systemd/rustbgpd-dataplane.conf",
 )
 MONITORING = (
@@ -32,6 +33,7 @@ MONITORING = (
     ),
 )
 SYSTEMD_UNIT = "examples/systemd/rustbgpd.service"
+SYSTEMD_TEMPLATE = "examples/systemd/rustbgpd@.service"
 COMPOSE_FILE = "examples/docker-compose/docker-compose.yml"
 LICENSE_MAP = "LICENSES.md"
 SYSTEMD_DIRECTIVES = {
@@ -40,6 +42,21 @@ SYSTEMD_DIRECTIVES = {
     ("Service", "Restart"): "on-failure",
     ("Service", "RestartSec"): "5",
     ("Service", "TimeoutStopSec"): "32min",
+}
+TEMPLATE_DIRECTIVES = {
+    ("Service", "ExecStart"): "/usr/local/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml",
+    ("Service", "StateDirectory"): "rustbgpd/%i rustbgpd/%i/activation",
+    ("Service", "StateDirectoryMode"): "0700",
+    ("Service", "RuntimeDirectory"): "rustbgpd/%i",
+    ("Service", "RuntimeDirectoryMode"): "0700",
+    ("Service", "UMask"): "0077",
+    ("Service", "NoNewPrivileges"): "yes",
+    ("Service", "ProtectSystem"): "strict",
+    ("Service", "ProtectHome"): "yes",
+    ("Service", "ReadWritePaths"): "/var/lib/rustbgpd/%i",
+    ("Service", "PrivateTmp"): "yes",
+    ("Service", "AmbientCapabilities"): "CAP_NET_BIND_SERVICE",
+    ("Service", "CapabilityBoundingSet"): "CAP_NET_BIND_SERVICE",
 }
 
 
@@ -177,6 +194,32 @@ def check_systemd_unit(errors: list[str], text: str) -> None:
             )
 
 
+def check_systemd_template(
+    errors: list[str], text: str, *, packaged: bool = False
+) -> None:
+    assignments = systemd_assignments(text)
+    expected_directives = TEMPLATE_DIRECTIVES | {
+        ("Service", "ExecStart"): (
+            "/usr/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml"
+            if packaged
+            else TEMPLATE_DIRECTIVES[("Service", "ExecStart")]
+        )
+    }
+    for (section, key), expected in expected_directives.items():
+        actual = [
+            value
+            for found_section, found_key, value in assignments
+            if found_section == section and found_key == key
+        ]
+        if actual != [expected]:
+            errors.append(
+                f"systemd template: [{section}] {key} must occur once with value {expected!r}, got {actual!r}"
+            )
+    if "%I" in text:
+        errors.append("systemd template: unescaped %I must not replace the exact router handle")
+    check_systemd_unit(errors, text)
+
+
 def compose_service(text: str, name: str) -> tuple[str, ...]:
     lines = text.splitlines()
     marker = f"  {name}:"
@@ -219,6 +262,7 @@ def check(root: Path) -> list[str]:
     read = lambda path: (root / path).read_text(encoding="utf-8")
     try:
         check_systemd_unit(errors, read(SYSTEMD_UNIT))
+        check_systemd_template(errors, read(SYSTEMD_TEMPLATE))
         check_compose(errors, read(COMPOSE_FILE))
         license_map = read(LICENSE_MAP)
         for clause in (
@@ -229,6 +273,17 @@ def check(root: Path) -> list[str]:
             if clause not in license_map:
                 errors.append(f"license map: missing CDLA clause {clause!r}")
         release = read(".github/workflows/release.yml")
+        build_packages = read("scripts/build-packages.sh")
+        require_patterns(
+            errors,
+            "native systemd staging",
+            build_packages,
+            (
+                exact("for unit in rustbgpd.service 'rustbgpd@.service'; do"),
+                r"^\s+sed 's\|\^ExecStart=/usr/local/bin/rustbgpd \|ExecStart=/usr/bin/rustbgpd \|' \\$",
+                r"^grep -qxF 'ExecStart=/usr/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config\.toml' \\$",
+            ),
+        )
         package_tar = (
             "tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz rustbgpd rbgp "
             "rs-config-render birdwatcher-adapter LICENSE-MIT LICENSE-APACHE LICENSES.md rustbgpd.schema.json share"
@@ -239,7 +294,7 @@ def check(root: Path) -> list[str]:
             for binary in BINARIES
         ) + (
             r"^cp LICENSE-MIT LICENSE-APACHE LICENSES\.md staging/$",
-            r"^cp examples/systemd/rustbgpd\.service examples/systemd/rustbgpd-dataplane\.conf staging/share/systemd/$",
+            r"^cp examples/systemd/rustbgpd\.service examples/systemd/rustbgpd@\.service examples/systemd/rustbgpd-dataplane\.conf staging/share/systemd/$",
             r"^cp docs/grafana/rustbgpd-overview\.json staging/share/monitoring/$",
             r"^cp examples/prometheus/rustbgpd-alerts\.yml examples/prometheus/rustbgpd-alerts_test\.yml staging/share/monitoring/$",
             exact(package_tar),
@@ -290,6 +345,12 @@ def check(root: Path) -> list[str]:
         license_mapping = (LICENSE_MAP, "/usr/share/doc/rustbgpd/LICENSES.md")
         if license_mapping not in mappings:
             errors.append(f"native license mapping missing {license_mapping!r}")
+        template_mapping = (
+            "${PKGROOT}/lib/systemd/system/rustbgpd@.service",
+            "/lib/systemd/system/rustbgpd@.service",
+        )
+        if template_mapping not in mappings:
+            errors.append(f"native systemd template mapping missing {template_mapping!r}")
 
         contract = read(".github/workflows/release-install-contract.yml")
         native = select_script(
@@ -310,16 +371,23 @@ def check(root: Path) -> list[str]:
                 r"^for tree in extracted/deb extracted/rpm; do$",
                 r"^for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do$",
                 r'^test -x "\$tree/usr/bin/\$exe" ',
-                r"^for file in lib/systemd/system/rustbgpd\.service usr/share/man/man1/rbgp\.1\.gz usr/share/man/man8/rustbgpd\.8\.gz usr/share/doc/rustbgpd/LICENSES\.md; do$",
+                r"^for file in lib/systemd/system/rustbgpd\.service lib/systemd/system/rustbgpd@\.service usr/share/man/man1/rbgp\.1\.gz usr/share/man/man8/rustbgpd\.8\.gz usr/share/doc/rustbgpd/LICENSES\.md; do$",
                 r'^test -s "\$tree/\$file" ',
                 r'^"\$tree/usr/bin/rustbgpd" --check "\$tree/etc/rustbgpd/config\.toml"$',
                 r'^unit="\$tree/lib/systemd/system/rustbgpd\.service"$',
                 r"^for directive in StartLimitIntervalSec=10min StartLimitBurst=5 Restart=on-failure RestartSec=5 TimeoutStopSec=32min; do$",
                 r'^grep -qxF "\$directive" "\$unit"$',
-                r"^from scripts\.check_release_install_contract import systemd_assignments, systemd_status_is_70$",
+                r'^template="\$tree/lib/systemd/system/rustbgpd@\.service"$',
+                exact("grep -qxF 'ExecStart=/usr/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml' \"$template\""),
+                exact("grep -qxF 'StateDirectory=rustbgpd/%i rustbgpd/%i/activation' \"$template\""),
+                exact("grep -qxF 'ReadWritePaths=/var/lib/rustbgpd/%i' \"$template\""),
+                r"^from scripts\.check_release_install_contract import check_systemd_template, systemd_assignments, systemd_status_is_70$",
                 r"^for _, key, value in systemd_assignments\(Path\(sys\.argv\[1\]\)\.read_text\(\)\):$",
                 r'^if key in \{"SuccessExitStatus", "RestartPreventExitStatus"\} and any\($',
                 r"^systemd_status_is_70\(token\) for token in value\.split\(\)$",
+                r'^template_errors = \[\]$',
+                r'^check_systemd_template\(template_errors, Path\(sys\.argv\[2\]\)\.read_text\(\), packaged=True\)$',
+                r'^if template_errors: raise SystemExit\("; "\.join\(template_errors\)\)$',
             ),
         )
         if "--to-stdout" in native:

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -16,7 +16,8 @@ RPM_EXTRACT = "cpio --quiet -id --no-absolute-filenames --directory=extracted/rp
 EXE_LOOP = "for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do"
 IMAGE_RUN = "run: docker run --rm --entrypoint birdwatcher-adapter"
 UNIT_ASSERT = 'grep -qxF "$directive" "$unit"'
-STATUS_GUARD = "from scripts.check_release_install_contract import systemd_assignments, systemd_status_is_70"
+TEMPLATE_EXEC_ASSERT = "grep -qxF 'ExecStart=/usr/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml' \"$template\""
+STATUS_GUARD = "from scripts.check_release_install_contract import check_systemd_template, systemd_assignments, systemd_status_is_70"
 MONITORING_MAPPING = "native monitoring mappings"
 GREP_ASSERT = 'if ! grep -qxF "$f" <<<"$entries"; then'
 TAR_SIZE_ASSERT = (
@@ -26,14 +27,82 @@ INPUTS = (
     WORKFLOW,
     RELEASE,
     "packaging/nfpm.yaml",
+    "scripts/build-packages.sh",
     "docs/grafana/rustbgpd-overview.json",
     "examples/prometheus/rustbgpd-alerts.yml",
     "examples/prometheus/rustbgpd-alerts_test.yml",
     contract.SYSTEMD_UNIT,
+    contract.SYSTEMD_TEMPLATE,
     contract.COMPOSE_FILE,
     contract.LICENSE_MAP,
 )
 MUTATIONS = (
+    (
+        "scripts/build-packages.sh",
+        "for unit in rustbgpd.service 'rustbgpd@.service'; do",
+        "for unit in rustbgpd.service; do",
+        "native systemd staging",
+    ),
+    (
+        "scripts/build-packages.sh",
+        "sed 's|^ExecStart=/usr/local/bin/rustbgpd |ExecStart=/usr/bin/rustbgpd |' \\",
+        "sed 's|/usr/local/bin|/usr/bin|g' \\",
+        "native systemd staging",
+    ),
+    (
+        contract.SYSTEMD_TEMPLATE,
+        "/var/lib/rustbgpd/%i/activation/current/config.toml",
+        "/etc/rustbgpd/%i/config.toml",
+        "systemd template",
+    ),
+    (
+        contract.SYSTEMD_TEMPLATE,
+        "StateDirectory=rustbgpd/%i rustbgpd/%i/activation",
+        "StateDirectory=rustbgpd/%i",
+        "systemd template",
+    ),
+    (
+        contract.SYSTEMD_TEMPLATE,
+        "ReadWritePaths=/var/lib/rustbgpd/%i",
+        "ReadWritePaths=/var/lib/rustbgpd/%i /var/lib/rustbgpd/ixp-manager-host",
+        "systemd template",
+    ),
+    (
+        contract.SYSTEMD_TEMPLATE,
+        "%i",
+        "%I",
+        "systemd template",
+    ),
+    (
+        "packaging/nfpm.yaml",
+        "  - src: ${PKGROOT}/lib/systemd/system/rustbgpd@.service\n    dst: /lib/systemd/system/rustbgpd@.service",
+        "  - src: omitted-template\n    dst: /lib/systemd/system/omitted-template",
+        "native systemd template mapping",
+    ),
+    (
+        RELEASE,
+        " examples/systemd/rustbgpd@.service",
+        " examples/systemd/omitted-template.service",
+        "tarball package commands",
+    ),
+    (
+        RELEASE,
+        "                   share/systemd/rustbgpd@.service \\\n",
+        "",
+        "tarball payload assertions",
+    ),
+    (
+        WORKFLOW,
+        "                        lib/systemd/system/rustbgpd@.service \\\n",
+        "",
+        "real native package assertions",
+    ),
+    (
+        WORKFLOW,
+        TEMPLATE_EXEC_ASSERT,
+        "true # " + TEMPLATE_EXEC_ASSERT,
+        "real native package assertions",
+    ),
     (
         contract.LICENSE_MAP,
         '5.4. "Results" means any outcome obtained by computational analysis',

--- a/tests/interop/configs/frr-bgpd-m97-ixp-manager-dual.conf
+++ b/tests/interop/configs/frr-bgpd-m97-ixp-manager-dual.conf
@@ -1,0 +1,29 @@
+frr defaults traditional
+hostname m97-member
+service integrated-vtysh-config
+!
+ip route 31.135.128.0/19 Null0
+ipv6 route 2001:678:20::/48 Null0
+!
+router bgp 42
+ bgp router-id 10.1.0.36
+ no bgp ebgp-requires-policy
+ neighbor 192.0.2.18 remote-as 65501
+ neighbor 192.0.2.18 password mcWsqMdzGwTKt67g
+ neighbor 192.0.2.18 timers 3 9
+ neighbor 2001:db8::8 remote-as 65501
+ neighbor 2001:db8::8 local-as 1213 no-prepend replace-as
+ neighbor 2001:db8::8 password N7rX2SdfbRsyBLTm
+ neighbor 2001:db8::8 timers 3 9
+ !
+ address-family ipv4 unicast
+  network 31.135.128.0/19
+  neighbor 192.0.2.18 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  network 2001:678:20::/48
+  neighbor 2001:db8::8 activate
+ exit-address-family
+exit
+!

--- a/tests/interop/m97-ixp-manager-authenticated-lifecycle.clab.yml
+++ b/tests/interop/m97-ixp-manager-authenticated-lifecycle.clab.yml
@@ -1,5 +1,6 @@
 # Containerlab topology: pinned IXP Manager v7.4 lifecycle API, real MySQL,
 # rustbgpd, and the M96 MD5-authenticated FRR member.
+# M97 extends that proof to paired IPv4/IPv6 handles in the same namespace.
 #
 # Build prerequisites:
 #   docker build --target dev -t rustbgpd:dev .
@@ -20,7 +21,9 @@ topology:
       cmd: sleep infinity
       exec:
         - ip addr add 192.0.2.18/32 dev eth1
+        - ip -6 addr add 2001:db8::8/128 dev eth1
         - ip route add 10.1.0.36/32 dev eth1
+        - ip -6 route add 2001:db8:1::10/128 dev eth1
         - ip link set eth1 up
 
     ixp-manager:
@@ -53,10 +56,12 @@ topology:
       image: quay.io/frrouting/frr:10.3.1
       binds:
         - ./configs/frr-daemons:/etc/frr/daemons:ro
-        - ./configs/frr-bgpd-m96-ixp-manager.conf:/etc/frr/frr.conf:ro
+        - ./configs/frr-bgpd-m97-ixp-manager-dual.conf:/etc/frr/frr.conf:ro
       exec:
         - ip addr add 10.1.0.36/32 dev eth1
+        - ip -6 addr add 2001:db8:1::10/128 dev eth1
         - ip route add 192.0.2.18/32 dev eth1
+        - ip -6 route add 2001:db8::8/128 dev eth1
         - ip link set eth1 up
 
   links:

--- a/tests/interop/scripts/test-m97-ixp-manager-authenticated-lifecycle.sh
+++ b/tests/interop/scripts/test-m97-ixp-manager-authenticated-lifecycle.sh
@@ -1,22 +1,29 @@
 #!/usr/bin/env bash
 # M97: pinned IXP Manager v7.4 authenticated lifecycle and MD5 FRR continuity.
+# This tranche proves two packaged per-handle deployment identities.
 
 set -euo pipefail
 umask 077
 
-STATE=/var/lib/m97-lifecycle
+RUNTIME_ROOT=/var/lib/rustbgpd
+HOST_STATE=/var/lib/rustbgpd/ixp-manager-host
 
 # This file is copied into the rustbgpd container as the activation helper.
 if [ "${1:-}" = internal-activate ]; then
-    [ "$#" -eq 2 ] && [ "$2" = barrier ] || exit 64
-    touch /tmp/m97-activation-entered
+    [ "$#" -eq 3 ] && [ "$3" = barrier ] || exit 64
+    handle=$2
+    runtime=$RUNTIME_ROOT/$handle
+    state=$runtime/activation
+    pidfile=/tmp/m97-$handle.pid
+    touch "/tmp/m97-activation-entered-$handle"
     sleep 4
-    if pid=$(pidof -s rustbgpd 2>/dev/null); then
+    if [ -s "$pidfile" ] && pid=$(cat "$pidfile") && kill -0 "$pid" 2>/dev/null; then
         kill -HUP "$pid"
     else
         mkdir -p /var/lib/rustbgpd
-        nohup /usr/local/bin/rustbgpd "$STATE/current/config.toml" \
+        nohup /usr/local/bin/rustbgpd "$state/current/config.toml" \
             >/dev/null 2>&1 </dev/null &
+        printf '%s\n' "$!" >"$pidfile"
     fi
     exit 0
 fi
@@ -30,14 +37,20 @@ ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
 TOPOLOGY=$ROOT/tests/interop/m97-ixp-manager-authenticated-lifecycle.clab.yml
 ORIGIN=http://127.0.0.1:18080
 HANDLE=b2-rs1-lan1-ipv4
+HANDLE4=$HANDLE
+HANDLE6=b2-rs1-lan1-ipv6
 EXPECTED_COMMIT=300b7e0ba9adb0aaac975899e45fc8bcbc0ca37d
 TARGET=$ROOT/target/x86_64-unknown-linux-musl/debug/rs-config-render
 BIN=/usr/local/bin/rs-config-render
 ACT=/usr/local/bin/m97-activate
 KEY_FILE=/var/lib/m97-api-key
 WRONG_KEY_FILE=/var/lib/m97-wrong-api-key
-ADDR=unix:///var/lib/rustbgpd/grpc.sock
+PEER4=10.1.0.36
+PEER6=2001:db8:1::10
+PREFIX4=31.135.128.0/19
+PREFIX6=2001:678:20::/48
 MD5=mcWsqMdzGwTKt67g
+MD56=N7rX2SdfbRsyBLTm
 WORK=$(mktemp -d)
 LIFECYCLE_PID=
 
@@ -98,11 +111,19 @@ docker exec -i "$MYSQL" mysql --user root ixp_ci <<'SQL'
 UPDATE routers SET template='api/v4/router/server/rustbgpd/json',
   last_update_started=NULL, last_updated=NULL, pause_updates=0
   WHERE handle='b2-rs1-lan1-ipv4';
+UPDATE routers SET template='api/v4/router/server/rustbgpd/json',
+  last_update_started=NULL, last_updated=NULL, pause_updates=0
+  WHERE handle='b2-rs1-lan1-ipv6';
 UPDATE route_server_filters_prod SET enabled=0;
 UPDATE vlaninterface SET rsclient=0 WHERE id<>3;
+UPDATE vlaninterface SET rsclient=1, ipv4enabled=0, ipv6enabled=1 WHERE id=1;
+UPDATE vlaninterface SET ipv6enabled=0 WHERE id=3;
 DELETE FROM irrdb_asn WHERE customer_id=3 AND protocol=4 AND asn<>42;
 DELETE FROM irrdb_prefix
   WHERE customer_id=3 AND protocol=4 AND prefix<>'31.135.128.0/19';
+DELETE FROM irrdb_asn WHERE customer_id=2 AND protocol=6 AND asn<>1213;
+DELETE FROM irrdb_prefix
+  WHERE customer_id=2 AND protocol=6 AND prefix<>'2001:678:20::/48';
 SQL
 
 docker exec "$RUST" sh -ec \
@@ -153,14 +174,14 @@ api() {
             if ($match[1] !== "200" || $body === false) { exit(71); }
             fwrite(STDOUT, $body);
         } else { fwrite(STDOUT, $match[1]); }
-    ' "$1" "$ORIGIN/admin/api/v4/router/$2/$HANDLE" "$3" "$4"
+    ' "$1" "$ORIGIN/admin/api/v4/router/$2/$3" "$4" "$5"
 }
 
-[ "$(api POST get-update-lock none status)" = 401 ] \
+[ "$(api POST get-update-lock "$HANDLE4" none status)" = 401 ] \
     || fail "real IXP Manager accepted a request without an API key"
-[ "$(api POST get-update-lock wrong status)" = 401 ] \
+[ "$(api POST get-update-lock "$HANDLE4" wrong status)" = 401 ] \
     || fail "real IXP Manager accepted a wrong API key"
-api GET gen-config valid body >"$WORK/foil.json"
+api GET gen-config "$HANDLE4" valid body >"$WORK/foil.json"
 cmp -s "$WORK/foil.json" \
     "$ROOT/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json" \
     || fail "real v7.4 Foil API capture drifted from the pinned oracle"
@@ -171,35 +192,40 @@ cargo +1.98.0 build --locked --target x86_64-unknown-linux-musl \
 docker cp "$TARGET" "$RUST:$BIN"
 docker cp "$0" "$RUST:$ACT"
 docker exec "$RUST" sh -ec \
-    "chmod 700 '$BIN' '$ACT'; rm -rf '$STATE' /var/lib/m97-wrong-state \
-       /var/lib/m97-initial-candidate /var/lib/m97-refused-candidate;
-     mkdir -m 700 '$STATE' /var/lib/m97-wrong-state"
+    "umask 077; chmod 700 '$BIN' '$ACT'; rm -rf '$RUNTIME_ROOT' \
+       /var/lib/m97-candidate-* /tmp/m97-activation-entered-* /tmp/m97-*.pid;
+     mkdir -m 700 -p '$HOST_STATE' '$RUNTIME_ROOT/$HANDLE4/activation' \
+       '$RUNTIME_ROOT/$HANDLE6/activation';
+     chmod 700 '$RUNTIME_ROOT' '$RUNTIME_ROOT/$HANDLE4' \
+       '$RUNTIME_ROOT/$HANDLE6'"
 
 lifecycle() {
-    local candidate=$1 state=$2 key=$3
+    local handle=$1 candidate=$2 key=$3
     shift 3
+    local runtime=$RUNTIME_ROOT/$handle
     docker exec "$RUST" "$BIN" ixp-manager-lifecycle run \
         --ixp-origin "$ORIGIN" --allow-http-loopback \
-        --router-handle "$HANDLE" --api-key-file "$key" \
-        --candidate-dir "$candidate" --state-dir "$state" \
+        --router-handle "$handle" --api-key-file "$key" \
+        --candidate-dir "$candidate" --runtime-state-dir "$runtime" \
+        --state-dir "$runtime/activation" --host-state-dir "$HOST_STATE" \
         --check-with /usr/local/bin/rustbgpd \
         --max-prefix-restart-seconds 300 \
-        --rbgp /usr/local/bin/rbgp --rbgp-addr "$ADDR" \
+        --rbgp /usr/local/bin/rbgp --rbgp-addr "unix://$runtime/grpc.sock" \
         --settle-seconds 20 --request-timeout-seconds 30 \
         --activation-command "$ACT" --activation-arg internal-activate \
-        --activation-arg barrier "$@"
+        --activation-arg "$handle" --activation-arg barrier "$@"
 }
 
 set +e
-lifecycle /var/lib/m97-wrong-candidate /var/lib/m97-wrong-state \
-    "$WRONG_KEY_FILE" --initial >"$WORK/wrong.output" 2>&1
+lifecycle "$HANDLE4" /var/lib/m97-candidate-wrong "$WRONG_KEY_FILE" \
+    --initial >"$WORK/wrong.output" 2>&1
 status=$?
 set -e
 [ "$status" -eq 2 ] || fail "wrong-key lifecycle exited $status, expected 2"
-docker exec "$RUST" test ! -e /var/lib/m97-wrong-state/ixp-manager-lifecycle.json \
+docker exec "$RUST" test ! -e "$RUNTIME_ROOT/$HANDLE4/activation/ixp-manager-lifecycle.json" \
     || fail "wrong-key refusal retained a lifecycle journal"
 [ "$(docker exec "$MYSQL" mysql --batch --skip-column-names --user root ixp_ci \
-    -e "SELECT IF(last_update_started IS NULL AND last_updated IS NULL,1,0) FROM routers WHERE handle='$HANDLE'")" = 1 ] \
+    -e "SELECT IF(last_update_started IS NULL AND last_updated IS NULL,1,0) FROM routers WHERE handle='$HANDLE4'")" = 1 ] \
     || fail "wrong-key request changed router timestamps"
 ok "wrong API key was definitely refused without acquiring a lock"
 
@@ -208,13 +234,14 @@ sql() {
         -e "$1"
 }
 neighbor() {
-    docker exec "$RUST" /usr/local/bin/rbgp --addr "$ADDR" --json \
-        neighbor 10.1.0.36
+    docker exec "$RUST" /usr/local/bin/rbgp \
+        --addr "unix://$RUNTIME_ROOT/$1/grpc.sock" --json neighbor "$2"
 }
 has_route() {
-    docker exec "$RUST" /usr/local/bin/rbgp --addr "$ADDR" --json \
-        rib received 10.1.0.36 2>/dev/null \
-        | jq -e --arg prefix "$1" \
+    docker exec "$RUST" /usr/local/bin/rbgp \
+        --addr "unix://$RUNTIME_ROOT/$1/grpc.sock" --json \
+        rib received "$2" 2>/dev/null \
+        | jq -e --arg prefix "$3" \
             '[.[] | select(.prefix == $prefix)] | length == 1' >/dev/null
 }
 wait_for() {
@@ -227,107 +254,193 @@ wait_for() {
     fail "$label did not converge"
 }
 session_ready() {
-    neighbor 2>/dev/null | jq -e '.state == "Established"' >/dev/null
+    neighbor "$1" "$2" 2>/dev/null | jq -e '.state == "Established"' >/dev/null
 }
 
-docker exec "$RUST" rm -f /tmp/m97-activation-entered
-lifecycle /var/lib/m97-initial-candidate "$STATE" "$KEY_FILE" --initial \
-    >"$WORK/initial.output" 2>&1 &
-LIFECYCLE_PID=$!
-wait_for "activation barrier entered while the upstream lock is held" \
-    docker exec "$RUST" test -e /tmp/m97-activation-entered
-[ "$(sql "SELECT IF(last_update_started IS NOT NULL AND last_updated IS NULL,1,0) FROM routers WHERE handle='$HANDLE'")" = 1 ] \
-    || fail "database did not expose the acquired update lock"
-[ "$(api POST get-update-lock valid status)" = 423 ] \
-    || fail "a competing authenticated update was not refused with HTTP 423"
-set +e
-wait "$LIFECYCLE_PID"
-status=$?
-set -e
-LIFECYCLE_PID=
-[ "$status" -eq 0 ] || { cat "$WORK/initial.output" >&2; fail "initial lifecycle exited $status"; }
-[ "$(cat "$WORK/initial.output")" = 'IXP Manager lifecycle activated' ] \
-    || fail "initial lifecycle output changed"
-[ "$(sql "SELECT IF(last_update_started IS NOT NULL AND last_updated>=last_update_started,1,0) FROM routers WHERE handle='$HANDLE'")" = 1 ] \
-    || fail "updated callback was not visible in the real database"
-docker exec "$RUST" test ! -e "$STATE/ixp-manager-lifecycle.json" \
-    || fail "successful updated callback retained a lifecycle journal"
-docker exec "$RUST" test -s /var/lib/m97-initial-candidate/render-receipt.json \
-    || fail "real Foil capture was not rendered and checked"
-wait_for "MD5 FRR session Established" session_ready
-wait_for "pinned IXP prefix accepted" has_route 31.135.128.0/19
-ok "real lock transition, competing 423, activation, and updated callback"
+activate_initial() {
+    local handle=$1 other=$2 peer=$3 prefix=$4 label=$5 other_mode=$6
+    local candidate=/var/lib/m97-candidate-$label-initial
+    local marker=/tmp/m97-activation-entered-$handle
+    docker exec "$RUST" rm -f "$marker" "/tmp/m97-activation-entered-$other"
+    lifecycle "$handle" "$candidate" "$KEY_FILE" --initial \
+        >"$WORK/$label-initial.output" 2>&1 &
+    LIFECYCLE_PID=$!
+    wait_for "$label activation barrier entered with upstream lock held" \
+        docker exec "$RUST" test -e "$marker"
+    [ "$(sql "SELECT IF(last_update_started IS NOT NULL AND last_updated IS NULL,1,0) FROM routers WHERE handle='$handle'")" = 1 ] \
+        || fail "$label database lock was not visible"
+    [ "$(api POST get-update-lock "$handle" valid status)" = 423 ] \
+        || fail "$label competing authenticated update was not HTTP 423"
+    docker exec "$RUST" cat "$HOST_STATE/ixp-manager-host-fence.json" \
+        >"$WORK/$label-fence.json"
+    set +e
+    wait "$LIFECYCLE_PID"
+    status=$?
+    set -e
+    LIFECYCLE_PID=
+    [ "$status" -eq 0 ] || { cat "$WORK/$label-initial.output" >&2; fail "$label lifecycle exited $status"; }
+    [ "$(cat "$WORK/$label-initial.output")" = 'IXP Manager lifecycle activated' ] \
+        || fail "$label lifecycle output changed"
+    [ "$(sql "SELECT IF(last_update_started IS NOT NULL AND last_updated>=last_update_started,1,0) FROM routers WHERE handle='$handle'")" = 1 ] \
+        || fail "$label updated callback was not visible"
+    docker exec "$RUST" test ! -e "$RUNTIME_ROOT/$handle/activation/ixp-manager-lifecycle.json" \
+        || fail "$label successful callback retained a journal"
+    jq -e --arg h "$handle" --arg r "$RUNTIME_ROOT/$handle" --arg s "$RUNTIME_ROOT/$handle/activation" --arg hs "$HOST_STATE" --arg a "unix://$RUNTIME_ROOT/$handle/grpc.sock" \
+        --slurpfile rr <(docker exec "$RUST" cat "$candidate/render-receipt.json") --slurpfile ar <(docker exec "$RUST" cat "$RUNTIME_ROOT/$handle/activation/activation-receipt.json") '
+        . == {router_handle:$h,runtime_state_dir:$r,activation_state_dir:$s,host_state_dir:$hs,rbgp_addr:$a}
+        and $rr[0].input.router_handle == $h and $rr[0].host == {router_handle:$h,runtime_state_dir:$r}
+        and $ar[0].host == .' "$WORK/$label-fence.json" >/dev/null \
+        || fail "$label fence/render/activation receipts do not match the exact handle binding"
+    docker exec "$RUST" test ! -e "$HOST_STATE/ixp-manager-host-fence.json" \
+        || fail "$label terminal callback retained its host fence"
+    docker cp "$WORK/$label-fence.json" "$RUST:/tmp/$label-fence.json" >/dev/null
+    docker exec "$RUST" sh -ec \
+        "install -m 600 '/tmp/$label-fence.json' '$HOST_STATE/ixp-manager-host-fence.json'; sync -f '$HOST_STATE'"
+    other_before=$(sql "SELECT CONCAT(IFNULL(last_update_started,'NULL'),'|',IFNULL(last_updated,'NULL')) FROM routers WHERE handle='$other'")
+    extra=()
+    [ "$other_mode" = initial ] && extra=(--initial)
+    set +e
+    lifecycle "$other" "/var/lib/m97-candidate-$label-host-refused" \
+        "$KEY_FILE" "${extra[@]}" >"$WORK/$label-host-refused.output" 2>&1
+    host_status=$?
+    set -e
+    [ "$host_status" -eq 5 ] || fail "$other escaped the durable shared fence with exit $host_status"
+    grep -qxF 'rs-config-render: IXP Manager lifecycle: manual recovery required; upstream lock retained' \
+        "$WORK/$label-host-refused.output" \
+        || fail "$other shared-fence recovery diagnostic changed"
+    [ "$other_before" = "$(sql "SELECT CONCAT(IFNULL(last_update_started,'NULL'),'|',IFNULL(last_updated,'NULL')) FROM routers WHERE handle='$other'")" ] \
+        || fail "$other reached IXP Manager behind the shared host fence"
+    docker exec "$RUST" test ! -e "/tmp/m97-activation-entered-$other" \
+        || fail "$other activated behind the shared host fence"
+    docker exec "$RUST" test ! -e "$RUNTIME_ROOT/$other/activation/ixp-manager-lifecycle.json" \
+        || fail "$other wrote a lifecycle journal behind the shared fence"
+    docker exec "$RUST" test ! -e "/var/lib/m97-candidate-$label-host-refused" \
+        || fail "$other rendered a candidate behind the shared fence"
+    docker exec "$RUST" sh -ec \
+        "rm '$HOST_STATE/ixp-manager-host-fence.json'; sync -f '$HOST_STATE'"
+    wait_for "$label MD5 session Established" session_ready "$handle" "$peer"
+    wait_for "$label pinned prefix accepted" has_route "$handle" "$peer" "$prefix"
+}
 
-prior_link=$(docker exec "$RUST" readlink "$STATE/current")
+activate_initial "$HANDLE4" "$HANDLE6" "$PEER4" "$PREFIX4" ipv4 initial
+activate_initial "$HANDLE6" "$HANDLE4" "$PEER6" "$PREFIX6" ipv6 existing
+ok "both sequential lifecycles held the shared fence and paired HTTP 423 locks"
+
+STATE4=$RUNTIME_ROOT/$HANDLE4/activation
+STATE6=$RUNTIME_ROOT/$HANDLE6/activation
+prior_link4=$(docker exec "$RUST" readlink "$STATE4/current")
+prior_link6=$(docker exec "$RUST" readlink "$STATE6/current")
 docker exec "$RUST" sh -c \
-    "find -L '$STATE/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
+    "find -L '$STATE4/current' '$STATE6/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
     >"$WORK/prior-files"
-docker exec "$RUST" cat "$STATE/activation-receipt.json" \
-    >"$WORK/activation-receipt.json"
-receipt_before=$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")
-pid_before=$(docker exec "$RUST" pidof -s rustbgpd)
-session_before=$(neighbor)
-last_updated=$(sql "SELECT DATE_FORMAT(last_updated,'%Y-%m-%d %H:%i:%s') FROM routers WHERE handle='$HANDLE'")
+docker exec "$RUST" cat "$STATE4/activation-receipt.json" \
+    >"$WORK/activation-receipt-ipv4.json"
+docker exec "$RUST" cat "$STATE6/activation-receipt.json" \
+    >"$WORK/activation-receipt-ipv6.json"
+receipt_before=$(docker exec "$RUST" sha256sum "$STATE4/activation-receipt.json" "$STATE6/activation-receipt.json")
+pid_before=$(docker exec "$RUST" cat "/tmp/m97-$HANDLE4.pid" "/tmp/m97-$HANDLE6.pid")
+session4_before=$(neighbor "$HANDLE4" "$PEER4")
+session6_before=$(neighbor "$HANDLE6" "$PEER6")
+last_updated=$(sql "SELECT DATE_FORMAT(last_updated,'%Y-%m-%d %H:%i:%s') FROM routers WHERE handle='$HANDLE4'")
 [ -n "$last_updated" ] || fail "updated timestamp was empty"
 sql "UPDATE route_server_filters_prod SET customer_id=3, enabled=1 WHERE id=31" \
     >/dev/null
-docker exec "$RUST" rm -f /tmp/m97-activation-entered
+docker exec "$RUST" rm -f "/tmp/m97-activation-entered-$HANDLE4"
 set +e
-lifecycle /var/lib/m97-refused-candidate "$STATE" "$KEY_FILE" \
+lifecycle "$HANDLE4" /var/lib/m97-candidate-ipv4-refused "$KEY_FILE" \
     >"$WORK/refused.output" 2>&1
 status=$?
 set -e
 [ "$status" -eq 2 ] || { cat "$WORK/refused.output" >&2; fail "refusal exited $status"; }
-docker exec "$RUST" test ! -e /tmp/m97-activation-entered \
+docker exec "$RUST" test ! -e "/tmp/m97-activation-entered-$HANDLE4" \
     || fail "pre-activation refusal invoked the activation command"
-[ "$(docker exec "$RUST" readlink "$STATE/current")" = "$prior_link" ] \
-    || fail "pre-activation refusal moved current"
+if [ "$(docker exec "$RUST" readlink "$STATE4/current")" != "$prior_link4" ] \
+    || [ "$(docker exec "$RUST" readlink "$STATE6/current")" != "$prior_link6" ]; then
+    fail "one-handle refusal moved either current link"
+fi
 docker exec "$RUST" sh -c \
-    "find -L '$STATE/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
+    "find -L '$STATE4/current' '$STATE6/current' -type f -print0 | sort -z | xargs -0 sha256sum" \
     >"$WORK/after-refusal-files"
 cmp -s "$WORK/prior-files" "$WORK/after-refusal-files" \
     || fail "pre-activation refusal changed prior runtime bytes"
-[ "$receipt_before" = "$(docker exec "$RUST" sha256sum "$STATE/activation-receipt.json")" ] \
-    || fail "pre-activation refusal rewrote the activation receipt"
-[ "$(docker exec "$RUST" pidof -s rustbgpd)" = "$pid_before" ] \
-    || fail "rustbgpd PID changed across pre-activation refusal"
-release_pair=$(sql "SELECT CONCAT(DATE_FORMAT(last_update_started,'%Y-%m-%d %H:%i:%s'),'|',DATE_FORMAT(last_updated,'%Y-%m-%d %H:%i:%s')) FROM routers WHERE handle='$HANDLE'")
+[ "$receipt_before" = "$(docker exec "$RUST" sha256sum "$STATE4/activation-receipt.json" "$STATE6/activation-receipt.json")" ] \
+    || fail "one-handle refusal rewrote either activation receipt"
+[ "$(docker exec "$RUST" cat "/tmp/m97-$HANDLE4.pid" "/tmp/m97-$HANDLE6.pid")" = "$pid_before" ] \
+    || fail "either rustbgpd PID changed across one-handle refusal"
+release_pair=$(sql "SELECT CONCAT(DATE_FORMAT(last_update_started,'%Y-%m-%d %H:%i:%s'),'|',DATE_FORMAT(last_updated,'%Y-%m-%d %H:%i:%s')) FROM routers WHERE handle='$HANDLE4'")
 [ "$release_pair" = "$last_updated|$last_updated" ] \
     || fail "release callback did not restore the prior database timestamp"
-docker exec "$RUST" test ! -e "$STATE/ixp-manager-lifecycle.json" \
+docker exec "$RUST" test ! -e "$STATE4/ixp-manager-lifecycle.json" \
     || fail "delivered release callback retained a lifecycle journal"
-session_after=$(neighbor)
-jq -n --argjson before "$session_before" --argjson after "$session_after" '
-    $before.state == "Established" and $after.state == "Established"
-    and (($before.flap_count // 0) == ($after.flap_count // 0))
-    and (($after.uptime_seconds // 0) >= ($before.uptime_seconds // 0))' \
-    >/dev/null || fail "MD5 session flapped across pre-activation refusal"
-wait_for "route preserved after release" has_route 31.135.128.0/19
-ok "pre-activation refusal released the DB lock and preserved prior runtime/session"
+session4_after=$(neighbor "$HANDLE4" "$PEER4")
+session6_after=$(neighbor "$HANDLE6" "$PEER6")
+session_stable() {
+    local before=$1 after=$2 label=$3
+    jq -n --argjson before "$before" --argjson after "$after" '
+        $before.state == "Established" and $after.state == "Established"
+        and (($before.flap_count // 0) == ($after.flap_count // 0))
+        and (($after.uptime_seconds // 0) >= ($before.uptime_seconds // 0))' \
+        >/dev/null || fail "$label MD5 session flapped across refusal"
+}
+session_stable "$session4_before" "$session4_after" IPv4
+session_stable "$session6_before" "$session6_after" IPv6
+wait_for "IPv4 route preserved after release" has_route "$HANDLE4" "$PEER4" "$PREFIX4"
+wait_for "IPv6 route preserved during IPv4 refusal" has_route "$HANDLE6" "$PEER6" "$PREFIX6"
+ok "one-handle failure released its DB lock and preserved both runtimes/sessions"
 
 docker exec "$RUST" bash -ec \
-    "test \"\$(stat -c %a '$STATE')\" = 700;
-     test \"\$(stat -c %a '$STATE/ixp-manager-lifecycle.lock')\" = 600;
-     test \"\$(stat -c %a '$STATE/activation.lock')\" = 600;
-     test \"\$(stat -c %a '$STATE/activation-receipt.json')\" = 600;
+    "pid4=\$(cat '/tmp/m97-$HANDLE4.pid'); pid6=\$(cat '/tmp/m97-$HANDLE6.pid');
+     test \"\$pid4\" != \"\$pid6\"; kill -0 \"\$pid4\"; kill -0 \"\$pid6\";
+     test -S '$RUNTIME_ROOT/$HANDLE4/grpc.sock';
+     test -S '$RUNTIME_ROOT/$HANDLE6/grpc.sock';
+     test ! -e '$HOST_STATE/ixp-manager-host-fence.json';
+     test \"\$(stat -c %a '$HOST_STATE')\" = 700;
+     test \"\$(stat -c %a '$HOST_STATE/ixp-manager-host.lock')\" = 600;
      test \"\$(stat -c %a '$KEY_FILE')\" = 600;
-     test -L '$STATE/current';
-     ! find '$STATE/generations' -type d ! -perm 700 -print -quit | grep -q .;
-     ! find '$STATE/generations' -type f ! -perm 600 -print -quit | grep -q ."
+     for state in '$STATE4' '$STATE6'; do
+       test \"\$(stat -c %a \"\$state\")\" = 700;
+       test \"\$(stat -c %a \"\$state/ixp-manager-lifecycle.lock\")\" = 600;
+       test \"\$(stat -c %a \"\$state/activation.lock\")\" = 600;
+       test \"\$(stat -c %a \"\$state/activation-receipt.json\")\" = 600;
+       test -L \"\$state/current\";
+       ! find \"\$state/generations\" -type d ! -perm 700 -print -quit | grep -q .;
+       ! find \"\$state/generations\" -type f ! -perm 600 -print -quit | grep -q .;
+     done"
+listeners=$(docker exec "$RUST" ss -Hlnpt 'sport = :179')
+[ "$(printf '%s\n' "$listeners" | wc -l)" -eq 2 ] \
+    || fail "expected exactly two TCP/179 listeners"
+printf '%s\n' "$listeners" | grep -F "192.0.2.18:179" | grep -F "pid=$(docker exec "$RUST" cat "/tmp/m97-$HANDLE4.pid")" >/dev/null \
+    || fail "IPv4 listener is not owned by its handle PID"
+printf '%s\n' "$listeners" | grep -F "[2001:db8::8]:179" | grep -F "pid=$(docker exec "$RUST" cat "/tmp/m97-$HANDLE6.pid")" >/dev/null \
+    || fail "IPv6 listener is not owned by its handle PID"
+for handle in "$HANDLE4" "$HANDLE6"; do
+    config=$RUNTIME_ROOT/$handle/activation/current/config.toml
+    docker exec "$RUST" grep -qxF "runtime_state_dir = \"$RUNTIME_ROOT/$handle\"" "$config" \
+        || fail "$handle config is not bound to its packaged runtime path"
+    docker exec "$RUST" grep -qxF "path = \"$RUNTIME_ROOT/$handle/grpc.sock\"" "$config" \
+        || fail "$handle config is not bound to its exact UDS"
+done
 if docker exec "$RUST" cat "$KEY_FILE" \
     | grep -RFl -f - "$WORK" >/dev/null 2>&1; then
     fail "API key escaped into retained host artifacts"
 fi
 docker exec "$RUST" sh -ec \
-    "! grep -RFl -f '$KEY_FILE' '$STATE' /var/lib/m97-initial-candidate \
-       /var/lib/m97-refused-candidate >/dev/null 2>&1"
+    "! grep -RFl -f '$KEY_FILE' '$RUNTIME_ROOT' /var/lib/m97-candidate-* \
+       >/dev/null 2>&1"
 docker exec "$IXP" sh -ec \
     '! grep -F -f /tmp/m97-api-key /tmp/m97-server.log >/dev/null 2>&1'
-if printf '%s' "$MD5" | grep -Fl -f - "$WORK/initial.output" \
-    "$WORK/refused.output" "$WORK/activation-receipt.json" >/dev/null; then
+if printf '%s\n%s\n' "$MD5" "$MD56" | grep -Fl -f - \
+    "$WORK/wrong.output" "$WORK/ipv4-initial.output" \
+    "$WORK/ipv4-host-refused.output" "$WORK/ipv6-initial.output" \
+    "$WORK/ipv6-host-refused.output" "$WORK/refused.output" \
+    "$WORK/activation-receipt-ipv4.json" \
+    "$WORK/activation-receipt-ipv6.json" >/dev/null; then
     fail "MD5 secret escaped into lifecycle output or receipt"
 fi
 docker exec "$FRR" vtysh -c 'show bgp neighbors 192.0.2.18 json' \
     | jq -e '.["192.0.2.18"].bgpState == "Established"' >/dev/null \
     || fail "FRR does not report the authenticated session Established"
-ok "M97 authenticated lifecycle, private modes, cleanup, and redaction complete"
+docker exec "$FRR" vtysh -c 'show bgp neighbors 2001:db8::8 json' \
+    | jq -e '.["2001:db8::8"].bgpState == "Established"' >/dev/null \
+    || fail "FRR does not report the IPv6 authenticated session Established"
+ok "M97 two-handle listeners, private state, cleanup, and redaction complete"

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -85,7 +85,7 @@ sudo -u rustbgpd /usr/bin/rs-config-render activate \
   --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
   --activation-command /usr/bin/sudo \
   --activation-arg=-n --activation-arg /usr/bin/systemctl \
-  --activation-arg reload-or-restart --activation-arg rustbgpd
+  --activation-arg reload-or-restart --activation-arg rustbgpd@rs1-ipv4
 ```
 
 The service must read
@@ -107,9 +107,11 @@ link without a second activation and verifies the unchanged prior runtime. Once
 the command starts, a nonzero exit, timeout, or unsettled runtime leaves
 `current` on the candidate and returns exit 5 for explicit operator recovery.
 
-Authorize the `rustbgpd` account in sudoers for only the exact
-`/usr/bin/systemctl reload-or-restart rustbgpd` command. The private
-`activation-receipt.json` is written last; generations are retained for
+Authorize the `rustbgpd` account in sudoers for only the exact per-handle
+`/usr/bin/systemctl reload-or-restart rustbgpd@rs1-ipv4` command. A second
+handle uses its own runtime/activation/UDS and service instance but the same
+host-state directory, which serializes lifecycle ownership across the host.
+The private `activation-receipt.json` is written last; generations are retained for
 operator inspection. Exit 0 means activated or no-op, 2 refusal, 4 proven
 pre-effect restoration, and 5 means recovery or receipt durability is
 unproven. A receipt may
@@ -139,7 +141,7 @@ sudo -u rustbgpd /usr/bin/rs-config-render ixp-manager-lifecycle run \
   --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
   --activation-command /usr/bin/sudo \
   --activation-arg=-n --activation-arg /usr/bin/systemctl \
-  --activation-arg reload-or-restart --activation-arg rustbgpd
+  --activation-arg reload-or-restart --activation-arg rustbgpd@rs1-ipv4
 ```
 
 Supply a new absent or empty mode-0700 candidate directory for each run. The


### PR DESCRIPTION
## Summary

- ship an opt-in `rustbgpd@.service` in release tarballs, deb, and rpm packages
- preserve private per-handle activation state and the durable shared-host lifecycle fence
- extend M97 to prove paired IPv4/IPv6 IXP Manager handles, distinct PIDs/UDS/listeners, real MD5 sessions, serialization, and failure containment

Linear: LAN-1144

## Verification

- release-install checker and 39 destructive mutations
- real tar, deb, and rpm build/extraction with full template inventory
- full local M97 twice, including exact fence/receipt/TOML/UDS identity
- split-host-state and removed-IPv6-MD5 destructive runs
- shell syntax, ShellCheck, YAML parse, tracker, v1, image-primer, scale-split, and diff/scope checks

No new CI job; M97 remains a local adoption proof.