### PR TITLE
chore: drop unused thiserror deps; reword the 1.x/2.x duplicate note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `tools/rs-config-render/README.md`, mirrored in `docs/deployment.md` and
   asserted by a test. (LAN-1174)
 
+- `rustbgpd-rib`, `rustbgpd-policy`, and `rustbgpd-bmp` no longer declare an
+  unused `thiserror` dependency; the ROADMAP entry that tracked the transitive
+  `thiserror` 1.x/2.x duplicate is now a dependency-hygiene note naming the
+  pulling crate (`protobuf` via `prometheus`) instead of an open item. (LAN-1213)
+
 ### Fixed
 
 - The `AS4_PATH`, `COMMUNITIES`, `EXTENDED_COMMUNITIES`, `CLUSTER_LIST`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,7 +3132,6 @@ dependencies = [
  "bytes",
  "rustbgpd-telemetry",
  "rustbgpd-wire",
- "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3238,7 +3237,6 @@ dependencies = [
  "rustc-hash 2.1.3",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -3259,7 +3257,6 @@ dependencies = [
  "rustbgpd-wire",
  "rustc-hash 2.1.3",
  "smallvec",
- "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2148,10 +2148,10 @@ branch is between features.
 - **Mega-module posture.** Prior concern and test-module extraction waves are
   complete (inventory refresh: #1552). Further splits are not planned; revisit
   only when measured conflict frequency or review cost demonstrates demand.
-- [ ] **Doc-precision + lint-policy consistency sweep (v0.41.0 review).** A
+- [x] **Doc-precision + lint-policy consistency sweep (v0.41.0 review).** A
   whole-codebase review found no correctness or security defects; the residue was
   documentation/policy drift, all low-risk. The documentation and lint-policy
-  sub-items are now closed:
+  sub-items are closed:
   - ARCHITECTURE.md design-invariant #3 re-enumerates the intentional
     unbounded-channel set (collision notifications, `peer_manager` internals,
     the `reload.rs` coordinator, the transport writer's priority channel, BFD
@@ -2171,11 +2171,12 @@ branch is between features.
     `dhat-heap` allocator features, and the test/bench targets that carry
     justified `unsafe` outside any shipped path.
 
-  The one live residue is the `thiserror` 1.x/2.x duplicate (1.0.69 + 2.0.19 both
-  resolved) — upstream-blocked, since 1.x is transitive through
-  `protobuf` / `prometheus` and `rtnetlink`, and no first-party crate depends
-  on 1.x directly. Periodic hygiene at a dependency refresh, not actionable
-  until upstream moves off it.
+  Dependency-hygiene note, not a work item: the lockfile resolves both
+  `thiserror` 1.x and 2.x. Every first-party crate that derives with it
+  declares `thiserror = "2"` via the workspace dependency; the 1.x copy is
+  transitive only, pulled by `protobuf` (the `prometheus` text-format
+  dependency). It clears when `protobuf` moves to
+  2.x; re-check with `cargo tree -i thiserror@1` at a dependency refresh.
 - [x] **Retire `rustbgpctl` in favor of `rbgp` (single CLI name).** The CLI
   crate now ships only the `rbgp` binary. The old `include!` alias/shim and
   long-form binary are removed; supported docs, package artifacts, generated

--- a/crates/bmp/Cargo.toml
+++ b/crates/bmp/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 rustbgpd-telemetry.workspace = true
 rustbgpd-wire.workspace = true
 bytes.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -24,7 +24,6 @@ rustbgpd-wire.workspace = true
 # Module content digests for `rbgp policy check --list-deps`
 # (LAN-300); already in the workspace dependency graph.
 sha2 = "0.11"
-thiserror.workspace = true
 # Rate-limited eval-error WARN (LAN-299, ADR-0103 Decision 4).
 tracing.workspace = true
 

--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -23,7 +23,6 @@ rustc-hash.workspace = true
 prefix-trie.workspace = true
 ipnet.workspace = true
 lru.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
## Summary

1. **Dead `thiserror` declarations removed.** At HEAD `85649600`, `crates/rib/Cargo.toml`, `crates/policy/Cargo.toml`, and `crates/bmp/Cargo.toml` each declared `thiserror.workspace = true`; `grep -rn thiserror crates/{rib,policy,bmp}/src` returns nothing. Their error enums (`RibCommandError`, `EvalErrorKind`, `LoadError`, …) use hand-written `Display`/`Error` impls; no TODO or recent commit points at a pending derive (the declarations date from the initial workspace setup and the BMP exporter landing). `Cargo.lock` changes only by dropping the three `"thiserror 2.0.20"` edges; no version moves.
2. **ROADMAP duplicate note reworded.** The "Doc-precision + lint-policy consistency sweep" item stayed `[ ]` because of a trailing paragraph calling the `thiserror` 1.x/2.x duplicate "the one live residue (1.0.69 + 2.0.19 …)" and attributing 1.x to `protobuf`/`prometheus` and `rtnetlink`. At HEAD the lock has 1.0.69 + 2.0.20; `rtnetlink 0.22.0` already depends on 2.x; and `cargo tree -i thiserror@1.0.69` shows the only path is `protobuf 3.7.2 → prometheus 0.14.0 → (first-party crates)`. The paragraph is now a dependency-hygiene note naming the pulling crate and the re-check command, and the item is marked `[x]` — nothing is left that anyone in this repo can act on.

## Verification

- `cargo build --workspace` rc 0; `cargo metadata --locked` rc 0 after the lock update.
- `cargo tree -i thiserror@1.0.69 --edges normal,build`: root `thiserror v1.0.69 ← protobuf v3.7.2 ← prometheus v0.14.0 ← rustbgpd / rustbgpd-api / rustbgpd-telemetry …` (plus `protobuf-support`); no first-party `thiserror = "1"` anywhere (workspace dependency is `thiserror = "2"`, every user is `.workspace = true`).
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `scripts/check_public_tracker_ids.py`: rc 0.
- `cargo test --workspace --no-fail-fast`: four load-sensitive targets were red while another full battery ran on the same host (`rs-config-render --test activation`, `rustbgpd --test config_persistence_lifecycle`, `rustbgpd --test runtime_config_settlement_matrix`, `rustbgpd-api --lib` 2 s EHM delivery waits). Re-run in isolation: all green (`config_persistence_lifecycle` needed a third isolated run — it fails on `timeout.status_reports_auto_reverted: got=pending` when the host is saturated; unrelated to this diff, which removes no code).

LAN-1213
