### PR TITLE
Fix quickstart shutdown dispatch ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The Shutdown RPC now synchronously signals main's coordinated teardown watch
+  without sending directly to PeerManager. Quickstart timeout failures kill and
+  reap the daemon before preserving stderr and cleanup evidence; this removes
+  the proven pre-signal stall and order bypass without attributing historical
+  timeout latency. (LAN-1221)
 - Mixed daemon-owned and unmarked static Linux FDB contributors now classify foreign in either
   order; reconciliation relinquishes ownership once and preserves the operator row. (LAN-1218)
 - Startup now resolves validated policy and EVPN state and acquires BFD, BGP,

--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -60,7 +60,7 @@ impl ControlService {
     }
 
     /// Route health snapshots through the peer manager's read-only readiness
-    /// lane while retaining the ordinary sender for shutdown.
+    /// lane while retaining the ordinary sender as the health fallback.
     #[must_use]
     pub fn with_peer_manager_readiness(
         mut self,
@@ -149,14 +149,7 @@ impl proto::control_service_server::ControlService for ControlService {
         let reason = request.into_inner().reason;
         info!(reason = %reason, "shutdown requested via gRPC");
 
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let shutdown_tx = self.shutdown_tx.clone();
-
-        // Spawn the shutdown sequence so the RPC can return before we stop
-        tokio::spawn(async move {
-            let _ = peer_mgr_tx.send(PeerManagerCommand::Shutdown).await;
-            let _ = shutdown_tx.send(true);
-        });
+        let _ = self.shutdown_tx.send(true);
 
         Ok(Response::new(proto::ShutdownResponse {}))
     }
@@ -227,8 +220,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shutdown_takes_sender() {
-        let (peer_tx, _peer_rx) = mpsc::channel(16);
+    async fn shutdown_signals_watch_without_peer_manager_command() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        peer_tx.send(PeerManagerCommand::Shutdown).await.unwrap();
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
         let metrics = BgpMetrics::new();
@@ -242,17 +236,47 @@ mod tests {
             None,
         );
 
-        let resp = svc
-            .shutdown(Request::new(proto::ShutdownRequest {
+        let resp = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            svc.shutdown(Request::new(proto::ShutdownRequest {
                 reason: "test".into(),
-            }))
-            .await;
+            })),
+        )
+        .await
+        .expect("Shutdown RPC blocked on a full PeerManager channel");
         assert!(resp.is_ok());
+        assert!(
+            shutdown_rx
+                .has_changed()
+                .expect("shutdown watch sender remains open")
+        );
+        assert!(*shutdown_rx.borrow_and_update());
+        assert!(matches!(
+            peer_rx.recv().await,
+            Some(PeerManagerCommand::Shutdown)
+        ));
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            peer_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
 
-        // Give the spawned task a moment to fire
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        shutdown_rx.changed().await.unwrap();
-        assert!(*shutdown_rx.borrow());
+    #[test]
+    fn shutdown_body_is_synchronous_and_watch_only() {
+        let source = include_str!("control_service.rs");
+        let body = source
+            .split_once("    async fn shutdown(")
+            .unwrap()
+            .1
+            .split_once("    async fn trigger_mrt_dump(")
+            .unwrap()
+            .0;
+        let signal = body.find("self.shutdown_tx.send(true)").unwrap();
+        let response = body.find("Ok(Response::new").unwrap();
+        assert!(signal < response);
+        assert!(!body.contains("tokio::spawn"));
+        assert!(!body.contains("PeerManagerCommand::Shutdown"));
     }
 
     #[tokio::test]

--- a/docs/adr/0020-global-control-services-coordinated-shutdown.md
+++ b/docs/adr/0020-global-control-services-coordinated-shutdown.md
@@ -26,7 +26,8 @@ Options considered for shutdown coordination:
 
 ## Decision
 
-Implement both services and use two `oneshot` channels for shutdown coordination.
+Implement both services. The original two-`oneshot` design evolved into one
+tonic-stop `oneshot` plus a `watch<bool>` signal from ControlService to main.
 
 ### GlobalService
 
@@ -42,27 +43,31 @@ Implement both services and use two `oneshot` channels for shutdown coordination
   previously counted all configured peers and summed per-peer prefix counts.)
 - `GetMetrics` — gathers Prometheus text from the explicit `BgpMetrics` registry,
   reusing the same pattern as `metrics_server.rs`.
-- `Shutdown` — sends `PeerManagerCommand::Shutdown`, then fires the gRPC shutdown
-  oneshot. The shutdown sequence is spawned so the RPC can return a response before
-  the server stops.
+- `Shutdown` — after authorization and logging, synchronously sets only the
+  RPC-to-main shutdown watch. The handler neither spawns teardown nor sends
+  `PeerManagerCommand::Shutdown`; tonic remains available long enough for the
+  accepted in-flight response to complete.
 
 ### Coordinated shutdown
 
-Two oneshot channels:
-- `grpc_shutdown_tx/rx` — main fires this after PeerManager drains, stopping tonic.
-- `rpc_shutdown_tx/rx` — ControlService fires this from the Shutdown RPC.
+Two distinct channels:
+- `grpc_shutdown_tx/rx` — a oneshot main fires late in teardown to stop tonic.
+- `rpc_shutdown_tx/rx` — a `watch<bool>` ControlService sets to ask main to shut
+  down.
 
