### PR TITLE
Preserve IXP Manager effective no-transit defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   daemon generation at the stable `current` path; operators explicitly SIGHUP
   the adapter after activation. The renderer accepts 4096 aliases and refuses
   4097 without adding runtime orchestration or a compatibility claim. (LAN-1172)
+- The IXP Manager v7.4 exporter now preserves the stock no-transit policy
+  without an operator override: its exact pinned 15-ASN default is resolved
+  after exclusions and accepted through a v2-only source token. Explicit
+  overrides still replace the default, ignore exclusions, and may be empty;
+  legacy implicit and v1 token use remain fail-closed. Real `bird2` and
+  `bird2-2025` policy parity is executable in the pinned oracle. (LAN-1173)
 - The IXP Manager v7.4 renderer and Birdwatcher adapter now cover all ten
   reject reasons active in the pinned route-server templates, with named
   AS-path length/first-AS and separate IRRDB origin/prefix policy terms. The
@@ -78,9 +84,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `rs-config-render` now accepts a strict IXP Manager v7.4 Foil JSON export,
   writes a private route-server candidate, validates it with the selected
   `rustbgpd` binary's version and `--check --strict` modes, then writes the
-  receipt last. Applicable UI filters, BIRD skin overrides, implicit
-  no-transit policy, incomplete or ambiguous member data, and unsupported
-  router modes fail closed. The local activation command rechecks and
+  receipt last. Applicable UI filters, BIRD skin overrides, the legacy
+  `IXP_MANAGER_IMPLICIT_DEFAULT` token, incomplete or ambiguous member data,
+  and unsupported router modes fail closed. The local activation command rechecks and
   atomically publishes immutable generations, settles real health/config diff,
   no-ops on equal content, and restores the prior link without a second
   activation only when the command cannot start. Once started, failure or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -636,6 +636,9 @@ peer context or wildcard matching. Every candidate also binds its exact
 Birdwatcher member aliases into the same private receipt and immutable
 activation generation; the stable `current` path changes atomically with
 daemon configuration, while adapter SIGHUP remains an explicit operator step.
+The pinned v7.4 exporter now also resolves the stock 15-ASN no-transit default,
+exclusions, and explicit-override precedence; a v2-only token removes the
+stock-install refusal while legacy and v1 version skew still fail closed.
 Generic UI-filter semantics, custom-skin
 migration, and multi-address ownership remain open. The external adapter now
 also serves the IXP Manager v7.4 status, live protocol inventory/detail,

--- a/integrations/ixp-manager/gpl-2.0-only/README.md
+++ b/integrations/ixp-manager/gpl-2.0-only/README.md
@@ -9,7 +9,8 @@ the active IXP Manager `VIEW_SKIN`. IXP Manager v7.4 then renders the strict
 `rustbgpd.ixp-manager.router-config/v2` JSON document through its normal router
 configuration generator. The exporter reads IXP Manager's sanitized session,
 IRR, max-prefix, authentication, RPKI, and route-filter state; it does not copy
-or translate the upstream BIRD templates.
+or translate the upstream BIRD templates. It does re-express the exact pinned
+v7.4 15-ASN default no-transit list inside this segregated GPL subtree.
 
 The exporter preserves every applicable UI filter as one ordered row,
 including peer identity, distinct received and advertised prefixes, protocol,
@@ -27,8 +28,10 @@ candidate, or receipt. The Rust renderer has no HTTP client and does not handle
 IXP Manager credentials.
 
 The exporter deliberately reports active BIRD skin overrides so the Rust
-renderer can refuse instead of silently losing policy. It also distinguishes
-an unset no-transit override from an explicitly empty override. This is not a
-generic IXP Manager policy engine or a custom-skin translator. See
+renderer can refuse instead of silently losing policy. An unset no-transit
+override emits the pinned default after exclusions; an explicit override
+replaces that set, ignores exclusions, and may intentionally be empty. Both
+paths are sorted and deduplicated. This is not a generic IXP Manager policy
+engine or a custom-skin translator. See
 `tools/rs-config-render/README.md` for the bounded manual render and
 strict-check workflow.

--- a/integrations/ixp-manager/gpl-2.0-only/api/v4/router/server/rustbgpd/json.foil.php
+++ b/integrations/ixp-manager/gpl-2.0-only/api/v4/router/server/rustbgpd/json.foil.php
@@ -54,10 +54,24 @@ if( (bool)$router->rpki ) {
 }
 sort( $caches, SORT_STRING );
 
