### PR TITLE
ci: disable the bench nightly schedule after runner retirement

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -2,6 +2,19 @@ name: Criterion Bench Nightly
 
 # Nightly perf TRIPWIRE — not a source of published benchmark truth.
 #
+# DORMANT since 2026-08-21: the `[self-hosted, rustbgpd-bench]` VPS was
+# deregistered and reclaimed. The schedule trigger is removed so nothing
+# queues against a label with no runner behind it; a scheduled run would
+# otherwise sit pending forever instead of failing. Everything else is
+# retained deliberately.
+#
+# TO REVIVE: register a runner carrying the `rustbgpd-bench` label, then
+# restore the schedule below. Re-measure the new host's same-SHA noise
+# floor before trusting any comparison — the ~11% figure in this file and
+# in docs/BENCHMARKS.md is specific to the retired VPS and does not carry
+# over. Re-check the nightly ladder for a free slot (fuzz 04:00,
+# audit 06:00) rather than assuming 05:00 is still unclaimed.
+#
 # Runs the same pinned A/B harness as `bench.yml` (bench/compare-criterion.sh)
 # on the dedicated self-hosted runner, comparing the current default-branch tip
 # against the **latest release tag**. A release-anchored baseline is the right
@@ -30,8 +43,9 @@ name: Criterion Bench Nightly
 # run summary. workflow_dispatch runs keep single-run verdicts.
 
 on:
-  schedule:
-    - cron: "0 5 * * *" # nightly at 05:00 UTC (between fuzz@04:00 and audit@06:00)
+  # schedule:
+  #   - cron: "0 5 * * *" # nightly at 05:00 UTC (between fuzz@04:00 and audit@06:00)
+  #   ^ restore together with a runner carrying the `rustbgpd-bench` label.
   workflow_dispatch:
     inputs:
       base_ref:

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -56,11 +56,24 @@ v0.4.2 snapshot. See *End-to-End System Benchmarks* below.
 
 ## Secondary measurement environment — self-hosted VPS bench runner
 
+> **Retired 2026-08-21.** This runner was deregistered and the host
+> reclaimed. Benchmarking now runs on the primary host described above,
+> which is an upgrade for measurement: bare metal instead of a
+> virtualized guest, and directly comparable to the published receipts
+> rather than needing its own baseline. `bench-nightly.yml` and
+> `bench.yml` are retained with their schedule disabled — see those
+> files to revive them against a future runner.
+>
+> This section stays because the numbers below and elsewhere in this
+> document were measured here, and a published figure keeps the
+> environment that produced it. Everything in it describes the retired
+> host, in the past tense of fact: the ~11% noise floor is a property of
+> that VPS and must not be assumed for any replacement.
+
 The `Criterion Bench Compare` workflow (`.github/workflows/bench.yml`)
-runs on a dedicated VPS registered as a `[self-hosted, rustbgpd-bench]`
-runner. Numbers from CI dispatches are produced in this environment,
-not the primary host described above. Two environments give us A/B
-deltas on PRs without coupling them to a single machine.
+ran on a dedicated VPS registered as a `[self-hosted, rustbgpd-bench]`
+runner. Numbers from CI dispatches were produced in this environment,
+not the primary host described above.
 
 | Field | Value |
 |-------|-------|
@@ -126,7 +139,9 @@ not a merge gate.
 
 ### Host coexistence: bench vs. soak
 
-The VPS bench runner is also planned to run rustbgpd's soak suite.
+Bench and soak workloads share the primary host. That coexistence is now
+the normal case rather than a plan: the 24h flagship soak receipts record
+the primary host, and benchmarking moved there when the VPS was retired.
 Both workloads acquire an exclusive `flock` on
 `${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` before doing
 real work — the bench script via `bench/compare-criterion.sh` directly, the soak