-Shutdown flow (ctrl-c path):
-1. `tokio::select!` on `ctrl_c()` and `rpc_shutdown_rx`
-2. Send `PeerManagerCommand::Shutdown` to PeerManager
-3. Await PeerManager `JoinHandle` (peers send NOTIFICATIONs, close TCP)
-4. Send `grpc_shutdown_tx` — tonic's `serve_with_shutdown` exits
-5. `run()` returns cleanly
+Signals, a true RPC watch value, and unexpected supervised component exits all
+enter main's common ordered shutdown path. Main closes admission and settles
+configuration work, fences EVPN runtime apply, and drains the EVPN originators,
+segment routes, and IMET routes while BGP sessions are still alive. It then
+sends the sole `PeerManagerCommand::Shutdown`, awaits peer teardown, drains the
+remaining local dataplane, BFD, and BMP owners, and only then fires
+`grpc_shutdown_tx` to stop tonic.
 
 Shutdown flow (RPC path):
-1. Shutdown RPC spawns: send `PeerManagerCommand::Shutdown`, then fire
-   `rpc_shutdown_tx`
-2. Main's `select!` detects `rpc_shutdown_rx`, enters the same drain sequence
+1. The authorized handler synchronously sets `rpc_shutdown_tx` and returns its
+   response; it does not spawn or directly shut down PeerManager.
+2. Main's `select!` observes the true watch value and enters the common ordered
+   path above.
 
 ## Consequences
 
@@ -70,10 +75,13 @@ Shutdown flow (RPC path):
 - All 5 proto services are now implemented — no more UNIMPLEMENTED surprises.
 - Peers receive proper Cease NOTIFICATIONs on shutdown.
 - gRPC server exits gracefully — in-flight RPCs can complete.
+- The watch-only handler removes the proven pre-signal bounded-channel stall and
+  teardown-order bypass. It does not attribute every historical quickstart
+  timeout to that path; other bounded shutdown stages remain independent.
 - No new dependencies.
 
 **Negative:**
 - `SetGlobal` returns UNIMPLEMENTED — callers must handle this. Documented as
   deferred; the proto already exists so the surface is stable.
-- `Shutdown` RPC has no authentication — any gRPC client can shut down the daemon.
-  Access control is a post-v1 concern (same as all other RPCs).
+- At adoption the `Shutdown` RPC had no authentication; current listeners
+  require mutating access before the watch-only dispatch.

--- a/tests/quickstart_dynamic_neighbor.rs
+++ b/tests/quickstart_dynamic_neighbor.rs
@@ -16,6 +16,12 @@ struct Daemon {
     stderr_path: PathBuf,
 }
 
+fn shutdown_timeout_message(daemon_stderr: &str, cleanup: &str) -> String {
+    format!(
+        "rustbgpd did not stop after rbgp shutdown\ncleanup: {cleanup}\ndaemon stderr:\n{daemon_stderr}"
+    )
+}
+
 impl Daemon {
     fn spawn(config_path: &Path, stderr_path: PathBuf) -> Self {
         let stderr = File::create(&stderr_path).expect("create daemon stderr log");
@@ -60,9 +66,11 @@ impl Daemon {
                 Err(_) => break,
             }
         }
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-        panic!("rustbgpd did not stop after rbgp shutdown");
+        let try_wait = self.child.try_wait();
+        let kill = self.child.kill();
+        let reap = self.child.wait();
+        let cleanup = format!("try_wait: {try_wait:?}; kill: {kill:?}; reap: {reap:?}");
+        panic!("{}", shutdown_timeout_message(&self.stderr(), &cleanup));
     }
 }
 
@@ -421,4 +429,23 @@ fn documented_passwordless_dynamic_neighbor_flow_works_for_both_starters() {
 
     run_starter("lab", &lab, &group_json, &commands);
     run_starter("minimal", &minimal, &group_json, &commands);
+}
+
+#[test]
+fn shutdown_timeout_diagnostic_is_ordered_and_preserves_evidence() {
+    let message = shutdown_timeout_message("stderr sentinel", "cleanup sentinel");
+    assert!(message.contains("stderr sentinel") && message.contains("cleanup sentinel"));
+    let source = include_str!("quickstart_dynamic_neighbor.rs");
+    let tail = source
+        .split_once("let deadline = Instant::now() + Duration::from_secs(5);")
+        .unwrap()
+        .1
+        .split_once("\n    }\n}")
+        .unwrap()
+        .0;
+    let kill = tail.find("self.child.kill()").unwrap();
+    let reap = tail.find("self.child.wait()").unwrap();
+    let panic = tail.find("panic!(").unwrap();
+    assert!(kill < reap && reap < panic);
+    assert!(tail.contains("try_wait") && tail.contains("&self.stderr()"));
 }


### PR DESCRIPTION
## Summary

- Signal the coordinated shutdown watch synchronously from the Shutdown RPC instead of queueing a direct PeerManager shutdown.
- Prove a full PeerManager channel cannot stall the RPC or receive a second shutdown command.
- Keep the quickstart five-second bound while killing and reaping timed-out daemons before reporting stderr and cleanup outcomes.

This removes the proven pre-signal stall and teardown-order bypass. It does not attribute historical quickstart timeout latency to that path.

## Verification

- Focused ControlService shutdown and quickstart diagnostic tests
- Exact real quickstart flow
- gRPC failure and common-shutdown integration tests
- Locked all-feature workspace tests
- Strict Clippy and warning-denied docs
- CI/release contracts and v1 stable-surface inventory
- Four destructive mutations for ordering, signaling, direct dispatch, and timeout evidence

Linear: LAN-1221
