### PR TITLE
docs: surface the IRR-scale reload result in README, BENCHMARKS, and COMPARISON

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,21 @@ behavior.
 reproducible receipt:
 
 - **Policy reload at IXP scale** (700 route-server clients × 400,400 routes,
-  live churn, same harness / same host): new policy fully delivered to every
-  member in **1.28–1.57 s p50** vs BIRD 3.3.1's 64–85 s and OpenBGPD 9.1's
-  244–251 s — [IXP receipt matrix](docs/perf/ixp-matrix-2026-07.md)
+  live churn, same harness / same host — the policy-file reload, not the IRR
+  filter refresh below): new policy fully delivered to every member in
+  **1.28–1.57 s p50** vs BIRD 3.3.1's 64–85 s and OpenBGPD 9.1's 244–251 s —
+  [IXP receipt matrix](docs/perf/ixp-matrix-2026-07.md)
+- **IRR-scale filter reload** (320 route-server members × 183,040 prefixes ×
+  3,218,965 IRR filter entries, same harness / same host): steady-state reload
+  completion p50 **3.25–3.77 s** (reloads 2–4, both announcement-overlap
+  points) vs BIRD 3.3.1's ~11.5–13.6 s, every member's received view
+  byte-identical to the ungrouped per-client-best baseline, sampler RSS peak
+  1,972–2,098 MiB vs BIRD's 1,375–1,420 MiB. The earlier
+  [per-client receipt](docs/perf/irr-reload-comparison-2026-08.md) measured
+  67.2–69.4 s at this shape (~87–143 s once announcement overlap was
+  modelled); [ADR-0126](docs/adr/0126-shared-group-per-client-best.md)'s
+  shared winner walk, one per update group, is what changed it —
+  [grouped per-client-best receipt](docs/perf/irr-reload-grouped-per-client-best-2026-08.md)
 - **Member-flap propagation** (50 members flap, 650 observers): re-announce
   p50 **0.49–0.55 s** vs BIRD's 2.9–3.7 s and OpenBGPD's 21.1–21.6 s;
   withdraw p50 0.31–0.47 s, also fastest — [same matrix](docs/perf/ixp-matrix-2026-07.md#s3--flapstorm-member-down--member-up-propagation)
@@ -44,9 +56,15 @@ reproducible receipt:
   S2 settled RSS is a dead heat in these runs (rustbgpd 419/419 vs BIRD's
   422/412 MiB, one run each way) — published in the
   [same receipt](docs/perf/ixp-matrix-2026-07.md#memory), methodology and
-  fairness protocol included
+  fairness protocol included. At the IRR-scale shape BIRD also holds the
+  lower RSS peak (1,375–1,420 MiB vs rustbgpd's 1,972–2,098 MiB), and
+  rustbgpd's first-reload-cheap pattern (completion p50 2.1–2.3 s at reload 1
+  vs 3.3–3.8 s after in the
+  [grouped receipt](docs/perf/irr-reload-grouped-per-client-best-2026-08.md#what-it-costs-now-cross-daemon-comparison))
+  remains the open item the
+  [per-client receipt](docs/perf/irr-reload-comparison-2026-08.md) recorded
 
-All matrix figures above are from the v0.64.0 same-host refresh (2026-08-08);
+All IXP-matrix figures above are from the v0.64.0 same-host refresh (2026-08-08);
 the original campaign, all earlier bands, and every raw artifact set are
 preserved in the receipt.
 
@@ -298,12 +316,13 @@ host** — 700 route-server clients × 400,400 routes with live churn, each
 incumbent at its documented strongest configuration, receiver-side timestamps,
 two independent campaign runs, losses published alongside wins:
 
-| KPI (700 clients × 400,400 routes, p50) | rustbgpd | BIRD 3.3.1 | OpenBGPD 9.1 |
+| KPI (700 clients × 400,400 routes unless noted, p50) | rustbgpd | BIRD 3.3.1 | OpenBGPD 9.1 |
 |---|---|---|---|
 | Sessions Established | **0.7 s** | 18.2–20.5 s | 68.9–85.8 s |
 | Cold start, full table to all members | **4.8–5.0 s** | 60.9–63.3 s | 338.0–352.1 s |
-| Reload: UPDATE stall | 0.42–0.60 s | 1.70–2.70 s | **0.25–0.29 s** |
-| Reload: new policy fully delivered | **1.28–1.57 s** | 64.3–84.5 s | 244.0–251.3 s |
+| Policy reload: UPDATE stall | 0.42–0.60 s | 1.70–2.70 s | **0.25–0.29 s** |
+| Policy reload: new policy fully delivered | **1.28–1.57 s** | 64.3–84.5 s | 244.0–251.3 s |
+| IRR-scale filter reload: steady-state completion (320 members × 183,040 routes × 3,218,965 IRR entries) | **3.25–3.77 s** | ~11.5–13.6 s | ~56–59 s |
 | Flapstorm: withdraw propagation | **0.31–0.47 s** | 0.47–0.61 s | 10.45–11.47 s |
 | Flapstorm: re-announce | **0.49–0.55 s** | 2.85–3.74 s | 21.14–21.54 s |
 | Settled RSS (S2, runs A/B) | 419 / 419 MiB | 422 / 412 MiB | 756 / 753 MiB |
@@ -320,6 +339,18 @@ method, configuration disclosure, honesty notes, raw artifacts — and a
 post-publication note where the receipt's own tables exposed a rustbgpd
 re-announce plateau that was root-caused, fixed, and rerun (9.5–9.8 s →
 0.46–0.49 s).
+
+The IRR-scale row is a separate campaign, the
+[grouped per-client-best IRR reload receipt](docs/perf/irr-reload-grouped-per-client-best-2026-08.md)
+(ADR-0126 acceptance): reloads 2–4 at both announcement-overlap points, with
+every member's received view byte-identical to the ungrouped per-client-best
+baseline. The earlier
+[per-client receipt](docs/perf/irr-reload-comparison-2026-08.md) measured
+67.2–69.4 s at the same shape; ADR-0126's shared winner walk is what changed
+it. BIRD still holds the lower RSS peak there (1,375–1,420 MiB vs rustbgpd's
+1,972–2,098 MiB), and the first-reload-cheap pattern (completion p50 2.1–2.3 s
+at reload 1 vs 3.3–3.8 s after) remains the open item the per-client receipt
+recorded.
 
 At route-reflector shapes, the
 [1000-peer scale receipt](docs/perf/scale-receipt-2026-07.md) measures 1,000

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1420,7 +1420,23 @@ unbounded loop and hung about 11 minutes before the attempt was killed. The
 comparison is therefore four-way. Root cause and retained evidence are in the
 [receipt](perf/competitive-bgperf2-2026-07.md#openbgpd-could-not-be-collected--harness-defect-not-a-daemon-result).
 The [IXP receipt matrix](perf/ixp-matrix-2026-07.md) carries a head-to-head
-OpenBGPD 9.1 comparison through a different harness.
+OpenBGPD 9.1 comparison through a different harness (700 clients × 400,400
+routes, policy reload), and the IRR-scale reload receipts carry a third:
+
+| IRR-scale filter reload (320 members × 183,040 routes × 3,218,965 IRR entries, steady-state reloads 2–4, both announcement-overlap points) | rustbgpd | BIRD 3.3.1 | OpenBGPD 9.1 |
+|---|---|---|---|
+| Reload completion p50 | **3.25–3.77 s** | ~11.5–13.6 s | ~56–59 s |
+| Sampler RSS peak | 1,972–2,098 MiB | **1,375–1,420 MiB** | 1,133–1,439 MiB |
+
+Source: the [grouped per-client-best IRR reload
+receipt](perf/irr-reload-grouped-per-client-best-2026-08.md) (ADR-0126
+acceptance), every member's received view byte-identical to the ungrouped
+per-client-best baseline. The earlier [per-client
+receipt](perf/irr-reload-comparison-2026-08.md) measured 67.2–69.4 s at the
+same shape; ADR-0126's shared winner walk is what changed it. BIRD still holds
+the lower RSS peak, and rustbgpd's first-reload-cheap pattern (completion p50
+2.1–2.3 s at reload 1 vs 3.3–3.8 s after) remains the open item the
+per-client receipt recorded.
 
 One BIRD cell needed a third run: 100p × 1k total measured 24.51 s, then
 15.17 s, then 15.22 s, and the published median is 15.22 s. The outlier is a

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -359,6 +359,21 @@ OpenBGPD 9.1 head-to-head at 700 peers × 400k prefixes under live churn
 convergence, and RSS — with identical wire inputs, config disclosure,
 and the losses published alongside the wins.
 
+At IRR scale, the [grouped per-client-best IRR reload
+receipt](perf/irr-reload-grouped-per-client-best-2026-08.md) (ADR-0126
+acceptance) reloads 320 members × 183,040 prefixes × 3,218,965 IRR filter
+entries through one harness on one host: steady-state reload completion p50
+3.25–3.77 s for rustbgpd (reloads 2–4, both announcement-overlap points) vs
+~11.5–13.6 s for BIRD 3.3.1 and ~56–59 s for OpenBGPD 9.1, with every
+member's received view byte-identical to the ungrouped per-client-best
+baseline. The earlier
+[per-client receipt](perf/irr-reload-comparison-2026-08.md) measured
+67.2–69.4 s at the same shape; ADR-0126's shared winner walk is what changed
+it. BIRD still holds the lower RSS peak there (1,375–1,420 MiB vs rustbgpd's
+1,972–2,098 MiB), and rustbgpd's first-reload-cheap pattern (completion p50
+2.1–2.3 s at reload 1 vs 3.3–3.8 s after) remains the open item the
+per-client receipt recorded.
+
 A separate [1,000-peer retained receipt](perf/route-server-1000-2026-07.md)
 exercises a uniform all-eBGP route-server fleet against the real daemon: 400k
 routes, 399.6 million observer-NLRI cold deliveries, four generation-complete


### PR DESCRIPTION
## Why

`README.md`, `docs/BENCHMARKS.md`, and `docs/COMPARISON.md` carried no mention of the IRR-scale reload receipts, and the README's reload bullets and table were the 700 × 400,400 policy reload without saying so — a skimmer could read them as the IRR refresh. This labels the existing figures as the policy reload and adds the grouped per-client-best IRR reload result with its history and losses alongside.

Docs only; no IXP-matrix figure or the RR headline is touched.

## Files

- `README.md` — "Policy reload at IXP scale" bullet labelled as the policy-file reload; new "IRR-scale filter reload" bullet; losses bullet extended; table header "unless noted", the two `Reload:` rows relabelled `Policy reload:`, one IRR-scale row added, one provenance paragraph after the table.
- `docs/BENCHMARKS.md` — two-row IRR-scale table + source paragraph next to the existing IXP-matrix pointer in the bgperf2 section.
- `docs/COMPARISON.md` — one paragraph after the IXP-matrix route-server paragraph in the performance snapshot.

## Figures → receipt lines

Primary source: `docs/perf/irr-reload-grouped-per-client-best-2026-08.md` (grouped receipt); history: `docs/perf/irr-reload-comparison-2026-08.md` (per-client receipt).

| Figure | Source |
|---|---|
| 320 members × 183,040 prefixes, 3,218,965 IRR filter entries | grouped receipt lines 7, 257–258 |
| steady-state completion p50 3.25–3.77 s (reloads 2–4, both overlap points) | grouped receipt lines 100–101 (`3.25–3.38 s and 3.46–3.77 s (per-reload p50 range, reloads 2–4)`), 152; `docs/RECEIPTS.md` row wording `3.25–3.77 s` |
| BIRD 3.3.1 ~11.5–13.6 s | grouped receipt line 108 (`BIRD (~11.5–13.6 s)`); table cells lines 75–76, 88–89 |
| OpenBGPD 9.1 ~56–59 s | grouped receipt line 109 (`OpenBGPD (~56–59 s)`); table cells lines 77–78, 90–91 |
| received views byte-identical to the ungrouped per-client-best baseline | grouped receipt lines 24–49 (digests lines 34–35), 149 |
| rustbgpd sampler RSS peak 1,972–2,098 MiB | grouped receipt lines 114, 151; cells lines 71–72, 84–85 |
| BIRD sampler RSS peak 1,375–1,420 MiB (min–max of the four BIRD cells) | grouped receipt lines 75 (1,375), 76 (1,377), 88 (1,420), 89 (1,415) |
| OpenBGPD sampler RSS peak 1,133–1,439 MiB (min–max of the four OpenBGPD cells; BENCHMARKS table only) | grouped receipt lines 77 (1,392), 78 (1,133), 90 (1,313), 91 (1,439) |
| first-reload-cheap: completion p50 2.1–2.3 s at reload 1 vs 3.3–3.8 s after | grouped receipt lines 124–127 |
| "open item" status of that pattern | per-client receipt lines 35–40 (`recorded as an **open item**`), 69 |
| earlier per-client receipt 67.2–69.4 s | per-client receipt line 20 (`53.7–54.7 s; 67.2–69.4 s`), line 37 (`~67–69 s`) |
| ~87–143 s once announcement overlap was modelled (README bullet only) | grouped receipt lines 7–9, 99 (`~87 s (F = 0.1) to ~135–143 s (F = 0.5)`); `docs/RECEIPTS.md` row wording `~87–143 s` |
| ADR-0126 shared winner walk, one per update group | grouped receipt lines 10–13 |

## Gates (all rc 0)

- `python3 scripts/check_public_tracker_ids.py`
- relative links in the three touched files resolve (148 checked, 0 missing)
- doc-contract tests that read the touched files: `cargo test -p rustbgpd-rib --lib benchmarks_doc_type_size_rows_match_compiler` (reads `docs/BENCHMARKS.md`) and `cargo test -p rustbgpctl curated_documentation_commands_parse_with_the_real_cli` (reads `README.md`) — both pass
