### PR TITLE
Scrub router-owned large communities in IXP exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `.rpol` now supports the exact removal-only
+  `remove large-community <u32>:*:*` form with bounded, fail-closed arrived-route
+  evaluation. Pinned IXP Manager v7.4 candidates append a router-AS scrub last
+  to global and per-client override export chains while preserving foreign
+  administrators. (LAN-1112)
 - `NeighborState.rejected_routes_retained` now carries the exact session
   actor's bounded retained-reject count with rolling-upgrade presence.
   `birdwatcher-adapter` protocol inventory consumes it in one `ListNeighbors`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -629,8 +629,10 @@ non-overlapping peer-scoped or global PREPEND receive actions. Global PREPEND
 uses the typed first path ASN, matching a pinned BIRD baseline-delta proof;
 optional prefix guards, continuation/termination, 256-per-client and 4096-total
 caps, and overlapping-PREPEND refusal are exercised against the real Foil and
-MySQL seed. Generic UI-filter semantics, custom-skin migration, and
-multi-address ownership remain open. The external adapter now
+MySQL seed. Global and per-client override export chains now end with a
+router-own-AS large-community scrub, matching the pinned templates without
+peer context or wildcard matching. Generic UI-filter semantics, custom-skin
+migration, and multi-address ownership remain open. The external adapter now
 also serves the IXP Manager v7.4 status, live protocol inventory/detail,
 symbols, member received, and member export slice through startup-only direct
 aliases or a bounded file-backed resolver that swaps atomically on Unix SIGHUP

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1615,7 +1615,7 @@ impl PolicyChain {
                     || !mods.large_communities_add.is_empty()
                     || !mods.large_communities_remove.is_empty()
             }
-            TermAction::CommunityVar { .. } => true,
+            TermAction::CommunityVar { .. } | TermAction::RemoveLargeCommunityAdmin { .. } => true,
             TermAction::Deny
             | TermAction::Bind { .. }
             | TermAction::ForEach(_)

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -595,6 +595,17 @@ fn trace_rpol_policy(
             }
             continue;
         }
+        if let TermAction::RemoveLargeCommunityAdmin { global_admin } = &term.action {
+            if !crate::eval::exec_remove_large_community_admin(*global_admin, ctx, &mut continued) {
+                term_traces.push(format!(
+                    "term {}: large-community input exceeds the wildcard-removal bound — fail closed => reject",
+                    term.name.as_deref().unwrap_or("<unnamed>"),
+                ));
+                decided = Some((index, term));
+                break;
+            }
+            continue;
+        }
         // Loop control at policy level is a compiler bug: fail closed,
         // exactly like the live walk's StrayLoopControl rail.
         if matches!(&term.action, TermAction::Break | TermAction::ContinueLoop) {
@@ -739,6 +750,9 @@ fn render_term_action(action: &TermAction, tables: &CompiledChain) -> String {
         TermAction::ContinueLoop => return "continue (loop)".to_string(),
         TermAction::CommunityVar { add, name, .. } => {
             return format!("{} community {name}", if *add { "add" } else { "remove" });
+        }
+        TermAction::RemoveLargeCommunityAdmin { global_admin } => {
+            return format!("remove large-community {global_admin}:*:*");
         }
     };
     let mut parts = mods.map_or_else(Vec::new, render_action_stmts);

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -15,6 +15,7 @@
 //! (the `ATTR` const generic) — the plain [`CompiledChain::evaluate`]
 //! path never touches it.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -54,6 +55,10 @@ pub(crate) static NO_DATASETS: PinnedDatasets = [const { None }; MAX_UNIT_DATASE
 /// enforces per policy, and the runtime fuel every evaluation starts
 /// with (LAN-303). Not operator-tunable.
 pub(crate) const MAX_EVAL_COST: u64 = 1_000_000;
+
+/// Conservative upper bound derived from a 16-bit attribute-value length and
+/// 12-octet RFC 8092 values. Wildcard removal pre-pays this full scan.
+pub(crate) const MAX_LARGE_COMMUNITIES_PER_ROUTE: u64 = 5_461;
 
 /// Hard per-loop iteration cap (ADR-0103 Decision 3,
 /// `MAX_LOOP_ITERATIONS`): a loop whose source still has elements
@@ -526,6 +531,37 @@ pub(crate) fn exec_community_var(
     Ok(())
 }
 
+/// Execute the bounded `.rpol` global-admin wildcard removal. The arrived
+/// route is the sole authority: one scan produces stable, deduplicated concrete
+/// removals, which then merge through the ordinary policy-local accumulator.
+/// Input beyond the pre-paid wire bound fails closed before the scan.
+pub(crate) fn exec_remove_large_community_admin(
+    global_admin: u32,
+    ctx: &RouteContext<'_>,
+    continued: &mut Option<RouteModifications>,
+) -> bool {
+    if ctx.large_communities.len()
+        > usize::try_from(MAX_LARGE_COMMUNITIES_PER_ROUTE).expect("fixed bound fits usize")
+    {
+        return false;
+    }
+    let mut mods = RouteModifications::default();
+    let mut seen: HashSet<_> = continued.as_ref().map_or_else(HashSet::new, |current| {
+        current.large_communities_remove.iter().copied().collect()
+    });
+    for community in ctx.large_communities {
+        if community.global_admin == global_admin && seen.insert(*community) {
+            mods.large_communities_remove.push(*community);
+        }
+    }
+    if !mods.large_communities_remove.is_empty() {
+        continued
+            .get_or_insert_with(RouteModifications::default)
+            .merge_from(mods);
+    }
+    true
+}
+
 /// A policy's disposition of the route, borrowing the matched term's
 /// modifications (cloned only if merged). `PermitOwned` carries
 /// modifications accumulated from `Continue` terms merged with the
@@ -958,6 +994,16 @@ impl CompiledChain {
                                 break;
                             }
                         }
