### PR TITLE
ci: exercise kernel dataplane invariants

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -802,7 +802,7 @@ jobs:
   netns:
     needs: classify_changes
     if: needs.classify_changes.outputs.run_labs == 'true'
-    name: Privileged netns selectors (fdb_nhg + fib_runtime + bfd_runtime + dataplane_vlan_fdb + svd_fdb_vni + managed_bridge + managed_vxlan + managed_svd_vxlan + managed_vlan_upper + managed_ready + managed_ip_vrf_ready + l3_multipath + l3_all_active_writer)
+    name: Privileged netns selectors (kernel dataplane inventory)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -853,6 +853,21 @@ jobs:
       - name: ADR-0091 managed bridge plus VXLAN readiness netns test
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh managed_ready
 
+      - name: ADR-0085 link-carrier monitor netns test
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier
+
+      - name: Single-active AC-gate netns test
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh ac_gate
+
+      - name: Raw nexthop socket netns tests
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh nexthop_raw
+
+      - name: L2 foreign-takeover preservation netns test
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l2
+
+      - name: Reserved-NHID non-clobber netns test
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_nhid
+
       # l3_multipath / l3_all_active_writer create a `vrf` device; the slim
       # hosted Azure kernel ships vrf only via linux-modules-extra for the exact
       # running kernel, which can lag the kernel in the apt mirror
@@ -893,6 +908,14 @@ jobs:
       - name: LAN-76 all-active Type 5 L3 writer netns proof
         if: steps.vrf.outputs.vrf-available == 'true'
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh l3_all_active_writer
+
+      - name: L3 foreign-takeover preservation netns test
+        if: steps.vrf.outputs.vrf-available == 'true'
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l3
+
+      - name: Route-event wake latency netns test
+        if: steps.vrf.outputs.vrf-available == 'true'
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh l3_route_event
 
   check:
     name: check

--- a/crates/evpn-linux/tests/docker/README.md
+++ b/crates/evpn-linux/tests/docker/README.md
@@ -39,6 +39,13 @@ bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg   # FDB nexthop g
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg_roundtrip # FDB-NHG round-trip only
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg_cve # FDB-NHG nolearning guard only
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime # ADR-0061 FIB runtime
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier # ADR-0085 carrier monitor
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh ac_gate # AC-gate port-state round-trip
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh nexthop_raw # all five raw nexthop tests
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l2 # L2 foreign takeover
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_nhid # reserved-NHID non-clobber
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l3 # L3 foreign takeover (VRF)
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh l3_route_event # route-event wake (VRF)
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh dataplane_vlan_fdb # ADR-0089 VLAN FDB proof
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh svd_fdb_vni # LAN-64 SVD explicit FDB VNI proof
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh l3_multipath # LAN-70 L3VNI multipath/FDB-NHG proof
@@ -69,6 +76,11 @@ caches across runs.
 | `fdb_nhg_roundtrip` | `round_trip_install_and_remove_fdb_nhg`          | FDB-NHG member + group + FDB-row install, dump, and teardown      |
 | `fdb_nhg_cve` | `cve_guard_blocks_install_when_learning_enabled`        | CVE-2025-39851 nolearning readiness guard for FDB-NHG installs   |
 | `fib_runtime` | `fib_runtime::tests::netns_general_unicast_fib_runtime_round_trip` | ADR-0061 route install / foreign preservation / withdraw / drain |
+| `link_carrier` | `link_carrier_monitor_tracks_veth_carrier_transitions` | RTNLGRP_LINK carrier transitions |
+| `ac_gate` | `linux_dataplane_set_ac_port_state_round_trip` | AC-gate port state and flood-flag preservation |
+| `nexthop_raw` | `netns_nexthop_raw` | all five raw nexthop socket tests |
+| `foreign_state_l2` / `foreign_state_nhid` | exact `netns_foreign_state` L2/NHID tests | foreign takeover and reserved-NHID non-clobber |
+| `foreign_state_l3` / `l3_route_event` | exact VRF-dependent tests | L3 foreign takeover and route-event wake latency |
 | `dataplane_vlan_fdb` | `linux_dataplane_programs_vlan_scoped_remote_mac_add_remove` | ADR-0089 VLAN-scoped single-dst FDB add/remove and scoped delete |
 | `svd_fdb_vni` | `svd_topology_is_ready_and_programs_vni_scoped_fdb_rows` | LAN-64 collect-metadata VXLAN Ready + explicit `src_vni` FDB programming / scoped-delete proof |
 | `l3_multipath` | `l3vxlan_all_active_multipath_kernel_shape` | LAN-70 L3VNI route multipath acceptance, same-MAC FDB collapse, and FDB-NHG lifecycle |
