### PR TITLE
CI: enforce root Cargo lockfile fidelity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,16 +164,16 @@ jobs:
           bash tests/interop/scripts/test-test-vtep-route-oracles.sh
       - run: python3 scripts/check-v1-stable-surface.py
       - run: python3 scripts/reflow-release-notes.py --selftest
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --locked --workspace --all-targets -- -D warnings
       # `bench-internals` is off by default and its bench target carries
       # `required-features`, so nothing above compiles the feature-gated
       # bench_support surface; it has silently broken before when a
       # manager API grew an argument.
-      - run: cargo check -p rustbgpd-rib --features bench-internals --benches
+      - run: cargo check --locked -p rustbgpd-rib --features bench-internals --benches
       # Transport has the same feature-gated `bench-internals` bench surface.
-      - run: cargo check -p rustbgpd-transport --features bench-internals --benches
+      - run: cargo check --locked -p rustbgpd-transport --features bench-internals --benches
       # API owns the feature-gated event-history producer bench.
-      - run: cargo check -p rustbgpd-api --features bench-internals --benches
+      - run: cargo check --locked -p rustbgpd-api --features bench-internals --benches
       # `--no-run` above proves the bench targets compile, not that they run.
       # A fixture the codec later made illegal (RFC 9774 AS_SET in the wire
       # `rich` AS_PATH) compiled clean and panicked on first iteration, so two
@@ -188,23 +188,23 @@ jobs:
       # the PR critical path while retaining the harness's path assertions.
       - name: Smoke MRT snapshot allocation benchmark modes
         run: |
-          cargo test -p rustbgpd-mrt --bench snapshot_allocation -- timing --candidate --smoke
-          cargo test -p rustbgpd-mrt --features snapshot-allocation-diagnostics --bench snapshot_allocation -- diagnostic --candidate --smoke
+          cargo test --locked -p rustbgpd-mrt --bench snapshot_allocation -- timing --candidate --smoke
+          cargo test --locked -p rustbgpd-mrt --features snapshot-allocation-diagnostics --bench snapshot_allocation -- diagnostic --candidate --smoke
       # Same class of gap for the root crate: `bench-internals` exposes
       # `pub mod config` (and its EVPN reload-diff dependencies) in the
       # lib, a surface the default `--all-targets` clippy never compiles.
       # LAN-198: `config` referenced binary-only modules, so the lib
       # failed to build under `--all-features` while the bin stayed green.
-      - run: cargo check -p rustbgpd --all-features --lib
+      - run: cargo check --locked -p rustbgpd --all-features --lib
       # The root `Config` API is exported only by `bench-internals`, so the
       # normal workspace test cannot compile this cheap allocation gate.
       - name: Gate eager policy-set sharing allocation shape
-        run: cargo test -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation shared_set_batch_allocations_do_not_scale_per_peer -- --exact
+        run: cargo test --locked -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation shared_set_batch_allocations_do_not_scale_per_peer -- --exact
       # jemalloc became the default feature; keep the stock-glibc build
       # compiling (debug/fallback builds use it) and keep the
       # deny(unsafe_code) lint posture — it is only armed when neither
       # allocator feature is on, so the default build no longer checks it.
-      - run: cargo check -p rustbgpd --no-default-features --all-targets
+      - run: cargo check --locked -p rustbgpd --no-default-features --all-targets
       - name: Verify committed RIB rebaseline receipt
         run: |
           set -euo pipefail
@@ -323,10 +323,10 @@ jobs:
             --install-archive \
             "$RUNNER_TEMP/rustbgpd-v064-artifact/rustbgpd-linux-amd64.tar.gz" \
             "$RUNNER_TEMP/rustbgpd-v064"
-      - run: cargo test --workspace
+      - run: cargo test --locked --workspace
         env:
           RUSTBGPD_V064_VALIDATOR: ${{ runner.temp }}/rustbgpd-v064/rustbgpd-v0.64.0