+                        TermAction::RemoveLargeCommunityAdmin { global_admin } => {
+                            if !exec_remove_large_community_admin(
+                                *global_admin,
+                                ctx,
+                                &mut continued,
+                            ) {
+                                denied = true;
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -1136,6 +1182,13 @@ impl CompiledChain {
                             return PolicyDecision::Error { kind, term_index };
                         }
                     }
+                    TermAction::RemoveLargeCommunityAdmin { global_admin } => {
+                        if !exec_remove_large_community_admin(*global_admin, ctx, &mut continued) {
+                            return PolicyDecision::Deny {
+                                term_index: Some(term_index),
+                            };
+                        }
+                    }
                 }
             }
         }
@@ -1257,6 +1310,15 @@ impl CompiledChain {
                     TermAction::CommunityVar { add, slot, .. } => {
                         exec_community_var(*add, *slot, locals.as_ref(), continued)
                             .map_err(|kind| (kind, iterations - 1))?;
+                    }
+                    TermAction::RemoveLargeCommunityAdmin { global_admin } => {
+                        if !exec_remove_large_community_admin(*global_admin, ctx, continued) {
+                            return Ok(LoopOutcome {
+                                iterations,
+                                decided_at: Some(iterations - 1),
+                                flow: LoopFlow::Deny,
+                            });
+                        }
                     }
                     // `break` exits the innermost loop: the enclosing
                     // walk continues after it.

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -793,6 +793,13 @@ pub enum TermAction {
         /// The binding name as written, for explain surfaces.
         name: Box<str>,
     },
+    /// Scan the arrived route's large communities once and stage concrete
+    /// removals for every value whose global administrator equals this ASN.
+    /// `.rpol` `remove large-community <u32>:*:*`; route-only and internal.
+    RemoveLargeCommunityAdmin {
+        /// Exact RFC 8092 global administrator to remove.
+        global_admin: u32,
+    },
 }
 
 /// One guarded action inside a [`CompiledPolicy`] — the compiled form

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -520,6 +520,10 @@ impl ActionStmt {
 pub enum CommunityArg {
     /// A community literal of the action's kind.
     Lit(Spanned<CommunityLit>),
+    /// `remove large-community <global-admin>:*:*` — the one supported
+    /// wildcard form. The evaluator expands it against the arrived route
+    /// into concrete large-community removals.
+    LargeAdminWildcard(Spanned<u32>),
     /// A `let`/loop binding or policy parameter (standard communities
     /// only; parameters resolve to literals at compile time).
     Var(Spanned<String>),

--- a/crates/policy/src/rpol/lexer.rs
+++ b/crates/policy/src/rpol/lexer.rs
@@ -33,6 +33,9 @@ pub enum Tok {
     /// `RT:65001:100`, `RO:192.0.2.1:5` — extended-community literal.
     #[regex(r"(RT|RO):([0-9]+|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):[0-9]+")]
     ExtCommunityLit,
+    /// `65000:*:*` — exact global-admin large-community removal wildcard.
+    #[regex(r"[0-9]+:\*:\*")]
+    LargeCommunityWildcard,
     /// `65000:1:2` or `LC:65000:1:2` — large-community literal.
     #[regex(r"(LC:)?[0-9]+:[0-9]+:[0-9]+")]
     LargeCommunityLit,
@@ -241,6 +244,7 @@ impl Tok {
     pub fn describe(self) -> &'static str {
         match self {
             Tok::ExtCommunityLit => "extended-community literal",
+            Tok::LargeCommunityWildcard => "large-community global-admin wildcard",
             Tok::LargeCommunityLit => "large-community literal",
             Tok::StdCommunityLit => "community literal",
             Tok::PrefixLit => "prefix literal",
@@ -363,6 +367,7 @@ mod tests {
         assert_eq!(kinds("2001:db8::1"), vec![Tok::Ipv6Lit]);
         assert_eq!(kinds("65000:100"), vec![Tok::StdCommunityLit]);
         assert_eq!(kinds("65000:1:2"), vec![Tok::LargeCommunityLit]);
+        assert_eq!(kinds("65000:*:*"), vec![Tok::LargeCommunityWildcard]);
         assert_eq!(kinds("LC:65000:1:2"), vec![Tok::LargeCommunityLit]);
         assert_eq!(kinds("RT:65001:100"), vec![Tok::ExtCommunityLit]);
         assert_eq!(kinds("RO:192.0.2.1:5"), vec![Tok::ExtCommunityLit]);

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -638,6 +638,18 @@ impl<'a> Lowerer<'a> {
                 // staged modifications first preserves execution
                 // order). Parameter references are compile-time
                 // constants and stage as literals in `apply_action`.
+                Stmt::Action(ActionStmt::Community {
+                    arg: CommunityArg::LargeAdminWildcard(global),
+                    ..
+                }) => {
+                    flush_pending(&mut out, &mut pending);
+                    out.push((
+                        MatchExpr::True,
+                        TermAction::RemoveLargeCommunityAdmin {
+                            global_admin: global.node,
+                        },
+                    ));
+                }
                 Stmt::Action(
                     action @ ActionStmt::Community {
                         add,
@@ -1227,6 +1239,15 @@ impl Lowerer<'_> {
                 // term, in execution order relative to staged
                 // modifications.
                 ActionStmt::Community {
+                    arg: CommunityArg::LargeAdminWildcard(global),
+                    ..
+                } => {
+                    flush(&mut tail, &mut mods);
+                    tail.push(TermAction::RemoveLargeCommunityAdmin {
+                        global_admin: global.node,
+                    });
+                }
+                ActionStmt::Community {
                     add,
                     arg: CommunityArg::Var(name),
                     ..
@@ -1298,6 +1319,10 @@ impl Lowerer<'_> {
             // writing the value. (Binding-valued references are emitted as
             // their own CommunityVar terms by the statement/body lowerers
             // and never reach here.)
+            ActionStmt::Community {
+                arg: CommunityArg::LargeAdminWildcard(_),
+                ..
+            } => unreachable!("route-dependent wildcard action handled by callers"),
             ActionStmt::Community {
                 add,
                 arg: CommunityArg::Var(name),
@@ -1637,7 +1662,7 @@ fn accept_predicate(policy: &CompiledPolicy) -> MatchExpr {
     let mut arms: Vec<MatchExpr> = Vec::new();
     for term in &policy.terms {
         match term.action {
-            TermAction::Continue(_) => {}
+            TermAction::Continue(_) | TermAction::RemoveLargeCommunityAdmin { .. } => {}
             // LAN-302/LAN-303: the typechecker rejects `apply` of a
             // policy that declares bindings or contains loops, so an
             // inlined predicate never contains these terms.

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -926,6 +926,19 @@ impl Parser<'_> {
                 // is purely additive (a non-well-known identifier was a
                 // parse error before).
                 let arg = match self.peek() {
+                    Some(wildcard) if wildcard.kind == Tok::LargeCommunityWildcard => {
+                        self.bump();
+                        let global = self
+                            .text(wildcard)
+                            .split(':')
+                            .next()
+                            .expect("token shape")
+                            .to_owned();
+                        CommunityArg::LargeAdminWildcard(Spanned::new(
+                            self.parse_u32_text(&global, wildcard.span)?,
+                            wildcard.span,
+                        ))
+                    }
                     Some(ident)
                         if ident.kind == Tok::Ident && !self.is_well_known_community(ident) =>
                     {
@@ -936,6 +949,7 @@ impl Parser<'_> {
                 };
                 let end = match &arg {
                     CommunityArg::Lit(lit) => lit.span,
+                    CommunityArg::LargeAdminWildcard(global) => global.span,
                     CommunityArg::Var(name) => name.span,
                 };
                 let span = token.span.to(end);

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -291,6 +291,112 @@ fn else_lowers_to_negated_guard() {
 }
 
 #[test]
+fn large_community_admin_wildcard_is_route_only_and_concrete_end_to_end() {
+    use crate::engine::{PolicyChain, apply_modifications, explain::explain_chain_statements};
+    use rustbgpd_wire::{LargeCommunity, PathAttribute};
+
+    let own_a = LargeCommunity::new(65_501, 1, 2);
+    let foreign = LargeCommunity::new(64_496, 3, 4);
+    let own_b = LargeCommunity::new(65_501, 5, 6);
+    let staged = LargeCommunity::new(65_501, 9, 9);
+    let communities = Box::leak(vec![own_a, foreign, own_a, own_b].into_boxed_slice());
+    let ctx = RouteContext {
+        large_communities: communities,
+        ..route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound)
+    };
+    let mut compiled = compile_ok(
+        "policy scrub { term stage { add large-community 65501:9:9 } term remove-own { remove large-community 65501:*:*; remove large-community 65501:*:* } term allow { accept } }",
+    );
+    let live = compiled.evaluate(&ctx);
+    assert_eq!(
+        live.modifications.large_communities_remove,
+        vec![own_a, own_b]
+    );
+    assert_eq!(live.modifications.large_communities_add, vec![staged]);
+    let mut hits = compiled.zero_term_hits();
+    assert_eq!(compiled.evaluate_recording_hits(&ctx, &mut hits), live);
+    let oversized = vec![own_a; 5_462];
+    let oversized_ctx = RouteContext {
+        large_communities: &oversized,
+        ..ctx
+    };
+    let dry = compiled.evaluate_recording_hits(&oversized_ctx, &mut hits);
+    assert_eq!(dry, crate::PolicyResult::deny());
+    let mut attrs = vec![PathAttribute::LargeCommunities(communities.to_vec())];
+    apply_modifications(&mut attrs, &live.modifications);
+    let expected = vec![PathAttribute::LargeCommunities(vec![foreign, staged])];
+    assert_eq!(attrs, expected);
+
+    compiled.policies[0].terms.remove(0);
+    assert!(!compiled.requires_peer_context());
+    let chain = PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "scrub".to_string(),
+        Arc::new(compiled),
+    )]);
+    assert!(chain.modifies_source_control_communities());
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    let traced_removals = trace.steps[0]
+        .modifications
+        .iter()
+        .filter(|line| line.starts_with("large_community - 65501:"))
+        .count();
+    assert_eq!(traced_removals, 2);
+    assert_eq!(chain.evaluate(&oversized_ctx), crate::PolicyResult::deny());
+    let oversized_trace = explain_chain_statements(Some(&chain), &oversized_ctx);
+    assert_eq!(oversized_trace.action, PolicyAction::Deny);
+}
+
+#[test]
+fn large_community_wildcard_syntax_is_exact_and_removal_only() {
+    for bad in [
+        "add large-community 65501:*:*",
+        "remove community 65501:*:*",
+        "remove large-community *:*:*",
+        "remove large-community 65501:*:1",
+        "remove large-community 65501:1:*",
+        "remove large-community router-asn:*:*",
+        "remove large-community LC:65501:*:*",
+        "remove large-community 65501 :*:*",
+        "remove large-community 65501:*: *",
+        "remove large-community 4294967296:*:*",
+        "if route.large-communities has 65501:*:* { accept }",
+    ] {
+        let rendered = diagnostics_of(&format!("policy p {{ term t {{ {bad} }} }}")).1;
+        assert!(!rendered.is_empty(), "unsupported shape compiled: {bad}");
+    }
+}
+
+#[test]
+fn large_community_wildcard_prepays_the_full_wire_scan() {
+    let wildcard = "remove large-community 65501:*:*;";
+    let source = |n| format!("policy p {{ term t {{ {} accept }} }}", wildcard.repeat(n));
+    compile_ok(&source(183));
+    let (_, rendered) = diagnostics_of(&source(184));
+    assert!(rendered.contains("exceeds the worst-case evaluation budget"));
+
+    let guarded = "set med 2; set local-pref 100; set med 3; remove large-community 65501:*:*;";
+    let conditional = |n| {
+        format!(
+            "policy p {{ term t {{ if route.med == 1 && route.local-pref == 100 {{ {} accept }} reject }} }}",
+            guarded.repeat(n)
+        )
+    };
+    compile_ok(&conditional(181));
+    let (_, rendered) = diagnostics_of(&conditional(182));
+    assert!(rendered.contains("exceeds the worst-case evaluation budget"));
+
+    let nested = |n| {
+        format!(
+            "asn-set one {{ 1 }} fn bump(x: u32) -> u32 {{ x }} policy p {{ term t {{ for c in one {{ if route.med == 1 && route.local-pref == 100 {{ remove community c; add community c; set med bump(2); {} accept }} }} reject }} }}",
+            guarded.repeat(n)
+        )
+    };
+    compile_ok(&nested(180));
+    let (_, rendered) = diagnostics_of(&nested(181));
+    assert!(rendered.contains("exceeds the worst-case evaluation budget"));
+}
+
+#[test]
 fn apply_inlines_the_target_decision() {
     let chain = compile_ok(
         "policy inner {

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -972,6 +972,20 @@ impl<'a> Checker<'a> {
                     );
                 }
             }
+            ActionStmt::Community {
+                add,
+                kind,
+                arg: CommunityArg::LargeAdminWildcard(global),
+                ..
+            } => {
+                if *add || *kind != CommunityKind::Large {
+                    self.diags.push(Diagnostic::new(
+                        global.span,
+                        "large-community wildcard requires `remove large-community`",
+                        "wildcards are removal-only and large-community-only",
+                    ));
+                }
+            }
             // LAN-303: `add/remove community <binding>` — bindings are
             // u32-valued, so the variable form is standard-kind only,
             // and the name must resolve to a binding or parameter.
@@ -2326,22 +2340,19 @@ fn bound_policy<'a>(
             match stmt {
                 Stmt::If(if_stmt) => {
                     let cost = guard_cost(&if_stmt.cond, pred_cost, fns);
-                    arms.push(cost);
-                    if if_stmt.else_actions.is_some() {
-                        arms.push(cost.saturating_add(1));
+                    arms.extend(
+                        (0..guarded_action_terms(&if_stmt.then_actions, fns)).map(|_| cost),
+                    );
+                    if let Some(actions) = &if_stmt.else_actions {
+                        arms.extend(
+                            (0..guarded_action_terms(actions, fns)).map(|_| cost.saturating_add(1)),
+                        );
                     }
                     for action in if_stmt
                         .then_actions
                         .iter()
                         .chain(if_stmt.else_actions.iter().flatten())
                     {
-                        // A body `let` (LAN-302) lowers to its own Bind
-                        // term that re-evaluates the branch guard (the
-                        // else side adds a negation) — charge one arm
-                        // per binding on top of its initializer cost.
-                        if matches!(action, ActionStmt::Let { .. }) {
-                            arms.push(cost.saturating_add(1));
-                        }
                         action_cost = action_cost.saturating_add(action_value_cost(action, fns));
                     }
                 }
@@ -2482,9 +2493,17 @@ fn for_costs(
                 let guard = guard_cost(&if_stmt.cond, pred_cost, fns);
                 // Upper bound per iteration: the guard (twice with an
                 // else — the negated arm) plus every body action.
-                let arms: u64 = if if_stmt.else_actions.is_some() { 2 } else { 1 };
-                nodes = nodes.saturating_add(guard.saturating_mul(arms));
-                body_steps = body_steps.saturating_add(guard.saturating_mul(arms));
+                let mut guards =
+                    guard.saturating_mul(guarded_action_terms(&if_stmt.then_actions, fns));
+                if let Some(actions) = &if_stmt.else_actions {
+                    guards = guards.saturating_add(
+                        guard
+                            .saturating_add(1)
+                            .saturating_mul(guarded_action_terms(actions, fns)),
+                    );
+                }
+                nodes = nodes.saturating_add(guards);
+                body_steps = body_steps.saturating_add(guards);
                 for action in if_stmt
                     .then_actions
                     .iter()
@@ -2524,6 +2543,23 @@ fn binding_value_cmp(rhs: &Rhs, resolved: Field, scope: &Scope<'_>) -> bool {
         if scope.is_local(&name.node) && value_field_of(resolved).is_some())
 }
 
+/// Conservative guarded-tail count: every source action plus every Bind term
+/// hoisted by an inline user call, with one arm retained for an empty branch.
+fn guarded_action_terms(actions: &[ActionStmt], fns: &HashMap<&str, FnCost>) -> u64 {
+    actions
+        .iter()
+        .map(|action| {
+            1 + match action {
+                ActionStmt::SetLocalPref(expr, _)
+                | ActionStmt::SetMed(expr, _)
+                | ActionStmt::Let { init: expr, .. } => call_slots(expr, fns),
+                _ => 0,
+            }
+        })
+        .fold(0, u64::saturating_add)
+        .max(1)
+}
+
 /// The value-expression steps an action contributes to the
 /// evaluation-cost budget (LAN-299: only the computed `set` values
 /// carry expressions; everything else is constant-time. LAN-302: a
@@ -2533,6 +2569,10 @@ fn action_value_cost(action: &ActionStmt, fns: &HashMap<&str, FnCost>) -> u64 {
     match action {
         ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => value_cost(expr, fns),
         ActionStmt::Let { init, .. } => value_cost(init, fns).saturating_add(1),
+        ActionStmt::Community {
+            arg: CommunityArg::LargeAdminWildcard(_),
+            ..
+        } => crate::eval::MAX_LARGE_COMMUNITIES_PER_ROUTE,
         _ => 0,
     }
 }

--- a/docs/adr/0101-route-server-profile.md
+++ b/docs/adr/0101-route-server-profile.md
@@ -103,6 +103,9 @@ Add-Path send, so mitigation (b) existed; the gap was (a).
    identical to an enabled one's, and tagged-route divergence is
    evaluated per member. `rs_control_communities` defaults on for
    rs-clients again on the strength of this.
+   The pinned IXP Manager renderer also appends a router-AS wildcard scrub as
+   the final global or per-client export policy, so received own-AS control
+   communities do not escape while foreign administrators remain untouched.
 
 4. **RPKI/ASPA enforcement stays in policy — no hard-coded RS gate.**
    Validation state is computed at import; enforcement is rpol/TOML

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -981,6 +981,7 @@ Two consequences worth internalizing:
 | `set next-hop <ip>` / `set next-hop self` | override `NEXT_HOP` |
 | `add community 65001:999` / `remove community ...` | standard communities |
 | `add large-community 65000:1:2` / `remove ...` | large communities |
+| `remove large-community 65000:*:*` | every arrived large community with global administrator 65000 |
 | `add ext-community RT:65001:100` / `remove ...` | extended communities (RT/RO, or well-known: `add ext-community OV_INVALID`) |
 | `prepend as <asn> <count>` | prepend `<count>` copies of `<asn>` (count: literal 1–255) |
 | `prepend as self\|peer\|origin\|path-first <count>` | prepend a computed ASN (see below) |
@@ -997,6 +998,13 @@ when the matched term's action executes — constant expressions have
 already folded to literals at compile time, and expressions reading
 route/peer fields evaluate per route (an evaluation error denies the
 route; see "Value expressions").
+
+The large-community wildcard is deliberately removal-only and accepts exactly
+one decimal `u32` global administrator followed by `:*:*`, with no spaces or
+prefix. It scans only the arrived route, preserves foreign administrators, and
+stages concrete, first-seen deduplicated removals. An input with more than 5,461
+arrived large communities fails the route closed before scanning; the compiler
+pre-pays that same conservative wire-derived bound.
 
 ### Computed prepend operands
 

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -60,6 +60,10 @@ receipt-last publication, and v3 refusal are load-bearing. This proves only the
 bounded manual export subset; it does not make the adapter runtime-compatible
 or claim a generic IXP Manager policy engine.
 
+The strict candidates also append the router-own-AS large-community scrub last
+to the global export chain and every v2 client receive override. The manifest
+pins its exact removal-only syntax, placement, and foreign-admin preservation.
+
 Run the gate from the repository root:
 
 ```console

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -44,6 +44,12 @@
     "ixp_manager_version": "7.4.0",
     "router_handle": "b2-rs1-lan1-ipv4",
     "strict_receipt_required": true,
+    "own_as_large_community_scrub": {
+      "syntax": "remove large-community <router-asn>:*:*",
+      "global_export_chain_position": "last",
+      "client_override_export_chain_position": "last",
+      "foreign_global_admins": "preserved"
+    },
     "ui_filters": {
       "advertise_actions": [
         "AS_IS",

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -63,6 +63,12 @@ MANUAL_CONFIG_EXPORT = {
     "ixp_manager_version": "7.4.0",
     "router_handle": "b2-rs1-lan1-ipv4",
     "strict_receipt_required": True,
+    "own_as_large_community_scrub": {
+        "syntax": "remove large-community <router-asn>:*:*",
+        "global_export_chain_position": "last",
+        "client_override_export_chain_position": "last",
+        "foreign_global_admins": "preserved",
+    },
     "ui_filters": {
         "advertise_actions": [
             "AS_IS", "NO_ADVERTISE", "PREPEND_ONCE", "PREPEND_TWICE",

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -69,6 +69,9 @@ community and matching rules accumulate after hygiene and IRR checks. Receive
 PREPEND with a peer uses its literal ASN and an exact first-AS guard; global
 PREPEND uses the typed route's first path ASN. An optional received-prefix guard
 is exact, and PREPEND continues; receive AS_IS or deny terminates in order.
+Every v1 global export chain and v2 per-client receive override ends with
+`ixp-manager-own-as-export-scrub`, which removes concrete large communities
+under the router ASN while preserving communities owned by other administrators.
 Reachable overlapping receive PREPEND, malformed peers, noncanonical or wrong-family
 prefixes, malformed order/actions, more than 256 rows per client, or more than
 4096 rows total are refused before a receipt. The older `ixp-manager-v1`

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -688,7 +688,9 @@ fn render_config(
             client.vlan_interface_id
         );
     }
-    out.push_str("]\nexport_chain = [\"ixp-transparent-export\"]\n");
+    out.push_str(
+        "]\nexport_chain = [\"ixp-transparent-export\", \"ixp-manager-own-as-export-scrub\"]\n",
+    );
     for client in &document.clients {
         let family = if router.protocol == 4 {
             "ipv4_unicast"
@@ -716,7 +718,7 @@ fn render_config(
         {
             let _ = writeln!(
                 out,
-                "export_policy_chain = [\"ixp-transparent-export\", \"client-{}-receive\"]",
+                "export_policy_chain = [\"ixp-transparent-export\", \"client-{}-receive\", \"ixp-manager-own-as-export-scrub\"]",
                 client.vlan_interface_id
             );
         }
@@ -779,6 +781,11 @@ fn render_hygiene(document: &Document) -> String {
             document.policy.minimum_prefix_length + 1
         );
     }
+    let _ = writeln!(
+        out,
+        "policy ixp-manager-own-as-export-scrub {{\n    term remove-own-as-large-communities {{ remove large-community {}:*:* }}\n    term accept-unmatched {{ accept }}\n}}",
+        document.router.asn
+    );
     out
 }
 

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -1293,6 +1293,7 @@ fn unsafe_term(
     match &term.action {
         TermAction::Permit(mods) | TermAction::Continue(mods) => unsafe_mods(mods, forbidden),
         TermAction::CommunityVar { .. } => Some("community variables are refused"),
+        TermAction::RemoveLargeCommunityAdmin { .. } => Some("community removal is refused"),
         TermAction::ForEach(node) => node
             .body
             .iter()
@@ -2798,6 +2799,21 @@ mod tests {
         assert_eq!(expected_fingerprint().len(), 16);
         let again = expected_fingerprint();
         assert_eq!(expected_fingerprint(), again);
+    }
+
+    #[test]
+    fn site_local_refuses_large_community_wildcard_removal() {
+        let file = rustbgpd_policy::rpol::RpolFile::parse(
+            "policy scrub { term t { remove large-community 65501:*:*; accept } }",
+        )
+        .unwrap();
+        let chain = file
+            .compile_policy("scrub", &[], &mut rustbgpd_policy::sets::SetStore::new())
+            .unwrap();
+        assert_eq!(
+            unsafe_chain(&chain, &[]),
+            Some("community removal is refused")
+        );
     }
 
     #[test]

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -107,6 +107,7 @@ fn supported_render_is_deterministic_and_explicit() {
         "interpret_rfc1997 = true",
         "max_prefix_restart_seconds = 300",
         "md5_password = \"mcWsqMdzGwTKt67g\"",
+        "export_chain = [\"ixp-transparent-export\", \"ixp-manager-own-as-export-scrub\"]",
     ] {
         assert!(config.contains(expected), "missing {expected}");
     }
@@ -124,6 +125,16 @@ fn supported_render_is_deterministic_and_explicit() {
     let hygiene = &rendered(&transit).unwrap().files["policy/ixp-hygiene.rpol"];
     assert!(hygiene.contains("if route.as-path matches \"_(42)_\""));
     assert!(!hygiene.contains("peer.asn in ixp-manager-no-transit"));
+    assert!(hygiene.contains("remove large-community 65501:*:*"));
+    assert_terms(
+        hygiene,
+        "ixp-manager-own-as-export-scrub",
+        &["remove-own-as-large-communities", "accept-unmatched"],
+    );
+    assert_policy_tests(
+        hygiene,
+        "test own-as-scrub-executes { route { large-communities [65501:1:2, 64496:3:4, 65501:5:6] } expect ixp-manager-own-as-export-scrub == accept }",
+    );
     let mut maximum = value();
     maximum["policy"]["minimum_prefix_length"] = 32.into();
     assert!(
@@ -292,7 +303,7 @@ fn v1_and_v2_dispatch_are_strict_and_v1_output_stays_legacy() {
     for (name, expected) in [
         (
             "config.toml",
-            "56248e088030f41ee5cf31b5cb5d034e4239c65180b1874879cb56fe932f6263",
+            "7ed88dd78d15be8b4e0949afbcc9479afa13d852db472e1d2d7b37ff71f48685",
         ),
         (
             "policy/client-3.rpol",
@@ -300,7 +311,7 @@ fn v1_and_v2_dispatch_are_strict_and_v1_output_stays_legacy() {
         ),
         (
             "policy/ixp-hygiene.rpol",
-            "9b985aa25791348137ecb047614627ba7aaa0a214b008f045bc77c1fc8b7ced5",
+            "326b2121b023329d2b4a7542a2510d01220782552fcfd4e7920de1df5f658094",
         ),
     ] {
         assert_eq!(content_digest(&v1.files[name]), expected, "{name} drifted");
@@ -350,7 +361,7 @@ fn v2_filter_policies_preserve_order_direction_and_reachability() {
     assert!(!full["policy/client-4.rpol"].contains("ui-"));
     assert!(
         full["config.toml"]
-            .contains("export_policy_chain = [\"ixp-transparent-export\", \"client-1-receive\"]")
+            .contains("export_policy_chain = [\"ixp-transparent-export\", \"client-1-receive\", \"ixp-manager-own-as-export-scrub\"]")
     );
     assert_eq!(full["config.toml"].matches("client-1-receive").count(), 1);
     assert_policy_tests(


### PR DESCRIPTION
## Summary

- Add removal-only `remove large-community <u32>:*:*` syntax and lower it to concrete route modifications without peer context or API/schema changes.
- Fail closed above the prepaid 5,461-value scan bound, preserve stable first-seen order, and deduplicate concrete removals across repeated wildcard actions.
- Conservatively prepay every guarded lowering tail, including nested loops and hoisted inline-call bindings, while preserving the exact straight-line boundary.
- Append the router own-AS scrub last in every pinned IXP Manager v1 and v2 export chain, while preserving foreign administrators and refusing the action in site-local policy input.

## Verification

- Focused policy, renderer, and site-local suites; locked serial workspace; strict all-target/all-feature Clippy; warning-denied docs; fmt and repository contract gates.
- Pinned IXP Manager v7.4 / Bird's Eye oracle with exact v1/v2 chain placement and runtime compatibility still false.
- Eleven original destructive mutations plus cross-action dedup and guarded-cost recovery mutations all failed and restored byte-for-byte.

The ordinary parallel workspace can still encounter the known unrelated rs-config-render lifecycle host-fence test race; the exact lifecycle test and full serial workspace pass.