### PR TITLE
ci: semver-check the publishable crates against crates.io

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,73 @@
+name: semver-checks
+
+# Guards the crates.io-published library crates against an accidental API
+# break. The crate set is re-derived on every run from the workspace: every
+# member whose manifest does NOT carry `publish = false` (today
+# `rustbgpd-wire` and `rustbgpd-fsm`) is checked with cargo-semver-checks
+# against its latest published version.
+#
+# Baseline: no `baseline-version` / `baseline-rev` / `baseline-root` input is
+# passed on purpose. cargo-semver-checks then uses its default baseline — the
+# latest normal (non-prerelease, non-yanked) release of the crate on crates.io
+# — i.e. exactly what consumers have. The required release type is derived
+# from the manifest version versus that baseline (for 0.x crates a minor bump
+# is treated as major and a patch bump as minor; an unchanged version is
+# checked as a minor release). A change that breaks the published API without
+# a version bump therefore fails, and one whose Cargo.toml already carries the
+# appropriate bump passes.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    # GitHub cannot derive this filter from the manifests. The `publishable`
+    # step below re-derives the crate set and fails the job if a publishable
+    # crate's directory is missing from this list.
+    paths:
+      - "crates/wire/**"
+      - "crates/fsm/**"
+      - ".github/workflows/semver-checks.yml"
+  workflow_dispatch:
+
+jobs:
+  semver-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - name: Derive the publishable crate set
+        id: publishable
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo metadata --locked --no-deps --format-version 1 > "$RUNNER_TEMP/metadata.json"
+          python3 - "$RUNNER_TEMP/metadata.json" .github/workflows/semver-checks.yml <<'PY' \
+            | tee -a "$GITHUB_OUTPUT"
+          import json, os, sys
+          meta = json.load(open(sys.argv[1]))
+          root = meta["workspace_root"]
+          publishable = sorted(
+              (p["name"], os.path.relpath(os.path.dirname(p["manifest_path"]), root))
+              for p in meta["packages"]
+              if p["publish"] is None
+          )
+          if not publishable:
+              sys.exit("no publishable crate found; did every manifest gain publish = false?")
+          filter_text = open(sys.argv[2]).read()
+          missing = [d for _, d in publishable if f'- "{d}/**"' not in filter_text]
+          if missing:
+              sys.exit(f"publishable crate dirs missing from the pull_request paths filter: {missing}")
+          print("publishable:", ", ".join(f"{n} ({d})" for n, d in publishable), file=sys.stderr)
+          print("packages=" + ",".join(n for n, _ in publishable))
+          PY
+      - uses: obi1kenobi/cargo-semver-checks-action@v2.9
+        with:
+          package: ${{ steps.publishable.outputs.packages }}
+          # The action installs the latest stable toolchain itself (its
+          # documented default), matching the `stable` posture of ci.yml, and
+          # caches the baseline rustdoc between runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- A `semver-checks` CI workflow runs `cargo-semver-checks` for every
+  publishable workspace crate (re-derived from the manifests; today
+  `rustbgpd-wire` and `rustbgpd-fsm`) against its latest crates.io release on
+  pull requests that touch the crate, so an API break without the matching
+  version bump fails before publish. (LAN-1209)
+
 - The Shutdown RPC now synchronously signals main's coordinated teardown watch
   without sending directly to PeerManager. Quickstart timeout failures kill and
   reap the daemon before preserving stderr and cleanup evidence; this removes

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -425,9 +425,10 @@ To be the de facto Rust BGP codec, the concrete gaps:
    crate* (gated on a `tokio-codec` feature that pulls `bytes` only — no full
    tokio) so any async consumer gets framed decode for free. This is the
    "battery-included" ergonomic that bgp-rs/zettabgp lack.
-3. **Run `cargo-semver-checks` in CI** against the published wire crate so
-   accidental breaking changes are caught before publish. Add to
-   `.github/workflows/ci.yml` on the wire crate path.
+3. **Run `cargo-semver-checks` in CI** against the published crates so
+   accidental breaking changes are caught before publish. Done: the
+   `semver-checks` workflow checks every publishable workspace crate against
+   its latest crates.io release on pull requests that touch it.
 4. **docs.rs is the storefront.** Ensure `cargo doc` is warning-clean (already
    a release gate) and that the README's supported-RFC table stays the landing
    page. Add per-type examples in doc-comments for `decode_message`,

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -684,7 +684,9 @@ changed.
 1. **Did `crates/wire/` change since the last wire publish?**
    - If no: skip. Do not publish a no-op release.
    - If yes: continue.
