### PR TITLE
Support bounded overlapping IXP prepends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   canonical max-prefix keys without per-peer reject-route fanout. (LAN-1157)
 - The pinned IXP Manager v7.4 Foil exporter now emits strict
   `router-config/v2` ordered UI-filter rows. `rs-config-render` translates all
-  advertise actions and exact ordered receive AS_IS/deny plus non-overlapping
-  peer-scoped or global PREPEND. Global rules use the typed first path ASN,
-  matching pinned BIRD `bgp_path.first`; optional prefix guards are exact and
-  overlapping PREPEND remains fail-closed. The real Foil/MySQL oracle captures
-  both forms, strict-checks them, and executes first-versus-origin policies; v1
-  behavior and bytes remain unchanged. This remains a bounded subset, not a
-  generic IXP Manager policy engine. (LAN-1156, LAN-1158)
+  advertise actions and exact ordered receive AS_IS/deny and PREPEND. Reachable
+  overlapping PREPEND compiles into at most 4096 disjoint first-AS and exact-
+  prefix cells, accumulating in row order and terminating on AS_IS or deny.
+  Global cells use the typed first path ASN, matching pinned BIRD
+  `bgp_path.first`; 255 prepends succeed and 256 refuses. The real Foil/MySQL
+  oracle captures and executes the overlap while non-overlap and v1 bytes stay
+  unchanged. This remains a bounded subset, not a generic IXP Manager policy
+  engine. (LAN-1156, LAN-1158, LAN-1160)
 - The IXP Manager v7.4 renderer and Birdwatcher adapter now cover all ten
   reject reasons active in the pinned route-server templates, with named
   AS-path length/first-AS and separate IRRDB origin/prefix policy terms. The

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -624,12 +624,13 @@ and delivers explicit updated/release callbacks. The packaged opt-in
 `rustbgpd@.service` and M97 prove two exact IPv4/IPv6 handles in one host
 namespace with shared-fence serialization and independent MD5-BGP continuity.
 Its strict router-config/v2 boundary now preserves the pinned v7.4 UI-filter
-rows and translates all advertise actions plus ordered AS_IS/deny and
-non-overlapping peer-scoped or global PREPEND receive actions. Global PREPEND
-uses the typed first path ASN, matching a pinned BIRD baseline-delta proof;
-optional prefix guards, continuation/termination, 256-per-client and 4096-total
-caps, and overlapping-PREPEND refusal are exercised against the real Foil and
-MySQL seed. Global and per-client override export chains now end with a
+rows and translates all advertise actions plus ordered AS_IS/deny and PREPEND
+receive actions. Reachable overlap compiles to at most 4096 disjoint first-AS
+and exact-prefix cells; prepends accumulate in row order, AS_IS/deny terminate,
+and global cells use the typed first path ASN. Exact 255/256 prepend and
+4096-cell synthesis boundaries, non-overlap bytes, and sequential pinned BIRD
+output are exercised against the real Foil and MySQL seed. Global and
+per-client override export chains now end with a
 router-own-AS large-community scrub, matching the pinned templates without
 peer context or wildcard matching. Generic UI-filter semantics, custom-skin
 migration, and multi-address ownership remain open. The external adapter now

--- a/integrations/ixp-manager/gpl-2.0-only/README.md
+++ b/integrations/ixp-manager/gpl-2.0-only/README.md
@@ -14,10 +14,11 @@ or translate the upstream BIRD templates.
 The exporter preserves every applicable UI filter as one ordered row,
 including peer identity, distinct received and advertised prefixes, protocol,
 and both actions. The Rust renderer translates the bounded pinned-v7.4 subset
-exactly: advertise control actions, receive AS_IS/deny, and non-overlapping
-peer-scoped receive PREPEND. Missing peers, global or reachable overlapping
-receive PREPEND, malformed order or prefixes, and more than 256 rows per client
-or 4096 total are refused.
+exactly: advertise control actions and ordered receive AS_IS, deny, and
+PREPEND. Reachable overlap is bounded into disjoint peer and exact-prefix
+cells; counts above 255 or more than 4096 compiled cells refuse. Missing peers,
+malformed order or prefixes, and more than 256 rows per client or 4096 total
+are also refused.
 
 Fetch that document separately through the authenticated IXP Manager API into
 a regular, non-symlink mode-0600 local file. Keep API keys in the fetcher's

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -49,12 +49,13 @@ the active route-server-template partition `1,3,5,6,7,8,9,10,13,14`, keeps
 `2,4,11,12,15` defined-only, and proves fallback `0` remains untranslated.
 
 The same pinned v7.4 Foil/MySQL journey captures complete ordered UI-filter
-rows 31, 33, and 35, then proves a supported row 32 global PREPEND beside the
-distinct peer-scoped row 33. A baseline-delta check binds row 32 to BIRD's
-`bgp_path.first` behavior without retaining raw config. Both strict v2 captures
-render and pass `rustbgpd --check --strict`; the
-oracle executes the generated advertise and receive policies with `rbgp policy
-check`, distinguishing path-first from origin and target-peer ASNs. Exact row
+rows 31, 33, and 35, then proves unscoped row 32 PREPEND_ONCE overlaps
+peer-and-prefix row 33 PREPEND_TWICE before row 35 AS_IS. An in-memory
+baseline-delta proves pinned BIRD emits both matching actions sequentially
+without retaining raw config. Both strict v2 captures render and pass
+`rustbgpd --check --strict`; the oracle executes the disjoint-cell result with
+`rbgp policy check`, including target, peer-miss, prefix-miss, path-first, and
+unusable-path cases. Exact row
 objects, raw repeated-render bytes, v2 completion counts,
 receipt-last publication, and v3 refusal are load-bearing. This proves only the
 bounded manual export subset; it does not make the adapter runtime-compatible
