### PR TITLE
Complete pinned IXP Manager reject reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The IXP Manager v7.4 renderer and Birdwatcher adapter now cover all ten
+  reject reasons active in the pinned route-server templates, with named
+  AS-path length/first-AS and separate IRRDB origin/prefix policy terms. The
+  pinned PHP consumer verifies every display meaning from 1 through 15 while
+  keeping the five defined-only IDs and ambiguous causes on fallback 0;
+  `runtime_compatibility` remains false. (LAN-1131)
 - `RibService.LookupBestPath` now provides an outside-v1, bounded IPv4/IPv6
   longest-prefix lookup that returns the installed winner and every alternative
   for the matched prefix in one actor turn. `birdwatcher-adapter` exposes that

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -630,11 +630,13 @@ symbols, member received, and member export slice through startup-only direct
 aliases or a bounded file-backed resolver that swaps atomically on Unix SIGHUP
 with an enforced response maximum. Its exact member filtered-prefix wildcard
 journey reads retained rejects, scrubs the daemon-owned reason namespace, and
-synthesizes only conservative reason ids. Its bounded table search now returns
+synthesizes all ten reasons active in the pinned v7.4 route-server templates.
+The remaining IDs 2, 4, 11, 12, and 15 are defined by the upstream display but
+inactive in those templates and deliberately fall back to 0 rather than
+claiming policy semantics. Its bounded table search now returns
 the installed winner first plus every alternative for one longest matched
 prefix in a single actor turn. Remaining Bird's Eye work is full table
-snapshots/counts, other wildcard-community searches, and the complete
-reject-reason inventory;
+snapshots/counts and other wildcard-community searches;
 no full compatibility claim is made.
 [ADR-0126](docs/adr/0126-shared-group-per-client-best.md) (Accepted) landed
 shared-group per-client best-path: the `per_client_best` path-hiding

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -41,8 +41,10 @@ daemon order. Bounded longest-prefix table search atomically returns the
 installed winner first and every alternative for that one matched prefix. The
 exact `{daemon ASN}:1101:*` filtered-prefix query reads only retained rejects,
 scrubs that reserved namespace, and adds one conservative reason. This remains
-partial runtime support: complete rejected-route reasons and full table
-snapshots are still unavailable. Global table lists, counts, and other
+partial runtime support: the ten reasons active in the pinned v7.4 route-server
+templates are mapped, while IDs 2, 4, 11, 12, and 15 are display-only and
+remain fallback 0 rather than gaining invented semantics. Full table snapshots,
+global table lists, counts, and other
 wildcard-community endpoints are not served. The adapter's table identity is a
 validated view over one global Loc-RIB, and `api.version` is rustbgpd product
 identity, not a Bird's Eye version claim; the adapter is not described as fully
@@ -67,6 +69,9 @@ schema versions or fields, incomplete terminal markers, placeholder or overlong
 effective authentication, and symlink/public input or output paths.
 It renders only independently owned rustbgpd policy; no IXP Manager BIRD
 template or GPL source enters the binary or packaged artifacts.
+The generated policy names the pinned active AS-path length/first-AS and IRRDB
+origin/prefix rejects individually; its 64/65 path boundary and authorized
+fallthrough are executed by focused tests.
 
 The local activation helper consumes only a complete strict-check receipt. M96
 feeds the live pinned Foil capture into the real renderer/checker, then proves

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -219,6 +219,13 @@ route also carries human-readable `reject_reason` / `reject_reason_detail`
 fields (plus `rpki_validation` / `aspa_validation`) as extra JSON keys —
 visible to curl users, ignored by parsers that don't know them.
 