-      - run: cargo doc --workspace --lib --no-deps
+      - run: cargo doc --locked --workspace --lib --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
 
@@ -371,8 +371,8 @@ jobs:
             --locked --all-targets -- -D warnings
           # The IRR manifest contract exercises the production rustbgpd
           # renderer, so make that prerequisite explicit on a clean runner.
-          cargo build -p rs-config-render
-          cargo test --test reloadstall_scenario_emitted_check
+          cargo build --locked -p rs-config-render
+          cargo test --locked --test reloadstall_scenario_emitted_check
           bash -n bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh
           shellcheck bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh
           shellcheck bench/smoke-benches.sh
@@ -465,7 +465,7 @@ jobs:
           # Distinct cache key from the `check` job so MSRV builds don't
           # share artifacts compiled by stable rustc.
           key: msrv-1.95
-      - run: cargo check --workspace --all-targets
+      - run: cargo check --locked --workspace --all-targets
 
   evpn_bum_filter_kernel:
     # Runs the Gate 8b BUM-suppression primitive against a real

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,7 +45,7 @@ jobs:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      - run: cargo test --locked --workspace
 
   build-and-push:
     needs: [verify-tag-version, test]

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -529,14 +529,14 @@ jobs:
           set -euo pipefail
           receipt='listener::tests::overlapping_tcp_ao_owned_union_kernel_receipt'
           test_count="$({
-            cargo test -p rustbgpd-transport --lib -- --list
+            cargo test --locked -p rustbgpd-transport --lib -- --list
           } | awk -v target="${receipt}:" \
             '$1 == target && $2 == "test" { count++ } END { print count + 0 }')"
           if [ "$test_count" -ne 1 ]; then
             echo "error: expected exactly one kernel receipt named $receipt; found $test_count" >&2
             exit 1
           fi
-          cargo test -p rustbgpd-transport --lib "$receipt" -- \
+          cargo test --locked -p rustbgpd-transport --lib "$receipt" -- \
             --ignored --exact --nocapture
 
       - name: Run queued-child TCP-AO successor reconciliation receipt
@@ -545,14 +545,14 @@ jobs:
           set -euo pipefail
           receipt='listener::tests::queued_tcp_ao_child_reconciles_immediate_listener_successor'
           test_count="$({
-            cargo test -p rustbgpd-transport --lib -- --list
+            cargo test --locked -p rustbgpd-transport --lib -- --list
           } | awk -v target="${receipt}:" \
             '$1 == target && $2 == "test" { count++ } END { print count + 0 }')"
           if [ "$test_count" -ne 1 ]; then
             echo "error: expected exactly one kernel receipt named $receipt; found $test_count" >&2
             exit 1
           fi
-          cargo test -p rustbgpd-transport --lib "$receipt" -- \
+          cargo test --locked -p rustbgpd-transport --lib "$receipt" -- \
             --ignored --exact --nocapture
 
       - name: Run TCP-AO deletion and listener-queue boundary receipt
@@ -561,14 +561,14 @@ jobs:
           set -euo pipefail
           receipt='socket_opts::tests::tcp_ao_delete_kernel_receipt_preserves_covering_owners_and_queue_boundary'
           test_count="$({
-            cargo test -p rustbgpd-transport --lib -- --list
+            cargo test --locked -p rustbgpd-transport --lib -- --list
           } | awk -v target="${receipt}:" \
             '$1 == target && $2 == "test" { count++ } END { print count + 0 }')"
           if [ "$test_count" -ne 1 ]; then
             echo "error: expected exactly one kernel receipt named $receipt; found $test_count" >&2
             exit 1
           fi
-          cargo test -p rustbgpd-transport --lib "$receipt" -- \
+          cargo test --locked -p rustbgpd-transport --lib "$receipt" -- \
             --ignored --exact --nocapture
 
       # The staged verified archive (LAN-1024) composes with the buildx GHA