-2. Decide semver bump (see below)
+2. Decide semver bump (see below). The `semver-checks` workflow already
+   compared the crate against its latest crates.io release on the PR, so a
+   bump it reported as required is not optional.
 3. Update `version` in `crates/wire/Cargo.toml`
 4. Add a `rustbgpd-wire` entry in `CHANGELOG.md`
 5. `cargo publish -p rustbgpd-wire --dry-run`
@@ -716,6 +718,8 @@ do not force an FSM release for every daemon tag.
      non-breaking negotiation surfaces.
    - **Major**: changed method signatures, removed variants, or enum/struct
      shape changes not protected by `#[non_exhaustive]`.
+   The `semver-checks` workflow applies the same crates.io comparison to this
+   crate on the PR.
 3. Update `version` in `crates/fsm/Cargo.toml`
 4. Add a `rustbgpd-fsm` entry in `CHANGELOG.md`
 5. `cargo publish -p rustbgpd-fsm --dry-run`


### PR DESCRIPTION
## Summary

`docs/EMBEDDING.md` has recommended `cargo-semver-checks` in CI since the wire crate was published; nothing implemented it. This adds `.github/workflows/semver-checks.yml`.

- **Publishable set is re-derived, not hardcoded.** A step runs `cargo metadata --locked --no-deps` and selects every workspace member whose `publish` is unset (i.e. no `publish = false`): today `rustbgpd-wire` and `rustbgpd-fsm`. The same step asserts each crate's directory appears in the workflow's `pull_request.paths` filter (GitHub cannot derive that filter from manifests) and fails the job if the list drifts. Verified locally by executing the step body: positive run emits `packages=rustbgpd-fsm,rustbgpd-wire`; removing `crates/fsm/**` from the filter makes it exit 1 with the missing dir named.
- **Baseline = last published version on crates.io.** No `baseline-version` / `baseline-rev` / `baseline-root` input is passed; the tool's documented default is "the latest normal (non-prerelease, non-yanked) version published on crates.io", pinned by comment in the workflow. The required release type is derived from the manifest version versus that baseline — for 0.x crates a minor bump counts as major and a patch bump as minor; an unchanged version is checked as a minor release (observed locally: `Checking rustbgpd-wire v0.17.1 -> v0.17.1 (no change; assume minor)`). So an API break without a bump fails, and a manifest already carrying the appropriate bump passes.
- **Triggers:** `pull_request` on `crates/wire/**`, `crates/fsm/**`, the workflow file itself; plus `workflow_dispatch`.
- **Action pin:** `obi1kenobi/cargo-semver-checks-action@v2.9` (version tag, per repo posture). The action installs latest stable itself (its documented default, matching ci.yml's `stable` posture) and caches baseline rustdoc.
- `docs/EMBEDDING.md` item 3 now says the check is enforced; `docs/RELEASE_CHECKLIST.md` adds one sentence at each crate's "decide semver bump" step. CHANGELOG `### Added`.

## Local gate

`cargo install cargo-semver-checks --locked` (0.50.0), then `cargo semver-checks check-release --package rustbgpd-wire --package rustbgpd-fsm` in the worktree:

```
Checking rustbgpd-fsm v0.4.1 -> v0.4.1 (no change; assume minor)
 Checked 196 checks: 196 pass, 58 skip
 Summary no semver update required
Checking rustbgpd-wire v0.17.1 -> v0.17.1 (no change; assume minor)
 Checked 196 checks: 196 pass, 58 skip
 Summary no semver update required
```

Note: crates.io currently has `rustbgpd-wire 0.17.1` and `rustbgpd-fsm 0.4.1` (published 2026-08-19), equal to the manifests at HEAD — nothing is already broken against the published API.

## Gates

YAML parses (`yaml.safe_load`); `scripts/check_ci_scale_split_contract.py`, `scripts/check_ci_image_primer_contract.py`, `scripts/check_public_tracker_ids.py` rc 0; `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` rc 0. `cargo test --workspace --no-fail-fast` (no Rust change in this PR): three load-sensitive integration targets were red while another full battery ran on the same host (`rs-config-render --test activation`, `rustbgpd --test config_migration`, `rustbgpd --test config_persistence_lifecycle`); each re-run in isolation is green.

LAN-1209