@@ -295,9 +310,18 @@ cross-stack comparison below or the explain-cache comparison
 
 `.github/workflows/bench.yml` exposes the same comparison as a manual
 `Criterion Bench Compare` workflow. It targets a `[self-hosted,
-rustbgpd-bench]` runner and is intentionally not wired to normal pull-request
-events yet. Enable PR-triggered benchmark comments only after the replacement
-runner exists and its run-to-run noise floor is measured.
+rustbgpd-bench]` runner, and **no runner currently carries that label** — the
+VPS was retired 2026-08-21. The workflow is dispatch-only, so it cannot fire on
+its own; a manual dispatch today queues until a matching runner appears.
+
+`bench-nightly.yml` is the same harness on a schedule, and that schedule is
+disabled for the same reason — a scheduled job against an absent label queues
+indefinitely rather than failing.
+
+Both files are kept intact for revival. Enable PR-triggered benchmark comments
+only after a replacement runner exists **and its own run-to-run noise floor has
+been measured** — the ~11% figure in this document belongs to the retired VPS
+and does not transfer.
 
 ## Reading the comparison output (for PR review)
 

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -213,7 +213,7 @@ artifacts under [`artifacts/soak/`](artifacts/soak/). Harnesses live in
 | [`kernel-dataplane.yml`](../.github/workflows/kernel-dataplane.yml) | PR, push, nightly 07:00 UTC | Privileged EVPN/FIB/BFD/TCP-AO dataplane receipts + netns selectors |
 | [`fuzz.yml`](../.github/workflows/fuzz.yml) | nightly 04:00 UTC + manual dispatch | The sole scheduled 19-target campaign: libFuzzer wire, policy, EVPN route-target, MRT/warm-bundle, BFD, and RTR harnesses |
 | [`clusterfuzzlite.yml`](../.github/workflows/clusterfuzzlite.yml) | manual dispatch | On-demand official ClusterFuzzLite address-sanitized code-change fuzzing for the exact 19-target inventory; not a PR or scheduled gate |
-| [`bench-nightly.yml`](../.github/workflows/bench-nightly.yml) | nightly 05:00 UTC | Benchmark tracking on the bench runner |
+| [`bench-nightly.yml`](../.github/workflows/bench-nightly.yml) | manual dispatch (schedule disabled) | Benchmark tripwire; dormant since the bench runner was retired 2026-08-21 |
 | [`audit.yml`](../.github/workflows/audit.yml) | daily 06:00 UTC | `cargo audit` / dependency advisories |
 | [`privileged-interop.yml`](../.github/workflows/privileged-interop.yml) | manual dispatch | Direct-`cargo` privileged netns suites |
 


### PR DESCRIPTION
The `[self-hosted, rustbgpd-bench]` VPS was deregistered and the host reclaimed for other use.

## Why a schedule change rather than a deletion

A scheduled job against a runner label with nothing behind it **queues indefinitely rather than failing** — it never surfaces as a red, it just accumulates pending runs. That is the only hazard the retirement creates, and it comes from exactly one line.

- `bench-nightly.yml` had `schedule: cron "0 5 * * *"`. Commented out.
- `bench.yml` is `workflow_dispatch`-only and cannot fire on its own. **Unchanged.**

Both workflows are retained in full so the harness can be revived against a future runner on another host. Restore steps are recorded in the `bench-nightly.yml` header: register a runner carrying the label, uncomment the schedule, re-check the nightly ladder for a free slot, and re-measure the new host's noise floor before trusting any comparison.

## Docs record the retirement without rewriting measurement history

The *Secondary measurement environment* section in `BENCHMARKS.md` keeps its heading and its hardware table. Two reasons:

- An in-document anchor targets that heading (the noise-floor rationale reference in the comparison-reading guidance).
- Published figures elsewhere in the document were measured on that host, including the `+1.4% / +2.3%` A/B and the worked multi-attempt examples. A number keeps the environment that produced it.

The section is marked retired and rewritten in the past tense, with the **~11% noise floor flagged as a property of that VPS that does not transfer** to any replacement.

Also corrected: the claim that the VPS was "planned to run rustbgpd's soak suite". The 24h flagship soak receipts record the primary host, and benchmarking now shares it — so the bench/soak `flock` coexistence described in that section is the normal case rather than a plan.

The two flagship soak receipts are deliberately **untouched**. They describe what happened during those runs.

## Verification

- `bench-nightly.yml` parses as valid YAML with the schedule removed and `workflow_dispatch` intact.
- Neither bench workflow appears in `TRIGGER_HASHES`, so the `on:` edit does not trip the CI image-primer contract — confirmed by running it.
- Contract scripts green: image-primer, scale-split, public-tracker-ids, v1-stable-surface, release-install, grafana-dashboard.
- The section heading and its anchor reference both still resolve.

LAN-1119