### PR TITLE
Supervise BGP ingress tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The bound BGP listener and inbound accept-forwarding tasks are now retained
+  beside the existing gRPC and RIB supervision. An unexpected clean return or
+  panic enters the same coordinated peer teardown and exits 1; live bound-listener
+  and accepted-connection fault proofs preserve signal and Shutdown RPC exit 0.
+  This does not add PeerManager supervision or in-process respawn. (LAN-1207)
 - BLACKHOLE kernel ownership now survives crashes through a private,
   descriptor-relative `blackhole-owned.json` exact-prefix receipt. Adoption
   and deletion require both receipt authority and the kernel marker; install

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -412,9 +412,10 @@ Notes on the sandbox:
   `1` on a component failure it cannot recover from in place. Startup exits
   immediately if legacy BGP mode binds neither family, explicit
   `listen_addresses` cannot bind every configured endpoint, or a configured
-  `prometheus_addr` health listener cannot bind. An unexpected gRPC server or
-  RIB manager exit instead runs the coordinated peer teardown before exit 1.
-  These components are not respawned in place; the supervisor is the recovery path.
+  `prometheus_addr` health listener cannot bind. An unexpected gRPC server,
+  RIB manager, BGP listener task, or inbound accept-forwarding task exit instead
+  runs the coordinated peer teardown before exit 1. These components are not
+  respawned in place; the supervisor is the recovery path.
   Exit 70 is also a failure: it is the runtime-config settlement watchdog's
   fail-stop recovery request and must remain restartable. `RestartSec=5`
   retries a transient failure, while `StartLimitBurst=5` and

--- a/src/main.rs
+++ b/src/main.rs
@@ -2376,7 +2376,8 @@ reported at least one warning. For
 neither family; explicit
 .B listen_addresses
 mode could not bind every configured endpoint; a configured metrics/readiness
-listener failed to bind; or the RIB manager or gRPC server exited unexpectedly),
+listener failed to bind; or the RIB manager, gRPC server, BGP listener task,
+or BGP accept-forwarding task exited unexpectedly),
 so that a supervisor configured
 with
 .B Restart=on\-failure