+$defaultNoTransit = [
+    174, 701, 1299, 2914, 3257, 3320, 3356, 3491, 4134, 5511, 6453, 6461,
+    6762, 6830, 7018,
+];
 $override = config( 'ixp.no_transit_asns.override' );
-$noTransitSource = $override === false
-    ? 'IXP_MANAGER_IMPLICIT_DEFAULT' : 'IXP_NO_TRANSIT_ASNS_OVERRIDE';
-$noTransit = $override === false ? [] : array_map( 'intval', $override );
+if( $override === false ) {
+    $excluded = array_fill_keys( array_map(
+        'intval', (array)config( 'ixp.no_transit_asns.exclude' )
+    ), true );
+    $noTransit = array_values( array_filter(
+        $defaultNoTransit, static fn( $asn ) => !isset( $excluded[$asn] )
+    ) );
+    $noTransitSource = 'IXP_MANAGER_EFFECTIVE_DEFAULT';
+} else {
+    $noTransit = array_map( 'intval', $override );
+    $noTransitSource = 'IXP_NO_TRANSIT_ASNS_OVERRIDE';
+}
+$noTransit = array_values( array_unique( $noTransit, SORT_NUMERIC ) );
 sort( $noTransit, SORT_NUMERIC );
 
 $clients = [];

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -68,6 +68,13 @@ receipt digest. The executable contract records the stable activation-current
 path, v4/v6 table names, member-name format, and 4096-alias cap. Adapter SIGHUP
 remains an operator action outside this oracle.
 
+The real pinned exporter is also exercised for the stock 15-ASN no-transit
+default, selected and complete exclusions, explicit-empty, and deduplicated
+explicit-nonempty overrides. Each result is compared with both pinned `bird2`
+and `bird2-2025` policy, strict-rendered, and executed through the generated
+Rust policy. The legacy implicit token and v1 use of the effective-default token
+remain fail-closed.
+
 The strict candidates also append the router-own-AS large-community scrub last
 to the global export chain and every v2 client receive override. The manifest
 pins its exact removal-only syntax, placement, and foreign-admin preservation.

--- a/tests/compat/ixp-manager-birdseye/config-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/config-consumer.php
@@ -30,9 +30,87 @@ $render = static function (string $name) use ($router, $output): string {
     return $json;
 };
 
