### PR TITLE
perf(rib): guard the selection-gate scans behind the deferral Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   old numbers. The authoritative table is the "Exit codes" section of
   `tools/rs-config-render/README.md`, mirrored in `docs/deployment.md` and
   asserted by a test. (LAN-1174)
+- Outbound Adj-RIB-Out commits now test for an active RFC 4724 selection
+  deferral once before scanning every family queue for a gated family; with no
+  deferral configured the per-route scans are skipped. Gate behavior is
+  unchanged. (LAN-1161)
 
 - `rustbgpd-rib`, `rustbgpd-policy`, and `rustbgpd-bmp` no longer declare an
   unused `thiserror` dependency; the ROADMAP entry that tracked the transitive

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -2109,46 +2109,50 @@ impl RibManager {
         #[cfg(feature = "bench-internals")]
         let bench_per_client_best_resync = self.peer_per_client_best.contains(&peer)
             && (self.dirty_peers.contains(&peer) || self.force_outbound_peers.contains(&peer));
-        let gated = announce
-            .iter()
-            .any(|route| self.selection_deferred(prefix_family(&route.prefix)))
-            || withdraw
+        // Every arm below is provably false without an active deferral state:
+        // `selection_deferred` / `selection_convergence_held` short-circuit on
+        // `None`. Guard once so the common no-gate commit skips all the scans.
+        let gated = self.selection_deferral.is_some()
+            && (announce
                 .iter()
-                .any(|(prefix, _)| self.selection_deferred(prefix_family(prefix)))
-            || end_of_rib
-                .iter()
-                .any(|family| self.selection_convergence_held(*family))
-            || refresh_markers
-                .iter()
-                .any(|(afi, safi, _)| self.selection_convergence_held((*afi, *safi)))
-            || flowspec_announce
-                .iter()
-                .any(|route| self.selection_deferred((route.afi, Safi::FlowSpec)))
-            || flowspec_withdraw
-                .iter()
-                .any(|key| self.selection_deferred((key.afi, Safi::FlowSpec)))
-            || ((!evpn_announce.is_empty() || !evpn_withdraw.is_empty())
-                && self.selection_deferred((Afi::L2Vpn, Safi::Evpn)))
-            || bgpls_announce
-                .iter()
-                .any(|route| self.selection_deferred(route.family.to_afi_safi()))
-            || bgpls_withdraw
-                .iter()
-                .any(|key| self.selection_deferred(key.family.to_afi_safi()))
-            || vpn_announce
-                .iter()
-                .any(|route| self.selection_deferred(route.afi_safi()))
-            || vpn_withdraw
-                .iter()
-                .any(|key| self.selection_deferred(key.afi_safi()))
-            || labeled_announce
-                .iter()
-                .any(|route| self.selection_deferred(route.afi_safi()))
-            || labeled_withdraw
-                .iter()
-                .any(|key| self.selection_deferred(key.afi_safi()))
-            || ((!rtc_announce.is_empty() || !rtc_withdraw.is_empty())
-                && self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()));
+                .any(|route| self.selection_deferred(prefix_family(&route.prefix)))
+                || withdraw
+                    .iter()
+                    .any(|(prefix, _)| self.selection_deferred(prefix_family(prefix)))
+                || end_of_rib
+                    .iter()
+                    .any(|family| self.selection_convergence_held(*family))
+                || refresh_markers
+                    .iter()
+                    .any(|(afi, safi, _)| self.selection_convergence_held((*afi, *safi)))
+                || flowspec_announce
+                    .iter()
+                    .any(|route| self.selection_deferred((route.afi, Safi::FlowSpec)))
+                || flowspec_withdraw
+                    .iter()
+                    .any(|key| self.selection_deferred((key.afi, Safi::FlowSpec)))
+                || ((!evpn_announce.is_empty() || !evpn_withdraw.is_empty())
+                    && self.selection_deferred((Afi::L2Vpn, Safi::Evpn)))
+                || bgpls_announce
+                    .iter()
+                    .any(|route| self.selection_deferred(route.family.to_afi_safi()))
+                || bgpls_withdraw
+                    .iter()
+                    .any(|key| self.selection_deferred(key.family.to_afi_safi()))
+                || vpn_announce
+                    .iter()
+                    .any(|route| self.selection_deferred(route.afi_safi()))
+                || vpn_withdraw
+                    .iter()
+                    .any(|key| self.selection_deferred(key.afi_safi()))
+                || labeled_announce
+                    .iter()
+                    .any(|route| self.selection_deferred(route.afi_safi()))
+                || labeled_withdraw
+                    .iter()
+                    .any(|key| self.selection_deferred(key.afi_safi()))
+                || ((!rtc_announce.is_empty() || !rtc_withdraw.is_empty())
+                    && self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi())));
         if gated {
             warn!(%peer, "outbound transaction intersected an active RFC 4724 selection gate; failing closed");
             return false;

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -719,6 +719,66 @@ fn staged_selection_rejects_eor_and_refresh_marker_commits() {
 }
 
 #[test]
+fn deferred_selection_rejects_route_commit_until_release() {
+    let source = peer(1);
+    let target = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    assert!(manager.selection_deferred(FAMILY));
+
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(4);
+    manager.outbound_peers.insert(target, outbound_tx);
+    manager.peer_export_encoders.insert(
+        target,
+        crate::manager::permissive_test_exact_export_encoder(),
+    );
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let commit = |manager: &mut RibManager| {
+        manager.try_send_and_commit_outbound_update(
+            target,
+            vec![None].into(),
+            vec![make_route_with_lp(prefix, Ipv4Addr::new(10, 0, 0, 2), 100)].into(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+    };
+    assert!(
+        !commit(&mut manager),
+        "active selection deferral must fail a route-bearing commit closed"
+    );
+    assert!(outbound_rx.try_recv().is_err());
+
+    let released = manager
+        .selection_deferral
+        .as_mut()
+        .unwrap()
+        .expire(&metrics);
+    assert_eq!(released, vec![FAMILY]);
+    assert!(manager.selection_deferral.is_some());
+    assert!(!manager.selection_deferred(FAMILY));
+    assert!(
+        commit(&mut manager),
+        "a released deferral must let the same route commit through"
+    );
+    assert!(outbound_rx.try_recv().is_ok());
+}
+
+#[test]
 fn staged_selection_classifies_refresh_response_as_convergence_deferred() {
     let source = peer(1);
     let target = peer(2);


### PR DESCRIPTION
## Summary

`try_send_and_commit_outbound_update` opened with fourteen `.any(..)` scans over every family queue, each asking `selection_deferred` / `selection_convergence_held` whether the family is behind an RFC 4724 selection gate. Both predicates are false whenever `self.selection_deferral` is `None`, which is the steady state for every deployment without a configured deferral, so every outbound commit paid the full scans for nothing.

The chain is now `self.selection_deferral.is_some() && (<the same fourteen arms>)`. The arms are unchanged; only the short-circuit in front is new. `is_some()` is used rather than `has_deferred_selection()` because `selection_convergence_held` can be true for a staged family that `has_deferred_selection` would not report.

## Tests

- New `deferred_selection_rejects_route_commit_until_release`: a route-bearing commit fails closed while the family's selection is deferred, and the same commit succeeds after the deferral is released (the `Option` is still `Some` at that point, so the guard alone does not explain the success).
- Existing `staged_selection_rejects_eor_and_refresh_marker_commits` still pins the `selection_convergence_held` arm.

## Measurement

`rrharness flood <clients> 100000 5` (manager-direct, cold stage), base = `origin/main` at `85649600`, head = this branch, both built `--release --locked` into separate target directories, pinned to one performance-governor core with `taskset`. Two interleaved rounds (round 1 order A,B,A,B; round 2 order B,A,B,A per rung). The host was shared and busy during both rounds (1-minute load 12–24 on 64 cores), so treat the spread as noise-dominated.

`cold_staged_s`:

| clients | A (base) | B (head) |
|---|---|---|
| 256 | 0.528, 0.537, 0.570, 0.671 | 0.540, 0.518, 0.681, 0.542 |
| 512 | 0.948, 0.914, 0.991, 0.915 | 0.858, 0.973, 1.212, 0.963 |
| 1000 | 2.022, 1.601, 2.025, 1.520 | 1.451, 1.407, 1.441, 1.512 |

256 and 512 are indistinguishable under this noise. At 1000 clients every head sample sits at or below the base range, but the base samples themselves span 1.52–2.03 s, so this is at most suggestive. No S2 matrix or published-receipt claim is made; that needs an exact-tag campaign on a quiet host. "No measurable change" is an acceptable outcome for this change: it is a strict Pareto fix by construction.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo doc` with `-D warnings`, `scripts/check-clippy-reasons.py`, `cargo check -p rustbgpd-rib --features bench-internals --benches`, and `bench/smoke-benches.sh` all clean. `cargo test --workspace --no-fail-fast` was clean except for one wall-clock assertion in `tools/rs-config-render/tests/activation.rs` (`elapsed < 4 s`) that tripped on the loaded host; re-running `-p rs-config-render --test activation` in isolation passes in 3.0 s. That test is outside this change's surface.
