### PR TITLE
feat: present ARouteServer reject tags

### DIFF
--- a/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
+++ b/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
@@ -190,7 +190,7 @@ still refuses an untranslated mode.
 | Informational communities (IRRDB pass/fail tags, custom) | rpol `add community`/`large-community`/`ext-community` | Shipped |
 | Reject policy `reject` | default-reject term tail | Shipped |
 | Reject policy `tag` (keep, low pref, reason community) | `set local-pref` + `add community`, no reject | Expressible in daemon policy; renderer still refuses this mode until its tag translation semantics are defined |
-| Reject policy `tag_and_reject` (BIRD-only; feeds Alice-LG) | native reject-reason retention plus renderer reason-community translation | Native bounded retention, `PolicyService.ListRejectedRoutes`, CLI, and the Birdwatcher filtered view are shipped; the separate noexport view is backed by export-explain truth; renderer still refuses `tag` and `tag_and_reject` until the community translation semantics exist |
+| Reject policy `tag_and_reject` (BIRD-only; feeds Alice-LG) | native reject-reason retention plus renderer-owned presentation artifact | Shipped for the pinned conservative vocabulary: exact effective peers and configured dynamic/cause-map communities feed the startup-only Birdwatcher adapter, which scrubs forged values; long-path/next-hop map unconditionally, black-list/IRR map only for valid IPv4 or provable `2000::/3` IPv6, and precedence-ambiguous causes stay generic; plain `tag`, extended/announcer tags, and full compatibility remain refused |
 | BLACKHOLE handling (RFC 7999) + propagation control | renderer-owned import/export policy and optional next-hop rewrite | Shipped in `rs-config-render`: typed local markers normalize to `BLACKHOLE`; IRR origin plus covering-prefix authorization precedes ordinary length/RPKI gates; per-client announce/suppress inheritance, marker scrub, optional `NO_EXPORT`, and v4/v6 rewrites are explicit. Generated configs set `honor_blackhole = false`, so the daemon's implicit `NO_ADVERTISE` path is not used. ADR-0107 still makes BLACKHOLE no ownership bypass |
 | GRACEFUL_SHUTDOWN recv (RFC 8326) | `honor_graceful_shutdown` | Shipped |
 | `--perform-graceful-shutdown` of the RS itself | generator emits a temporary config; daemon needs nothing new | N/A to daemon |
@@ -203,8 +203,8 @@ still refuses an untranslated mode.
 
 Summary: the daemon primitives needed for a pilot are shipped except the
 explicitly deferred NEXT_HOP same-AS inventory mode. The renderer remains
-fail-closed on `tag` and `tag_and_reject` because their translation semantics
-are not implemented. The external IXP pilot and optional upstream contribution
+fail-closed on plain `tag`; pinned `tag_and_reject` presentation is external,
+startup-only, and does not alter daemon policy semantics. The external IXP pilot and optional upstream contribution
 are still pending; active ceilings remain accepted-route-only. ARouteServer
 blackhole `propagate-unchanged` and `rewrite-next-hop` are renderer-owned and
 fail closed on malformed or incomplete context.
@@ -216,12 +216,11 @@ fail closed on malformed or incomplete context.
 1. `rs-config-render` under `tools/`: consume `arouteserver
    template-context` output, emit `config.toml` + per-client `.rpol`
    (basic filters, IRR prefix/origin sets, max-prefix, RPKI knobs,
-   `reject`/`tag` policies), refuse unsupported knobs loudly
-   (RTT communities, `same-as`, `tag`, `tag_and_reject`), fingerprint the
+   `reject`/`tag_and_reject` policies), refuse unsupported knobs loudly
+   (RTT communities, `same-as`, `tag`), fingerprint the
    consumed context shape, abort on empty/implausible sets, write the
    refresh receipt. *Delivered: `tools/rs-config-render/` (reject
-   policy only; `tag` and `tag_and_reject` are refused pending renderer
-   translation semantics).*
+   and pinned `tag_and_reject` policies; plain `tag` is refused).*
 2. Refresh-loop cookbook: cron cadence, `--check` gate, SIGHUP,
    fail-stale semantics, staleness alerting; extends the existing
    route-server example. *Delivered:
@@ -274,7 +273,8 @@ exists.
   the same dependency every incumbent deployment already carries — and a
   fingerprint check absorbs `template-context` shape drift.
 - The residual gaps stay explicit: ADR-0107 same-AS remains deferred;
-  renderer `tag` and `tag_and_reject` translation remains fail-closed;
+  renderer `tag` remains fail-closed and `tag_and_reject` is a bounded
+  startup-only Birdwatcher presentation rather than full compatibility;
   external pilot/upstream work remains pending; native ingestion remains
   demand-gated.
 - Security boundary is explicit: external registry data enters only as

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -43,6 +43,7 @@ Flags (also settable via env):
 | `--listen` | `BIRDWATCHER_ADAPTER_LISTEN` | `127.0.0.1:8080` | REST listen address |
 | `--protocol-alias PROTOCOL=PEER_IP@TABLE` | `BIRDWATCHER_ADAPTER_PROTOCOL_ALIASES` (semicolon-delimited) | (unset) | Repeatable startup-only Bird's Eye protocol/table identity |
 | `--protocol-alias-file PATH` | `BIRDWATCHER_ADAPTER_PROTOCOL_ALIAS_FILE` | (unset) | File-backed aliases; mutually exclusive with `--protocol-alias` |
+| `--arouteserver-reject-communities-file PATH` | `BIRDWATCHER_ADAPTER_AROUTESERVER_REJECT_COMMUNITIES_FILE` | (unset) | Startup-only artifact emitted by `rs-config-render` for effective `tag_and_reject` peers |
 | `--max-routes` | `BIRDWATCHER_ADAPTER_MAX_ROUTES` | `1000` | Maximum RIB-derived route-array response size; must be non-zero |
 
 The command-line token path takes precedence over the environment variable.
@@ -252,6 +253,28 @@ The ids are append-only and term detail does not create new ids. Each filtered
 route also carries human-readable `reject_reason` / `reject_reason_detail`
 fields (plus `rpki_validation` / `aspa_validation`) as extra JSON keys —
 visible to curl users, ignored by parsers that don't know them.
+
+When the renderer artifact is configured, ordinary `/routes/filtered/{id}`
+responses for peers named in it use the site's ARouteServer namespaces: the
+adapter removes every received value in each configured dynamic namespace and
+every exact configured cause-map value, then adds generic cause `0`, a known
+cause when the structured daemon reason is unambiguous, and its configured map
+value. Unknown reasons remain generic; AS_SET paths and BLACKHOLE requests
+cannot receive the guarded late causes. Order is stable and duplicates are
+removed. The artifact is parsed once at
+startup; changing it requires an adapter restart. A malformed, oversized, or
+over-4096-peer artifact refuses startup without echoing its contents.
+Only long-AS-path (`1`) and next-hop (`5`) causes are unconditional. Black-list
+(`3`) and IRR origin/prefix (`9`/`12`) causes require a valid IPv4 prefix or an
+IPv6 prefix provably inside `2000::/3`; malformed or outside-range prefixes stay
+generic. Causes `2`, `6`, `7`, `8`, `10`, `13`, `14`, and `15` also stay generic
+because the retained rustbgpd reason cannot prove ARouteServer's first cause.
+
+This presentation applies only to the ordinary filtered endpoint. The IXP
+Manager `{daemon ASN}:1101:*` wildcard keeps its separate scrub and mapping
+rules, so configuring ARouteServer data does not change that consumer surface.
+This remains an adapter presentation feature; no full runtime compatibility
+claim is made.
 
 The IXP Manager wildcard uses its separate `{daemon ASN}:1101:<id>` namespace.
 For the pinned v7.4 route-server templates the adapter maps the ten active IDs

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -97,6 +97,9 @@ struct Args {
     )]
     protocol_alias_file: Option<PathBuf>,
 
+    #[arg(long, env = "BIRDWATCHER_ADAPTER_AROUTESERVER_REJECT_COMMUNITIES_FILE")]
+    arouteserver_reject_communities_file: Option<PathBuf>,
+
     /// Maximum routes returned by RIB-derived route-array endpoints.
     #[arg(
         long,
