### PR TITLE
test: prove IXP Manager Nagios generators include a rustbgpd route server

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -87,6 +87,17 @@ secret-free receipts/output. M97 adds two exact IPv4/IPv6 handles in one host
 namespace: distinct PIDs, state/UDS endpoints, TCP/179 listeners, and real
 MD5-FRR sessions, plus a shared durable host fence, paired competing-423
 behavior, sequential callbacks, and cross-handle failure containment.
+M98 proves the monitoring seam: both pinned v7.4 Nagios generators
+(`birdseye-daemons`, `birdseye-bgp-sessions`) filter routers on
+`api_type = Birdseye`, so an excluded route server is silently absent rather
+than an error. The oracle sets the fixture route server to that API type with
+the live adapter URL, renders both generators through the real controller, and
+asserts the router's host, service, and hostgroup membership plus both
+route-server client session services with the rendered alias names, then runs
+the pinned Bird's Eye daemon plugin against the emitted `_apiurl` and requires
+`OK` with a populated `Last Reconfigure` and the one configured, down session
+counted. Alerting content, thresholds, notification routing, and the session
+plugin against a live member session are not covered.
 Ambiguous remote or activation effects remain operator
 owned. Filter translation, custom-skin migration, and multi-address parity
 remain open.
@@ -135,6 +146,7 @@ dispatch always run.
 - **Live policy-presence safety** — ADR-0112 RFC 8212 import-presence transitions qualified for Route Refresh, rejected whole when one peer cannot converge, and converged on the wire when it can: **M95**.
 - **IXP Manager local activation** — pinned v7.4 Foil render, atomic publication, live settlement, and pre-effect restoration against MD5-authenticated FRR: **M96** (local).
 - **IXP Manager authenticated lifecycle** — pinned v7.4 API lock/fetch/callback state for two same-host IPv4/IPv6 handles, with shared-fence, database, and MD5-FRR proof: **M97** (local).
+- **IXP Manager Nagios monitoring** — pinned v7.4 `birdseye-daemons` and `birdseye-bgp-sessions` generators include the rustbgpd route server, and the pinned Bird's Eye daemon plugin reports `OK` with `Last Reconfigure` against the live adapter: **M98** (`ixp-compat.yml`).
 - **Graceful Shutdown** — receiver/initiator coverage across unicast, FlowSpec, and EVPN: **M35**, **M35b**, **M35c**.
 - **BLACKHOLE FIB discard** — RFC 7999 install/withdraw plus durable exact-prefix
   crash ownership and an unreceipted `proto bgp` negative: **M41**, **M62**.

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -47,6 +47,18 @@ direction. `api.version` remains
 identity, not Bird's Eye semantic-version compatibility. No full compatibility
 claim is made and `runtime_compatibility` remains false.
 
+The same live adapter also backs the pinned Nagios journey. IXP Manager's
+`birdseye-daemons` and `birdseye-bgp-sessions` generators filter routers on
+`api_type = Birdseye`, so an excluded route server is absent from generated
+monitoring rather than an error. The gate sets fixture router `b2-rs1-lan1-ipv4`
+to that API type with the adapter URL, renders both generators through the real
+`NagiosController`, and asserts the router's host, service, and hostgroup
+membership plus both route-server client session services named
+`pb_0001_as1213` and `pb_0004_as112`. It then runs the pinned Bird's Eye
+`nagios-check-birdseye.php` plugin against the emitted `_apiurl` and requires
+`OK` with a populated `Last Reconfigure` and the one configured, down session
+counted. Alerting content and thresholds are out of scope.
+
 The real pinned IXP Manager PHP extension also translates every defined
 `:1101:<id>` display entry from 1 through 15. The executable contract records
 the active route-server-template partition `1,3,5,6,7,8,9,10,13,14`, keeps

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -57,7 +57,10 @@ membership plus both route-server client session services named
 `pb_0001_as1213` and `pb_0004_as112`. It then runs the pinned Bird's Eye
 `nagios-check-birdseye.php` plugin against the emitted `_apiurl` and requires
 `OK` with a populated `Last Reconfigure` and the one configured, down session
