### PR TITLE
Fail-stop when RibManager exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The daemon now fail-stops if its RIB manager returns or panics: it runs the
+  existing coordinated peer teardown and exits 1 so `Restart=on-failure` can
+  recover it. A real-session fault-injection proof pins the failure before
+  shared route-page generation advances; PeerManager supervision remains out
+  of scope. (LAN-1187)
 - `birdwatcher-adapter` now serves IXP Manager's full table view by atomically
   joining global Received candidates with installed Best winners under one
   shared page generation. Output is deterministic, winner-first, capped

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -573,6 +573,9 @@ pub struct RibManager {
     /// re-arm) becomes deterministically observable. `None` in
     /// production — the only cost when unset is an `is_some()` check.
     test_ingest_stall: Option<std::time::Duration>,
+    /// Test-only fail-stop probe. Captured once at construction so a live
+    /// process cannot change supervision behavior by mutating its environment.
+    test_panic_on_peer_up: Option<()>,
     /// Update-group fingerprint registry (slice 1): membership (group
     /// id or ungrouped reason) per registered peer. Since slice 2 the
     /// distribution path reads it: grouped peers share the staged
@@ -782,6 +785,21 @@ fn initial_route_page_version() -> RoutePageVersion {
 /// production. Read once at RIB-manager construction; unset, empty,
 /// zero, or unparseable values disable the stall.
 const TEST_INGEST_STALL_ENV: &str = "RUSTBGPD_TEST_RIB_INGEST_STALL_MS";
+
+/// Test-only fail-stop probe used by the daemon supervision integration test.
+/// The panic occurs before any page-generation mutation for the `PeerUp`.
+const TEST_PANIC_ON_PEER_UP_ENV: &str = "RUSTBGPD_TEST_RIB_PANIC_ON_PEER_UP";
+
+fn test_panic_on_peer_up_override(env: Option<&str>) -> bool {
+    match env.map(str::trim) {
+        Some("1") => true,
+        None => false,
+        Some(_) => {
+            warn!("ignoring invalid {TEST_PANIC_ON_PEER_UP_ENV} (expected 1)");
+            false
+        }
+    }
+}
 
 /// Pure core of the [`TEST_INGEST_STALL_ENV`] override with the
 /// environment value injected, so the parse rule (positive u64
@@ -1069,6 +1087,22 @@ impl RibManager {
                  (ADR-0078 fault injection — test use only, never set in production)"
             );
         }
+        let test_panic_on_peer_up_env = match std::env::var(TEST_PANIC_ON_PEER_UP_ENV) {
+            Ok(value) => Some(value),
+            Err(std::env::VarError::NotPresent) => None,
+            Err(std::env::VarError::NotUnicode(_)) => {
+                warn!("ignoring non-unicode {TEST_PANIC_ON_PEER_UP_ENV}");
+                None
+            }
+        };
+        let test_panic_on_peer_up =
+            test_panic_on_peer_up_override(test_panic_on_peer_up_env.as_deref());
+        if test_panic_on_peer_up {
+            warn!(
+                "{TEST_PANIC_ON_PEER_UP_ENV} active: panicking on PeerUp \
+                 (fail-stop supervision fault injection — test use only)"
+            );
+        }
         Self {
             ribs: HashMap::new(),
             attr_intern: crate::attr_intern::AttrInternTable::new(),
@@ -1185,6 +1219,7 @@ impl RibManager {
             route_page_table_version: Some(initial_route_page_version()),
             route_page_advertised_version: Some(initial_route_page_version()),
             test_ingest_stall,
+            test_panic_on_peer_up: test_panic_on_peer_up.then_some(()),
         }
     }
 
@@ -1739,6 +1774,10 @@ impl RibManager {
         reason = "dispatcher needs one arm per RibUpdate variant"
     )]
     fn handle_update(&mut self, update: RibUpdate) {
+        assert!(
+            !(self.test_panic_on_peer_up.is_some() && matches!(&update, RibUpdate::PeerUp { .. })),
+            "{TEST_PANIC_ON_PEER_UP_ENV} triggered before route-page generation advance"
+        );
         self.advance_route_pages_for_update(&update);
         match update {
             RibUpdate::RoutesReceived {

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -1624,6 +1624,16 @@ fn test_ingest_stall_override_parse_rules() {
     assert_eq!(test_ingest_stall_override(Some("1.5")), None);
 }
 
+#[test]
+fn peer_up_panic_override_accepts_only_trimmed_one() {
+    assert!(!test_panic_on_peer_up_override(None));
+    assert!(test_panic_on_peer_up_override(Some("1")));
+    assert!(test_panic_on_peer_up_override(Some(" 1 ")));
+    for value in ["", "0", "2", "true", "-1"] {
+        assert!(!test_panic_on_peer_up_override(Some(value)), "{value:?}");
+    }
+}
+
 #[tokio::test]
 async fn peer_deleted_reaps_metric_series_peer_down_does_not() {
     fn peer_series_count(metrics: &BgpMetrics, peer: &str) -> usize {

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -1418,6 +1418,22 @@ fn route_page_versions(manager: &RibManager) -> [RoutePageVersion; 3] {
     ]
 }
 
+#[test]
+fn peer_up_fault_fires_before_shared_page_generation_advances() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_panic_on_peer_up = Some(());
+    let before = route_page_versions(&manager);
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = peer_up_direct(&mut manager, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    }));
+    assert!(
+        panic.is_err(),
+        "real PeerUp must trigger the fail-stop probe"
+    );
+    assert_eq!(route_page_versions(&manager), before);
+}
+
 fn assert_only_advertised_page_version_advanced_once(
     before: [RoutePageVersion; 3],
     after: [RoutePageVersion; 3],

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -719,8 +719,8 @@ impl PeerSession {
     /// peer's hold timer stays fed by the writer-owned KEEPALIVE
     /// cadence while parked.
     ///
-    /// `Err` means the RIB manager is gone (daemon shutdown) — the
-    /// caller should abandon the rest of its turn.
+    /// `Err` means the RIB actor is unavailable — the caller should
+    /// abandon the rest of its turn.
     pub(super) async fn deliver_routes_to_rib(&self, update: RibUpdate) -> Result<(), ()> {
         match self.rib_tx.try_send(update) {
             Ok(()) => Ok(()),

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -700,6 +700,13 @@ coordinated shutdown (NOTIFICATION to all peers, GR marker write). This is
 deliberate: losing the control plane means losing the ability to shut down
 cleanly later. See [ADR-0022](adr/0022-grpc-server-supervision.md).
 
+### RIB manager exits unexpectedly
+
+The daemon likewise treats any RIB manager return or panic as fatal. It logs
+`RIB manager exited unexpectedly`, performs the ordinary coordinated shutdown
+(including peer NOTIFICATIONs), and exits 1 for `Restart=on-failure`. The
+daemon does not claim active supervision of the PeerManager itself.
+
 ### RPKI cache unreachable
 
 Each RTR client reconnects independently after a fixed `retry_interval`
@@ -1572,6 +1579,7 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 | `received shutdown signal` | INFO | SIGTERM/SIGINT received |
 | `shutdown initiated via gRPC` | INFO | `Shutdown` RPC called |
 | `gRPC server exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
+| `RIB manager exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `config reloaded` | INFO | SIGHUP reload succeeded |
 | `config reload failed` | ERROR | SIGHUP reload failed — previous config kept |
 | `GR restart marker` | INFO | Restart marker written or read |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -409,11 +409,12 @@ Notes on the sandbox:
   need a restart.
 - `Restart=on-failure` is load-bearing. The daemon exits `0` only on an
   operator-initiated shutdown (SIGINT/SIGTERM, the `Shutdown` RPC) and
-  `1` on a component failure it cannot recover from in place — the BGP
-  listener failing to bind, a configured `prometheus_addr` health
-  listener failing to bind, or the gRPC server exiting unexpectedly.
-  None of these listeners is rebound without a restart, so the daemon exits
-  rather than run on deaf; the supervisor's retry is the recovery path.
+  `1` on a component failure it cannot recover from in place. Startup exits
+  immediately if legacy BGP mode binds neither family, explicit
+  `listen_addresses` cannot bind every configured endpoint, or a configured
+  `prometheus_addr` health listener cannot bind. An unexpected gRPC server or
+  RIB manager exit instead runs the coordinated peer teardown before exit 1.
+  These components are not respawned in place; the supervisor is the recovery path.
   Exit 70 is also a failure: it is the runtime-config settlement watchdog's
   fail-stop recovery request and must remain restartable. `RestartSec=5`
   retries a transient failure, while `StartLimitBurst=5` and

--- a/src/main.rs
+++ b/src/main.rs
@@ -2372,8 +2372,12 @@ The config was rejected, or
 reported at least one warning. For
 .BR \-\-diff ,
 1 means the diff carries actionable changes. A running daemon also exits
-1 when a component failure ends it (the BGP listener failed to bind, or
-the gRPC server exited unexpectedly), so that a supervisor configured
+1 when a component failure ends it (legacy BGP listen mode could bind
+neither family; explicit
+.B listen_addresses
+mode could not bind every configured endpoint; a configured metrics/readiness
+listener failed to bind; or the RIB manager or gRPC server exited unexpectedly),
+so that a supervisor configured
 with
 .B Restart=on\-failure
 restarts it. An operator\-initiated shutdown exits 0.
@@ -2453,7 +2457,9 @@ fn main() -> ExitCode {
                   includes a valid config that was warned about\n  \
                1  The config was rejected, or --check --strict found warnings.\n     \
                   A running daemon exits 1 on a component failure that ends it\n     \
-                  (BGP or metrics/readiness listener bind, unexpected gRPC server exit)\n  \
+                  (legacy BGP mode bound neither family; an explicit listen_addresses\n     \
+                  endpoint failed to bind; configured metrics/readiness bind failure;\n     \
+                  or unexpected RIB manager or gRPC server exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
                     env!("CARGO_PKG_VERSION")
@@ -2788,14 +2794,14 @@ fn main() -> ExitCode {
         .enable_all()
         .build()
         .unwrap_or_else(|e| fatal_startup_error("failed to create tokio runtime", e));
-    let grpc_server_failed = rt.block_on(run(
+    let component_failed = rt.block_on(run(
         accepted,
         boot_revert_notice,
         launch_identity.expect("daemon boot resolved launch config identity"),
         profiler,
     ));
     shutdown_daemon_runtime(rt);
-    if grpc_server_failed {
+    if component_failed {
         // The coordinated teardown already ran (NOTIFICATIONs, GR marker,
         // checkpoints); the non-zero code tells supervisors (e.g. systemd
         // Restart=on-failure) this was a component failure, not a clean stop.
@@ -3006,8 +3012,8 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
     clippy::too_many_lines,
     reason = "runtime startup keeps listener, API, and shutdown wiring in one owner"
 )]
-/// Returns `true` when shutdown was caused by the gRPC server exiting
-/// unexpectedly (a component failure — the process must exit non-zero),
+/// Returns `true` when shutdown was caused by an unexpected component exit
+/// (a failure — the process must exit non-zero),
 /// `false` for operator-initiated shutdowns (signals, Shutdown RPC).
 async fn run<T>(
     accepted: Arc<AcceptedConfigSnapshot>,
@@ -3557,7 +3563,7 @@ async fn run<T>(
     } else {
         None
     };
-    tokio::spawn(rib_manager.run());
+    let mut rib_handle = tokio::spawn(rib_manager.run());
 
     // Validation snapshot channel: broadcast VRP + ASPA tables to transport
     // sessions for import-time route validation.  Starts empty — sessions fall
@@ -5014,7 +5020,8 @@ async fn run<T>(
         Err(reason) => error!(error = %reason, "invalid [gnmi_dialout] section; dial-out disabled"),
     }
 
-    // Wait for shutdown signal: SIGINT, SIGTERM, Shutdown RPC, unexpected gRPC exit, or SIGHUP
+    // Wait for shutdown signal, Shutdown RPC, SIGHUP, or an unexpected
+    // gRPC/RIB component exit.
     //
     // SIGHUP runs `reload_config` on a dedicated tokio task so the
     // signal-arm dispatch returns immediately. Without this, the SIGHUP
@@ -5033,7 +5040,7 @@ async fn run<T>(
     let mut reload_in_flight: Option<
         tokio::task::JoinHandle<Result<SighupAuthority, SighupReloadError>>,
     > = None;
-    let mut grpc_server_failed = false;
+    let mut component_failed = false;
     loop {
         tokio::select! {
             _ = sigint.recv() => {
@@ -5054,7 +5061,13 @@ async fn run<T>(
             result = &mut grpc_handle => {
                 error!(?result, "gRPC server exited unexpectedly");
                 info!("initiating shutdown due to gRPC server failure");
-                grpc_server_failed = true;
+                component_failed = true;
+                break;
+            }
+            result = &mut rib_handle => {
+                error!(?result, "RIB manager exited unexpectedly");
+                info!("initiating shutdown due to RIB manager failure");
+                component_failed = true;
                 break;
             }
             _ = sighup.recv() => {
@@ -5598,7 +5611,7 @@ async fn run<T>(
     }
 
     info!("rustbgpd exiting");
-    grpc_server_failed
+    component_failed
 }
 
 #[cfg(test)]
@@ -6135,6 +6148,8 @@ mod tests {
             man.contains(".SH EXIT STATUS"),
             "man page missing the EXIT STATUS section"
         );
+        assert!(man.contains("legacy BGP listen mode could bind\nneither family"));
+        assert!(man.contains("mode could not bind every configured endpoint"));
     }
 
     fn tcp_ao_neighbor_toml(address: &str) -> String {

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -7,12 +7,19 @@
 //! daemon needs: the gRPC server exiting unexpectedly, the BGP listener
 //! failing to bind, and the metrics/readiness listener failing to bind.
 
+use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use rustbgpd_wire::constants::{HEADER_LEN, MAX_MESSAGE_LEN};
+use rustbgpd_wire::message::{Message, decode_message, encode_message};
+use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
+use rustbgpd_wire::open::OpenMessage;
 
 fn private_tempdir() -> tempfile::TempDir {
     let temp = tempfile::tempdir().expect("create temp dir");
@@ -112,11 +119,19 @@ fn write_config(dir: &Path, grpc_port: u16, bgp_port: u16) -> PathBuf {
 }
 
 fn spawn_daemon(dir: &Path, config_path: &Path) -> Daemon {
+    spawn_daemon_with_env(dir, config_path, None)
+}
+
+fn spawn_daemon_with_env(dir: &Path, config_path: &Path, env: Option<(&str, &str)>) -> Daemon {
     let stdout_path = dir.join("rustbgpd.stdout.log");
     let stderr_path = dir.join("rustbgpd.stderr.log");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rustbgpd"));
+    command.arg(config_path);
+    if let Some((key, value)) = env {
+        command.env(key, value);
+    }
     Daemon {
-        child: Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
-            .arg(config_path)
+        child: command
             .stdout(Stdio::from(
                 std::fs::File::create(&stdout_path).expect("daemon stdout log"),
             ))
@@ -128,6 +143,24 @@ fn spawn_daemon(dir: &Path, config_path: &Path) -> Daemon {
         stdout_path,
         stderr_path,
     }
+}
+
+fn write_rib_fault_config(dir: &Path) -> PathBuf {
+    let config_path = write_config(dir, DAEMON_CHOOSES, DAEMON_CHOOSES);
+    let config = std::fs::read_to_string(&config_path)
+        .expect("read test config")
+        .replace(
+            "listen_port = 0",
+            "listen_port = 0\nlisten_addresses = [\"127.0.0.1\"]",
+        );
+    std::fs::write(
+        &config_path,
+        format!(
+            "{config}\n[[neighbors]]\naddress = \"127.0.0.1\"\nremote_asn = 65020\ngraceful_restart = false\n"
+        ),
+    )
+    .expect("write RIB fault config");
+    config_path
 }
 
 /// Port the config asks for when the test does not care about the value.
@@ -164,6 +197,76 @@ fn wait_for_bound_grpc_port(daemon: &mut Daemon) -> u16 {
     );
 }
 
+fn wait_for_bound_bgp_port(daemon: &mut Daemon) -> u16 {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        let logs = daemon.logs();
+        if let Some(port) = logs
+            .split(r#""addr":"127.0.0.1:"#)
+            .skip(1)
+            .filter_map(|rest| rest.split('"').next()?.parse().ok())
+            .find(|port| *port != 0)
+        {
+            return port;
+        }
+        if let Ok(Some(status)) = daemon.child.try_wait() {
+            panic!("rustbgpd exited before binding BGP: {status}\n{logs}");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "rustbgpd never logged a bound BGP listener\n{}",
+        daemon.logs()
+    );
+}
+
+fn read_bgp_message(stream: &mut TcpStream) -> Message {
+    let mut frame = vec![0; HEADER_LEN];
+    stream.read_exact(&mut frame).expect("read BGP header");
+    let total = usize::from(u16::from_be_bytes([frame[16], frame[17]]));
+    assert!((HEADER_LEN..=usize::from(MAX_MESSAGE_LEN)).contains(&total));
+    frame.resize(total, 0);
+    stream
+        .read_exact(&mut frame[HEADER_LEN..])
+        .expect("read BGP body");
+    decode_message(&mut Bytes::from(frame), MAX_MESSAGE_LEN).expect("decode daemon BGP frame")
+}
+
+fn establish_bgp_and_observe_shutdown(port: u16) {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect BGP peer");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+    let open = Message::Open(OpenMessage {
+        version: 4,
+        my_as: 65020,
+        hold_time: 90,
+        bgp_identifier: "10.0.0.2".parse().unwrap(),
+        capabilities: vec![],
+    });
+    stream
+        .write_all(&encode_message(&open).expect("encode OPEN"))
+        .expect("write OPEN");
+    assert!(matches!(read_bgp_message(&mut stream), Message::Open(_)));
+    stream
+        .write_all(&encode_message(&Message::Keepalive).unwrap())
+        .expect("write KEEPALIVE");
+
+    let mut established = false;
+    loop {
+        match read_bgp_message(&mut stream) {
+            Message::Keepalive => established = true,
+            Message::Notification(notification) => {
+                assert!(established, "shutdown followed an established session");
+                assert_eq!(notification.code, NotificationCode::Cease);
+                assert_eq!(notification.subcode, cease_subcode::ADMINISTRATIVE_SHUTDOWN);
+                return;
+            }
+            _ => {}
+        }
+    }
+}
+
 #[test]
 fn grpc_bind_failure_exits_nonzero() {
     let temp = private_tempdir();
@@ -182,6 +285,77 @@ fn grpc_bind_failure_exits_nonzero() {
         "gRPC server failure must exit 1, got {status}\n{}",
         daemon.logs()
     );
+}
+
+#[test]
+fn rib_manager_panic_drains_established_peer_and_exits_nonzero() {
+    let temp = private_tempdir();
+    let config_path = write_rib_fault_config(temp.path());
+    let mut daemon = spawn_daemon_with_env(
+        temp.path(),
+        &config_path,
+        Some(("RUSTBGPD_TEST_RIB_PANIC_ON_PEER_UP", "1")),
+    );
+    establish_bgp_and_observe_shutdown(wait_for_bound_bgp_port(&mut daemon));
+
+    let status = daemon.wait_within(Duration::from_secs(30));
+    let logs = daemon.logs();
+    assert_eq!(status.code(), Some(1), "RIB failure must exit 1\n{logs}");
+    assert!(logs.contains("RIB manager exited unexpectedly"), "{logs}");
+    assert!(
+        logs.contains("initiating shutdown due to RIB manager failure"),
+        "{logs}"
+    );
+    assert!(logs.contains("shutdown requested"), "{logs}");
+
+    let reports = std::fs::read_dir(temp.path().join("runtime/crash"))
+        .expect("panic report directory")
+        .flatten()
+        .map(|entry| std::fs::read_to_string(entry.path()).expect("read panic report"))
+        .collect::<Vec<_>>();
+    assert_eq!(reports.len(), 1, "one durable panic report: {reports:?}");
+    assert!(reports[0].contains("triggered before route-page generation advance"));
+}
+
+#[test]
+fn rib_supervision_is_fail_stop_and_uses_common_peer_teardown() {
+    let source = include_str!("../src/main.rs");
+    let retained = source
+        .find("let mut rib_handle = tokio::spawn(rib_manager.run());")
+        .expect("RIB JoinHandle must be retained");
+    let arm = source
+        .find("result = &mut rib_handle => {")
+        .expect("shutdown select must supervise the RIB task");
+    let exact_arm = &source[arm..source[arm..].find("            }").unwrap() + arm];
+    assert!(exact_arm.contains("RIB manager exited unexpectedly"));
+    assert!(exact_arm.contains("component_failed = true;"));
+    assert!(exact_arm.contains("break;"));
+    assert!(
+        !exact_arm.contains("Ok(") && !exact_arm.contains("is_ok") && !exact_arm.contains("is_err")
+    );
+    let teardown = source
+        .find("send(PeerManagerCommand::Shutdown)")
+        .expect("component failure must retain coordinated peer shutdown");
+    assert!(retained < arm && arm < teardown);
+}
+
+#[test]
+fn help_and_man_distinguish_bgp_bind_modes_and_supervised_exits() {
+    let output = |flag| {
+        let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+            .arg(flag)
+            .output()
+            .expect("run rustbgpd display mode");
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).expect("display output is UTF-8")
+    };
+    let help = output("--help");
+    assert!(help.contains("legacy BGP mode bound neither family; an explicit listen_addresses"));
+    assert!(help.contains("endpoint failed to bind; configured metrics/readiness bind failure;"));
+    assert!(help.contains("or unexpected RIB manager or gRPC server exit"));
+    let man = output("--man");
+    assert!(man.contains("legacy BGP listen mode could bind\nneither family; explicit\n.B listen_addresses\nmode could not bind every configured endpoint"));
+    assert!(man.contains("configured metrics/readiness\nlistener failed to bind; or the RIB manager or gRPC server exited unexpectedly"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- retain and supervise the RibManager task alongside the existing gRPC and operator shutdown paths
- treat any unexpected RIB return or panic as fatal, then use the existing coordinated PeerManager shutdown before exiting 1
- add a construction-time, test-only PeerUp panic probe that fires before shared table-generation advancement
- clarify closed-RIB and operator exit-status documentation without claiming PeerManager supervision

## Verification

- real BGP Established session observed Administrative Shutdown after the injected RIB panic, followed by exit 1 and one durable panic report
- focused parse, shared-generation ordering, source-contract, and full daemon failure tests
- eight destructive mutations covering supervision, status, teardown, ordering, and strict injection parsing
- strict all-target/all-feature Clippy, warning-denied docs, formatting, v1 surface, tracker, scale-split, lint, and diff contracts
- full workspace passed serially; one ordinary parallel run hit the existing rs-config-render shared host-lock test race outside this patch

Linear: LAN-1187