--- a/.github/workflows/privileged-interop.yml
+++ b/.github/workflows/privileged-interop.yml
@@ -55,7 +55,7 @@ jobs:
               "RUSTUP_HOME=${RUSTUP_HOME:-$HOME/.rustup}" \
               CARGO_TARGET_DIR=target/privileged-ci \
               EVPN_LINUX_NETNS=1 \
-              cargo test -p rustbgpd-evpn-linux --test "$1" -- --nocapture
+              cargo test --locked -p rustbgpd-evpn-linux --test "$1" -- --nocapture
           }
           run_privileged_cargo_test netns_dataplane
           run_privileged_cargo_test netns_fdb_nhg

--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -80,13 +80,13 @@ jobs:
       - name: Check repository release install contract
         run: python3 scripts/check_release_install_contract.py
       - name: Test Birdwatcher endpoint parser
-        run: cargo test -p birdwatcher-adapter
+        run: cargo test --locked -p birdwatcher-adapter
       - name: Test Birdwatcher UDS startup and recovery
-        run: cargo test --test birdwatcher_adapter_smoke
+        run: cargo test --locked --test birdwatcher_adapter_smoke
       - name: Build native package inputs
         run: |
           set -euo pipefail
-          cargo build --profile ci \
+          cargo build --locked --profile ci \
             -p rustbgpd -p rustbgpctl -p rs-config-render -p birdwatcher-adapter
           mkdir -p staging/share/man/man1 staging/share/man/man8 staging/share/completions
           cp target/ci/rustbgpd target/ci/rbgp target/ci/rs-config-render \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      - run: cargo test --locked --workspace
 
   build:
     needs: verify-tag-version
@@ -123,7 +123,7 @@ jobs:
         # aarch64-linux-gnu-gcc toolchain installed above.
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --workspace --release --features rustbgpd/jemalloc --target ${{ matrix.target }}
+        run: cargo build --locked --workspace --release --features rustbgpd/jemalloc --target ${{ matrix.target }}
 
       - name: Package binaries
         run: |
@@ -179,7 +179,7 @@ jobs:
             RBGP=target/${{ matrix.target }}/release/rbgp
             RUSTBGPD=target/${{ matrix.target }}/release/rustbgpd
           else
-            cargo build -p rustbgpctl -p rustbgpd
+            cargo build --locked -p rustbgpctl -p rustbgpd
             RBGP=target/debug/rbgp
             RUSTBGPD=target/debug/rustbgpd
           fi

--- a/.github/workflows/update-group-fault.yml
+++ b/.github/workflows/update-group-fault.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -euo pipefail
           test_name='manager::tests::update_groups_fault_corpus::deterministic_fault_corpus_extended'
-          listing="$(cargo test -p rustbgpd-rib --lib "$test_name" -- --ignored --exact --list)"
+          listing="$(cargo test --locked -p rustbgpd-rib --lib "$test_name" -- --ignored --exact --list)"
           printf '%s\n' "$listing"
           if ! grep -Fqx "$test_name: test" <<<"$listing"; then
             echo "exact ignored test missing: $test_name" >&2
@@ -52,7 +52,7 @@ jobs:
           : >"$log"
 
           set +e
-          cargo test -p rustbgpd-rib --lib "$test_name" -- \
+          cargo test --locked -p rustbgpd-rib --lib "$test_name" -- \
             --ignored --exact --nocapture 2>&1 | tee -a "$log"
           pipeline_status=("${PIPESTATUS[@]}")
           corpus_status=${pipeline_status[0]}
@@ -73,7 +73,7 @@ jobs:
               RUSTBGPD_UPDATE_GROUP_SEED_COUNT=1 \
               RUSTBGPD_UPDATE_GROUP_SCENARIO="$scenario" \
               RUSTBGPD_UPDATE_GROUP_MINIMIZE=1 \
