### PR TITLE
docs: state that RTR transport is unauthenticated and unencrypted

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2174,6 +2174,10 @@ You need a running RPKI validator that speaks RTR:
 | [FORT](https://fortproject.net/) | 8323 | C, lightweight |
 | [OctoRPKI](https://github.com/cloudflare/cfrpki) | 8282 | Go, Cloudflare |
 
+RTR runs over plain TCP with no authentication or encryption. Keep caches on
+loopback or a trusted segment, or tunnel the session; see the
+[security checklist](deployment.md#security-checklist) in the deployment guide.
+
 ### Basic setup
 
 ```toml

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1188,6 +1188,12 @@ short version for first deployment:
   is fine for single-host operator access.
 - **BGP authentication.** TCP-MD5 (RFC 2385) and TCP-AO (RFC 5925) are
   both supported. TCP-AO is preferred; see ADR-0062.
+- **RPKI cache transport.** RTR (RFC 8210) sessions are plain TCP:
+  unauthenticated and unencrypted. Run caches on loopback or a trusted
+  segment, or tunnel the session (WireGuard, an SSH or stunnel forward).
+  A remote cache reached over an untrusted path is a validation-integrity
+  problem: anything on the path can rewrite the VRPs the daemon validates
+  against.
 - **Firewall.** Allow inbound TCP/179 only from configured peer
   addresses (or address ranges if using `[[dynamic_neighbors]]`).
   Block everything else.


### PR DESCRIPTION
## Summary

RTR (RFC 8210) sessions are plain TCP: no authentication, no encryption. The deployment guide said nothing about it.

- `docs/deployment.md` — one bullet in the security checklist: keep caches on loopback or a trusted segment, or tunnel the session; a remote cache over an untrusted path is a validation-integrity problem.
- `docs/CONFIGURATION.md` — one short paragraph in `[rpki]` prerequisites linking to that checklist.

Docs only; no code change.

## Gates

- `python3 scripts/check_public_tracker_ids.py` rc 0
- Relative-link check on both touched files rc 0