### PR TITLE
fix: unify rs-config-render exit codes across subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   atomically publishes immutable generations, settles real health/config diff,
   no-ops on equal content, and restores the prior link without a second
   activation only when the command cannot start. Once started, failure or
-  unsettled state retains the candidate. Exit 4 proves pre-effect restoration;
+  unsettled state retains the candidate. Exit 7 proves pre-effect restoration;
   exit 5 reports that recovery or receipt durability is unproven. M96 proves the
   pre-effect path against MD5-authenticated FRR; focused tests prove the started
   failure boundary. (LAN-1105)
@@ -167,6 +167,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   successfully accepted full policy generation, and `birdwatcher-adapter`
   renders it as status `last_reconfig`; rejected loads leave the prior value
   unchanged and pre-acceptance zero remains an empty string. (LAN-1110)
+
+### Changed
+
+- `rs-config-render` now uses one exit-code table across every subcommand
+  (render, IXP Manager candidate, `activate`, `ixp-manager-lifecycle`): each
+  code has exactly one meaning. This renumbers codes that previously meant
+  different things per subcommand — `activate`/lifecycle rollback moves from
+  4 to 7, and the IXP Manager candidate-output and strict-check failures move
+  from 3 to 8 and 9 — a breaking change for wrappers that branched on the
+  old numbers. The authoritative table is the "Exit codes" section of
+  `tools/rs-config-render/README.md`, mirrored in `docs/deployment.md` and
+  asserted by a test. (LAN-1174)
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -616,7 +616,7 @@ ships as `tools/rs-config-render`. Its manual IXP Manager v7.4 seam now accepts
 an original Foil JSON export, fails closed on unsupported effective policy, and
 writes a private candidate, validates it with the selected rustbgpd binary's
 strict offline check, then writes the validated receipt last. Its local helper
-now rechecks, atomically publishes and settles immutable generations. Exit 4
+now rechecks, atomically publishes and settles immutable generations. Exit 7
 is limited to a command that could not start and proves exact prior-link/runtime
 restoration without a second activation. A started command that fails or does
 not settle leaves the candidate current; exit 5 requires explicit recovery.

--- a/docs/cookbook/activation-manual-recovery.md
+++ b/docs/cookbook/activation-manual-recovery.md
@@ -270,19 +270,16 @@ cron may resume.
 
 A wrapper around that cron run can rely on 5 meaning "a human is needed", and
 on a 2 whose message is `IXP Manager update lock was not acquired` meaning step