-                cargo test -p rustbgpd-rib --lib "$test_name" -- \
+                cargo test --locked -p rustbgpd-rib --lib "$test_name" -- \
                   --ignored --exact --nocapture 2>&1 | tee -a "$log"
               pipeline_status=("${PIPESTATUS[@]}")
               minimize_status=${pipeline_status[0]}

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 ROSTER = {
@@ -17,6 +18,37 @@ ROSTER = {
     "evpn_bum_filter_kernel",
 }
 RESULTS = ("V064_VALIDATOR", "CORE", "CORE_TESTS", "SCALE_RECEIPTS")
+WORKFLOWS = tuple(
+    f".github/workflows/{name}.yml"
+    for name in ("ci", "container", "kernel-dataplane", "privileged-interop",
+                 "release-install-contract", "release", "update-group-fault")
+)
+EXPECTED_ROOT_COMMANDS = {
+    WORKFLOWS[0]: Counter(build=1, check=6, clippy=1, doc=1, test=5),
+    WORKFLOWS[1]: Counter(test=1),
+    WORKFLOWS[2]: Counter(test=6),
+    WORKFLOWS[3]: Counter(test=1),
+    WORKFLOWS[4]: Counter(build=1, test=2),
+    WORKFLOWS[5]: Counter(build=2, test=1),
+    WORKFLOWS[6]: Counter(test=3),
+}
+EXPECTED_STANDALONE_COMMANDS = (
+    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked"),
+    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked"),
+    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked"),
+    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked"),
+    (WORKFLOWS[0],
+     "cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml --locked --all-targets -- -D warnings"),
+    (WORKFLOWS[0], "cargo run --manifest-path bench/scale/rrtransport/Cargo.toml --locked -- smoke"),
+    (
+        WORKFLOWS[0],
+        "cargo clippy --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked --all-targets -- -D warnings",
+    ),
+)
+CARGO_COMMAND = re.compile(r"(?<![\w-])cargo(?:\s+\+\S+)?\s+(build|check|test|clippy|doc|bench|run)\b")
+LOCKED_TOKEN = re.compile(r"(?<!\S)--locked(?=\s|$)")
+ARG_SEPARATOR = re.compile(r"(?<!\S)--(?=\s|$)")
+MANIFEST_PATH = re.compile(r"(?<!\S)--manifest-path(?:=|\s+)([^\s;|&)]+)")
 
 
 def _jobs(text: str) -> dict[str, str]:
@@ -49,15 +81,82 @@ def named_step(job: str, name: str) -> str:
     return "" if match is None else match.group(1)
 
 
+def _logical_lines(text: str) -> list[str]:
+    logical: list[str] = []
+    pending = ""
+    for raw in text.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        pending += stripped
+        if re.search(r"\\\s*$", pending):
+            pending = re.sub(r"[ \t]*\\\s*$", " ", pending)
+            continue
+        logical.append(pending)
+        pending = ""
+    if pending:
+        logical.append(pending)
+    return logical
+
+
+def _cargo_commands(text: str) -> list[tuple[str, str]]:
+    commands: list[tuple[str, str]] = []
+    for line in _logical_lines(text):
+        matches = list(CARGO_COMMAND.finditer(line))
+        for index, match in enumerate(matches):
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(line)
+            command = line[match.start() : end].strip()
+            if boundary := re.search(r"&&|\|\||[;|&)]", command):
+                command = command[: boundary.start()].rstrip()
+            commands.append((match.group(1), command))
+    return commands
+
+
+def _check_dependency_commands(root: Path, errors: list[str]) -> None:
+    root_commands: dict[str, Counter[str]] = {}
+    standalone: list[tuple[str, str]] = []
+    directory = root / ".github/workflows"
+    for path in sorted((*directory.glob("*.yml"), *directory.glob("*.yaml"))):
+        if not (commands := _cargo_commands(path.read_text())):
+            continue
+        workflow = path.relative_to(root).as_posix()
+        counts: Counter[str] = Counter()
+        for subcommand, command in commands:
+            locked = list(LOCKED_TOKEN.finditer(command))
+            separator = ARG_SEPARATOR.search(command)
+            if not locked:
+                errors.append(f"{workflow}: {subcommand} command is missing --locked: {command}")
+            elif len(locked) > 1:
+                errors.append(f"{workflow}: {subcommand} command has duplicate --locked: {command}")
+            elif separator is not None and locked[0].start() > separator.start():
+                errors.append(f"{workflow}: {subcommand} command has --locked after Cargo's -- separator: {command}")
+            if MANIFEST_PATH.search(command):
+                standalone.append((workflow, command))
+            else:
+                counts[subcommand] += 1
+        root_commands[workflow] = counts
+
+    if root_commands != EXPECTED_ROOT_COMMANDS:
+        errors.append(
+            f"root Cargo command inventory drifted: expected {EXPECTED_ROOT_COMMANDS}, got {root_commands}"
+        )
+    if tuple(standalone) != EXPECTED_STANDALONE_COMMANDS:
+        errors.append("standalone Cargo command inventory or flags drifted")
+
+
 def check(root: Path) -> list[str]:
     text = (root / ".github/workflows/ci.yml").read_text()
     jobs = _jobs(text)
     errors: list[str] = []
+    _check_dependency_commands(root, errors)
     if set(jobs) != ROSTER:
         errors.append("exact CI job roster drifted")
 
     core_tests = jobs.get("core_tests", "")
-    for command in ("cargo test --workspace", "cargo doc --workspace --lib --no-deps"):
+    for command in (
+        "cargo test --locked --workspace",
+        "cargo doc --locked --workspace --lib --no-deps",
+    ):
         if text.count(command) != 1 or command not in core_tests:
             errors.append(f"{command} must exist exactly once in core_tests")
     if 'RUSTDOCFLAGS: "-D warnings"' not in core_tests:

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -7,19 +7,30 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.check_ci_scale_split_contract import _jobs, aggregate_shell, check
+from scripts.check_ci_scale_split_contract import WORKFLOWS, _jobs, aggregate_shell, check
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ".github/workflows/ci.yml"
 
 
 class ScaleSplitContractTests(unittest.TestCase):
-    def mutate(self, old: str, new: str = "", occurrence: int = 0) -> None:
+    def copy_workflows(self, root: Path) -> None:
+        for workflow in WORKFLOWS:
+            target = root / workflow
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / workflow, target)
+
+    def mutate(
+        self,
+        old: str,
+        new: str = "",
+        occurrence: int = 0,
+        workflow: str = WORKFLOW,
+    ) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            target = root / WORKFLOW
-            target.parent.mkdir(parents=True)
-            shutil.copy2(ROOT / WORKFLOW, target)
+            self.copy_workflows(root)
+            target = root / workflow
             text = target.read_text()
             start = 0
             for _ in range(occurrence + 1):