-counted. Alerting content and thresholds are out of scope.
+counted. The step writes `nagios-monitoring.json` into the capture directory
+and prints one `nagios proof:` line on stderr; `verify_capture.py --nagios`
+fails the gate when that artifact is missing or drifted. Alerting content and
+thresholds are out of scope.
 
 The real pinned IXP Manager PHP extension also translates every defined
 `:1101:<id>` display entry from 1 through 15. The executable contract records

--- a/tests/compat/ixp-manager-birdseye/adapter-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/adapter-consumer.php
@@ -189,3 +189,4 @@ foreach ($responses as $journey => $response) {
 $responses['symbols'] = $symbols;
 
 echo json_encode($responses, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES) . "\n";
+fwrite(STDERR, "adapter proof: $protocol " . implode(', ', array_keys($responses)) . " verified\n");

--- a/tests/compat/ixp-manager-birdseye/config-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/config-consumer.php
@@ -11,13 +11,19 @@ $ixp = getenv('IXP_MANAGER_ROOT');
 require $ixp . '/vendor/autoload.php';
 $app = require $ixp . '/bootstrap/app.php';
 require_once $ixp . '/version.php';
-$app->make(Kernel::class)->bootstrap();
-// The console bootstrap renders uncaught exceptions to stdout and exits 0;
-// the gate must go red instead.
-set_exception_handler(static function (Throwable $exception): never {
+// IXP Manager's console bootstrap installs an exception handler that renders
+// to stdout and exits 0; the gate must go red instead, both for failures inside
+// bootstrap() and for everything after it.
+$die = static function (Throwable $exception): never {
     fwrite(STDERR, $exception . "\n");
     exit(1);
-});
+};
+try {
+    $app->make(Kernel::class)->bootstrap();
+} catch (Throwable $exception) {
+    $die($exception);
+}
+set_exception_handler($die);
 
 $output = rtrim((string)getenv('CAPTURE_OUTPUT'), '/');
 $router = Router::whereHandle('b2-rs1-lan1-ipv4')->firstOrFail();

--- a/tests/compat/ixp-manager-birdseye/config-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/config-consumer.php
@@ -12,6 +12,12 @@ require $ixp . '/vendor/autoload.php';
 $app = require $ixp . '/bootstrap/app.php';
 require_once $ixp . '/version.php';
 $app->make(Kernel::class)->bootstrap();
+// The console bootstrap renders uncaught exceptions to stdout and exits 0;
+// the gate must go red instead.
+set_exception_handler(static function (Throwable $exception): never {
+    fwrite(STDERR, $exception . "\n");
+    exit(1);
+});
 
 $output = rtrim((string)getenv('CAPTURE_OUTPUT'), '/');
 $router = Router::whereHandle('b2-rs1-lan1-ipv4')->firstOrFail();

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -53,6 +53,12 @@
     "defined_only_ids": [2, 4, 11, 12, 15],
     "fallback_id": 0
   },
