### PR TITLE
IXP Manager: support path-first global prepends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The pinned IXP Manager v7.4 Foil exporter now emits strict
   `router-config/v2` ordered UI-filter rows. `rs-config-render` translates all
   advertise actions and exact ordered receive AS_IS/deny plus non-overlapping
-  peer-scoped PREPEND, while refusing global/overlapping PREPEND, malformed
-  scopes, missing peers, and 256-per-client or 4096-total overflow before a
-  receipt. The real Foil/MySQL oracle captures rows 31/33/35, strict-checks both
-  reachable variants, and executes their generated policies; v1 behavior and
-  bytes remain unchanged. This is a bounded subset, not a generic IXP Manager
-  policy engine. (LAN-1156)
+  peer-scoped or global PREPEND. Global rules use the typed first path ASN,
+  matching pinned BIRD `bgp_path.first`; optional prefix guards are exact and
+  overlapping PREPEND remains fail-closed. The real Foil/MySQL oracle captures
+  both forms, strict-checks them, and executes first-versus-origin policies; v1
+  behavior and bytes remain unchanged. This remains a bounded subset, not a
+  generic IXP Manager policy engine. (LAN-1156, LAN-1158)
 - The IXP Manager v7.4 renderer and Birdwatcher adapter now cover all ten
   reject reasons active in the pinned route-server templates, with named
   AS-path length/first-AS and separate IRRDB origin/prefix policy terms. The

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -625,10 +625,11 @@ and delivers explicit updated/release callbacks. The packaged opt-in
 namespace with shared-fence serialization and independent MD5-BGP continuity.
 Its strict router-config/v2 boundary now preserves the pinned v7.4 UI-filter
 rows and translates all advertise actions plus ordered AS_IS/deny and
-non-overlapping peer-scoped PREPEND receive actions. Exact prefix direction,
-first-AS guards, continuation/termination, 256-per-client and 4096-total caps,
-and fail-closed global/overlapping PREPEND are exercised against the real Foil
-and MySQL seed. Generic UI-filter semantics, custom-skin migration, and
+non-overlapping peer-scoped or global PREPEND receive actions. Global PREPEND
+uses the typed first path ASN, matching a pinned BIRD baseline-delta proof;
+optional prefix guards, continuation/termination, 256-per-client and 4096-total
+caps, and overlapping-PREPEND refusal are exercised against the real Foil and
+MySQL seed. Generic UI-filter semantics, custom-skin migration, and
 multi-address ownership remain open. The external adapter now
 also serves the IXP Manager v7.4 status, live protocol inventory/detail,
 symbols, member received, and member export slice through startup-only direct

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -280,7 +280,7 @@ pub enum NextHopAction {
 }
 
 /// Computed `AS_PATH` prepend operand (LAN-296): `.rpol`
-/// `prepend as self|peer|origin <count>`.
+/// `prepend as self|peer|origin|path-first <count>`.
 ///
 /// # Decision note — direction-aware computed prepend operands
 ///
@@ -348,6 +348,9 @@ pub enum PrependAs {
     /// `prepend as origin` — the route's origin AS
     /// (`RouteContext::origin_asn`).
     OriginAs,
+    /// `prepend as path-first` — the first ASN of the leading,
+    /// non-empty `AS_SEQUENCE` in the typed route `AS_PATH`.
+    PathFirst,
 }
 
 impl PrependAs {
@@ -358,6 +361,7 @@ impl PrependAs {
             PrependAs::LocalAs => "self",
             PrependAs::PeerAs => "peer",
             PrependAs::OriginAs => "origin",
+            PrependAs::PathFirst => "path-first",
         }
     }
 