@@ -32,6 +43,76 @@ class ScaleSplitContractTests(unittest.TestCase):
     def test_live_contract(self) -> None:
         self.assertEqual([], check(ROOT))
 
+    def test_comments_toolchain_selector_and_new_workflow_boundaries(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.copy_workflows(root)
+            target = root / WORKFLOW
+            target.write_text(
+                "# cargo check --workspace\n"
+                + target.read_text().replace(
+                    "cargo check --locked -p rustbgpd-rib",
+                    "cargo +1.95 check --locked -p rustbgpd-rib",
+                    1,
+                )
+            )
+            self.assertEqual([], check(root))
+            added = root / ".github/workflows/new.yml"
+            added.write_text("jobs:\n  new:\n    steps:\n      - run: cargo +1.95 check --workspace\n")
+            self.assertIn("command is missing --locked", "\n".join(check(root)))
+            added.write_text(added.read_text().replace("check --workspace", "check --locked --locked --workspace"))
+            self.assertIn("command has duplicate --locked", "\n".join(check(root)))
+            added.unlink()
+            target.write_text(target.read_text() + "\n      - run: cargo check --workspace -- --locked \\\n")
+            self.assertIn("command has --locked after Cargo's -- separator", "\n".join(check(root)))
+
+    def test_lockfile_fidelity_mutations_fail_closed(self) -> None:
+        cases = (
+            (
+                WORKFLOW,
+                "cargo clippy --locked --workspace --all-targets",
+                "cargo clippy --workspace --all-targets",
+            ),
+            (
+                ".github/workflows/update-group-fault.yml",
+                'listing="$(cargo test --locked -p rustbgpd-rib --lib "$test_name" -- --ignored --exact --list)"',
+                'listing="$(cargo test -p rustbgpd-rib --lib "$test_name" -- --ignored --exact --list)" --locked',
+            ),
+            (
+                WORKFLOW,
+                "cargo check --locked -p rustbgpd-rib --features bench-internals --benches",
+                "cargo check -p rustbgpd-rib --features bench-internals --benches; echo --locked",
+            ),
+            (
+                WORKFLOW,
+                "cargo test --locked -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation shared_set_batch_allocations_do_not_scale_per_peer -- --exact",
+                "cargo test -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation shared_set_batch_allocations_do_not_scale_per_peer -- --locked --exact",
+            ),
+            (
+                WORKFLOW,
+                "bench/scale/rrharness/Cargo.toml --locked",
+                "bench/scale/rrharness/Cargo.toml",
+            ),
+            (
+                WORKFLOW,
+                "bench/scale/rrtransport/Cargo.toml --locked -- smoke",
+                "bench/scale/renamed/Cargo.toml --locked -- smoke",
+            ),
+            (
+                WORKFLOW,
+                "- run: cargo test --locked --workspace",
+                "- run: cargo test --locked --workspace\n      - run: cargo check --workspace",
+            ),
+            (
+                WORKFLOW,
+                "cargo build --locked -p rs-config-render",
+                "true",
+            ),
+        )
+        for workflow, old, new in cases:
+            with self.subTest(workflow=workflow, seam=old):
+                self.mutate(old, new, workflow=workflow)
+
     def test_semantic_mutations_fail_closed(self) -> None:
         cases = (
             ("  v064_validator:\n", "  renamed_validator:\n"),
@@ -41,8 +122,8 @@ class ScaleSplitContractTests(unittest.TestCase):
             ("  check:\n", "  renamed_check:\n"),
             ("  msrv:\n", "  renamed_msrv:\n"),
             ("  evpn_bum_filter_kernel:\n", "  renamed_evpn:\n"),
-            ("- run: cargo test --workspace", "- run: true"),
-            ("- run: cargo doc --workspace --lib --no-deps", "- run: true"),
+            ("- run: cargo test --locked --workspace", "- run: true"),
+            ("- run: cargo doc --locked --workspace --lib --no-deps", "- run: true"),
             ('RUSTDOCFLAGS: "-D warnings"', 'RUSTDOCFLAGS: ""'),
             (
                 "- name: Wire crate README freshness gate",


### PR DESCRIPTION
Closes LAN-1200.

Adds --locked to all 31 root dependency-resolving Cargo commands across the seven GitHub workflows while preserving the exact seven standalone-manifest commands.

Extends the existing scale-split contract to inventory every Cargo-bearing workflow, bound tokens to the Cargo command segment, support continuations and toolchain selectors, and fail closed on command deletion, nesting, reclassification, new workflows, or misplaced lock flags.

Verified with focused contract, image-primer, release-install, YAML, strict Clippy, warning-denied docs, and serial workspace gates. The exact invalid bgpkit-parser 0.20 lock-only change fails locked metadata with rc 101; Cargo.lock remains byte-identical. The ordinary parallel workspace run encountered the existing rs-config-render shared host-lock race; the bounded serial workspace run passed.