-config(['ixp.no_transit_asns.override' => false]);
-$render('config-implicit.json');
-config(['ixp.no_transit_asns.override' => []]);
+$writeDocument = static function (string $name, array $document) use ($output): void {
+    $json = json_encode($document, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        . "\n";
+    $path = $output . '/' . $name;
+    file_put_contents($path, $json, LOCK_EX);
+    chmod($path, 0600);
+};
+$defaultTransit = [
+    174, 701, 1299, 2914, 3257, 3320, 3356, 3491, 4134, 5511, 6453, 6461,
+    6762, 6830, 7018,
+];
+foreach (['server', 'collector'] as $kind) {
+    foreach (['bird2', 'bird2-2025'] as $tree) {
+        $source = file_get_contents(
+            "$ixp/resources/views/api/v4/router/$kind/$tree/filter-transit-networks.foil.php"
+        );
+        if (!is_string($source)
+            || !preg_match('/\$no_transit_asns = \[(.*?)\];/s', $source, $block)
+            || preg_match_all('/^\s*(\d+)\s*=>/m', $block[1], $matches) !== 15
+            || array_map('intval', $matches[1]) !== $defaultTransit) {
+            $fail('pinned BIRD default transit list drifted');
+        }
+    }
+}
+$birdTransit = static function (string $config) use ($fail): array {
+    if (preg_match('/define TRANSIT_ASNS = \[\s*([0-9, ]+)\s*\];/', $config, $match)) {
+        $asns = array_map('intval', preg_split('/,\s*/', trim($match[1])));
+        $asns = array_values(array_unique($asns, SORT_NUMERIC));
+        sort($asns, SORT_NUMERIC);
+        return $asns;
+    }
+    if (str_contains($config, "function filter_has_transit_path()\n{\n    return false;\n}")
+        || str_contains(
+            $config, "function filter_has_transit_path() -> bool\n{\n    return false;\n}"
+        )) {
+        return [];
+    }
+    $fail('pinned BIRD transit policy shape drifted');
+};
+$captureTransit = static function (
+    string $name,
+    array|false $override,
+    array $exclude,
+    array $expected,
+) use ($router, $render, $birdTransit, $fail): array {
+    config([
+        'ixp.no_transit_asns.override' => $override,
+        'ixp.no_transit_asns.exclude' => $exclude,
+    ]);
+    $router->template = 'api/v4/router/server/rustbgpd/json';
+    $document = json_decode($render($name), true, 512, JSON_THROW_ON_ERROR);
+    $source = $override === false
+        ? 'IXP_MANAGER_EFFECTIVE_DEFAULT' : 'IXP_NO_TRANSIT_ASNS_OVERRIDE';
+    if ($document['policy']['no_transit'] !== ['source' => $source, 'asns' => $expected]) {
+        $fail('effective no-transit export drifted');
+    }
+    foreach (['bird2', 'bird2-2025'] as $tree) {
+        $router->template = "api/v4/router/server/$tree/standard";
+        $bird = (new ConfigurationGenerator($router))->render()->render();
+        if ($birdTransit($bird) !== $expected) {
+            $fail('Rust and pinned BIRD no-transit policy diverged');
+        }
+    }
+    return $document;
+};
+
+$default = $captureTransit('config-default.json', false, [], $defaultTransit);
+$implicit = $default;
+$implicit['policy']['no_transit'] = [
+    'source' => 'IXP_MANAGER_IMPLICIT_DEFAULT', 'asns' => [],
+];
+$writeDocument('config-implicit.json', $implicit);
+$captureTransit(
+    'config-default-excluded.json', false, [174, 701],
+    array_values(array_diff($defaultTransit, [174, 701])),
+);
+$captureTransit('config-default-all-excluded.json', false, $defaultTransit, []);
+$captureTransit('config-explicit-empty.json', [], [174], []);
+$captureTransit('config-explicit-nonempty.json', [64512, 64511, 64512], [64511], [64511, 64512]);
+
+config(['ixp.no_transit_asns.override' => [], 'ixp.no_transit_asns.exclude' => []]);
 DB::table('route_server_filters_prod')->where('id', 32)->update([
     'peer_id' => null, 'vlan_id' => 1, 'received_prefix' => null,
     'advertised_prefix' => null, 'protocol' => 4, 'action_advertise' => 'AS_IS',

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -52,6 +52,14 @@
     "ixp_manager_version": "7.4.0",
     "router_handle": "b2-rs1-lan1-ipv4",
     "strict_receipt_required": true,
+    "no_transit": {
+      "effective_default_source": "IXP_MANAGER_EFFECTIVE_DEFAULT",
+      "explicit_override_source": "IXP_NO_TRANSIT_ASNS_OVERRIDE",
+      "legacy_implicit_source": "IXP_MANAGER_IMPLICIT_DEFAULT refused",
+      "default_asns": [174, 701, 1299, 2914, 3257, 3320, 3356, 3491, 4134, 5511, 6453, 6461, 6762, 6830, 7018],
+      "precedence": "default exclusions apply before explicit override replacement",
+      "version_skew": "fail-closed"
+    },
     "birdwatcher_protocol_aliases": {
       "candidate_path": "birdwatcher-protocol-aliases.conf",
       "current_path": "<runtime-state-dir>/activation/current/birdwatcher-protocol-aliases.conf",

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -76,7 +76,10 @@ docker run --rm --user "$(id -u):$(id -g)" \
   "$image" /harness/run-in-container.sh
 
 supported="$capture_output/ixp-manager-v7.4-rustbgpd.json"
-for capture in config-implicit.json config-ui-filter.json config-skin.json "$supported"; do
+for capture in config-default.json config-default-excluded.json \
+  config-default-all-excluded.json config-explicit-empty.json \
+  config-explicit-nonempty.json config-implicit.json config-ui-filter.json \
+  config-skin.json "$supported"; do
   [ -f "$capture_output/$(basename "$capture")" ] || { echo "missing real IXP Manager capture: $capture" >&2; exit 1; }
   chmod 600 "$capture_output/$(basename "$capture")"
 done
@@ -109,11 +112,23 @@ candidate_full="$tmp/candidate-full"
 candidate_supported="$tmp/candidate-supported"
 render_v2 "$capture_output/config-ui-filter.json" "$candidate_full"
 render_v2 "$supported" "$candidate_supported"
+candidate_default="$tmp/candidate-default"
+candidate_excluded="$tmp/candidate-default-excluded"
+candidate_all_excluded="$tmp/candidate-default-all-excluded"
+candidate_explicit_empty="$tmp/candidate-explicit-empty"
+candidate_explicit_nonempty="$tmp/candidate-explicit-nonempty"
+render_v2 "$capture_output/config-default.json" "$candidate_default"
+render_v2 "$capture_output/config-default-excluded.json" "$candidate_excluded"
+render_v2 "$capture_output/config-default-all-excluded.json" "$candidate_all_excluded"
+render_v2 "$capture_output/config-explicit-empty.json" "$candidate_explicit_empty"
+render_v2 "$capture_output/config-explicit-nonempty.json" "$candidate_explicit_nonempty"
 expected_v2_aliases="$tmp/expected-v2-aliases"
 printf '%s\n' \
   'pb_0001_as1213=10.1.0.10@master4' \
   'pb_0004_as112=10.1.0.6@master4' >"$expected_v2_aliases"
-for candidate in "$candidate_full" "$candidate_supported"; do
+for candidate in "$candidate_full" "$candidate_supported" "$candidate_default" \
+  "$candidate_excluded" "$candidate_all_excluded" "$candidate_explicit_empty" \
+  "$candidate_explicit_nonempty"; do
   aliases="$candidate/birdwatcher-protocol-aliases.conf"
   cmp "$expected_v2_aliases" "$aliases"
   [ "$(stat -c %a "$aliases")" = 600 ]
@@ -167,6 +182,24 @@ check_policy() {
   printf '\n%s\n' "$tests" >>"$proof"
   "$repo/target/debug/rbgp" policy check "$proof" >/dev/null
 }
+check_policy "$candidate_default/policy/ixp-hygiene.rpol" "$tmp/default-hygiene.rpol" '
+test default-listed-rejects { route { prefix 77.72.72.0/21; as-path "174"; rpki valid } expect ixp-manager-hygiene == reject }
+test default-unlisted-accepts { route { prefix 77.72.72.0/21; as-path "64512"; rpki valid } expect ixp-manager-hygiene == accept }
+'
+check_policy "$candidate_excluded/policy/ixp-hygiene.rpol" "$tmp/excluded-hygiene.rpol" '
+test excluded-accepts { route { prefix 77.72.72.0/21; as-path "174"; rpki valid } expect ixp-manager-hygiene == accept }
+test remaining-default-rejects { route { prefix 77.72.72.0/21; as-path "1299"; rpki valid } expect ixp-manager-hygiene == reject }
+'
+check_policy "$candidate_all_excluded/policy/ixp-hygiene.rpol" "$tmp/all-excluded-hygiene.rpol" '
+test all-excluded-accepts { route { prefix 77.72.72.0/21; as-path "174"; rpki valid } expect ixp-manager-hygiene == accept }
+'
+check_policy "$candidate_explicit_empty/policy/ixp-hygiene.rpol" "$tmp/explicit-empty-hygiene.rpol" '
+test explicit-empty-accepts { route { prefix 77.72.72.0/21; as-path "174"; rpki valid } expect ixp-manager-hygiene == accept }
+'
+check_policy "$candidate_explicit_nonempty/policy/ixp-hygiene.rpol" "$tmp/explicit-hygiene.rpol" '
+test override-rejects { route { prefix 77.72.72.0/21; as-path "64511"; rpki valid } expect ixp-manager-hygiene == reject }
+test former-default-accepts { route { prefix 77.72.72.0/21; as-path "174"; rpki valid } expect ixp-manager-hygiene == accept }
+'
 check_policy "$candidate_full/policy/client-1.rpol" "$tmp/full-client-1.rpol" '
 test full-advertise-accumulates {
     route { prefix 77.72.72.0/21; as-path "1213" }

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -71,6 +71,17 @@ MANUAL_CONFIG_EXPORT = {
     "ixp_manager_version": "7.4.0",
     "router_handle": "b2-rs1-lan1-ipv4",
     "strict_receipt_required": True,
+    "no_transit": {
+        "effective_default_source": "IXP_MANAGER_EFFECTIVE_DEFAULT",
+        "explicit_override_source": "IXP_NO_TRANSIT_ASNS_OVERRIDE",
+        "legacy_implicit_source": "IXP_MANAGER_IMPLICIT_DEFAULT refused",
+        "default_asns": [
+            174, 701, 1299, 2914, 3257, 3320, 3356, 3491, 4134, 5511,
+            6453, 6461, 6762, 6830, 7018,
+        ],
+        "precedence": "default exclusions apply before explicit override replacement",
+        "version_skew": "fail-closed",
+    },
     "birdwatcher_protocol_aliases": {
         "candidate_path": "birdwatcher-protocol-aliases.conf",
         "current_path": "<runtime-state-dir>/activation/current/birdwatcher-protocol-aliases.conf",
@@ -179,6 +190,23 @@ if manifest.get("routing_tables") != ["master4"]:
 
 if len(sys.argv) == 3:
     config_capture = Path(sys.argv[2])
+    default_asns = MANUAL_CONFIG_EXPORT["no_transit"]["default_asns"]
+    no_transit_cases = {
+        "config-default.json": ("IXP_MANAGER_EFFECTIVE_DEFAULT", default_asns),
+        "config-default-excluded.json": (
+            "IXP_MANAGER_EFFECTIVE_DEFAULT", default_asns[2:],
+        ),
+        "config-default-all-excluded.json": ("IXP_MANAGER_EFFECTIVE_DEFAULT", []),
+        "config-explicit-empty.json": ("IXP_NO_TRANSIT_ASNS_OVERRIDE", []),
+        "config-explicit-nonempty.json": (
+            "IXP_NO_TRANSIT_ASNS_OVERRIDE", [64511, 64512],
+        ),
+        "config-implicit.json": ("IXP_MANAGER_IMPLICIT_DEFAULT", []),
+    }
+    for name, (source, asns) in no_transit_cases.items():
+        policy = json.loads((config_capture / name).read_text())["policy"]["no_transit"]
+        if policy != {"source": source, "asns": asns}:
+            fail(f"{name}: effective no-transit capture drifted")
     full = json.loads((config_capture / "config-ui-filter.json").read_text())
     supported = json.loads(
         (config_capture / "ixp-manager-v7.4-rustbgpd.json").read_text()

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -90,6 +90,14 @@ receipt. The older `ixp-manager-v1`
 boundary remains available for legacy captures and still refuses active UI
 filters; lifecycle fetches require v2.
 
+For v2, the exporter resolves IXP Manager v7.4's pinned 15-ASN default
+no-transit policy after exclusions and labels it
+`IXP_MANAGER_EFFECTIVE_DEFAULT`. An explicit override keeps the existing
+`IXP_NO_TRANSIT_ASNS_OVERRIDE` source, replaces the default, ignores exclusions,
+and may be empty. Lists must be sorted, unique, and nonzero. The legacy empty
+`IXP_MANAGER_IMPLICIT_DEFAULT` token remains refused, and the new token is
+refused under v1, so old/new exporter-renderer version skew fails closed.
+
 After reviewing a complete candidate, install `config.toml` and its `policy/`
 directory together using the existing coordinated-file procedure, then SIGHUP
 rustbgpd. A failed export, refusal, render, or check leaves the running daemon

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -499,8 +499,11 @@ fn validate(
     if (router.protocol == 4) != local.is_ipv4() {
         return Err(Error::Refused("invalid addressing"));
     }
-    if document.policy.no_transit.source != "IXP_NO_TRANSIT_ASNS_OVERRIDE" {
-        return Err(Error::Refused("explicit no-transit override required"));
+    if document.policy.no_transit.source != "IXP_NO_TRANSIT_ASNS_OVERRIDE"
+        && !(expected == SchemaVersion::V2
+            && document.policy.no_transit.source == "IXP_MANAGER_EFFECTIVE_DEFAULT")
+    {
+        return Err(Error::Refused("unsupported no-transit source"));
     }
     if !strictly_sorted(&document.policy.no_transit.asns)
         || document.policy.no_transit.asns.contains(&0)

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -9,6 +9,9 @@ const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
 const V2_FILTERS: &[u8] = include_bytes!("fixtures/ixp-manager-v2-ui-filters.json");
 const V2_SUPPORTED: &[u8] = include_bytes!("fixtures/ixp-manager-v2-supported.json");
 const SECRET: &str = "mcWsqMdzGwTKt67g";
+const DEFAULT_TRANSIT: [u32; 15] = [
+    174, 701, 1299, 2914, 3257, 3320, 3356, 3491, 4134, 5511, 6453, 6461, 6762, 6830, 7018,
+];
 
 fn digest(path: &std::path::Path) -> String {
     use sha2::{Digest, Sha256};
@@ -167,6 +170,61 @@ fn supported_render_is_deterministic_and_explicit() {
         !rendered(&maximum).unwrap().files["policy/ixp-hygiene.rpol"]
             .contains("ixp-manager-too-specific")
     );
+}
+
+#[test]
+fn effective_default_no_transit_is_v2_only_exact_and_executable() {
+    let mut default = v2_value(V2_SUPPORTED);
+    default["policy"]["no_transit"]["source"] = "IXP_MANAGER_EFFECTIVE_DEFAULT".into();
+    default["policy"]["no_transit"]["asns"] = serde_json::to_value(DEFAULT_TRANSIT).unwrap();
+    let files = rendered_v2(&default).unwrap().files;
+    assert_eq!(
+        files["birdwatcher-protocol-aliases.conf"],
+        "pb_0001_as1213=10.1.0.10@master4\npb_0004_as112=10.1.0.6@master4\n"
+    );
+    let hygiene = &files["policy/ixp-hygiene.rpol"];
+    assert!(hygiene.contains(
+        "asn-set ixp-manager-no-transit-asns { 174, 701, 1299, 2914, 3257, 3320, 3356, 3491, 4134, 5511, 6453, 6461, 6762, 6830, 7018 }"
+    ));
+    assert!(hygiene.contains(
+        "term reject-transit-leak { if route.as-path matches \"_(174|701|1299|2914|3257|3320|3356|3491|4134|5511|6453|6461|6762|6830|7018)_\" { reject } }"
+    ));
+    assert_policy_tests(
+        hygiene,
+        r#"
+test pinned-default-rejects { route { prefix 77.72.72.0/21; as-path "174"; rpki valid } expect ixp-manager-hygiene == reject }
+test unlisted-accepts { route { prefix 77.72.72.0/21; as-path "64512"; rpki valid } expect ixp-manager-hygiene == accept }
+"#,
+    );
+
+    let mut empty = default.clone();
+    empty["policy"]["no_transit"]["asns"] = serde_json::json!([]);
+    assert!(
+        !rendered_v2(&empty).unwrap().files["policy/ixp-hygiene.rpol"]
+            .contains("reject-transit-leak")
+    );
+    for invalid in [
+        serde_json::json!([0]),
+        serde_json::json!([701, 174]),
+        serde_json::json!([174, 174]),
+    ] {
+        let mut input = default.clone();
+        input["policy"]["no_transit"]["asns"] = invalid;
+        assert_eq!(
+            rendered_v2(&input).unwrap_err(),
+            Error::Refused("invalid no-transit data")
+        );
+    }
+    let mut implicit = empty;
+    implicit["policy"]["no_transit"]["source"] = "IXP_MANAGER_IMPLICIT_DEFAULT".into();
+    assert_eq!(
+        rendered_v2(&implicit).unwrap_err(),
+        Error::Refused("unsupported no-transit source")
+    );
+    let mut v1 = value();
+    v1["policy"]["no_transit"]["source"] = "IXP_MANAGER_EFFECTIVE_DEFAULT".into();
+    v1["policy"]["no_transit"]["asns"] = serde_json::to_value(DEFAULT_TRANSIT).unwrap();
+    assert!(rendered(&v1).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Resolve the exact pinned IXP Manager v7.4 15-ASN stock no-transit set after exclusions while preserving explicit-override precedence.
- Accept the effective-default source only for v2; legacy implicit and v1 version skew remain fail-closed.
- Prove real bird2 and bird2-2025 parity plus generated Rust policy execution while preserving LAN-1172 alias bytes and runtime_compatibility false.

## Verification

- Pinned IXP Manager/Birdseye oracle and focused renderer, activation, and lifecycle tests
- Serial workspace tests, strict all-target/all-feature Clippy, and warning-denied docs
- Eight destructive mutations covering the default, precedence, token, version, and generated-policy seams

Linear: LAN-1173

## Boundary

This remains pinned-v7.4 compatibility, not custom-skin or full-runtime compatibility. Adapter SIGHUP remains an explicit operator step.