@@ -371,6 +375,10 @@ impl PrependAs {
             PrependAs::LocalAs => local_asn,
             PrependAs::PeerAs => ctx.peer_asn,
             PrependAs::OriginAs => ctx.origin_asn,
+            PrependAs::PathFirst => match ctx.as_path?.segments.first()? {
+                AsPathSegment::AsSequence(asns) => asns.first().copied(),
+                AsPathSegment::AsSet(_) => None,
+            },
         }
         .filter(|&asn| asn != 0)
     }

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -212,6 +212,7 @@ impl fmt::Display for EvalErrorKind {
                     PrependAs::LocalAs => write!(f, "the chain carries no local ASN")?,
                     PrependAs::PeerAs => write!(f, "the peer ASN is unknown")?,
                     PrependAs::OriginAs => write!(f, "the route has no origin AS")?,
+                    PrependAs::PathFirst => write!(f, "the route has no usable first path ASN")?,
                 }
                 write!(f, ")")
             }

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -1022,7 +1022,8 @@ impl CompiledChain {
 
     /// Whether evaluating this chain needs the typed `AS_PATH` on the
     /// route context — true iff some term (loop bodies included)
-    /// iterates `route.as-path` (LAN-303, [`LoopSource::AsPath`]).
+    /// iterates `route.as-path` (LAN-303, [`LoopSource::AsPath`]) or
+    /// resolves `prepend as path-first`.
     /// Construction sites that leave [`crate::engine::RouteContext::as_path`]
     /// `None` make such loops iterate zero times, so callers with a
     /// typed path in hand should always pass it.
@@ -1032,6 +1033,11 @@ impl CompiledChain {
             matches!(
                 &term.action,
                 TermAction::ForEach(node) if node.source == LoopSource::AsPath
+            )
+        }) || self.any_action_mods(&|mods| {
+            matches!(
+                mods.as_path_prepend_computed,
+                Some((crate::engine::PrependAs::PathFirst, _))
             )
         })
     }

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -399,7 +399,7 @@ pub enum PrependAsArg {
     /// and denotes the origin operand (see [`Self::operand`]) — the
     /// grammar-evolution rules (ADR-0103 Decision 2) forbid reserving
     /// `origin`, so a parameter of that name keeps its existing
-    /// meaning.
+    /// meaning. `path-first` follows the same contextual rule.
     Value(U32Arg),
     /// `prepend as self <count>` — the local speaker's ASN.
     SelfAs,
@@ -419,9 +419,14 @@ impl PrependAsArg {
             PrependAsArg::SelfAs => Some(crate::engine::PrependAs::LocalAs),
             PrependAsArg::Peer => Some(crate::engine::PrependAs::PeerAs),
             PrependAsArg::Value(U32Arg::Param(name))
-                if name.node == "origin" && !is_param(&name.node) =>
+                if matches!(name.node.as_str(), "origin" | "path-first")
+                    && !is_param(&name.node) =>
             {
-                Some(crate::engine::PrependAs::OriginAs)
+                Some(if name.node == "origin" {
+                    crate::engine::PrependAs::OriginAs
+                } else {
+                    crate::engine::PrependAs::PathFirst
+                })
             }
             PrependAsArg::Value(_) => None,
         }

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -950,7 +950,7 @@ impl Parser<'_> {
                 self.bump();
                 self.expect(
                     Tok::AsKw,
-                    "`as` (`prepend as <asn|self|peer|origin> <count>`)",
+                    "`as` (`prepend as <asn|self|peer|origin|path-first> <count>`)",
                 )?;
                 // Computed operands (LAN-296): `self` / `peer` are
                 // keyword tokens (previously parse errors here, so
@@ -963,7 +963,9 @@ impl Parser<'_> {
                 } else if self.eat(Tok::PeerKw).is_some() {
                     PrependAsArg::Peer
                 } else {
-                    PrependAsArg::Value(self.u32_arg("an ASN, `self`, `peer`, or `origin`")?)
+                    PrependAsArg::Value(
+                        self.u32_arg("an ASN, `self`, `peer`, `origin`, or `path-first`")?,
+                    )
                 };
                 let count = self.u32_arg("a prepend count")?;
                 let span = token.span.to(count.span());

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -2118,6 +2118,7 @@ fn computed_prepend_operands_lower_to_computed_slot() {
         ("self", PrependAs::LocalAs),
         ("peer", PrependAs::PeerAs),
         ("origin", PrependAs::OriginAs),
+        ("path-first", PrependAs::PathFirst),
     ] {
         let chain = compile_ok(&format!(
             "policy p {{ term t {{ prepend as {source_operand} 3; accept }} }}"
@@ -2142,20 +2143,75 @@ fn fixed_prepend_forms_unchanged() {
     assert_eq!(mods.as_path_prepend, Some((65001, 3)));
     assert_eq!(mods.as_path_prepend_computed, None);
 
-    let mut store = SetStore::new();
-    let set =
-        super::RpolFile::parse("policy p(origin: u32) { term t { prepend as origin 2; accept } }")
-            .expect("compiles");
-    let chain = set
-        .compile_policy("p", &[64999], &mut store)
-        .expect("policy exists");
-    let mods = first_term_mods(&chain);
+    for name in ["origin", "path-first"] {
+        let mut store = SetStore::new();
+        let set = super::RpolFile::parse(&format!(
+            "policy p({name}: u32) {{ term t {{ prepend as {name} 2; accept }} }}"
+        ))
+        .expect("compiles");
+        let chain = set
+            .compile_policy("p", &[64999], &mut store)
+            .expect("policy exists");
+        assert_eq!(first_term_mods(&chain).as_path_prepend, Some((64999, 2)));
+        assert_eq!(first_term_mods(&chain).as_path_prepend_computed, None);
+    }
+}
+
+fn path_first_ctx(segments: Vec<rustbgpd_wire::AsPathSegment>) -> RouteContext<'static> {
+    let path = Box::leak(Box::new(rustbgpd_wire::AsPath { segments }));
+    RouteContext {
+        as_path: Some(path),
+        ..prepend_ctx(None, None)
+    }
+}
+
+#[test]
+fn prepend_path_first_uses_only_a_valid_leading_sequence() {
+    use rustbgpd_wire::AsPathSegment::{AsSequence, AsSet};
+    let chain = compile_ok("policy p { term t { prepend as path-first 2; accept } }");
+    for (segments, expected) in [
+        (vec![AsSequence(vec![64500])], Some(64500)),
+        (vec![AsSequence(vec![64501, 64500])], Some(64501)),
+        (vec![], None),
+        (vec![AsSequence(vec![]), AsSequence(vec![64500])], None),
+        (vec![AsSet(vec![64501]), AsSequence(vec![64500])], None),
+        (vec![AsSequence(vec![0, 64500])], None),
+    ] {
+        let result = chain.evaluate(&path_first_ctx(segments));
+        assert_eq!(
+            result.action,
+            expected.map_or(PolicyAction::Deny, |_| PolicyAction::Permit)
+        );
+        assert_eq!(
+            result.modifications.as_path_prepend,
+            expected.map(|asn| (asn, 2))
+        );
+    }
     assert_eq!(
-        mods.as_path_prepend,
-        Some((64999, 2)),
-        "a parameter named `origin` must stay a parameter"
+        chain.evaluate(&prepend_ctx(None, None)).action,
+        PolicyAction::Deny
     );
-    assert_eq!(mods.as_path_prepend_computed, None);
+    assert!(chain.requires_as_path_asns());
+    assert!(!chain.requires_peer_context());
+}
+
+#[test]
+fn path_first_failure_discards_earlier_staged_modifications() {
+    use rustbgpd_wire::AsPathSegment::AsSet;
+    let chain = compile_ok(
+        "policy p {
+            term staged { set local-pref 200 }
+            term path { prepend as path-first 1; accept }
+        }",
+    );
+    for ctx in [
+        prepend_ctx(None, None),
+        path_first_ctx(vec![AsSet(vec![64500])]),
+    ] {
+        let result = chain.evaluate(&ctx);
+        assert_eq!(result.action, PolicyAction::Deny);
+        assert!(result.modifications.is_empty());
+    }
 }
 
 #[test]
@@ -2239,7 +2295,7 @@ fn computed_prepend_peer_context_flags() {
     assert!(peer_chain.requires_peer_context());
     assert!(peer_chain.peer_prepend_action().is_some());
 
-    for operand in ["self", "origin"] {
+    for operand in ["self", "origin", "path-first"] {
         let chain = compile_ok(&format!(
             "policy p {{ term t {{ prepend as {operand} 3; accept }} }}"
         ));
@@ -2341,6 +2397,24 @@ fn computed_prepend_explain_renders_operand_and_agrees() {
         step.term_traces
     );
     assert!(step.modifications.is_empty(), "a deny contributes no mods");
+
+    let compiled = compile_ok("policy p { term t { prepend as path-first 2; accept } }");
+    let chain = PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "p".to_string(),
+        std::sync::Arc::new(compiled),
+    )]);
+    let trace = explain_chain_statements(
+        Some(&chain),
+        &path_first_ctx(vec![rustbgpd_wire::AsPathSegment::AsSequence(vec![
+            64501, 64500,
+        ])]),
+    );
+    assert!(
+        trace.steps[0]
+            .term_traces
+            .iter()
+            .any(|line| { line.contains("prepend as path-first 2") })
+    );
 }
 
 /// In-language `test` fixtures cover all three operands: `peer { asn }`

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -1016,7 +1016,7 @@ impl<'a> Checker<'a> {
                 }
             }
             ActionStmt::Prepend { asn, count, .. } => {
-                // A computed operand (`self`/`peer`, or an `origin`
+                // A computed operand (`self`/`peer`, or an `origin`/`path-first`
                 // identifier that is not a declared parameter —
                 // LAN-296) needs no parameter check; the operand
                 // decision itself is shared with lowering via

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -983,7 +983,7 @@ Two consequences worth internalizing:
 | `add large-community 65000:1:2` / `remove ...` | large communities |
 | `add ext-community RT:65001:100` / `remove ...` | extended communities (RT/RO, or well-known: `add ext-community OV_INVALID`) |
 | `prepend as <asn> <count>` | prepend `<count>` copies of `<asn>` (count: literal 1–255) |
-| `prepend as self\|peer\|origin <count>` | prepend a computed ASN (see below) |
+| `prepend as self\|peer\|origin\|path-first <count>` | prepend a computed ASN (see below) |
 
 The kind keyword must match the literal's kind (`add community
 RT:...` is a compile error pointing at `add ext-community`). Within a
@@ -1010,8 +1010,11 @@ route; see "Value expressions").
   non-empty `AS_SEQUENCE` (the same value `route.origin-as` reads).
   A policy *parameter* named `origin` shadows the operand — the
   parameter keeps its existing meaning.
+- **`path-first`** — the first ASN of a non-empty leading
+  `AS_SEQUENCE` in the typed route `AS_PATH`. A parameter with this
+  name also shadows the operand.
 
-**Direction legality.** `self` and `origin` are legal on import and
+**Direction legality.** `self`, `origin`, and `path-first` are legal on import and
 export chains. `peer` is **import-only**: on an export chain it would
 prepend the *receiving* peer's own ASN, which the receiver rejects as
 an own-AS loop (RFC 4271 §9.1.2) unless it runs allowas-in. A chain
@@ -1024,6 +1027,7 @@ policy and term, never a per-route runtime surprise.
 | `self`   | yes | yes | outbound TE; inbound self-prepend biases best-path like the literal form already could |
 | `peer`   | yes | **rejected at attach** | the inbound "prepend the neighbor's AS" idiom |
 | `origin` | yes | yes | origin AS is already in the path — no loop-detection impact |
+| `path-first` | yes | yes | route-derived BIRD `bgp_path.first` equivalent; does not read peer identity |
 
 *Comparison:* FRR's `set as-path prepend last-as N` (prepend the
 neighbor's AS) is its inbound route-map idiom and the model for
@@ -1035,7 +1039,8 @@ peer-AS prepend, hence the attach-time rejection.
 
 **Failure is closed.** A computed operand resolves when the matched
 term's action executes. If the value is unknown — no usable
-`AS_SEQUENCE` for `origin`, unknown peer ASN for `peer`, a chain
+`AS_SEQUENCE` for `origin`, no non-empty leading `AS_SEQUENCE` for
+`path-first` (including a leading `AS_SET`), unknown peer ASN for `peer`, a chain
 evaluated outside a daemon config for `self` — or the context value is
 zero (AS 0 is prohibited on the wire, RFC 7607), the route is
 **denied**: staged modifications are discarded, ASN 0 is never
@@ -1044,7 +1049,7 @@ reason.
 
 **Update-group note.** `prepend as peer` reads peer identity, so (like
 `peer.asn` guards) it keeps its peers out of shared update groups;
-`self` and `origin` never disqualify grouping.
+`self`, `origin`, and `path-first` never disqualify grouping.
 
 Extended-community wire encoding follows the daemon's other
 frontends: dotted-quad admin → RFC 4360 type 0x01, ASN > 65535 →
@@ -1290,7 +1295,7 @@ action      := "accept" | "reject"
              | "set" "next-hop" (IP | "self")
              | ("add" | "remove") ("community" | "large-community" | "ext-community") community
              | ("add" | "remove") "community" IDENT      # binding-valued
-             | "prepend" "as" (u32arg | "self" | "peer" | "origin") INT
+             | "prepend" "as" (u32arg | "self" | "peer" | "origin" | "path-first") INT
 expr        := and ("||" and)*
 and         := unary ("&&" unary)*
 unary       := "!" unary | "(" expr ")" | "apply" "(" IDENT ["(" u32arg,* ")"] ")" | predicate

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -49,10 +49,13 @@ the active route-server-template partition `1,3,5,6,7,8,9,10,13,14`, keeps
 `2,4,11,12,15` defined-only, and proves fallback `0` remains untranslated.
 
 The same pinned v7.4 Foil/MySQL journey captures complete ordered UI-filter
-rows 31, 33, and 35, then disables row 31 and proves rows 33 and 35 remain in
-order. Both strict v2 captures render and pass `rustbgpd --check --strict`; the
+rows 31, 33, and 35, then proves a supported row 32 global PREPEND beside the
+distinct peer-scoped row 33. A baseline-delta check binds row 32 to BIRD's
+`bgp_path.first` behavior without retaining raw config. Both strict v2 captures
+render and pass `rustbgpd --check --strict`; the
 oracle executes the generated advertise and receive policies with `rbgp policy
-check`. Exact row objects, raw repeated-render bytes, v2 completion counts,
+check`, distinguishing path-first from origin and target-peer ASNs. Exact row
+objects, raw repeated-render bytes, v2 completion counts,
 receipt-last publication, and v3 refusal are load-bearing. This proves only the
 bounded manual export subset; it does not make the adapter runtime-compatible
 or claim a generic IXP Manager policy engine.

--- a/tests/compat/ixp-manager-birdseye/config-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/config-consumer.php
@@ -33,6 +33,30 @@ $render = static function (string $name) use ($router, $output): string {
 config(['ixp.no_transit_asns.override' => false]);
 $render('config-implicit.json');
 config(['ixp.no_transit_asns.override' => []]);
+DB::table('route_server_filters_prod')->where('id', 32)->update([
+    'peer_id' => null, 'vlan_id' => 1, 'received_prefix' => '203.0.113.0/24',
+    'advertised_prefix' => null, 'protocol' => 4, 'action_advertise' => 'AS_IS',
+    'action_receive' => 'PREPEND_ONCE', 'order_by' => 3,
+]);
+DB::table('route_server_filters_prod')->update(['enabled' => 0]);
+$router->template = 'api/v4/router/server/bird2/standard';
+$birdBaseline = (new ConfigurationGenerator($router))->render()->render();
+DB::table('route_server_filters_prod')->where('id', 32)->update(['enabled' => 1]);
+$birdCandidate = (new ConfigurationGenerator($router))->render()->render();
+$prepend = 'bgp_path.prepend( bgp_path.first );';
+$peerGuard = 'if ( bgp_path.first =';
+$fragment = "    if ( net = 203.0.113.0/24 ) then {\n"
+    . "        # PREPEND_ONCE\n"
+    . "        bgp_path.prepend( bgp_path.first );\n"
+    . "    }\n";
+if (substr_count($birdCandidate, $prepend) - substr_count($birdBaseline, $prepend) !== 1
+    || substr_count($birdCandidate, $peerGuard) - substr_count($birdBaseline, $peerGuard) !== 0
+    || str_contains($birdBaseline, $fragment)
+    || substr_count($birdCandidate, $fragment) !== 1) {
+    $fail('isolated pinned BIRD global PREPEND drifted');
+}
+unset($birdBaseline, $birdCandidate, $fragment, $prepend, $peerGuard);
+$router->template = 'api/v4/router/server/rustbgpd/json';
 DB::table('vlaninterface')->whereNotIn('id', [1, 4])->update(['rsclient' => 0]);
 DB::table('irrdb_asn')->where('customer_id', 2)->where('protocol', 4)
     ->where('asn', '<>', 1213)->delete();
@@ -53,11 +77,14 @@ if (array_column($filters, 'id') !== [31, 33, 35]
 }
 
 DB::table('route_server_filters_prod')->where('id', 31)->update(['enabled' => 0]);
+DB::table('route_server_filters_prod')->where('id', 32)->update(['enabled' => 1]);
 $supportedRaw = $render('ixp-manager-v7.4-rustbgpd.json');
 $supported = json_decode($supportedRaw, true, 512, JSON_THROW_ON_ERROR);
-if (array_column($supported['ui_filters'], 'id') !== [33, 35]
+if (array_column($supported['ui_filters'], 'id') !== [32, 33, 35]
     || array_column($supported['ui_filters'], 'action_receive')
-        !== ['PREPEND_TWICE', 'AS_IS']) {
+        !== ['PREPEND_ONCE', 'PREPEND_TWICE', 'AS_IS']
+    || $supported['ui_filters'][0]['peer'] !== null
+    || $supported['ui_filters'][0]['received_prefix'] !== '203.0.113.0/24') {
     $fail('row-31-disabled ordered UI-filter export drifted');
 }
 $second = (new ConfigurationGenerator($router))->render()->render();

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -59,7 +59,8 @@
         "PREPEND_TWICE",
         "PREPEND_THRICE"
       ],
-      "receive_prepend_requires_peer": true,
+      "global_receive_prepend": "path-first-with-optional-received-prefix",
+      "peer_receive_prepend": "literal-peer-asn",
       "overlapping_receive_prepend": false,
       "per_client_cap": 256,
       "total_cap": 4096

--- a/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json
@@ -77,6 +77,17 @@
     ],
     "ui_filters": [
         {
+            "id": 32,
+            "customer_id": 2,
+            "peer": null,
+            "received_prefix": "203.0.113.0/24",
+            "advertised_prefix": null,
+            "protocol": 4,
+            "action_advertise": "AS_IS",
+            "action_receive": "PREPEND_ONCE",
+            "order_by": 3
+        },
+        {
             "id": 33,
             "customer_id": 2,
             "peer": {
@@ -109,7 +120,7 @@
     "complete": {
         "handle": "b2-rs1-lan1-ipv4",
         "client_count": 2,
-        "ui_filter_count": 2,
+        "ui_filter_count": 3,
         "marker": "END_OF_RUSTBGPD_IXP_MANAGER_CONFIG_b2-rs1-lan1-ipv4"
     }
 }

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -109,6 +109,10 @@ candidate_full="$tmp/candidate-full"
 candidate_supported="$tmp/candidate-supported"
 render_v2 "$capture_output/config-ui-filter.json" "$candidate_full"
 render_v2 "$supported" "$candidate_supported"
+[ "$(grep -Fxc '    term ui-receive-32 { if route.prefix == 203.0.113.0/24 { prepend as path-first 1 } }' \
+  "$candidate_supported/policy/client-1.rpol")" -eq 1 ]
+[ "$(grep -Fxc '    term ui-receive-33 { if route.as-path matches "^112_" && route.prefix == 192.175.48.0/24 { prepend as 112 2 } }' \
+  "$candidate_supported/policy/client-1.rpol")" -eq 1 ]
 
 legacy="$tmp/candidate-v1"
 legacy_input="$tmp/ixp-manager-v1-supported.json"
@@ -167,6 +171,14 @@ test supported-advertise-prefix-direction {
 test supported-receive-prepend-then-accept {
     route { prefix 192.175.48.0/24; as-path "112" }
     expect client-1-receive == accept with prepend as 112 2
+}
+test supported-global-prepend-uses-first-not-origin {
+    route { prefix 203.0.113.0/24; as-path "64501 64500" }
+    expect client-1-receive == accept with prepend as 64501 1
+}
+test supported-global-prepend-prefix-miss {
+    route { prefix 203.0.114.0/24; as-path "64501 64500" }
+    expect client-1-receive == accept
 }'
 
 "$root/run-adapter-consumer.sh" "$tmp/ixp-manager" "$image" >/dev/null

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -72,7 +72,8 @@ MANUAL_CONFIG_EXPORT = {
             "AS_IS", "NO_ADVERTISE", "PREPEND_ONCE", "PREPEND_TWICE",
             "PREPEND_THRICE",
         ],
-        "receive_prepend_requires_peer": True,
+        "global_receive_prepend": "path-first-with-optional-received-prefix",
+        "peer_receive_prepend": "literal-peer-asn",
         "overlapping_receive_prepend": False,
         "per_client_cap": 256,
         "total_cap": 4096,
@@ -99,6 +100,16 @@ FULL_UI_FILTERS = [
         "action_advertise": "AS_IS", "action_receive": "AS_IS", "order_by": 6,
     },
 ]
+SUPPORTED_UI_FILTERS = [
+    {
+        "id": 32, "customer_id": 2, "peer": None,
+        "received_prefix": "203.0.113.0/24", "advertised_prefix": None,
+        "protocol": 4, "action_advertise": "AS_IS",
+        "action_receive": "PREPEND_ONCE", "order_by": 3,
+    },
+    FULL_UI_FILTERS[1],
+    FULL_UI_FILTERS[2],
+]
 
 
 def fail(message: str) -> None:
@@ -122,6 +133,17 @@ if manifest.get("reject_reasons") != REJECT_REASONS:
     fail("pinned reject-reason display or active partition drifted")
 if manifest.get("manual_config_export") != MANUAL_CONFIG_EXPORT:
     fail("strict manual v2 export contract drifted")
+consumer_source = (root / "config-consumer.php").read_text()
+for required in [
+    "$router->template = 'api/v4/router/server/bird2/standard';",
+    "substr_count($birdCandidate, $prepend) - substr_count($birdBaseline, $prepend) !== 1",
+    "substr_count($birdCandidate, $peerGuard) - substr_count($birdBaseline, $peerGuard) !== 0",
+    "str_contains($birdBaseline, $fragment)",
+    "substr_count($birdCandidate, $fragment) !== 1",
+    "unset($birdBaseline, $birdCandidate, $fragment, $prepend, $peerGuard);",
+]:
+    if required not in consumer_source:
+        fail(f"pinned in-memory BIRD path-first proof drifted: {required}")
 if manifest.get("protocol_aliases") != {
     "member-v4": "pb_as64496",
     "member-v4-reloaded": "pb_reloaded_as64496",
@@ -138,7 +160,7 @@ if len(sys.argv) == 3:
     )
     for name, document, filters in [
         ("full", full, FULL_UI_FILTERS),
-        ("row-31-disabled", supported, FULL_UI_FILTERS[1:]),
+        ("row-31-disabled", supported, SUPPORTED_UI_FILTERS),
     ]:
         if document.get("schema") != MANUAL_CONFIG_EXPORT["schema"]:
             fail(f"{name} UI-filter capture schema drifted")

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -66,9 +66,10 @@ candidate without that receipt is incomplete and must not be deployed.
 `ixp-manager-v2` preserves ordered UI-filter rows. Advertise AS_IS is a no-op;
 deny and prepend actions add the exact IXP Manager route-server control large
 community and matching rules accumulate after hygiene and IRR checks. Receive
-PREPEND requires a peer, applies exact first-AS and received-prefix guards, and
-continues; receive AS_IS or deny terminates in order. Global or reachable
-overlapping receive PREPEND, missing peers, noncanonical or wrong-family
+PREPEND with a peer uses its literal ASN and an exact first-AS guard; global
+PREPEND uses the typed route's first path ASN. An optional received-prefix guard
+is exact, and PREPEND continues; receive AS_IS or deny terminates in order.
+Reachable overlapping receive PREPEND, malformed peers, noncanonical or wrong-family
 prefixes, malformed order/actions, more than 256 rows per client, or more than
 4096 rows total are refused before a receipt. The older `ixp-manager-v1`
 boundary remains available for legacy captures and still refuses active UI

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -555,9 +555,6 @@ fn validate_ui_filters(
         {
             return Err(Error::Refused("UI-filter peer identity is missing"));
         }
-        if filter.action_receive.prepend_count().is_some() && filter.peer.is_none() {
-            return Err(Error::Refused("global receive PREPEND is unsupported"));
-        }
         previous = Some(order_key);
     }
     for (right_index, right) in filters.iter().enumerate() {
@@ -868,7 +865,7 @@ fn render_client(
                     .peer
                     .as_ref()
                     .and_then(|peer| peer.asn)
-                    .expect("validated PREPEND peer"),
+                    .map_or_else(|| "path-first".to_owned(), |asn| asn.to_string()),
                 action.prepend_count().expect("PREPEND action")
             ),
         };

--- a/tools/rs-config-render/tests/fixtures/ixp-manager-v2-supported.json
+++ b/tools/rs-config-render/tests/fixtures/ixp-manager-v2-supported.json
@@ -77,6 +77,17 @@
     ],
     "ui_filters": [
         {
+            "id": 32,
+            "customer_id": 2,
+            "peer": null,
+            "received_prefix": "203.0.113.0/24",
+            "advertised_prefix": null,
+            "protocol": 4,
+            "action_advertise": "AS_IS",
+            "action_receive": "PREPEND_ONCE",
+            "order_by": 3
+        },
+        {
             "id": 33,
             "customer_id": 2,
             "peer": {
@@ -109,7 +120,7 @@
     "complete": {
         "handle": "b2-rs1-lan1-ipv4",
         "client_count": 2,
-        "ui_filter_count": 2,
+        "ui_filter_count": 3,
         "marker": "END_OF_RUSTBGPD_IXP_MANAGER_CONFIG_b2-rs1-lan1-ipv4"
     }
 }

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -381,11 +381,17 @@ test full-first-rule-denies-receive {
     assert_terms(
         client,
         "client-1-receive",
-        &["ui-receive-33", "ui-receive-35", "accept-unmatched"],
+        &[
+            "ui-receive-32",
+            "ui-receive-33",
+            "ui-receive-35",
+            "accept-unmatched",
+        ],
     );
     assert!(client.contains(
         "route.as-path matches \"^112_\" && route.prefix == 192.175.48.0/24 { prepend as 112 2 }"
     ));
+    assert!(client.contains("route.prefix == 203.0.113.0/24 { prepend as path-first 1 }"));
     assert!(!client.contains("ui-receive-31"));
     assert_policy_tests(
         client,
@@ -401,6 +407,30 @@ test wrong-received-prefix-does-not-prepend {
 test wrong-first-as-does-not-prepend {
     route { prefix 192.175.48.0/24; as-path "113" }
     expect client-1-receive == accept
+}
+test global-prepend-uses-path-first-not-origin {
+    route { prefix 203.0.113.0/24; as-path "64501 64500" }
+    expect client-1-receive == accept with prepend as 64501 1
+}
+test global-prepend-has-exact-prefix-guard {
+    route { prefix 203.0.114.0/24; as-path "64501 64500" }
+    expect client-1-receive == accept
+}
+"#,
+    );
+
+    let mut unscoped = v2_value(V2_SUPPORTED);
+    unscoped["ui_filters"].as_array_mut().unwrap().remove(1);
+    unscoped["ui_filters"][0]["received_prefix"] = serde_json::Value::Null;
+    unscoped["complete"]["ui_filter_count"] = 2.into();
+    let unscoped = &rendered_v2(&unscoped).unwrap().files["policy/client-1.rpol"];
+    assert!(unscoped.contains("term ui-receive-32 { prepend as path-first 1 }"));
+    assert_policy_tests(
+        unscoped,
+        r#"
+test unscoped-global-prepend {
+    route { prefix 203.0.113.0/24; as-path "64501 64500" }
+    expect client-1-receive == accept with prepend as 64501 1
 }
 "#,
     );
@@ -536,12 +566,12 @@ fn v2_receive_terminal_pruning_is_scope_aware_and_off_router_peers_are_valid() {
             "received_prefix": null, "advertised_prefix": null, "protocol": 4,
             "action_advertise": "AS_IS", "action_receive": "NO_ADVERTISE", "order_by": 7
         }));
-    terminal["complete"]["ui_filter_count"] = 3.into();
+    terminal["complete"]["ui_filter_count"] = 4.into();
     let source = &rendered_v2(&terminal).unwrap().files["policy/client-1.rpol"];
     assert!(source.contains("ui-receive-35"));
     assert!(!source.contains("ui-receive-37"));
 
-    terminal["ui_filters"][1]["action_receive"] = "NO_ADVERTISE".into();
+    terminal["ui_filters"][2]["action_receive"] = "NO_ADVERTISE".into();
     let source = &rendered_v2(&terminal).unwrap().files["policy/client-1.rpol"];
     assert_policy_tests(
         source,
@@ -555,21 +585,22 @@ test prepend-is-discarded-by-later-deny {
 
     let mut nonoverlap = v2_value(V2_SUPPORTED);
     nonoverlap["ui_filters"].as_array_mut().unwrap().insert(
-        1,
+        0,
         serde_json::json!({
             "id": 34, "customer_id": 2, "peer": {"customer_id": 4, "asn": 112},
             "received_prefix": "198.51.100.0/24", "advertised_prefix": null, "protocol": 4,
-            "action_advertise": "AS_IS", "action_receive": "PREPEND_ONCE", "order_by": 5
+            "action_advertise": "AS_IS", "action_receive": "PREPEND_ONCE", "order_by": 2
         }),
     );
-    nonoverlap["complete"]["ui_filter_count"] = 3.into();
+    nonoverlap["complete"]["ui_filter_count"] = 4.into();
     let source = &rendered_v2(&nonoverlap).unwrap().files["policy/client-1.rpol"];
     assert_terms(
         source,
         "client-1-receive",
         &[
-            "ui-receive-33",
             "ui-receive-34",
+            "ui-receive-32",
+            "ui-receive-33",
             "ui-receive-35",
             "accept-unmatched",
         ],
@@ -600,41 +631,41 @@ fn v2_refuses_malformed_unrepresentable_and_capped_filter_sets() {
     };
     refuses(
         v2_value(V2_SUPPORTED),
-        "/ui_filters/0/peer/asn",
+        "/ui_filters/1/peer/asn",
         serde_json::Value::Null,
     );
     refuses(
         v2_value(V2_SUPPORTED),
-        "/ui_filters/0/peer",
-        serde_json::Value::Null,
-    );
-    refuses(
-        v2_value(V2_SUPPORTED),
-        "/ui_filters/0/received_prefix",
+        "/ui_filters/1/received_prefix",
         "192.175.48.1/24".into(),
     );
     refuses(
         v2_value(V2_SUPPORTED),
-        "/ui_filters/0/received_prefix",
+        "/ui_filters/1/received_prefix",
         "192.175.48.0/024".into(),
     );
     refuses(
         v2_value(V2_SUPPORTED),
-        "/ui_filters/0/advertised_prefix",
+        "/ui_filters/1/advertised_prefix",
         "2001:db8::/32".into(),
     );
-    refuses(v2_value(V2_SUPPORTED), "/ui_filters/0/protocol", 6.into());
+    refuses(v2_value(V2_SUPPORTED), "/ui_filters/1/protocol", 6.into());
     refuses(
         v2_value(V2_SUPPORTED),
-        "/ui_filters/0/customer_id",
+        "/ui_filters/1/customer_id",
         999.into(),
     );
-    refuses(v2_value(V2_SUPPORTED), "/ui_filters/1/order_by", 3.into());
-    refuses(v2_value(V2_SUPPORTED), "/ui_filters/1/order_by", 4.into());
+    refuses(v2_value(V2_SUPPORTED), "/ui_filters/0/order_by", 0.into());
+    refuses(v2_value(V2_SUPPORTED), "/ui_filters/0/order_by", 4.into());
     refuses(
         v2_value(V2_SUPPORTED),
-        "/ui_filters/0/action_receive",
+        "/ui_filters/1/action_receive",
         "UNKNOWN".into(),
+    );
+    refuses(
+        v2_value(V2_SUPPORTED),
+        "/ui_filters/0/received_prefix",
+        serde_json::Value::Null,
     );
     for field in ["peer", "received_prefix", "advertised_prefix", "protocol"] {
         let mut missing = v2_value(V2_SUPPORTED);
@@ -663,21 +694,23 @@ fn v2_refuses_malformed_unrepresentable_and_capped_filter_sets() {
         v6["clients"][index]["peering_ips"] = serde_json::json!([address]);
         v6["clients"][index]["prefixes"] = serde_json::json!([prefix]);
     }
+    v6["ui_filters"][1]["protocol"] = 6.into();
+    v6["ui_filters"][1]["received_prefix"] = "2001:db8:2::/48".into();
+    v6["ui_filters"][1]["advertised_prefix"] = "2001:db8:1::/48".into();
     v6["ui_filters"][0]["protocol"] = 6.into();
-    v6["ui_filters"][0]["received_prefix"] = "2001:db8:2::/064".into();
-    v6["ui_filters"][0]["advertised_prefix"] = "2001:db8:1::/48".into();
+    v6["ui_filters"][0]["received_prefix"] = "2001:db8:3::/064".into();
     assert!(rendered_v2(&v6).is_err());
 
     let mut overlap = v2_value(V2_SUPPORTED);
     overlap["ui_filters"].as_array_mut().unwrap().insert(
-        1,
+        0,
         serde_json::json!({
             "id": 34, "customer_id": 2, "peer": {"customer_id": 4, "asn": 112},
             "received_prefix": null, "advertised_prefix": null, "protocol": 4,
-            "action_advertise": "AS_IS", "action_receive": "PREPEND_ONCE", "order_by": 5
+            "action_advertise": "AS_IS", "action_receive": "PREPEND_ONCE", "order_by": 2
         }),
     );
-    overlap["complete"]["ui_filter_count"] = 3.into();
+    overlap["complete"]["ui_filter_count"] = 4.into();
     assert!(rendered_v2(&overlap).is_err());
 
     let template = serde_json::json!({


### PR DESCRIPTION
## Summary

- add typed `.rpol` `prepend as path-first N`, resolving only a valid leading `AS_SEQUENCE` and failing closed without usable typed path data
- render strict `router-config/v2` global receive PREPEND with optional exact prefix guards while preserving peer-scoped and v1 behavior
- prove the pinned IXP Manager v7.4 journey through in-memory BIRD baseline deltas, real MySQL/Rust capture, strict rendering, and executable policies

## Verification

- 12 destructive mutations failed and restored exact source hashes
- focused policy, renderer, lifecycle, and pinned compatibility suites passed
- serial `cargo test --workspace --locked -- --test-threads=1` passed
- strict all-feature Clippy, warning-denied docs, format, and repository contract gates passed

The ordinary parallel workspace run encountered the existing shared host-fence process-state race in `corrupt_or_contradictory_durable_state_never_sends_a_callback`. That test passed in isolation and the full workspace passed serially; this adapter/policy change does not alter lifecycle state handling.

This remains a bounded IXP Manager integration subset. `runtime_compatibility` stays false.