@@ -134,9 +146,9 @@ runs the shell spike and Rust round-trip against the GitHub-hosted
 runner's kernel (Ubuntu 24.04, kernel 6.x — well past the 4.18 floor
 for `IFLA_BRPORT_BCAST_FLOOD`).
 
-Other selectors are local / manual validation unless a workflow names
-them explicitly. In particular, `fdb_nhg` and `fib_runtime` are
-reviewer-run privileged smokes today, not default PR-CI gates.
+The kernel-dataplane workflow names its CI-gated privileged selector
+inventory explicitly; its L3/VRF selectors run only when the existing
+host VRF-availability probe succeeds.
 
 The CI step pre-builds the harness image with `docker/build-push-action`
 + GHA layer caching, then invokes `run-netns-tests.sh` with

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -50,6 +50,16 @@
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh ac_gate
 #       (single-active AC-gate IFLA_BRPORT_STATE round-trip +
 #        flood-flag non-clobber proof)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh nexthop_raw
+#       (all five raw RTM_NEWNEXTHOP/RTM_DELNEXTHOP proofs)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l2
+#       (L2 foreign-takeover preservation proof)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_nhid
+#       (reserved-NHID foreign-object non-clobber proof)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l3
+#       (L3 foreign-takeover preservation proof; requires VRF)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh l3_route_event
+#       (route-event wake proof; requires VRF)
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh dataplane_vlan_fdb
 #       (ADR-0089 VLAN-scoped single-dst FDB add/remove proof)
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh svd_fdb_vni
@@ -110,6 +120,11 @@ case "${1:-all}" in
     bgp_unnumbered)     TEST_BIN="netns_bgp_unnumbered"; FILTER="" ;;
     link_carrier)       TEST_BIN="netns_link_carrier"; FILTER="" ;;
     ac_gate)            TEST_BIN="netns_ac_gate"; FILTER="" ;;
+    nexthop_raw)        TEST_BIN="netns_nexthop_raw"; FILTER="" ;;
+    foreign_state_l2)   TEST_BIN="netns_foreign_state"; FILTER="l2_foreign_takeover_row_survives_withdrawal_and_shutdown" ;;
+    foreign_state_nhid) TEST_BIN="netns_foreign_state"; FILTER="nhid_reserved_range_foreign_object_not_clobbered_adopted_or_reaped" ;;
+    foreign_state_l3)   TEST_BIN="netns_foreign_state"; FILTER="l3_foreign_takeover_triple_survives_withdrawal_and_shutdown" ;;
+    l3_route_event)     TEST_BIN="netns_l3_install"; FILTER="linux_dataplane_route_event_wakes_within_2s" ;;
     dataplane_vlan_fdb) TEST_BIN="netns_dataplane"; FILTER="linux_dataplane_programs_vlan_scoped_remote_mac_add_remove" ;;
     macip_vlan_attribution) TEST_BIN="netns_dataplane"; FILTER="linux_dataplane_attributes_vlan_mac_ip_observations" ;;
     svd_fdb_vni)        TEST_BIN="netns_svd"; FILTER="svd_topology_is_ready_and_programs_vni_scoped_fdb_rows" ;;
@@ -122,7 +137,7 @@ case "${1:-all}" in
     managed_ready)      TEST_BIN="netns_managed_netdev"; FILTER="managed_bridge_and_vxlan_make_instance_ready_round_trip" ;;
     managed_ip_vrf_ready) TEST_BIN="netns_managed_netdev"; FILTER="managed_vrf_and_l3vxlan_make_ip_vrf_ready_round_trip" ;;
     *)
-        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier, ac_gate, dataplane_vlan_fdb, macip_vlan_attribution, svd_fdb_vni, l3_multipath, l3_all_active_writer, managed_bridge, managed_vxlan, managed_svd_vxlan, managed_vlan_upper, managed_ready, managed_ip_vrf_ready" >&2
+        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier, ac_gate, nexthop_raw, foreign_state_l2, foreign_state_nhid, foreign_state_l3, l3_route_event, dataplane_vlan_fdb, macip_vlan_attribution, svd_fdb_vni, l3_multipath, l3_all_active_writer, managed_bridge, managed_vxlan, managed_svd_vxlan, managed_vlan_upper, managed_ready, managed_ip_vrf_ready" >&2
         exit 2
         ;;
 esac

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -20,6 +20,28 @@ KERNEL = (
     "m36 m37 m37-ip m38 m39 m39b m48 m60 m61 m62 m40 m42 m50 m52 "
     "m58 m53 m51 m43 m47 m69 m70 m65 m71 m72 m66 m67 m68"
 ).split()