+The IXP Manager wildcard uses its separate `{daemon ASN}:1101:<id>` namespace.
+For the pinned v7.4 route-server templates the adapter maps the ten active IDs
+`1,3,5,6,7,8,9,10,13,14`: prefix length, bogon, AS-path length/first-AS,
+NEXT_HOP, IRRDB prefix/origin, RPKI-invalid, and transit-free-AS rejects.
+Generated-policy mappings require the exact renderer policy/term identity;
+ambiguous, custom, and the five defined-only IDs `2,4,11,12,15` remain `0`.
+
 Alice-LG config to render the reasons:
 
 ```ini

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -1303,18 +1303,45 @@ fn ixp_manager_rejected_route_to_birdwatcher(
 
 fn ixp_manager_reject_reason_id(route: &proto::RejectedRoute) -> u64 {
     match (route.reason.as_str(), route.reason_detail.as_str()) {
-        ("policy_reject", detail) if detail.ends_with(":reject-too-specific") => 1,
-        ("policy_reject", detail) if detail.ends_with(":reject-non-global") => 3,
+        ("policy_reject", "ixp-manager-hygiene:reject-too-specific") => 1,
+        ("policy_reject", "reject-special-purpose:reject-non-global") => 3,
+        ("policy_reject", "ixp-manager-hygiene:reject-as-path-too-long") => 5,
+        ("policy_reject", "ixp-manager-hygiene:reject-as-path-too-short") => 6,
+        ("treat_as_withdraw", "aspa_first_as_mismatch") if route.as_path.is_empty() => 6,
         ("treat_as_withdraw", "aspa_first_as_mismatch") => 7,
+        ("policy_reject", detail)
+            if ixp_manager_client_term(detail, "reject-first-as-not-peer-as") =>
+        {
+            7
+        }
         ("next_hop_ownership", _) => 8,
         ("policy_reject", detail)
-            if detail.ends_with(":reject-rpki-invalid") && route.rpki_validation == "invalid" =>
+            if ixp_manager_client_term(detail, "reject-irrdb-prefix-filtered") =>
+        {
+            9
+        }
+        ("policy_reject", detail)
+            if ixp_manager_client_term(detail, "reject-irrdb-origin-as-filtered") =>
+        {
+            10
+        }
+        ("policy_reject", "ixp-manager-hygiene:reject-rpki-invalid")
+            if route.rpki_validation == "invalid" =>
         {
             13
         }
-        ("policy_reject", detail) if detail.ends_with(":reject-transit-leak") => 14,
+        ("policy_reject", "ixp-manager-hygiene:reject-transit-leak") => 14,
         _ => 0,
     }
+}
+
+fn ixp_manager_client_term(detail: &str, expected: &str) -> bool {
+    detail.rsplit_once(':').is_some_and(|(policy, term)| {
+        term == expected
+            && policy
+                .strip_prefix("client-")
+                .is_some_and(|id| !id.is_empty() && id.bytes().all(|byte| byte.is_ascii_digit()))
+    })
 }
 
 fn render_rejected_route(
@@ -2082,39 +2109,54 @@ mod tests {
 
     #[test]
     fn ixp_manager_reason_mapping_is_conservative_and_stable() {
+        const TOO_SPECIFIC: &str = "ixp-manager-hygiene:reject-too-specific";
+        const NON_GLOBAL: &str = "reject-special-purpose:reject-non-global";
+        const PATH_LONG: &str = "ixp-manager-hygiene:reject-as-path-too-long";
+        const PATH_SHORT: &str = "ixp-manager-hygiene:reject-as-path-too-short";
+        const FIRST_AS: &str = "client-3:reject-first-as-not-peer-as";
+        const IRR_PREFIX: &str = "client-3:reject-irrdb-prefix-filtered";
+        const IRR_ORIGIN: &str = "client-3:reject-irrdb-origin-as-filtered";
+        const RPKI: &str = "ixp-manager-hygiene:reject-rpki-invalid";
+        const TRANSIT: &str = "ixp-manager-hygiene:reject-transit-leak";
         let route = |reason: &str, detail: &str, rpki: &str| proto::RejectedRoute {
             reason: reason.to_string(),
             reason_detail: detail.to_string(),
             rpki_validation: rpki.to_string(),
             ..Default::default()
         };
-        for (entry, id) in [
+        let mut core_first_as = route("treat_as_withdraw", "aspa_first_as_mismatch", "not_found");
+        assert_eq!(ixp_manager_reject_reason_id(&core_first_as), 6);
+        core_first_as.as_path = "43 42".to_string();
+        assert_eq!(ixp_manager_reject_reason_id(&core_first_as), 7);
+        for (reason, detail, rpki, id) in [
+            ("policy_reject", TOO_SPECIFIC, "valid", 1),
+            ("policy_reject", NON_GLOBAL, "valid", 3),
+            ("policy_reject", PATH_LONG, "valid", 5),
+            ("policy_reject", PATH_SHORT, "valid", 6),
+            ("policy_reject", FIRST_AS, "valid", 7),
+            ("next_hop_ownership", "strict_peer", "valid", 8),
+            ("policy_reject", IRR_PREFIX, "valid", 9),
+            ("policy_reject", IRR_ORIGIN, "valid", 10),
+            ("policy_reject", RPKI, "invalid", 13),
+            ("policy_reject", TRANSIT, "valid", 14),
+            ("policy_reject", RPKI, "valid", 0),
             (
-                route("policy_reject", "ixp:reject-too-specific", "valid"),
-                1,
-            ),
-            (route("policy_reject", "ixp:reject-non-global", "valid"), 3),
-            (
-                route("treat_as_withdraw", "aspa_first_as_mismatch", "not_found"),
-                7,
-            ),
-            (route("next_hop_ownership", "strict_peer", "valid"), 8),
-            (
-                route("policy_reject", "ixp:reject-rpki-invalid", "invalid"),
-                13,
-            ),
-            (
-                route("policy_reject", "ixp:reject-transit-leak", "valid"),
-                14,
-            ),
-            (
-                route("policy_reject", "ixp:reject-rpki-invalid", "valid"),
+                "policy_reject",
+                "custom:reject-as-path-too-long",
+                "valid",
                 0,
             ),
-            (route("otc_route_leak", "ingress_from_peer", "valid"), 0),
-            (route("rr_loop", "cluster_list", "valid"), 0),
-            (route("policy_reject", "custom:unknown", "invalid"), 0),
+            (
+                "policy_reject",
+                "client-x:reject-irrdb-prefix-filtered",
+                "valid",
+                0,
+            ),
+            ("otc_route_leak", "ingress_from_peer", "valid", 0),
+            ("rr_loop", "cluster_list", "valid", 0),
+            ("policy_reject", "custom:unknown", "invalid", 0),
         ] {
+            let entry = route(reason, detail, rpki);
             assert_eq!(ixp_manager_reject_reason_id(&entry), id, "{entry:?}");
         }
     }

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -43,6 +43,11 @@ direction. `api.version` remains
 identity, not Bird's Eye semantic-version compatibility. No full compatibility
 claim is made and `runtime_compatibility` remains false.
 
+The real pinned IXP Manager PHP extension also translates every defined
+`:1101:<id>` display entry from 1 through 15. The executable contract records
+the active route-server-template partition `1,3,5,6,7,8,9,10,13,14`, keeps
+`2,4,11,12,15` defined-only, and proves fallback `0` remains untranslated.
+
 Run the gate from the repository root:
 
 ```console
