### PR TITLE
perf(rib): cache the nearest GR, LLGR, and refresh deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The RFC 9234 OTC egress fallback no longer clones routes it is about to
   block; only the permitted subset is copied into the rebuilt announce slice.
   Withdraw conversion and diagnostics are unchanged. (LAN-1167)
+- The RIB manager now caches the nearest GR, LLGR, and enhanced-route-refresh
+  deadline instead of rescanning each registry on every actor-loop iteration;
+  a rescan happens only after an entry whose deadline equals the cached
+  minimum is removed or overwritten (conservative on ties). Timer firing and
+  sweep behavior are unchanged. (LAN-1166)
 
 - `rustbgpd-rib`, `rustbgpd-policy`, and `rustbgpd-bmp` no longer declare an
   unused `thiserror` dependency; the ROADMAP entry that tracked the transitive

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -1,5 +1,8 @@
-use std::collections::HashSet;
+use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::net::IpAddr;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use rustbgpd_rpki::VrpTable;
@@ -12,6 +15,121 @@ use super::helpers::{
     validate_route_rpki,
 };
 use crate::route::{BgpLsFamily, BgpLsRouteKey};
+
+/// Deadline registry with a cached minimum. The actor loop probes the
+/// nearest GR / LLGR / refresh deadline on every iteration; with the cache
+/// that probe is O(1) while the registry is untouched, and the only full
+/// scan happens on the first probe after an entry whose deadline equals the
+/// cached minimum is removed or overwritten — conservative on ties: any tied
+/// entry invalidates, even when another entry still holds that deadline.
+/// Inserts fold into the cache directly.
+///
+/// Reads go through `Deref`; every mutation goes through the methods below
+/// so the cache can never be bypassed. Values are never handed out `&mut`.
+#[derive(Debug)]
+pub(super) struct DeadlineMap<K> {
+    map: HashMap<K, tokio::time::Instant>,
+    min: Option<tokio::time::Instant>,
+    /// True when `min` may be wrong and the next probe must rescan.
+    stale: bool,
+}
+
+impl<K> Default for DeadlineMap<K> {
+    fn default() -> Self {
+        Self {
+            map: HashMap::new(),
+            min: None,
+            stale: false,
+        }
+    }
+}
+
+impl<K: Eq + Hash> DeadlineMap<K> {
+    pub(super) fn insert(
+        &mut self,
+        key: K,
+        deadline: tokio::time::Instant,
+    ) -> Option<tokio::time::Instant> {
+        let prev = self.map.insert(key, deadline);
+        if let Some(prev) = prev {
+            self.note_removed(prev);
+        }
+        if !self.stale {
+            self.min = Some(self.min.map_or(deadline, |min| min.min(deadline)));
+        }
+        prev
+    }
+
+    pub(super) fn remove<Q>(&mut self, key: &Q) -> Option<tokio::time::Instant>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let prev = self.map.remove(key);
+        if let Some(prev) = prev {
+            self.note_removed(prev);
+        }
+        prev
+    }
+
+    /// Keep only the entries whose key satisfies `keep`.
+    pub(super) fn retain(&mut self, mut keep: impl FnMut(&K) -> bool) {
+        let before = self.map.len();
+        self.map.retain(|key, _| keep(key));
+        if self.map.len() != before {
+            // The dropped entries are not known here; rescan lazily.
+            self.stale = !self.map.is_empty();
+            if self.map.is_empty() {
+                self.min = None;
+            }
+        }
+    }
+
+    /// Nearest deadline, or `None` when the registry is empty. O(1) unless
+    /// the cached minimum was invalidated since the last probe.
+    pub(super) fn min(&mut self) -> Option<tokio::time::Instant> {
+        if self.stale {
+            self.min = self.map.values().copied().min();
+            self.stale = false;
+        }
+        self.min
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_stale(&self) -> bool {
+        self.stale
+    }
+
+    /// Account for a removed or overwritten deadline. Invalidates on value
+    /// equality with the cached minimum, so with tied minima removing any one
+    /// of them forces a rescan (the cache never returns a stale answer, it
+    /// just rescans more often than strictly necessary).
+    fn note_removed(&mut self, removed: tokio::time::Instant) {
+        if self.map.is_empty() {
+            self.min = None;
+            self.stale = false;
+        } else if self.min == Some(removed) {
+            self.stale = true;
+        }
+    }
+}
+
+impl<K> Deref for DeadlineMap<K> {
+    type Target = HashMap<K, tokio::time::Instant>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<'a, K> IntoIterator for &'a DeadlineMap<K> {
+    type Item = (&'a K, &'a tokio::time::Instant);
+    type IntoIter = std::collections::hash_map::Iter<'a, K, tokio::time::Instant>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.iter()
+    }
+}
 
 impl RibManager {
     #[expect(
@@ -654,9 +772,12 @@ impl RibManager {
                     .min()
                     .unwrap_or(llgr_config.local_llgr_stale_time);
                 let effective = peer_family_stale.min(llgr_config.local_llgr_stale_time);
-                self.llgr_stale_deadlines
-                    .entry((peer, afi, safi))
-                    .or_insert(now + std::time::Duration::from_secs(u64::from(effective)));
+                if !self.llgr_stale_deadlines.contains_key(&(peer, afi, safi)) {
+                    self.llgr_stale_deadlines.insert(
+                        (peer, afi, safi),
+                        now + std::time::Duration::from_secs(u64::from(effective)),
+                    );
+                }
             }
             self.llgr_peers
                 .insert(peer, llgr_families.into_iter().collect());
@@ -970,18 +1091,18 @@ impl RibManager {
     }
 
     /// Find the nearest GR stale deadline, if any.
-    pub(super) fn next_gr_deadline(&self) -> Option<tokio::time::Instant> {
-        self.gr_stale_deadlines.values().copied().min()
+    pub(super) fn next_gr_deadline(&mut self) -> Option<tokio::time::Instant> {
+        self.gr_stale_deadlines.min()
     }
 
     /// Find the nearest LLGR stale deadline, if any.
-    pub(super) fn next_llgr_deadline(&self) -> Option<tokio::time::Instant> {
-        self.llgr_stale_deadlines.values().copied().min()
+    pub(super) fn next_llgr_deadline(&mut self) -> Option<tokio::time::Instant> {
+        self.llgr_stale_deadlines.min()
     }
 
     /// Find the nearest enhanced route refresh deadline, if any.
-    pub(super) fn next_refresh_deadline(&self) -> Option<tokio::time::Instant> {
-        self.refresh_deadlines.values().copied().min()
+    pub(super) fn next_refresh_deadline(&mut self) -> Option<tokio::time::Instant> {
+        self.refresh_deadlines.min()
     }
 
     /// Sweep any inbound enhanced route refresh windows whose deadline has

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -354,7 +354,7 @@ pub struct RibManager {
     /// Active inbound enhanced route refresh windows by peer/family.
     refresh_in_progress: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Per-peer/per-family deadlines for active enhanced route refresh windows.
-    refresh_deadlines: HashMap<(IpAddr, Afi, Safi), tokio::time::Instant>,
+    refresh_deadlines: graceful_restart::DeadlineMap<(IpAddr, Afi, Safi)>,
     /// Unicast routes still awaiting replacement during an inbound refresh.
     refresh_stale_routes: HashMap<IpAddr, HashSet<(Prefix, u32)>>,
     /// `FlowSpec` routes still awaiting replacement during an inbound refresh.
@@ -376,7 +376,7 @@ pub struct RibManager {
     /// Value is the set of (AFI, SAFI) families still awaiting End-of-RIB.
     gr_peers: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Deadlines for sweeping stale routes per GR peer.
-    gr_stale_deadlines: HashMap<IpAddr, tokio::time::Instant>,
+    gr_stale_deadlines: graceful_restart::DeadlineMap<IpAddr>,
     /// Configured stale-routes-time per GR peer (seconds), used to reset
     /// the timer on `PeerUp` during graceful restart.
     gr_stale_routes_time: HashMap<IpAddr, u64>,
@@ -389,7 +389,7 @@ pub struct RibManager {
     /// deliberately survives re-establishment while routes remain
     /// LLGR-stale: the ORIGINAL Long-Lived Stale Time bounds total
     /// retention, so a reconnect-then-down never restarts the timer.
-    llgr_stale_deadlines: HashMap<(IpAddr, Afi, Safi), tokio::time::Instant>,
+    llgr_stale_deadlines: graceful_restart::DeadlineMap<(IpAddr, Afi, Safi)>,
     /// Configured per-peer LLGR parameters, stored on `PeerGracefulRestart`.
     llgr_peer_config: HashMap<IpAddr, LlgrPeerConfig>,
     /// Maximum Add-Path paths per prefix per peer (0 = single-best only).
@@ -1141,7 +1141,7 @@ impl RibManager {
             pending_initial_registrations: VecDeque::new(),
             initial_dump_defer_min_routes: INITIAL_DUMP_DEFER_MIN_ROUTES,
             refresh_in_progress: HashMap::new(),
-            refresh_deadlines: HashMap::new(),
+            refresh_deadlines: graceful_restart::DeadlineMap::default(),
             refresh_stale_routes: HashMap::new(),
             refresh_stale_flowspec: HashMap::new(),
             refresh_stale_evpn: HashMap::new(),
@@ -1151,10 +1151,10 @@ impl RibManager {
             refresh_stale_rtc: HashMap::new(),
             refresh_stale_counts: HashMap::new(),
             gr_peers: HashMap::new(),
-            gr_stale_deadlines: HashMap::new(),
+            gr_stale_deadlines: graceful_restart::DeadlineMap::default(),
             gr_stale_routes_time: HashMap::new(),
             llgr_peers: HashMap::new(),
-            llgr_stale_deadlines: HashMap::new(),
+            llgr_stale_deadlines: graceful_restart::DeadlineMap::default(),
             llgr_peer_config: HashMap::new(),
             peer_add_path_send_max: HashMap::new(),
             peer_add_path_send_limits: HashMap::new(),
@@ -1399,7 +1399,7 @@ impl RibManager {
         self.refresh_stale_counts
             .retain(|(stale_peer, _, _), _| *stale_peer != peer);
         self.refresh_deadlines
-            .retain(|(stale_peer, _, _), _| *stale_peer != peer);
+            .retain(|(stale_peer, _, _)| *stale_peer != peer);
     }
 
     /// Advance one scope version without ever reusing a process-local value.

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -329,7 +329,7 @@ impl RibManager {
         // Per-family LLGR deadlines can outlive both maps above (they
         // survive re-establishment while routes remain LLGR-stale); a full
         // teardown ends retention outright.
-        self.llgr_stale_deadlines.retain(|&(p, _, _), _| p != peer);
+        self.llgr_stale_deadlines.retain(|&(p, _, _)| p != peer);
 
         self.clear_peer_adj_rib_in(peer);
 

--- a/crates/rib/src/manager/tests/gr_llgr.rs
+++ b/crates/rib/src/manager/tests/gr_llgr.rs
@@ -2118,3 +2118,77 @@ async fn evpn_gr_stale_routes_keep_exporting_during_gr_window() {
     drop(tx);
     handle.await.unwrap();
 }
+
+mod deadline_map {
+    use std::time::Duration;
+
+    use crate::manager::graceful_restart::DeadlineMap;
+
+    fn at(secs: u64) -> tokio::time::Instant {
+        tokio::time::Instant::now() + Duration::from_secs(secs)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn min_tracks_inserts_without_rescanning() {
+        let mut map = DeadlineMap::default();
+        assert_eq!(map.min(), None);
+        map.insert("b", at(30));
+        map.insert("a", at(10));
+        map.insert("c", at(20));
+        assert!(!map.is_stale());
+        assert_eq!(map.min(), Some(at(10)));
+        assert_eq!(map.len(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn removing_the_minimum_invalidates_and_rescans() {
+        let mut map = DeadlineMap::default();
+        map.insert("a", at(10));
+        map.insert("b", at(20));
+        map.insert("c", at(30));
+        assert_eq!(map.remove("b"), Some(at(20)));
+        assert!(
+            !map.is_stale(),
+            "dropping a non-minimum entry keeps the cache"
+        );
+        assert_eq!(map.remove("a"), Some(at(10)));
+        assert!(map.is_stale());
+        assert_eq!(map.min(), Some(at(30)));
+        assert!(!map.is_stale());
+        assert_eq!(map.remove("missing"), None);
+        assert_eq!(map.min(), Some(at(30)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn overwriting_the_minimum_rescans_to_the_new_value() {
+        let mut map = DeadlineMap::default();
+        map.insert("a", at(10));
+        map.insert("b", at(20));
+        assert_eq!(map.insert("a", at(40)), Some(at(10)));
+        assert_eq!(map.min(), Some(at(20)));
+        assert_eq!(map.insert("b", at(5)), Some(at(20)));
+        assert_eq!(map.min(), Some(at(5)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retain_and_drain_to_empty_report_none() {
+        let mut map = DeadlineMap::default();
+        map.insert(("p1", 1), at(10));
+        map.insert(("p1", 2), at(20));
+        map.insert(("p2", 1), at(15));
+        map.retain(|&(peer, _)| peer != "p1");
+        assert_eq!(map.min(), Some(at(15)));
+        assert_eq!(map.len(), 1);
+        map.retain(|_| true);
+        assert!(!map.is_stale());
+        assert_eq!(map.min(), Some(at(15)));
+        assert_eq!(map.remove(&("p2", 1)), Some(at(15)));
+        assert!(map.is_empty());
+        assert!(!map.is_stale());
+        assert_eq!(map.min(), None);
+        map.insert(("p3", 1), at(7));
+        assert_eq!(map.min(), Some(at(7)));
+        map.retain(|_| false);
+        assert_eq!(map.min(), None);
+    }
+}


### PR DESCRIPTION
## Summary

The actor loop re-arms three timers on every iteration by asking for the nearest GR stale deadline, the nearest LLGR stale deadline, and the nearest enhanced-route-refresh deadline. Each answer was a full `values().copied().min()` scan of its registry, so an idle loop iteration cost O(retained entries) three times over.

The three registries are now a small `DeadlineMap<K>` (in `graceful_restart.rs`) that keeps the minimum cached:

- `insert` folds the new deadline into the cached minimum (O(1)); overwriting the entry that holds the minimum marks the cache stale.
- `remove` of the entry holding the minimum marks the cache stale; removing anything else leaves it valid. Draining to empty resets to `None` without a rescan.
- `retain` marks the cache stale only if it dropped something.
- `min()` rescans once when stale, then answers from the cache.

No heap: cancellation would need tombstones, and the number of live deadlines is small enough that one lazy rescan after a removal is cheaper and simpler.

Reads go through `Deref<Target = HashMap<_, Instant>>` (plus `IntoIterator for &DeadlineMap`), and every mutation goes through the wrapper — the registries are private to it, so nothing can change a deadline behind the cache. `retain` takes `FnMut(&K) -> bool` rather than exposing `&mut Instant`. All insert / remove / retain / `entry().or_insert` sites across `graceful_restart.rs`, `route_refresh.rs`, `peer_lifecycle.rs`, and `mod.rs` are routed through it; `next_*_deadline` take `&mut self` now because the first probe after an invalidation refreshes the cache.

## Tests

`manager::tests::gr_llgr::deadline_map`: minimum tracks inserts without going stale; removing a non-minimum keeps the cache, removing the minimum marks it stale and the next probe rescans to the right value; overwriting the minimum key rescans; `retain` and drain-to-empty report `None`. The existing GR / LLGR / refresh suites are unchanged.

## Sizing

Steady state this is near-free either way: the registries are small unless many peers are in GR/LLGR retention or have refresh windows open. It matters when they are — every loop iteration then paid three linear scans. Mass-flap (the minimum entry removed and re-inserted between probes) degrades to roughly the old cost plus one bookkeeping step, never worse.

Microbench of the probe itself (standalone copy of the data structure, one pinned core; `before` = `values().min()` per probe, `after` = cached probe, `after_flap` = remove + re-insert the minimum before every probe, i.e. a forced rescan per probe):

| entries | before ns/probe | after ns/probe | after_flap ns/probe |
|---|---|---|---|
| 0 | 0.4 | 0.4 | – |
| 1 | 1.0 | 0.4 | 22.7 |
| 10 | 10.5 | 0.4 | 45.9 |
| 100 | 107.6 | 0.4 | 135.3 |
| 1000 | 1107.3 | 0.4 | 1170.8 |
| 10000 | 10954.2 | 0.4 | 11232.4 |

This is the timer-arm path only. No convergence-path claim is made.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo doc` with `-D warnings`, `scripts/check-clippy-reasons.py`, `cargo check -p rustbgpd-rib --features bench-internals --benches`, and `bench/smoke-benches.sh` all clean. `cargo test --workspace --no-fail-fast` was clean except for one wall-clock assertion in `tools/rs-config-render/tests/activation.rs` (`elapsed < 4 s`) that tripped on a loaded shared host; re-running `-p rs-config-render --test activation` in isolation passes in 3.0 s. That test is outside this change's surface.
