### PR TITLE
docs: align the Birdwatcher adapter README and RECEIPTS with the IXP Manager contract

### DIFF
--- a/.github/workflows/public-docs-contract.yml
+++ b/.github/workflows/public-docs-contract.yml
@@ -16,6 +16,10 @@ on:
       - SUPPORT.md
       - scripts/check_public_tracker_ids.py
       - scripts/test_check_public_tracker_ids.py
+      - examples/birdwatcher-adapter/README.md
+      - tests/compat/ixp-manager-birdseye/contract.json
+      - scripts/check_ixp_manager_docs.py
+      - scripts/test_check_ixp_manager_docs.py
       - .github/workflows/public-docs-contract.yml
   pull_request:
     paths: *paths
@@ -32,3 +36,7 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_public_tracker_ids.py
           python3 scripts/check_public_tracker_ids.py
+      - name: Check IXP Manager docs against the pinned contract
+        run: |
+          python3 -m unittest -v scripts/test_check_ixp_manager_docs.py
+          python3 scripts/check_ixp_manager_docs.py

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -83,6 +83,7 @@ id matches the milestone. Full procedures: [`INTEROP.md`](INTEROP.md).
 | M93 | Exact required-family OPEN 2/7 rejection, dual-stack recovery, and empty-requirement partial-negotiation compatibility | BIRD 2.0.12 |
 | M94 | RFC 6793 legacy ingress reconstruction, semantic loop rejection, exact type 2/17 + type 7/18 egress, withdrawal, and session continuity | ExaBGP 5.0.9 source + independent Python OLD-speaker sink |
 | M95 | ADR-0112 live RFC 8212 policy-presence transitions: Route Refresh qualification, whole-edit rejection with nothing mutated, real refresh convergence in both directions, and GR-stale deferral | FRR 10.3.1 + BIRD 2.0.12 (Route Refresh disabled) |
+| M98 | [IXP Manager Nagios monitoring](INTEROP.md#ixp-manager-v74-manual-configuration-oracle): the pinned v7.4 `birdseye-daemons` and `birdseye-bgp-sessions` generators include the rustbgpd route server (host, service, hostgroup, both client session services with rendered alias names), and the pinned Bird's Eye daemon plugin reports `OK` with `Last Reconfigure` against the live adapter; gated by `ixp-compat.yml` | IXP Manager v7.4.0 + Bird's Eye v2.1.0 plugin + live `birdwatcher-adapter` |
 
 ## Interop labs — kernel dataplane, PR + nightly (`kernel-dataplane.yml`)
 
@@ -139,6 +140,8 @@ covered by later CI receipts). Procedures and results:
 | M32 / M32b | EVPN multi-homing Type 1 EAD + Type 4 ES reflection (kernel bond / synthetic ESI) | FRR 10.3.1 ×3 |
 | M33 | EVPN RR scale: 50k Type 2 routes + 60 s of 1000/s churn | in-tree `bench/evpn-load` |
 | M90 | ADR-0110 filtering differential: one arouteserver site produces BIRD and rustbgpd policy, with exact verdict/explain parity over 11 announcements and a red-producing policy mutation | BIRD 2.0.12 + GoBGP 3.37.0 ×3 + arouteserver 1.23.2 |