@@ -64,7 +69,9 @@ Exact protocol-route, exact export-route, filtered-prefix wildcard, and bounded
 less-specific table lookup journeys are runtime-supported. The table lookup
 returns one matched prefix atomically with its installed winner first and every
 same-prefix Add-Path alternative; it is not a full table snapshot. Complete
-rejected-route reasons and full-table snapshots remain blockers. Protocol
+All ten reject reasons emitted by the pinned route-server templates are
+runtime-supported; emitting the five defined-only display reasons and
+full-table snapshots remain blockers. Protocol
 aliases supplied directly remain immutable after startup; bounded file-backed
 aliases reload as one whole resolver generation on Unix `SIGHUP`. Promoting any
 blocker, weakening the explicit alias or product-version

--- a/tests/compat/ixp-manager-birdseye/adapter-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/adapter-consumer.php
@@ -6,6 +6,7 @@ use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use IXP\Models\Router;
 use IXP\Services\LookingGlass\BirdsEye;
+use IXP\Utils\Foil\Extensions\Bird;
 
 require getenv('IXP_MANAGER_ROOT') . '/vendor/autoload.php';
 
@@ -23,13 +24,88 @@ $knownProtocols = array_values($manifest['protocol_aliases'] ?? []);
 $table = $manifest['routing_tables'][0] ?? null;
 $versionPrefix = $manifest['adapter_api_version']['prefix'] ?? null;
 $filtered = $manifest['filtered_prefix_query'] ?? [];