@@ -122,6 +125,125 @@ struct IdentityResolver {
 
 const MAX_ALIAS_FILE_BYTES: usize = 1024 * 1024;
 const MAX_ALIAS_FILE_ENTRIES: usize = 4096;
+const ARS_REJECT_SCHEMA: &str = "rustbgpd.arouteserver-reject-communities.v1";
+struct ArsRejectCommunities {
+    peers: Vec<IpAddr>,
+    std: Option<ArsCommunityFamily>,
+    lrg: Option<ArsCommunityFamily>,
+}
+
+struct ArsCommunityFamily {
+    dynamic: Option<Vec<u64>>,
+    cause_map: BTreeMap<u8, Vec<u64>>,
+}
+
+fn ars_artifact_error() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "invalid ARouteServer artifact")
+}
+
+fn load_arouteserver_reject_communities(path: &FsPath) -> io::Result<ArsRejectCommunities> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?
+        .take((MAX_ALIAS_FILE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_ALIAS_FILE_BYTES {
+        return Err(ars_artifact_error());
+    }
+    let value: Value = serde_json::from_slice(&bytes).map_err(|_| ars_artifact_error())?;
+    let root = ars_object(&value, &["schema", "peers", "std", "lrg"])?;
+    if root.get("schema").and_then(Value::as_str) != Some(ARS_REJECT_SCHEMA) {
+        return Err(ars_artifact_error());
+    }
+    let peer_values = root
+        .get("peers")
+        .and_then(Value::as_array)
+        .ok_or_else(ars_artifact_error)?;
+    if peer_values.len() > MAX_ALIAS_FILE_ENTRIES {
+        return Err(ars_artifact_error());
+    }
+    let peer_text = peer_values
+        .iter()
+        .map(Value::as_str)
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(ars_artifact_error)?;
+    if peer_text.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(ars_artifact_error());
+    }
+    let peers = peer_text
+        .into_iter()
+        .map(str::parse)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| ars_artifact_error())?;
+    let family = |name, count, max| {
+        root.get(name)
+            .map(|value| parse_ars_family(value, count, max))
+            .transpose()
+    };
+    let std = family("std", 2, u16::MAX as u64)?;
+    let lrg = family("lrg", 3, u32::MAX as u64)?;
+    if std.is_none() && lrg.is_none() {
+        return Err(ars_artifact_error());
+    }
+    Ok(ArsRejectCommunities { peers, std, lrg })
+}
+
+fn ars_object<'a>(
+    value: &'a Value,
+    allowed: &[&str],
+) -> io::Result<&'a serde_json::Map<String, Value>> {
+    let object = value.as_object().ok_or_else(ars_artifact_error)?;
+    if object.keys().any(|key| !allowed.contains(&key.as_str())) {
+        return Err(ars_artifact_error());
+    }
+    Ok(object)
+}
+
+fn parse_ars_family(value: &Value, count: usize, max: u64) -> io::Result<ArsCommunityFamily> {
+    let family = ars_object(value, &["dynamic", "cause_map"])?;
+    let dynamic = family
+        .get("dynamic")
+        .map(|value| {
+            parse_ars_parts(
+                value
+                    .as_str()
+                    .and_then(|value| value.strip_suffix(":dyn_val"))
+                    .ok_or_else(ars_artifact_error)?,
+                count - 1,
+                max,
+            )
+        })
+        .transpose()?;
+    let mut cause_map = BTreeMap::new();
+    let causes = family
+        .get("cause_map")
+        .map(|value| value.as_object().ok_or_else(ars_artifact_error))
+        .transpose()?;
+    for (code, value) in causes.into_iter().flatten() {
+        let code = code.parse::<u8>().map_err(|_| ars_artifact_error())?;
+        if !(1..=15).contains(&code) {
+            return Err(ars_artifact_error());
+        }
+        cause_map.insert(
+            code,
+            parse_ars_parts(value.as_str().ok_or_else(ars_artifact_error)?, count, max)?,
+        );
+    }
+    if dynamic.is_none() && cause_map.is_empty() {
+        return Err(ars_artifact_error());
+    }
+    Ok(ArsCommunityFamily { dynamic, cause_map })
+}
+
+fn parse_ars_parts(text: &str, count: usize, max: u64) -> io::Result<Vec<u64>> {
+    let parts = text
+        .split(':')
+        .map(|part| part.parse::<u64>().ok().filter(|value| *value <= max))
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(ars_artifact_error)?;
+    (parts.len() == count)
+        .then_some(parts)
+        .ok_or_else(ars_artifact_error)
+}
 
 fn load_alias_file(path: &FsPath) -> io::Result<IdentityResolver> {
     let mut bytes = Vec::new();
@@ -424,6 +546,7 @@ struct AppState {
     identities: Arc<IdentityResolver>,
     identity_store: Arc<ResolverStore>,
     max_routes: u64,
+    arouteserver_reject_communities: Option<Arc<ArsRejectCommunities>>,
 }
 
 impl Clone for AppState {
@@ -433,6 +556,7 @@ impl Clone for AppState {
             identities: self.identity_store.snapshot(),
             identity_store: Arc::clone(&self.identity_store),
             max_routes: self.max_routes,
+            arouteserver_reject_communities: self.arouteserver_reject_communities.clone(),
         }
     }
 }
@@ -471,6 +595,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         identities: identity_store.snapshot(),
         identity_store,
         max_routes: args.max_routes,
+        arouteserver_reject_communities: args
+            .arouteserver_reject_communities_file
+            .as_deref()
+            .map(load_arouteserver_reject_communities)
+            .transpose()?
+            .map(Arc::new),
     };
 
     let app = Router::new()
@@ -1336,6 +1466,7 @@ async fn routes_filtered(
         &resp,
         peer_addr,
         &state.identities,
+        state.arouteserver_reject_communities.as_deref(),
     )))
 }
 
