### PR TITLE
perf(rib): stop cloning blocked routes in the OTC egress fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   deferral once before scanning every family queue for a gated family; with no
   deferral configured the per-route scans are skipped. Gate behavior is
   unchanged. (LAN-1161)
+- The RFC 9234 OTC egress fallback no longer clones routes it is about to
+  block; only the permitted subset is copied into the rebuilt announce slice.
+  Withdraw conversion and diagnostics are unchanged. (LAN-1167)
 
 - `rustbgpd-rib`, `rustbgpd-policy`, and `rustbgpd-bmp` no longer declare an
   unused `thiserror` dependency; the ROADMAP entry that tracked the transitive

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -2234,12 +2234,11 @@ impl RibManager {
             // Preserve the caller's withdrawal order while making duplicate
             // detection constant-time for large policy reload/resync batches.
             let mut withdrawn_keys: HashSet<(Prefix, u32)> = withdraw.iter().copied().collect();
-            for (route, next_hop) in announce
-                .iter()
-                .cloned()
-                .zip(next_hop_override.iter().cloned())
-            {
-                if otc_egress_blocked(&route, local_role) {
+            // `announce` is a shared slice, so the permitted subset has to be
+            // copied into a fresh one; blocked routes are inspected in place
+            // and never cloned.
+            for (route, next_hop) in announce.iter().zip(next_hop_override.iter()) {
+                if otc_egress_blocked(route, local_role) {
                     // A per-client-best group member's prior wire view is
                     // group-derived (no per-peer unicast Adj-RIB-Out), so
                     // the previously-advertised gate below cannot see it. A
@@ -2267,8 +2266,8 @@ impl RibManager {
                         withdraw.push((route.prefix, route.path_id));
                     }
                 } else {
-                    permitted.push(route);
-                    permitted_next_hops.push(next_hop);
+                    permitted.push(route.clone());
+                    permitted_next_hops.push(next_hop.clone());
                 }
             }
             announce = permitted.into();


### PR DESCRIPTION
## Summary

When at least one route in an outbound batch is blocked by the RFC 9234 OTC egress backstop, the fallback rebuilds the announce set. It did so by cloning every route and next-hop action up front (`announce.iter().cloned().zip(next_hop_override.iter().cloned())`) and then discarding the clones it decided to block.

The loop now walks both slices by reference, decides on the borrowed route, and clones only the permitted subset into the rebuilt slice. `announce` is an `Arc<[Route]>` shared with group members, so it cannot be consumed element-wise; the permitted copies are the minimum needed to produce the new slice. `Vec::retain` is not applicable because the blocked branch has a side effect (the conditional withdraw conversion).

Behaviour is unchanged: the single-best staging `debug_assert`, the per-client-best `pending_otc_blocked` withdraw conversion, the `withdrawn_keys` de-duplication, and the ordering of the permitted routes are all as before. This removes a clone; no other performance claim is made.

## Tests

All existing RFC 9234 egress tests pass unchanged (`cargo test -p rustbgpd-rib --lib otc`: 21 passed) along with the full workspace battery.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo doc` with `-D warnings`, `scripts/check-clippy-reasons.py`, `cargo check -p rustbgpd-rib --features bench-internals --benches`, and `bench/smoke-benches.sh` all clean. `cargo test --workspace --no-fail-fast` was clean except for two daemon-lifecycle integration tests that tripped on a loaded shared host (`config_persistence_lifecycle`: a commit-confirm timeout status still `pending`; `runtime_config_settlement_matrix`: the daemon socket not yet present); both pass when re-run in isolation (`--test config_persistence_lifecycle`: 10 passed; `--test runtime_config_settlement_matrix`: 2 passed). Neither exercises the OTC egress path.