@@ -2459,7 +2460,8 @@ fn main() -> ExitCode {
                   A running daemon exits 1 on a component failure that ends it\n     \
                   (legacy BGP mode bound neither family; an explicit listen_addresses\n     \
                   endpoint failed to bind; configured metrics/readiness bind failure;\n     \
-                  or unexpected RIB manager or gRPC server exit)\n  \
+                  or unexpected RIB manager, gRPC server, BGP listener task,\n     \
+                  or BGP accept-forwarding task exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
                     env!("CARGO_PKG_VERSION")
@@ -2968,6 +2970,43 @@ const RIB_CHANNEL_CAPACITY: usize = 4096;
 /// unset, zero, or unparseable values keep the production capacity.
 const TEST_RIB_CHANNEL_CAPACITY_ENV: &str = "RUSTBGPD_TEST_RIB_CHANNEL_CAPACITY";
 
+/// Test-only fault injection; never set this in production. The only accepted
+/// values are `listener_panic` and `forwarder_return`; all others are ignored
+/// with a sanitized warning.
+const TEST_BGP_INGRESS_EXIT_ENV: &str = "RUSTBGPD_TEST_BGP_INGRESS_EXIT";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TestBgpIngressExit {
+    ListenerPanic,
+    ForwarderReturn,
+}
+
+fn parse_test_bgp_ingress_exit(raw: Option<&str>) -> Result<Option<TestBgpIngressExit>, ()> {
+    match raw {
+        None => Ok(None),
+        Some("listener_panic") => Ok(Some(TestBgpIngressExit::ListenerPanic)),
+        Some("forwarder_return") => Ok(Some(TestBgpIngressExit::ForwarderReturn)),
+        Some(_) => Err(()),
+    }
+}
+
+fn resolve_test_bgp_ingress_exit() -> Option<TestBgpIngressExit> {
+    let raw = match std::env::var(TEST_BGP_INGRESS_EXIT_ENV) {
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            warn!(
+                "ignoring invalid {TEST_BGP_INGRESS_EXIT_ENV}; expected listener_panic or forwarder_return"
+            );
+            return None;
+        }
+    };
+    parse_test_bgp_ingress_exit(raw.as_deref()).unwrap_or_else(|()| {
+        warn!("ignoring invalid {TEST_BGP_INGRESS_EXIT_ENV}; expected listener_panic or forwarder_return");
+        None
+    })
+}
+
 /// Resolve the RIB channel capacity: [`TEST_RIB_CHANNEL_CAPACITY_ENV`]
 /// (if a positive integer) overrides the production default.
 fn resolve_rib_channel_capacity() -> usize {
@@ -3031,6 +3070,7 @@ async fn run<T>(
         .unwrap_or_else(|e| fatal_startup_error("failed to register SIGTERM handler", e));
     let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
         .unwrap_or_else(|e| fatal_startup_error("failed to register SIGHUP handler", e));
+    let test_bgp_ingress_exit = resolve_test_bgp_ingress_exit();
 
     let mut config = accepted.config();
     // Snapshot the gRPC listener config as it was at process start.
@@ -4944,7 +4984,7 @@ async fn run<T>(
     // partially initialized peer manager.
     let listener_peer_mgr_tx = peer_mgr_tx.clone();
     let listener_gate = daemon_gate.clone();
-    tokio::spawn(async move {
+    let mut bgp_forwarder_handle = tokio::spawn(async move {
         while let Some(conn) = accept_rx.recv().await {
             // Coordinated shutdown has begun: drop (close) the socket
             // instead of admitting a session into teardown.
@@ -4954,6 +4994,9 @@ async fn run<T>(
                     "rejecting inbound BGP connection: daemon is shutting down"
                 );
                 continue;
+            }
+            if test_bgp_ingress_exit == Some(TestBgpIngressExit::ForwarderReturn) {
+                return;
             }
             if let Err(e) = listener_peer_mgr_tx
                 .send(PeerManagerCommand::AcceptInbound {
@@ -4968,7 +5011,14 @@ async fn run<T>(
             }
         }
     });
-    tokio::spawn(listener.run());
+    let mut bgp_listener_handle = tokio::spawn(async move {
+        assert_ne!(
+            test_bgp_ingress_exit,
+            Some(TestBgpIngressExit::ListenerPanic),
+            "injected BGP listener task panic after successful bind"
+        );
+        listener.run().await;
+    });
 
     // Spawn telemetry HTTP server (if configured). `/metrics` serves
     // Prometheus text; `/livez` and `/readyz` provide minimal probe bodies.
@@ -5068,6 +5118,18 @@ async fn run<T>(
             result = &mut rib_handle => {
                 error!(?result, "RIB manager exited unexpectedly");
                 info!("initiating shutdown due to RIB manager failure");
+                component_failed = true;
+                break;
+            }
+            result = &mut bgp_listener_handle => {
+                error!(?result, "BGP listener task exited unexpectedly");
+                info!("initiating shutdown due to BGP listener task failure");
+                component_failed = true;
+                break;
+            }
+            result = &mut bgp_forwarder_handle => {
+                error!(?result, "BGP accept-forwarding task exited unexpectedly");
+                info!("initiating shutdown due to BGP accept-forwarding task failure");
                 component_failed = true;
                 break;
             }
@@ -5665,12 +5727,12 @@ mod tests {
         let post_registration_barrier = production
             .find("// Activate BGP ingress only after the complete configured-peer roster is")
             .expect("post-registration BGP ingress barrier must remain explicit");
-        let accept_forwarding_loop = production
-            .find("while let Some(conn) = accept_rx.recv().await {")
-            .expect("BGP accept forwarding loop must remain explicit");
+        let accept_forwarding_spawn = production
+            .find("let mut bgp_forwarder_handle = tokio::spawn(async move {")
+            .expect("BGP accept forwarding handle must remain retained");
         let listener_run_spawn = production
-            .find("tokio::spawn(listener.run());")
-            .expect("BGP listener run spawn must remain explicit");
+            .find("let mut bgp_listener_handle = tokio::spawn(async move {")
+            .expect("BGP listener run handle must remain retained");
         let metrics_startup = production
             .find("// Spawn telemetry HTTP server (if configured).")
             .expect("metrics/readiness startup boundary must remain explicit");
@@ -5698,10 +5760,26 @@ mod tests {
                 "configured-peer loop lost fatal startup arm: {fatal_message}"
             );
         }
-        assert!(post_registration_barrier < accept_forwarding_loop);
+        assert!(post_registration_barrier < accept_forwarding_spawn);
         assert!(post_registration_barrier < listener_run_spawn);
-        assert!(accept_forwarding_loop < metrics_startup);
+        assert!(accept_forwarding_spawn < metrics_startup);
         assert!(listener_run_spawn < metrics_startup);
+    }
+
+    #[test]
+    fn bgp_ingress_fault_parser_accepts_only_exact_modes() {
+        assert_eq!(parse_test_bgp_ingress_exit(None), Ok(None));
+        assert_eq!(
+            parse_test_bgp_ingress_exit(Some("listener_panic")),
+            Ok(Some(TestBgpIngressExit::ListenerPanic))
+        );
+        assert_eq!(
+            parse_test_bgp_ingress_exit(Some("forwarder_return")),
+            Ok(Some(TestBgpIngressExit::ForwarderReturn))
+        );
+        for raw in ["", "listener", " listener_panic", "forwarder_return "] {
+            assert_eq!(parse_test_bgp_ingress_exit(Some(raw)), Err(()));
+        }
     }
 
     #[test]

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -2,10 +2,8 @@
 //!
 //! Operator-initiated shutdown (SIGTERM) exits 0; a component failure
 //! exits non-zero, so supervisors like systemd with `Restart=on-failure`
-//! restart the daemon instead of treating it as a clean stop. Three
-//! component failures are covered, all provoked by holding the port the
-//! daemon needs: the gRPC server exiting unexpectedly, the BGP listener
-//! failing to bind, and the metrics/readiness listener failing to bind.
+//! restart the daemon instead of treating it as a clean stop. Live proofs cover
+//! startup binds, the RIB manager, and both inbound-admission tasks.
 
 use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
@@ -267,6 +265,22 @@ fn establish_bgp_and_observe_shutdown(port: u16) {
     }
 }
 
+fn run_bgp_ingress_fault(mode: &str, connect: bool) -> (ExitStatus, String) {
+    let temp = private_tempdir();
+    let config_path = write_rib_fault_config(temp.path());
+    let mut daemon = spawn_daemon_with_env(
+        temp.path(),
+        &config_path,
+        Some(("RUSTBGPD_TEST_BGP_INGRESS_EXIT", mode)),
+    );
+    let port = wait_for_bound_bgp_port(&mut daemon);
+    let _connection = connect.then(|| {
+        TcpStream::connect(("127.0.0.1", port)).expect("connect to real bound BGP listener")
+    });
+    let status = daemon.wait_within(Duration::from_secs(30));
+    (status, daemon.logs())
+}
+
 #[test]
 fn grpc_bind_failure_exits_nonzero() {
     let temp = private_tempdir();
@@ -340,6 +354,99 @@ fn rib_supervision_is_fail_stop_and_uses_common_peer_teardown() {
 }
 
 #[test]
+fn bgp_ingress_tasks_are_retained_unconditionally_supervised_and_torn_down() {
+    let source = include_str!("../src/main.rs");
+    let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
+    assert_eq!(
+        production
+            .matches("std::env::var(TEST_BGP_INGRESS_EXIT_ENV)")
+            .count(),
+        1
+    );
+    let teardown = production
+        .find("send(PeerManagerCommand::Shutdown)")
+        .unwrap();
+    for (handle, diagnostic) in [
+        (
+            "bgp_listener_handle",
+            "BGP listener task exited unexpectedly",
+        ),
+        (
+            "bgp_forwarder_handle",
+            "BGP accept-forwarding task exited unexpectedly",
+        ),
+    ] {
+        let retained = production
+            .find(&format!("let mut {handle} = tokio::spawn"))
+            .unwrap_or_else(|| panic!("{handle} not retained"));
+        let arm = production
+            .find(&format!("result = &mut {handle} => {{"))
+            .unwrap_or_else(|| panic!("{handle} not selected"));
+        let body = production[arm..].split_once("\n            }").unwrap().0;
+        assert!(body.contains(diagnostic), "{handle}: {body}");
+        assert!(
+            body.contains("component_failed = true;"),
+            "{handle}: {body}"
+        );
+        assert!(body.contains("break;"), "{handle}: {body}");
+        assert!(
+            !body.contains("is_ok") && !body.contains("is_err"),
+            "{handle}: {body}"
+        );
+        assert!(retained < arm && arm < teardown, "{handle} ordering");
+    }
+    let rpc = production
+        .split_once("changed = rpc_shutdown_rx.changed() => {")
+        .unwrap()
+        .1;
+    let rpc = rpc.split_once("\n            }").unwrap().0;
+    assert!(
+        !rpc.contains("component_failed"),
+        "Shutdown RPC must stay clean"
+    );
+}
+
+#[test]
+fn bound_bgp_listener_panic_uses_common_shutdown_and_exits_nonzero() {
+    let (status, logs) = run_bgp_ingress_fault("listener_panic", false);
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "listener task panic must exit 1\n{logs}"
+    );
+    assert!(
+        logs.contains("injected BGP listener task panic after successful bind"),
+        "{logs}"
+    );
+    assert!(
+        logs.contains("BGP listener task exited unexpectedly"),
+        "{logs}"
+    );
+    assert!(
+        logs.contains("initiating shutdown due to BGP listener task failure"),
+        "{logs}"
+    );
+}
+
+#[test]
+fn accepted_connection_forwarder_return_uses_common_shutdown_and_exits_nonzero() {
+    let (status, logs) = run_bgp_ingress_fault("forwarder_return", true);
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "forwarder return must exit 1\n{logs}"
+    );
+    assert!(
+        logs.contains("BGP accept-forwarding task exited unexpectedly"),
+        "{logs}"
+    );
+    assert!(
+        logs.contains("initiating shutdown due to BGP accept-forwarding task failure"),
+        "{logs}"
+    );
+}
+
+#[test]
 fn help_and_man_distinguish_bgp_bind_modes_and_supervised_exits() {
     let output = |flag| {
         let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
@@ -352,10 +459,11 @@ fn help_and_man_distinguish_bgp_bind_modes_and_supervised_exits() {
     let help = output("--help");
     assert!(help.contains("legacy BGP mode bound neither family; an explicit listen_addresses"));
     assert!(help.contains("endpoint failed to bind; configured metrics/readiness bind failure;"));
-    assert!(help.contains("or unexpected RIB manager or gRPC server exit"));
+    assert!(help.contains("or unexpected RIB manager, gRPC server, BGP listener task,"));
+    assert!(help.contains("or BGP accept-forwarding task exit"));
     let man = output("--man");
     assert!(man.contains("legacy BGP listen mode could bind\nneither family; explicit\n.B listen_addresses\nmode could not bind every configured endpoint"));
-    assert!(man.contains("configured metrics/readiness\nlistener failed to bind; or the RIB manager or gRPC server exited unexpectedly"));
+    assert!(man.contains("the RIB manager, gRPC server, BGP listener task,\nor BGP accept-forwarding task exited unexpectedly"));
 }
 
 #[test]
@@ -494,7 +602,12 @@ fn sigterm_exits_zero() {
     let temp = private_tempdir();
 
     let config_path = write_config(temp.path(), DAEMON_CHOOSES, DAEMON_CHOOSES);
-    let mut daemon = spawn_daemon(temp.path(), &config_path);
+    let hidden = "unknown-mode-must-not-be-echoed";
+    let mut daemon = spawn_daemon_with_env(
+        temp.path(),
+        &config_path,
+        Some(("RUSTBGPD_TEST_BGP_INGRESS_EXIT", hidden)),
+    );
 
     // Wait until the gRPC listener is up so SIGTERM lands on a fully
     // started daemon. No spawn retry: the daemon picks its own ports, so a
@@ -526,10 +639,18 @@ fn sigterm_exits_zero() {
     assert!(sigterm.success(), "kill -TERM failed: {sigterm}");
 
     let status = daemon.wait_within(Duration::from_secs(120));
+    let logs = daemon.logs();
     assert_eq!(
         status.code(),
         Some(0),
-        "SIGTERM must exit 0, got {status}\n{}",
-        daemon.logs()
+        "SIGTERM must exit 0, got {status}\n{logs}"
+    );
+    assert!(
+        logs.contains("ignoring invalid RUSTBGPD_TEST_BGP_INGRESS_EXIT"),
+        "{logs}"
+    );
+    assert!(
+        !logs.contains(hidden),
+        "unknown environment value leaked: {logs}"
     );
 }


### PR DESCRIPTION
## Summary

- retain and supervise the bound BGP listener and inbound accept-forwarding tasks
- route both clean returns and panics through the existing coordinated peer teardown and exit 1
- preserve clean signal and Shutdown RPC exits, with bounded live fault hooks and exact operator documentation

Tracks LAN-1207.

## Validation

- focused parser, ordering, source-geometry, listener, forwarder, RIB, signal, help, and man-page proofs
- 8 causal mutations, each red and restored
- serial locked workspace tests; strict all-target/all-feature Clippy; warning-denied docs; fmt
- v1, tracker, scale, Clippy-reason, and release-note contracts and self-tests

## Scope

This does not add PeerManager supervision, readiness semantics, in-process respawn, or a generic task supervisor.