@@ -94,9 +95,9 @@ blocker, weakening the explicit alias or product-version
 posture, enabling debug mode, skipping a case, or drifting a pin or response
 makes the gate fail.
 
-The manual-export matrix separately records the 256-per-client and 4096-total
-UI-filter caps and keeps the full IXP Manager UI-filter policy engine
-unsupported.
+The manual-export matrix separately records the 256-per-client, 4096-total-row,
+and 4096 compiled receive-cell caps. Bounded pinned-v7.4 overlap is supported;
+the full IXP Manager UI-filter policy engine remains unsupported.
 
 ## Provenance and licensing
 

--- a/tests/compat/ixp-manager-birdseye/config-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/config-consumer.php
@@ -34,28 +34,43 @@ config(['ixp.no_transit_asns.override' => false]);
 $render('config-implicit.json');
 config(['ixp.no_transit_asns.override' => []]);
 DB::table('route_server_filters_prod')->where('id', 32)->update([
-    'peer_id' => null, 'vlan_id' => 1, 'received_prefix' => '203.0.113.0/24',
+    'peer_id' => null, 'vlan_id' => 1, 'received_prefix' => null,
     'advertised_prefix' => null, 'protocol' => 4, 'action_advertise' => 'AS_IS',
     'action_receive' => 'PREPEND_ONCE', 'order_by' => 3,
 ]);
 DB::table('route_server_filters_prod')->update(['enabled' => 0]);
 $router->template = 'api/v4/router/server/bird2/standard';
 $birdBaseline = (new ConfigurationGenerator($router))->render()->render();
-DB::table('route_server_filters_prod')->where('id', 32)->update(['enabled' => 1]);
+DB::table('route_server_filters_prod')->whereIn('id', [32, 33])->update(['enabled' => 1]);
 $birdCandidate = (new ConfigurationGenerator($router))->render()->render();
 $prepend = 'bgp_path.prepend( bgp_path.first );';
 $peerGuard = 'if ( bgp_path.first =';
-$fragment = "    if ( net = 203.0.113.0/24 ) then {\n"
-    . "        # PREPEND_ONCE\n"
-    . "        bgp_path.prepend( bgp_path.first );\n"
-    . "    }\n";
-if (substr_count($birdCandidate, $prepend) - substr_count($birdBaseline, $prepend) !== 1
-    || substr_count($birdCandidate, $peerGuard) - substr_count($birdBaseline, $peerGuard) !== 0
-    || str_contains($birdBaseline, $fragment)
-    || substr_count($birdCandidate, $fragment) !== 1) {
-    $fail('isolated pinned BIRD global PREPEND drifted');
+$global = "    # PREPEND_ONCE\n    bgp_path.prepend( bgp_path.first );\n";
+$specific = "    if ( bgp_path.first = 112 ) then {\n"
+    . "        if ( net = 192.175.48.0/24 ) then {\n"
+    . "            # PREPEND_TWICE\n"
+    . "            bgp_path.prepend( bgp_path.first );\n"
+    . "            bgp_path.prepend( bgp_path.first );\n"
+    . "        }\n    }\n";
+$globalPosition = strpos($birdCandidate, $global);
+$specificPosition = strpos($birdCandidate, $specific);
+if (substr_count($birdCandidate, $prepend) - substr_count($birdBaseline, $prepend) !== 3
+    || substr_count($birdCandidate, $peerGuard) - substr_count($birdBaseline, $peerGuard) !== 1
+    || str_contains($birdBaseline, $global) || str_contains($birdBaseline, $specific)
+    || $globalPosition === false || $specificPosition === false
+    || $globalPosition >= $specificPosition) {
+    $fail('pinned BIRD overlapping PREPEND order drifted');
 }
-unset($birdBaseline, $birdCandidate, $fragment, $prepend, $peerGuard);
+unset(
+    $birdBaseline,
+    $birdCandidate,
+    $global,
+    $specific,
+    $globalPosition,
+    $specificPosition,
+    $prepend,
+    $peerGuard,
+);
 $router->template = 'api/v4/router/server/rustbgpd/json';
 DB::table('vlaninterface')->whereNotIn('id', [1, 4])->update(['rsclient' => 0]);
 DB::table('irrdb_asn')->where('customer_id', 2)->where('protocol', 4)
@@ -84,7 +99,7 @@ if (array_column($supported['ui_filters'], 'id') !== [32, 33, 35]
     || array_column($supported['ui_filters'], 'action_receive')
         !== ['PREPEND_ONCE', 'PREPEND_TWICE', 'AS_IS']
     || $supported['ui_filters'][0]['peer'] !== null
-    || $supported['ui_filters'][0]['received_prefix'] !== '203.0.113.0/24') {
+    || $supported['ui_filters'][0]['received_prefix'] !== null) {
     $fail('row-31-disabled ordered UI-filter export drifted');
 }
 $second = (new ConfigurationGenerator($router))->render()->render();

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -75,7 +75,8 @@
       ],
       "global_receive_prepend": "path-first-with-optional-received-prefix",
       "peer_receive_prepend": "literal-peer-asn",
-      "overlapping_receive_prepend": false,
+      "overlapping_receive_prepend": true,
+      "compiled_receive_cell_cap": 4096,
       "per_client_cap": 256,
       "total_cap": 4096
     }