+  "nagios_monitoring": {
+    "router_filter": "api_type = Birdseye",
+    "generators": ["birdseye-daemons", "birdseye-bgp-sessions"],
+    "daemon_check": "nagios-check-birdseye.php",
+    "session_protocol": "pb_{vlan_interface_id:04}_as{asn}"
+  },
   "runtime_compatibility": false,
   "manual_config_export": {
     "schema": "rustbgpd.ixp-manager.router-config/v2",

--- a/tests/compat/ixp-manager-birdseye/nagios-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/nagios-consumer.php
@@ -12,13 +12,19 @@ $ixp = getenv('IXP_MANAGER_ROOT');
 require $ixp . '/vendor/autoload.php';
 $app = require $ixp . '/bootstrap/app.php';
 require_once $ixp . '/version.php';
-$app->make(Kernel::class)->bootstrap();
-// The console bootstrap renders uncaught exceptions to stdout and exits 0;
-// the gate must go red instead.
-set_exception_handler(static function (Throwable $exception): never {
+// IXP Manager's console bootstrap installs an exception handler that renders
+// to stdout and exits 0; the gate must go red instead, both for failures inside
+// bootstrap() and for everything after it.
+$die = static function (Throwable $exception): never {
     fwrite(STDERR, $exception . "\n");
     exit(1);
-});
+};
+try {
+    $app->make(Kernel::class)->bootstrap();
+} catch (Throwable $exception) {
+    $die($exception);
+}
+set_exception_handler($die);
 
 $manifest = json_decode(
     file_get_contents(__DIR__ . '/contract.json'),

--- a/tests/compat/ixp-manager-birdseye/nagios-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/nagios-consumer.php
@@ -37,8 +37,9 @@ if ($handle !== 'b2-rs1-lan1-ipv4' || ($manifest['nagios_monitoring'] ?? null) !
 }
 $api = getenv('BIRDSEYE_API');
 $plugin = getenv('BIRDSEYE_ROOT') . '/bin/nagios-check-birdseye.php';
-if (!is_string($api) || $api === '' || !is_file($plugin)) {
-    throw new RuntimeException('BIRDSEYE_API and the pinned Bird\'s Eye checkout are required');
+$output = rtrim((string) getenv('CAPTURE_OUTPUT'), '/');
+if (!is_string($api) || $api === '' || !is_file($plugin) || !is_dir($output)) {
+    throw new RuntimeException('BIRDSEYE_API, CAPTURE_OUTPUT, and the pinned Bird\'s Eye checkout are required');
 }
 $fail = static function (string $message, string ...$raw): never {
     fwrite(STDERR, $message . "\n");
@@ -133,9 +134,17 @@ if ($check['up'] !== '0' || $check['total'] !== '1') {
     $fail('daemon check did not count the one configured, down session', $pluginOutput);
 }
 
-echo json_encode([
+$summary = json_encode([
+    'router_handle' => $handle,
     'daemon_host' => $host[0],
     'session_protocols' => $protocols,
     'daemon_check' => $pluginOutput,
     'last_reconfig' => $check['last_reconfig'],
 ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . "\n";
+$path = $output . '/nagios-monitoring.json';
+file_put_contents($path, $summary, LOCK_EX);
+chmod($path, 0600);
+echo $summary;
+fwrite(STDERR, "nagios proof: birdseye-daemons includes $handle; birdseye-bgp-sessions includes $handle"
+    . ' (protocols: ' . implode(', ', $protocols) . '); nagios-check-birdseye.php OK,'
+    . " Last Reconfigure {$check['last_reconfig']} populated\n");

--- a/tests/compat/ixp-manager-birdseye/nagios-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/nagios-consumer.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Http\Request;
+use IXP\Http\Controllers\Api\V4\NagiosController;
+use IXP\Models\Router;
+use IXP\Models\Vlan;
+
+$ixp = getenv('IXP_MANAGER_ROOT');
+require $ixp . '/vendor/autoload.php';
+$app = require $ixp . '/bootstrap/app.php';
+require_once $ixp . '/version.php';
+$app->make(Kernel::class)->bootstrap();
+// The console bootstrap renders uncaught exceptions to stdout and exits 0;
+// the gate must go red instead.
+set_exception_handler(static function (Throwable $exception): never {
+    fwrite(STDERR, $exception . "\n");
+    exit(1);
+});
+
+$manifest = json_decode(
+    file_get_contents(__DIR__ . '/contract.json'),
+    true,
+    512,
+    JSON_THROW_ON_ERROR,
+);
+$handle = $manifest['manual_config_export']['router_handle'] ?? null;
+if ($handle !== 'b2-rs1-lan1-ipv4' || ($manifest['nagios_monitoring'] ?? null) !== [
+    'router_filter' => 'api_type = Birdseye',
+    'generators' => ['birdseye-daemons', 'birdseye-bgp-sessions'],
+    'daemon_check' => 'nagios-check-birdseye.php',
+    'session_protocol' => 'pb_{vlan_interface_id:04}_as{asn}',
+]) {
+    throw new RuntimeException('Nagios monitoring contract drifted');
+}
+$api = getenv('BIRDSEYE_API');
+$plugin = getenv('BIRDSEYE_ROOT') . '/bin/nagios-check-birdseye.php';
+if (!is_string($api) || $api === '' || !is_file($plugin)) {
+    throw new RuntimeException('BIRDSEYE_API and the pinned Bird\'s Eye checkout are required');
+}
+$fail = static function (string $message, string ...$raw): never {
+    fwrite(STDERR, $message . "\n");
+    foreach ($raw as $dump) {
+        fwrite(STDERR, "--- raw output ---\n" . $dump . "\n");
+    }
+    exit(1);
+};
+
+// The pinned CI fixture ships this router as api_type None with no API URL,
+// exactly the row shape both generators silently exclude.
+$router = Router::whereHandle($handle)->firstOrFail();
+$router->api_type = Router::API_TYPE_BIRDSEYE;
+$router->api = $api;
+$router->save();
+$vlan = Vlan::findOrFail($router->vlan_id);
+$controller = new NagiosController();
+
+$daemons = $controller->birdseyeDaemons(Request::create('/'), 'default', $vlan);
+$daemonConfig = $daemons->getContent();
+if ($daemons->getStatusCode() !== 200
+    || !str_starts_with((string) $daemons->headers->get('Content-Type'), 'text/plain')) {
+    $fail('birdseye-daemons generator did not return text/plain 200', $daemonConfig);
+}
+if (!preg_match(
+    "/^define host\s+\{\n\s+use\s+ixp-manager-host-birdseye-daemon\n\s+host_name\s+bird-$handle\n"
+    . "\s+alias\s+(?<alias>.+)\n\s+address\s+(?<address>\S+)\n\s+_apiurl\s+(?<apiurl>\S+)\n\}$/m",
+    $daemonConfig,
+    $host,
+)) {
+    $fail("birdseye-daemons generator omitted router $handle", $daemonConfig);
+}
+if ($host['apiurl'] !== $api || $host['alias'] !== $router->name || $host['address'] !== $router->mgmt_host) {
+    $fail("birdseye-daemons host bird-$handle does not describe the live router", $daemonConfig);
+}
+if (!preg_match(
+    "/^define service\s+\{\n\s+use\s+ixp-manager-service-birdseye-daemon\n\s+host_name\s+bird-$handle\n\}$/m",
+    $daemonConfig,
+)) {
+    $fail("birdseye-daemons generator emitted no service for bird-$handle", $daemonConfig);
+}
+if (!preg_match('/^define hostgroup \{\n\s+hostgroup_name\s+bird-daemons-vlanid-' . $vlan->id . "\n.*?members\s+(?<members>.*?)\n\}/ms", $daemonConfig, $group)
+    || !in_array("bird-$handle", preg_split('/,\s*\\\\?\s*/', $group['members']), true)) {
+    $fail("birdseye-daemons hostgroup omitted bird-$handle", $daemonConfig);
+}
+
+$sessions = $controller->birdseyeBgpSessions(Request::create('/'), $vlan, (int) $router->protocol, (int) $router->type);
+$sessionConfig = $sessions->getContent();
+if ($sessions->getStatusCode() !== 200
+    || !str_starts_with((string) $sessions->headers->get('Content-Type'), 'text/plain')) {
+    $fail('birdseye-bgp-sessions generator did not return text/plain 200', $sessionConfig);
+}
+preg_match_all(
+    "/^define service\s+\{\n\s+use\s+ixp-manager-member-bgp-session-service\n\s+host_name\s+(?<host>\S+)\n"
+    . "\s+service_description\s+BGP session to $handle\n\s+_api_url\s+(?<apiurl>\S+)\n\s+_protocol\s+(?<protocol>\S+)\n\}$/m",
+    $sessionConfig,
+    $services,
+    PREG_SET_ORDER,
+);
+$protocols = array_column($services, 'protocol');
+sort($protocols);
+if ($protocols !== ['pb_0001_as1213', 'pb_0004_as112']) {
+    $fail("birdseye-bgp-sessions generator did not emit both route-server client sessions for $handle", $sessionConfig);
+}
+foreach ($services as $service) {
+    if ($service['apiurl'] !== $api) {
+        $fail("birdseye-bgp-sessions service {$service['host']} does not point at the live adapter", $sessionConfig);
+    }
+}
+if (!str_contains($sessionConfig, "hostgroup_name  birdseye-rs-bgp-sessions-vlanid-{$vlan->id}-ipv{$router->protocol}-$handle\n")) {
+    $fail("birdseye-bgp-sessions generator emitted no per-router hostgroup for $handle", $sessionConfig);
+}
+
+// Drive the pinned Bird's Eye daemon plugin exactly as Nagios would: with the
+// _apiurl the generator emitted, not the URL this script configured.
+exec(
+    'php ' . escapeshellarg($plugin) . ' -a ' . escapeshellarg($host['apiurl']) . ' 2>&1',
+    $pluginLines,
+    $pluginStatus,
+);
+$pluginOutput = implode("\n", $pluginLines);
+if ($pluginStatus !== 0 || !preg_match(
+    "/^OK: Bird (?<daemon>rustbgpd \S+)\. Bird's Eye (?<api>rustbgpd \S+)\. Router ID (?<router_id>\S+)\. "
+    . "Uptime: \d+ days\. Last Reconfigure: (?<last_reconfig>\d{4}-\d\d-\d\d \d\d:\d\d:\d\d)\."
+    . "(?<up>\d+) BGP sessions up of (?<total>\d+)\.$/",
+    $pluginOutput,
+    $check,
+)) {
+    $fail("pinned nagios-check-birdseye.php did not report OK (exit $pluginStatus)", $pluginOutput, $daemonConfig);
+}
+if ($check['up'] !== '0' || $check['total'] !== '1') {
+    $fail('daemon check did not count the one configured, down session', $pluginOutput);
+}
+
+echo json_encode([
+    'daemon_host' => $host[0],
+    'session_protocols' => $protocols,
+    'daemon_check' => $pluginOutput,
+    'last_reconfig' => $check['last_reconfig'],
+], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . "\n";

--- a/tests/compat/ixp-manager-birdseye/run-adapter-consumer.sh
+++ b/tests/compat/ixp-manager-birdseye/run-adapter-consumer.sh
@@ -7,6 +7,7 @@ ixp_manager=${1:?IXP Manager checkout is required}
 image=${2:?PHP contract image is required}
 birdseye=${3:?Birdseye checkout is required}
 database=${4:?IXP Manager MySQL address is required}
+capture_output=${CAPTURE_OUTPUT:?capture output directory is required}
 tmp=$(mktemp -d)
 daemon_pid=
 adapter_pid=
@@ -125,7 +126,9 @@ docker run --rm --network host --user "$(id -u):$(id -g)" \
   --env BIRDSEYE_API="http://127.0.0.1:$port" \
   --env DB_HOST="$database" \
   --env DB_DATABASE=ixp_ci --env DB_USERNAME=root --env DB_PASSWORD= \
+  --env CAPTURE_OUTPUT=/capture-output \
   --volume "$root:/harness:ro" \
   --volume "$ixp_manager:/upstreams/ixp-manager" \
   --volume "$birdseye:/upstreams/birdseye:ro" \
+  --volume "$capture_output:/capture-output" \
   "$image" php /harness/nagios-consumer.php

--- a/tests/compat/ixp-manager-birdseye/run-adapter-consumer.sh
+++ b/tests/compat/ixp-manager-birdseye/run-adapter-consumer.sh
@@ -5,6 +5,8 @@ root=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 repo=$(CDPATH='' cd -- "$root/../../.." && pwd)
 ixp_manager=${1:?IXP Manager checkout is required}
 image=${2:?PHP contract image is required}
+birdseye=${3:?Birdseye checkout is required}
+database=${4:?IXP Manager MySQL address is required}
 tmp=$(mktemp -d)
 daemon_pid=
 adapter_pid=
@@ -110,3 +112,20 @@ if grep -q 'secret_member\|secret_peer' "$tmp/adapter.log"; then
   exit 1
 fi
 run_consumer pb_reloaded_as64496
+
+# Both pinned Nagios generators filter routers on api_type = Birdseye, so an
+# excluded route server is simply absent from generated monitoring. Point the
+# fixture router at the live adapter, render both generators, then run the
+# pinned daemon plugin against the _apiurl the generator emitted. The host
+# network namespace reaches both the loopback adapter and the MySQL bridge
+# address; the pinned IXP Manager database config has no port knob.
+docker run --rm --network host --user "$(id -u):$(id -g)" \
+  --env IXP_MANAGER_ROOT=/upstreams/ixp-manager \
+  --env BIRDSEYE_ROOT=/upstreams/birdseye \
+  --env BIRDSEYE_API="http://127.0.0.1:$port" \
+  --env DB_HOST="$database" \
+  --env DB_DATABASE=ixp_ci --env DB_USERNAME=root --env DB_PASSWORD= \
+  --volume "$root:/harness:ro" \
+  --volume "$ixp_manager:/upstreams/ixp-manager" \
+  --volume "$birdseye:/upstreams/birdseye:ro" \
+  "$image" php /harness/nagios-consumer.php

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -242,5 +242,6 @@ test supported-leading-set-fails-closed {
 
 mysql_address=$(docker inspect \
   --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$mysql")
-"$root/run-adapter-consumer.sh" "$tmp/ixp-manager" "$image" "$tmp/birdseye" \
-  "$mysql_address" >/dev/null
+CAPTURE_OUTPUT="$capture_output" "$root/run-adapter-consumer.sh" \
+  "$tmp/ixp-manager" "$image" "$tmp/birdseye" "$mysql_address" >/dev/null
+python3 "$root/verify_capture.py" --nagios "$capture_output/nagios-monitoring.json"

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -240,4 +240,7 @@ test supported-leading-set-fails-closed {
     expect client-1-receive == error absent-prepend-operand
 }'
 
-"$root/run-adapter-consumer.sh" "$tmp/ixp-manager" "$image" >/dev/null
+mysql_address=$(docker inspect \
+  --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$mysql")
+"$root/run-adapter-consumer.sh" "$tmp/ixp-manager" "$image" "$tmp/birdseye" \
+  "$mysql_address" >/dev/null

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -3,6 +3,7 @@ import difflib
 import json
 import os
 from pathlib import Path
+import re
 import sys
 
 EXPECTED = {
@@ -166,7 +167,6 @@ def fail(message: str) -> None:
 
 
 root = Path(__file__).resolve().parent
-capture = Path(sys.argv[1])
 manifest = json.loads((root / "contract.json").read_text())
 if manifest.get("runtime_compatibility") is not False:
     fail("contract oracle must not promote a runtime compatibility claim")
@@ -208,6 +208,30 @@ if manifest.get("protocol_aliases") != {
 if manifest.get("routing_tables") != ["master4"]:
     fail("live routing-table identity drifted")
 
+if sys.argv[1] == "--nagios":
+    # The live-adapter leg writes this after both pinned Nagios generators and
+    # the pinned daemon plugin ran; a missing or drifted file means the step
+    # did not execute, which is exactly the silent failure under test.
+    summary = json.loads(Path(sys.argv[2]).read_text())
+    handle = MANUAL_CONFIG_EXPORT["router_handle"]
+    if summary.get("router_handle") != handle:
+        fail("nagios capture: router handle drifted")
+    if f"host_name               bird-{handle}\n" not in summary.get("daemon_host", ""):
+        fail("nagios capture: birdseye-daemons host stanza omitted the router")
+    if summary.get("session_protocols") != ["pb_0001_as1213", "pb_0004_as112"]:
+        fail("nagios capture: birdseye-bgp-sessions client protocols drifted")
+    if not re.fullmatch(
+        r"OK: Bird rustbgpd \S+\. Bird's Eye rustbgpd \S+\. Router ID \S+\. "
+        r"Uptime: \d+ days\. Last Reconfigure: \d{4}-\d\d-\d\d \d\d:\d\d:\d\d\."
+        r"0 BGP sessions up of 1\.",
+        summary.get("daemon_check", ""),
+    ):
+        fail("nagios capture: pinned nagios-check-birdseye.php line drifted")
+    if not summary.get("last_reconfig"):
+        fail("nagios capture: daemon check Last Reconfigure is empty")
+    sys.exit(0)
+
+capture = Path(sys.argv[1])
 if len(sys.argv) == 3:
     config_capture = Path(sys.argv[2])
     default_asns = MANUAL_CONFIG_EXPORT["no_transit"]["default_asns"]

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -76,6 +76,12 @@ REJECT_REASONS = {
     "defined_only_ids": [2, 4, 11, 12, 15],
     "fallback_id": 0,
 }
+NAGIOS_MONITORING = {
+    "router_filter": "api_type = Birdseye",
+    "generators": ["birdseye-daemons", "birdseye-bgp-sessions"],
+    "daemon_check": "nagios-check-birdseye.php",
+    "session_protocol": "pb_{vlan_interface_id:04}_as{asn}",
+}
 MANUAL_CONFIG_EXPORT = {
     "schema": "rustbgpd.ixp-manager.router-config/v2",
     "ixp_manager_version": "7.4.0",
@@ -180,6 +186,8 @@ if manifest.get("reject_reasons") != REJECT_REASONS:
     fail("pinned reject-reason display or active partition drifted")
 if manifest.get("manual_config_export") != MANUAL_CONFIG_EXPORT:
     fail("strict manual v2 export contract drifted")
+if manifest.get("nagios_monitoring") != NAGIOS_MONITORING:
+    fail("pinned Nagios monitoring contract drifted")
 consumer_source = (root / "config-consumer.php").read_text()
 for required in [
     "$router->template = 'api/v4/router/server/bird2/standard';",


### PR DESCRIPTION
## Summary

Adds a Nagios monitoring step to the pinned IXP Manager v7.4.0 / Bird's Eye v2.1.0 contract oracle (`tests/compat/ixp-manager-birdseye/`). Both upstream Nagios generators filter routers on `api_type = Birdseye`, so a route server that does not pass that filter is silently absent from generated monitoring rather than producing an error. Until now nothing proved a rustbgpd route server passes it.

## What is proven

- The fixture router `b2-rs1-lan1-ipv4` (shipped by upstream's CI dump as `api_type = None`, `api = NULL`) is set to `api_type = Birdseye` with its API URL pointing at the live `birdwatcher-adapter` the harness already stands up, through the real Eloquent model.
- `NagiosController::birdseyeDaemons` (template `default`, scoped to the router's VLAN) returns `text/plain` 200 and the output contains the router: the `bird-b2-rs1-lan1-ipv4` host stanza whose `_apiurl` equals the live adapter URL and whose `alias`/`address` match the router row, a `define service` for that host, and `bird-b2-rs1-lan1-ipv4` in the `bird-daemons-vlanid-1` hostgroup members.
- `NagiosController::birdseyeBgpSessions` (VLAN 1, IPv4, route server) returns `text/plain` 200 and the output contains exactly the two route-server client session services for `BGP session to b2-rs1-lan1-ipv4`, `_protocol pb_0001_as1213` and `pb_0004_as112` (the same names `rs-config-render` writes to the Birdwatcher alias file), each with `_api_url` equal to the live adapter URL, plus the per-router hostgroup `birdseye-rs-bgp-sessions-vlanid-1-ipv4-b2-rs1-lan1-ipv4`.
- The pinned Bird's Eye Nagios daemon plugin `bin/nagios-check-birdseye.php` is executed with the `_apiurl` taken from the generated daemon config (not from the harness variable) and must exit 0 with `OK: ... Last Reconfigure: <YYYY-MM-DD HH:MM:SS>.0 BGP sessions up of 1.` — `last_reconfig` populated and parseable, the one configured (down) session counted.
- Containment is asserted on the generated text, not on HTTP status: other fixture routers already carry `api_type = Birdseye`, so both generators return 200 whether or not this router is included.

The step runs in the existing `ixp-compat.yml` job via `run.sh` → `run-adapter-consumer.sh`; no new workflow. The MySQL container now also publishes an ephemeral loopback port so the host-network PHP container can reach both the database and the adapter.

## Deliberate red

Locally, with the consumer temporarily setting the router to `api_type = Other` (not committed), the oracle exits 1 at the new step:

```
birdseye-daemons generator omitted router b2-rs1-lan1-ipv4
--- raw output ---
# ... generated birdseye-daemons config follows ...
```

That raw output is a complete HTTP 200 daemon config listing the ten other fixture routers that already carry `api_type = Birdseye` (`bird-as112-lan1-ipv4`, `bird-b2-rc1-lan1-ipv4`, `bird-rs1-lan1-ipv6`, ...) and no `bird-b2-rs1-lan1-ipv4` — the silent-exclusion failure mode under test. After restoring the consumer the oracle is green again.

Two defects were found and fixed in the step itself while proving it:

- The pinned IXP Manager `config/database.php` has no `port` knob, so publishing MySQL on an ephemeral host port cannot work; the host-network PHP container now reaches MySQL at its bridge address on 3306 instead.
- IXP Manager's console bootstrap renders an uncaught exception to stdout and exits 0, which turned a database connection failure into a green run. Both Laravel-bootstrapped consumers (`nagios-consumer.php`, `config-consumer.php`) now wrap `bootstrap()` itself in try/catch and install the same stderr-and-exit-1 handler afterwards, so a failure during bootstrap (after the `HandleExceptions` bootstrapper installs IXP Manager's handler) and a failure after bootstrap both go red. Proven locally with a poisoned `bootstrap/cache/packages.php` that throws during `RegisterProviders`: the previous consumers exit 0 with the rendered box on stdout and nothing on stderr; the amended ones exit 1 with `RuntimeException: induced bootstrap failure …` on stderr and empty stdout. `adapter-consumer.php` and `consumer.php` only build a bare container and never bootstrap, so PHP's default uncaught-exception exit (255) already fails them.

Green evidence from the same local run (stdout of the consumer):

```
"daemon_host": "define host     {\n        use                     ixp-manager-host-birdseye-daemon\n        host_name               bird-b2-rs1-lan1-ipv4\n        alias                   Bird2 - INEX LAN1 - Route Server - IPv4\n        address                 203.0.113.18\n        _apiurl                 http://127.0.0.1:35127\n}",
"session_protocols": ["pb_0001_as1213", "pb_0004_as112"],
"daemon_check": "OK: Bird rustbgpd 0.65.0. Bird's Eye rustbgpd 0.65.0. Router ID 10.0.0.1. Uptime: 0 days. Last Reconfigure: 2026-08-22 14:55:05.0 BGP sessions up of 1."
```

## Loud on success

The step writes `nagios-monitoring.json` (router handle, daemon host stanza, session protocols, plugin line, `last_reconfig`) into the capture directory and prints one line on stderr, e.g.

```
nagios proof: birdseye-daemons includes b2-rs1-lan1-ipv4; birdseye-bgp-sessions includes b2-rs1-lan1-ipv4 (protocols: pb_0001_as1213, pb_0004_as112); nagios-check-birdseye.php OK, Last Reconfigure 2026-08-22 15:21:43 populated
```

`run.sh` then runs `verify_capture.py --nagios <capture>/nagios-monitoring.json`, which fails when the artifact is missing, names a different router, lacks the two client protocols, or carries a plugin line that is not `OK … Last Reconfigure <timestamp>.0 BGP sessions up of 1.` The adapter consumer prints a matching `adapter proof:` line for each of its three journeys, since its stdout is also discarded.

## Not proven

- Alerting content, thresholds, notification routing, or any Nagios runtime behaviour.
- The per-session plugin (`nagios-check-birdseye-bgp-sessions.php`) against a live member session: the harness peer is a configured, down session under a different alias, so only the session generator's output is asserted.
- The authenticated HTTP route (`/api/v4/nagios/...` with an API key); the controller methods are invoked directly, as the manual-configuration leg already does with `ConfigurationGenerator`.
- Any other VLAN, protocol, router type, or custom skin template.

## Gates

- `tests/compat/ixp-manager-birdseye/run.sh` end to end: green on the committed harness (two consecutive local runs), red with the deliberate `api_type = Other` negative, green again after restoring it.
- `cargo fmt --all -- --check`: clean.
- `cargo test --workspace --no-fail-fast`: exit 101 in two full runs on a host shared with four other concurrent cargo builds (load average ~15): 8010 passed / 2 failed each time, and the failures rotate among wall-clock-bound tests — `tools/rs-config-render/tests/activation.rs` `started_failure_timeout_and_unsettled_retain_candidate_without_rollback` (`started.elapsed() < 4s`; 3.7–4.5 s across six isolated reruns, passing once) in both runs, `tests/config_persistence_lifecycle.rs` `config_persistence_history_rollback_and_commit_confirm_hold_on_the_wire` in the first (passes in isolation), `tests/runtime_config_settlement_matrix.rs` `runtime_config_settlement_matrix_four_rows_three_cycles` in the second. This change touches no Rust, so every test binary is identical to `main`.
- `python3 scripts/check_public_tracker_ids.py`: clean.
- No Rust or workflow files changed, so clippy / clippy-reasons / YAML validation are not applicable.