-3 was skipped. One pair of codes it cannot yet tell apart: exit 4 from the
-lifecycle means the activation command never started and the prior runtime was
-proven untouched, while exit 4 from the arouteserver render mode of the same
-binary means the context's top-level shape drifted from the pinned
-fingerprint. A wrapper that drives both paths through one exit-code table will
-file a benign, already-released lifecycle rollback as a renderer problem (or
-the reverse) until those codes are separated.
+3 was skipped. Every `rs-config-render` subcommand shares one exit-code table
+(the [tool README](../../tools/rs-config-render/README.md#exit-codes)), so a
+wrapper can branch on the code alone: 7 is always the benign, already-released
+lifecycle rollback and 4 is always arouteserver shape drift.
 
 ## What this runbook does not cover
 
 - Exit 6 (one callback pending): run `ixp-manager-lifecycle resume`; it replays
   only that callback.
-- Exit 4 (the activation command never started): nothing to recover, `current`
+- Exit 7 (the activation command never started): nothing to recover, `current`
   was restored and the lock released.
 - An unreadable or foreign fence or journal (wrong mode, symlink, another
   handle's binding, unparseable JSON): the helper exits 5 for those too;

--- a/docs/cookbook/ixp-manager-route-server.md
+++ b/docs/cookbook/ixp-manager-route-server.md
@@ -363,16 +363,16 @@ Exit codes, and exactly what each one guarantees:
 |---|---|---|
 | 0 | activated, or no-op (equal content) | `current` → the candidate's generation; receipt current |
 | 2 | refused before any effect (bad candidate/receipt, wrong modes, `--initial` misuse, helper contract violation) | unchanged |
-| 4 | the activation command **could not start** | the prior `current` is restored without a second activation and the prior runtime is verified unchanged — proven pre-effect restoration |
+| 7 | the activation command **could not start** | the prior `current` is restored without a second activation and the prior runtime is verified unchanged — proven pre-effect restoration |
 | 5 | the command started and then failed, timed out, or the runtime did not settle | `current` stays on the candidate; **recovery is operator-owned**; a synced owner fence stays in the host-state directory and every later activation or lifecycle run returns 5 until it is resolved — [Activation manual recovery](activation-manual-recovery.md) |
 
-Real exit-4 and exit-5 runs, on a changed candidate:
+Real exit-7 and exit-5 runs, on a changed candidate:
 
 ```console
 $ rs-config-render activate … --candidate candidate-2 --activation-command /usr/local/bin/does-not-exist
 rs-config-render: activation: activation command did not start; prior generation restored
 $ echo $?
-4
+7
 $ readlink /var/lib/rustbgpd/b2-rs1-lan1-ipv4/activation/current
 generations/a43f75ab…                       # unchanged
 
@@ -428,7 +428,7 @@ success the command prints `IXP Manager lifecycle updated`.
 |---|---|
 | 0 | `updated` delivered |
 | 2 | no lock acquired, or a definite pre-activation refusal was released back to IXP Manager |
-| 4 | activation command never started; exact prior runtime proven; release delivered |
+| 7 | activation command never started; exact prior runtime proven; release delivered |
 | 5 | lock acquisition or activation effect is **uncertain** — no callback is issued; the owner fence stands; operator recovery ([runbook](activation-manual-recovery.md)) |
 | 6 | one durable `updated` or release callback is still pending — retry only that with `resume` |
 
@@ -554,7 +554,7 @@ handle; the activation path must be exactly `<runtime>/activation`; mode
 0700, owned by `rustbgpd`), or `--initial` was passed with a live daemon
 or omitted on first publication. Nothing was published.
 
-**Activate exits 4.** `sudo`/`systemctl` could not be executed (sudoers
+**Activate exits 7.** `sudo`/`systemctl` could not be executed (sudoers
 line missing, wrong path). The prior generation is restored and the prior
 runtime proven unchanged. Fix the command and re-run.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -209,14 +209,14 @@ the [tool README](../tools/rs-config-render/README.md#exit-codes):
 |---|---|
 | 0 | **success** — rendered, candidate validated, activated or no-op, or `updated` delivered |
 | 1 | **invalid input** — the context or IXP Manager document is unreadable, unparseable, or carries an unknown field, or a site-local file is unreadable (also the generic failure when the final stdout line cannot be written) |
-| 2 | **refused** — an unsupported knob, an invalid option combination, an unmet precondition, no upstream lock acquired, or a definite pre-activation refusal released; nothing written, nothing activated |
+| 2 | **refused** — an unsupported knob, an invalid option combination, an unmet precondition (including an unavailable strict checker), no upstream lock acquired, or a definite pre-activation refusal released; nothing is published or activated and no generation, receipt, or journal is left behind (the lifecycle folds a strict-check rejection into this code and leaves that candidate, receipt-less, in its candidate directory for inspection) |
 | 3 | **aborted** — a generated set is empty or under the plausibility floor (arouteserver mode) |
 | 4 | **shape drift** — the context's top-level structure drifted from the pinned fingerprint; pass `--allow-shape-drift` to proceed (arouteserver mode) |
 | 5 | **manual recovery** — the activation effect is uncertain: `current` stays on the candidate, retained state and any upstream lock are kept, and no callback is issued; inspect before acting |
 | 6 | **callback pending** — one durable `updated` or release callback is undelivered; run `ixp-manager-lifecycle resume` |
 | 7 | **rolled back** — the activation command never started; the prior generation is restored and proven and the lock is released; retrying is safe |
 | 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode) or could not be created or written (arouteserver mode) |
-| 9 | **strict check failed** — `rustbgpd --check --strict` rejected the rendered candidate; files are written without a receipt |
+| 9 | **strict check failed** — `rustbgpd --check --strict` ran and rejected the rendered IXP Manager candidate (the only path to this code); its files stay in the candidate directory without a receipt |
 
 ### Debian / RPM packages
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -152,7 +152,7 @@ let another process publish or reload during the call. Add `--initial` only when
 both no current generation and no reachable daemon exist. Normalized comparison
 TOML is limited to 4,194,299 bytes (4 MiB minus five encoded-request bytes).
 
-The activation executable must be synchronous. Exit 4 occurs only when it could
+The activation executable must be synchronous. Exit 7 occurs only when it could
 not start: the prior link is restored without another activation and the prior
 runtime is verified unchanged. Once it starts, a nonzero exit, timeout, or
 unsettled result leaves `current` on the candidate and returns exit 5. Leave
@@ -189,6 +189,24 @@ effect. Exit 6 means one callback is pending and may be retried with
 uncertain and no callback is attempted automatically — see the
 [activation manual-recovery runbook](cookbook/activation-manual-recovery.md).
 Delivery is at-least-once.
+
+#### rs-config-render exit codes
+
+Every `rs-config-render` subcommand shares one exit-code table, mirrored from
+the [tool README](../tools/rs-config-render/README.md#exit-codes):
+
+| Exit | Meaning |
+|---|---|
+| 0 | **success** — rendered, candidate validated, activated or no-op, or `updated` delivered |
+| 1 | **invalid input** — the context or IXP Manager document is unreadable, unparseable, or carries an unknown field, or a site-local file is unreadable (also the generic failure when the final stdout line cannot be written) |
+| 2 | **refused** — an unsupported knob, an invalid option combination, an unmet precondition, no upstream lock acquired, or a definite pre-activation refusal released; nothing written, nothing activated |
+| 3 | **aborted** — a generated set is empty or under the plausibility floor (arouteserver mode) |
+| 4 | **shape drift** — the context's top-level structure drifted from the pinned fingerprint; pass `--allow-shape-drift` to proceed (arouteserver mode) |
+| 5 | **manual recovery** — the activation effect is uncertain: `current` stays on the candidate, retained state and any upstream lock are kept, and no callback is issued; inspect before acting |
+| 6 | **callback pending** — one durable `updated` or release callback is undelivered; run `ixp-manager-lifecycle resume` |
+| 7 | **rolled back** — the activation command never started; the prior generation is restored and proven and the lock is released; retrying is safe |
+| 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode) or could not be created or written (arouteserver mode) |
+| 9 | **strict check failed** — `rustbgpd --check --strict` rejected the rendered candidate; files are written without a receipt |
 
 ### Debian / RPM packages
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -129,26 +129,34 @@ rs-config-render --version
 in the archive either way, so install it now rather than discovering it is
 missing from a cron refresh later.
 
-For an IXP Manager candidate, point the service at a stable activation symlink,
-then let the renderer publish and settle an immutable generation:
+For an IXP Manager candidate, run the per-handle
+[`rustbgpd@.service`](#systemd) instance (its `ExecStart` reads
+`/var/lib/rustbgpd/<handle>/activation/current/config.toml`), then let the
+renderer publish and settle an immutable generation under that handle:
 
 ```console
 sudo -u rustbgpd /usr/local/bin/rs-config-render activate \
+  --router-handle rs1-ipv4 \
   --candidate /var/lib/rustbgpd/ixp-manager/candidate \
-  --state-dir /var/lib/rustbgpd/ixp-manager/activation \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
   --check-with /usr/local/bin/rustbgpd --rbgp /usr/local/bin/rbgp \
-  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
   --activation-command /usr/bin/sudo \
   --activation-arg=-n --activation-arg /usr/bin/systemctl \
-  --activation-arg reload-or-restart --activation-arg rustbgpd
+  --activation-arg reload-or-restart --activation-arg rustbgpd@rs1-ipv4
 ```
 
 Render and activate as the `rustbgpd` service identity; it must own the private
-candidate and activation-state parent. Configure `ExecStart` to read
-`.../activation/current/config.toml`, and authorize that account in sudoers for
-only `/usr/bin/systemctl reload-or-restart rustbgpd`. Pre-create the absolute
-state directory as a non-symlink mode-0700 directory owned by `rustbgpd`; do not
-let another process publish or reload during the call. Add `--initial` only when
+candidate, the per-handle runtime and activation directories, and the shared
+host-state directory. The runtime directory basename must equal the handle, the
+activation directory must be exactly `<runtime>/activation`, and `--rbgp-addr`
+must be that runtime's `grpc.sock`. Authorize that account in sudoers for only
+the literal `/usr/bin/systemctl reload-or-restart rustbgpd@rs1-ipv4`. Pre-create
+the absolute runtime, activation, and host-state directories as non-symlink
+mode-0700 directories owned by `rustbgpd`; do not let another process publish or
+reload during the call. Add `--initial` only when
 both no current generation and no reachable daemon exist. Normalized comparison
 TOML is limited to 4,194,299 bytes (4 MiB minus five encoded-request bytes).
 
@@ -171,13 +179,15 @@ sudo -u rustbgpd /usr/local/bin/rs-config-render ixp-manager-lifecycle run \
   --ixp-origin https://ixp.example.net --router-handle rs1-ipv4 \
   --api-key-file /var/lib/rustbgpd/ixp-manager/api-key \
   --candidate-dir /var/lib/rustbgpd/ixp-manager/candidate-1 \
-  --state-dir /var/lib/rustbgpd/ixp-manager/activation \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
   --max-prefix-restart-seconds 300 \
   --check-with /usr/local/bin/rustbgpd --rbgp /usr/local/bin/rbgp \
-  --rbgp-addr unix:///var/lib/rustbgpd/grpc.sock \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
   --activation-command /usr/bin/sudo \
   --activation-arg=-n --activation-arg /usr/bin/systemctl \
-  --activation-arg reload-or-restart --activation-arg rustbgpd
+  --activation-arg reload-or-restart --activation-arg rustbgpd@rs1-ipv4
 ```
 
 The helper uses the exact v7.4 lock, Foil configuration, updated, and release

--- a/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
+++ b/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
@@ -233,7 +233,7 @@ docker exec "$RUST" bash -c \
 pid_before=$(docker exec "$RUST" pidof -s rustbgpd)
 state_before=$(neighbor)
 start_observer
-activate /var/lib/m96-restart-candidate 4 rollback "" /definitely/missing/m96-activation
+activate /var/lib/m96-restart-candidate 7 rollback "" /definitely/missing/m96-activation
 stop_observer "$WORK/rollback-observer" "$prior_link"
 receipt >"$WORK/rollback-receipt.json"
 bad_target="generations/$(jq -r .candidate_sha256 "$WORK/rollback-receipt.json")"

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -136,7 +136,7 @@ including five bytes of protobuf overhead, remains within 4 MiB.
 
 The helper rechecks a private immutable generation, atomically renames the
 relative `current` symlink, runs one synchronous executable, and requires both
-`rbgp health` and `rbgp config diff` to settle. Equal content is a no-op. Exit 4
+`rbgp health` and `rbgp config diff` to settle. Equal content is a no-op. Exit 7
 is limited to a command that could not start: the helper restores the prior
 link without a second activation and verifies the unchanged prior runtime. Once
 the command starts, a nonzero exit, timeout, or unsettled runtime leaves
@@ -149,9 +149,9 @@ Authorize the `rustbgpd` account in sudoers for only the exact per-handle
 handle uses its own runtime/activation/UDS and service instance but the same
 host-state directory, which serializes lifecycle ownership across the host.
 The private `activation-receipt.json` is written last; generations are retained for
-operator inspection. Exit 0 means activated or no-op, 2 refusal, 4 proven
+operator inspection. Exit 0 means activated or no-op, 2 refusal, 7 proven
 pre-effect restoration, and 5 means recovery or receipt durability is
-unproven. A receipt may
+unproven (the full table is under [Exit codes](#exit-codes)). A receipt may
 therefore be absent or stale after exit 5. The helper does not deploy services,
 prune generations, retry indefinitely, or call IXP Manager. These examples use
 package paths; release archives install the three binaries under `/usr/local/bin`.
@@ -199,7 +199,7 @@ body ceiling, and 4 MiB configuration ceiling.
 
 Lifecycle intent is written and synced before every upstream request. Exit 0
 means `updated` was delivered. Exit 2 means no lock was acquired or a definite
-pre-activation refusal was released. Exit 4 means the activation command never
+pre-activation refusal was released. Exit 7 means the activation command never
 started, exact prior runtime was proven, and release was delivered. Exit 5
 does not issue a callback because lock acquisition or an activation effect is
 uncertain. Exit 6 leaves one durable `updated` or release callback pending.
@@ -301,17 +301,30 @@ daemon's own reload seam guarantees a bad swap can never evict working
 policy either. Alert on the age of `render-receipt.json` — a pipeline
 stuck for more than a couple of refresh intervals should page, not rot.
 
-## Failure policy
+## Exit codes
 
-Distinct exit codes, so the cron wrapper can tell "fix the renderer"
-from "fix the data":
+One table for every subcommand (`render`, `--input-format ixp-manager-*`,
+`activate`, `ixp-manager-lifecycle run|resume`): each code has exactly one
+meaning, so a cron or systemd wrapper can branch on the code alone without
+knowing which subcommand ran. The mapping is asserted by
+`tests/exit_codes.rs` against this table and its mirror in
+`docs/deployment.md`.
 
 | Exit | Meaning |
 |---|---|
-| 1 | unreadable/unparseable context |
-| 2 | **refused** — the context uses a knob the renderer will not silently drop |
-| 3 | **aborted** — a generated set is empty or under the plausibility floor |
-| 4 | **shape mismatch** — the context's top-level structure (document keys or report sections) drifted from the pinned fingerprint |
+| 0 | **success** — rendered, candidate validated, activated or no-op, or `updated` delivered |
+| 1 | **invalid input** — the context or IXP Manager document is unreadable, unparseable, or carries an unknown field, or a site-local file is unreadable (also the generic failure when the final stdout line cannot be written) |
+| 2 | **refused** — an unsupported knob, an invalid option combination, an unmet precondition, no upstream lock acquired, or a definite pre-activation refusal released; nothing written, nothing activated |
+| 3 | **aborted** — a generated set is empty or under the plausibility floor (arouteserver mode) |
+| 4 | **shape drift** — the context's top-level structure drifted from the pinned fingerprint; pass `--allow-shape-drift` to proceed (arouteserver mode) |
+| 5 | **manual recovery** — the activation effect is uncertain: `current` stays on the candidate, retained state and any upstream lock are kept, and no callback is issued; inspect before acting |
+| 6 | **callback pending** — one durable `updated` or release callback is undelivered; run `ixp-manager-lifecycle resume` |
+| 7 | **rolled back** — the activation command never started; the prior generation is restored and proven and the lock is released; retrying is safe |
+| 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode) or could not be created or written (arouteserver mode) |
+| 9 | **strict check failed** — `rustbgpd --check --strict` rejected the rendered candidate; files are written without a receipt |
+
+Codes 1–4 and 8–9 leave the previous configuration running untouched
+(fail-stale); 5 and 6 need an operator; 7 is safe to retry.
 
 Refused knobs: RTT-based communities and `rtt_thresholds` (the daemon
 has no RTT source; permanent), configured

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -314,14 +314,14 @@ knowing which subcommand ran. The mapping is asserted by
 |---|---|
 | 0 | **success** — rendered, candidate validated, activated or no-op, or `updated` delivered |
 | 1 | **invalid input** — the context or IXP Manager document is unreadable, unparseable, or carries an unknown field, or a site-local file is unreadable (also the generic failure when the final stdout line cannot be written) |
-| 2 | **refused** — an unsupported knob, an invalid option combination, an unmet precondition, no upstream lock acquired, or a definite pre-activation refusal released; nothing written, nothing activated |
+| 2 | **refused** — an unsupported knob, an invalid option combination, an unmet precondition (including an unavailable strict checker), no upstream lock acquired, or a definite pre-activation refusal released; nothing is published or activated and no generation, receipt, or journal is left behind (the lifecycle folds a strict-check rejection into this code and leaves that candidate, receipt-less, in its candidate directory for inspection) |
 | 3 | **aborted** — a generated set is empty or under the plausibility floor (arouteserver mode) |
 | 4 | **shape drift** — the context's top-level structure drifted from the pinned fingerprint; pass `--allow-shape-drift` to proceed (arouteserver mode) |
 | 5 | **manual recovery** — the activation effect is uncertain: `current` stays on the candidate, retained state and any upstream lock are kept, and no callback is issued; inspect before acting |
 | 6 | **callback pending** — one durable `updated` or release callback is undelivered; run `ixp-manager-lifecycle resume` |
 | 7 | **rolled back** — the activation command never started; the prior generation is restored and proven and the lock is released; retrying is safe |
 | 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode) or could not be created or written (arouteserver mode) |
-| 9 | **strict check failed** — `rustbgpd --check --strict` rejected the rendered candidate; files are written without a receipt |
+| 9 | **strict check failed** — `rustbgpd --check --strict` ran and rejected the rendered IXP Manager candidate (the only path to this code); its files stay in the candidate directory without a receipt |
 
 Codes 1–4 and 8–9 leave the previous configuration running untouched
 (fail-stale); 5 and 6 need an operator; 7 is safe to retry.

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::time::Duration;
 
+use crate::Exit;
 use crate::ixp_manager_host::Binding;
 
 #[derive(Debug)]
@@ -29,6 +30,16 @@ pub enum Error {
     Refused(&'static str),
     RolledBack,
     RecoveryRequired,
+}
+
+impl Error {
+    pub const fn exit_code(&self) -> Exit {
+        match self {
+            Self::Refused(_) => Exit::Refused,
+            Self::RolledBack => Exit::RolledBack,
+            Self::RecoveryRequired => Exit::ManualRecovery,
+        }
+    }
 }
 
 #[cfg(not(unix))]

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -385,12 +385,14 @@ mod unix {
         }
     }
 
+    /// Publish the verified candidate as an immutable generation; the flag is
+    /// true when this call created it (false when equal content already existed).
     fn copy_generation(
         candidate: &Path,
         state: &Path,
         verified: &Verified,
         binding: &Binding,
-    ) -> AResult<PathBuf> {
+    ) -> AResult<(PathBuf, bool)> {
         let generations = state.join("generations");
         create_private_dir(&generations)?;
         let final_path = generations.join(&verified.digest);
@@ -400,7 +402,7 @@ mod unix {
                 return Err(Error::Refused("immutable generation content mismatch"));
             }
             sync_dir(&generations)?;
-            return Ok(final_path);
+            return Ok((final_path, false));
         }
         let temporary = generations.join(unique_name(&format!(".{}", verified.digest)));
         fs::DirBuilder::new()
@@ -447,7 +449,7 @@ mod unix {
             .map_err(|_| Error::Refused("cannot publish generation"))?;
         staging.0.take();
         sync_dir(&generations)?;
-        Ok(final_path)
+        Ok((final_path, true))
     }
 
     fn current_target(state: &Path, binding: &Binding) -> AResult<Option<String>> {
@@ -825,12 +827,15 @@ mod unix {
             initial: options.initial,
             ..Phases::default()
         };
-        let generation = copy_generation(
+        let (generation, created) = copy_generation(
             options.candidate,
             options.state_dir,
             &candidate,
             options.binding,
         )?;
+        // A refusal from here until `current` is published must leave no trace:
+        // a generation this run created and never linked is removed again.
+        let mut unpublished = Staging(created.then(|| generation.clone()));
         let check_child = Command::new(options.checker)
             .args(["--check", "--strict"])
             .arg(generation.join("config.toml"))
@@ -884,6 +889,7 @@ mod unix {
                     "atomic current publication failed before rename",
                 ));
             }
+            unpublished.0.take();
             phases.candidate_publication = Some(publication);
             if publication == Publication::Durable {
                 phases.candidate = activate_and_settle(options, candidate_comparison.as_ref());
@@ -923,6 +929,7 @@ mod unix {
                 "atomic current publication failed before rename",
             ));
         }
+        unpublished.0.take();
         phases.candidate_publication = Some(publication);
         if publication == Publication::Durable {
             phases.candidate = activate_and_settle(options, candidate_comparison.as_ref());

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -50,6 +50,11 @@ pub enum Error {
     Refused(&'static str),
     Input,
     Output,
+    /// The checker binary could not run (`--version` or `--check` failed to
+    /// spawn, `--version` exited nonzero or printed an unrecognised line): an
+    /// unmet precondition, not a verdict on the candidate.
+    CheckerUnavailable,
+    /// The checker ran `--check --strict` and rejected the candidate.
     Checker,
 }
 
@@ -57,7 +62,7 @@ impl Error {
     pub const fn exit_code(&self) -> Exit {
         match self {
             Self::Input => Exit::InvalidInput,
-            Self::Refused(_) => Exit::Refused,
+            Self::Refused(_) | Self::CheckerUnavailable => Exit::Refused,
             Self::Output => Exit::OutputUnusable,
             Self::Checker => Exit::StrictCheckFailed,
         }
@@ -72,7 +77,12 @@ impl std::fmt::Display for Error {
             Self::Output => {
                 f.write_str("candidate output must be an absent or empty private directory")
             }
-            Self::Checker => f.write_str("strict checker failed; candidate has no receipt"),
+            Self::CheckerUnavailable => {
+                f.write_str("strict checker is unavailable; candidate has no receipt")
+            }
+            Self::Checker => {
+                f.write_str("strict checker rejected the candidate; candidate has no receipt")
+            }
         }
     }
 }
@@ -1127,20 +1137,20 @@ fn prepare_output(out: &Path) -> Result<(), Error> {
 }
 
 fn safe_version(output: &[u8]) -> Result<String, Error> {
-    let text = std::str::from_utf8(output).map_err(|_| Error::Checker)?;
+    let text = std::str::from_utf8(output).map_err(|_| Error::CheckerUnavailable)?;
     let mut words = text
         .lines()
         .next()
-        .ok_or(Error::Checker)?
+        .ok_or(Error::CheckerUnavailable)?
         .split_ascii_whitespace();
-    let name = words.next().ok_or(Error::Checker)?;
-    let version = words.next().ok_or(Error::Checker)?;
+    let name = words.next().ok_or(Error::CheckerUnavailable)?;
+    let version = words.next().ok_or(Error::CheckerUnavailable)?;
     if name != "rustbgpd"
         || !version
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b".+-_".contains(&b))
     {
-        return Err(Error::Checker);
+        return Err(Error::CheckerUnavailable);
     }
     Ok(format!("rustbgpd {version}"))
 }
@@ -1190,6 +1200,18 @@ fn write_checked_candidate_for(
     expected: SchemaVersion,
 ) -> Result<usize, Error> {
     let candidate = render_document(input, restart_seconds, binding, expected)?;
+    // Probe the checker before writing anything so an unavailable checker is a
+    // trace-free refusal.
+    let version = Command::new(checker)
+        .arg("--version")
+        .output()
+        .map_err(|_| Error::CheckerUnavailable)?;
+    if !version.status.success() {
+        return Err(Error::CheckerUnavailable);
+    }
+    let mut version_bytes = version.stdout;
+    version_bytes.extend(version.stderr);
+    let version = safe_version(&version_bytes)?;
     prepare_output(out)?;
     for (relative, contents) in &candidate.files {
         let path = out.join(relative);
@@ -1198,22 +1220,20 @@ fn write_checked_candidate_for(
         }
         write_private(&path, contents.as_bytes()).map_err(|_| Error::Output)?;
     }
-    let version = Command::new(checker)
-        .arg("--version")
-        .output()
-        .map_err(|_| Error::Checker)?;
-    if !version.status.success() {
-        return Err(Error::Checker);
-    }
-    let mut version_bytes = version.stdout;
-    version_bytes.extend(version.stderr);
-    let version = safe_version(&version_bytes)?;
-    let checked = Command::new(checker)
+    let checked = match Command::new(checker)
         .arg("--check")
         .arg("--strict")
         .arg(out.join("config.toml"))
         .output()
-        .map_err(|_| Error::Checker)?;
+    {
+        Ok(checked) => checked,
+        Err(_) => {
+            // The checker vanished between the probe and the check: take the
+            // written files back so the refusal leaves the empty directory.
+            let _ = fs::remove_dir_all(out).and_then(|()| create_private_dir(out));
+            return Err(Error::CheckerUnavailable);
+        }
+    };
     if !checked.status.success() {
         return Err(Error::Checker);
     }

--- a/tools/rs-config-render/src/ixp_manager.rs
+++ b/tools/rs-config-render/src/ixp_manager.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
+use crate::Exit;
 use crate::ixp_manager_host::RenderBinding;
 
 #[cfg(unix)]
@@ -53,11 +54,12 @@ pub enum Error {
 }
 
 impl Error {
-    pub const fn exit_code(&self) -> u8 {
+    pub const fn exit_code(&self) -> Exit {
         match self {
-            Self::Input => 1,
-            Self::Refused(_) => 2,
-            Self::Output | Self::Checker => 3,
+            Self::Input => Exit::InvalidInput,
+            Self::Refused(_) => Exit::Refused,
+            Self::Output => Exit::OutputUnusable,
+            Self::Checker => Exit::StrictCheckFailed,
         }
     }
 }

--- a/tools/rs-config-render/src/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/src/ixp_manager_lifecycle.rs
@@ -4,6 +4,7 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::time::Duration;
 
+use crate::Exit;
 use crate::ixp_manager_host::Binding;
 
 #[derive(Debug)]
@@ -53,12 +54,12 @@ pub enum Error {
 }
 
 impl Error {
-    pub const fn exit_code(&self) -> u8 {
+    pub const fn exit_code(&self) -> Exit {
         match self {
-            Self::Refused(_) => 2,
-            Self::RolledBack => 4,
-            Self::ManualRecovery => 5,
-            Self::CallbackPending => 6,
+            Self::Refused(_) => Exit::Refused,
+            Self::RolledBack => Exit::RolledBack,
+            Self::ManualRecovery => Exit::ManualRecovery,
+            Self::CallbackPending => Exit::CallbackPending,
         }
     }
 }

--- a/tools/rs-config-render/src/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/src/ixp_manager_lifecycle.rs
@@ -629,6 +629,8 @@ mod unix {
         let path = journal_path(options.state_dir);
         match fs::symlink_metadata(&path) {
             Ok(_) if private(&path, false, 0o600) => {
+                // Refusal must not leave the fence this run just wrote.
+                guard.clear().map_err(host_error)?;
                 return Err(Error::Refused("pending lifecycle state requires resume"));
             }
             Ok(_) => return Err(Error::ManualRecovery),

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -129,17 +129,82 @@ impl Default for Options {
     }
 }
 
+/// Process exit codes shared by every `rs-config-render` subcommand.
+///
+/// One code has exactly one meaning regardless of subcommand, so a wrapper can
+/// branch on the code alone. The `repr(u8)` discriminants are the only source
+/// of numbers; every error type maps into this enum, and the "Exit codes" table
+/// in `README.md` (mirrored in `docs/deployment.md`) is asserted against it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Exit {
+    /// Rendered, validated, activated, no-op, or `updated` delivered.
+    Success = 0,
+    /// Input unreadable or invalid: context/document unreadable, unparseable,
+    /// unknown field, site-local file unreadable; also the generic failure
+    /// when the final stdout report cannot be written.
+    InvalidInput = 1,
+    /// Refused: unsupported knob, invalid option combination, unmet
+    /// precondition, no lock acquired or a definite pre-activation refusal
+    /// released. Nothing written, nothing activated.
+    Refused = 2,
+    /// Aborted: a generated set is empty or under the plausibility floor.
+    Implausible = 3,
+    /// Context top-level shape differs from the pinned fingerprint.
+    ShapeDrift = 4,
+    /// Activation effect uncertain; `current` left on the candidate, retained
+    /// state and any upstream lock kept; no callback issued.
+    ManualRecovery = 5,
+    /// One durable lifecycle callback is pending; run `resume`.
+    CallbackPending = 6,
+    /// Activation command never started; prior generation restored and proven,
+    /// lock released; retry is safe.
+    RolledBack = 7,
+    /// Output directory unusable: not an absent or empty private directory
+    /// (IXP Manager mode) or could not be created or written.
+    OutputUnusable = 8,
+    /// `rustbgpd --check --strict` rejected the candidate; no receipt written.
+    StrictCheckFailed = 9,
+}
+
+impl Exit {
+    /// Every code, in numeric order. The table test enumerates this.
+    pub const ALL: [Exit; 10] = [
+        Exit::Success,
+        Exit::InvalidInput,
+        Exit::Refused,
+        Exit::Implausible,
+        Exit::ShapeDrift,
+        Exit::ManualRecovery,
+        Exit::CallbackPending,
+        Exit::RolledBack,
+        Exit::OutputUnusable,
+        Exit::StrictCheckFailed,
+    ];
+
+    pub const fn code(self) -> u8 {
+        self as u8
+    }
+}
+
+impl From<Exit> for std::process::ExitCode {
+    fn from(exit: Exit) -> Self {
+        Self::from(exit.code())
+    }
+}
+
 #[derive(Debug)]
 pub enum RenderError {
     /// Context unreadable / not valid YAML-or-JSON / missing required
-    /// fields. Exit 1.
+    /// fields. [`Exit::InvalidInput`].
     Parse(String),
     /// Unsupported knob in the context; the render must not proceed.
-    /// Exit 2.
+    /// [`Exit::Refused`].
     Refused(Vec<String>),
-    /// Empty or implausibly small generated set. Exit 3.
+    /// Empty or implausibly small generated set. [`Exit::Implausible`].
     Implausible(Vec<String>),
-    /// Top-level key structure differs from the pinned shape. Exit 4.
+    /// Top-level key structure differs from the pinned shape.
+    /// [`Exit::ShapeDrift`].
     ShapeMismatch {
         expected_fingerprint: String,
         found_fingerprint: String,
@@ -149,12 +214,12 @@ pub enum RenderError {
 }
 
 impl RenderError {
-    pub fn exit_code(&self) -> i32 {
+    pub const fn exit_code(&self) -> Exit {
         match self {
-            RenderError::Parse(_) => 1,
-            RenderError::Refused(_) => 2,
-            RenderError::Implausible(_) => 3,
-            RenderError::ShapeMismatch { .. } => 4,
+            RenderError::Parse(_) => Exit::InvalidInput,
+            RenderError::Refused(_) => Exit::Refused,
+            RenderError::Implausible(_) => Exit::Implausible,
+            RenderError::ShapeMismatch { .. } => Exit::ShapeDrift,
         }
     }
 }

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use clap::{Parser, Subcommand, ValueEnum};
 
 use rs_config_render::{
-    Options, RenderError, SiteLocalFile, SiteLocalInput, render, render_site_local,
+    Exit, Options, RenderError, SiteLocalFile, SiteLocalInput, render, render_site_local,
 };
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -230,14 +230,14 @@ fn stdout_exit_with(
     diagnostic: &mut dyn std::io::Write,
 ) -> ExitCode {
     match result {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(StdoutWriteError::BrokenPipe) => ExitCode::from(1),
+        Ok(()) => Exit::Success.into(),
+        Err(StdoutWriteError::BrokenPipe) => Exit::InvalidInput.into(),
         Err(StdoutWriteError::Other(error)) => {
             let _ = writeln!(
                 diagnostic,
                 "rs-config-render: failed to write stdout: {error}"
             );
-            ExitCode::from(1)
+            Exit::InvalidInput.into()
         }
     }
 }
@@ -279,7 +279,7 @@ fn lifecycle_exit(
         }
         Err(error) => {
             eprintln!("rs-config-render: IXP Manager lifecycle: {error}");
-            ExitCode::from(error.exit_code())
+            error.exit_code().into()
         }
     }
 }
@@ -293,7 +293,7 @@ fn main() -> ExitCode {
                     Ok(binding) => binding,
                     Err(reason) => {
                         eprintln!("rs-config-render: IXP Manager lifecycle: {reason}");
-                        return ExitCode::from(2);
+                        return Exit::Refused.into();
                     }
                 };
                 lifecycle_exit(rs_config_render::ixp_manager_lifecycle::run(
@@ -323,7 +323,7 @@ fn main() -> ExitCode {
                     Ok(binding) => binding,
                     Err(reason) => {
                         eprintln!("rs-config-render: IXP Manager lifecycle: {reason}");
-                        return ExitCode::from(2);
+                        return Exit::Refused.into();
                     }
                 };
                 lifecycle_exit(rs_config_render::ixp_manager_lifecycle::resume(
@@ -345,7 +345,7 @@ fn main() -> ExitCode {
             Ok(binding) => binding,
             Err(reason) => {
                 eprintln!("rs-config-render: activation: {reason}");
-                return ExitCode::from(2);
+                return Exit::Refused.into();
             }
         };
         let options = rs_config_render::activation::Options {
@@ -371,18 +371,17 @@ fn main() -> ExitCode {
                 }))
             }
             Err(error) => {
-                let (code, message) = match error {
-                    rs_config_render::activation::Error::Refused(reason) => (2, reason),
-                    rs_config_render::activation::Error::RolledBack => (
-                        4,
-                        "activation command did not start; prior generation restored",
-                    ),
+                let message = match error {
+                    rs_config_render::activation::Error::Refused(reason) => reason,
+                    rs_config_render::activation::Error::RolledBack => {
+                        "activation command did not start; prior generation restored"
+                    }
                     rs_config_render::activation::Error::RecoveryRequired => {
-                        (5, "recovery required; inspect private activation state")
+                        "recovery required; inspect private activation state"
                     }
                 };
                 eprintln!("rs-config-render: activation: {message}");
-                ExitCode::from(code)
+                error.exit_code().into()
             }
         };
     }
@@ -401,7 +400,7 @@ fn main() -> ExitCode {
             || cli.allow_shape_drift
         {
             eprintln!("rs-config-render: IXP Manager mode does not accept arouteserver options");
-            return ExitCode::from(2);
+            return Exit::Refused.into();
         }
         let (Some(restart), Some(checker)) =
             (cli.max_prefix_restart_seconds, cli.check_with.as_deref())
@@ -409,7 +408,7 @@ fn main() -> ExitCode {
             eprintln!(
                 "rs-config-render: IXP Manager mode requires --max-prefix-restart-seconds and --check-with"
             );
-            return ExitCode::from(2);
+            return Exit::Refused.into();
         };
         let (Some(handle), Some(runtime)) = (
             cli.router_handle.as_deref(),
@@ -418,14 +417,14 @@ fn main() -> ExitCode {
             eprintln!(
                 "rs-config-render: IXP Manager mode requires --router-handle and --runtime-state-dir"
             );
-            return ExitCode::from(2);
+            return Exit::Refused.into();
         };
         let binding = match rs_config_render::ixp_manager_host::RenderBinding::new(handle, runtime)
         {
             Ok(binding) => binding,
             Err(reason) => {
                 eprintln!("rs-config-render: {reason}");
-                return ExitCode::from(2);
+                return Exit::Refused.into();
             }
         };
         return match rs_config_render::ixp_manager::write_checked_candidate(
@@ -445,7 +444,7 @@ fn main() -> ExitCode {
             })),
             Err(error) => {
                 eprintln!("rs-config-render: {error}");
-                ExitCode::from(error.exit_code())
+                error.exit_code().into()
             }
         };
     }
@@ -457,7 +456,7 @@ fn main() -> ExitCode {
         eprintln!(
             "rs-config-render: IXP Manager options require --input-format ixp-manager-v1 or ixp-manager-v2"
         );
-        return ExitCode::from(2);
+        return Exit::Refused.into();
     }
     if customized && (cli.extra_rpol.is_empty() || cli.merge_toml.len() != 1) {
         eprintln!(
@@ -467,7 +466,7 @@ fn main() -> ExitCode {
                     .into(),
             ])
         );
-        return ExitCode::from(2);
+        return Exit::Refused.into();
     }
     let context = match std::fs::read_to_string(&cli.context) {
         Ok(context) => context,
@@ -476,7 +475,7 @@ fn main() -> ExitCode {
                 "rs-config-render: cannot read {}: {e}",
                 cli.context.display()
             );
-            return ExitCode::from(1);
+            return Exit::InvalidInput.into();
         }
     };
     let opts = Options {
@@ -503,7 +502,7 @@ fn main() -> ExitCode {
         Ok(site) => site,
         Err(error) => {
             eprintln!("rs-config-render: {error}");
-            return ExitCode::from(1);
+            return Exit::InvalidInput.into();
         }
     };
     let rendered = match site.as_ref().map_or_else(
@@ -513,7 +512,7 @@ fn main() -> ExitCode {
         Ok(rendered) => rendered,
         Err(e) => {
             eprintln!("rs-config-render: {e}");
-            return ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1));
+            return e.exit_code().into();
         }
     };
     for warning in &rendered.warnings {
@@ -525,11 +524,11 @@ fn main() -> ExitCode {
             && let Err(e) = std::fs::create_dir_all(parent)
         {
             eprintln!("rs-config-render: cannot create {}: {e}", parent.display());
-            return ExitCode::from(1);
+            return Exit::OutputUnusable.into();
         }
         if let Err(e) = std::fs::write(&path, contents) {
             eprintln!("rs-config-render: cannot write {}: {e}", path.display());
-            return ExitCode::from(1);
+            return Exit::OutputUnusable.into();
         }
     }
     let receipt_path = cli.out_dir.join("render-receipt.json");
@@ -540,7 +539,7 @@ fn main() -> ExitCode {
             "rs-config-render: cannot write {}: {e}",
             receipt_path.display()
         );
-        return ExitCode::from(1);
+        return Exit::OutputUnusable.into();
     }
     stdout_exit(write_stdout(|writer| {
         writeln!(
@@ -565,13 +564,16 @@ mod tests {
         let result = write_stdout_with(&mut writer, |out| out.write_all(b"complete"));
         assert_eq!(writer.buffer(), b"complete");
         let mut err = Vec::new();
-        assert_eq!(stdout_exit_with(result, &mut err), ExitCode::from(1));
+        assert_eq!(
+            stdout_exit_with(result, &mut err),
+            ExitCode::from(Exit::InvalidInput)
+        );
         let err_text = String::from_utf8(err.clone()).unwrap();
         assert!(err_text.starts_with("rs-config-render: failed to write stdout: "));
         assert!(err_text.ends_with('\n'));
         err.clear();
         let broken = stdout_exit_with(Err(StdoutWriteError::BrokenPipe), &mut err);
-        assert_eq!(broken, ExitCode::from(1));
+        assert_eq!(broken, ExitCode::from(Exit::InvalidInput));
         assert!(err.is_empty());
     }
 }

--- a/tools/rs-config-render/tests/activation.rs
+++ b/tools/rs-config-render/tests/activation.rs
@@ -1,5 +1,6 @@
 #![cfg(unix)]
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
@@ -653,4 +654,75 @@ fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
     assert!(source.contains(
         ".and_then(|file| file.sync_all())\n            .map_err(|_| Error::RecoveryRequired)"
     ));
+}
+
+/// Relative path → kind and content (file digest or symlink target).
+fn snapshot(root: &Path) -> BTreeMap<String, String> {
+    fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<String, String>) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.strip_prefix(root).unwrap().display().to_string();
+            let metadata = fs::symlink_metadata(&path).unwrap();
+            if metadata.file_type().is_symlink() {
+                out.insert(
+                    name,
+                    format!("link:{}", fs::read_link(&path).unwrap().display()),
+                );
+            } else if metadata.is_dir() {
+                out.insert(name, "dir".to_owned());
+                walk(root, &path, out);
+            } else {
+                let digest: String = Sha256::digest(fs::read(&path).unwrap())
+                    .iter()
+                    .map(|byte| format!("{byte:02x}"))
+                    .collect();
+                out.insert(name, format!("file:{digest}"));
+            }
+        }
+    }
+    let mut out = BTreeMap::new();
+    walk(root, root, &mut out);
+    out
+}
+
+#[test]
+fn refused_after_generation_copy_leaves_the_state_directory_unchanged() {
+    let rig = Rig::new();
+    let first = rig.candidate("candidate-first", 100);
+    assert_eq!(
+        rig.run(&first, true, &rig.activation),
+        Ok(Status::Activated)
+    );
+    let second = rig.candidate("candidate-second", 101);
+    let before = snapshot(&rig.state);
+
+    rig.set("checker-mode", "fail");
+    assert_eq!(
+        rig.run(&second, false, &rig.activation),
+        Err(Error::Refused("strict candidate check failed"))
+    );
+    assert_eq!(
+        snapshot(&rig.state),
+        before,
+        "strict-check refusal left a trace"
+    );
+
+    rig.set("checker-mode", "ok");
+    rig.set("health-mode", "unhealthy");
+    assert_eq!(
+        rig.run(&second, false, &rig.activation),
+        Err(Error::Refused("current runtime is not known-good"))
+    );
+    assert_eq!(
+        snapshot(&rig.state),
+        before,
+        "known-good refusal left a trace"
+    );
+
+    rig.set("health-mode", "ok");
+    assert_eq!(
+        rig.run(&second, false, &rig.activation),
+        Ok(Status::Activated)
+    );
+    assert_ne!(snapshot(&rig.state), before);
 }

--- a/tools/rs-config-render/tests/exit_codes.rs
+++ b/tools/rs-config-render/tests/exit_codes.rs
@@ -1,0 +1,164 @@
+//! One exit-code namespace for every subcommand: the `Exit` enum is the only
+//! source of numbers, every error type maps into it, and the README table
+//! (plus its `docs/deployment.md` mirror) must list exactly those codes.
+
+use rs_config_render::{Exit, RenderError, activation, ixp_manager, ixp_manager_lifecycle};
+
+fn table_rows(markdown: &str) -> Vec<String> {
+    let mut lines = markdown.lines();
+    let mut tables = Vec::new();
+    while let Some(line) = lines.next() {
+        if line.trim() != "| Exit | Meaning |" {
+            continue;
+        }
+        assert_eq!(lines.next().map(str::trim), Some("|---|---|"));
+        let rows: Vec<String> = lines
+            .by_ref()
+            .take_while(|l| l.starts_with('|'))
+            .map(str::to_owned)
+            .collect();
+        tables.push(rows);
+    }
+    assert_eq!(
+        tables.len(),
+        1,
+        "expected exactly one `| Exit | Meaning |` table"
+    );
+    tables.pop().unwrap()
+}
+
+fn row_code(row: &str) -> u8 {
+    row.trim_start_matches('|')
+        .split('|')
+        .next()
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap_or_else(|_| panic!("exit-code row without a numeric first column: {row}"))
+}
+
+#[test]
+fn every_exit_code_is_unique_and_enumerated() {
+    // Exhaustiveness witness: adding an `Exit` variant fails to compile here
+    // until it is also added to `Exit::ALL` and the README table.
+    for exit in Exit::ALL {
+        match exit {
+            Exit::Success
+            | Exit::InvalidInput
+            | Exit::Refused
+            | Exit::Implausible
+            | Exit::ShapeDrift
+            | Exit::ManualRecovery
+            | Exit::CallbackPending
+            | Exit::RolledBack
+            | Exit::OutputUnusable
+            | Exit::StrictCheckFailed => {}
+        }
+    }
+    let codes: Vec<u8> = Exit::ALL.iter().map(|e| e.code()).collect();
+    assert_eq!(codes, (0..=9).collect::<Vec<u8>>());
+    assert_eq!(
+        std::process::ExitCode::from(Exit::RolledBack),
+        std::process::ExitCode::from(7)
+    );
+}
+
+#[test]
+fn readme_table_and_deployment_mirror_list_exactly_the_enum() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let readme = std::fs::read_to_string(root.join("README.md")).unwrap();
+    let deployment = std::fs::read_to_string(root.join("../../docs/deployment.md")).unwrap();
+    let rows = table_rows(&readme);
+    assert_eq!(
+        rows,
+        table_rows(&deployment),
+        "docs/deployment.md exit-code table must mirror the README byte for byte"
+    );
+    let documented: Vec<u8> = rows.iter().map(|r| row_code(r)).collect();
+    let defined: Vec<u8> = Exit::ALL.iter().map(|e| e.code()).collect();
+    assert_eq!(
+        documented, defined,
+        "README exit-code table drifted from `Exit`"
+    );
+}
+
+#[test]
+fn every_error_variant_maps_to_the_shared_table() {
+    // Each list is exhaustive for its enum; a new variant must be added here
+    // (the `match` in each closure makes omission a compile error).
+    let render = [
+        (RenderError::Parse(String::new()), Exit::InvalidInput),
+        (RenderError::Refused(Vec::new()), Exit::Refused),
+        (RenderError::Implausible(Vec::new()), Exit::Implausible),
+        (
+            RenderError::ShapeMismatch {
+                expected_fingerprint: String::new(),
+                found_fingerprint: String::new(),
+                missing: Vec::new(),
+                unexpected: Vec::new(),
+            },
+            Exit::ShapeDrift,
+        ),
+    ];
+    for (error, exit) in &render {
+        match error {
+            RenderError::Parse(_)
+            | RenderError::Refused(_)
+            | RenderError::Implausible(_)
+            | RenderError::ShapeMismatch { .. } => {}
+        }
+        assert_eq!(error.exit_code(), *exit, "{error:?}");
+    }
+
+    let candidate = [
+        (ixp_manager::Error::Input, Exit::InvalidInput),
+        (ixp_manager::Error::Refused(""), Exit::Refused),
+        (ixp_manager::Error::Output, Exit::OutputUnusable),
+        (ixp_manager::Error::Checker, Exit::StrictCheckFailed),
+    ];
+    for (error, exit) in &candidate {
+        match error {
+            ixp_manager::Error::Input
+            | ixp_manager::Error::Refused(_)
+            | ixp_manager::Error::Output
+            | ixp_manager::Error::Checker => {}
+        }
+        assert_eq!(error.exit_code(), *exit, "{error:?}");
+    }
+
+    let activate = [
+        (activation::Error::Refused(""), Exit::Refused),
+        (activation::Error::RolledBack, Exit::RolledBack),
+        (activation::Error::RecoveryRequired, Exit::ManualRecovery),
+    ];
+    for (error, exit) in &activate {
+        match error {
+            activation::Error::Refused(_)
+            | activation::Error::RolledBack
+            | activation::Error::RecoveryRequired => {}
+        }
+        assert_eq!(error.exit_code(), *exit, "{error:?}");
+    }
+
+    let lifecycle = [
+        (ixp_manager_lifecycle::Error::Refused(""), Exit::Refused),
+        (ixp_manager_lifecycle::Error::RolledBack, Exit::RolledBack),
+        (
+            ixp_manager_lifecycle::Error::ManualRecovery,
+            Exit::ManualRecovery,
+        ),
+        (
+            ixp_manager_lifecycle::Error::CallbackPending,
+            Exit::CallbackPending,
+        ),
+    ];
+    for (error, exit) in &lifecycle {
+        match error {
+            ixp_manager_lifecycle::Error::Refused(_)
+            | ixp_manager_lifecycle::Error::RolledBack
+            | ixp_manager_lifecycle::Error::ManualRecovery
+            | ixp_manager_lifecycle::Error::CallbackPending => {}
+        }
+        assert_eq!(error.exit_code(), *exit, "{error:?}");
+    }
+}

--- a/tools/rs-config-render/tests/exit_codes.rs
+++ b/tools/rs-config-render/tests/exit_codes.rs
@@ -37,25 +37,47 @@ fn row_code(row: &str) -> u8 {
         .unwrap_or_else(|_| panic!("exit-code row without a numeric first column: {row}"))
 }
 
+/// Every `Exit` variant, enumerated independently of `Exit::ALL`: a chain
+/// whose arms name each variant literally. Adding a variant makes the `match`
+/// non-exhaustive until an arm exists, and the linked arm puts it in the chain;
+/// exactly one arm (the last variant) ends the chain.
+fn witnessed() -> Vec<Exit> {
+    let mut chain = Vec::new();
+    let mut next = Some(Exit::Success);
+    while let Some(exit) = next {
+        chain.push(exit);
+        next = match exit {
+            Exit::Success => Some(Exit::InvalidInput),
+            Exit::InvalidInput => Some(Exit::Refused),
+            Exit::Refused => Some(Exit::Implausible),
+            Exit::Implausible => Some(Exit::ShapeDrift),
+            Exit::ShapeDrift => Some(Exit::ManualRecovery),
+            Exit::ManualRecovery => Some(Exit::CallbackPending),
+            Exit::CallbackPending => Some(Exit::RolledBack),
+            Exit::RolledBack => Some(Exit::OutputUnusable),
+            Exit::OutputUnusable => Some(Exit::StrictCheckFailed),
+            Exit::StrictCheckFailed => None,
+        };
+    }
+    chain
+}
+
 #[test]
 fn every_exit_code_is_unique_and_enumerated() {
-    // Exhaustiveness witness: adding an `Exit` variant fails to compile here
-    // until it is also added to `Exit::ALL` and the README table.
-    for exit in Exit::ALL {
-        match exit {
-            Exit::Success
-            | Exit::InvalidInput
-            | Exit::Refused
-            | Exit::Implausible
-            | Exit::ShapeDrift
-            | Exit::ManualRecovery
-            | Exit::CallbackPending
-            | Exit::RolledBack
-            | Exit::OutputUnusable
-            | Exit::StrictCheckFailed => {}
-        }
-    }
+    assert_eq!(
+        witnessed(),
+        Exit::ALL.to_vec(),
+        "`Exit::ALL` must list every variant"
+    );
     let codes: Vec<u8> = Exit::ALL.iter().map(|e| e.code()).collect();
+    assert_eq!(
+        codes
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        codes.len(),
+        "duplicate exit code"
+    );
     assert_eq!(codes, (0..=9).collect::<Vec<u8>>());
     assert_eq!(
         std::process::ExitCode::from(Exit::RolledBack),
@@ -114,6 +136,7 @@ fn every_error_variant_maps_to_the_shared_table() {
         (ixp_manager::Error::Input, Exit::InvalidInput),
         (ixp_manager::Error::Refused(""), Exit::Refused),
         (ixp_manager::Error::Output, Exit::OutputUnusable),
+        (ixp_manager::Error::CheckerUnavailable, Exit::Refused),
         (ixp_manager::Error::Checker, Exit::StrictCheckFailed),
     ];
     for (error, exit) in &candidate {
@@ -121,6 +144,7 @@ fn every_error_variant_maps_to_the_shared_table() {
             ixp_manager::Error::Input
             | ixp_manager::Error::Refused(_)
             | ixp_manager::Error::Output
+            | ixp_manager::Error::CheckerUnavailable
             | ixp_manager::Error::Checker => {}
         }
         assert_eq!(error.exit_code(), *exit, "{error:?}");

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -4,7 +4,7 @@
 //! fixture proves the implausible-set abort and every other case is a
 //! targeted mutation of the same context.
 
-use rs_config_render::{Options, RenderError, render};
+use rs_config_render::{Exit, Options, RenderError, render};
 
 const FIXTURE: &str = include_str!("fixtures/context-small.yml");
 
@@ -960,7 +960,7 @@ fn sectioned_malformed_section_body_is_a_parse_error() {
     assert_ne!(corrupted, SECTIONED, "corruption target not found");
     match render(&corrupted, &Options::default()) {
         Err(err @ RenderError::Parse(_)) => {
-            assert_eq!(err.exit_code(), 1);
+            assert_eq!(err.exit_code(), Exit::InvalidInput);
             assert!(err.to_string().contains("rpki_roas"), "{err}");
         }
         other => panic!("expected parse error, got {other:?}"),

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -1194,7 +1194,7 @@ fn cli_enforces_private_checker_order_receipt_last_and_redaction() {
 
     let failed = temp.path().join("failed");
     let result = run_cli(&temp, &failed, true, 0o600, &[]);
-    assert_eq!(result.status.code(), Some(3));
+    assert_eq!(result.status.code(), Some(9));
     assert!(failed.join("config.toml").is_file());
     assert!(!failed.join("render-receipt.json").exists());
     assert!(!String::from_utf8_lossy(&result.stderr).contains(SECRET));
@@ -1204,14 +1204,14 @@ fn cli_enforces_private_checker_order_receipt_last_and_redaction() {
     fs::write(nonempty.join("old"), b"stale").unwrap();
     assert_eq!(
         run_cli(&temp, &nonempty, false, 0o600, &[]).status.code(),
-        Some(3)
+        Some(8)
     );
     let public = temp.path().join("public");
     fs::create_dir(&public).unwrap();
     set_mode(&public, 0o755);
     assert_eq!(
         run_cli(&temp, &public, false, 0o600, &[]).status.code(),
-        Some(3)
+        Some(8)
     );
     assert_eq!(
         run_cli(&temp, &temp.path().join("public-input"), false, 0o644, &[])
@@ -1233,7 +1233,7 @@ fn cli_enforces_private_checker_order_receipt_last_and_redaction() {
     symlink(&empty, &out_link).unwrap();
     assert_eq!(
         run_cli(&temp, &out_link, false, 0o600, &[]).status.code(),
-        Some(3)
+        Some(8)
     );
     fs::remove_file(temp.path().join("input.json")).unwrap();
     let input_target = temp.path().join("input-target.json");

--- a/tools/rs-config-render/tests/ixp_manager.rs
+++ b/tools/rs-config-render/tests/ixp_manager.rs
@@ -1305,3 +1305,34 @@ fn workflow_and_gpl_source_only_boundaries_are_pinned() {
         "integrations/ixp-manager/gpl-2.0-only/LICENSE"
     ]));
 }
+
+#[test]
+fn missing_checker_is_refused_before_any_write() {
+    use std::process::Command;
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("input.json");
+    fs::write(&input, FIXTURE).unwrap();
+    set_mode(&input, 0o600);
+    let out = temp.path().join("candidate");
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args(["--input-format", "ixp-manager-v1", "--context"])
+        .arg(&input)
+        .arg("--out-dir")
+        .arg(&out)
+        .args(["--max-prefix-restart-seconds", "300", "--check-with"])
+        .arg(temp.path().join("no-such-rustbgpd"))
+        .args(["--router-handle", "b2-rs1-lan1-ipv4"])
+        .arg("--runtime-state-dir")
+        .arg(temp.path().join("b2-rs1-lan1-ipv4"))
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("strict checker is unavailable"),
+        "{output:?}"
+    );
+    assert!(
+        !out.exists(),
+        "an unavailable checker must not leave a candidate"
+    );
+}


### PR DESCRIPTION
## Summary

`rs-config-render` had four independent exit-code mappings (`RenderError`, `ixp_manager::Error`, `activation::Error` in `main.rs`, `ixp_manager_lifecycle::Error`) that disagreed: exit 4 meant "pinned shape drift, retry is useless" for a render and "rolled back, retry is right" for `activate`/lifecycle; exit 3 meant "implausible set" for a render and "candidate dir not empty or strict check failed" for an IXP Manager candidate. This unifies them into one table across every subcommand.

## Unified table (authoritative: `tools/rs-config-render/README.md` → "Exit codes"; mirrored in `docs/deployment.md`)

| Exit | Meaning | Raised by |
|---|---|---|
| 0 | success | all |
| 1 | invalid input — context/document unreadable, unparseable, unknown field; site-local file unreadable (also the generic failure when stdout cannot be written) | render, IXP Manager candidate |
| 2 | refused — unsupported knob, invalid option combination, unmet precondition, no lock acquired / definite pre-activation refusal released; nothing written or activated | all |
| 3 | aborted — generated set empty or under the plausibility floor | render |
| 4 | shape drift — pinned fingerprint mismatch | render |
| 5 | manual recovery — activation effect uncertain; `current` on candidate, retained state and upstream lock kept | `activate`, lifecycle |
| 6 | callback pending — run `ixp-manager-lifecycle resume` | lifecycle |
| 7 | rolled back — activation command never started; prior generation restored and proven; retry is safe | `activate`, lifecycle |
| 8 | output unusable — candidate dir not absent/empty private (IXP Manager mode) or could not be created/written (arouteserver mode) | IXP Manager candidate, render |
| 9 | strict check failed — `rustbgpd --check --strict` rejected the candidate; no receipt | IXP Manager candidate |

Codes 1–4, 5, 6 keep their existing meanings. Moves: rollback 4 → 7; IXP Manager candidate `Output` 3 → 8 and `Checker` 3 → 9; arouteserver-mode out-dir write failures 1 → 8. Every code now has exactly one meaning, so a wrapper can branch on the code alone.

## Mechanism

- One `#[repr(u8)] enum Exit` in `lib.rs` is the only source of numbers (duplicate discriminants are a compile error). Every error type's `exit_code()` returns `Exit`; `main.rs` has no numeric literals left.
- `tools/rs-config-render/tests/exit_codes.rs` asserts: `Exit::ALL` is exhaustive (match witness) and unique; the README table lists exactly the enum's codes; `docs/deployment.md`'s table mirrors the README byte for byte; every `Error` variant of all four error enums maps to the expected `Exit` (each list is guarded by an exhaustive match, so a new variant fails to compile until mapped). Negative-checked: renumbering one row in `docs/deployment.md` fails the test.
- No compatibility shim or dual mapping.

## Breaking change

Wrappers that branched on the old numbers for `activate` / `ixp-manager-lifecycle` rollback (4) or for IXP Manager candidate output/strict-check failures (3) must be updated. Accepted: pre-pilot, alpha posture, no outside consumers. Recorded under CHANGELOG `[Unreleased] → Changed`.

## Consumer sweep (every site that asserted or documented an old number)

Updated:
- `tools/rs-config-render/tests/ixp_manager.rs` — `Some(3)` → `Some(9)` (checker failed) and `Some(8)` (non-empty / public / symlinked output dir)
- `tools/rs-config-render/tests/golden.rs` — `exit_code() == 1` → `Exit::InvalidInput`
- `tools/rs-config-render/src/main.rs` unit test — `ExitCode::from(1)` → `ExitCode::from(Exit::InvalidInput)`
- `tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh` — rollback expectation 4 → 7
- `tools/rs-config-render/README.md` — activation/lifecycle prose (4 → 7), per-mode table replaced by the single table
- `docs/deployment.md` — prose (4 → 7) plus the mirrored table
- `ROADMAP.md`, `CHANGELOG.md` (unreleased LAN-1105 entry) — "Exit 4" → "Exit 7"

Checked and unchanged (no old number asserted or already consistent): `tests/interop/scripts/test-m97-ixp-manager-authenticated-lifecycle.sh` (asserts 0/2/5 only), `tests/compat/ixp-manager-birdseye/run.sh` (asserts non-zero only), `tests/interop/scripts/test-m90-differential.sh` and `prove-context-ingestion.sh` (render codes unchanged), `tests/rs_config_render_emitted_check.rs` (matches variants, not codes), `docs/cookbook/ixp-filter-pipeline.md` (render codes 2/3/4 unchanged), `integrations/ixp-manager/gpl-2.0-only/README.md`, `examples/`, `.github/workflows/*` (no exit-code assertions on this tool).

## Also in this PR

`docs/deployment.md`'s `activate` and `ixp-manager-lifecycle run` examples omitted the required `--router-handle`, `--runtime-state-dir`, and `--host-state-dir` flags and targeted the singleton `rustbgpd` unit; they failed clap parsing as written (`error: the following required arguments were not provided`). Both now carry the full per-handle binding and reload `rustbgpd@rs1-ipv4`, matching the tool README. Proven by running every `rs-config-render` console example in `docs/deployment.md` and the tool README against the built binary with a throwaway state directory: each reaches a tool precondition error (not a usage error).

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `scripts/check_public_tracker_ids.py` — all rc 0 on the rebased tree, except that the full-workspace test run tripped one pre-existing load-sensitive daemon test each time it ran (`config_migration::both_validator_deadlines_kill_reap_sanitize_and_clean_stage` once, `config_persistence_lifecycle::…commit_confirm_hold_on_the_wire` once); both are unrelated to this tool, pass in isolation, and are noted on the tracker separately. `tools/rs-config-render` is a workspace member, so the workspace gates cover it.

## Review follow-ups (second commit on this branch)

**Exit 9 is exact.** `ixp_manager::Error::Checker` (exit 9) is now returned only when `rustbgpd --check --strict` ran and exited nonzero. A checker that cannot be spawned, exits nonzero on `--version`, or prints an unrecognised version line is a new `Error::CheckerUnavailable` mapped to exit 2 (unmet precondition; message `strict checker is unavailable; candidate has no receipt`). The `--version` probe now runs before any candidate file is written, so that refusal is trace-free; if the checker disappears between the probe and the `--check` spawn, the written files are taken back (`remove_dir_all` + recreate the empty 0700 dir) and exit 2 is returned. Test: `missing_checker_is_refused_before_any_write` (binary run with a nonexistent `--check-with` → exit 2, message, no candidate directory). Rows 2 and 9 of the table describe exactly these paths.

**Exit 2 leaves no trace.** `activate_inner` now tracks whether `copy_generation` created the generation and removes it on any refusal before `current` is published (`Staging` guard disarmed right after a successful `publish_current`); pre-existing (content-equal) generations are never touched. The lifecycle `run` path that refuses over a pending journal (`pending lifecycle state requires resume`) now clears the fence it had just written instead of leaving it behind. Test: `refused_after_generation_copy_leaves_the_state_directory_unchanged` — snapshot of the state tree (paths, symlink targets, file digests) is identical before and after a strict-check refusal and a known-good-runtime refusal, and a later activation of the same candidate succeeds. One path intentionally keeps a trace and row 2 says so: the lifecycle folds a strict-check *rejection* into exit 2 and leaves that candidate, receipt-less, in its per-run candidate directory — those files are the only evidence of why `--check --strict` rejected an IXP Manager export. Structural residue that is not "output" and exists after every first successful run too: the fixed-name `activation.lock` file and an empty `generations/` directory.

**`Exit::ALL` witness.** `tests/exit_codes.rs::witnessed()` enumerates the enum by a literal chain (`Exit::Success => Some(Exit::InvalidInput) … Exit::StrictCheckFailed => None`); adding a variant makes that `match` non-exhaustive, and the test asserts the chain equals `Exit::ALL`, that codes are unique, and that the README/deployment tables list exactly `ALL`. Negative-checked: dropping one variant from `ALL` fails the test.

**Consumer sweep, second pass** (`git grep -nE 'exit (4|3)\b|Exit (4|3)\b|exits? (4|3)\b' -- docs tests tools examples integrations .github README.md ROADMAP.md CHANGELOG.md`): updated `docs/cookbook/activation-manual-recovery.md` (the "cannot yet tell apart" paragraph replaced with the unified-table pointer; "Exit 4" → "Exit 7" in the not-covered list) and `docs/cookbook/ixp-manager-route-server.md` (both exit tables, the sample console transcript, and "Activate exits 4" → 7). Remaining hits are unrelated: `docs/cookbook/ixp-filter-pipeline.md` (render 3/4, unchanged meanings), `rbgp policy check --coverage-min` exit 3 (completions, CHANGELOG history), soak scripts' own `exit 3`/`exit 4`, `docs/soaks/*`, `tests/soak/*`.

**Gates after the follow-up:** fmt 0, clippy 0, doc 0, clippy-reasons 0, tracker-ids 0; `cargo test --workspace --no-fail-fast` red only on the known `started_failure_timeout_and_unsettled_retain_candidate_without_rollback` 4 s wall-clock bound under full-workspace load (4.78 s); the target passes in isolation (3.0 s).
