### PR TITLE
feat: add opt-in rs-config-render generation pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rs-config-render prune --keep N` removes activation generations that no
+  retention rule keeps: the `current` target, the last activation receipt's
+  candidate and predecessor, anything a pending lifecycle journal names, and
+  the N most recent generations always survive. It is a dry run unless
+  `--apply` is given, refuses outright while a host fence exists, and never
+  runs from the activation path. The README documents the rule, a cron-safe
+  pattern, and measured bytes per generation. (LAN-1180)
 - A `semver-checks` CI workflow runs `cargo-semver-checks` for every
   publishable workspace crate (re-derived from the manifests; today
   `rustbgpd-wire` and `rustbgpd-fsm`) against its latest crates.io release on

--- a/docs/cookbook/route-server-shadow-pilot.md
+++ b/docs/cookbook/route-server-shadow-pilot.md
@@ -512,8 +512,10 @@ the facts rather than discovering them mid-pilot:
   command, one fence per host, no remote activation, no cross-host
   coordination. Two hosts are two independent lifecycles.
 - **Automatic housekeeping of activation state.** Every activated
-  generation is retained under `<runtime>/activation/generations/` and
-  never pruned; exit 5 (`ManualRecovery`) leaves a fence that blocks
+  generation is retained under `<runtime>/activation/generations/` until
+  an operator runs the opt-in, dry-run-by-default
+  [`rs-config-render prune`](../../tools/rs-config-render/README.md#pruning-retained-generations);
+  exit 5 (`ManualRecovery`) leaves a fence that blocks
   every later run until an operator resolves it —
   [Activation manual recovery](activation-manual-recovery.md). Neither
   matters to a shadow that never activates, but both matter to the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -215,7 +215,7 @@ the [tool README](../tools/rs-config-render/README.md#exit-codes):
 | 5 | **manual recovery** — the activation effect is uncertain: `current` stays on the candidate, retained state and any upstream lock are kept, and no callback is issued; inspect before acting |
 | 6 | **callback pending** — one durable `updated` or release callback is undelivered; run `ixp-manager-lifecycle resume` |
 | 7 | **rolled back** — the activation command never started; the prior generation is restored and proven and the lock is released; retrying is safe |
-| 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode) or could not be created or written (arouteserver mode) |
+| 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode), could not be created or written (arouteserver mode), or a `prune --apply` removal failed |
 | 9 | **strict check failed** — `rustbgpd --check --strict` ran and rejected the rendered IXP Manager candidate (the only path to this code); its files stay in the candidate directory without a receipt |
 
 ### Debian / RPM packages

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -153,7 +153,9 @@ operator inspection. Exit 0 means activated or no-op, 2 refusal, 7 proven
 pre-effect restoration, and 5 means recovery or receipt durability is
 unproven (the full table is under [Exit codes](#exit-codes)). A receipt may
 therefore be absent or stale after exit 5. The helper does not deploy services,
-prune generations, retry indefinitely, or call IXP Manager. These examples use
+retry indefinitely, or call IXP Manager, and the activation path never removes a
+generation; retention is the separate, operator-run
+[`prune`](#pruning-retained-generations) command. These examples use
 package paths; release archives install the three binaries under `/usr/local/bin`.
 
 ### Authenticated IXP Manager lifecycle
@@ -228,6 +230,71 @@ or idempotency token. `resume` never refetches, rerenders, or activates. It has
 no automatic action for exit 5; inspect retained activation/lifecycle state and
 the live daemon before explicitly resolving the upstream router lock, following
 the [activation manual-recovery runbook](../../docs/cookbook/activation-manual-recovery.md).
+
+### Pruning retained generations
+
+Every distinct activated candidate becomes an immutable, content-addressed
+directory under `<state-dir>/generations/`; an identical re-render is a no-op
+and adds nothing. Nothing in the activation or lifecycle path ever removes one,
+because after an exit 5 those directories are the only forensics. Retention is
+a separate, opt-in command that defaults to a dry run:
+
+```console
+sudo -u rustbgpd /usr/bin/rs-config-render prune --keep 10 \
+  --router-handle rs1-ipv4 \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock
+```
+
+The retention rule, evaluated under the activation state lock:
+
+- the `current` target is kept (`current`);
+- the last `activation-receipt.json`'s candidate (`receipt`) and
+  `previous_generation` (`predecessor`) are kept, so the generation a
+  rollback restored from and the one it rolled back are both retained;
+- a generation whose `render-receipt.json` a pending lifecycle journal names
+  is kept (`journal`);
+- the `--keep N` most recently published generations are kept (`keep-N`);
+  `--keep 0` keeps only the referenced ones;
+- everything else is removed — by `--apply` only.
+
+`prune` **refuses outright (exit 2) while any host fence exists**, and while
+the activation receipt or lifecycle journal exists but cannot be parsed; resolve
+the fence with the [manual-recovery
+runbook](../../docs/cookbook/activation-manual-recovery.md) first. Output is
+exact and stable: one `keep <digest> <reasons>` line per retained generation,
+newest first, one `remove <digest>` line per removal, then a summary. Without
+`--apply` nothing is removed and the `remove` lines are exactly what `--apply`
+would remove; a second `--apply` removes nothing. A removal that fails exits 8
+and names the generation on stderr; rerun after fixing the directory.
+
+A cron-safe pattern runs the dry run on the same schedule as the lifecycle and
+applies only from a reviewed ticket, or applies unconditionally with a generous
+`--keep` — a refusal under a fence is the intended outcome, not an error to
+suppress:
+
+```sh
+# cron, as the rustbgpd identity, after the lifecycle run
+/usr/bin/rs-config-render prune --keep 48 --apply \
+  --router-handle rs1-ipv4 --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
+  || [ $? -eq 2 ]   # 2 = fenced or busy: leave it, the operator has work to do
+```
+
+Sizing: a generation is the rendered candidate copied verbatim — `config.toml`,
+the shared hygiene policy, one `.rpol` per member, the alias and reject maps,
+and the receipt. Measured on ext4 (4 KiB blocks) with synthetic IXP Manager v2
+members carrying 8 IRR prefixes each: 100 members → 104 files, 129 KiB apparent
+/ 484 KiB allocated; 250 members → 314 KiB / 1,188 KiB; 500 members →
+622 KiB / 2,348 KiB (32 prefixes per member: 851 KiB / 2,348 KiB). Allocation is
+block-dominated at roughly 4.8 KiB per member per generation, so a 500-member
+route server spends about 2.3 MiB per distinct generation; an hourly lifecycle
+whose render differs every run (the worst case) would retain about 20 GiB a
+year unpruned, and `--keep 48` bounds it to about 110 MiB.
 
 Release tarballs (`rustbgpd-<arch>.tar.gz` on the [releases
 page](https://github.com/lance0/rustbgpd/releases)) ship the
@@ -320,11 +387,12 @@ knowing which subcommand ran. The mapping is asserted by
 | 5 | **manual recovery** — the activation effect is uncertain: `current` stays on the candidate, retained state and any upstream lock are kept, and no callback is issued; inspect before acting |
 | 6 | **callback pending** — one durable `updated` or release callback is undelivered; run `ixp-manager-lifecycle resume` |
 | 7 | **rolled back** — the activation command never started; the prior generation is restored and proven and the lock is released; retrying is safe |
-| 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode) or could not be created or written (arouteserver mode) |
+| 8 | **output unusable** — the candidate directory is not an absent or empty private directory (IXP Manager mode), could not be created or written (arouteserver mode), or a `prune --apply` removal failed |
 | 9 | **strict check failed** — `rustbgpd --check --strict` ran and rejected the rendered IXP Manager candidate (the only path to this code); its files stay in the candidate directory without a receipt |
 
 Codes 1–4 and 8–9 leave the previous configuration running untouched
-(fail-stale); 5 and 6 need an operator; 7 is safe to retry.
+(fail-stale); 5 and 6 need an operator; 7 is safe to retry. `prune` uses 0, 2
+(fenced, busy, or unreadable forensic state — nothing removed), and 8.
 
 Refused knobs: RTT-based communities and `rtt_thresholds` (the daemon
 has no RTT source; permanent), configured

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -89,7 +89,7 @@ mod unix {
         config: Vec<u8>,
     }
 
-    fn private(path: &Path, directory: bool, mode: u32) -> bool {
+    pub(crate) fn private(path: &Path, directory: bool, mode: u32) -> bool {
         fs::symlink_metadata(path).is_ok_and(|metadata| {
             let kind = metadata.file_type();
             let exact_kind = kind.is_dir() == directory
@@ -107,7 +107,7 @@ mod unix {
             })
     }
 
-    fn valid_digest(value: &str) -> bool {
+    pub(crate) fn valid_digest(value: &str) -> bool {
         value.len() == 64
             && value
                 .bytes()
@@ -316,7 +316,7 @@ mod unix {
             .ok_or(Error::Refused("state directories must be mode 0700"))
     }
 
-    fn state_lock(state: &Path) -> AResult<File> {
+    pub(crate) fn state_lock(state: &Path) -> AResult<File> {
         let path = state.join("activation.lock");
         let file = match OpenOptions::new()
             .read(true)
@@ -973,4 +973,4 @@ mod unix {
 #[cfg(unix)]
 pub use unix::activate;
 #[cfg(unix)]
-pub(crate) use unix::activate_guarded;
+pub(crate) use unix::{activate_guarded, private, state_lock, valid_digest};

--- a/tools/rs-config-render/src/ixp_manager_host.rs
+++ b/tools/rs-config-render/src/ixp_manager_host.rs
@@ -134,6 +134,14 @@ mod unix {
             .map_err(|_| Error::Refused("another host command is active"))?;
         Ok(file)
     }
+    /// True unless the fence file is proven absent; an unreadable fence counts
+    /// as present so callers fail closed.
+    pub(crate) fn fence_present(state: &Path) -> bool {
+        !matches!(
+            fs::symlink_metadata(state.join(FENCE)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound
+        )
+    }
     fn read_fence(state: &Path) -> Result<Option<Binding>, Error> {
         let path = state.join(FENCE);
         let metadata = match fs::symlink_metadata(&path) {
@@ -218,3 +226,5 @@ mod unix {
 }
 #[cfg(unix)]
 pub use unix::Guard;
+#[cfg(unix)]
+pub(crate) use unix::fence_present;

--- a/tools/rs-config-render/src/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/src/ixp_manager_lifecycle.rs
@@ -543,6 +543,20 @@ mod unix {
         Ok(journal)
     }
 
+    /// The `candidate_sha256` of a pending journal: `Ok(None)` when no journal
+    /// exists or it predates the candidate, `Err(())` when one exists but cannot
+    /// be parsed (callers treat that as forensic state and fail closed).
+    pub(crate) fn journal_candidate(state: &Path) -> std::result::Result<Option<String>, ()> {
+        let bytes = match fs::read(journal_path(state)) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(()),
+        };
+        serde_json::from_slice::<Journal>(&bytes)
+            .map(|journal| journal.candidate_sha256)
+            .map_err(|_| ())
+    }
+
     fn remove_journal(state: &Path) -> Result<()> {
         fs::remove_file(journal_path(state)).map_err(|_| Error::ManualRecovery)?;
         sync_dir(state)
@@ -800,5 +814,7 @@ mod unix {
     }
 }
 
+#[cfg(unix)]
+pub(crate) use unix::journal_candidate;
 #[cfg(unix)]
 pub use unix::{resume, run};

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -47,6 +47,8 @@ pub mod activation;
 pub mod ixp_manager;
 pub mod ixp_manager_host;
 pub mod ixp_manager_lifecycle;
+#[cfg(unix)]
+pub mod prune;
 
 /// Top-level keys of the supported `template-context` shape, sorted.
 ///

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -52,6 +52,23 @@ struct ActivateArgs {
     activation_arg: Vec<OsString>,
 }
 
+#[derive(Parser)]
+#[command(
+    name = "rs-config-render prune",
+    about = "Remove activation generations no retention rule keeps (dry run unless --apply)"
+)]
+struct PruneArgs {
+    #[command(flatten)]
+    host: HostBindingArgs,
+    /// Most recent generations to retain besides current, its predecessor,
+    /// and anything a receipt or pending lifecycle journal references
+    #[arg(long)]
+    keep: usize,
+    /// Remove the planned generations instead of only reporting them
+    #[arg(long)]
+    apply: bool,
+}
+
 #[derive(clap::Args)]
 struct HostBindingArgs {
     #[arg(long)]
@@ -253,6 +270,13 @@ fn parse_activation() -> Option<ActivateArgs> {
         .then(|| ActivateArgs::parse_from(std::iter::once(binary).chain(args)))
 }
 
+fn parse_prune() -> Option<PruneArgs> {
+    let mut args = std::env::args_os();
+    let binary = args.next()?;
+    (args.next().as_deref() == Some(OsStr::new("prune")))
+        .then(|| PruneArgs::parse_from(std::iter::once(binary).chain(args)))
+}
+
 fn parse_lifecycle() -> Option<LifecycleArgs> {
     let mut args = std::env::args_os();
     let binary = args.next()?;
@@ -285,6 +309,48 @@ fn lifecycle_exit(
 }
 
 fn main() -> ExitCode {
+    if let Some(args) = parse_prune() {
+        let binding = match args.host.binding() {
+            Ok(binding) => binding,
+            Err(reason) => {
+                eprintln!("rs-config-render: prune: {reason}");
+                return Exit::Refused.into();
+            }
+        };
+        return match rs_config_render::prune::prune(&rs_config_render::prune::Options {
+            state_dir: &args.host.state_dir,
+            keep: args.keep,
+            apply: args.apply,
+            binding: &binding,
+        }) {
+            Ok(plan) => {
+                for (digest, error) in &plan.failed {
+                    eprintln!("rs-config-render: prune: cannot remove {digest}: {error}");
+                }
+                let (kept, removed) = (plan.kept.len(), plan.removed.len());
+                let summary = if args.apply {
+                    format!("prune: removed {removed} generation(s), kept {kept}")
+                } else {
+                    format!(
+                        "prune: dry run — {removed} generation(s) would be removed, {kept} kept; pass --apply to remove"
+                    )
+                };
+                let written = stdout_exit(write_stdout(|writer| {
+                    write!(writer, "{plan}")?;
+                    writeln!(writer, "{summary}")
+                }));
+                if plan.failed.is_empty() {
+                    written
+                } else {
+                    Exit::OutputUnusable.into()
+                }
+            }
+            Err(error) => {
+                eprintln!("rs-config-render: prune: {error}");
+                error.exit_code().into()
+            }
+        };
+    }
     if let Some(args) = parse_lifecycle() {
         return match args.command {
             LifecycleCommand::Run(args) => {

--- a/tools/rs-config-render/src/prune.rs
+++ b/tools/rs-config-render/src/prune.rs
@@ -1,0 +1,248 @@
+//! Opt-in retention for activation generations.
+//!
+//! Generations are content-addressed and immutable; the activation path never
+//! removes one. `prune` is a separate operator-run command: it plans under the
+//! activation state lock, defaults to a dry run, and refuses outright while a
+//! host fence exists, so it can never remove the forensic state an exit 5
+//! leaves behind.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::SystemTime;
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::ixp_manager_host::{self, Binding};
+use crate::{Exit, activation, ixp_manager_lifecycle};
+
+const GENERATIONS: &str = "generations";
+const RECEIPT: &str = "render-receipt.json";
+const ACTIVATION_RECEIPT: &str = "activation-receipt.json";
+
+#[derive(Debug)]
+pub struct Options<'a> {
+    pub state_dir: &'a Path,
+    /// Most recent generations retained regardless of references.
+    pub keep: usize,
+    /// Remove the planned generations; otherwise report only.
+    pub apply: bool,
+    pub binding: &'a Binding,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    Refused(&'static str),
+}
+
+impl Error {
+    pub const fn exit_code(&self) -> Exit {
+        match self {
+            Self::Refused(_) => Exit::Refused,
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Refused(reason) => formatter.write_str(reason),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// One retained generation and every rule that retains it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Kept {
+    pub digest: String,
+    pub reasons: Vec<&'static str>,
+}
+
+/// The plan; newest generation first within each list.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Plan {
+    pub kept: Vec<Kept>,
+    /// Removed by `--apply`; otherwise what `--apply` would remove.
+    pub removed: Vec<String>,
+    /// `--apply` removals that failed, with the I/O error text. Non-empty
+    /// means the state directory needs attention and the run exits nonzero.
+    pub failed: Vec<(String, String)>,
+}
+
+impl std::fmt::Display for Plan {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for kept in &self.kept {
+            writeln!(formatter, "keep {} {}", kept.digest, kept.reasons.join(","))?;
+        }
+        for digest in &self.removed {
+            writeln!(formatter, "remove {digest}")?;
+        }
+        Ok(())
+    }
+}
+
+fn generation_digest(target: &str) -> Option<&str> {
+    target
+        .strip_prefix("generations/")
+        .filter(|digest| activation::valid_digest(digest))
+}
+
+fn receipt_sha256(generation: &Path) -> Option<String> {
+    let bytes = fs::read(generation.join(RECEIPT)).ok()?;
+    Some(
+        Sha256::digest(bytes)
+            .iter()
+            .fold(String::with_capacity(64), |mut output, byte| {
+                use std::fmt::Write as _;
+                write!(output, "{byte:02x}").expect("String writes cannot fail");
+                output
+            }),
+    )
+}
+
+/// Plan and, with `apply`, remove generations that no retention rule keeps.
+///
+/// Retained: the `current` target, the last activation receipt's candidate and
+/// previous generation, the generation a pending lifecycle journal names, and
+/// the `keep` most recently published generations.
+pub fn prune(options: &Options<'_>) -> Result<Plan, Error> {
+    if options.state_dir != options.binding.activation_state_dir {
+        return Err(Error::Refused("state directory must match host binding"));
+    }
+    if !options.state_dir.is_absolute() || !activation::private(options.state_dir, true, 0o700) {
+        return Err(Error::Refused(
+            "state directory must be a pre-created absolute mode-0700 directory",
+        ));
+    }
+    if ixp_manager_host::fence_present(&options.binding.host_state_dir) {
+        return Err(Error::Refused(
+            "host fence present; resolve it before pruning (retained state is forensic)",
+        ));
+    }
+    let _lock = activation::state_lock(options.state_dir).map_err(|error| match error {
+        activation::Error::Refused(reason) => Error::Refused(reason),
+        activation::Error::RolledBack | activation::Error::RecoveryRequired => {
+            Error::Refused("state lock failed")
+        }
+    })?;
+    let generations_dir = options.state_dir.join(GENERATIONS);
+    let mut generations: BTreeMap<String, SystemTime> = BTreeMap::new();
+    match fs::read_dir(&generations_dir) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry.map_err(|_| Error::Refused("generations are unreadable"))?;
+                let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                    continue;
+                };
+                let metadata = entry
+                    .metadata()
+                    .map_err(|_| Error::Refused("generations are unreadable"))?;
+                // Staging leftovers (`.<digest>.<pid>.<nanos>`) are not generations.
+                if activation::valid_digest(&name) && metadata.file_type().is_dir() {
+                    // ponytail: publication order = directory mtime (set when the
+                    // generation was staged, immediately before its rename into
+                    // place); the receipt carries no timestamp to prefer.
+                    generations.insert(name, metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH));
+                }
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => return Err(Error::Refused("generations are unreadable")),
+    }
+    let mut reasons: BTreeMap<&str, Vec<&'static str>> = BTreeMap::new();
+    let mut retain = |digest: &str, reason: &'static str| {
+        if let Some((key, _)) = generations.get_key_value(digest) {
+            reasons.entry(key.as_str()).or_default().push(reason);
+        }
+    };
+    match fs::read_link(options.state_dir.join("current")) {
+        Ok(target) => {
+            let digest = target
+                .to_str()
+                .and_then(generation_digest)
+                .ok_or(Error::Refused(
+                    "current must be a relative generation symlink",
+                ))?;
+            if !generations.contains_key(digest) {
+                return Err(Error::Refused(
+                    "current target is not a published generation",
+                ));
+            }
+            retain(digest, "current");
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => return Err(Error::Refused("current generation is unreadable")),
+    }
+    match fs::read(options.state_dir.join(ACTIVATION_RECEIPT)) {
+        Ok(bytes) => {
+            let receipt: Value = serde_json::from_slice(&bytes)
+                .map_err(|_| Error::Refused("activation receipt is unreadable"))?;
+            let candidate = receipt["candidate_sha256"]
+                .as_str()
+                .filter(|digest| activation::valid_digest(digest))
+                .ok_or(Error::Refused("activation receipt is unreadable"))?;
+            retain(candidate, "receipt");
+            if let Some(previous) = receipt["previous_generation"].as_str() {
+                let previous = generation_digest(previous)
+                    .ok_or(Error::Refused("activation receipt is unreadable"))?;
+                retain(previous, "predecessor");
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => return Err(Error::Refused("activation receipt is unreadable")),
+    }
+    if let Some(journal_candidate) = ixp_manager_lifecycle::journal_candidate(options.state_dir)
+        .map_err(|()| {
+            Error::Refused("lifecycle journal is unreadable; resolve it before pruning")
+        })?
+    {
+        let referenced: Vec<String> = generations
+            .keys()
+            .filter(|digest| {
+                receipt_sha256(&generations_dir.join(digest)).as_deref()
+                    == Some(journal_candidate.as_str())
+            })
+            .cloned()
+            .collect();
+        for digest in &referenced {
+            retain(digest, "journal");
+        }
+    }
+    let mut by_recency: Vec<(&String, &SystemTime)> = generations.iter().collect();
+    by_recency.sort_by(|left, right| right.1.cmp(left.1).then_with(|| left.0.cmp(right.0)));
+    for (digest, _) in by_recency.iter().take(options.keep) {
+        retain(digest, "keep-N");
+    }
+    let mut plan = Plan::default();
+    for (digest, _) in &by_recency {
+        match reasons.get(digest.as_str()) {
+            Some(found) => plan.kept.push(Kept {
+                digest: (*digest).clone(),
+                reasons: found.clone(),
+            }),
+            None => plan.removed.push((*digest).clone()),
+        }
+    }
+    if options.apply {
+        for digest in &plan.removed {
+            if let Err(error) = fs::remove_dir_all(generations_dir.join(digest)) {
+                plan.failed.push((digest.clone(), error.to_string()));
+            }
+        }
+        if !plan.removed.is_empty()
+            && fs::File::open(&generations_dir)
+                .and_then(|directory| directory.sync_all())
+                .is_err()
+        {
+            plan.failed
+                .push((GENERATIONS.to_owned(), "directory sync failed".to_owned()));
+        }
+        plan.removed
+            .retain(|digest| !plan.failed.iter().any(|(failed, _)| failed == digest));
+    }
+    Ok(plan)
+}

--- a/tools/rs-config-render/tests/activation.rs
+++ b/tools/rs-config-render/tests/activation.rs
@@ -726,3 +726,223 @@ fn refused_after_generation_copy_leaves_the_state_directory_unchanged() {
     );
     assert_ne!(snapshot(&rig.state), before);
 }
+
+mod prune {
+    use super::*;
+    use rs_config_render::prune::{Error as PruneError, Kept, Options as PruneOptions, prune};
+
+    impl Rig {
+        fn prune(
+            &self,
+            keep: usize,
+            apply: bool,
+        ) -> Result<rs_config_render::prune::Plan, PruneError> {
+            prune(&PruneOptions {
+                state_dir: &self.state,
+                keep,
+                apply,
+                binding: &self.binding(&self.state),
+            })
+        }
+
+        /// Activate `count` distinct candidates in order and return their
+        /// generation digests, oldest first.
+        fn generations(&self, count: u64) -> Vec<String> {
+            (0..count)
+                .map(|index| {
+                    let candidate = self.candidate(&format!("candidate-{index}"), 100 + index);
+                    // Distinct directory mtimes order the keep-N window.
+                    std::thread::sleep(Duration::from_millis(20));
+                    assert_eq!(
+                        self.run(&candidate, index == 0, &self.activation),
+                        Ok(Status::Activated)
+                    );
+                    self.current().trim_start_matches("generations/").to_owned()
+                })
+                .collect()
+        }
+
+        fn generation_exists(&self, digest: &str) -> bool {
+            self.state.join("generations").join(digest).is_dir()
+        }
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        Sha256::digest(bytes)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    fn kept(digest: &str, reasons: &[&'static str]) -> Kept {
+        Kept {
+            digest: digest.to_owned(),
+            reasons: reasons.to_vec(),
+        }
+    }
+
+    #[test]
+    fn prune_keeps_current_predecessor_receipt_and_journal_and_refuses_under_a_fence() {
+        let rig = Rig::new();
+        let g = rig.generations(5);
+
+        // keep 0: only references survive — current (+receipt candidate) and predecessor.
+        let plan = rig.prune(0, false).unwrap();
+        assert_eq!(
+            plan.kept,
+            vec![
+                kept(&g[4], &["current", "receipt"]),
+                kept(&g[3], &["predecessor"])
+            ]
+        );
+        assert_eq!(plan.removed, vec![g[2].clone(), g[1].clone(), g[0].clone()]);
+        assert!(plan.failed.is_empty());
+        assert!(
+            g.iter().all(|digest| rig.generation_exists(digest)),
+            "dry run removed nothing"
+        );
+
+        // A pending lifecycle journal naming g[1]'s render receipt keeps g[1].
+        let journal = serde_json::json!({
+            "schema": "rustbgpd.ixp-manager.lifecycle/v1",
+            "ixp_manager_version": "7.4.0",
+            "origin": "https://ixp.example.net",
+            "router_handle": "b2-rs1-lan1-ipv4",
+            "host": rig.binding(&rig.state),
+            "phase": "manual_recovery",
+            "callback": null,
+            "callback_attempts": 0,
+            "candidate_sha256": sha256_hex(
+                &fs::read(rig.state.join("generations").join(&g[1]).join("render-receipt.json")).unwrap()
+            ),
+            "activation_outcome": "recovery_required",
+            "error_class": "activation"
+        });
+        let journal_path = rig.state.join("ixp-manager-lifecycle.json");
+        fs::write(&journal_path, serde_json::to_vec(&journal).unwrap()).unwrap();
+        let plan = rig.prune(0, false).unwrap();
+        assert_eq!(
+            plan.kept,
+            vec![
+                kept(&g[4], &["current", "receipt"]),
+                kept(&g[3], &["predecessor"]),
+                kept(&g[1], &["journal"]),
+            ]
+        );
+        assert_eq!(plan.removed, vec![g[2].clone(), g[0].clone()]);
+
+        // An unparseable journal is forensic state: refuse.
+        fs::write(&journal_path, b"{not json").unwrap();
+        assert!(matches!(rig.prune(0, true), Err(PruneError::Refused(_))));
+        fs::write(&journal_path, serde_json::to_vec(&journal).unwrap()).unwrap();
+
+        // Any host fence refuses outright, even with --apply.
+        let fence = rig.host.join("ixp-manager-host-fence.json");
+        fs::write(&fence, b"{}").unwrap();
+        assert_eq!(
+            rig.prune(0, true),
+            Err(PruneError::Refused(
+                "host fence present; resolve it before pruning (retained state is forensic)"
+            ))
+        );
+        assert!(
+            g.iter().all(|digest| rig.generation_exists(digest)),
+            "refusal removed nothing"
+        );
+        fs::remove_file(&fence).unwrap();
+
+        // Apply removes exactly the plan and leaves a coherent state.
+        let applied = rig.prune(0, true).unwrap();
+        assert_eq!(applied.removed, vec![g[2].clone(), g[0].clone()]);
+        assert!(applied.failed.is_empty());
+        for (index, digest) in g.iter().enumerate() {
+            assert_eq!(
+                rig.generation_exists(digest),
+                [1, 3, 4].contains(&index),
+                "{index}"
+            );
+        }
+        assert_eq!(rig.current(), format!("generations/{}", g[4]));
+        let again = rig.prune(0, true).unwrap();
+        assert!(again.removed.is_empty(), "{again:?}");
+        assert_eq!(again.kept.len(), 3);
+        fs::remove_file(&journal_path).unwrap();
+        let candidate = rig.candidate("candidate-noop", 104);
+        assert_eq!(
+            rig.run(&candidate, false, Path::new("/bin/false")),
+            Ok(Status::Noop)
+        );
+    }
+
+    #[test]
+    fn prune_cli_dry_run_lists_exactly_what_apply_removes_and_is_idempotent() {
+        let rig = Rig::new();
+        let g = rig.generations(4);
+        let run = |apply: bool| {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_rs-config-render"));
+            command
+                .args([
+                    "prune",
+                    "--router-handle",
+                    "b2-rs1-lan1-ipv4",
+                    "--keep",
+                    "1",
+                ])
+                .arg("--runtime-state-dir")
+                .arg(&rig.runtime)
+                .arg("--state-dir")
+                .arg(&rig.state)
+                .arg("--host-state-dir")
+                .arg(&rig.host)
+                .arg("--rbgp-addr")
+                .arg(rig.binding(&rig.state).rbgp_addr());
+            if apply {
+                command.arg("--apply");
+            }
+            let output = command.output().unwrap();
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            let removed: Vec<String> = stdout
+                .lines()
+                .filter_map(|line| line.strip_prefix("remove "))
+                .map(str::to_owned)
+                .collect();
+            (output.status.code(), stdout, removed)
+        };
+
+        let (code, stdout, dry) = run(false);
+        assert_eq!(code, Some(0), "{stdout}");
+        assert_eq!(dry, vec![g[1].clone(), g[0].clone()]);
+        assert!(
+            stdout.contains(&format!("keep {} current,receipt,keep-N\n", g[3])),
+            "{stdout}"
+        );
+        assert!(
+            stdout.contains(&format!("keep {} predecessor\n", g[2])),
+            "{stdout}"
+        );
+        assert!(
+            stdout.ends_with("prune: dry run — 2 generation(s) would be removed, 2 kept; pass --apply to remove\n"),
+            "{stdout}"
+        );
+        assert!(g.iter().all(|digest| rig.generation_exists(digest)));
+
+        let (code, stdout, applied) = run(true);
+        assert_eq!(code, Some(0), "{stdout}");
+        assert_eq!(applied, dry);
+        assert!(
+            stdout.ends_with("prune: removed 2 generation(s), kept 2\n"),
+            "{stdout}"
+        );
+        for (index, digest) in g.iter().enumerate() {
+            assert_eq!(rig.generation_exists(digest), index >= 2, "{index}");
+        }
+
+        let (code, stdout, second) = run(true);
+        assert_eq!(code, Some(0), "{stdout}");
+        assert!(second.is_empty(), "{stdout}");
+        assert!(
+            stdout.ends_with("prune: removed 0 generation(s), kept 2\n"),
+            "{stdout}"
+        );
+    }
+}

--- a/tools/rs-config-render/tests/exit_codes.rs
+++ b/tools/rs-config-render/tests/exit_codes.rs
@@ -2,7 +2,7 @@
 //! source of numbers, every error type maps into it, and the README table
 //! (plus its `docs/deployment.md` mirror) must list exactly those codes.
 
-use rs_config_render::{Exit, RenderError, activation, ixp_manager, ixp_manager_lifecycle};
+use rs_config_render::{Exit, RenderError, activation, ixp_manager, ixp_manager_lifecycle, prune};
 
 fn table_rows(markdown: &str) -> Vec<String> {
     let mut lines = markdown.lines();
@@ -160,6 +160,14 @@ fn every_error_variant_maps_to_the_shared_table() {
             activation::Error::Refused(_)
             | activation::Error::RolledBack
             | activation::Error::RecoveryRequired => {}
+        }
+        assert_eq!(error.exit_code(), *exit, "{error:?}");
+    }
+
+    let pruning = [(prune::Error::Refused(""), Exit::Refused)];
+    for (error, exit) in &pruning {
+        match error {
+            prune::Error::Refused(_) => {}
         }
         assert_eq!(error.exit_code(), *exit, "{error:?}");
     }


### PR DESCRIPTION
## Summary

Adds `rs-config-render prune --keep N`: an opt-in, operator-owned retention command for activation generations. The activation and lifecycle paths are unchanged and still never remove a generation; `prune` is a separate subcommand that plans under the activation state lock, defaults to a dry run, and refuses outright while any host fence exists, so the forensic state an exit 5 leaves behind can never be removed by it.

Stacked on #1791 (unified exit codes): this branch is based on `fix/rs-config-render-unified-exit-codes` because `prune` maps into the shared `Exit` enum. Re-derive onto `main` once #1791 merges.

## Retention rule (evaluated under `activation.lock`)

Kept, with the reason printed per generation:
- `current` — the `current` symlink target
- `receipt` — the last `activation-receipt.json`'s `candidate_sha256`
- `predecessor` — that receipt's `previous_generation`
- `journal` — any generation whose `render-receipt.json` SHA-256 equals a pending `ixp-manager-lifecycle.json`'s `candidate_sha256`
- `keep-N` — the N most recently published generations (directory mtime; `--keep 0` keeps only the referenced ones)

Everything else is removed — by `--apply` only. Staging leftovers (`.<digest>.<pid>.<nanos>`) are not generations and are ignored.

## Refusal conditions (exit 2, nothing removed)

- any host fence (`ixp-manager-host-fence.json`) in the host-state directory — an unreadable fence counts as present
- activation receipt present but unparseable; lifecycle journal present but unparseable
- `current` present but not a valid relative generation symlink, or pointing at an unpublished generation
- state directory not a pre-created absolute mode-0700 directory, binding mismatch, or `activation.lock` held by a concurrent activation

A `--apply` removal that fails is reported per generation on stderr and exits 8 (`output unusable`, whose README row now names this case); rerun after fixing the directory.

## Output contract

`keep <digest> <reason,reason>` per retained generation (newest first), `remove <digest>` per removal, then `prune: dry run — N generation(s) would be removed, M kept; pass --apply to remove` or `prune: removed N generation(s), kept M`. The dry-run `remove` set is exactly what `--apply` removes; a second `--apply` removes nothing.

## Measured on-disk size per generation

A generation is the rendered candidate copied verbatim (`config.toml`, hygiene policy, one `.rpol` per member, alias and reject maps, receipt). Synthetic IXP Manager v2 members rendered through the real `rustbgpd --check --strict` on ext4 (4 KiB blocks):

| members | prefixes/member | files | apparent | allocated |
|---|---|---|---|---|
| 100 | 8 | 104 | 129 KiB | 484 KiB |
| 250 | 8 | 254 | 314 KiB | 1,188 KiB |
| 500 | 8 | 504 | 622 KiB | 2,348 KiB |
| 500 | 32 | 504 | 851 KiB | 2,348 KiB |

Allocation is block-dominated at about 4.8 KiB per member per generation (one `.rpol` file per member). A 500-member route server spends about 2.3 MiB per distinct generation; identical re-renders are no-ops (content-addressed) so growth is per *changed* render. The hourly worst case (every run differs) is about 20 GiB a year unpruned; `--keep 48` bounds it to about 110 MiB. These figures are in the README sizing paragraph.

## Tests (`tools/rs-config-render/tests/activation.rs`, `prune` module, using the existing activation rig with real activations)

- `prune_keeps_current_predecessor_receipt_and_journal_and_refuses_under_a_fence` — five real generations; keep 0 retains exactly current(+receipt) and predecessor; a pending journal naming generation 2's receipt retains it with reason `journal`; an unparseable journal refuses; a fence refuses even with `--apply` and removes nothing; `--apply` removes exactly the dry-run set and leaves `current` resolvable (a follow-up activation no-ops); a second `--apply` removes nothing.
- `prune_cli_dry_run_lists_exactly_what_apply_removes_and_is_idempotent` — through the binary with `--keep 1`: pins the `keep … current,receipt,keep-N` / `predecessor` / `remove` lines and both summary lines; `--apply` removes exactly the dry-run `remove` set; the third run removes nothing.
- `tests/exit_codes.rs` — `prune::Error` added to the exhaustive per-variant mapping.

## Docs

- `tools/rs-config-render/README.md` — new "Pruning retained generations" section (rule, command, refusal, output contract, cron-safe pattern, sizing); the "does not prune" sentence now points at it; exit-code table row 8 names the removal-failure case (mirrored in `docs/deployment.md`, asserted by the table test).
- `docs/cookbook/route-server-shadow-pilot.md` — the one "retained … and never pruned" sentence now points at `prune`.
- CHANGELOG `[Unreleased] → Added`.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `scripts/check_public_tracker_ids.py` — all rc 0.

## Rebase note

Rebased onto the current head of `fix/rs-config-render-unified-exit-codes` (review follow-ups: exact exit 9, trace-free refusals, `Exit::ALL` witness). Still one commit ahead of that branch; three adjacent-line conflicts resolved (row 8 from this PR + row 9 from the base in both tables; both appended test blocks kept in `tests/activation.rs`). Gates re-run on the rebased tree: fmt, clippy, doc, clippy-reasons, tracker-ids all rc 0; the full workspace test run was red only on the known `started_failure_timeout_and_unsettled_retain_candidate_without_rollback` 4 s wall-clock bound and the pre-existing `config_migration` pid-file race, both unrelated; the activation target passes in isolation (3.0 s, 10 tests) and serially (8.0 s).