+$expectedReasons = [
+    1 => 'PREFIX LENGTH TOO LONG', 2 => 'PREFIX LENGTH TOO SHORT',
+    3 => 'BOGON', 4 => 'BOGON ASN', 5 => 'AS PATH TOO LONG',
+    6 => 'AS PATH TOO SHORT', 7 => 'FIRST AS NOT PEER AS',
+    8 => 'NEXT HOP NOT PEER IP', 9 => 'IRRDB PREFIX FILTERED',
+    10 => 'IRRDB ORIGIN AS FILTERED', 11 => 'PREFIX NOT IN ORIGIN AS',
+    12 => 'RPKI UNKNOWN', 13 => 'RPKI INVALID', 14 => 'TRANSIT FREE ASN',
+    15 => 'TOO MANY COMMUNITIES',
+];
+$reasonContract = $manifest['reject_reasons'] ?? [];
 if (
     !in_array($protocol, $knownProtocols, true)
     || $table !== 'master4'
     || $versionPrefix !== 'rustbgpd '
     || $filtered !== ['global_admin' => 65001, 'function' => 1101]
+    || ($reasonContract['display'] ?? null) !== $expectedReasons
+    || ($reasonContract['active_ids'] ?? null) !== [1, 3, 5, 6, 7, 8, 9, 10, 13, 14]
+    || ($reasonContract['defined_only_ids'] ?? null) !== [2, 4, 11, 12, 15]
+    || ($reasonContract['fallback_id'] ?? null) !== 0
 ) {
     throw new RuntimeException('adapter consumer contract drifted');
+}
+$bird = new Bird();
+foreach ($expectedReasons as $id => $meaning) {
+    if ($bird->translateBgpFilteringLargeCommunity(":1101:$id") !== [$meaning, 'danger']) {
+        throw new RuntimeException("IXP Manager reject reason $id drifted");
+    }
+}
+if ($bird->translateBgpFilteringLargeCommunity(':1101:0') !== null) {
+    throw new RuntimeException('fallback reason 0 must remain untranslated');
+}
+$expectedActive = [1, 3, 5, 6, 7, 8, 9, 10, 13, 14];
+$expectedDefinedOnly = [2, 4, 11, 12, 15];
+foreach (['bird2', 'bird2-2025'] as $template) {
+    $directory = getenv('IXP_MANAGER_ROOT') . "/resources/views/api/v4/router/server/$template";
+    $definitions = file_get_contents("$directory/community-filtering-definitions.foil.php");
+    if (!is_string($definitions)) {
+        throw new RuntimeException("$template reject-reason definitions are required");
+    }
+    preg_match_all(
+        '/define\s+(IXP_LC_FILTERED_[A-Z0-9_]+)\s*=\s*\([^,]+,\s*1101,\s*(\d+)\s*\)/',
+        $definitions,
+        $definedMatches,
+        PREG_SET_ORDER,
+    );
+    $symbolIds = [];
+    foreach ($definedMatches as $match) {
+        $symbolIds[$match[1]] = (int) $match[2];
+    }
+    if (array_values($symbolIds) !== range(1, 15)) {
+        throw new RuntimeException("$template reject-reason definitions drifted");
+    }
+    $symbols = [];
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory)) as $file) {
+        if (!$file->isFile() || $file->getFilename() === 'community-filtering-definitions.foil.php') {
+            continue;
+        }
+        $contents = file_get_contents($file->getPathname());
+        if (!is_string($contents)) {
+            throw new RuntimeException("$template source is unreadable");
+        }
+        preg_match_all(
+            '/^[ \t]*bgp_large_community\.add\s*\(\s*(IXP_LC_FILTERED_[A-Z0-9_]+)\s*\)\s*;/m',
+            $contents,
+            $matches,
+        );
+        foreach ($matches[1] as $symbol) {
+            $symbols[$symbol] = true;
+        }
+    }
+    $active = [];
+    foreach (array_keys($symbols) as $symbol) {
+        if (!isset($symbolIds[$symbol])) {
+            throw new RuntimeException("$template references an unknown reject-reason symbol");
+        }
+        $active[] = $symbolIds[$symbol];
+    }
+    sort($active);
+    $active = array_values(array_unique($active));
+    if ($active !== $expectedActive || array_values(array_diff(range(1, 15), $active)) !== $expectedDefinedOnly) {
+        throw new RuntimeException("$template active reject-reason partition drifted");
+    }
 }
 
 $container = new Container();

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -16,6 +16,28 @@
     "global_admin": 65001,
     "function": 1101
   },