@@ -1424,7 +1555,9 @@ fn filtered_routes_body(
     resp: &proto::ListRejectedRoutesResponse,
     peer: IpAddr,
     identities: &IdentityResolver,
+    arouteserver: Option<&ArsRejectCommunities>,
 ) -> Value {
+    let arouteserver = arouteserver.filter(|config| config.peers.contains(&peer));
     if !resp.retention_enabled {
         info!(
             peer = %peer,
@@ -1435,7 +1568,7 @@ fn filtered_routes_body(
     let routes: Vec<Value> = if resp.retention_enabled {
         resp.routes
             .iter()
-            .map(|r| rejected_route_to_birdwatcher(r, peer, identities))
+            .map(|r| rejected_route_to_birdwatcher(r, peer, identities, arouteserver))
             .collect()
     } else {
         Vec::new()
@@ -1488,6 +1621,7 @@ fn rejected_route_to_birdwatcher(
     route: &proto::RejectedRoute,
     peer: IpAddr,
     identities: &IdentityResolver,
+    arouteserver: Option<&ArsRejectCommunities>,
 ) -> Value {
     render_rejected_route(
         route,
@@ -1495,6 +1629,7 @@ fn rejected_route_to_birdwatcher(
         identities,
         reject_reason_community(&route.reason),
         None,
+        arouteserver,
     )
 }
 
@@ -1514,7 +1649,63 @@ fn ixp_manager_rejected_route_to_birdwatcher(
             ixp_manager_reject_reason_id(route),
         ],
         Some([daemon_asn, IXP_MANAGER_REJECT_FUNCTION]),
+        None,
     )
+}
+
+fn arouteserver_reject_cause(route: &proto::RejectedRoute) -> Option<u8> {
+    let detail = route.reason_detail.as_str();
+    let late_cause = || {
+        !route.as_path.contains('{')
+            && !route.communities.contains(&0xffff_029a)
+            && match route.prefix.parse::<IpAddr>() {
+                Ok(IpAddr::V4(_)) => route.prefix_length <= 32,
+                Ok(IpAddr::V6(address)) => {
+                    (3..=128).contains(&route.prefix_length)
+                        && address.segments()[0] & 0xe000 == 0x2000
+                }
+                Err(_) => false,
+            }
+    };
+    match (route.reason.as_str(), detail) {
+        ("policy_reject", "rs-hygiene:reject-long-as-path") => Some(1),
+        ("next_hop_ownership", _) => Some(5),
+        ("policy_reject", "rs-hygiene:reject-black-list-prefix") if late_cause() => Some(3),
+        ("policy_reject", detail)
+            if late_cause() && detail.ends_with(":reject-irrdb-origin-as-filtered") =>
+        {
+            Some(9)
+        }
+        ("policy_reject", detail)
+            if late_cause() && detail.ends_with(":reject-irrdb-prefix-filtered") =>
+        {
+            Some(12)
+        }
+        _ => None,
+    }
+}
+
+fn apply_ars_family(values: &mut Vec<Vec<u64>>, family: &ArsCommunityFamily, cause: Option<u8>) {
+    values.retain(|value| {
+        family
+            .dynamic
+            .as_ref()
+            .is_none_or(|prefix| !value.starts_with(prefix))
+            && !family.cause_map.values().any(|mapped| value == mapped)
+    });
+    if let Some(prefix) = &family.dynamic {
+        for suffix in [Some(0), cause.map(u64::from)].into_iter().flatten() {
+            values.push(prefix.iter().copied().chain([suffix]).collect());
+        }
+    }
+    if let Some(value) = cause.and_then(|cause| family.cause_map.get(&cause)) {
+        values.push(value.clone());
+    }
+}
+
+fn stable_dedupe<T: Clone + Eq + std::hash::Hash>(values: &mut Vec<T>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.clone()));
 }
 
 fn ixp_manager_reject_reason_id(route: &proto::RejectedRoute) -> u64 {
@@ -1566,11 +1757,12 @@ fn render_rejected_route(
     identities: &IdentityResolver,
     reason_community: [u64; 3],
     reserved_namespace: Option<[u64; 2]>,
+    arouteserver: Option<&ArsRejectCommunities>,
 ) -> Value {
-    let communities: Vec<Vec<u32>> = route
+    let mut communities: Vec<Vec<u64>> = route
         .communities
         .iter()
-        .map(|c| vec![(*c >> 16) & 0xffff, *c & 0xffff])
+        .map(|c| vec![u64::from((*c >> 16) & 0xffff), u64::from(*c & 0xffff)])
         .collect();
 
     // Wire large communities the route carried, then the synthesized reason
@@ -1588,7 +1780,19 @@ fn render_rejected_route(
             .then_some(parts)
         })
         .collect();
-    large_communities.push(reason_community.to_vec());
+    if let Some(config) = arouteserver {
+        let cause = arouteserver_reject_cause(route);
+        if let Some(family) = &config.std {
+            apply_ars_family(&mut communities, family, cause);
+        }
+        if let Some(family) = &config.lrg {
+            apply_ars_family(&mut large_communities, family, cause);
+        }
+        stable_dedupe(&mut communities);
+        stable_dedupe(&mut large_communities);
+    } else {
+        large_communities.push(reason_community.to_vec());
+    }
 
     // The retained AS_PATH is a lossless display string ("65001 {65002
     // 65003}"); birdwatcher wants an ASN array, so flatten it (AS_SET
@@ -2174,6 +2378,7 @@ mod tests {
             identities: store.snapshot(),
             identity_store: store,
             max_routes: 1,
+            arouteserver_reject_communities: None,
         };
         let mut neighbor = proto::NeighborState {
             config: Some(proto::NeighborConfig {
@@ -2365,7 +2570,7 @@ mod tests {
             ..Default::default()
         };
         let peer: IpAddr = "192.0.2.1".parse().unwrap();
-        let json = rejected_route_to_birdwatcher(&route, peer, &IdentityResolver::default());
+        let json = rejected_route_to_birdwatcher(&route, peer, &IdentityResolver::default(), None);
 
         assert_eq!(json["network"], "10.66.0.0/24");
         assert_eq!(json["gateway"], "192.0.2.99");
@@ -2391,6 +2596,142 @@ mod tests {
         );
     }
 
+    fn ars_config(peer: IpAddr) -> ArsRejectCommunities {
+        let family = |dynamic, cause| ArsCommunityFamily {
+            dynamic: Some(dynamic),
+            cause_map: [(3, cause)].into(),
+        };
+        ArsRejectCommunities {
+            peers: [peer].into(),
+            std: Some(family(vec![65520], vec![64512, 3])),
+            lrg: Some(family(vec![64496, 65520], vec![64496, 65521, 3])),
+        }
+    }
+
+    #[test]
+    fn arouteserver_translation_is_scoped_scrubbed_deduped_and_conservative() {
+        let peer = "192.0.2.1".parse().unwrap();
+        let config = ars_config(peer);
+        let render = |route: &proto::RejectedRoute, peer| {
+            let configured = Some(&config).filter(|config| config.peers.contains(&peer));
+            rejected_route_to_birdwatcher(route, peer, &IdentityResolver::default(), configured)
+        };
+        let cause = |prefix: &str, length, reason: &str, detail: &str| {
+            arouteserver_reject_cause(&proto::RejectedRoute {
+                prefix: prefix.into(),
+                prefix_length: length,
+                reason: reason.into(),
+                reason_detail: detail.into(),
+                ..Default::default()
+            })
+        };
+        for (reason, detail, expected) in [
+            ("policy_reject", "rs-hygiene:reject-long-as-path", 1),
+            ("next_hop_ownership", "foreign_next_hop", 5),
+        ] {
+            assert_eq!(cause("fc00::", 7, reason, detail), Some(expected));
+        }
+        for (detail, expected) in [
+            ("rs-hygiene:reject-black-list-prefix", 3),
+            ("client:x:reject-irrdb-origin-as-filtered", 9),
+            ("client:x:reject-irrdb-prefix-filtered", 12),
+        ] {
+            let actual = cause("2001:db8::", 32, "policy_reject", detail);
+            assert_eq!(actual, Some(expected));
+            for (prefix, length) in [
+                ("fc00::", 7),
+                ("2000::", 2),
+                ("2001:db8::", 129),
+                ("192.0.2.0", 33),
+                ("malformed", 24),
+            ] {
+                assert_eq!(cause(prefix, length, "policy_reject", detail), None);
+            }
+        }
+        for (reason, detail) in [
+            ("policy_reject", "rs-hygiene:reject-bogon-prefix"),
+            ("treat_as_withdraw", "aspa_first_as_mismatch"),
+            ("policy_reject", "rs-hygiene:reject-invalid-asn"),
+            ("policy_reject", "rs-hygiene:reject-transit-free-in-path"),
+            ("policy_reject", "rs-hygiene:reject-never-via-rs"),
+            ("policy_reject", "reject-special-purpose:reject-non-global"),
+            ("policy_reject", "rs-hygiene:reject-v4-len-outside-window"),
+            ("policy_reject", "client:x:reject-rpki-invalid"),
+        ] {
+            assert_eq!(cause("192.0.2.0", 24, reason, detail), None);
+        }
+        let mut route = proto::RejectedRoute {
+            prefix: "192.0.2.0".into(),
+            prefix_length: 24,
+            reason: "policy_reject".into(),
+            reason_detail: "rs-hygiene:reject-black-list-prefix".into(),
+            communities: vec![
+                (65520 << 16) | 99,
+                (64512 << 16) | 3,
+                (65000 << 16) | 7,
+                (65000 << 16) | 7,
+            ],
+            large_communities: vec![
+                "64496:65520:99".into(),
+                "64496:65521:3".into(),
+                "65000:7:1".into(),
+                "65000:7:1".into(),
+            ],
+            ..Default::default()
+        };
+        route.as_path = "{64500}".into();
+        assert_eq!(arouteserver_reject_cause(&route), None);
+        route.as_path.clear();
+        route.communities.push(0xffff_029a);
+        assert_eq!(arouteserver_reject_cause(&route), None);
+        route.communities.pop();
+        let translated = render(&route, peer);
+        assert_eq!(
+            translated["bgp"]["communities"].to_string(),
+            "[[65000,7],[65520,0],[65520,3],[64512,3]]"
+        );
+        assert_eq!(
+            translated["bgp"]["large_communities"].to_string(),
+            "[[65000,7,1],[64496,65520,0],[64496,65520,3],[64496,65521,3]]"
+        );
+        route.reason_detail = "unknown".into();
+        route.large_communities.clear();
+        let large = |peer| render(&route, peer)["bgp"]["large_communities"].to_string();
+        let other = "192.0.2.2".parse().unwrap();
+        assert_eq!(large(peer), "[[64496,65520,0]]");
+        assert_eq!(large(other), "[[64496,65520,1]]");
+    }
+
+    #[test]
+    fn arouteserver_artifact_parser_is_strict_and_bounded() {
+        let path = std::env::temp_dir().join(format!("ars-{}.json", std::process::id()));
+        let write = |bytes| std::fs::write(&path, bytes).unwrap();
+        let valid = r#"{"schema":"rustbgpd.arouteserver-reject-communities.v1","peers":["192.0.2.1"],"std":{"dynamic":"65520:dyn_val","cause_map":{"3":"64512:3"}},"lrg":{"dynamic":"64496:65520:dyn_val"}}"#;
+        for invalid in [
+            valid.replace("\"schema\"", "\"unknown\":1,\"schema\""),
+            valid.replace("\"3\"", "\"0\""),
+            valid.replace("\"3\"", "\"16\""),
+            valid.replace("65520:dyn_val", "dyn_val:65520"),
+            valid.replace(
+                "\"dynamic\":\"65520:dyn_val\"",
+                "\"dynamic\":\"65520:dyn_val\",\"ext\":\"RT:1:1\"",
+            ),
+            valid.replace("\"192.0.2.1\"", "\"192.0.2.2\",\"192.0.2.1\""),
+        ] {
+            write(invalid.into_bytes());
+            assert!(load_arouteserver_reject_communities(&path).is_err());
+        }
+        write(vec![b' '; MAX_ALIAS_FILE_BYTES + 1]);
+        assert!(load_arouteserver_reject_communities(&path).is_err());
+        let peers = (0..=MAX_ALIAS_FILE_ENTRIES)
+            .map(|index| format!(r#""2001:db8::{index:x}""#))
+            .collect::<Vec<_>>()
+            .join(",");
+        write(format!(r#"{{"schema":"{ARS_REJECT_SCHEMA}","peers":[{peers}],"std":{{"dynamic":"65520:dyn_val"}}}}"#).into_bytes());
+        assert!(load_arouteserver_reject_communities(&path).is_err());
+        std::fs::remove_file(path).unwrap();
+    }
+
     /// Sparse retention entries (pre-policy safety gates keep only what
     /// was decodable) render with empty sentinels, and the reason
     /// community is still present.
@@ -2403,7 +2744,7 @@ mod tests {
             ..Default::default()
         };
         let peer: IpAddr = "2001:db8::1".parse().unwrap();
-        let json = rejected_route_to_birdwatcher(&route, peer, &IdentityResolver::default());
+        let json = rejected_route_to_birdwatcher(&route, peer, &IdentityResolver::default(), None);
         assert_eq!(json["network"], "2001:db8:bad::/48");
         assert_eq!(json["from_protocol"], "bgp_2001_db8__1");
         assert_eq!(json["age"], "");
@@ -2549,7 +2890,7 @@ mod tests {
                 },
                 evictions_since_reset: Some(0),
             };
-            let body = filtered_routes_body(&resp, peer, &IdentityResolver::default());
+            let body = filtered_routes_body(&resp, peer, &IdentityResolver::default(), None);
             assert!(body["api"].is_object(), "{body}");
             assert_eq!(body["api"]["max_routes"], 1024, "{body}");
             assert_eq!(body["routes"], serde_json::json!([]), "{body}");
@@ -2839,6 +3180,7 @@ mod tests {
             identities: store.snapshot(),
             identity_store: Arc::clone(&store),
             max_routes: 1,
+            arouteserver_reject_communities: None,
         };
         let request_a = state.clone();
         assert_eq!(store.replace(parse("old")).unwrap(), (1, false));

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -471,9 +471,15 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
                 PathAttribute::Med(med),
             ];
             if forge_reason {
+                attributes.push(PathAttribute::Communities(vec![
+                    (65520 << 16) | 99,
+                    (64512 << 16) | 3,
+                ]));
                 attributes.push(PathAttribute::LargeCommunities(vec![
                     LargeCommunity::new(65001, 1101, 99),
                     LargeCommunity::new(65001, 999, 7),
+                    LargeCommunity::new(64496, 65520, 99),
+                    LargeCommunity::new(64496, 65521, 3),
                 ]));
             }
             rustbgpd_wire::attribute::encode_path_attributes(&attributes, &mut attrs, true, false)
@@ -696,6 +702,26 @@ fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
         );
     }
     let adapter = include_str!("../examples/birdwatcher-adapter/src/main.rs");
+    let causes = adapter
+        .split_once("fn arouteserver_reject_cause(")
+        .unwrap()
+        .1
+        .split_once("fn apply_ars_family(")
+        .unwrap()
+        .0
+        .split_whitespace()
+        .collect::<String>();
+    for exact in [
+        r#"("policy_reject","rs-hygiene:reject-long-as-path")=>Some(1)"#,
+        r#"("policy_reject","rs-hygiene:reject-black-list-prefix")iflate_cause()=>Some(3)"#,
+        r#"("next_hop_ownership",_)=>Some(5)"#,
+        r#"iflate_cause()&&detail.ends_with(":reject-irrdb-origin-as-filtered")=>{Some(9)}"#,
+        r#"iflate_cause()&&detail.ends_with(":reject-irrdb-prefix-filtered")=>{Some(12)}"#,
+    ] {
+        assert!(causes.contains(exact), "cause mapping drifted: {exact}");
+    }
+    assert!(causes.contains("(3..=128).contains(&route.prefix_length)"));
+    assert!(causes.contains("address.segments()[0]&0xe000==0x2000"));
     let inventory = adapter
         .split_once("async fn protocol_rows(")
         .unwrap()
@@ -753,11 +779,37 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         "pb_0001_as65020=127.0.0.1@master4\npb_0002_as65030=127.0.0.2@master4\n",
     )
     .expect("write initial aliases");
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let ars_context = temp.path().join("arouteserver-context.yml");
+    let context =
+        std::fs::read_to_string(workspace.join("tests/interop/m90-differential/context.yml"))
+            .expect("read renderer context")
+            .replacen("192.0.2.11", "127.0.0.1", 1);
+    std::fs::write(&ars_context, context).expect("write smoke renderer context");
+    let ars_output = temp.path().join("arouteserver-render");
+    let rendered = Command::new(&cargo)
+        .current_dir(workspace)
+        .args(["run", "--quiet", "-p", "rs-config-render", "--"])
+        .arg("--context")
+        .arg(&ars_context)
+        .arg("--out-dir")
+        .arg(&ars_output)
+        .status()
+        .expect("run rs-config-render");
+    assert!(
+        rendered.success(),
+        "rs-config-render must emit smoke artifact"
+    );
+    let ars_artifact = ars_output.join("birdwatcher-reject-communities.json");
+    assert!(
+        ars_artifact.is_file(),
+        "renderer must emit startup artifact"
+    );
 
     // Spawn the adapter before its Unix socket exists. Built via
     // `cargo run` (same fallback pattern the rbgp test helper uses) —
     // the workspace build has usually compiled it already.
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let adapter_stderr = temp.path().join("adapter.stderr.log");
     let mut adapter = Proc {
         child: Command::new(&cargo)
@@ -770,6 +822,8 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .arg(format!("127.0.0.1:{PROCESS_CHOOSES}"))
             .arg("--protocol-alias-file")
             .arg(&aliases_path)
+            .arg("--arouteserver-reject-communities-file")
+            .arg(&ars_artifact)
             .args(["--max-routes", "2"])
             .stdout(Stdio::null())
             .stderr(Stdio::from(
@@ -1109,12 +1163,15 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     assert_eq!(reject["network"], "10.98.0.0/24", "{filtered}");
     assert_eq!(reject["reject_reason"], "as_path_loop", "{filtered}");
     assert_eq!(reject["from_protocol"], "pb_0001_as65020", "{filtered}");
-    let large_communities = &reject["bgp"]["large_communities"];
-    assert!(
-        large_communities
-            .as_array()
-            .is_some_and(|lcs| lcs.contains(&serde_json::json!([64496, 65520, 4]))),
-        "filtered route must carry the synthesized as_path_loop community: {filtered}"
+    assert_eq!(
+        reject["bgp"]["communities"],
+        serde_json::json!([[65520, 0]]),
+        "ARouteServer presentation must scrub forged values and stay conservative: {filtered}"
+    );
+    assert_eq!(
+        reject["bgp"]["large_communities"],
+        serde_json::json!([[65001, 1101, 99], [65001, 999, 7], [64496, 65520, 0]]),
+        "ARouteServer presentation must scrub both configured namespaces: {filtered}"
     );
 
     // IXP Manager v7.4 asks for `{daemon ASN}:1101:*`. This view uses only
@@ -1132,6 +1189,8 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         .as_array()
         .unwrap();
     assert!(ixp_communities.contains(&serde_json::json!([65001, 999, 7])));
+    assert!(ixp_communities.contains(&serde_json::json!([64496, 65520, 99])));
+    assert!(ixp_communities.contains(&serde_json::json!([64496, 65521, 3])));
     assert_eq!(
         ixp_communities
             .iter()

--- a/tests/interop/m90-differential/README.md
+++ b/tests/interop/m90-differential/README.md
@@ -104,7 +104,24 @@ diverge and the lab fails.
   `router_id` in `general.yml` renders into both configs); they never
   peer with each other, so this is harmless.
 
-## Verified M90 receipt — 2026-07-19
+## Verified tag-and-reject receipt — 2026-08-22
+
+The LAN-1178 candidate on base `74496199bf66c81f784e605e864fc400e14ab7a0`
+ran against pinned ARouteServer 1.23.2, BIRD 2.0.12
+(`sha256:16f97b815292d2ca3acea82d22a6973b9f767ccfed7bf0d60eed8729725e493d`),
+GoBGP 3.37.0 (`sha256:a1dfdfc695108ac66245f7a2585b207ea0fdee4760d332bf2b0e2eda32f2e449`),
+and rustbgpd 0.65.0 (`sha256:481c00aae1ee5a8e28d25b20ac208470de7064004a04d9adda9ad3b180e8d1c0`).
+The fresh-image context proof passed 16/16 and the differential passed 74/74:
+all 11 verdicts and all six sessions survived, the artifact carried the exact
+three peers and standard/large values, and every BIRD filtered rejection kept
+generic plus first-cause tags. The two compound length rows honestly expose
+the precedence boundary: BIRD's earlier IRR check tags `12`, rustbgpd retains
+the shared-hygiene length term, and the adapter emits generic `0` only rather
+than guessing `12` or `13`. Fixture hashes: `general.yml` `c47fed81...`,
+`context.yml` `f979b7b7...`, sectioned context `f61c2a6d...`, and
+`announcements.json` `e55a7fae...`.
+
+## Earlier verified M90 receipt — 2026-07-19
 
 The lab was run from source revision
 `dfb03c1cfcaaed90543124d57fd1913abd63d73a` with these immutable

--- a/tests/interop/m90-differential/announcements.json
+++ b/tests/interop/m90-differential/announcements.json
@@ -26,6 +26,7 @@
     "expect": "reject",
     "policy": "rs-hygiene",
     "term": "reject-black-list-prefix",
+    "cause": 3,
     "why": "the IXP peering LAN is in global_black_list_pref; hygiene runs before the client IRR policy"
   },
   {
@@ -45,8 +46,9 @@
     "prefix": "198.51.100.0/24",
     "expect": "reject",
     "policy": "client-as64501-1",
-    "term": "rest",
-    "why": "member1's prefix, absent from member2's IRR set; passes hygiene, falls through accept-authorized to the fail-closed tail"
+    "term": "reject-irrdb-prefix-filtered",
+    "cause": 12,
+    "why": "member1's prefix is absent from member2's IRR set; the tag-and-reject prefix term decides"
   },
   {
     "client": "member2",
@@ -56,8 +58,9 @@
     "prefix": "203.0.113.192/26",
     "expect": "reject",
     "policy": "client-as64501-1",
-    "term": "rest",
-    "why": "unregistered more-specific of member2's own exact /25 route object (allow_longer_prefixes off)"
+    "term": "reject-irrdb-prefix-filtered",
+    "cause": 12,
+    "why": "unregistered more-specific of member2's exact /25 route object is rejected by the prefix term"
   },
   {
     "client": "member3",
@@ -77,6 +80,7 @@
     "expect": "reject",
     "policy": "rs-hygiene",
     "term": "reject-bogon-prefix",
+    "cause": 2,
     "why": "inside bogon 10.0.0.0/8 (subtree match); bogon term precedes the length-window term"
   },
   {
@@ -88,6 +92,7 @@
     "expect": "reject",
     "policy": "rs-hygiene",
     "term": "reject-v4-len-outside-window",
+    "cause": 12,
     "why": "length 30 exceeds the ipv4_pref_len max of 28 (even though it sits under member3's route object)"
   },
   {
@@ -99,6 +104,7 @@
     "expect": "reject",
     "policy": "rs-hygiene",
     "term": "reject-v4-len-outside-window",
+    "cause": 12,
     "why": "default route; length 0 is below the ipv4_pref_len min of 8"
   },
   {
@@ -111,6 +117,7 @@
     "expect": "reject",
     "policy": "rs-hygiene",
     "term": "reject-never-via-rs",
+    "cause": 15,
     "why": "wire AS_PATH is 64502 65551; 65551 is in never_via_route_servers_asns, and the hygiene term fires before any origin/IRR evaluation"
   }
 ]

--- a/tests/interop/m90-differential/context-sectioned.yml
+++ b/tests/interop/m90-differential/context-sectioned.yml
@@ -204,9 +204,9 @@ cfg:
       type: inbound
     reject_cause:
       ext: null
-      lrg: null
+      lrg: 64496:65520:dyn_val
       peer_as: false
-      std: null
+      std: 65520:dyn_val
       type: internal
     reject_cause_map_1:
       ext: null
@@ -258,9 +258,9 @@ cfg:
       type: internal
     reject_cause_map_3:
       ext: null
-      lrg: null
+      lrg: 64496:65521:3
       peer_as: false
-      std: null
+      std: '64512:3'
       type: internal
     reject_cause_map_4:
       ext: null
@@ -384,7 +384,7 @@ cfg:
       policy: strict
     reject_invalid_as_in_as_path: false
     reject_policy:
-      policy: reject
+      policy: tag_and_reject
     roles:
       enabled: false
       strict_mode: false
@@ -501,7 +501,7 @@ clients:
         policy: strict
       reject_invalid_as_in_as_path: false
       reject_policy:
-        policy: reject
+        policy: tag_and_reject
       roles:
         enabled: false
         local_role: rs
@@ -562,7 +562,7 @@ clients:
         policy: strict
       reject_invalid_as_in_as_path: false
       reject_policy:
-        policy: reject
+        policy: tag_and_reject
       roles:
         enabled: false
         local_role: rs
@@ -623,7 +623,7 @@ clients:
         policy: strict
       reject_invalid_as_in_as_path: false
       reject_policy:
-        policy: reject
+        policy: tag_and_reject
       roles:
         enabled: false
         local_role: rs

--- a/tests/interop/m90-differential/context.yml
+++ b/tests/interop/m90-differential/context.yml
@@ -21,7 +21,7 @@ list_ip_vers: [4, 6]
 live_tests: false
 rtt_based_functions_are_used: false
 perform_graceful_shutdown: false
-any_reject_cause_map_community_set: false
+any_reject_cause_map_community_set: true
 asn3216_map: {}
 arin_whois_records: {}
 registrobr_whois_records: {}
@@ -53,7 +53,10 @@ cfg:
     policy_ipv4: null
     policy_ipv6: null
   rtt_thresholds: null
-  communities: {}
+  communities:
+    reject_cause: {std: "65520:dyn_val", lrg: "64496:65520:dyn_val", ext: null}
+    reject_cause_map_3: {std: "64512:3", lrg: "64496:65521:3", ext: null}
+    rejected_route_announced_by: {std: null, lrg: null, ext: null}
   filtering:
     next_hop:
       policy: strict
@@ -79,7 +82,7 @@ cfg:
       count_rejected_routes: false
       peering_db: {enabled: false}
     reject_policy:
-      policy: reject
+      policy: tag_and_reject
 asns:
   AS64500: {as_sets: ["AS-M90-ONE"]}
   AS64501: {as_sets: ["AS-M90-TWO"]}

--- a/tests/interop/m90-differential/general.yml
+++ b/tests/interop/m90-differential/general.yml
@@ -21,6 +21,14 @@ cfg:
   path_hiding: True
   gtsm: False
   add_path: False
+  communities:
+    reject_cause:
+      std: "65520:dyn_val"
+      lrg: "rs_as:65520:dyn_val"
+    reject_cause_map:
+      "3":
+        std: "64512:3"
+        lrg: "rs_as:65521:3"
   filtering:
     next_hop:
       policy: "strict"
@@ -56,3 +64,5 @@ cfg:
       count_rejected_routes: False
       peering_db:
         enabled: False
+    reject_policy:
+      policy: "tag_and_reject"

--- a/tests/interop/m90-differential/prove-context-ingestion.sh
+++ b/tests/interop/m90-differential/prove-context-ingestion.sh
@@ -100,8 +100,15 @@ for render in render-real render-hand; do
         || die "$render config does not emit exactly three IPv4 limits of 100"
     [ "$(grep -c '^max_prefixes_ipv6 = 12000$' "$WORK/$render/config.toml")" -eq 3 ] \
         || die "$render config does not emit exactly three IPv6 limits of 12000"
+    jq -e '
+        .schema == "rustbgpd.arouteserver-reject-communities.v1" and
+        .peers == ["192.0.2.11", "192.0.2.12", "192.0.2.13"] and
+        .std == {"dynamic":"65520:dyn_val","cause_map":{"3":"64512:3"}} and
+        .lrg == {"dynamic":"64496:65520:dyn_val","cause_map":{"3":"64496:65521:3"}}
+    ' "$WORK/$render/birdwatcher-reject-communities.json" >/dev/null \
+        || die "$render reject-community artifact has the wrong peers or configured values"
 done
-ok "receipts and configs carry identical exact per-client limits"
+ok "receipts, configs, and startup artifacts carry exact member data"
 
 step "pipeline gates on the real-dump render"
 cargo run -q -p rustbgpd --manifest-path "$REPO_DIR/Cargo.toml" -- \

--- a/tests/interop/scripts/test-m90-differential.sh
+++ b/tests/interop/scripts/test-m90-differential.sh
@@ -100,10 +100,27 @@ bird_route_all() {
     docker exec "$BIRD" birdc "show route ${1:?} all" 2>/dev/null
 }
 
+bird_filtered_route_all() {
+    docker exec "$BIRD" birdc "show route ${1:?} filtered all" 2>/dev/null
+}
+
 # True if BIRD holds a path for the net from the given arouteserver
 # client protocol (protocol names follow the client ids: AS64500_1 ...).
 bird_has_from()   { bird_route_all "${1:?}" | grep -qF "[${2:?} "; }
 bird_lacks_from() { ! bird_has_from "$1" "$2"; }
+
+bird_filtered_has_tags() {
+    local output cause=${3:?}
+    output=$(bird_filtered_route_all "${1:?}")
+    grep -qF "[${2:?} " <<<"$output" \
+        && grep -Eq "\\(65520,[[:space:]]*0\\)" <<<"$output" \
+        && grep -Eq "\\(65520,[[:space:]]*$cause\\)" <<<"$output" \
+        && grep -Eq "\\(64496,[[:space:]]*65520,[[:space:]]*0\\)" <<<"$output" \
+        && grep -Eq "\\(64496,[[:space:]]*65520,[[:space:]]*$cause\\)" <<<"$output" \
+        && { [ "$cause" -ne 3 ] \
+            || { grep -Eq "\\(64512,[[:space:]]*3\\)" <<<"$output" \
+                && grep -Eq "\\(64496,[[:space:]]*65521,[[:space:]]*3\\)" <<<"$output"; }; }
+}
 
 rs_accepted_has()   { rs_ctl rib received "${1:?}" | grep -qF "${2:?}"; }
 rs_accepted_lacks() { ! rs_accepted_has "$1" "$2"; }
@@ -207,6 +224,24 @@ render_rustbgpd_config() {
     else
         fail "render receipt/config missing exact 3-member 100/12000 max-prefix limits"
         cat "$RENDER_DIR/render-receipt.json" >&2 || true
+        return 1
+    fi
+    if jq -e '
+        .schema == "rustbgpd.arouteserver-reject-communities.v1" and
+        .peers == ["192.0.2.11", "192.0.2.12", "192.0.2.13"] and
+        .std == {"dynamic":"65520:dyn_val","cause_map":{"3":"64512:3"}} and
+        .lrg == {"dynamic":"64496:65520:dyn_val","cause_map":{"3":"64496:65521:3"}}
+    ' "$RENDER_DIR/birdwatcher-reject-communities.json" >/dev/null; then
+        ok "renderer artifact carries the exact three members and configured communities"
+    else
+        fail "renderer reject-community artifact does not match the pinned site"
+        return 1
+    fi
+    if cargo test -q -p birdwatcher-adapter \
+        arouteserver_translation_is_scoped_scrubbed_deduped_and_conservative; then
+        ok "adapter maps order-ambiguous length/RPKI reasons to generic zero only"
+    else
+        fail "adapter order-ambiguous generic fallback proof failed"
         return 1
     fi
 
@@ -339,7 +374,7 @@ assert_rejects() {
     # a short settle for in-flight UPDATEs).
     sleep 2
 
-    local entry client ip prefix proto policy term explain
+    local entry client ip prefix proto policy term cause explain
     while IFS= read -r entry; do
         client=$(jq -r '.client' <<<"$entry")
         ip=$(jq -r '.ip' <<<"$entry")
@@ -347,6 +382,7 @@ assert_rejects() {
         proto=$(jq -r '.bird_protocol' <<<"$entry")
         policy=$(jq -r '.policy' <<<"$entry")
         term=$(jq -r '.term' <<<"$entry")
+        cause=$(jq -r '.cause' <<<"$entry")
 
         # Positive signal first: the rejection is retained with the
         # canonical reason token.
@@ -372,6 +408,12 @@ assert_rejects() {
         else
             fail "BIRD ACCEPTED $prefix from $client — differential verdict mismatch"
             bird_route_all "$prefix" >&2 || true
+        fi
+        if bird_filtered_has_tags "$prefix" "$proto" "$cause"; then
+            ok "BIRD filtered route carries generic and cause $cause communities"
+        else
+            fail "BIRD filtered route lacks exact generic/cause $cause communities"
+            bird_filtered_route_all "$prefix" >&2 || true
         fi
     done < <(jq -c '.[] | select(.expect == "reject")' "$MANIFEST")
 }

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -316,9 +316,7 @@ has no RTT source; permanent), configured
 cannot reproduce its tagging and inbound anti-spoof scrubbing), `next_hop.policy` other
 than `strict`
 (`same-as` needs the deferred fleet-inventory mode), `reject_policy`
-`tag`/`tag_and_reject` (reject-reason community wiring is a tracked
-follow-up; the daemon retains rejected routes with reasons natively —
-see the route-server cookbook's filtered-route view), `prepend_rs_as`,
+`tag` (it accepts invalid routes into the master table), `prepend_rs_as`,
 `perform_graceful_shutdown`, `max_prefix.action` `block`/`warning`,
 and an effective `max_prefix.count_rejected_routes: true` while a positive
 shutdown or restart limit is active (ARouteServer 1.23.2 defaults this option to true,
@@ -330,6 +328,15 @@ enforcement knobs. `shutdown` emits the positive family ceilings;
 `restart` additionally requires a positive `restart_after` in minutes, checked
 while converting to `u32` seconds. An absent action or zero family limits emit
 neither ceilings nor a restart timer.
+
+An effective `reject_policy: tag_and_reject` instead emits ordered origin- and
+prefix-reject terms plus `birdwatcher-reject-communities.json`. The startup
+artifact contains only effective tag-and-reject peer addresses and configured
+standard/large dynamic and cause-map values; absent families stay absent. The
+adapter validates it strictly, refuses files over 1 MiB or 4096 unique peers,
+and never silently downgrades an invalid artifact. Extended communities and
+`rejected_route_announced_by` remain refused because the retained route lacks
+authoritative data to reproduce them.
 
 The renderer also refuses effective nonzero multihop and RFC 8950 on an
 IPv6 session. Blackhole policies support `propagate-unchanged` and

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -914,6 +914,7 @@ struct ResolvedClient<'a> {
     blackhole: Option<ResolvedBlackhole>,
     pref_len: Option<(u8, u8)>,
     reject_rpki_invalid: bool,
+    tag_and_reject: bool,
 }
 #[derive(Clone)]
 struct ResolvedBlackhole {
@@ -993,6 +994,9 @@ fn render_inner(
             format!("policy/client-{}.rpol", rc.slug),
             render_client_rpol(rc, &found_fingerprint),
         );
+    }
+    if let Some(artifact) = render_reject_communities(&ctx, &resolved)? {
+        files.insert("birdwatcher-reject-communities.json".to_owned(), artifact);
     }
     files.insert(
         "config.toml".to_owned(),
@@ -1666,14 +1670,145 @@ fn check_next_hop_policy(policy: &str, scope: &str, refusals: &mut Vec<String>) 
 
 fn check_reject_policy(policy: &str, scope: &str, refusals: &mut Vec<String>) {
     match policy {
-        "reject" => {}
-        "tag" | "tag_and_reject" => refusals.push(format!(
-            "{scope}: reject_policy `{policy}` needs reject-reason community wiring for \
-             the looking-glass surface; only `reject` is rendered (the daemon retains \
-             rejected routes with reasons natively — see the route-server cookbook)"
+        "reject" | "tag_and_reject" => {}
+        "tag" => refusals.push(format!(
+            "{scope}: reject_policy `tag` accepts invalid routes into BIRD's master table; \
+             native rejected-route retention cannot reproduce that behavior"
         )),
         other => refusals.push(format!("{scope}: unknown reject_policy `{other}`")),
     }
+}
+
+#[derive(Serialize)]
+struct RejectCommunityArtifact<'a> {
+    schema: &'static str,
+    peers: Vec<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    std: Option<RejectCommunityFamily<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lrg: Option<RejectCommunityFamily<'a>>,
+}
+
+#[derive(Serialize)]
+struct RejectCommunityFamily<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dynamic: Option<&'a str>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    cause_map: BTreeMap<u8, &'a str>,
+}
+
+fn render_reject_communities(
+    ctx: &Context,
+    clients: &[ResolvedClient<'_>],
+) -> Result<Option<String>, RenderError> {
+    let peers = clients
+        .iter()
+        .filter(|client| client.tag_and_reject)
+        .map(|client| client.client.ip.as_str())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if peers.is_empty() {
+        return Ok(None);
+    }
+    let reject = ctx.cfg.communities.get("reject_cause");
+    let mut refusals = Vec::new();
+    if reject.is_none_or(|values| values.std.is_none() && values.lrg.is_none()) {
+        refusals.push("tag_and_reject requires communities.reject_cause std or lrg".to_owned());
+    }
+    if reject.and_then(|values| values.ext.as_ref()).is_some() {
+        refusals.push("communities.reject_cause.ext is unsupported".to_owned());
+    }
+    for (value, parts, max) in [
+        (reject.and_then(|v| v.std.as_deref()), 2, u16::MAX as u64),
+        (reject.and_then(|v| v.lrg.as_deref()), 3, u32::MAX as u64),
+    ] {
+        if value.is_some_and(|value| !valid_reject_community(value, parts, max, true)) {
+            refusals.push("communities.reject_cause must place dyn_val exactly last".to_owned());
+        }
+    }
+    if ctx
+        .cfg
+        .communities
+        .get("rejected_route_announced_by")
+        .is_some_and(community_configured)
+    {
+        refusals.push(
+            "communities.rejected_route_announced_by requires authoritative announcer data"
+                .to_owned(),
+        );
+    }
+    for (name, values) in ctx
+        .cfg
+        .communities
+        .iter()
+        .filter(|(name, _)| name.starts_with("reject_cause_map_"))
+    {
+        if name[17..]
+            .parse::<u8>()
+            .ok()
+            .is_none_or(|code| !(1..=15).contains(&code))
+        {
+            refusals.push(format!("communities.{name} has a cause outside 1..15"));
+        }
+        if values.ext.is_some() {
+            refusals.push(format!("communities.{name}.ext is unsupported"));
+        }
+        for (value, parts, max) in [
+            (values.std.as_deref(), 2, u16::MAX as u64),
+            (values.lrg.as_deref(), 3, u32::MAX as u64),
+        ] {
+            if value.is_some_and(|value| !valid_reject_community(value, parts, max, false)) {
+                refusals.push(format!("communities.{name} is malformed"));
+            }
+        }
+    }
+    if !refusals.is_empty() {
+        return Err(RenderError::Refused(refusals));
+    }
+    let reject = reject.expect("validated reject_cause");
+    let cause_map = |select: fn(&CommunityValues) -> Option<&str>| {
+        ctx.cfg
+            .communities
+            .iter()
+            .filter_map(|(name, values)| {
+                Some((
+                    name.strip_prefix("reject_cause_map_")?.parse().ok()?,
+                    select(values)?,
+                ))
+            })
+            .collect::<BTreeMap<u8, &str>>()
+    };
+    let std_map = cause_map(|values| values.std.as_deref());
+    let lrg_map = cause_map(|values| values.lrg.as_deref());
+    let artifact = RejectCommunityArtifact {
+        schema: "rustbgpd.arouteserver-reject-communities.v1",
+        peers,
+        std: (reject.std.is_some() || !std_map.is_empty()).then_some(RejectCommunityFamily {
+            dynamic: reject.std.as_deref(),
+            cause_map: std_map,
+        }),
+        lrg: (reject.lrg.is_some() || !lrg_map.is_empty()).then_some(RejectCommunityFamily {
+            dynamic: reject.lrg.as_deref(),
+            cause_map: lrg_map,
+        }),
+    };
+    serde_json::to_string_pretty(&artifact)
+        .map(|mut json| {
+            json.push('\n');
+            Some(json)
+        })
+        .map_err(|error| RenderError::Parse(error.to_string()))
+}
+
+fn valid_reject_community(value: &str, parts: usize, max: u64, dynamic: bool) -> bool {
+    let mut fields = value.split(':').collect::<Vec<_>>();
+    if fields.len() != parts || (dynamic && fields.pop() != Some("dyn_val")) {
+        return false;
+    }
+    fields
+        .iter()
+        .all(|field| field.parse::<u64>().is_ok_and(|value| value <= max))
 }
 
 #[derive(Clone, Copy)]
@@ -1772,6 +1907,12 @@ fn resolve_clients<'a>(
     for client in &ctx.clients {
         let slug = client.id.to_lowercase().replace('_', "-");
         let filtering = &client.cfg.filtering;
+        let tag_and_reject = filtering
+            .reject_policy
+            .as_ref()
+            .unwrap_or(&ctx.cfg.filtering.reject_policy)
+            .policy
+            == "tag_and_reject";
         let enforce_origin = ctx.cfg.filtering.irrdb.enforce_origin_in_as_set;
         let enforce_prefix = ctx.cfg.filtering.irrdb.enforce_prefix_in_as_set;
 
@@ -1894,6 +2035,7 @@ fn resolve_clients<'a>(
             },
             reject_rpki_invalid: ctx.cfg.filtering.rpki_bgp_origin_validation.enabled
                 && ctx.cfg.filtering.rpki_bgp_origin_validation.reject_invalid,
+            tag_and_reject,
         });
     }
 
@@ -2624,18 +2766,35 @@ fn render_client_rpol(rc: &ResolvedClient<'_>, fingerprint: &str) -> String {
         }
     }
 
-    let _ = write!(
-        out,
-        "\npolicy client-{slug} {{\n\
-         {blackhole_terms}\
-         \x20   term accept-authorized {{\n\
-         \x20       if {} {{ accept }}\n\
-         \x20   }}\n\
-         \x20   # Fail-closed: anything the IRR data does not authorize is rejected.\n\
-         \x20   term rest {{ reject }}\n\
-         }}\n",
-        conjuncts.join(" && ")
-    );
+    if rc.tag_and_reject {
+        let _ = write!(out, "\npolicy client-{slug} {{\n{blackhole_terms}");
+        if rc.enforce_origin {
+            let _ = writeln!(
+                out,
+                "    term reject-irrdb-origin-as-filtered {{ if !(route.origin-as in client-{slug}-origins) {{ reject }} }}"
+            );
+        }
+        if rc.enforce_prefix {
+            let _ = writeln!(
+                out,
+                "    term reject-irrdb-prefix-filtered {{ if !(route.prefix in client-{slug}-prefixes) {{ reject }} }}"
+            );
+        }
+        out.push_str("    term accept-authorized { accept }\n}\n");
+    } else {
+        let _ = write!(
+            out,
+            "\npolicy client-{slug} {{\n\
+             {blackhole_terms}\
+             \x20   term accept-authorized {{\n\
+             \x20       if {} {{ accept }}\n\
+             \x20   }}\n\
+             \x20   # Fail-closed: anything the IRR data does not authorize is rejected.\n\
+             \x20   term rest {{ reject }}\n\
+             }}\n",
+            conjuncts.join(" && ")
+        );
+    }
 
     // In-language tests derived from the client's own IRR data.
     if let (true, Some(first_origin)) = (rc.enforce_origin, rc.origins.first()) {

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -316,11 +316,6 @@ fn refusal_matrix() {
             "reject_policy `tag`",
         ),
         (
-            &["cfg", "filtering", "reject_policy", "policy"],
-            Value::String("tag_and_reject".into()),
-            "reject_policy `tag_and_reject`",
-        ),
-        (
             &["rtt_based_functions_are_used"],
             Value::Bool(true),
             "RTT-based communities",
@@ -358,6 +353,109 @@ fn refusal_matrix() {
         assert!(
             items.iter().any(|i| i.contains(marker)),
             "no refusal containing {marker:?} for {path:?}: {items:?}"
+        );
+    }
+}
+
+fn tag_and_reject_value() -> serde_yaml::Value {
+    let mut value = healthy_value();
+    set_path(
+        &mut value,
+        &["cfg", "filtering", "reject_policy", "policy"],
+        "tag_and_reject".into(),
+    );
+    for (name, values) in [
+        (
+            "reject_cause",
+            "{std: '65520:dyn_val', lrg: '64496:65520:dyn_val'}",
+        ),
+        (
+            "reject_cause_map_3",
+            "{std: '64512:3', lrg: '64496:65521:3'}",
+        ),
+        ("reject_cause_map_12", "{lrg: '64496:65521:12'}"),
+    ] {
+        set_general_community(&mut value, name, serde_yaml::from_str(values).unwrap());
+    }
+    set_client(
+        &mut value,
+        0,
+        &["cfg", "filtering", "reject_policy"],
+        serde_yaml::from_str("{policy: reject}").unwrap(),
+    );
+    value
+}
+
+#[test]
+fn tag_and_reject_artifact_and_order_are_exact_and_mixed_policy_scoped() {
+    let baseline = render(&to_yaml(&healthy_value()), &rtr_options()).unwrap();
+    let rendered = render(&to_yaml(&tag_and_reject_value()), &rtr_options()).unwrap();
+    assert_eq!(
+        rendered.files["birdwatcher-reject-communities.json"],
+        "{\n  \"schema\": \"rustbgpd.arouteserver-reject-communities.v1\",\n  \"peers\": [\n    \"2001:db8:0:1::22\"\n  ],\n  \"std\": {\n    \"dynamic\": \"65520:dyn_val\",\n    \"cause_map\": {\n      \"3\": \"64512:3\"\n    }\n  },\n  \"lrg\": {\n    \"dynamic\": \"64496:65520:dyn_val\",\n    \"cause_map\": {\n      \"3\": \"64496:65521:3\",\n      \"12\": \"64496:65521:12\"\n    }\n  }\n}\n"
+    );
+    assert_eq!(
+        rendered.files["policy/client-as4242-1.rpol"],
+        baseline.files["policy/client-as4242-1.rpol"]
+    );
+    let policy = &rendered.files["policy/client-as197000-1.rpol"];
+    let positions = [
+        "reject-irrdb-origin-as-filtered",
+        "reject-irrdb-prefix-filtered",
+        "term accept-authorized",
+    ]
+    .map(|term| policy.find(term).unwrap());
+    assert!(
+        positions.windows(2).all(|pair| pair[0] < pair[1]),
+        "{policy}"
+    );
+    assert!(!policy.contains("term rest"), "{policy}");
+
+    let mut reverse = tag_and_reject_value();
+    set_path(
+        &mut reverse,
+        &["cfg", "filtering", "reject_policy", "policy"],
+        "reject".into(),
+    );
+    set_client(
+        &mut reverse,
+        0,
+        &["cfg", "filtering", "reject_policy"],
+        serde_yaml::from_str("{policy: tag_and_reject}").unwrap(),
+    );
+    let reverse = render(&to_yaml(&reverse), &rtr_options()).unwrap();
+    let artifact: serde_json::Value =
+        serde_json::from_str(&reverse.files["birdwatcher-reject-communities.json"]).unwrap();
+    assert_eq!(artifact["peers"], serde_json::json!(["192.0.2.11"]));
+    assert!(reverse.files["policy/client-as4242-1.rpol"].contains("reject-irrdb-prefix-filtered"));
+    assert_eq!(
+        reverse.files["policy/client-as197000-1.rpol"],
+        baseline.files["policy/client-as197000-1.rpol"]
+    );
+}
+
+#[test]
+fn tag_and_reject_refuses_malformed_extended_announcer_and_invalid_causes() {
+    for (name, values, marker) in [
+        ("reject_cause", "{std: 'dyn_val:1'}", "dyn_val exactly last"),
+        (
+            "reject_cause",
+            "{lrg: '64496:65520:dyn_val', ext: 'RT:1:1'}",
+            ".ext is unsupported",
+        ),
+        (
+            "rejected_route_announced_by",
+            "{std: '65520:dyn_val'}",
+            "authoritative announcer data",
+        ),
+        ("reject_cause_map_16", "{std: '64512:16'}", "outside 1..15"),
+    ] {
+        let mut value = tag_and_reject_value();
+        set_general_community(&mut value, name, serde_yaml::from_str(values).unwrap());
+        let errors = refusals(render(&to_yaml(&value), &rtr_options()));
+        assert!(
+            errors.iter().any(|error| error.contains(marker)),
+            "{errors:?}"
         );
     }
 }


### PR DESCRIPTION
Linear: LAN-1178

## Summary

- resolve effective `tag_and_reject` policy and emit its exact deterministic startup artifact
- strictly scope and scrub conservative Birdwatcher reject-tag presentation while keeping the IXP view isolated
- prove ordered renderer semantics through the live adapter and pinned ARouteServer/BIRD M90

## Verification

- focused renderer and adapter suites plus the real live adapter smoke
- pinned M90 differential: 74 passed, 0 failed; context ingestion: 16/16
- serial locked workspace, strict all-target/all-feature Clippy, and warning-denied docs
- v1, tracker, scale, Clippy, reflow, release, and primer contracts
- 19 destructive mutations failed and were restored

## Boundary

Plain `tag`, extended and announcer mappings, hot reload, and full runtime compatibility remain refused. The artifact is startup-only. The ordinary parallel `rs-config-render` suite encountered the known shared host-lock race; its bounded serial run passed.