+| M96 | [IXP Manager local activation](INTEROP.md#ixp-manager-v74-manual-configuration-oracle): the pinned v7.4 Foil capture through the real renderer/strict checker, then atomic initial, no-op, hot-reload, and pre-effect spawn-failure restoration with exact prior bytes, unchanged daemon PID, and session continuity | FRR 10.3.1 (TCP MD5) + pinned IXP Manager v7.4.0 capture |
+| M97 | [IXP Manager authenticated lifecycle](INTEROP.md#ixp-manager-v74-manual-configuration-oracle): pinned v7.4 API lock/fetch/callback state for two same-host IPv4/IPv6 handles with distinct PIDs, state/UDS endpoints, and TCP/179 listeners, plus a shared durable host fence, paired competing-423 behavior, sequential callbacks, and cross-handle failure containment | FRR 10.3.1 (TCP MD5) + IXP Manager v7.4.0 + MySQL 8.4 |
 
 ## Performance and scale receipts
 

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -179,13 +179,33 @@ unknown identities return 404, and daemon failures return a sanitized 502.
 
 This is deliberately partial IXP Manager support: status, live BGP inventory
 and detail, protocol symbols, member received routes, and member exported
-routes, including exact protocol/export lookup, are available. The exact
-filtered-prefix wildcard journey described below and a single-prefix
-less-specific table search are also available. The table name validates the
-live routing-table identity over rustbgpd's one global Loc-RIB; it is not an
-independent table selector. Full table snapshots, counts, other
-large-community wildcard queries, and the complete reject-reason inventory are
-not implemented; the adapter does not claim full Bird's Eye compatibility.
+routes are available, and the boundary is the executable contract in
+[`tests/compat/ixp-manager-birdseye/contract.json`](../../tests/compat/ixp-manager-birdseye/contract.json)
+(`runtime_supported` / `unsupported`). The table below is checked against that
+contract by `scripts/check_ixp_manager_docs.py`, so the two cannot drift
+silently:
+
+| Contract capability | Status | Adapter surface |
+|---|---|---|
+| `exact-protocol-route` | supported | `/route/{prefix}/protocol/{id}`: exact prefix on every gRPC page, every Add-Path candidate in daemon order |
+| `exact-export-route` | supported | `/route/{prefix}/export/{id}`: the same discipline over the Adj-RIB-Out |
+| `filtered-prefix-wildcard` | supported | `/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`, answered from the session's retained rejects only |
+| `less-specific-longest-prefix-match` | supported | `/route/{prefix}/table/{table}`: one bounded longest-prefix lookup |
+| `atomic-full-table-snapshot` | supported | `/routes/table/{table}`: accepted candidates joined with installed winners under one Received/Best generation; refuses rather than truncates |
+| `atomic-all-candidate-prefix-snapshot` | supported | the table lookup returns the installed winner first and every same-prefix alternative in one response |
+| `file-backed-runtime-protocol-alias-reconfiguration` | supported | `--protocol-alias-file`, replaced as one resolver generation on `SIGHUP` |
+| `active-rejected-route-reason-inventory` | supported | the ten template-active `{daemon ASN}:1101:<id>` reasons tabulated below |
+| `live-session-transport-detail` | supported | `source_address`, `keepalive`, `connection`, `bgp_session` from one `ListNeighbors` snapshot |
+| `full-table-count` | unsupported | no count endpoints; the full-table view does not add counts |
+| `direct-runtime-protocol-alias-reconfiguration` | unsupported | `--protocol-alias` values are startup-only and do not reload |
+| `live-hold-keepalive-countdowns` | unsupported | `hold_timer_now` / `keepalive_now` are never fabricated |
+| `defined-only-rejected-route-reason-emission` | unsupported | the five display-only reason ids are never emitted; such causes fall back to `0` |
+| `full-ixp-manager-ui-filter-policy-engine` | unsupported | only the bounded `rs-config-render` manual-export subset exists |
+
+Other large-community wildcard queries return an empty route array. The table
+name validates the live routing-table identity over rustbgpd's one global
+Loc-RIB; it is not an independent table selector. The adapter does not claim
+full Bird's Eye compatibility.
 
 IXP Manager v7.4 queries member-filtered prefixes through
 `/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`. The adapter answers only
@@ -201,18 +221,37 @@ positive eviction count marks retained loss without hiding retained rows.
 Each returned route carries exactly one synthesized `{daemon ASN}:1101:<id>`
 reason. Before adding it, the adapter removes every wire-supplied community in
 that reserved namespace, preventing a member from forging the displayed
-reason while preserving unrelated large communities. Mapping is deliberately
+reason while preserving unrelated large communities. The emitted ids are
+exactly the ten active in the pinned IXP Manager v7.4 route-server templates
+(`reject_reasons.active_ids` in the contract); generated-policy causes require
+the exact renderer policy/term identity, and mapping is deliberately
 conservative:
 
-| Retained cause | IXP Manager reason id |
-|---|---:|
-| `.rpol` term `reject-too-specific` | 1 |
-| `.rpol` term `reject-non-global` | 3 |
-| first-AS mismatch | 7 |
-| strict next-hop ownership | 8 |
-| `.rpol` term `reject-rpki-invalid` with invalid RPKI state | 13 |
-| `.rpol` term `reject-transit-leak` | 14 |
-| any other or ambiguous cause | 0 |
+| Retained cause | IXP Manager reason id | Bird's Eye display |
+|---|---:|---|
+| `.rpol` term `ixp-manager-hygiene:reject-too-specific` | 1 | PREFIX LENGTH TOO LONG |
+| `.rpol` term `reject-special-purpose:reject-non-global` | 3 | BOGON |
+| `.rpol` term `ixp-manager-hygiene:reject-as-path-too-long` | 5 | AS PATH TOO LONG |
+| `.rpol` term `ixp-manager-hygiene:reject-as-path-too-short`, or first-AS treat-as-withdraw on an empty AS_PATH | 6 | AS PATH TOO SHORT |
+| first-AS mismatch: treat-as-withdraw, or generated `client-<id>:reject-first-as-not-peer-as` | 7 | FIRST AS NOT PEER AS |
+| strict next-hop ownership | 8 | NEXT HOP NOT PEER IP |
+| generated `client-<id>:reject-irrdb-prefix-filtered` | 9 | IRRDB PREFIX FILTERED |
+| generated `client-<id>:reject-irrdb-origin-as-filtered` | 10 | IRRDB ORIGIN AS FILTERED |
+| `.rpol` term `ixp-manager-hygiene:reject-rpki-invalid` with invalid RPKI state | 13 | RPKI INVALID |
+| `.rpol` term `ixp-manager-hygiene:reject-transit-leak` | 14 | TRANSIT FREE ASN |
+| any other or ambiguous cause | 0 | (fallback; IXP Manager leaves it untranslated) |
+
+The five ids the pinned templates define but never set
+(`reject_reasons.defined_only_ids`) are display-only: the adapter never emits
+them, and such causes fall back to `0` rather than gaining invented semantics:
+
+| Defined-only id | Bird's Eye display | Emitted as |
+|---:|---|---:|
+| 2 | PREFIX LENGTH TOO SHORT | 0 |
+| 4 | BOGON ASN | 0 |
+| 11 | PREFIX NOT IN ORIGIN AS | 0 |
+| 12 | RPKI UNKNOWN | 0 |
+| 15 | TOO MANY COMMUNITIES | 0 |
 
 ## Filtered routes and reject reasons
 

--- a/scripts/check_ixp_manager_docs.py
+++ b/scripts/check_ixp_manager_docs.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Fail closed when the IXP Manager documentation drifts from its contract.
+
+Three documents restate facts that `tests/compat/ixp-manager-birdseye/contract.json`
+pins executably, and each has drifted silently before:
+
+- the Birdwatcher adapter README's reason-id tables versus
+  `reject_reasons.active_ids` / `defined_only_ids` / `fallback_id` / `display`;
+- the same README's capability table versus `runtime_supported` / `unsupported`;
+- `docs/RECEIPTS.md`, which must carry a row for every M-series receipt that
+  `docs/INTEROP.md` claims in its IXP Manager sections.
+
+The checks parse the markdown tables positively; an absent table or an empty
+M-number set is itself a failure, because a guard that cannot fail is worse
+than no guard.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "tests" / "compat" / "ixp-manager-birdseye" / "contract.json"
+README = ROOT / "examples" / "birdwatcher-adapter" / "README.md"
+INTEROP = ROOT / "docs" / "INTEROP.md"
+RECEIPTS = ROOT / "docs" / "RECEIPTS.md"
+
+REASON_HEADER = ("Retained cause", "IXP Manager reason id", "Bird's Eye display")
+DEFINED_ONLY_HEADER = ("Defined-only id", "Bird's Eye display", "Emitted as")
+CAPABILITY_HEADER = ("Contract capability", "Status", "Adapter surface")
+M_NUMBER = re.compile(r"\bM\d+[a-z]?\b")
+HEADING = re.compile(r"^(#+)\s+(.*)$")
+
+
+def _cells(line: str) -> tuple[str, ...]:
+    return tuple(cell.strip() for cell in line.strip().strip("|").split("|"))
+
+
+def table_rows(document: str, header: tuple[str, ...]) -> list[tuple[str, ...]] | None:
+    """Body rows of the one markdown table whose header row is `header`."""
+    lines = document.splitlines()
+    starts = [i for i, line in enumerate(lines) if _cells(line) == header]
+    if len(starts) != 1:
+        return None
+    rows: list[tuple[str, ...]] = []
+    for line in lines[starts[0] + 2 :]:  # skip the |---| separator
+        if not line.lstrip().startswith("|"):
+            break
+        rows.append(_cells(line))
+    return rows
+
+
+def check_reason_ids(readme: str, contract: dict) -> list[str]:
+    reasons = contract["reject_reasons"]
+    display = {int(k): v for k, v in reasons["display"].items()}
+    active = set(reasons["active_ids"])
+    defined_only = set(reasons["defined_only_ids"])
+    fallback = reasons["fallback_id"]
+    errors: list[str] = []
+
+    rows = table_rows(readme, REASON_HEADER)
+    if rows is None:
+        return [f"README reason-id table with header {REASON_HEADER} not found exactly once"]
+    seen: dict[int, str] = {}
+    for row in rows:
+        if len(row) != 3 or not row[1].isdigit():
+            errors.append(f"README reason-id row is malformed: {row}")
+            continue
+        seen[int(row[1])] = row[2]
+    if fallback not in seen:
+        errors.append(f"README reason-id table has no fallback row for id {fallback}")
+    tabulated = set(seen) - {fallback}
+    if tabulated != active:
+        errors.append(
+            "README reason-id table ids do not match contract active_ids: "
+            f"table={sorted(tabulated)} contract={sorted(active)}"
+        )
+    for reason_id in sorted(tabulated & active):
+        if seen[reason_id] != display[reason_id]:
+            errors.append(
+                f"README reason id {reason_id} displays {seen[reason_id]!r}, "
+                f"contract says {display[reason_id]!r}"
+            )
+
+    rows = table_rows(readme, DEFINED_ONLY_HEADER)
+    if rows is None:
+        return errors + [
+            f"README defined-only table with header {DEFINED_ONLY_HEADER} not found exactly once"
+        ]
+    seen = {}
+    for row in rows:
+        if len(row) != 3 or not row[0].isdigit() or not row[2].isdigit():
+            errors.append(f"README defined-only row is malformed: {row}")
+            continue
+        seen[int(row[0])] = row[1]
+        if int(row[2]) != fallback:
+            errors.append(f"README defined-only id {row[0]} is emitted as {row[2]}, not {fallback}")
+    if set(seen) != defined_only:
+        errors.append(
+            "README defined-only table ids do not match contract defined_only_ids: "
+            f"table={sorted(seen)} contract={sorted(defined_only)}"
+        )
+    for reason_id in sorted(set(seen) & defined_only):
+        if seen[reason_id] != display[reason_id]:
+            errors.append(
+                f"README defined-only id {reason_id} displays {seen[reason_id]!r}, "
+                f"contract says {display[reason_id]!r}"
+            )
+    return errors
+
+
+def check_capabilities(readme: str, contract: dict) -> list[str]:
+    rows = table_rows(readme, CAPABILITY_HEADER)
+    if rows is None:
+        return [f"README capability table with header {CAPABILITY_HEADER} not found exactly once"]
+    errors: list[str] = []
+    status: dict[str, str] = {}
+    for row in rows:
+        if len(row) != 3 or not (row[0].startswith("`") and row[0].endswith("`")):
+            errors.append(f"README capability row is malformed: {row}")
+            continue
+        if row[1] not in ("supported", "unsupported"):
+            errors.append(f"README capability {row[0]} has unknown status {row[1]!r}")
+            continue
+        status[row[0].strip("`")] = row[1]
+    for key, expected in (("runtime_supported", "supported"), ("unsupported", "unsupported")):
+        contract_set = set(contract[key])
+        table_set = {slug for slug, value in status.items() if value == expected}
+        if table_set != contract_set:
+            errors.append(
+                f"README capabilities marked {expected} do not match contract {key}: "
+                f"table={sorted(table_set)} contract={sorted(contract_set)}"
+            )
+    return errors
+
+
+def interop_ixp_receipts(interop: str) -> set[str]:
+    """M-numbers claimed inside INTEROP.md's IXP Manager headings and CI bullets."""
+    found: set[str] = set()
+    level = None
+    for line in interop.splitlines():
+        heading = HEADING.match(line)
+        if heading:
+            depth = len(heading.group(1))
+            if level is not None and depth <= level:
+                level = None
+            if "ixp" in heading.group(2).lower():
+                level = depth
+                continue
+        if level is not None or line.lstrip().startswith("- **IXP"):
+            found.update(M_NUMBER.findall(line))
+    return found
+
+
+def receipt_rows(receipts: str) -> set[str]:
+    """M-numbers in the first cell of every `| Receipt | ... |` table row."""
+    found: set[str] = set()
+    in_table = False
+    for line in receipts.splitlines():
+        if not line.lstrip().startswith("|"):
+            in_table = False
+            continue
+        first = _cells(line)[0]
+        if first == "Receipt":
+            in_table = True
+        elif in_table:
+            found.update(M_NUMBER.findall(first))
+    return found
+
+
+def check_receipts(interop: str, receipts: str) -> list[str]:
+    claimed = interop_ixp_receipts(interop)
+    if not claimed:
+        return ["INTEROP.md IXP Manager sections name no M-series receipts; the walk is broken"]
+    missing = sorted(claimed - receipt_rows(receipts), key=lambda m: (len(m), m))
+    return [
+        f"INTEROP.md claims {m} in its IXP Manager sections but RECEIPTS.md has no row for it"
+        for m in missing
+    ]
+
+
+def check(readme: str, contract: dict, interop: str, receipts: str) -> list[str]:
+    return (
+        check_reason_ids(readme, contract)
+        + check_capabilities(readme, contract)
+        + check_receipts(interop, receipts)
+    )
+
+
+def main() -> int:
+    try:
+        errors = check(
+            README.read_text(encoding="utf-8"),
+            json.loads(CONTRACT.read_text(encoding="utf-8")),
+            INTEROP.read_text(encoding="utf-8"),
+            RECEIPTS.read_text(encoding="utf-8"),
+        )
+    except (OSError, KeyError, ValueError) as error:
+        errors = [f"cannot load the IXP Manager contract surface: {error!r}"]
+    for error in errors:
+        print(f"IXP Manager docs check failed: {error}", file=sys.stderr)
+    if not errors:
+        print("IXP Manager docs check passed")
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_ixp_manager_docs.py
+++ b/scripts/test_check_ixp_manager_docs.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Mutation proofs for the fail-closed IXP Manager docs contract gate."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_ixp_manager_docs as checker
+
+README = checker.README.read_text(encoding="utf-8")
+CONTRACT = json.loads(checker.CONTRACT.read_text(encoding="utf-8"))
+INTEROP = checker.INTEROP.read_text(encoding="utf-8")
+RECEIPTS = checker.RECEIPTS.read_text(encoding="utf-8")
+
+
+def row(document: str, prefix: str) -> str:
+    (line,) = [line for line in document.splitlines() if line.startswith(prefix)]
+    return line + "\n"
+
+
+def without(document: str, prefix: str) -> str:
+    return document.replace(row(document, prefix), "", 1)
+
+
+class IxpManagerDocsTests(unittest.TestCase):
+    def assert_red(self, needle: str, readme=README, interop=INTEROP, receipts=RECEIPTS) -> None:
+        errors = checker.check(readme, CONTRACT, interop, receipts)
+        self.assertTrue(any(needle in error for error in errors), errors)
+
+    def test_tree_is_green(self) -> None:
+        self.assertEqual(checker.check(README, CONTRACT, INTEROP, RECEIPTS), [])
+
+    def test_dropped_active_reason_row_is_red(self) -> None:
+        self.assert_red("active_ids", readme=without(README, "| `.rpol` term `ixp-manager-hygiene:reject-as-path-too-long` |"))
+
+    def test_reason_display_drift_is_red(self) -> None:
+        self.assert_red("reason id 3 displays", readme=README.replace("| 3 | BOGON |", "| 3 | BOGUS |", 1))
+
+    def test_missing_fallback_row_is_red(self) -> None:
+        self.assert_red("no fallback row", readme=without(README, "| any other or ambiguous cause |"))
+
+    def test_dropped_defined_only_row_is_red(self) -> None:
+        self.assert_red("defined_only_ids", readme=without(README, "| 11 | PREFIX NOT IN ORIGIN AS |"))
+
+    def test_defined_only_emission_drift_is_red(self) -> None:
+        self.assert_red(
+            "defined-only id 12 is emitted as 12",
+            readme=README.replace("| 12 | RPKI UNKNOWN | 0 |", "| 12 | RPKI UNKNOWN | 12 |", 1),
+        )
+
+    def test_capability_status_flip_is_red(self) -> None:
+        self.assert_red(
+            "runtime_supported",
+            readme=README.replace("| `atomic-full-table-snapshot` | supported |", "| `atomic-full-table-snapshot` | unsupported |", 1),
+        )
+
+    def test_dropped_capability_row_is_red(self) -> None:
+        self.assert_red("contract unsupported", readme=without(README, "| `full-table-count` |"))
+
+    def test_missing_tables_are_red(self) -> None:
+        errors = checker.check("# empty\n", CONTRACT, INTEROP, RECEIPTS)
+        self.assertTrue(any("reason-id table" in e for e in errors), errors)
+        self.assertTrue(any("capability table" in e for e in errors), errors)
+
+    def test_receipt_row_removal_is_red(self) -> None:
+        self.assert_red("claims M96", receipts=without(RECEIPTS, "| M96 |"))
+
+    def test_new_interop_claim_without_receipt_row_is_red(self) -> None:
+        unreceipted = next(f"M{n}" for n in range(100, 10000) if f"| {f'M{n}'} " not in RECEIPTS)
+        bullet = f"- **IXP Manager future proof** — a new claim: **{unreceipted}**.\n"
+        self.assert_red(f"claims {unreceipted}", interop=INTEROP + bullet)
+
+    def test_empty_interop_claims_are_red(self) -> None:
+        self.assert_red("walk is broken", interop="# no ixp sections\n")
+
+    def test_recipe_table_does_not_count_as_receipt_row(self) -> None:
+        self.assertNotIn("M14", checker.receipt_rows("| Receipts | Recipe |\n|---|---|\n| M14, M76 | x |\n"))
+        self.assertIn("M14", checker.receipt_rows("| Receipt | Proves |\n|---|---|\n| M14 | x |\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Fixes

1. **Reason-id table** (`examples/birdwatcher-adapter/README.md`): the "Retained cause → IXP Manager reason id" table listed ids 1, 3, 7, 8, 13, 14 while `ixp_manager_reject_reason_id` in `src/main.rs` and `contract.json` `reject_reasons.active_ids` map ten template-active ids (1, 3, 5, 6, 7, 8, 9, 10, 13, 14). The table now carries all ten with the exact retained cause (policy/term identity) and the Bird's Eye display string from `reject_reasons.display`, keeps the fallback `0` row, and a second table states the five defined-only ids (2, 4, 11, 12, 15) that are never emitted and fall back to `0`.
2. **Supported/unsupported statements** (same README): the paragraph said "Full table snapshots, counts, other large-community wildcard queries, and the complete reject-reason inventory are not implemented" while the same README documents `GET /routes/table/{table}` and the contract lists `atomic-full-table-snapshot` as runtime-supported. The paragraph is now a capability table keyed verbatim by the contract's `runtime_supported` and `unsupported` entries, with the remaining non-contract caveats (other wildcard queries, table identity, no full Bird's Eye claim) kept as prose.
3. **`docs/RECEIPTS.md`**: adds M96 (IXP Manager local activation) and M97 (IXP Manager authenticated lifecycle, two handles) rows to the manual/local gates table, linking the `INTEROP.md#ixp-manager-v74-manual-configuration-oracle` anchor. M98 (IXP Manager Nagios monitoring, `ixp-compat.yml`-gated) is added to the PR-gated table, linking the same anchor, now that #1786 has merged; before the row existed the new check reported `INTEROP.md claims M98 in its IXP Manager sections but RECEIPTS.md has no row for it` on the rebased tree, which is the gap it is there to catch.

## Check

`scripts/check_ixp_manager_docs.py` (pure Python, no Rust build) fails closed on:

- README reason-id table ids ≠ `reject_reasons.active_ids`, display strings ≠ `reject_reasons.display`, missing fallback row, defined-only table ≠ `defined_only_ids` or emitted as anything but `fallback_id`;
- README capability table statuses ≠ `runtime_supported` / `unsupported` (set equality both ways);
- any M-number named inside `docs/INTEROP.md`'s IXP headings or `- **IXP …` CI-coverage bullets that has no `| Receipt |` table row in `docs/RECEIPTS.md`;
- an absent table or an empty INTEROP claim set (a guard that cannot fail is itself a failure).

Wired into `.github/workflows/public-docs-contract.yml` next to the tracker-ID gate (unit tests first, then the check), with the README, `contract.json`, and both scripts added to the lane's path filter because the main CI lane ignores `**/*.md`.

## Proof

- `python3 -m unittest -v scripts/test_check_ixp_manager_docs.py`: 13 tests OK, including green-tree, dropped active row, display drift, missing fallback, dropped defined-only row, defined-only emission drift, capability status flip, dropped capability row, missing tables, removed M96 receipt row, new M98 INTEROP claim without a row, empty INTEROP claims, and the recipe table not counting as a receipt row.
- Deliberate red against the pre-fix `origin/main` docs (rc 1):
  ```
  IXP Manager docs check failed: README reason-id table with header ('Retained cause', 'IXP Manager reason id', "Bird's Eye display") not found exactly once
  IXP Manager docs check failed: README capability table with header ('Contract capability', 'Status', 'Adapter surface') not found exactly once
  IXP Manager docs check failed: INTEROP.md claims M96 in its IXP Manager sections but RECEIPTS.md has no row for it
  IXP Manager docs check failed: INTEROP.md claims M97 in its IXP Manager sections but RECEIPTS.md has no row for it
  ```
- Deliberate red against a mutated copy of the fixed tree (id 9 row and M97 row removed, rc 1):
  ```
  IXP Manager docs check failed: README reason-id table ids do not match contract active_ids: table=[1, 3, 5, 6, 7, 8, 10, 13, 14] contract=[1, 3, 5, 6, 7, 8, 9, 10, 13, 14]
  IXP Manager docs check failed: INTEROP.md claims M97 in its IXP Manager sections but RECEIPTS.md has no row for it
  ```
- `python3 scripts/check_ixp_manager_docs.py` on this branch: rc 0. `python3 scripts/check_public_tracker_ids.py`: rc 0 (605 documents). Workflow YAML parses. All relative links and anchors in the two touched markdown files resolve.

Refs LAN-1231.