--- a/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/ixp-manager-v7.4-rustbgpd.json
@@ -80,7 +80,7 @@
             "id": 32,
             "customer_id": 2,
             "peer": null,
-            "received_prefix": "203.0.113.0/24",
+            "received_prefix": null,
             "advertised_prefix": null,
             "protocol": 4,
             "action_advertise": "AS_IS",

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -109,9 +109,9 @@ candidate_full="$tmp/candidate-full"
 candidate_supported="$tmp/candidate-supported"
 render_v2 "$capture_output/config-ui-filter.json" "$candidate_full"
 render_v2 "$supported" "$candidate_supported"
-[ "$(grep -Fxc '    term ui-receive-32 { if route.prefix == 203.0.113.0/24 { prepend as path-first 1 } }' \
+[ "$(grep -Fxc '    term ui-receive-cell-0000 { if route.as-path matches "^112_" && route.prefix == 192.175.48.0/24 { prepend as 112 3; accept } }' \
   "$candidate_supported/policy/client-1.rpol")" -eq 1 ]
-[ "$(grep -Fxc '    term ui-receive-33 { if route.as-path matches "^112_" && route.prefix == 192.175.48.0/24 { prepend as 112 2 } }' \
+[ "$(grep -Fxc '    term ui-receive-cell-0003 { if !(route.as-path matches "^(112)_") && !(route.prefix in client-1-ui-receive-prefixes) { prepend as path-first 1; accept } }' \
   "$candidate_supported/policy/client-1.rpol")" -eq 1 ]
 
 legacy="$tmp/candidate-v1"
@@ -168,17 +168,30 @@ test supported-advertise-prefix-direction {
     route { prefix 77.72.72.0/21; as-path "1213" }
     expect client-1 == accept with large-community 65501:102:112
 }
-test supported-receive-prepend-then-accept {
+test supported-overlap-accumulates-then-accepts {
     route { prefix 192.175.48.0/24; as-path "112" }
-    expect client-1-receive == accept with prepend as 112 2
+    expect client-1-receive == accept with prepend as 112 3
 }
-test supported-global-prepend-uses-first-not-origin {
-    route { prefix 203.0.113.0/24; as-path "64501 64500" }
+test supported-peer-miss-keeps-global-prepend {
+    route { prefix 192.175.48.0/24; as-path "64501 64500" }
     expect client-1-receive == accept with prepend as 64501 1
 }
-test supported-global-prepend-prefix-miss {
-    route { prefix 203.0.114.0/24; as-path "64501 64500" }
-    expect client-1-receive == accept
+test supported-prefix-miss-keeps-global-prepend {
+    route { prefix 203.0.113.0/24; as-path "112" }
+    expect client-1-receive == accept with prepend as 112 1
+}
+test supported-other-cell-uses-path-first {
+    route { prefix 203.0.113.0/24; as-path "64501 64500" }
+    peer { asn 65010 }
+    expect client-1-receive == accept with prepend as 64501 1
+}
+test supported-empty-path-fails-closed {
+    route { prefix 203.0.113.0/24; as-path "" }
+    expect client-1-receive == error absent-prepend-operand
+}
+test supported-leading-set-fails-closed {
+    route { prefix 203.0.113.0/24; as-path "{64500 64501}" }
+    expect client-1-receive == error absent-prepend-operand
 }'
 
 "$root/run-adapter-consumer.sh" "$tmp/ixp-manager" "$image" >/dev/null

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -88,7 +88,8 @@ MANUAL_CONFIG_EXPORT = {
         ],
         "global_receive_prepend": "path-first-with-optional-received-prefix",
         "peer_receive_prepend": "literal-peer-asn",
-        "overlapping_receive_prepend": False,
+        "overlapping_receive_prepend": True,
+        "compiled_receive_cell_cap": 4096,
         "per_client_cap": 256,
         "total_cap": 4096,
     },
@@ -117,7 +118,7 @@ FULL_UI_FILTERS = [
 SUPPORTED_UI_FILTERS = [
     {
         "id": 32, "customer_id": 2, "peer": None,
-        "received_prefix": "203.0.113.0/24", "advertised_prefix": None,
+        "received_prefix": None, "advertised_prefix": None,
         "protocol": 4, "action_advertise": "AS_IS",
         "action_receive": "PREPEND_ONCE", "order_by": 3,
     },
@@ -152,11 +153,12 @@ if manifest.get("manual_config_export") != MANUAL_CONFIG_EXPORT:
 consumer_source = (root / "config-consumer.php").read_text()
 for required in [
     "$router->template = 'api/v4/router/server/bird2/standard';",
-    "substr_count($birdCandidate, $prepend) - substr_count($birdBaseline, $prepend) !== 1",
-    "substr_count($birdCandidate, $peerGuard) - substr_count($birdBaseline, $peerGuard) !== 0",
-    "str_contains($birdBaseline, $fragment)",
-    "substr_count($birdCandidate, $fragment) !== 1",
-    "unset($birdBaseline, $birdCandidate, $fragment, $prepend, $peerGuard);",
+    "whereIn('id', [32, 33])->update(['enabled' => 1]);",
+    "substr_count($birdCandidate, $prepend) - substr_count($birdBaseline, $prepend) !== 3",
+    "substr_count($birdCandidate, $peerGuard) - substr_count($birdBaseline, $peerGuard) !== 1",
+    "$globalPosition >= $specificPosition",
+    "$birdBaseline,",
+    "$birdCandidate,",
 ]:
     if required not in consumer_source:
         fail(f"pinned in-memory BIRD path-first proof drifted: {required}")

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -69,12 +69,15 @@ community and matching rules accumulate after hygiene and IRR checks. Receive
 PREPEND with a peer uses its literal ASN and an exact first-AS guard; global
 PREPEND uses the typed route's first path ASN. An optional received-prefix guard
 is exact, and PREPEND continues; receive AS_IS or deny terminates in order.
+Reachable overlapping PREPEND is compiled into disjoint explicit/other first-AS
+and exact-prefix cells. Counts accumulate in original order; 255 succeeds, 256
+refuses, and more than 4096 compiled cells are refused without truncation.
 Every v1 global export chain and v2 per-client receive override ends with
 `ixp-manager-own-as-export-scrub`, which removes concrete large communities
 under the router ASN while preserving communities owned by other administrators.
-Reachable overlapping receive PREPEND, malformed peers, noncanonical or wrong-family
-prefixes, malformed order/actions, more than 256 rows per client, or more than
-4096 rows total are refused before a receipt. The older `ixp-manager-v1`
+Malformed peers, noncanonical or wrong-family prefixes, malformed order/actions,
+more than 256 rows per client, or more than 4096 rows total are refused before a
+receipt. The older `ixp-manager-v1`
 boundary remains available for legacy captures and still refuses active UI
 filters; lifecycle fetches require v2.
 

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -25,6 +25,7 @@ const SCHEMA_V2: &str = "rustbgpd.ixp-manager.router-config/v2";
 const IXP_VERSION: &str = "7.4.0";
 const MAX_FILTERS_PER_CLIENT: usize = 256;
 const MAX_FILTERS_TOTAL: usize = 4096;
+const MAX_COMPILED_RECEIVE_CELLS: usize = 4096;
 const BASE_HYGIENE: &str = include_str!("../../../examples/route-server/hygiene.rpol");
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -338,6 +339,113 @@ fn scope_covers(filter: &UiFilter, covered: FilterScope<'_>) -> bool {
         && (candidate.prefix.is_none() || candidate.prefix == covered.prefix)
 }
 
+#[derive(Debug)]
+struct ReceiveCell {
+    peer: Option<u32>,
+    prefix: Option<String>,
+    prepend: u8,
+    reject: bool,
+}
+
+struct CompiledReceive {
+    cells: Vec<ReceiveCell>,
+    peers: Vec<u32>,
+    prefixes: Vec<String>,
+}
+
+fn reachable_receive_overlap(filters: &[&UiFilter]) -> bool {
+    filters.iter().enumerate().any(|(right_index, right)| {
+        right.action_receive.prepend_count().is_some()
+            && filters[..right_index].iter().any(|left| {
+                left.action_receive.prepend_count().is_some()
+                    && intersection(left, right).is_some_and(|overlap| {
+                        !filters[..right_index].iter().rev().any(|filter| {
+                            filter.action_receive.terminates_receive()
+                                && scope_covers(filter, overlap)
+                        })
+                    })
+            })
+    })
+}
+
+fn reachable_receive_filters<'a>(filters: &[&'a UiFilter]) -> Vec<&'a UiFilter> {
+    filters
+        .iter()
+        .enumerate()
+        .filter_map(|(index, filter)| {
+            (!filters[..index].iter().any(|earlier| {
+                earlier.action_receive.terminates_receive() && scope_covers(earlier, scope(filter))
+            }))
+            .then_some(*filter)
+        })
+        .collect()
+}
+
+fn compile_receive_cells(filters: &[&UiFilter]) -> Result<CompiledReceive, Error> {
+    let peers = filters
+        .iter()
+        .filter_map(|filter| scope(filter).peer)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let prefixes = filters
+        .iter()
+        .filter_map(|filter| filter.received_prefix.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let count = (peers.len() + 1)
+        .checked_mul(prefixes.len() + 1)
+        .filter(|count| *count <= MAX_COMPILED_RECEIVE_CELLS)
+        .ok_or(Error::Refused("receive UI-filter cell cap exceeded"))?;
+    let mut cells = Vec::with_capacity(count);
+    for peer in peers.iter().copied().map(Some).chain(std::iter::once(None)) {
+        for prefix in prefixes
+            .iter()
+            .cloned()
+            .map(Some)
+            .chain(std::iter::once(None))
+        {
+            let mut prepend = 0_u8;
+            let mut reject = false;
+            for filter in filters {
+                let candidate = scope(filter);
+                if candidate.peer.is_some() && candidate.peer != peer
+                    || candidate.prefix.is_some() && candidate.prefix != prefix.as_deref()
+                {
+                    continue;
+                }
+                match filter.action_receive {
+                    FilterAction::AsIs => {
+                        reject = false;
+                        break;
+                    }
+                    FilterAction::NoAdvertise => {
+                        reject = true;
+                        break;
+                    }
+                    action => {
+                        prepend = prepend
+                            .checked_add(action.prepend_count().expect("PREPEND action"))
+                            .ok_or(Error::Refused("receive prepend accumulation exceeds 255"))?;
+                    }
+                }
+            }
+            cells.push(ReceiveCell {
+                peer,
+                prefix,
+                prepend,
+                reject,
+            });
+        }
+    }
+    Ok(CompiledReceive {
+        cells,
+        peers,
+        prefixes,
+    })
+}
+
 fn valid_handle(handle: &str) -> bool {
     !handle.is_empty()
         && handle.len() <= 128
@@ -557,29 +665,6 @@ fn validate_ui_filters(
         }
         previous = Some(order_key);
     }
-    for (right_index, right) in filters.iter().enumerate() {
-        if right.action_receive.prepend_count().is_none() {
-            continue;
-        }
-        for left in &filters[..right_index] {
-            if left.customer_id != right.customer_id
-                || left.action_receive.prepend_count().is_none()
-            {
-                continue;
-            }
-            let Some(overlap) = intersection(left, right) else {
-                continue;
-            };
-            let stopped = filters[..right_index].iter().rev().any(|filter| {
-                filter.customer_id == right.customer_id
-                    && filter.action_receive.terminates_receive()
-                    && scope_covers(filter, overlap)
-            });
-            if !stopped {
-                return Err(Error::Refused("overlapping receive PREPEND is unsupported"));
-            }
-        }
-    }
     Ok(())
 }
 
@@ -638,7 +723,7 @@ pub fn render_document(
                 prefixes,
                 filters.get(&client.customer_id).map_or(&[], Vec::as_slice),
                 document.router.asn,
-            ),
+            )?,
         );
     }
     files.insert(
@@ -806,8 +891,12 @@ fn render_client(
     prefixes: &[String],
     filters: &[&UiFilter],
     router_asn: u32,
-) -> String {
+) -> Result<String, Error> {
     let slug = client.vlan_interface_id;
+    let reachable_receive = reachable_receive_filters(filters);
+    let compiled_receive = reachable_receive_overlap(&reachable_receive)
+        .then(|| compile_receive_cells(&reachable_receive))
+        .transpose()?;
     let origins = client
         .origins
         .iter()
@@ -820,9 +909,19 @@ fn render_client(
     for prefix in prefixes {
         let _ = writeln!(out, "    {prefix},");
     }
+    out.push_str("}\n");
+    if let Some(compiled) = &compiled_receive
+        && !compiled.prefixes.is_empty()
+    {
+        let _ = writeln!(out, "prefix-set client-{slug}-ui-receive-prefixes {{");
+        for prefix in &compiled.prefixes {
+            let _ = writeln!(out, "    {prefix},");
+        }
+        out.push_str("}\n");
+    }
     let _ = write!(
         out,
-        "}}\npolicy client-{slug} {{\n    term reject-first-as-not-peer-as {{ if route.as-path.len >= 1 && !(route.as-path matches \"^{}_\") {{ reject }} }}\n    term reject-irrdb-origin-as-filtered {{ if !(route.origin-as in client-{slug}-origins) {{ reject }} }}\n    term reject-irrdb-prefix-filtered {{ if !(route.prefix in client-{slug}-prefixes) {{ reject }} }}\n",
+        "policy client-{slug} {{\n    term reject-first-as-not-peer-as {{ if route.as-path.len >= 1 && !(route.as-path matches \"^{}_\") {{ reject }} }}\n    term reject-irrdb-origin-as-filtered {{ if !(route.origin-as in client-{slug}-origins) {{ reject }} }}\n    term reject-irrdb-prefix-filtered {{ if !(route.prefix in client-{slug}-prefixes) {{ reject }} }}\n",
         client.asn
     );
     for filter in filters {
@@ -844,47 +943,93 @@ fn render_client(
     }
     out.push_str("    term accept-authorized { accept }\n}\n");
     if filters.is_empty() {
-        return out;
+        return Ok(out);
     }
     let _ = writeln!(out, "policy client-{slug}-receive {{");
-    for (index, filter) in filters.iter().enumerate() {
-        if filters[..index].iter().any(|earlier| {
-            earlier.action_receive.terminates_receive() && scope_covers(earlier, scope(filter))
-        }) {
-            continue;
+    if let Some(compiled) = compiled_receive {
+        let other_peers = (!compiled.peers.is_empty()).then(|| {
+            format!(
+                "!(route.as-path matches \"^({})_\")",
+                compiled
+                    .peers
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join("|")
+            )
+        });
+        for (index, cell) in compiled.cells.iter().enumerate() {
+            let mut guards = Vec::new();
+            match cell.peer {
+                Some(peer) => guards.push(format!("route.as-path matches \"^{peer}_\"")),
+                None => guards.extend(other_peers.iter().cloned()),
+            }
+            match &cell.prefix {
+                Some(prefix) => guards.push(format!("route.prefix == {prefix}")),
+                None if !compiled.prefixes.is_empty() => guards.push(format!(
+                    "!(route.prefix in client-{slug}-ui-receive-prefixes)"
+                )),
+                None => {}
+            }
+            let action = if cell.reject {
+                "reject".to_owned()
+            } else if cell.prepend == 0 {
+                "accept".to_owned()
+            } else {
+                format!(
+                    "prepend as {} {}; accept",
+                    cell.peer
+                        .map_or_else(|| "path-first".to_owned(), |peer| peer.to_string()),
+                    cell.prepend
+                )
+            };
+            write_filter_term(
+                &mut out,
+                &format!("ui-receive-cell-{index:04}"),
+                &guards,
+                &action,
+            );
         }
-        let mut guards = Vec::new();
-        if let Some(peer) = &filter.peer {
-            guards.push(format!(
-                "route.as-path matches \"^{}_\"",
-                peer.asn.expect("validated peer ASN")
-            ));
+    } else {
+        for (index, filter) in filters.iter().enumerate() {
+            if filters[..index].iter().any(|earlier| {
+                earlier.action_receive.terminates_receive() && scope_covers(earlier, scope(filter))
+            }) {
+                continue;
+            }
+            let mut guards = Vec::new();
+            if let Some(peer) = &filter.peer {
+                guards.push(format!(
+                    "route.as-path matches \"^{}_\"",
+                    peer.asn.expect("validated peer ASN")
+                ));
+            }
+            if let Some(prefix) = &filter.received_prefix {
+                guards.push(format!("route.prefix == {prefix}"));
+            }
+            let action = match filter.action_receive {
+                FilterAction::AsIs => "accept".to_owned(),
+                FilterAction::NoAdvertise => "reject".to_owned(),
+                action => format!(
+                    "prepend as {} {}",
+                    filter
+                        .peer
+                        .as_ref()
+                        .and_then(|peer| peer.asn)
+                        .map_or_else(|| "path-first".to_owned(), |asn| asn.to_string()),
+                    action.prepend_count().expect("PREPEND action")
+                ),
+            };
+            write_filter_term(
+                &mut out,
+                &format!("ui-receive-{}", filter.id),
+                &guards,
+                &action,
+            );
         }
-        if let Some(prefix) = &filter.received_prefix {
-            guards.push(format!("route.prefix == {prefix}"));
-        }
-        let action = match filter.action_receive {
-            FilterAction::AsIs => "accept".to_owned(),
-            FilterAction::NoAdvertise => "reject".to_owned(),
-            action => format!(
-                "prepend as {} {}",
-                filter
-                    .peer
-                    .as_ref()
-                    .and_then(|peer| peer.asn)
-                    .map_or_else(|| "path-first".to_owned(), |asn| asn.to_string()),
-                action.prepend_count().expect("PREPEND action")
-            ),
-        };
-        write_filter_term(
-            &mut out,
-            &format!("ui-receive-{}", filter.id),
-            &guards,
-            &action,
-        );
     }
     out.push_str("    term accept-unmatched { accept }\n}\n");
-    out
+    Ok(out)
 }
 
 #[cfg(unix)]

--- a/tools/rs-config-render/tests/fixtures/ixp-manager-v2-supported.json
+++ b/tools/rs-config-render/tests/fixtures/ixp-manager-v2-supported.json
@@ -80,7 +80,7 @@
             "id": 32,
             "customer_id": 2,
             "peer": null,
-            "received_prefix": "203.0.113.0/24",
+            "received_prefix": null,
             "advertised_prefix": null,
             "protocol": 4,
             "action_advertise": "AS_IS",

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -66,6 +66,28 @@ fn rendered_v2(
     )
 }
 
+fn receive_filter(
+    id: u64,
+    order: u64,
+    peer: Option<u32>,
+    prefix: Option<String>,
+    action: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "id": id, "customer_id": 2,
+        "peer": peer.map(|asn| serde_json::json!({"customer_id": 4, "asn": asn})),
+        "received_prefix": prefix, "advertised_prefix": null, "protocol": 4,
+        "action_advertise": "AS_IS", "action_receive": action, "order_by": order
+    })
+}
+
+fn with_receive_filters(filters: Vec<serde_json::Value>) -> serde_json::Value {
+    let mut input = v2_value(V2_SUPPORTED);
+    input["complete"]["ui_filter_count"] = filters.len().into();
+    input["ui_filters"] = filters.into();
+    input
+}
+
 fn assert_terms(source: &str, policy: &str, expected: &[&str]) {
     let file = RpolFile::parse(source).unwrap();
     let compiled = file
@@ -335,6 +357,10 @@ fn v1_and_v2_dispatch_are_strict_and_v1_output_stays_legacy() {
 #[test]
 fn v2_filter_policies_preserve_order_direction_and_reachability() {
     let full = rendered_v2(&v2_value(V2_FILTERS)).unwrap().files;
+    assert_eq!(
+        content_digest(&full.values().map(String::as_str).collect::<String>()),
+        "dfb2e0206b79de2c0b53f0e8e6a501550ba7b92c706f9e3183d349328efc31d6"
+    );
     let import = &full["policy/client-1.rpol"];
     assert_terms(
         import,
@@ -393,39 +419,40 @@ test full-first-rule-denies-receive {
         client,
         "client-1-receive",
         &[
-            "ui-receive-32",
-            "ui-receive-33",
-            "ui-receive-35",
+            "ui-receive-cell-0000",
+            "ui-receive-cell-0001",
+            "ui-receive-cell-0002",
+            "ui-receive-cell-0003",
             "accept-unmatched",
         ],
     );
     assert!(client.contains(
-        "route.as-path matches \"^112_\" && route.prefix == 192.175.48.0/24 { prepend as 112 2 }"
+        "route.as-path matches \"^112_\" && route.prefix == 192.175.48.0/24 { prepend as 112 3; accept }"
     ));
-    assert!(client.contains("route.prefix == 203.0.113.0/24 { prepend as path-first 1 }"));
+    assert!(client.contains("prepend as path-first 1; accept"));
     assert!(!client.contains("ui-receive-31"));
     assert_policy_tests(
         client,
         r#"
 test prepend-continues-to-as-is {
     route { prefix 192.175.48.0/24; as-path "112" }
-    expect client-1-receive == accept with prepend as 112 2
+    expect client-1-receive == accept with prepend as 112 3
 }
-test wrong-received-prefix-does-not-prepend {
+test wrong-received-prefix-keeps-global-prepend {
     route { prefix 198.51.100.0/24; as-path "112" }
-    expect client-1-receive == accept
+    expect client-1-receive == accept with prepend as 112 1
 }
-test wrong-first-as-does-not-prepend {
+test wrong-first-as-keeps-global-prepend {
     route { prefix 192.175.48.0/24; as-path "113" }
-    expect client-1-receive == accept
+    expect client-1-receive == accept with prepend as 113 1
 }
 test global-prepend-uses-path-first-not-origin {
     route { prefix 203.0.113.0/24; as-path "64501 64500" }
     expect client-1-receive == accept with prepend as 64501 1
 }
-test global-prepend-has-exact-prefix-guard {
+test global-prepend-is-unscoped {
     route { prefix 203.0.114.0/24; as-path "64501 64500" }
-    expect client-1-receive == accept
+    expect client-1-receive == accept with prepend as 64501 1
 }
 "#,
     );
@@ -557,6 +584,19 @@ test receive-as-is-terminates {
 }
 "#,
     );
+
+    let scoped =
+        |id, action| receive_filter(id, id, Some(112), Some("192.175.48.0/24".into()), action);
+    let scoped = with_receive_filters(vec![
+        scoped(1, "PREPEND_ONCE"),
+        scoped(2, "PREPEND_TWICE"),
+        scoped(3, "AS_IS"),
+    ]);
+    let source = &rendered_v2(&scoped).unwrap().files["policy/client-1.rpol"];
+    assert_policy_tests(
+        source,
+        "test scoped-miss-accepts-unchanged { route { prefix 198.51.100.0/24; as-path \"64501\" } expect client-1-receive == accept }",
+    );
 }
 
 #[test]
@@ -569,6 +609,7 @@ fn v2_receive_terminal_pruning_is_scope_aware_and_off_router_peers_are_valid() {
     assert!(source.contains("ui-receive-35"));
 
     let mut terminal = v2_value(V2_SUPPORTED);
+    terminal["ui_filters"][0]["received_prefix"] = "203.0.113.0/24".into();
     terminal["ui_filters"]
         .as_array_mut()
         .unwrap()
@@ -595,6 +636,7 @@ test prepend-is-discarded-by-later-deny {
     );
 
     let mut nonoverlap = v2_value(V2_SUPPORTED);
+    nonoverlap["ui_filters"][0]["received_prefix"] = "203.0.113.0/24".into();
     nonoverlap["ui_filters"].as_array_mut().unwrap().insert(
         0,
         serde_json::json!({
@@ -629,6 +671,165 @@ test second-nonoverlapping-prepend {
 }
 "#,
     );
+}
+
+#[test]
+fn v2_overlapping_receive_cells_preserve_order_scope_and_path_first() {
+    let mut input = v2_value(V2_SUPPORTED);
+    input["ui_filters"]
+        .as_array_mut()
+        .unwrap()
+        .push(receive_filter(37, 7, None, None, "NO_ADVERTISE"));
+    input["complete"]["ui_filter_count"] = 4.into();
+    let source = &rendered_v2(&input).unwrap().files["policy/client-1.rpol"];
+    assert_terms(
+        source,
+        "client-1-receive",
+        &[
+            "ui-receive-cell-0000",
+            "ui-receive-cell-0001",
+            "ui-receive-cell-0002",
+            "ui-receive-cell-0003",
+            "accept-unmatched",
+        ],
+    );
+    assert!(source.contains("prefix-set client-1-ui-receive-prefixes"));
+    assert!(source.contains("route.as-path matches \"^112_\" && route.prefix == 192.175.48.0/24 { prepend as 112 3; accept }"));
+    assert!(source.contains("prepend as path-first 1; accept"));
+    assert!(!source.contains("prepend as origin"));
+    assert!(!source.contains("prepend as peer"));
+    assert_policy_tests(
+        source,
+        r#"
+test overlap-accumulates-in-order {
+    route { prefix 192.175.48.0/24; as-path "112 64500" }
+    expect client-1-receive == accept with prepend as 112 3
+}
+test peer-miss-keeps-global-prepend {
+    route { prefix 192.175.48.0/24; as-path "113 64500" }
+    expect client-1-receive == accept with prepend as 113 1
+}
+test prefix-miss-keeps-global-prepend {
+    route { prefix 198.51.100.0/24; as-path "112 64500" }
+    expect client-1-receive == accept with prepend as 112 1
+}
+test other-cell-uses-path-first-not-origin-or-peer {
+    route { prefix 198.51.100.0/24; as-path "64501 64500" }
+    peer { asn 65010 }
+    expect client-1-receive == accept with prepend as 64501 1
+}
+test empty-global-path-fails-closed {
+    route { prefix 198.51.100.0/24; as-path "" }
+    expect client-1-receive == error absent-prepend-operand
+}
+test leading-set-global-path-fails-closed {
+    route { prefix 198.51.100.0/24; as-path "{64500 64501}" }
+    expect client-1-receive == error absent-prepend-operand
+}
+"#,
+    );
+
+    let mut deny = v2_value(V2_SUPPORTED);
+    deny["ui_filters"].as_array_mut().unwrap().insert(
+        2,
+        receive_filter(
+            34,
+            5,
+            Some(112),
+            Some("192.175.48.0/24".into()),
+            "NO_ADVERTISE",
+        ),
+    );
+    deny["complete"]["ui_filter_count"] = 4.into();
+    let source = &rendered_v2(&deny).unwrap().files["policy/client-1.rpol"];
+    assert_policy_tests(
+        source,
+        r#"
+test no-advertise-terminates-before-later-as-is {
+    route { prefix 192.175.48.0/24; as-path "112" }
+    expect client-1-receive == reject
+}
+"#,
+    );
+}
+
+#[test]
+fn v2_overlapping_receive_prepend_and_cell_bounds_are_exact() {
+    let mut filters = (1..=85)
+        .map(|id| receive_filter(id, id, None, None, "PREPEND_THRICE"))
+        .collect::<Vec<_>>();
+    filters.push(receive_filter(86, 86, None, None, "AS_IS"));
+    let source = &rendered_v2(&with_receive_filters(filters.clone()))
+        .unwrap()
+        .files["policy/client-1.rpol"];
+    assert!(source.contains("prepend as path-first 255; accept"));
+    assert_policy_tests(
+        source,
+        r#"
+test accumulated-255-executes {
+    route { prefix 198.51.100.0/24; as-path "64501" }
+    expect client-1-receive == accept with prepend as 64501 255
+}
+"#,
+    );
+    filters.insert(85, receive_filter(87, 86, None, None, "PREPEND_ONCE"));
+    filters[86]["order_by"] = 87.into();
+    assert_eq!(
+        rendered_v2(&with_receive_filters(filters)).unwrap_err(),
+        Error::Refused("receive prepend accumulation exceeds 255")
+    );
+
+    let cells = |peer_count: u64| {
+        let mut filters = vec![receive_filter(1, 1, None, None, "PREPEND_ONCE")];
+        for index in 0..peer_count {
+            let id = index + 2;
+            filters.push(receive_filter(
+                id,
+                id,
+                Some(64_000 + index as u32),
+                None,
+                "PREPEND_ONCE",
+            ));
+        }
+        for index in 0..63_u64 {
+            let id = peer_count + index + 2;
+            filters.push(receive_filter(
+                id,
+                id,
+                None,
+                Some(format!("198.18.0.{}/32", index + 1)),
+                "PREPEND_ONCE",
+            ));
+        }
+        let id = filters.len() as u64 + 1;
+        filters.push(receive_filter(id, id, None, None, "AS_IS"));
+        with_receive_filters(filters)
+    };
+    let at_cap = rendered_v2(&cells(63)).unwrap();
+    let source = &at_cap.files["policy/client-1.rpol"];
+    assert_eq!(source.matches("term ui-receive-cell-").count(), 4096);
+    let compiled = RpolFile::parse(source)
+        .unwrap()
+        .compile_policy("client-1-receive", &[], &mut SetStore::new())
+        .unwrap();
+    assert_eq!(compiled.policies[0].terms.len(), 4097);
+    assert_eq!(
+        rendered_v2(&cells(64)).unwrap_err(),
+        Error::Refused("receive UI-filter cell cap exceeded")
+    );
+
+    let mut dead_axes = cells(64);
+    let rows = dead_axes["ui_filters"].as_array_mut().unwrap();
+    let terminal = rows.pop().unwrap();
+    rows.insert(1, receive_filter(130, 2, None, None, "PREPEND_ONCE"));
+    rows.insert(2, terminal);
+    for (index, row) in rows.iter_mut().enumerate() {
+        row["order_by"] = ((index + 1) as u64).into();
+    }
+    dead_axes["complete"]["ui_filter_count"] = rows.len().into();
+    let source = &rendered_v2(&dead_axes).unwrap().files["policy/client-1.rpol"];
+    assert_eq!(source.matches("term ui-receive-cell-").count(), 1);
+    assert!(source.contains("prepend as path-first 2; accept"));
 }
 
 #[test]
@@ -673,11 +874,6 @@ fn v2_refuses_malformed_unrepresentable_and_capped_filter_sets() {
         "/ui_filters/1/action_receive",
         "UNKNOWN".into(),
     );
-    refuses(
-        v2_value(V2_SUPPORTED),
-        "/ui_filters/0/received_prefix",
-        serde_json::Value::Null,
-    );
     for field in ["peer", "received_prefix", "advertised_prefix", "protocol"] {
         let mut missing = v2_value(V2_SUPPORTED);
         missing["ui_filters"][0]
@@ -711,18 +907,6 @@ fn v2_refuses_malformed_unrepresentable_and_capped_filter_sets() {
     v6["ui_filters"][0]["protocol"] = 6.into();
     v6["ui_filters"][0]["received_prefix"] = "2001:db8:3::/064".into();
     assert!(rendered_v2(&v6).is_err());
-
-    let mut overlap = v2_value(V2_SUPPORTED);
-    overlap["ui_filters"].as_array_mut().unwrap().insert(
-        0,
-        serde_json::json!({
-            "id": 34, "customer_id": 2, "peer": {"customer_id": 4, "asn": 112},
-            "received_prefix": null, "advertised_prefix": null, "protocol": 4,
-            "action_advertise": "AS_IS", "action_receive": "PREPEND_ONCE", "order_by": 2
-        }),
-    );
-    overlap["complete"]["ui_filter_count"] = 4.into();
-    assert!(rendered_v2(&overlap).is_err());
 
     let template = serde_json::json!({
         "id": 1, "customer_id": 2, "peer": null,


### PR DESCRIPTION
## Summary

- compile reachable overlapping IXP Manager v7.4 receive PREPEND rows into bounded disjoint first-AS and exact-prefix cells
- preserve row-order accumulation and AS_IS/NO_ADVERTISE termination with fail-closed 255-prepend and 4096-cell limits
- prove the real pinned Foil/MySQL/BIRD journey while preserving non-overlap bytes and the existing runtime-compatibility posture

## Verification

- `tests/compat/ixp-manager-birdseye/run.sh`
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`
- 10 destructive mutations

LAN-1160