+NETNS_MAPPINGS = {
+    "link_carrier": ('TEST_BIN="netns_link_carrier"', 'FILTER=""'),
+    "ac_gate": ('TEST_BIN="netns_ac_gate"', 'FILTER=""'),
+    "nexthop_raw": ('TEST_BIN="netns_nexthop_raw"', 'FILTER=""'),
+    "foreign_state_l2": (
+        'TEST_BIN="netns_foreign_state"',
+        'FILTER="l2_foreign_takeover_row_survives_withdrawal_and_shutdown"',
+    ),
+    "foreign_state_nhid": (
+        'TEST_BIN="netns_foreign_state"',
+        'FILTER="nhid_reserved_range_foreign_object_not_clobbered_adopted_or_reaped"',
+    ),
+    "foreign_state_l3": (
+        'TEST_BIN="netns_foreign_state"',
+        'FILTER="l3_foreign_takeover_triple_survives_withdrawal_and_shutdown"',
+    ),
+    "l3_route_event": (
+        'TEST_BIN="netns_l3_install"',
+        'FILTER="linux_dataplane_route_event_wakes_within_2s"',
+    ),
+}
+NETNS_VRF_SELECTORS = {"foreign_state_l3", "l3_route_event"}
 WORKFLOWS = ("ci.yml", "audit.yml", "interop.yml", "kernel-dataplane.yml")
 GROUP = "group: ${{ github.workflow }}-${{ github.ref }}"
 PRIMER_GROUP = "group: rustbgpd-dev-image-${{ github.sha }}"
@@ -729,6 +751,35 @@ def check(root: Path) -> list[str]:
         errors.append("kernel-dataplane.yml:netns must remain independent")
     if "grpcurl_archive" in netns or GRPCURL_ACTION in netns:
         errors.append("kernel-dataplane.yml:netns must remain grpcurl-independent")
+    harness_path = root / "crates/evpn-linux/tests/docker/run-netns-tests.sh"
+    harness = harness_path.read_text() if harness_path.is_file() else ""
+    harness_missing = not harness
+    if harness_missing:
+        errors.append("netns harness is missing")
+    docker_args = re.search(r"(?ms)^DOCKER_ARGS=\(\n(.*?)^\)\n", harness)
+    netns_env = re.findall(r"(?m)^\s*-e\s+(EVPN_LINUX_NETNS=\S+)\s*$", docker_args.group(1)) if docker_args else []
+    if not harness_missing and (
+        harness.count("-e EVPN_LINUX_NETNS=1") != 1
+        or not docker_args
+        or netns_env != ["EVPN_LINUX_NETNS=1"]
+    ):
+        errors.append("netns harness must export EVPN_LINUX_NETNS=1 exactly once")
+    steps = re.split(r"(?m)(?=^      - name: )", netns)
+    for selector, mapping in NETNS_MAPPINGS.items():
+        case = re.search(rf"(?m)^    {re.escape(selector)}\)(.*?) ;;$", harness)
+        segments = [part.strip() for part in case.group(1).split(";")] if case else []
+        if not harness_missing and segments != list(mapping):
+            errors.append(f"netns harness mapping drifted for {selector}")
+        command = f"run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh {selector}"
+        matched = [step for step in steps if _has_line(step, f"        {command}")]
+        if len(matched) != 1:
+            errors.append(f"kernel-dataplane.yml:netns must invoke {selector} once")
+            continue
+        gated = _has_line(
+            matched[0], "        if: steps.vrf.outputs.vrf-available == 'true'"
+        )
+        if gated != (selector in NETNS_VRF_SELECTORS):
+            errors.append(f"kernel-dataplane.yml:netns {selector} VRF gate drifted")
 
     action = (
         root / ".github" / "actions" / "setup-dataplane-host" / "action.yml"

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -101,6 +101,9 @@ class PrimerContractTests(unittest.TestCase):
                 target = root / fixture
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(source, target)
+            harness = Path("crates/evpn-linux/tests/docker/run-netns-tests.sh")
+            (root / harness).parent.mkdir(parents=True)
+            shutil.copy2(ROOT / harness, root / harness)
             installer = root / ".github" / "scripts" / "install-grpcurl.sh"
             installer.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(ROOT / installer.relative_to(root), installer)
@@ -138,6 +141,9 @@ class PrimerContractTests(unittest.TestCase):
             ".github/actions/stage-gobgp-artifact",
         ):
             shutil.copytree(ROOT / fixture, root / fixture)