+  "reject_reasons": {
+    "display": {
+      "1": "PREFIX LENGTH TOO LONG",
+      "2": "PREFIX LENGTH TOO SHORT",
+      "3": "BOGON",
+      "4": "BOGON ASN",
+      "5": "AS PATH TOO LONG",
+      "6": "AS PATH TOO SHORT",
+      "7": "FIRST AS NOT PEER AS",
+      "8": "NEXT HOP NOT PEER IP",
+      "9": "IRRDB PREFIX FILTERED",
+      "10": "IRRDB ORIGIN AS FILTERED",
+      "11": "PREFIX NOT IN ORIGIN AS",
+      "12": "RPKI UNKNOWN",
+      "13": "RPKI INVALID",
+      "14": "TRANSIT FREE ASN",
+      "15": "TOO MANY COMMUNITIES"
+    },
+    "active_ids": [1, 3, 5, 6, 7, 8, 9, 10, 13, 14],
+    "defined_only_ids": [2, 4, 11, 12, 15],
+    "fallback_id": 0
+  },
   "runtime_compatibility": false,
   "manual_config_export": {
     "schema": "rustbgpd.ixp-manager.router-config/v1",
@@ -29,10 +51,11 @@
     "filtered-prefix-wildcard",
     "less-specific-longest-prefix-match",
     "atomic-all-candidate-prefix-snapshot",
-    "file-backed-runtime-protocol-alias-reconfiguration"
+    "file-backed-runtime-protocol-alias-reconfiguration",
+    "active-rejected-route-reason-inventory"
   ],
   "unsupported": [
-    "complete-rejected-route-reason-inventory",
+    "defined-only-rejected-route-reason-emission",
     "full-table-snapshot",
     "direct-runtime-protocol-alias-reconfiguration"
   ]

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -26,7 +26,7 @@ EXPECTED = {
     "bird_failure": 503,
 }
 UNSUPPORTED = {
-    "complete-rejected-route-reason-inventory",
+    "defined-only-rejected-route-reason-emission",
     "full-table-snapshot",
     "direct-runtime-protocol-alias-reconfiguration",
 }
@@ -37,9 +37,26 @@ RUNTIME_SUPPORTED = {
     "less-specific-longest-prefix-match",
     "atomic-all-candidate-prefix-snapshot",
     "file-backed-runtime-protocol-alias-reconfiguration",
+    "active-rejected-route-reason-inventory",
 }
 ADAPTER_API_VERSION = {"kind": "product-identity", "prefix": "rustbgpd "}
 FILTERED_PREFIX_QUERY = {"global_admin": 65001, "function": 1101}
+REJECT_REASONS = {
+    "display": {
+        str(reason_id): meaning
+        for reason_id, meaning in enumerate([
+            "PREFIX LENGTH TOO LONG", "PREFIX LENGTH TOO SHORT", "BOGON",
+            "BOGON ASN", "AS PATH TOO LONG", "AS PATH TOO SHORT",
+            "FIRST AS NOT PEER AS", "NEXT HOP NOT PEER IP",
+            "IRRDB PREFIX FILTERED", "IRRDB ORIGIN AS FILTERED",
+            "PREFIX NOT IN ORIGIN AS", "RPKI UNKNOWN", "RPKI INVALID",
+            "TRANSIT FREE ASN", "TOO MANY COMMUNITIES",
+        ], 1)
+    },
+    "active_ids": [1, 3, 5, 6, 7, 8, 9, 10, 13, 14],
+    "defined_only_ids": [2, 4, 11, 12, 15],
+    "fallback_id": 0,
+}
 
 
 def fail(message: str) -> None:
@@ -59,6 +76,8 @@ if manifest.get("adapter_api_version") != ADAPTER_API_VERSION:
     fail("adapter api.version must remain an honest product identity")
 if manifest.get("filtered_prefix_query") != FILTERED_PREFIX_QUERY:
     fail("filtered-prefix namespace drifted")
+if manifest.get("reject_reasons") != REJECT_REASONS:
+    fail("pinned reject-reason display or active partition drifted")
 if manifest.get("protocol_aliases") != {
     "member-v4": "pb_as64496",
     "member-v4-reloaded": "pb_reloaded_as64496",

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -495,6 +495,8 @@ fn render_hygiene(document: &Document) -> String {
             "    term reject-too-specific {{ if route.prefix in ixp-manager-too-specific {{ reject }} }}"
         );
     }
+    out.push_str("    term reject-as-path-too-short { if route.as-path.len == 0 { reject } }\n");
+    out.push_str("    term reject-as-path-too-long { if route.as-path.len >= 65 { reject } }\n");
     if document.router.rpki {
         out.push_str("    term reject-rpki-invalid { if route.rpki == invalid { reject } }\n");
     }
@@ -525,7 +527,8 @@ fn render_client(client: &Client, prefixes: &[String]) -> String {
     }
     let _ = write!(
         out,
-        "}}\npolicy client-{slug} {{\n    term accept-authorized {{ if route.origin-as in client-{slug}-origins && route.prefix in client-{slug}-prefixes {{ accept }} }}\n    term rest {{ reject }}\n}}\n"
+        "}}\npolicy client-{slug} {{\n    term reject-first-as-not-peer-as {{ if route.as-path.len >= 1 && !(route.as-path matches \"^{}_\") {{ reject }} }}\n    term reject-irrdb-origin-as-filtered {{ if !(route.origin-as in client-{slug}-origins) {{ reject }} }}\n    term reject-irrdb-prefix-filtered {{ if !(route.prefix in client-{slug}-prefixes) {{ reject }} }}\n    term accept-authorized {{ accept }}\n}}\n",
+        client.asn
     );
     out
 }

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -2,6 +2,8 @@ use std::fs;
 
 use rs_config_render::ixp_manager::{Error, render_document};
 use rs_config_render::ixp_manager_host::RenderBinding;
+use rustbgpd_policy::rpol::{RpolFile, run_rpol_tests};
+use rustbgpd_policy::sets::SetStore;
 
 const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
 const SECRET: &str = "mcWsqMdzGwTKt67g";
@@ -32,6 +34,26 @@ fn rendered(input: &serde_json::Value) -> Result<rs_config_render::ixp_manager::
     render_document(&serde_json::to_vec(input).unwrap(), 300, &binding())
 }
 
