### PR TITLE
Preserve foreign static FDB ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Mixed daemon-owned and unmarked static Linux FDB contributors now classify foreign in either
+  order; reconciliation relinquishes ownership once and preserves the operator row. (LAN-1218)
 - Startup now resolves validated policy and EVPN state and acquires BFD, BGP,
   and metrics resources before EventHistoryManager starts. Retained resources
   remain inactive until their existing activation barriers. Initial

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -118,8 +118,13 @@ pub(crate) async fn dump_fdb(
 /// carries it, the bridge-master row doesn't); flag bools OR
 /// together so an entry that has both `extern_learn` (set by
 /// rustbgpd) and `master` (set by the bridge-FDB plumbing) reads
-/// correctly downstream. Pure helper kept testable in isolation.
+/// owned normally. An unmarked static master overrides it to foreign.
 fn merge_fdb_rows(existing: &mut KernelFdbEntry, incoming: &KernelFdbEntry) {
+    let foreign_static_master = |row: &KernelFdbEntry| {
+        !row.flags.extern_learn && row.flags.master && (row.flags.permanent || row.flags.noarp)
+    };
+    let has_foreign_static_master =
+        foreign_static_master(existing) || foreign_static_master(incoming);
     if existing.dst.is_none() && incoming.dst.is_some() {
         existing.dst = incoming.dst;
     }
@@ -141,6 +146,9 @@ fn merge_fdb_rows(existing: &mut KernelFdbEntry, incoming: &KernelFdbEntry) {
     existing.flags.noarp |= incoming.flags.noarp;
     existing.flags.master |= incoming.flags.master;
     existing.flags.self_flag |= incoming.flags.self_flag;
+    if has_foreign_static_master {
+        existing.flags.extern_learn = false;
+    }
 }
 
 type FdbSnapshotRow = ((EvpnInstanceId, Option<u16>, MacAddress), KernelFdbEntry);
@@ -161,6 +169,7 @@ fn parse_fdb_entry(msg: &NeighbourMessage, cache: &LinkCache) -> Option<FdbSnaps
     let mut protocol: Option<u8> = None;
     let mut vlan: Option<u16> = None;
     let mut explicit_vni: Option<u32> = None;
+    let mut master = false;
     for attr in &msg.attributes {
         match attr {
             NeighbourAttribute::LinkLayerAddress(bytes) if bytes.len() == 6 => {
@@ -193,6 +202,7 @@ fn parse_fdb_entry(msg: &NeighbourMessage, cache: &LinkCache) -> Option<FdbSnaps
             // platform-independent and don't see netlink enums.
             NeighbourAttribute::Protocol(p) => protocol = Some(u8::from(*p)),
             NeighbourAttribute::Vlan(v) => vlan = Some(*v),
+            NeighbourAttribute::Controller(_) => master = true,
             // SVD / collect-metadata VXLAN rows need an explicit
             // VNI because the VXLAN ifindex no longer identifies one
             // VNI. `src_vni` is the bridge FDB spelling for "the VNI
@@ -239,7 +249,7 @@ fn parse_fdb_entry(msg: &NeighbourMessage, cache: &LinkCache) -> Option<FdbSnaps
     // `NeighbourFlags::Controller` is the netlink-packet-route
     // spelling for `NTF_MASTER` — the bit set by `bridge fdb add
     // ... master`.
-    if hf.contains(NeighbourFlags::Controller) {
+    if master || hf.contains(NeighbourFlags::Controller) {
         flags.master = true;
     }
     decode_state(msg.header.state, &mut flags);
@@ -744,6 +754,12 @@ mod tests {
         assert!(acc.flags.extern_learn);
         assert!(acc.flags.permanent);
         assert!(acc.flags.noarp);
+
+        let mut noarp_master = master_row;
+        noarp_master.flags.extern_learn = false;
+        noarp_master.flags.permanent = false;
+        merge_fdb_rows(&mut acc, &noarp_master);
+        assert!(!acc.flags.extern_learn);
     }
 
     #[test]
@@ -761,6 +777,8 @@ mod tests {
                 ..FlagSet::default()
             }),
         );
+        let mut foreign_master = acc.clone();
+        foreign_master.flags.extern_learn = false;
         let self_row = fdb_row(
             Some("10.0.0.2"),
             flags(FlagSet {
@@ -779,6 +797,9 @@ mod tests {
         );
         assert!(acc.flags.master);
         assert!(acc.flags.self_flag);
+        merge_fdb_rows(&mut foreign_master, &self_row);
+        assert!(!foreign_master.flags.extern_learn);
+        assert_eq!(foreign_master.dst, Some(ipa("10.0.0.2")));
     }
 
     #[test]
@@ -1037,12 +1058,15 @@ mod tests {
 
         // Current kernels return no protocol attribute at all.
         let mut unstamped = build_remote_fdb_message(11, mac, ipa("10.0.0.2"), None, None);
+        unstamped.header.flags.remove(NeighbourFlags::Controller);
+        unstamped.attributes.push(NeighbourAttribute::Controller(7));
         unstamped
             .attributes
             .retain(|a| !matches!(a, NeighbourAttribute::Protocol(_)));
         let (_, entry) = parse_fdb_entry(&unstamped, &cache).unwrap();
         assert_eq!(entry.protocol, None);
         assert!(entry.is_extern_learned());
+        assert!(entry.flags.master);
     }
 
     #[test]

--- a/crates/evpn-linux/tests/netns_foreign_state.rs
+++ b/crates/evpn-linux/tests/netns_foreign_state.rs
@@ -264,15 +264,24 @@ fn setup_l2_topology(ns: &NetnsFixture) {
     ns.exec("ip", &["link", "set", "vxlan100", "up"]);
 }
 
-fn l2_fdb_line(dump: &str, mac: &str) -> Option<String> {
-    dump.lines()
-        .find(|line| line.contains(mac) && !line.contains("dst"))
-        .map(str::to_owned)
-        .or_else(|| {
-            dump.lines()
-                .find(|line| line.contains(mac))
-                .map(str::to_owned)
+fn l2_rows_match(dump: &str, mac: &str, owned_sibling: bool) -> bool {
+    let rows: Vec<_> = dump.lines().filter(|line| line.starts_with(mac)).collect();
+    let has = |required: &str, forbidden: &str| {
+        rows.iter().any(|row| {
+            let tokens: Vec<_> = row.split_whitespace().collect();
+            let required = required
+                .split_whitespace()
+                .all(|token| tokens.contains(&token));
+            let allowed = forbidden
+                .split_whitespace()
+                .all(|token| !tokens.contains(&token));
+            required && allowed
         })
+    };
+    rows.len() == 2 + usize::from(owned_sibling)
+        && has("master br100 static", "vlan dst extern_learn self")
+        && has("vlan 1 master br100 static", "dst extern_learn self")
+        && (!owned_sibling || has("dst 10.0.0.2 self extern_learn permanent", "master vlan"))
 }
 
 /// LAN-283 L2: a foreign `static` FDB row that replaces the owned row
@@ -310,40 +319,68 @@ async fn l2_foreign_takeover_row_survives_withdrawal_and_shutdown() {
     );
 
     // 2. Foreign takeover: operator replaces the row (permanent, no
-    //    extern_learn) under the same key.
+    //    extern_learn) after deleting the owned master contributor.
+    run("bridge", &["fdb", "del", &mac, "dev", "vxlan100", "master"]);
     run(
         "bridge",
-        &[
-            "fdb", "replace", &mac, "dev", "vxlan100", "master", "static",
-        ],
+        &["fdb", "add", &mac, "dev", "vxlan100", "master", "static"],
     );
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(l2_rows_match(&dump, &mac, true), "takeover:\n{dump}");
 
     // 3. Re-reconcile with the MAC still desired — rustbgpd must NOT
     //    repair its row back over the foreign one.
     intent_tx.send(l2_intent(2, true)).unwrap();
-    let _ = wait_for_report_generation(&mut report_rx, 2).await;
+    let counters = tokio::time::timeout(Duration::from_secs(10), async {
+        let mut total = (0, 0);
+        loop {
+            let report = report_rx.recv().await.expect("dataplane report channel");
+            total.0 += report.foreign_state_counters.owned_relinquished;
+            total.1 += report.foreign_state_counters.replaces_blocked;
+            if report.intent_generation >= 2 {
+                break total;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for takeover report");
+    assert_eq!(counters, (1, 1));
     let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
-    let line = l2_fdb_line(&dump, &mac).expect("foreign row present");
     assert!(
-        !line.contains("extern_learn"),
+        l2_rows_match(&dump, &mac, true),
         "foreign row must not be replaced by an extern_learn repair:\n{dump}"
     );
 
-    // 4. Withdraw the MAC — the foreign row must survive.
-    intent_tx.send(l2_intent(3, false)).unwrap();
-    let _ = wait_for_report_generation(&mut report_rx, 3).await;
-    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
-    assert!(
-        l2_fdb_line(&dump, &mac).is_some(),
-        "foreign row must survive withdrawal:\n{dump}"
+    run(
+        "bridge",
+        &[
+            "fdb", "del", &mac, "dev", "vxlan100", "self", "dst", "10.0.0.2",
+        ],
     );
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(l2_rows_match(&dump, &mac, false), "cleanup:\n{dump}");
+    intent_tx.send(l2_intent(3, true)).unwrap();
+    let report = wait_for_report_generation(&mut report_rx, 3).await;
+    assert_eq!(report.foreign_state_counters, Default::default());
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(l2_rows_match(&dump, &mac, false), "reconcile:\n{dump}");
+
+    // 4. Withdraw the MAC — the foreign row must survive.
+    intent_tx.send(l2_intent(4, false)).unwrap();
+    let report = wait_for_report_generation(&mut report_rx, 4).await;
+    assert_eq!(report.foreign_state_counters, Default::default());
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(l2_rows_match(&dump, &mac, false), "withdrawal:\n{dump}");
 
     // 5. Shutdown drain — the foreign row must survive that too.
     shutdown.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(10), actor_join).await;
+    tokio::time::timeout(Duration::from_secs(10), actor_join)
+        .await
+        .expect("actor shutdown timed out")
+        .expect("actor panicked");
     let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
     assert!(
-        l2_fdb_line(&dump, &mac).is_some(),
+        l2_rows_match(&dump, &mac, false),
         "foreign row must survive the shutdown drain:\n{dump}"
     );
 }


### PR DESCRIPTION
## Summary

- classify mixed daemon-owned and unmarked static master FDB contributors as foreign in either netlink row order
- recognize typed `NDA_MASTER` attributes as well as header master flags
- preserve both operator static rows through reconcile, withdrawal, and shutdown without recreating the relinquished owned sibling

## Validation

- focused FDB merge and parser tests
- real privileged L2 foreign-takeover, VLAN FDB, and FDB-NHG kernel tests
- six destructive mutation probes
- locked serial workspace tests, strict Clippy, warning-denied docs, formatting, and repository contracts

Tracking: LAN-1218