+        harness = Path("crates/evpn-linux/tests/docker/run-netns-tests.sh")
+        (root / harness).parent.mkdir(parents=True)
+        shutil.copy2(ROOT / harness, root / harness)
         shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
         interop = root / "tests" / "interop"
         interop.mkdir(parents=True)
@@ -878,6 +884,35 @@ class PrimerContractTests(unittest.TestCase):
                     f"# {old}",
                     occurrence=2,
                 )
+
+    def test_kernel_netns_selector_contract_is_load_bearing(self):
+        workflow = ".github/workflows/kernel-dataplane.yml"
+        harness = "crates/evpn-linux/tests/docker/run-netns-tests.sh"
+        cases = (
+            (harness, "    -e EVPN_LINUX_NETNS=1", "    -e RUST_BACKTRACE=1"),
+            (harness, "    -e EVPN_LINUX_NETNS=1", ")\n-e EVPN_LINUX_NETNS=1\nDOCKER_ARGS+=("),
+            (harness, "    -e EVPN_LINUX_NETNS=1\n    -e RUST_BACKTRACE=1", "    -e EVPN_LINUX_NETNS=1\n    -e EVPN_LINUX_NETNS=0\n    -e RUST_BACKTRACE=1"),
+            (workflow, "run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier", "run: true"),
+            (workflow, "        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier", "        # run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier"),
+            (harness, 'ac_gate)            TEST_BIN="netns_ac_gate"', 'ac_gate)            TEST_BIN="netns_link_carrier"'),
+            (harness, 'ac_gate)            TEST_BIN="netns_ac_gate"; FILTER=""', 'ac_gate)            TEST_BIN="netns_ac_gate"; FILTER=""; TEST_BIN="netns_link_carrier"'),
+            (harness, 'ac_gate)            TEST_BIN="netns_ac_gate"; FILTER=""', 'ac_gate)            false; TEST_BIN="netns_ac_gate"; FILTER=""'),
+            (harness, 'nexthop_raw)        TEST_BIN="netns_nexthop_raw"', 'nexthop_raw)        TEST_BIN="netns_ac_gate"'),
+            (harness, "l2_foreign_takeover_row_survives_withdrawal_and_shutdown", "wrong_l2_filter"),
+            (workflow, "run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_nhid", "run: true"),
+            (workflow, "        if: steps.vrf.outputs.vrf-available == 'true'\n        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l3", "        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l3"),
+            (workflow, "        if: steps.vrf.outputs.vrf-available == 'true'\n        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l3", "        # if: steps.vrf.outputs.vrf-available == 'true'\n        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh foreign_state_l3"),
+            (harness, "linux_dataplane_route_event_wakes_within_2s", "wrong_route_event_filter"),
+        )
+        for relative, old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
+        with tempfile.TemporaryDirectory() as temporary:
+            self.stage_indexed_fixture(root := Path(temporary))
+            (root / harness).unlink()
+            workflow_path = root / workflow
+            workflow_path.write_text(workflow_path.read_text().replace("        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier", "        run: true"))
+            self.assertEqual(["netns harness is missing", "kernel-dataplane.yml:netns must invoke link_carrier once"], check(root))
 
     def test_destructive_workflow_seams(self):
         cases = (


### PR DESCRIPTION
## Summary

- run seven existing kernel netns selectors covering eleven existing tests in the current privileged job
- keep VRF-dependent L3 proofs behind the existing host capability gate
- pin selector mappings, invocation cardinality, and the EVPN_LINUX_NETNS=1 contract

## Verification

- all seven selectors and eleven real-kernel tests passed across the audited local ledger
- image-primer contract selftests and checker passed
- workspace tests, strict Clippy, warning-denied docs, and repository contracts passed

Linear: LAN-1216

LAN-1216 remains In Progress for the default-workspace soft-skip and VRF-receipt follow-ups.