+fn assert_terms(source: &str, policy: &str, expected: &[&str]) {
+    let file = RpolFile::parse(source).unwrap();
+    let compiled = file
+        .compile_policy(policy, &[], &mut SetStore::new())
+        .unwrap();
+    assert_eq!(
+        compiled.policies[0]
+            .terms
+            .iter()
+            .map(|term| term.name.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        expected
+    );
+}
+
+fn assert_policy_tests(source: &str, tests: &str) {
+    let report = run_rpol_tests(&format!("{source}\n{tests}")).unwrap();
+    assert!(report.all_passed(), "{:?}", report.failures);
+}
+
 #[test]
 fn supported_render_is_deterministic_and_explicit() {
     let first = render_document(FIXTURE, 300, &binding()).unwrap();
@@ -57,7 +79,7 @@ fn supported_render_is_deterministic_and_explicit() {
     let client = &first.files["policy/client-3.rpol"];
     assert!(client.contains("asn-set client-3-origins { 42 }"));
     assert!(client.contains("31.135.128.0/19"));
-    assert!(client.contains("term rest { reject }"));
+    assert!(client.contains("term accept-authorized { accept }"));
     let mut loose = value();
     loose["clients"][0]["more_specifics"] = true.into();
     assert!(
@@ -73,6 +95,88 @@ fn supported_render_is_deterministic_and_explicit() {
     assert!(
         !rendered(&maximum).unwrap().files["policy/ixp-hygiene.rpol"]
             .contains("ixp-manager-too-specific")
+    );
+}
+
+#[test]
+fn generated_reason_policies_execute_at_exact_boundaries_and_terms() {
+    let files = rendered(&value()).unwrap().files;
+    let hygiene = &files["policy/ixp-hygiene.rpol"];
+    assert_terms(
+        hygiene,
+        "ixp-manager-hygiene",
+        &[
+            "reject-too-specific",
+            "reject-as-path-too-short",
+            "reject-as-path-too-long",
+            "reject-rpki-invalid",
+        ],
+    );
+    let path64 = std::iter::repeat_n("42", 64).collect::<Vec<_>>().join(" ");
+    let path65 = std::iter::repeat_n("42", 65).collect::<Vec<_>>().join(" ");
+    assert_policy_tests(
+        hygiene,
+        &format!(
+            r#"
+test empty-as-path {{
+    route {{ prefix 31.135.128.0/19; as-path ""; rpki valid }}
+    expect ixp-manager-hygiene == reject
+}}
+test as-path-64 {{
+    route {{ prefix 31.135.128.0/19; as-path "{path64}"; rpki valid }}
+    expect ixp-manager-hygiene == accept
+}}
+test as-path-65 {{
+    route {{ prefix 31.135.128.0/19; as-path "{path65}"; rpki valid }}
+    expect ixp-manager-hygiene == reject
+}}
+"#,
+        ),
+    );
+
+    let client = &files["policy/client-3.rpol"];
+    assert!(
+        hygiene.contains("term reject-as-path-too-short { if route.as-path.len == 0 { reject } }")
+    );
+    assert!(
+        hygiene.contains("term reject-as-path-too-long { if route.as-path.len >= 65 { reject } }")
+    );
+    assert!(client.contains(
+        "term reject-irrdb-origin-as-filtered { if !(route.origin-as in client-3-origins) { reject } }"
+    ));
+    assert!(client.contains(
+        "term reject-irrdb-prefix-filtered { if !(route.prefix in client-3-prefixes) { reject } }"
+    ));
+    assert_terms(
+        client,
+        "client-3",
+        &[
+            "reject-first-as-not-peer-as",
+            "reject-irrdb-origin-as-filtered",
+            "reject-irrdb-prefix-filtered",
+            "accept-authorized",
+        ],
+    );
+    assert_policy_tests(
+        client,
+        r#"
+test nonempty-first-as-mismatch {
+    route { prefix 31.135.128.0/19; as-path "43 42" }
+    expect client-3 == reject
+}
+test bad-irrdb-origin {
+    route { prefix 31.135.128.0/19; as-path "42 43" }
+    expect client-3 == reject
+}
+test bad-irrdb-prefix {
+    route { prefix 31.135.160.0/19; as-path "42" }
+    expect client-3 == reject
+}
+test authorized-fallthrough {
+    route { prefix 31.135.128.0/19; as-path "42" }
+    expect client-3 == accept
+}
+"#,
     );
 }
 


### PR DESCRIPTION
## Summary

- generate exact AS-path length, first-AS, IRRDB origin, and IRRDB prefix rejection terms for the pinned IXP Manager v7.4 route-server contract
- map all ten reasons emitted by the pinned bird2 templates while preserving fallback 0 for ambiguous and defined-only causes
- derive the active reason partition from both real pinned template trees and verify all 15 display meanings through the real PHP consumer

## Validation

- executable generated-policy tests for empty, 64/65, first-AS, IRR origin/prefix, and authorized fallthrough
- populated live Birdwatcher smoke and full pinned IXP Manager v7.4 oracle
- complete locked workspace tests serially, strict all-target/all-feature Clippy, warning-denied docs, and contract gates
- thirteen destructive mutation proofs across policy attribution, adapter mapping, fallback, and upstream template drift

Linear: LAN-1131