### PR TITLE
test: add the populated Bird's Eye oracle leg and the runtime divergence allow-list

### DIFF
--- a/tests/compat/ixp-manager-birdseye/Dockerfile.oracle
+++ b/tests/compat/ixp-manager-birdseye/Dockerfile.oracle
@@ -1,0 +1,8 @@
+# Populated oracle leg: pinned BIRD 2.0.12 (Debian bookworm bird2) next to a
+# PHP runtime that satisfies the Bird's Eye v2.1.0 lockfile, so the real
+# Bird's Eye server can shell out to the real birdc in one container.
+FROM php:8.3-cli-bookworm@sha256:97bcc5ac3fce7ba7fb769b4709c9da2b64aef3a2685c8271c2c61b409d8fa74e
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends bird2 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -100,6 +100,30 @@ The strict candidates also append the router-own-AS large-community scrub last
 to the global export chain and every v2 client receive override. The manifest
 pins its exact removal-only syntax, placement, and foreign-admin preservation.
 
+The populated oracle leg stands the real reference next to the live leg. A
+pinned BIRD 2.0.12 (Debian bookworm `bird2`, `Dockerfile.oracle`) runs next to
+the same installed Bird's Eye checkout, and rustbgpd plus `birdwatcher-adapter`
+run on the host; both route servers (`oracle-bird.conf` and the rustbgpd
+config inside `run-oracle-leg.sh`: same ASN, router ID, descriptions, and
+accept-all policy) peer with two pinned ExaBGP announcers
+(`oracle-announcer-as64496.conf`, `oracle-announcer-as64497.conf`) over one
+harness network with both address families. The announcements are
+deterministic: a multi-hop AS path, MED, a received LOCAL_PREF, standard and
+large communities, an AGGREGATOR, and a more-specific inside a covering
+prefix. `oracle-consumer.php` drives the pinned IXP Manager `BirdsEye`
+consumer through all eleven in-scope endpoints (24 journeys, including a
+covering-only prefix, a host address, host-bit input, and a foreign
+large-community wildcard) against each leg, and `verify_capture.py
+--populated` normalizes both captures (timestamps, the rustbgpd version,
+countdowns, each leg's own route-server addresses, route and symbol order),
+pins them as `fixtures/populated-oracle.json` and
+`fixtures/populated-live.json`, diffs oracle against live through the
+`runtime_divergences` allow-list in `contract.json`, proves the allow-list
+fail-closed on every run (each entry removed in turn surfaces an unlisted
+difference; a bogus entry is reported stale), and checks the pinned
+`routes/web.php` route set against `birdseye_routes`. It prints one
+`populated oracle proof:` line; silent success is a failure.
+
 Run the gate from the repository root:
 
 ```console
@@ -224,32 +248,114 @@ route set parsed from pinned routes/web.php != SCOPE | OUT_OF_SCOPE
 
 Each `fail(...)` is the existing fail-closed style; the oracle and live
 captures are fixtures under `fixtures/` with the same `CAPTURE_FIXTURES=1`
-refresh path as today. This is not a one-assertion addition to an existing
-check, because the populated oracle leg does not exist yet, so it is described
-here and not implemented.
+refresh path as today. Everything below the first line is implemented in
+`verify_capture.py --populated` (see the populated oracle leg paragraph
+above); only the flag inversion on the first line is pending, behind the
+decisions in the work list.
 
 ### Work list
 
-Each line names the gap and the evidence that closes it.
+Each line names the gap and the evidence that closes it. Items 1, 2, 15, and
+16 are done; items 3 to 14 record what the oracle diff showed, with the
+observed JSON paths, so the remaining decisions are grounded. Every observed
+divergence is an entry in `contract.json` `runtime_divergences`; the README
+predicted eight more that the diff did not show, listed after the table.
 
-1. Populated oracle leg: pinned BIRD 2.0.12 + Bird's Eye 2.1.0 and rustbgpd + adapter fed identical synthetic announcements, both read by the pinned IXP Manager consumer, captured as an oracle/live fixture pair — evidence: `verify_capture.py` diffs the pair; today's live leg proves empty arrays only.
-2. Machine-readable divergence allow-list in `contract.json`, pinned to a constant in `verify_capture.py` like every other block — evidence: the gate fails on an unlisted difference and on a stale entry.
-3. `bgp.as_path` element type (integers vs strings) — decide emit-strings or allow-list; evidence: oracle diff clean.
-4. `bgp.local_pref` type (number vs string) — same decision; evidence: oracle diff clean.
-5. Route sentinels `gateway`, `interface`, `metric`, `primary`, `learnt_from`, `age` — allow-list entries citing the pinned parser's BIRD 2 `via`-line output in `fixtures/birdseye-contract.json`; evidence: entries present and non-stale.
-6. `bgp.atomic_aggr` / `bgp.aggregator` absent — emit when the attribute is present or allow-list; evidence: an aggregated announcement in the oracle topology.
-7. Protocol row fields `preference`, `input_filter`, `output_filter`, `route_changes.*`, `routes.preferred`, `description_short`, `hold_timer_now`, `keepalive_now` absent and `routes.filtered` extra — decide each (serve or allow-list); `routes.preferred` needs a per-peer best count on `NeighborState` first; evidence: oracle diff on an established peer.
-8. `status.version`, `status.message`, extra `current_server` — allow-list as product identity; evidence: entries present.
-9. `symbols` classes beyond `protocol` and `routing table` — allow-list (the daemon has no BIRD symbol table); evidence: entry present.
-10. `/route/{net}/protocol|export` exact-match versus Bird's Eye longest-match, and HTTP 400 on host or unmasked input on all three lookups — decide allow-list (IXP Manager always passes a listed exact network) or implement longest-match for peer views; evidence: oracle cases with a host address and a covering-only prefix.
-11. `lc-zwild` answers only `{daemon ASN}:1101:*` and returns empty for other `(x, y)` without scanning accepted routes — allow-list by design; evidence: an oracle case for a foreign `(x, y)`.
-12. Upstream failure HTTP 502 versus Bird's Eye 503 — allow-list or change; evidence: the existing `bird_failure` case mirrored on the live leg.
-13. No throttle (429) and no cache (`from_cache`, `ttl_mins`, `use_cache`) — allow-list as deployment concerns; evidence: entries present.
-14. `/api` base path — document as reverse-proxy configuration, not adapter behaviour; evidence: README line plus allow-list note.
-15. Out-of-scope set (`symbols/tables`, `symbols/protocols`, three counts, untabled `route/{net}`, `/test`, `/`, `/lg/*`) written into the gate so a new pinned upstream route fails it; evidence: route-table parse of `routes/web.php` at `birdseye_commit`.
-16. Which route and protocol fields the pinned IXP Manager looking-glass views actually read is unverified; reading `resources/views/services/lg/*.foil.php` at `ixp_manager_commit` would let the allow-list mark consumer-visible versus invisible divergences — evidence: a per-entry `consumer_visible` flag.
-17. `tests/birdwatcher_adapter_smoke.rs` pins `adapter-consumer.php` journey counts (`symbols()`, `protocolTable(`, `routesForTable(` exactly once each); a populated leg must keep or update that test — evidence: `cargo test --workspace` green.
-18. The flip itself: `runtime_compatibility: true`, the `verify_capture.py` inversion, this README's intro sentence, `docs/INTEROP.md`, and `CHANGELOG.md` — last, only after 1–17.
+1. Done. Populated oracle leg: pinned BIRD 2.0.12 + Bird's Eye 2.1.0 and
+   rustbgpd + adapter fed identical synthetic announcements, both read by the
+   pinned IXP Manager consumer, captured as the oracle/live fixture pair
+   `fixtures/populated-oracle.json` and `fixtures/populated-live.json`;
+   `verify_capture.py --populated` diffs the pair.
+2. Done. Machine-readable divergence allow-list `runtime_divergences` in
+   `contract.json` (per entry: endpoint, JSON path, kind, Bird's Eye shape,
+   adapter shape, rationale, `consumer_visible`), pinned to a constant in
+   `verify_capture.py`; the gate fails on an unlisted difference and on a stale
+   entry, and re-proves both on every run.
+3. `bgp.as_path` element type: observed on every route view,
+   `routes.*.bgp.as_path.*` strings upstream, integers from the adapter. Still
+   to decide: emit strings or keep the entry.
+4. `bgp.local_pref`: observed as a type and meaning difference,
+   `routes.*.bgp.local_pref` is the string `"100"` upstream (BIRD's default
+   local preference assigned at import, also for the route announced with
+   LOCAL_PREF 200, which both route servers ignore on the eBGP session) and the
+   number `0` from the adapter (the received attribute). Still to decide.
+5. Route sentinels: observed `routes.*.interface` (`"eth0"` vs `""`),
+   `routes.*.metric` (BIRD preference `100` vs `0`), `routes.*.primary`
+   (`true` for the best route in every upstream view, `false` from the adapter
+   outside the table view), `routes.*.learnt_from` (`""` upstream because BIRD
+   prints `from <address>` only when it differs from the next hop, peer address
+   from the adapter), and `routes.*.type` (`["BGP", "univ"]` from BIRD 2 vs the
+   BIRD 1 triple). Not observed: `gateway` (the pinned parser takes the BIRD 2
+   `via` line, which equals the adapter's next hop), `age` (both carry a
+   receive timestamp), `from_protocol`. The sentinel values in
+   `fixtures/birdseye-contract.json` come from `fake-birdc`'s BIRD 1 line
+   format, not from BIRD 2.
+6. `bgp.aggregator`: observed missing from the adapter
+   (`routes.*.bgp.aggregator` is `"203.0.113.1 AS64496"` upstream).
+   `bgp.atomic_aggr` is not exercised: rustbgpd currently treat-as-withdraws
+   any UPDATE carrying ATOMIC_AGGREGATE (the wire decoder keeps the attribute
+   opaque and the unrecognized-well-known check then rejects it), so the
+   topology announces AGGREGATOR without ATOMIC_AGGREGATE until that is fixed;
+   adding `atomic-aggregate;` back to the announcer config and refreshing the
+   fixtures closes the gap.
+7. Protocol row: observed missing `preference`, `input_filter`,
+   `output_filter`, `route_changes.*.*`, `routes.preferred`, `hold_timer_now`,
+   `keepalive_now`; observed extra `routes.filtered` and
+   `neighbor_capabilities` (BIRD 2 prints a multi-line `Neighbor capabilities`
+   block that the pinned `Neighbor caps:` regex never matches, so the oracle
+   row has no such field); observed `connection` as a whitespace-only
+   difference (`"  Established   "` vs `" Established"`). `routes.preferred`
+   upstream is the parser constant `0` (its `Routes:` regex drops BIRD's
+   preferred count), so a per-peer best count would not close that entry.
+   `description_short` is not observed (Bird's Eye emits it only with
+   `PARSER_PROTOCOL_BGP_DESCRIPTION`). `import_limit` and `limit_action` are
+   absent on both sides without a configured limit.
+8. `status.version`, `status.message`, extra `status.current_server`:
+   observed, allow-listed as product identity; `status.router_id`,
+   `last_reboot`, `last_reconfig`, and `server_time` match after timestamp
+   normalization.
+9. `symbols`: observed `symbols.protocol` carrying BIRD's `device1` next to
+   the BGP sessions, and a `symbols.undefined` class (BIRD 2.0.12 `show
+   symbols` reports configuration keywords there) the adapter never emits.
+10. Exact versus longest match: observed on `route/{net}/protocol` and
+    `route/{net}/export` (a covering-only prefix and a host address return the
+    covering route upstream, `routes: []` from the adapter) and on
+    `route/{net}/table` for host-bit input (HTTP 200 `routes: []` upstream
+    because BIRD rejects the lookup, HTTP 400 from the adapter, which the
+    consumer collapses to `""`). Still to decide.
+11. `lc-zwild`: observed for a foreign `(x, y)` (the route carrying that large
+    community upstream, `routes: []` from the adapter) plus the adapter's extra
+    `retention.*` and `api.max_routes` as the retention capacity for the daemon
+    `(x, y)`; both legs return `routes: []` for the daemon `(x, y)`.
+12. 502 versus 503: not observed; the populated leg has no upstream-failure
+    case (the existing `bird_failure` case stays on the `fake-birdc` oracle).
+13. Throttle and cache: not observed as a body difference; `ttl_mins` is
+    absent on both sides because `CACHE_DRIVER=array` strips it upstream and
+    `from_cache` is `false` on both; the per-minute throttle is not hit by the
+    24 journeys.
+14. `/api` base path: not a body difference; IXP Manager's `Router.api` base
+    URL absorbs it (`.../api` for Bird's Eye, the adapter root for rustbgpd).
+15. Done. The in-scope and out-of-scope route sets are `birdseye_routes` in
+    `contract.json`; `verify_capture.py --populated` parses `routes/web.php`
+    at `birdseye_commit` and fails on any new or removed route.
+16. Done. Every allow-list entry carries `consumer_visible`, set from the
+    pinned `resources/views/services/lg/*.foil.php` views, the looking-glass
+    layout, and the BGP-sessions diagnostics suite at `ixp_manager_commit`.
+17. `tests/birdwatcher_adapter_smoke.rs` pins `adapter-consumer.php` journey
+    counts (`symbols()`, `protocolTable(`, `routesForTable(` exactly once
+    each); the populated leg uses its own `oracle-consumer.php`, so the pin is
+    unchanged — evidence: `cargo test --workspace` green.
+18. The flip itself: `runtime_compatibility: true`, the `verify_capture.py`
+    inversion, this README's intro sentence, `docs/INTEROP.md`, and
+    `CHANGELOG.md` — last, only after 1–17.
+
+Normalization applied to both legs before the diff (recorded in each
+fixture's `provenance.normalization`): timestamps, the rustbgpd version,
+`hold_timer_now`/`keepalive_now`, each leg's own route-server addresses, and
+route and symbol list order. The two route servers cannot share one address
+on one segment, so `source_address` is compared as `<route-server>`; BIRD's
+default hold time is mirrored in the rustbgpd config so the negotiated timers
+match.
 
 ## Provenance and licensing
 

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -59,6 +59,488 @@
     "daemon_check": "nagios-check-birdseye.php",
     "session_protocol": "pb_{vlan_interface_id:04}_as{asn}"
   },
+  "populated_topology": {
+    "network": {
+      "ipv4": "198.51.100.0/24",
+      "ipv6": "2001:db8:5100::/64"
+    },
+    "route_servers": {
+      "oracle": {
+        "software": "BIRD 2.0.12 + Bird's Eye 2.1.0",
+        "ipv4": "198.51.100.3",
+        "ipv6": "2001:db8:5100::3"
+      },
+      "live": {
+        "software": "rustbgpd + birdwatcher-adapter",
+        "ipv4": "198.51.100.1",
+        "ipv6": "2001:db8:5100::1"
+      }
+    },
+    "router_id": "10.0.0.1",
+    "asn": 65001,
+    "max_routes": 100,
+    "protocols": {
+      "member-v4": "pb_as64496",
+      "member-v6": "pb6_as64496",
+      "second-member-v4": "pb_as64497",
+      "second-member-v6": "pb6_as64497"
+    },
+    "announcers": {
+      "64496": {
+        "ipv4": "198.51.100.2",
+        "ipv6": "2001:db8:5100::2",
+        "ipv4_routes": [
+          "203.0.113.0/24",
+          "203.0.113.128/25",
+          "203.0.113.64/26"
+        ],
+        "ipv6_routes": [
+          "2001:db8:a::/48",
+          "2001:db8:b::/48"
+        ]
+      },
+      "64497": {
+        "ipv4": "198.51.100.4",
+        "ipv6": "2001:db8:5100::4",
+        "ipv4_routes": [
+          "192.0.2.0/24"
+        ],
+        "ipv6_routes": [
+          "2001:db8:c::/48"
+        ]
+      }
+    }
+  },
+  "birdseye_routes": {
+    "in_scope": [
+      "api/status",
+      "api/protocols/bgp",
+      "api/protocol/{protocol}",
+      "api/symbols",
+      "api/routes/protocol/{protocol}",
+      "api/routes/table/{table}",
+      "api/routes/export/{protocol}",
+      "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "api/route/{net}/table/{table}",
+      "api/route/{net}/protocol/{protocol}",
+      "api/route/{net}/export/{protocol}"
+    ],
+    "out_of_scope": [
+      "test",
+      "/",
+      "api/symbols/tables",
+      "api/symbols/protocols",
+      "api/routes/count/protocol/{protocol}",
+      "api/routes/count/table/{table}",
+      "api/routes/count/export/{protocol}",
+      "api/route/{net}",
+      "lg/",
+      "lg/protocols/bgp",
+      "lg/routes/protocol/{protocol}",
+      "lg/routes/table/{table}",
+      "lg/routes/export/{protocol}",
+      "lg/route",
+      "lg/route/{net}/protocol/{protocol}",
+      "lg/route/{net}/table/{table}"
+    ]
+  },
+  "runtime_divergences": [
+    {
+      "endpoint": "*",
+      "path": "api.version",
+      "kind": "value",
+      "birdseye": "Bird's Eye semantic version (2.1.0)",
+      "adapter": "rustbgpd <version> product identity",
+      "rationale": "api.version names the implementation, not the contract; the gate keeps asserting the rustbgpd prefix",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": "*",
+      "path": "api.Version",
+      "kind": "extra",
+      "birdseye": "absent",
+      "adapter": "duplicate of api.version",
+      "rationale": "Birdwatcher-shaped api block; the Alice-LG surface of the same adapter reads it",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": "*",
+      "path": "api.result_from_cache",
+      "kind": "extra",
+      "birdseye": "absent",
+      "adapter": "always false",
+      "rationale": "Birdwatcher-shaped api block; there is no cache to skip",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": "api/status",
+      "path": "status.version",
+      "kind": "value",
+      "birdseye": "BIRD version (2.0.12)",
+      "adapter": "rustbgpd <version>",
+      "rationale": "product identity; the pinned looking-glass layout prints it as the router version",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": "api/status",
+      "path": "status.message",
+      "kind": "value",
+      "birdseye": "last show status line (Daemon is up and running)",
+      "adapter": "rustbgpd AS<asn>",
+      "rationale": "product identity; no pinned consumer reads status.message",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": "api/status",
+      "path": "status.current_server",
+      "kind": "extra",
+      "birdseye": "absent",
+      "adapter": "current wall-clock timestamp",
+      "rationale": "Birdwatcher status field; no pinned consumer reads it",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.connection",
+        "protocol.connection"
+      ],
+      "kind": "value",
+      "birdseye": "BIRD 2 info column with its padding (\"  Established   \")",
+      "adapter": "\" Established\" (one leading space)",
+      "rationale": "whitespace only; the bgp-summary modal and the diagnostics suite read connection but HTML collapses the padding",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.hold_timer_now",
+        "protocol.hold_timer_now",
+        "protocols.*.keepalive_now",
+        "protocol.keepalive_now"
+      ],
+      "kind": "missing",
+      "birdseye": "live countdowns from the BIRD timers",
+      "adapter": "absent",
+      "rationale": "live-hold-keepalive-countdowns is an unsupported entry; the daemon exposes negotiated values only, and the diagnostics suite guards them with isset",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.preference",
+        "protocol.preference"
+      ],
+      "kind": "missing",
+      "birdseye": "BIRD protocol preference (100)",
+      "adapter": "absent",
+      "rationale": "BIRD-internal route preference with no rustbgpd equivalent; shown by the bgp-summary modal when present",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.input_filter",
+        "protocol.input_filter",
+        "protocols.*.output_filter",
+        "protocol.output_filter"
+      ],
+      "kind": "missing",
+      "birdseye": "BIRD filter names (ACCEPT)",
+      "adapter": "absent",
+      "rationale": "rustbgpd policy chains have no BIRD filter identity; shown by the bgp-summary modal when present",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.route_changes.*.*",
+        "protocol.route_changes.*.*"
+      ],
+      "kind": "missing",
+      "birdseye": "BIRD per-channel route change statistics",
+      "adapter": "absent",
+      "rationale": "the gRPC NeighborState carries no import/export update and withdraw counters; the bgp-summary modal renders the block when present",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.routes.preferred",
+        "protocol.routes.preferred"
+      ],
+      "kind": "missing",
+      "birdseye": "always 0 (the pinned parser's Routes: regex drops BIRD's preferred count)",
+      "adapter": "absent",
+      "rationale": "the oracle value is a parser constant, not a best count; the adapter omits rather than fabricate one",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.routes.filtered",
+        "protocol.routes.filtered"
+      ],
+      "kind": "extra",
+      "birdseye": "absent",
+      "adapter": "retained-reject count",
+      "rationale": "Birdwatcher protocol field backing the filtered-route views; no pinned consumer reads it",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": [
+        "api/protocols/bgp",
+        "api/protocol/{protocol}"
+      ],
+      "path": [
+        "protocols.*.neighbor_capabilities.*",
+        "protocol.neighbor_capabilities.*"
+      ],
+      "kind": "extra",
+      "birdseye": "absent (BIRD 2 prints a multi-line Neighbor capabilities block the pinned Neighbor caps: regex never matches)",
+      "adapter": "negotiated capability list (refresh, AS4)",
+      "rationale": "the adapter keeps the BIRD 1 shape; the bgp-summary modal renders the list when present",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.bgp.as_path.*",
+      "kind": "type",
+      "birdseye": "strings",
+      "adapter": "integers",
+      "rationale": "Bird's Eye splits the BGP.as_path text; the adapter emits the numeric path; the pinned route views implode either",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.bgp.local_pref",
+      "kind": "type",
+      "birdseye": "string \"100\" (BIRD's default local preference assigned at import)",
+      "adapter": "number 0 (the received attribute, absent on an eBGP session)",
+      "rationale": "type and meaning differ: BIRD prints a local preference for every route, the adapter prints the attribute that arrived",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.bgp.med",
+      "kind": "extra",
+      "birdseye": "absent when the route carries no MED",
+      "adapter": "0 when absent",
+      "rationale": "the adapter always emits med; equal whenever the attribute is present",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.bgp.aggregator",
+      "kind": "missing",
+      "birdseye": "\"<address> AS<asn>\"",
+      "adapter": "absent",
+      "rationale": "the adapter does not emit AGGREGATOR; the pinned route view prints it when present",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.interface",
+      "kind": "value",
+      "birdseye": "BIRD egress interface (eth0)",
+      "adapter": "\"\"",
+      "rationale": "a route server has no kernel interface to report; no pinned consumer reads it",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.learnt_from",
+      "kind": "value",
+      "birdseye": "\"\" (BIRD prints from <address> only when it differs from the next hop)",
+      "adapter": "peer address",
+      "rationale": "no pinned consumer reads it",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.metric",
+      "kind": "value",
+      "birdseye": "BIRD route preference (100)",
+      "adapter": "0",
+      "rationale": "BIRD-internal preference; the pinned route view prints metric",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.primary",
+      "kind": "value",
+      "birdseye": "true for the best route in every view",
+      "adapter": "false outside the table view",
+      "rationale": "the adapter reports primary only where it reads the Loc-RIB; the pinned route view prints it",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+      ],
+      "path": "routes.*.type.*",
+      "kind": "semantics",
+      "birdseye": "[\"BGP\", \"univ\"] (BIRD 2 Type: BGP univ)",
+      "adapter": "[\"BGP\", \"unicast\", \"univ\"] (BIRD 1 shape)",
+      "rationale": "the adapter keeps the BIRD 1 type triple; the pinned route view prints the list",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": [
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/export/{protocol}"
+      ],
+      "path": "routes",
+      "kind": "semantics",
+      "birdseye": "show route for: longest match, so a covering-only prefix or a host address returns the covering route",
+      "adapter": "exact prefix match: the same inputs return []",
+      "rationale": "IXP Manager passes listed exact networks; the exact-vs-longest choice is recorded, not hidden",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": "api/route/{net}/table/{table}",
+      "path": "<response>",
+      "kind": "semantics",
+      "birdseye": "HTTP 200 with routes: [] for host-bit input (BIRD rejects the lookup)",
+      "adapter": "HTTP 400, which the pinned consumer collapses to \"\"",
+      "rationale": "network-aligned input only; IXP Manager renders an empty page either way",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "path": "routes",
+      "kind": "semantics",
+      "birdseye": "every route carrying (x, y, *) in the protocol's table",
+      "adapter": "retained rejects tagged <daemon asn>:1101:* only; [] for any other (x, y)",
+      "rationale": "the filtered-prefix view is the only pinned use; accepted routes are never scanned",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "path": "retention.*",
+      "kind": "extra",
+      "birdseye": "absent",
+      "adapter": "retention completeness metadata",
+      "rationale": "filtered_retention_metadata block; no pinned consumer reads it",
+      "consumer_visible": false
+    },
+    {
+      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "path": "api.max_routes",
+      "kind": "value",
+      "birdseye": "MAX_ROUTES",
+      "adapter": "retention capacity for the daemon (x, y)",
+      "rationale": "filtered_retention_metadata.api_max_routes; the pinned layout prints api.max_routes",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": "api/symbols",
+      "path": "symbols.protocol.*",
+      "kind": "semantics",
+      "birdseye": "every BIRD protocol, including device1",
+      "adapter": "BGP sessions only",
+      "rationale": "the daemon has no BIRD symbol table; the pinned route-search view lists symbols.protocol",
+      "consumer_visible": true
+    },
+    {
+      "endpoint": "api/symbols",
+      "path": "symbols.undefined.*",
+      "kind": "missing",
+      "birdseye": "BIRD 2.0.12 show symbols reports configuration keywords under an undefined class",
+      "adapter": "absent",
+      "rationale": "Bird's Eye passes every class through; no pinned consumer reads undefined",
+      "consumer_visible": false
+    }
+  ],
   "runtime_compatibility": false,
   "manual_config_export": {
     "schema": "rustbgpd.ixp-manager.router-config/v2",

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
@@ -1,0 +1,1338 @@
+{
+  "journeys": {
+    "lookup_export_covering": {
+      "endpoint": "api/route/{net}/export/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": []
+      }
+    },
+    "lookup_export_exact": {
+      "endpoint": "api/route/{net}/export/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64497
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "",
+            "learnt_from": "198.51.100.4",
+            "metric": 0,
+            "network": "192.0.2.0/24",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_export_v6": {
+      "endpoint": "api/route/{net}/export/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64497,
+                64530
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::4",
+            "metric": 0,
+            "network": "2001:db8:c::/48",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_protocol_covering": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": []
+      }
+    },
+    "lookup_protocol_exact": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496,
+                64510,
+                64520
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": 0,
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.0/24",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_protocol_host": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": []
+      }
+    },
+    "lookup_protocol_v6": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496,
+                64510
+              ],
+              "communities": [
+                [
+                  64496,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 20,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::2",
+            "metric": 0,
+            "network": "2001:db8:a::/48",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_table_exact": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.128/25",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_table_less_specific": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.128/25",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_table_unaligned": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": ""
+    },
+    "lookup_table_v6": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64497,
+                64530
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::4",
+            "metric": 0,
+            "network": "2001:db8:c::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "protocol_v4": {
+      "endpoint": "api/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "protocol": {
+          "bgp_session": [
+            "external",
+            "route-server",
+            "AS4"
+          ],
+          "bgp_state": "Established",
+          "bird_protocol": "BGP",
+          "connection": " Established",
+          "description": "oracle client AS64496",
+          "hold_timer": 180,
+          "keepalive": 60,
+          "neighbor_address": "198.51.100.2",
+          "neighbor_as": 64496,
+          "neighbor_capabilities": [
+            "AS4"
+          ],
+          "neighbor_id": "198.51.100.2",
+          "protocol": "pb_as64496",
+          "route_limit_at": 3,
+          "routes": {
+            "exported": 1,
+            "filtered": 0,
+            "imported": 3
+          },
+          "source_address": "<route-server>",
+          "state": "up",
+          "state_changed": "<timestamp>",
+          "table": "master4"
+        }
+      }
+    },
+    "protocol_v6": {
+      "endpoint": "api/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "protocol": {
+          "bgp_session": [
+            "external",
+            "route-server",
+            "AS4"
+          ],
+          "bgp_state": "Established",
+          "bird_protocol": "BGP",
+          "connection": " Established",
+          "description": "oracle client AS64496 IPv6",
+          "hold_timer": 180,
+          "keepalive": 60,
+          "neighbor_address": "2001:db8:5100::2",
+          "neighbor_as": 64496,
+          "neighbor_capabilities": [
+            "AS4"
+          ],
+          "neighbor_id": "198.51.100.2",
+          "protocol": "pb6_as64496",
+          "route_limit_at": 2,
+          "routes": {
+            "exported": 1,
+            "filtered": 0,
+            "imported": 2
+          },
+          "source_address": "<route-server>",
+          "state": "up",
+          "state_changed": "<timestamp>",
+          "table": "master6"
+        }
+      }
+    },
+    "protocols": {
+      "endpoint": "api/protocols/bgp",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "protocols": {
+          "pb6_as64496": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": " Established",
+            "description": "oracle client AS64496 IPv6",
+            "hold_timer": 180,
+            "keepalive": 60,
+            "neighbor_address": "2001:db8:5100::2",
+            "neighbor_as": 64496,
+            "neighbor_capabilities": [
+              "AS4"
+            ],
+            "neighbor_id": "198.51.100.2",
+            "protocol": "pb6_as64496",
+            "route_limit_at": 2,
+            "routes": {
+              "exported": 1,
+              "filtered": 0,
+              "imported": 2
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master6"
+          },
+          "pb6_as64497": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": " Established",
+            "description": "oracle client AS64497 IPv6",
+            "hold_timer": 180,
+            "keepalive": 60,
+            "neighbor_address": "2001:db8:5100::4",
+            "neighbor_as": 64497,
+            "neighbor_capabilities": [
+              "AS4"
+            ],
+            "neighbor_id": "198.51.100.4",
+            "protocol": "pb6_as64497",
+            "route_limit_at": 1,
+            "routes": {
+              "exported": 2,
+              "filtered": 0,
+              "imported": 1
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master6"
+          },
+          "pb_as64496": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": " Established",
+            "description": "oracle client AS64496",
+            "hold_timer": 180,
+            "keepalive": 60,
+            "neighbor_address": "198.51.100.2",
+            "neighbor_as": 64496,
+            "neighbor_capabilities": [
+              "AS4"
+            ],
+            "neighbor_id": "198.51.100.2",
+            "protocol": "pb_as64496",
+            "route_limit_at": 3,
+            "routes": {
+              "exported": 1,
+              "filtered": 0,
+              "imported": 3
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master4"
+          },
+          "pb_as64497": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": " Established",
+            "description": "oracle client AS64497",
+            "hold_timer": 180,
+            "keepalive": 60,
+            "neighbor_address": "198.51.100.4",
+            "neighbor_as": 64497,
+            "neighbor_capabilities": [
+              "AS4"
+            ],
+            "neighbor_id": "198.51.100.4",
+            "protocol": "pb_as64497",
+            "route_limit_at": 1,
+            "routes": {
+              "exported": 3,
+              "filtered": 0,
+              "imported": 1
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master4"
+          }
+        }
+      }
+    },
+    "routes_export_v4": {
+      "endpoint": "api/routes/export/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64497
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "",
+            "learnt_from": "198.51.100.4",
+            "metric": 0,
+            "network": "192.0.2.0/24",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_export_v6": {
+      "endpoint": "api/routes/export/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64497,
+                64530
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::4",
+            "metric": 0,
+            "network": "2001:db8:c::/48",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_protocol_v4": {
+      "endpoint": "api/routes/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496,
+                64510,
+                64520
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": 0,
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.0/24",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.128/25",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [],
+              "large_communities": [],
+              "local_pref": 0,
+              "med": 30,
+              "next_hop": "198.51.100.2",
+              "origin": "Incomplete"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.64/26",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_protocol_v6": {
+      "endpoint": "api/routes/protocol/{protocol}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496,
+                64510
+              ],
+              "communities": [
+                [
+                  64496,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 20,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::2",
+            "metric": 0,
+            "network": "2001:db8:a::/48",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [
+                [
+                  64496,
+                  700
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  2
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "EGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::2",
+            "metric": 0,
+            "network": "2001:db8:b::/48",
+            "primary": false,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_table_v4": {
+      "endpoint": "api/routes/table/{table}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64497
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "",
+            "learnt_from": "198.51.100.4",
+            "metric": 0,
+            "network": "192.0.2.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496,
+                64510,
+                64520
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": 0,
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.128/25",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [],
+              "large_communities": [],
+              "local_pref": 0,
+              "med": 30,
+              "next_hop": "198.51.100.2",
+              "origin": "Incomplete"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.64/26",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_table_v6": {
+      "endpoint": "api/routes/table/{table}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496,
+                64510
+              ],
+              "communities": [
+                [
+                  64496,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 20,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::2",
+            "metric": 0,
+            "network": "2001:db8:a::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64496
+              ],
+              "communities": [
+                [
+                  64496,
+                  700
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  2
+                ]
+              ],
+              "local_pref": 0,
+              "med": 0,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "EGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::2",
+            "metric": 0,
+            "network": "2001:db8:b::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                64497,
+                64530
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": 0,
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "",
+            "learnt_from": "2001:db8:5100::4",
+            "metric": 0,
+            "network": "2001:db8:c::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "unicast",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "status": {
+      "endpoint": "api/status",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "status": {
+          "current_server": "<timestamp>",
+          "last_reboot": "<timestamp>",
+          "last_reconfig": "<timestamp>",
+          "message": "rustbgpd AS65001",
+          "router_id": "10.0.0.1",
+          "server_time": "<timestamp>",
+          "version": "rustbgpd <version>"
+        }
+      }
+    },
+    "symbols": {
+      "endpoint": "api/symbols",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "symbols": {
+          "protocol": [
+            "pb6_as64496",
+            "pb6_as64497",
+            "pb_as64496",
+            "pb_as64497"
+          ],
+          "routing table": [
+            "master4",
+            "master6"
+          ]
+        }
+      }
+    },
+    "wildcard_daemon": {
+      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 1024,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "retention": {
+          "capacity": 1024,
+          "enabled": true,
+          "evictions_since_reset": 0,
+          "may_be_incomplete": false
+        },
+        "routes": []
+      }
+    },
+    "wildcard_foreign": {
+      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "retention": {
+          "capacity": null,
+          "enabled": null,
+          "evictions_since_reset": null,
+          "may_be_incomplete": null
+        },
+        "routes": []
+      }
+    }
+  },
+  "provenance": {
+    "birdseye_commit": "7f8c2375e610578bcf6ea5ceec630a180f945b89",
+    "ixp_manager_commit": "300b7e0ba9adb0aaac975899e45fc8bcbc0ca37d",
+    "leg": "live",
+    "normalization": [
+      "timestamps -> <timestamp>",
+      "rustbgpd <semver> -> rustbgpd <version>",
+      "hold_timer_now and keepalive_now -> <countdown>",
+      "each leg's own route-server addresses -> <route-server>",
+      "routes sorted by network, symbol lists sorted"
+    ],
+    "software": "rustbgpd + birdwatcher-adapter"
+  }
+}

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-oracle.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-oracle.json
@@ -1,0 +1,1623 @@
+{
+  "journeys": {
+    "lookup_export_covering": {
+      "endpoint": "api/route/{net}/export/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497"
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "192.0.2.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_export_exact": {
+      "endpoint": "api/route/{net}/export/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497"
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "192.0.2.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_export_v6": {
+      "endpoint": "api/route/{net}/export/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497",
+                "64530"
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:c::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_protocol_covering": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_protocol_exact": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_protocol_host": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_protocol_v6": {
+      "endpoint": "api/route/{net}/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510"
+              ],
+              "communities": [
+                [
+                  64496,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "med": 20,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:a::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_table_exact": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496"
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.128/25",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_table_less_specific": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496"
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.128/25",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "lookup_table_unaligned": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": []
+      }
+    },
+    "lookup_table_v6": {
+      "endpoint": "api/route/{net}/table/{table}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497",
+                "64530"
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:c::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "protocol_v4": {
+      "endpoint": "api/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "protocol": {
+          "bgp_session": [
+            "external",
+            "route-server",
+            "AS4"
+          ],
+          "bgp_state": "Established",
+          "bird_protocol": "BGP",
+          "connection": "  Established   ",
+          "description": "oracle client AS64496",
+          "hold_timer": 180,
+          "hold_timer_now": "<countdown>",
+          "input_filter": "ACCEPT",
+          "keepalive": 60,
+          "keepalive_now": "<countdown>",
+          "neighbor_address": "198.51.100.2",
+          "neighbor_as": 64496,
+          "neighbor_id": "198.51.100.2",
+          "output_filter": "ACCEPT",
+          "preference": 100,
+          "protocol": "pb_as64496",
+          "route_changes": {
+            "export_updates": {
+              "accepted": 1,
+              "filtered": 0,
+              "received": 4,
+              "rejected": 3
+            },
+            "export_withdraws": {
+              "accepted": 0,
+              "received": 0
+            },
+            "import_updates": {
+              "accepted": 3,
+              "filtered": 0,
+              "ignored": 0,
+              "received": 3,
+              "rejected": 0
+            },
+            "import_withdraws": {
+              "accepted": 0,
+              "ignored": 0,
+              "received": 0,
+              "rejected": 0
+            }
+          },
+          "route_limit_at": 3,
+          "routes": {
+            "exported": 1,
+            "imported": 3,
+            "preferred": 0
+          },
+          "source_address": "<route-server>",
+          "state": "up",
+          "state_changed": "<timestamp>",
+          "table": "master4"
+        }
+      }
+    },
+    "protocol_v6": {
+      "endpoint": "api/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "protocol": {
+          "bgp_session": [
+            "external",
+            "route-server",
+            "AS4"
+          ],
+          "bgp_state": "Established",
+          "bird_protocol": "BGP",
+          "connection": "  Established   ",
+          "description": "oracle client AS64496 IPv6",
+          "hold_timer": 180,
+          "hold_timer_now": "<countdown>",
+          "input_filter": "ACCEPT",
+          "keepalive": 60,
+          "keepalive_now": "<countdown>",
+          "neighbor_address": "2001:db8:5100::2",
+          "neighbor_as": 64496,
+          "neighbor_id": "198.51.100.2",
+          "output_filter": "ACCEPT",
+          "preference": 100,
+          "protocol": "pb6_as64496",
+          "route_changes": {
+            "export_updates": {
+              "accepted": 1,
+              "filtered": 0,
+              "received": 3,
+              "rejected": 2
+            },
+            "export_withdraws": {
+              "accepted": 0,
+              "received": 0
+            },
+            "import_updates": {
+              "accepted": 2,
+              "filtered": 0,
+              "ignored": 0,
+              "received": 2,
+              "rejected": 0
+            },
+            "import_withdraws": {
+              "accepted": 0,
+              "ignored": 0,
+              "received": 0,
+              "rejected": 0
+            }
+          },
+          "route_limit_at": 2,
+          "routes": {
+            "exported": 1,
+            "imported": 2,
+            "preferred": 0
+          },
+          "source_address": "<route-server>",
+          "state": "up",
+          "state_changed": "<timestamp>",
+          "table": "master6"
+        }
+      }
+    },
+    "protocols": {
+      "endpoint": "api/protocols/bgp",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "protocols": {
+          "pb6_as64496": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": "  Established   ",
+            "description": "oracle client AS64496 IPv6",
+            "hold_timer": 180,
+            "hold_timer_now": "<countdown>",
+            "input_filter": "ACCEPT",
+            "keepalive": 60,
+            "keepalive_now": "<countdown>",
+            "neighbor_address": "2001:db8:5100::2",
+            "neighbor_as": 64496,
+            "neighbor_id": "198.51.100.2",
+            "output_filter": "ACCEPT",
+            "preference": 100,
+            "protocol": "pb6_as64496",
+            "route_changes": {
+              "export_updates": {
+                "accepted": 1,
+                "filtered": 0,
+                "received": 3,
+                "rejected": 2
+              },
+              "export_withdraws": {
+                "accepted": 0,
+                "received": 0
+              },
+              "import_updates": {
+                "accepted": 2,
+                "filtered": 0,
+                "ignored": 0,
+                "received": 2,
+                "rejected": 0
+              },
+              "import_withdraws": {
+                "accepted": 0,
+                "ignored": 0,
+                "received": 0,
+                "rejected": 0
+              }
+            },
+            "route_limit_at": 2,
+            "routes": {
+              "exported": 1,
+              "imported": 2,
+              "preferred": 0
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master6"
+          },
+          "pb6_as64497": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": "  Established   ",
+            "description": "oracle client AS64497 IPv6",
+            "hold_timer": 180,
+            "hold_timer_now": "<countdown>",
+            "input_filter": "ACCEPT",
+            "keepalive": 60,
+            "keepalive_now": "<countdown>",
+            "neighbor_address": "2001:db8:5100::4",
+            "neighbor_as": 64497,
+            "neighbor_id": "198.51.100.4",
+            "output_filter": "ACCEPT",
+            "preference": 100,
+            "protocol": "pb6_as64497",
+            "route_changes": {
+              "export_updates": {
+                "accepted": 2,
+                "filtered": 0,
+                "received": 3,
+                "rejected": 1
+              },
+              "export_withdraws": {
+                "accepted": 0,
+                "received": 0
+              },
+              "import_updates": {
+                "accepted": 1,
+                "filtered": 0,
+                "ignored": 0,
+                "received": 1,
+                "rejected": 0
+              },
+              "import_withdraws": {
+                "accepted": 0,
+                "ignored": 0,
+                "received": 0,
+                "rejected": 0
+              }
+            },
+            "route_limit_at": 1,
+            "routes": {
+              "exported": 2,
+              "imported": 1,
+              "preferred": 0
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master6"
+          },
+          "pb_as64496": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": "  Established   ",
+            "description": "oracle client AS64496",
+            "hold_timer": 180,
+            "hold_timer_now": "<countdown>",
+            "input_filter": "ACCEPT",
+            "keepalive": 60,
+            "keepalive_now": "<countdown>",
+            "neighbor_address": "198.51.100.2",
+            "neighbor_as": 64496,
+            "neighbor_id": "198.51.100.2",
+            "output_filter": "ACCEPT",
+            "preference": 100,
+            "protocol": "pb_as64496",
+            "route_changes": {
+              "export_updates": {
+                "accepted": 1,
+                "filtered": 0,
+                "received": 4,
+                "rejected": 3
+              },
+              "export_withdraws": {
+                "accepted": 0,
+                "received": 0
+              },
+              "import_updates": {
+                "accepted": 3,
+                "filtered": 0,
+                "ignored": 0,
+                "received": 3,
+                "rejected": 0
+              },
+              "import_withdraws": {
+                "accepted": 0,
+                "ignored": 0,
+                "received": 0,
+                "rejected": 0
+              }
+            },
+            "route_limit_at": 3,
+            "routes": {
+              "exported": 1,
+              "imported": 3,
+              "preferred": 0
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master4"
+          },
+          "pb_as64497": {
+            "bgp_session": [
+              "external",
+              "route-server",
+              "AS4"
+            ],
+            "bgp_state": "Established",
+            "bird_protocol": "BGP",
+            "connection": "  Established   ",
+            "description": "oracle client AS64497",
+            "hold_timer": 180,
+            "hold_timer_now": "<countdown>",
+            "input_filter": "ACCEPT",
+            "keepalive": 60,
+            "keepalive_now": "<countdown>",
+            "neighbor_address": "198.51.100.4",
+            "neighbor_as": 64497,
+            "neighbor_id": "198.51.100.4",
+            "output_filter": "ACCEPT",
+            "preference": 100,
+            "protocol": "pb_as64497",
+            "route_changes": {
+              "export_updates": {
+                "accepted": 3,
+                "filtered": 0,
+                "received": 4,
+                "rejected": 1
+              },
+              "export_withdraws": {
+                "accepted": 0,
+                "received": 0
+              },
+              "import_updates": {
+                "accepted": 1,
+                "filtered": 0,
+                "ignored": 0,
+                "received": 1,
+                "rejected": 0
+              },
+              "import_withdraws": {
+                "accepted": 0,
+                "ignored": 0,
+                "received": 0,
+                "rejected": 0
+              }
+            },
+            "route_limit_at": 1,
+            "routes": {
+              "exported": 3,
+              "imported": 1,
+              "preferred": 0
+            },
+            "source_address": "<route-server>",
+            "state": "up",
+            "state_changed": "<timestamp>",
+            "table": "master4"
+          }
+        }
+      }
+    },
+    "routes_export_v4": {
+      "endpoint": "api/routes/export/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497"
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "192.0.2.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_export_v6": {
+      "endpoint": "api/routes/export/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497",
+                "64530"
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:c::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_protocol_v4": {
+      "endpoint": "api/routes/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496"
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.128/25",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "aggregator": "203.0.113.1 AS64496",
+              "as_path": [
+                "64496"
+              ],
+              "local_pref": "100",
+              "med": 30,
+              "next_hop": "198.51.100.2",
+              "origin": "Incomplete"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.64/26",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_protocol_v6": {
+      "endpoint": "api/routes/protocol/{protocol}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510"
+              ],
+              "communities": [
+                [
+                  64496,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "med": 20,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:a::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496"
+              ],
+              "communities": [
+                [
+                  64496,
+                  700
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "2001:db8:5100::2",
+              "origin": "EGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:b::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_table_v4": {
+      "endpoint": "api/routes/table/{table}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497"
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "192.0.2.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496"
+              ],
+              "communities": [
+                [
+                  64496,
+                  300
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  2,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.128/25",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "aggregator": "203.0.113.1 AS64496",
+              "as_path": [
+                "64496"
+              ],
+              "local_pref": "100",
+              "med": 30,
+              "next_hop": "198.51.100.2",
+              "origin": "Incomplete"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.64/26",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "routes_table_v6": {
+      "endpoint": "api/routes/table/{table}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510"
+              ],
+              "communities": [
+                [
+                  64496,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "med": 20,
+              "next_hop": "2001:db8:5100::2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:a::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496"
+              ],
+              "communities": [
+                [
+                  64496,
+                  700
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  3,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "2001:db8:5100::2",
+              "origin": "EGP"
+            },
+            "from_protocol": "pb6_as64496",
+            "gateway": "2001:db8:5100::2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:b::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          },
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497",
+                "64530"
+              ],
+              "communities": [
+                [
+                  64497,
+                  600
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  3,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "med": 5,
+              "next_hop": "2001:db8:5100::4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb6_as64497",
+            "gateway": "2001:db8:5100::4",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "2001:db8:c::/48",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    },
+    "status": {
+      "endpoint": "api/status",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "status": {
+          "last_reboot": "<timestamp>",
+          "last_reconfig": "<timestamp>",
+          "message": "Daemon is up and running",
+          "router_id": "10.0.0.1",
+          "server_time": "<timestamp>",
+          "version": "2.0.12"
+        }
+      }
+    },
+    "symbols": {
+      "endpoint": "api/symbols",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "symbols": {
+          "protocol": [
+            "device1",
+            "pb6_as64496",
+            "pb6_as64497",
+            "pb_as64496",
+            "pb_as64497"
+          ],
+          "routing table": [
+            "master4",
+            "master6"
+          ],
+          "undefined": [
+            "all",
+            "as",
+            "base",
+            "bgp",
+            "client",
+            "description",
+            "device",
+            "export",
+            "id",
+            "import",
+            "ipv4",
+            "ipv6",
+            "iso",
+            "local",
+            "log",
+            "long",
+            "neighbor",
+            "protocol",
+            "route",
+            "router",
+            "rs",
+            "stderr",
+            "table",
+            "timeformat"
+          ]
+        }
+      }
+    },
+    "wildcard_daemon": {
+      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": []
+      }
+    },
+    "wildcard_foreign": {
+      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+      "response": {
+        "api": {
+          "from_cache": false,
+          "max_routes": 100,
+          "version": "2.1.0"
+        },
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "eth0",
+            "learnt_from": "",
+            "metric": 100,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "provenance": {
+    "birdseye_commit": "7f8c2375e610578bcf6ea5ceec630a180f945b89",
+    "ixp_manager_commit": "300b7e0ba9adb0aaac975899e45fc8bcbc0ca37d",
+    "leg": "oracle",
+    "normalization": [
+      "timestamps -> <timestamp>",
+      "rustbgpd <semver> -> rustbgpd <version>",
+      "hold_timer_now and keepalive_now -> <countdown>",
+      "each leg's own route-server addresses -> <route-server>",
+      "routes sorted by network, symbol lists sorted"
+    ],
+    "software": "BIRD 2.0.12 + Bird's Eye 2.1.0"
+  }
+}

--- a/tests/compat/ixp-manager-birdseye/oracle-announcer-as64496.conf
+++ b/tests/compat/ixp-manager-birdseye/oracle-announcer-as64496.conf
@@ -1,0 +1,80 @@
+# ExaBGP announcer AS64496: one deterministic route set, announced verbatim to
+# both route servers (rustbgpd at the harness network gateway, BIRD at .3).
+# Passive: the route servers initiate. as-path is sent exactly as written.
+template {
+    neighbor rs4 {
+        router-id 198.51.100.2;
+        local-address 198.51.100.2;
+        local-as 64496;
+        peer-as 65001;
+        passive true;
+        family {
+            ipv4 unicast;
+        }
+        static {
+            route 203.0.113.0/24 {
+                next-hop 198.51.100.2;
+                origin igp;
+                as-path [ 64496 64510 64520 ];
+                med 10;
+                community [ 64496:100 64496:200 ];
+                large-community [ 64496:1:1 64496:1:2 ];
+            }
+            route 203.0.113.128/25 {
+                next-hop 198.51.100.2;
+                origin igp;
+                as-path [ 64496 ];
+                local-preference 200;
+                community [ 64496:300 ];
+                large-community [ 64496:2:1 ];
+            }
+            route 203.0.113.64/26 {
+                next-hop 198.51.100.2;
+                origin incomplete;
+                as-path [ 64496 ];
+                med 30;
+                aggregator ( 64496:203.0.113.1 );
+            }
+        }
+    }
+    neighbor rs6 {
+        router-id 198.51.100.2;
+        local-address 2001:db8:5100::2;
+        local-as 64496;
+        peer-as 65001;
+        passive true;
+        family {
+            ipv6 unicast;
+        }
+        static {
+            route 2001:db8:a::/48 {
+                next-hop 2001:db8:5100::2;
+                origin igp;
+                as-path [ 64496 64510 ];
+                med 20;
+                community [ 64496:600 ];
+                large-community [ 64496:3:1 ];
+            }
+            route 2001:db8:b::/48 {
+                next-hop 2001:db8:5100::2;
+                origin egp;
+                as-path [ 64496 ];
+                community [ 64496:700 ];
+                large-community [ 64496:3:2 ];
+            }
+        }
+    }
+}
+
+neighbor 198.51.100.1 {
+    inherit rs4;
+}
+neighbor 198.51.100.3 {
+    inherit rs4;
+}
+neighbor 2001:db8:5100::1 {
+    inherit rs6;
+}
+neighbor 2001:db8:5100::3 {
+    inherit rs6;
+}

--- a/tests/compat/ixp-manager-birdseye/oracle-announcer-as64497.conf
+++ b/tests/compat/ixp-manager-birdseye/oracle-announcer-as64497.conf
@@ -1,0 +1,56 @@
+# ExaBGP announcer AS64497: the second client, so both route servers have
+# something to export to AS64496 and two protocol rows per family.
+template {
+    neighbor rs4 {
+        router-id 198.51.100.4;
+        local-address 198.51.100.4;
+        local-as 64497;
+        peer-as 65001;
+        passive true;
+        family {
+            ipv4 unicast;
+        }
+        static {
+            route 192.0.2.0/24 {
+                next-hop 198.51.100.4;
+                origin igp;
+                as-path [ 64497 ];
+                community [ 64497:100 ];
+                large-community [ 64497:1:1 ];
+            }
+        }
+    }
+    neighbor rs6 {
+        router-id 198.51.100.4;
+        local-address 2001:db8:5100::4;
+        local-as 64497;
+        peer-as 65001;
+        passive true;
+        family {
+            ipv6 unicast;
+        }
+        static {
+            route 2001:db8:c::/48 {
+                next-hop 2001:db8:5100::4;
+                origin igp;
+                as-path [ 64497 64530 ];
+                med 5;
+                community [ 64497:600 ];
+                large-community [ 64497:3:1 ];
+            }
+        }
+    }
+}
+
+neighbor 198.51.100.1 {
+    inherit rs4;
+}
+neighbor 198.51.100.3 {
+    inherit rs4;
+}
+neighbor 2001:db8:5100::1 {
+    inherit rs6;
+}
+neighbor 2001:db8:5100::3 {
+    inherit rs6;
+}

--- a/tests/compat/ixp-manager-birdseye/oracle-bird.conf
+++ b/tests/compat/ixp-manager-birdseye/oracle-bird.conf
@@ -1,0 +1,43 @@
+# Pinned BIRD 2.0.12 route server behind the Bird's Eye oracle leg. Same
+# router ID, ASN, client descriptions, and accept-all policy as the rustbgpd
+# live leg; both serve the two ExaBGP announcers on the harness network.
+router id 10.0.0.1;
+timeformat base iso long;
+timeformat log iso long;
+timeformat protocol iso long;
+timeformat route iso long;
+log stderr all;
+
+protocol device { }
+
+protocol bgp pb_as64496 {
+    description "oracle client AS64496";
+    local 198.51.100.3 as 65001;
+    neighbor 198.51.100.2 as 64496;
+    rs client;
+    ipv4 { table master4; import all; export all; };
+}
+
+protocol bgp pb6_as64496 {
+    description "oracle client AS64496 IPv6";
+    local 2001:db8:5100::3 as 65001;
+    neighbor 2001:db8:5100::2 as 64496;
+    rs client;
+    ipv6 { table master6; import all; export all; };
+}
+
+protocol bgp pb_as64497 {
+    description "oracle client AS64497";
+    local 198.51.100.3 as 65001;
+    neighbor 198.51.100.4 as 64497;
+    rs client;
+    ipv4 { table master4; import all; export all; };
+}
+
+protocol bgp pb6_as64497 {
+    description "oracle client AS64497 IPv6";
+    local 2001:db8:5100::3 as 65001;
+    neighbor 2001:db8:5100::4 as 64497;
+    rs client;
+    ipv6 { table master6; import all; export all; };
+}

--- a/tests/compat/ixp-manager-birdseye/oracle-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/oracle-consumer.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use IXP\Models\Router;
+use IXP\Services\LookingGlass\BirdsEye;
+
+require getenv('IXP_MANAGER_ROOT') . '/vendor/autoload.php';
+
+// Drives every Bird's Eye endpoint IXP Manager v7.4.0's BirdsEye consumer
+// calls, through that consumer, against one populated route server: the
+// pinned BIRD 2.0.12 + Bird's Eye oracle or the rustbgpd + adapter live leg.
+// Both legs receive the same announcements, so the two outputs are an
+// oracle/live fixture pair that verify_capture.py --populated diffs.
+$manifest = json_decode(
+    file_get_contents(__DIR__ . '/contract.json'),
+    true,
+    512,
+    JSON_THROW_ON_ERROR,
+);
+$topology = $manifest['populated_topology'] ?? [];
+$v4 = $topology['protocols']['member-v4'] ?? null;
+$v6 = $topology['protocols']['member-v6'] ?? null;
+$filtered = $manifest['filtered_prefix_query'] ?? [];
+if ($v4 !== 'pb_as64496' || $v6 !== 'pb6_as64496'
+    || $filtered !== ['global_admin' => 65001, 'function' => 1101]) {
+    throw new RuntimeException('populated oracle topology drifted');
+}
+
+$container = new Container();
+Container::setInstance($container);
+$container->instance('config', new Repository([
+    'ixp_fe' => ['frontend' => ['disabled' => ['logs' => true]]],
+]));
+$router = new Router();
+$router->api = getenv('BIRDSEYE_API');
+$consumer = new BirdsEye($router);
+
+$journey = static fn (string $endpoint, string $response): array => [
+    'endpoint' => $endpoint,
+    'response' => $response,
+];
+$journeys = [
+    'status' => $journey('api/status', $consumer->status()),
+    'protocols' => $journey('api/protocols/bgp', $consumer->bgpSummary()),
+    'protocol_v4' => $journey('api/protocol/{protocol}', $consumer->bgpNeighbourSummary($v4)),
+    'protocol_v6' => $journey('api/protocol/{protocol}', $consumer->bgpNeighbourSummary($v6)),
+    'symbols' => $journey('api/symbols', $consumer->symbols()),
+    'routes_protocol_v4' => $journey('api/routes/protocol/{protocol}', $consumer->routesForProtocol($v4)),
+    'routes_protocol_v6' => $journey('api/routes/protocol/{protocol}', $consumer->routesForProtocol($v6)),
+    'routes_table_v4' => $journey('api/routes/table/{table}', $consumer->routesForTable('master4')),
+    'routes_table_v6' => $journey('api/routes/table/{table}', $consumer->routesForTable('master6')),
+    'routes_export_v4' => $journey('api/routes/export/{protocol}', $consumer->routesForExport($v4)),
+    'routes_export_v6' => $journey('api/routes/export/{protocol}', $consumer->routesForExport($v6)),
+    'lookup_protocol_exact' => $journey('api/route/{net}/protocol/{protocol}', $consumer->protocolRoute($v4, '203.0.113.0', 24)),
+    'lookup_protocol_covering' => $journey('api/route/{net}/protocol/{protocol}', $consumer->protocolRoute($v4, '203.0.113.0', 25)),
+    'lookup_protocol_host' => $journey('api/route/{net}/protocol/{protocol}', $consumer->protocolRoute($v4, '203.0.113.1', 32)),
+    'lookup_protocol_v6' => $journey('api/route/{net}/protocol/{protocol}', $consumer->protocolRoute($v6, '2001:db8:a::', 48)),
+    'lookup_table_exact' => $journey('api/route/{net}/table/{table}', $consumer->protocolTable('master4', '203.0.113.128', 25)),
+    'lookup_table_less_specific' => $journey('api/route/{net}/table/{table}', $consumer->protocolTable('master4', '203.0.113.192', 26)),
+    'lookup_table_unaligned' => $journey('api/route/{net}/table/{table}', $consumer->protocolTable('master4', '203.0.113.1', 24)),
+    'lookup_table_v6' => $journey('api/route/{net}/table/{table}', $consumer->protocolTable('master6', '2001:db8:c::', 48)),
+    'lookup_export_exact' => $journey('api/route/{net}/export/{protocol}', $consumer->exportRoute($v4, '192.0.2.0', 24)),
+    'lookup_export_covering' => $journey('api/route/{net}/export/{protocol}', $consumer->exportRoute($v4, '192.0.2.0', 25)),
+    'lookup_export_v6' => $journey('api/route/{net}/export/{protocol}', $consumer->exportRoute($v6, '2001:db8:c::', 48)),
+    'wildcard_daemon' => $journey(
+        'api/routes/lc-zwild/protocol/{protocol}/{x}/{y}',
+        $consumer->routesProtocolLargeCommunityWildXYRoutes($v4, $filtered['global_admin'], $filtered['function']),
+    ),
+    'wildcard_foreign' => $journey(
+        'api/routes/lc-zwild/protocol/{protocol}/{x}/{y}',
+        $consumer->routesProtocolLargeCommunityWildXYRoutes($v4, 64496, 1),
+    ),
+];
+
+echo json_encode(
+    ['ixp_manager_commit' => $manifest['ixp_manager_commit'], 'journeys' => $journeys],
+    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+) . "\n";

--- a/tests/compat/ixp-manager-birdseye/run-oracle-leg.sh
+++ b/tests/compat/ixp-manager-birdseye/run-oracle-leg.sh
@@ -1,0 +1,195 @@
+#!/bin/sh
+# Populated oracle leg: pinned BIRD 2.0.12 + Bird's Eye 2.1.0 (oracle) and
+# rustbgpd + birdwatcher-adapter (live) both peer with the same two ExaBGP
+# announcers on one harness network, and the same pinned IXP Manager BirdsEye
+# consumer reads both. Writes populated-oracle.raw.json and
+# populated-live.raw.json into CAPTURE_OUTPUT; verify_capture.py --populated
+# scrubs, pins, and diffs them against the runtime divergence allow-list.
+set -eu
+
+root=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo=$(CDPATH='' cd -- "$root/../../.." && pwd)
+ixp_manager=${1:?IXP Manager checkout is required}
+image=${2:?PHP contract image is required}
+birdseye=${3:?installed Birdseye checkout is required}
+capture_output=${CAPTURE_OUTPUT:?capture output directory is required}
+tmp=$(mktemp -d)
+network=rustbgpd-ixp-oracle-$$
+oracle=rustbgpd-ixp-oracle-$$
+announcer_a=rustbgpd-ixp-announcer-as64496-$$
+announcer_b=rustbgpd-ixp-announcer-as64497-$$
+exabgp='ghcr.io/exa-networks/exabgp@sha256:5554ac053766e66ca3b99eb6b66e83e32113913729a184dcbaf0cc4abd2f4244'
+daemon_pid=
+adapter_pid=
+cleanup() {
+  [ -z "$adapter_pid" ] || kill "$adapter_pid" 2>/dev/null || true
+  [ -z "$daemon_pid" ] || kill "$daemon_pid" 2>/dev/null || true
+  docker rm --force "$oracle" "$announcer_a" "$announcer_b" >/dev/null 2>&1 || true
+  docker network rm "$network" >/dev/null 2>&1 || true
+  rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
+
+cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" --bin rustbgpd
+cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" -p birdwatcher-adapter
+oracle_image=$(docker build --quiet --file "$root/Dockerfile.oracle" "$root")
+docker network create --subnet 198.51.100.0/24 \
+  --ipv6 --subnet 2001:db8:5100::/64 "$network" >/dev/null
+
+# Oracle: the Bird's Eye checkout installed from its committed lockfile earlier
+# in the gate, copied in next to the pinned BIRD so the real birdc is local.
+docker run --detach --name "$oracle" --network "$network" \
+  --ip 198.51.100.3 --ip6 2001:db8:5100::3 "$oracle_image" sleep infinity >/dev/null
+[ "$(docker exec "$oracle" bird --version 2>&1)" = 'BIRD version 2.0.12' ]
+docker cp "$birdseye/." "$oracle:/birdseye"
+docker cp "$root/oracle-bird.conf" "$oracle:/etc/bird/bird.conf"
+sed 's#^BIRDC=.*#BIRDC="/usr/sbin/birdc"#; s#^MAX_ROUTES=.*#MAX_ROUTES=100#' \
+  "$root/birdseye.env" | docker exec --interactive "$oracle" sh -c 'cat >/birdseye/.env'
+docker exec "$oracle" sh -c 'mkdir -p /run/bird && bird -c /etc/bird/bird.conf -s /run/bird/bird.ctl'
+docker exec --detach "$oracle" sh -c \
+  'cd /birdseye && exec php -d display_errors=0 -d log_errors=1 -S 0.0.0.0:18081 -t public public/index.php >/tmp/birdseye.log 2>&1'
+oracle_api=http://198.51.100.3:18081/api
+
+start_announcer() {
+  docker run --rm --volume "$root/$2:/etc/exabgp/exabgp.conf:ro" "$exabgp" \
+    validate /etc/exabgp/exabgp.conf >/dev/null
+  docker run --detach --name "$1" --network "$network" --ip "$3" --ip6 "$4" \
+    --env exabgp_tcp_bind="$3 $4" --env exabgp_tcp_port=179 \
+    --volume "$root/$2:/etc/exabgp/exabgp.conf:ro" \
+    "$exabgp" server /etc/exabgp/exabgp.conf >/dev/null
+}
+start_announcer "$announcer_a" oracle-announcer-as64496.conf 198.51.100.2 2001:db8:5100::2
+start_announcer "$announcer_b" oracle-announcer-as64497.conf 198.51.100.4 2001:db8:5100::4
+
+# Live: same ASN, router ID, descriptions, and accept-all policy as the oracle.
+socket=$tmp/rustbgpd.sock
+aliases=$tmp/protocol-aliases
+mkdir -p "$tmp/runtime"
+printf '%s\n' \
+  'pb_as64496=198.51.100.2@master4' \
+  'pb6_as64496=2001:db8:5100::2@master6' \
+  'pb_as64497=198.51.100.4@master4' \
+  'pb6_as64497=2001:db8:5100::4@master6' >"$aliases"
+cat >"$tmp/rustbgpd.toml" <<CONF
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 0
+runtime_state_dir = "$tmp/runtime"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "$socket"
+mode = 0o600
+
+[policy.definitions.accept-all]
+default_action = "permit"
+
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64496
+description = "oracle client AS64496"
+route_server_client = true
+graceful_restart = false
+hold_time = 240
+families = ["ipv4_unicast"]
+import_policy_chain = ["accept-all"]
+export_policy_chain = ["accept-all"]
+
+[[neighbors]]
+address = "2001:db8:5100::2"
+remote_asn = 64496
+description = "oracle client AS64496 IPv6"
+route_server_client = true
+graceful_restart = false
+hold_time = 240
+families = ["ipv6_unicast"]
+import_policy_chain = ["accept-all"]
+export_policy_chain = ["accept-all"]
+
+[[neighbors]]
+address = "198.51.100.4"
+remote_asn = 64497
+description = "oracle client AS64497"
+route_server_client = true
+graceful_restart = false
+hold_time = 240
+families = ["ipv4_unicast"]
+import_policy_chain = ["accept-all"]
+export_policy_chain = ["accept-all"]
+
+[[neighbors]]
+address = "2001:db8:5100::4"
+remote_asn = 64497
+description = "oracle client AS64497 IPv6"
+route_server_client = true
+graceful_restart = false
+hold_time = 240
+families = ["ipv6_unicast"]
+import_policy_chain = ["accept-all"]
+export_policy_chain = ["accept-all"]
+CONF
+
+"$repo/target/debug/rustbgpd" "$tmp/rustbgpd.toml" >"$tmp/daemon.log" 2>&1 &
+daemon_pid=$!
+for _ in $(seq 1 120); do
+  [ -S "$socket" ] && break
+  kill -0 "$daemon_pid" 2>/dev/null || { cat "$tmp/daemon.log" >&2; exit 1; }
+  sleep 0.1
+done
+[ -S "$socket" ] || { cat "$tmp/daemon.log" >&2; exit 1; }
+NO_COLOR=1 "$repo/target/debug/birdwatcher-adapter" \
+  --grpc-addr "unix://$socket" --listen 127.0.0.1:0 \
+  --protocol-alias-file "$aliases" --max-routes 100 \
+  >"$tmp/adapter.out" 2>"$tmp/adapter.log" &
+adapter_pid=$!
+port=
+for _ in $(seq 1 120); do
+  port=$(grep -o '127\.0\.0\.1:[0-9][0-9]*' "$tmp/adapter.log" | tail -1 | cut -d: -f2 || true)
+  [ -z "$port" ] || break
+  kill -0 "$adapter_pid" 2>/dev/null || { cat "$tmp/adapter.log" >&2; exit 1; }
+  sleep 0.1
+done
+[ -n "$port" ] || { cat "$tmp/adapter.log" >&2; exit 1; }
+live_api=http://127.0.0.1:$port
+
+# Both legs must hold every route from both announcers in both tables before
+# the consumer reads them: 4 IPv4 (3 + 1) and 3 IPv6 (2 + 1).
+table_size() {
+  curl --silent --max-time 5 "$1/routes/table/$2" | python3 -c \
+    'import json,sys; print(len(json.load(sys.stdin).get("routes", [])))' 2>/dev/null || echo -1
+}
+converged() {
+  [ "$(table_size "$oracle_api" master4)" = 4 ] && [ "$(table_size "$oracle_api" master6)" = 3 ] \
+    && [ "$(table_size "$live_api" master4)" = 4 ] && [ "$(table_size "$live_api" master6)" = 3 ]
+}
+for _ in $(seq 1 180); do
+  if converged; then break; fi
+  kill -0 "$daemon_pid" 2>/dev/null || { cat "$tmp/daemon.log" >&2; exit 1; }
+  sleep 1
+done
+if ! converged; then
+  echo "populated oracle leg did not converge: oracle master4=$(table_size "$oracle_api" master4) master6=$(table_size "$oracle_api" master6) live master4=$(table_size "$live_api" master4) master6=$(table_size "$live_api" master6)" >&2
+  docker exec "$oracle" cat /tmp/birdseye.log >&2 || true
+  docker logs "$announcer_a" >&2 || true
+  tail -n 40 "$tmp/daemon.log" >&2
+  exit 1
+fi
+# Let BIRD's route-change counters and both legs' session timers settle on one
+# stable snapshot before reading.
+sleep 3
+
+run_consumer() {
+  docker run --rm --network host --user "$(id -u):$(id -g)" \
+    --env IXP_MANAGER_ROOT=/upstreams/ixp-manager \
+    --env BIRDSEYE_API="$1" \
+    --volume "$root:/harness:ro" \
+    --volume "$ixp_manager:/upstreams/ixp-manager:ro" \
+    "$image" php /harness/oracle-consumer.php >"$2"
+  [ -s "$2" ]
+}
+run_consumer "$oracle_api" "$capture_output/populated-oracle.raw.json"
+run_consumer "$live_api" "$capture_output/populated-live.raw.json"
+chmod 600 "$capture_output/populated-oracle.raw.json" "$capture_output/populated-live.raw.json"

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -245,3 +245,10 @@ mysql_address=$(docker inspect \
 CAPTURE_OUTPUT="$capture_output" "$root/run-adapter-consumer.sh" \
   "$tmp/ixp-manager" "$image" "$tmp/birdseye" "$mysql_address" >/dev/null
 python3 "$root/verify_capture.py" --nagios "$capture_output/nagios-monitoring.json"
+
+# Populated oracle leg: pinned BIRD 2.0.12 + Bird's Eye and rustbgpd + adapter
+# fed by the same announcers, read by the same pinned consumer, diffed against
+# the runtime divergence allow-list. Prints one "populated oracle proof:" line.
+CAPTURE_OUTPUT="$capture_output" "$root/run-oracle-leg.sh" \
+  "$tmp/ixp-manager" "$image" "$tmp/birdseye" >/dev/null
+python3 "$root/verify_capture.py" --populated "$capture_output" "$tmp/birdseye/routes/web.php"

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -161,6 +161,509 @@ SUPPORTED_UI_FILTERS = [
     FULL_UI_FILTERS[2],
 ]
 
+# Runtime divergence allow-list (contract.json runtime_divergences) and the
+# pinned Bird's Eye route inventory (contract.json birdseye_routes).
+ROW = ["api/protocols/bgp", "api/protocol/{protocol}"]
+ROUTE_VIEWS = [
+    "api/routes/protocol/{protocol}", "api/routes/table/{table}",
+    "api/routes/export/{protocol}", "api/route/{net}/protocol/{protocol}",
+    "api/route/{net}/table/{table}", "api/route/{net}/export/{protocol}",
+    "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+]
+NON_TABLE_ROUTE_VIEWS = [
+    "api/routes/protocol/{protocol}", "api/routes/export/{protocol}",
+    "api/route/{net}/protocol/{protocol}", "api/route/{net}/export/{protocol}",
+    "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+]
+LC_ZWILD = "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
+
+
+def row(path):
+    return [f"protocols.*.{path}", f"protocol.{path}"]
+
+
+RUNTIME_DIVERGENCES = [
+    {
+        "endpoint": "*", "path": "api.version", "kind": "value",
+        "birdseye": "Bird's Eye semantic version (2.1.0)",
+        "adapter": "rustbgpd <version> product identity",
+        "rationale": "api.version names the implementation, not the contract; the gate keeps asserting the rustbgpd prefix",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": "*", "path": "api.Version", "kind": "extra",
+        "birdseye": "absent", "adapter": "duplicate of api.version",
+        "rationale": "Birdwatcher-shaped api block; the Alice-LG surface of the same adapter reads it",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": "*", "path": "api.result_from_cache", "kind": "extra",
+        "birdseye": "absent", "adapter": "always false",
+        "rationale": "Birdwatcher-shaped api block; there is no cache to skip",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": "api/status", "path": "status.version", "kind": "value",
+        "birdseye": "BIRD version (2.0.12)", "adapter": "rustbgpd <version>",
+        "rationale": "product identity; the pinned looking-glass layout prints it as the router version",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": "api/status", "path": "status.message", "kind": "value",
+        "birdseye": "last show status line (Daemon is up and running)", "adapter": "rustbgpd AS<asn>",
+        "rationale": "product identity; no pinned consumer reads status.message",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": "api/status", "path": "status.current_server", "kind": "extra",
+        "birdseye": "absent", "adapter": "current wall-clock timestamp",
+        "rationale": "Birdwatcher status field; no pinned consumer reads it",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": ROW, "path": row("connection"), "kind": "value",
+        "birdseye": "BIRD 2 info column with its padding (\"  Established   \")",
+        "adapter": "\" Established\" (one leading space)",
+        "rationale": "whitespace only; the bgp-summary modal and the diagnostics suite read connection but HTML collapses the padding",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROW, "path": row("hold_timer_now") + row("keepalive_now"), "kind": "missing",
+        "birdseye": "live countdowns from the BIRD timers", "adapter": "absent",
+        "rationale": "live-hold-keepalive-countdowns is an unsupported entry; the daemon exposes negotiated values only, and the diagnostics suite guards them with isset",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROW, "path": row("preference"), "kind": "missing",
+        "birdseye": "BIRD protocol preference (100)", "adapter": "absent",
+        "rationale": "BIRD-internal route preference with no rustbgpd equivalent; shown by the bgp-summary modal when present",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROW, "path": row("input_filter") + row("output_filter"), "kind": "missing",
+        "birdseye": "BIRD filter names (ACCEPT)", "adapter": "absent",
+        "rationale": "rustbgpd policy chains have no BIRD filter identity; shown by the bgp-summary modal when present",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROW, "path": row("route_changes.*.*"), "kind": "missing",
+        "birdseye": "BIRD per-channel route change statistics", "adapter": "absent",
+        "rationale": "the gRPC NeighborState carries no import/export update and withdraw counters; the bgp-summary modal renders the block when present",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROW, "path": row("routes.preferred"), "kind": "missing",
+        "birdseye": "always 0 (the pinned parser's Routes: regex drops BIRD's preferred count)", "adapter": "absent",
+        "rationale": "the oracle value is a parser constant, not a best count; the adapter omits rather than fabricate one",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROW, "path": row("routes.filtered"), "kind": "extra",
+        "birdseye": "absent", "adapter": "retained-reject count",
+        "rationale": "Birdwatcher protocol field backing the filtered-route views; no pinned consumer reads it",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": ROW, "path": row("neighbor_capabilities.*"), "kind": "extra",
+        "birdseye": "absent (BIRD 2 prints a multi-line Neighbor capabilities block the pinned Neighbor caps: regex never matches)",
+        "adapter": "negotiated capability list (refresh, AS4)",
+        "rationale": "the adapter keeps the BIRD 1 shape; the bgp-summary modal renders the list when present",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.bgp.as_path.*", "kind": "type",
+        "birdseye": "strings", "adapter": "integers",
+        "rationale": "Bird's Eye splits the BGP.as_path text; the adapter emits the numeric path; the pinned route views implode either",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.bgp.local_pref", "kind": "type",
+        "birdseye": "string \"100\" (BIRD's default local preference assigned at import)",
+        "adapter": "number 0 (the received attribute, absent on an eBGP session)",
+        "rationale": "type and meaning differ: BIRD prints a local preference for every route, the adapter prints the attribute that arrived",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.bgp.med", "kind": "extra",
+        "birdseye": "absent when the route carries no MED", "adapter": "0 when absent",
+        "rationale": "the adapter always emits med; equal whenever the attribute is present",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.bgp.aggregator", "kind": "missing",
+        "birdseye": "\"<address> AS<asn>\"", "adapter": "absent",
+        "rationale": "the adapter does not emit AGGREGATOR; the pinned route view prints it when present",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.interface", "kind": "value",
+        "birdseye": "BIRD egress interface (eth0)", "adapter": "\"\"",
+        "rationale": "a route server has no kernel interface to report; no pinned consumer reads it",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.learnt_from", "kind": "value",
+        "birdseye": "\"\" (BIRD prints from <address> only when it differs from the next hop)", "adapter": "peer address",
+        "rationale": "no pinned consumer reads it",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.metric", "kind": "value",
+        "birdseye": "BIRD route preference (100)", "adapter": "0",
+        "rationale": "BIRD-internal preference; the pinned route view prints metric",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": NON_TABLE_ROUTE_VIEWS, "path": "routes.*.primary", "kind": "value",
+        "birdseye": "true for the best route in every view", "adapter": "false outside the table view",
+        "rationale": "the adapter reports primary only where it reads the Loc-RIB; the pinned route view prints it",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ROUTE_VIEWS, "path": "routes.*.type.*", "kind": "semantics",
+        "birdseye": "[\"BGP\", \"univ\"] (BIRD 2 Type: BGP univ)", "adapter": "[\"BGP\", \"unicast\", \"univ\"] (BIRD 1 shape)",
+        "rationale": "the adapter keeps the BIRD 1 type triple; the pinned route view prints the list",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": ["api/route/{net}/protocol/{protocol}", "api/route/{net}/export/{protocol}"],
+        "path": "routes", "kind": "semantics",
+        "birdseye": "show route for: longest match, so a covering-only prefix or a host address returns the covering route",
+        "adapter": "exact prefix match: the same inputs return []",
+        "rationale": "IXP Manager passes listed exact networks; the exact-vs-longest choice is recorded, not hidden",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": "api/route/{net}/table/{table}", "path": "<response>", "kind": "semantics",
+        "birdseye": "HTTP 200 with routes: [] for host-bit input (BIRD rejects the lookup)",
+        "adapter": "HTTP 400, which the pinned consumer collapses to \"\"",
+        "rationale": "network-aligned input only; IXP Manager renders an empty page either way",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": LC_ZWILD, "path": "routes", "kind": "semantics",
+        "birdseye": "every route carrying (x, y, *) in the protocol's table",
+        "adapter": "retained rejects tagged <daemon asn>:1101:* only; [] for any other (x, y)",
+        "rationale": "the filtered-prefix view is the only pinned use; accepted routes are never scanned",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": LC_ZWILD, "path": "retention.*", "kind": "extra",
+        "birdseye": "absent", "adapter": "retention completeness metadata",
+        "rationale": "filtered_retention_metadata block; no pinned consumer reads it",
+        "consumer_visible": False,
+    },
+    {
+        "endpoint": LC_ZWILD, "path": "api.max_routes", "kind": "value",
+        "birdseye": "MAX_ROUTES", "adapter": "retention capacity for the daemon (x, y)",
+        "rationale": "filtered_retention_metadata.api_max_routes; the pinned layout prints api.max_routes",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": "api/symbols", "path": "symbols.protocol.*", "kind": "semantics",
+        "birdseye": "every BIRD protocol, including device1", "adapter": "BGP sessions only",
+        "rationale": "the daemon has no BIRD symbol table; the pinned route-search view lists symbols.protocol",
+        "consumer_visible": True,
+    },
+    {
+        "endpoint": "api/symbols", "path": "symbols.undefined.*", "kind": "missing",
+        "birdseye": "BIRD 2.0.12 show symbols reports configuration keywords under an undefined class", "adapter": "absent",
+        "rationale": "Bird's Eye passes every class through; no pinned consumer reads undefined",
+        "consumer_visible": False,
+    },
+]
+
+BIRDSEYE_ROUTES = {
+    "in_scope": [
+        "api/status",
+        "api/protocols/bgp",
+        "api/protocol/{protocol}",
+        "api/symbols",
+        "api/routes/protocol/{protocol}",
+        "api/routes/table/{table}",
+        "api/routes/export/{protocol}",
+        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
+        "api/route/{net}/table/{table}",
+        "api/route/{net}/protocol/{protocol}",
+        "api/route/{net}/export/{protocol}",
+    ],
+    "out_of_scope": [
+        "test",
+        "/",
+        "api/symbols/tables",
+        "api/symbols/protocols",
+        "api/routes/count/protocol/{protocol}",
+        "api/routes/count/table/{table}",
+        "api/routes/count/export/{protocol}",
+        "api/route/{net}",
+        "lg/",
+        "lg/protocols/bgp",
+        "lg/routes/protocol/{protocol}",
+        "lg/routes/table/{table}",
+        "lg/routes/export/{protocol}",
+        "lg/route",
+        "lg/route/{net}/protocol/{protocol}",
+        "lg/route/{net}/table/{table}",
+    ],
+}
+
+# --- populated oracle leg -------------------------------------------------------
+POPULATED_TOPOLOGY = {
+    "network": {"ipv4": "198.51.100.0/24", "ipv6": "2001:db8:5100::/64"},
+    "route_servers": {
+        "oracle": {
+            "software": "BIRD 2.0.12 + Bird's Eye 2.1.0",
+            "ipv4": "198.51.100.3", "ipv6": "2001:db8:5100::3",
+        },
+        "live": {
+            "software": "rustbgpd + birdwatcher-adapter",
+            "ipv4": "198.51.100.1", "ipv6": "2001:db8:5100::1",
+        },
+    },
+    "router_id": "10.0.0.1",
+    "asn": 65001,
+    "max_routes": 100,
+    "protocols": {
+        "member-v4": "pb_as64496",
+        "member-v6": "pb6_as64496",
+        "second-member-v4": "pb_as64497",
+        "second-member-v6": "pb6_as64497",
+    },
+    "announcers": {
+        "64496": {
+            "ipv4": "198.51.100.2", "ipv6": "2001:db8:5100::2",
+            "ipv4_routes": ["203.0.113.0/24", "203.0.113.128/25", "203.0.113.64/26"],
+            "ipv6_routes": ["2001:db8:a::/48", "2001:db8:b::/48"],
+        },
+        "64497": {
+            "ipv4": "198.51.100.4", "ipv6": "2001:db8:5100::4",
+            "ipv4_routes": ["192.0.2.0/24"],
+            "ipv6_routes": ["2001:db8:c::/48"],
+        },
+    },
+}
+POPULATED_NORMALIZATION = [
+    "timestamps -> <timestamp>",
+    "rustbgpd <semver> -> rustbgpd <version>",
+    "hold_timer_now and keepalive_now -> <countdown>",
+    "each leg's own route-server addresses -> <route-server>",
+    "routes sorted by network, symbol lists sorted",
+]
+TIMESTAMP = re.compile(
+    r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\+00:00)?$|^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$"
+)
+PRODUCT_VERSION = re.compile(r"^rustbgpd \d+\.\d+\.\d+\S*$")
+
+
+def normalize_value(value, key, own_addresses):
+    if isinstance(value, dict):
+        return {k: normalize_value(v, k, own_addresses) for k, v in value.items()}
+    if isinstance(value, list):
+        items = [normalize_value(v, key, own_addresses) for v in value]
+        if key == "routes":
+            items.sort(key=lambda route: (route.get("network", ""), json.dumps(route, sort_keys=True)))
+        return items
+    if key in ("hold_timer_now", "keepalive_now"):
+        return "<countdown>"
+    if isinstance(value, str):
+        if TIMESTAMP.match(value):
+            return "<timestamp>"
+        if PRODUCT_VERSION.match(value):
+            return "rustbgpd <version>"
+        if value in own_addresses:
+            return "<route-server>"
+    return value
+
+
+def normalize_leg(raw, leg):
+    own = set(POPULATED_TOPOLOGY["route_servers"][leg].values())
+    journeys = {}
+    for name, journey in raw["journeys"].items():
+        response = journey["response"]
+        if response != "":
+            response = normalize_value(json.loads(response), None, own)
+            if "symbols" in response:
+                response["symbols"] = {k: sorted(v) for k, v in response["symbols"].items()}
+        journeys[name] = {"endpoint": journey["endpoint"], "response": response}
+    return {
+        "provenance": {
+            "leg": leg,
+            "software": POPULATED_TOPOLOGY["route_servers"][leg]["software"],
+            "birdseye_commit": manifest["birdseye_commit"],
+            "ixp_manager_commit": raw["ixp_manager_commit"],
+            "normalization": POPULATED_NORMALIZATION,
+        },
+        "journeys": journeys,
+    }
+
+
+def flatten(value, prefix=""):
+    if isinstance(value, dict):
+        out = {}
+        for k, v in value.items():
+            out.update(flatten(v, f"{prefix}.{k}" if prefix else k))
+        return out
+    if isinstance(value, list):
+        out = {}
+        for i, v in enumerate(value):
+            out.update(flatten(v, f"{prefix}.{i}" if prefix else str(i)))
+        return out
+    return {prefix: value}
+
+
+def json_type(value):
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, (int, float)):
+        return "number"
+    return "string"
+
+
+def journey_diffs(oracle, live):
+    """Classified differences for one journey: (path, kind, oracle, live)."""
+    if oracle == "" or live == "":
+        if oracle == live:
+            return []
+        return [("<response>", "semantics", oracle, live)]
+    flat_oracle = flatten(oracle)
+    flat_live = flatten(live)
+    diffs = []
+    for path in sorted(set(flat_oracle) | set(flat_live)):
+        if path not in flat_live:
+            diffs.append((path, "missing", flat_oracle[path], None))
+        elif path not in flat_oracle:
+            diffs.append((path, "extra", None, flat_live[path]))
+        elif flat_oracle[path] != flat_live[path]:
+            kind = "type" if json_type(flat_oracle[path]) != json_type(flat_live[path]) else "value"
+            diffs.append((path, kind, flat_oracle[path], flat_live[path]))
+    return diffs
+
+
+def path_matches(pattern, path, semantics):
+    """Segment-wise glob; a semantics entry covers the whole subtree under it."""
+    want = pattern.split(".")
+    have = path.split(".")
+    if len(have) < len(want) or (not semantics and len(have) != len(want)):
+        return False
+    return all(w in ("*", h) for w, h in zip(want, have))
+
+
+def entry_matches(entry, endpoint, diff):
+    endpoints = entry["endpoint"] if isinstance(entry["endpoint"], list) else [entry["endpoint"]]
+    paths = entry["path"] if isinstance(entry["path"], list) else [entry["path"]]
+    if "*" not in endpoints and endpoint not in endpoints:
+        return False
+    semantics = entry["kind"] == "semantics"
+    if not semantics and diff[1] != entry["kind"]:
+        return False
+    return any(path_matches(p, diff[0], semantics) for p in paths)
+
+
+def check_divergences(oracle_doc, live_doc, entries):
+    """Return (unlisted differences, stale entries) after applying the allow-list."""
+    unlisted = []
+    used = [False] * len(entries)
+    for name, journey in oracle_doc["journeys"].items():
+        endpoint = journey["endpoint"]
+        if live_doc["journeys"][name]["endpoint"] != endpoint:
+            fail(f"populated journey {name}: endpoint label drifted between legs")
+        for diff in journey_diffs(journey["response"], live_doc["journeys"][name]["response"]):
+            matched = False
+            for index, entry in enumerate(entries):
+                if entry_matches(entry, endpoint, diff):
+                    used[index] = True
+                    matched = True
+            if not matched:
+                unlisted.append((name, endpoint) + diff)
+    stale = [entry for entry, hit in zip(entries, used) if not hit]
+    return unlisted, stale
+
+
+def parse_birdseye_routes(web_php):
+    """Every route literal registered in Bird's Eye routes/web.php, with the
+    looking-glass group's prefix applied to the literals inside it."""
+    lg_group = web_php.find("'prefix' => 'lg'")
+    routes = set()
+    for match in re.finditer(r"\$router->get\(\s*'([^']*)'", web_php):
+        literal = match.group(1)
+        routes.add(f"lg/{literal}" if lg_group != -1 and match.start() > lg_group else literal)
+    return routes
+
+
+def verify_populated(capture_dir: Path, web_php: Path) -> None:
+    raw = {
+        leg: json.loads((capture_dir / f"populated-{leg}.raw.json").read_text())
+        for leg in ("oracle", "live")
+    }
+    for leg, document in raw.items():
+        if document.get("ixp_manager_commit") != manifest["ixp_manager_commit"]:
+            fail(f"populated {leg} capture: IXP Manager consumer commit drifted")
+    docs = {leg: normalize_leg(document, leg) for leg, document in raw.items()}
+    exercised = {j["endpoint"] for j in docs["oracle"]["journeys"].values()}
+    if exercised != set(BIRDSEYE_ROUTES["in_scope"]):
+        fail(
+            "populated journeys do not cover exactly the in-scope endpoints: "
+            f"missing={sorted(set(BIRDSEYE_ROUTES['in_scope']) - exercised)} "
+            f"unexpected={sorted(exercised - set(BIRDSEYE_ROUTES['in_scope']))}"
+        )
+    for leg, document in docs.items():
+        for name, journey in document["journeys"].items():
+            if journey["response"] == "" and name != "lookup_table_unaligned":
+                fail(f"populated {leg} capture: {name} returned a collapsed non-2xx response")
+    for leg, document in docs.items():
+        text = json.dumps(document, indent=2, sort_keys=True) + "\n"
+        fixture = root / "fixtures" / f"populated-{leg}.json"
+        if os.getenv("CAPTURE_FIXTURES") == "1":
+            output = Path(os.environ["CAPTURE_OUTPUT"])
+            output.mkdir(parents=True, exist_ok=True)
+            (output / fixture.name).write_text(text)
+        elif fixture.read_text() != text:
+            sys.stderr.writelines(difflib.unified_diff(
+                fixture.read_text().splitlines(True), text.splitlines(True),
+                fromfile=str(fixture), tofile=f"populated-{leg}-capture",
+            ))
+            fail(f"populated {leg} capture drifted from its fixture")
+
+    unlisted, stale = check_divergences(docs["oracle"], docs["live"], RUNTIME_DIVERGENCES)
+    for item in unlisted:
+        print(f"unlisted divergence: journey={item[0]} endpoint={item[1]} path={item[2]} "
+              f"kind={item[3]} oracle={item[4]!r} live={item[5]!r}", file=sys.stderr)
+    if unlisted:
+        fail(f"{len(unlisted)} oracle/live difference(s) are not on the runtime divergence allow-list")
+    for entry in stale:
+        print(f"stale allow-list entry: endpoint={entry['endpoint']} path={entry['path']} "
+              f"kind={entry['kind']}", file=sys.stderr)
+    if stale:
+        fail(f"{len(stale)} runtime divergence allow-list entries no longer match a real difference")
+    # The allow-list check proves itself fail-closed on every run: dropping any
+    # one entry must surface an unlisted difference, and a bogus entry must be
+    # reported stale.
+    for index in range(len(RUNTIME_DIVERGENCES)):
+        trimmed = RUNTIME_DIVERGENCES[:index] + RUNTIME_DIVERGENCES[index + 1:]
+        if not check_divergences(docs["oracle"], docs["live"], trimmed)[0]:
+            fail(f"allow-list entry {index} is redundant: removing it surfaces no difference")
+    bogus = {"endpoint": "api/status", "path": "status.router_id", "kind": "value"}
+    if check_divergences(docs["oracle"], docs["live"], RUNTIME_DIVERGENCES + [bogus])[1] != [bogus]:
+        fail("allow-list self-check: a bogus entry was not reported stale")
+
+    routes = parse_birdseye_routes(web_php.read_text())
+    pinned = set(BIRDSEYE_ROUTES["in_scope"]) | set(BIRDSEYE_ROUTES["out_of_scope"])
+    if routes != pinned:
+        fail(
+            "pinned Bird's Eye routes/web.php route set differs from scope and out-of-scope: "
+            f"new={sorted(routes - pinned)} gone={sorted(pinned - routes)}"
+        )
+    journeys = len(docs["oracle"]["journeys"])
+    print(
+        f"populated oracle proof: {journeys} journeys over {len(BIRDSEYE_ROUTES['in_scope'])} "
+        f"endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; "
+        f"{len(RUNTIME_DIVERGENCES)} allow-listed divergences, 0 unlisted, 0 stale; "
+        f"{len(routes)} pinned routes/web.php routes accounted for",
+        file=sys.stderr,
+    )
+
 
 def fail(message: str) -> None:
     raise SystemExit(message)
@@ -188,6 +691,12 @@ if manifest.get("manual_config_export") != MANUAL_CONFIG_EXPORT:
     fail("strict manual v2 export contract drifted")
 if manifest.get("nagios_monitoring") != NAGIOS_MONITORING:
     fail("pinned Nagios monitoring contract drifted")
+if manifest.get("populated_topology") != POPULATED_TOPOLOGY:
+    fail("populated oracle topology drifted")
+if manifest.get("birdseye_routes") != BIRDSEYE_ROUTES:
+    fail("pinned Bird's Eye route scope drifted")
+if manifest.get("runtime_divergences") != RUNTIME_DIVERGENCES:
+    fail("runtime divergence allow-list drifted")
 consumer_source = (root / "config-consumer.php").read_text()
 for required in [
     "$router->template = 'api/v4/router/server/bird2/standard';",
@@ -229,6 +738,10 @@ if sys.argv[1] == "--nagios":
         fail("nagios capture: pinned nagios-check-birdseye.php line drifted")
     if not summary.get("last_reconfig"):
         fail("nagios capture: daemon check Last Reconfigure is empty")
+    sys.exit(0)
+
+if sys.argv[1] == "--populated":
+    verify_populated(Path(sys.argv[2]), Path(sys.argv[3]))
     sys.exit(0)
 
 capture = Path(sys.argv[1])


### PR DESCRIPTION
## Summary

Items 1 and 2 of the `runtime_compatibility` work list in `tests/compat/ixp-manager-birdseye/README.md`: the populated oracle leg and the machine-readable divergence allow-list. **`contract.json` `runtime_compatibility` is unchanged (`false`).**

## What the leg stands up

- Oracle: pinned BIRD 2.0.12 (Debian bookworm `bird2`, `Dockerfile.oracle`, `oracle-bird.conf`) in one container with the Bird's Eye v2.1.0 checkout already installed from its committed lockfile earlier in the gate (real `birdc`, `APP_DEBUG=false`, `CACHE_DRIVER=array`, `MAX_ROUTES=100`).
- Live: rustbgpd + `birdwatcher-adapter` on the host (`run-oracle-leg.sh`), same ASN 65001, router ID, client descriptions, accept-all policy, and BIRD's default hold time.
- Announcers: two pinned ExaBGP containers (`oracle-announcer-as64496.conf`, `oracle-announcer-as64497.conf`), passive, each peering with both route servers over one harness network (`198.51.100.0/24`, `2001:db8:5100::/64`). AS64496 announces `203.0.113.0/24` (3-hop AS path, MED, two communities, two large communities), `203.0.113.128/25` (LOCAL_PREF 200, community, large community), `203.0.113.64/26` (AGGREGATOR, origin incomplete, MED), `2001:db8:a::/48`, `2001:db8:b::/48` (origin EGP); AS64497 announces `192.0.2.0/24` and `2001:db8:c::/48` so exports are populated.
- Consumer: `oracle-consumer.php` drives the pinned IXP Manager v7.4.0 `BirdsEye` class against each leg; `verify_capture.py --populated` normalizes, pins `fixtures/populated-oracle.json` / `fixtures/populated-live.json`, applies the allow-list, re-proves it fail-closed on every run (each entry removed in turn must surface an unlisted difference; a bogus entry must be reported stale), and parses the pinned `routes/web.php` against `birdseye_routes`.
- Wired into `run.sh` after the Nagios step (same `ixp-compat.yml` job); adds roughly 20 s of convergence plus one image build. Success prints one line on stderr:

```
populated oracle proof: 24 journeys over 11 endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; 30 allow-listed divergences, 0 unlisted, 0 stale; 27 pinned routes/web.php routes accounted for
```

## Endpoints diffed (24 journeys)

`api/status`, `api/protocols/bgp`, `api/protocol/{protocol}` (v4, v6), `api/symbols`, `api/routes/protocol/{protocol}` (v4, v6), `api/routes/table/{table}` (master4, master6), `api/routes/export/{protocol}` (v4, v6), `api/route/{net}/protocol/{protocol}` (exact, covering-only, host, v6), `api/route/{net}/table/{table}` (exact, less-specific, host-bit input, v6), `api/route/{net}/export/{protocol}` (exact, covering-only, v6), `api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` (daemon `65001:1101`, foreign `64496:1`).

Normalization applied to both legs (recorded in each fixture's provenance): timestamps, the rustbgpd version, `hold_timer_now`/`keepalive_now`, each leg's own route-server addresses (`source_address`), route and symbol list order.

## Allow-list entries (`contract.json` `runtime_divergences`)

- `*` / `api.version` / **value** / consumer_visible=true: api.version names the implementation, not the contract; the gate keeps asserting the rustbgpd prefix
- `*` / `api.Version` / **extra** / consumer_visible=false: Birdwatcher-shaped api block; the Alice-LG surface of the same adapter reads it
- `*` / `api.result_from_cache` / **extra** / consumer_visible=false: Birdwatcher-shaped api block; there is no cache to skip
- `api/status` / `status.version` / **value** / consumer_visible=true: product identity; the pinned looking-glass layout prints it as the router version
- `api/status` / `status.message` / **value** / consumer_visible=false: product identity; no pinned consumer reads status.message
- `api/status` / `status.current_server` / **extra** / consumer_visible=false: Birdwatcher status field; no pinned consumer reads it
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.connection, protocol.connection` / **value** / consumer_visible=true: whitespace only; the bgp-summary modal and the diagnostics suite read connection but HTML collapses the padding
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.hold_timer_now, protocol.hold_timer_now, protocols.*.keepalive_now, protocol.keepalive_now` / **missing** / consumer_visible=true: live-hold-keepalive-countdowns is an unsupported entry; the daemon exposes negotiated values only, and the diagnostics suite guards them with isset
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.preference, protocol.preference` / **missing** / consumer_visible=true: BIRD-internal route preference with no rustbgpd equivalent; shown by the bgp-summary modal when present
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.input_filter, protocol.input_filter, protocols.*.output_filter, protocol.output_filter` / **missing** / consumer_visible=true: rustbgpd policy chains have no BIRD filter identity; shown by the bgp-summary modal when present
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.route_changes.*.*, protocol.route_changes.*.*` / **missing** / consumer_visible=true: the gRPC NeighborState carries no import/export update and withdraw counters; the bgp-summary modal renders the block when present
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.routes.preferred, protocol.routes.preferred` / **missing** / consumer_visible=true: the oracle value is a parser constant, not a best count; the adapter omits rather than fabricate one
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.routes.filtered, protocol.routes.filtered` / **extra** / consumer_visible=false: Birdwatcher protocol field backing the filtered-route views; no pinned consumer reads it
- `api/protocols/bgp, api/protocol/{protocol}` / `protocols.*.neighbor_capabilities.*, protocol.neighbor_capabilities.*` / **extra** / consumer_visible=true: the adapter keeps the BIRD 1 shape; the bgp-summary modal renders the list when present
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.bgp.as_path.*` / **type** / consumer_visible=true: Bird's Eye splits the BGP.as_path text; the adapter emits the numeric path; the pinned route views implode either
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.bgp.local_pref` / **type** / consumer_visible=true: type and meaning differ: BIRD prints a local preference for every route, the adapter prints the attribute that arrived
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.bgp.med` / **extra** / consumer_visible=true: the adapter always emits med; equal whenever the attribute is present
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.bgp.aggregator` / **missing** / consumer_visible=true: the adapter does not emit AGGREGATOR; the pinned route view prints it when present
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.interface` / **value** / consumer_visible=false: a route server has no kernel interface to report; no pinned consumer reads it
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.learnt_from` / **value** / consumer_visible=false: no pinned consumer reads it
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.metric` / **value** / consumer_visible=true: BIRD-internal preference; the pinned route view prints metric
- `api/routes/protocol/{protocol}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.primary` / **value** / consumer_visible=true: the adapter reports primary only where it reads the Loc-RIB; the pinned route view prints it
- `api/routes/protocol/{protocol}, api/routes/table/{table}, api/routes/export/{protocol}, api/route/{net}/protocol/{protocol}, api/route/{net}/table/{table}, api/route/{net}/export/{protocol}, api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes.*.type.*` / **semantics** / consumer_visible=true: the adapter keeps the BIRD 1 type triple; the pinned route view prints the list
- `api/route/{net}/protocol/{protocol}, api/route/{net}/export/{protocol}` / `routes` / **semantics** / consumer_visible=true: IXP Manager passes listed exact networks; the exact-vs-longest choice is recorded, not hidden
- `api/route/{net}/table/{table}` / `<response>` / **semantics** / consumer_visible=true: network-aligned input only; IXP Manager renders an empty page either way
- `api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `routes` / **semantics** / consumer_visible=true: the filtered-prefix view is the only pinned use; accepted routes are never scanned
- `api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `retention.*` / **extra** / consumer_visible=false: filtered_retention_metadata block; no pinned consumer reads it
- `api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` / `api.max_routes` / **value** / consumer_visible=true: filtered_retention_metadata.api_max_routes; the pinned layout prints api.max_routes
- `api/symbols` / `symbols.protocol.*` / **semantics** / consumer_visible=true: the daemon has no BIRD symbol table; the pinned route-search view lists symbols.protocol
- `api/symbols` / `symbols.undefined.*` / **missing** / consumer_visible=false: Bird's Eye passes every class through; no pinned consumer reads undefined

## Predicted by the README but not observed (no entry)

- `routes.*.gateway`: the pinned parser takes the BIRD 2 `via` line, which equals the adapter's next hop.
- `routes.*.age`: both legs carry a receive timestamp.
- `routes.*.from_protocol`: equal.
- `bgp.atomic_aggr`: not exercised; rustbgpd currently treat-as-withdraws any UPDATE carrying ATOMIC_AGGREGATE (`crates/wire/src/attribute.rs` keeps the attribute opaque as `PathAttribute::Unknown` and `crates/wire/src/validate.rs` `check_unrecognized_wellknown` then rejects it with subcode 2), so the topology announces AGGREGATOR without ATOMIC_AGGREGATE until that is fixed. Tracked separately.
- `description_short`: Bird's Eye emits it only with `PARSER_PROTOCOL_BGP_DESCRIPTION`.
- `import_limit`, `limit_action`: absent on both sides without a configured limit.
- 502 versus 503: the populated leg has no upstream-failure case.
- throttle and cache (`ttl_mins`, `from_cache`, `use_cache`): `ttl_mins` is stripped upstream by `CACHE_DRIVER=array`, `from_cache` is `false` on both; the throttle is not hit.
- `/api` base path: absorbed by `Router.api`, not a body difference.
- daemon `(x, y)` `lc-zwild`: both legs return `routes: []`.

Observed but not predicted: `protocols.*.neighbor_capabilities` is extra on the live leg (BIRD 2 prints a multi-line `Neighbor capabilities` block the pinned `Neighbor caps:` regex never matches); `routes.preferred` upstream is the parser constant `0`; `symbols.undefined` (BIRD 2.0.12 keyword class); `connection` padding.

## Deliberate reds (both restored)

1. Removed the `api.Version` entry from `contract.json` and the `verify_capture.py` constant: `verify_capture.py --populated` exits 1 with `23 oracle/live difference(s) are not on the runtime divergence allow-list` (one `unlisted divergence:` line per journey).
2. Added a bogus `api/status` / `status.router_id` / `value` entry to both: exits 1 with `stale allow-list entry: endpoint=api/status path=status.router_id kind=value` and `1 runtime divergence allow-list entries no longer match a real difference`.

The same two proofs run inside `verify_capture.py --populated` on every gate run.

## Gates

- `bash tests/compat/ixp-manager-birdseye/run.sh` end to end on this tree: rc 0, all four proof lines printed (`IXP Manager/Bird's Eye pinned contract oracle passed`, `adapter proof:`, `nagios proof:`, `populated oracle proof:`).
- `python3 scripts/check_public_tracker_ids.py`: rc 0.
- No Rust, workflow, or `docs/` changes; `tests/birdwatcher_adapter_smoke.rs` pins on `adapter-consumer.php` and `ixp-compat.yml` are untouched.

