### PR TITLE
feat(monitoring): alert on BMP source drops and stream divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--apply` is given, refuses outright while a host fence exists, and never
   runs from the activation path. The README documents the rule, a cron-safe
   pattern, and measured bytes per generation. (LAN-1180)
+- The Prometheus alert pack gains `BmpSourceDrops`, `BmpLocRibSourceDrops`,
+  and `BmpCollectorDrops`, firing on any 10-minute increase of the BMP drop
+  counters so a lossy BMP feed is no longer silent. (LAN-1189)
 - A `semver-checks` CI workflow runs `cargo-semver-checks` for every
   publishable workspace crate (re-derived from the manifests; today
   `rustbgpd-wire` and `rustbgpd-fsm`) against its latest crates.io release on

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -76,7 +76,8 @@ peer, RFC 8212 missing import/export policy, sustained outbound-prefix blocking,
 dynamic-neighbor admission near-limit and rejection,
 actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
 selection-deferral timeout and ledger overflow, outbound route loss, RFC 9687
-send-hold teardown, live event-stream lag/desynchronization, and daemon down)
+send-hold teardown, live event-stream lag/desynchronization, BMP feed loss,
+and daemon down)
 ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
 with per-rule unit tests in
@@ -84,7 +85,7 @@ with per-rule unit tests in
 (`promtool test rules`). It assumes the scrape config above
 (`job_name: rustbgpd`).
 
-The three loss alerts use a 10-minute counter-increase window and clear after
+The loss alerts use a 10-minute counter-increase window and clear after
 the last increment ages out:
 
 - `BgpOutboundRouteDrops` is critical because the full outbound distribution
@@ -101,6 +102,14 @@ the last increment ages out:
   incremental events. Treat that consumer's local view as desynchronized:
   take a fresh authoritative snapshot for the named service and source, then
   restart the live watch. Use a durable cursor only when that API supports one.
+- `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` are
+  warning severity because routing is unaffected, but the BMP mirror is now
+  lossy: a dropped per-peer event forces a synthetic PeerDown/PeerUp so
+  collectors rebuild that peer, a dropped Loc-RIB event leaves Loc-RIB
+  collectors stale until their next reconnect, and a collector-side drop
+  leaves that collector incomplete until it reconnects. Find the slow
+  consumer via `bmp_collector_drops_total` and the
+  `bmp_loc_rib_dump_live_buffer_*` gauges.
 
 The rules intentionally alert on the exported loss counters, not adjacent
 queue-depth, subscriber-count, or slow-peer gauges. A flat non-zero counter is

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1117,6 +1117,11 @@ query with a new live watch.
 The sibling `bmp_source_drops_total{peer,reason}` counts the same kind of
 loss on the per-peer PeerSession→BmpManager path (RFC 7854 Adj-RIB
 monitoring) with the same `reason` vocabulary.
+The shipped alert pack
+([`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml))
+fires `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` on
+any 10-minute increase of these two counters and of
+`bmp_collector_drops_total`.
 
 ### Durable Event Cursor (ADR-0072)
 

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -501,3 +501,68 @@ groups:
             {{ $value | printf "%.0f" }} in the last 15 minutes. The family
             exceeded the bounded identity ledger and used a complete release
             sweep; inspect table scale and retained-key pressure.
+
+      - alert: BmpSourceDrops
+        # The per-peer PeerSession→BmpManager channel is lossy by design
+        # (it never backpressures the session). Any increment means the
+        # collectors' Adj-RIB monitoring view for this peer is now wrong;
+        # a dropped RouteMonitoring forces a synthetic PeerDown/PeerUp reset
+        # once the channel drains, so the collector rebuilds from scratch.
+        expr: increase(bmp_source_drops_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            BMP events dropped for {{ $labels.peer }} ({{ $labels.reason }})
+          description: >-
+            bmp_source_drops_total for peer {{ $labels.peer }} on
+            {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 10 minutes
+            (reason={{ $labels.reason }}). The BMP manager is not draining the
+            per-peer event channel as fast as the session produces events;
+            collectors receive a peer-state reset and rebuild this peer's view.
+            Find the slow collector via bmp_collector_drops_total and the
+            bmp_loc_rib_dump_live_buffer_* gauges.
+
+      - alert: BmpLocRibSourceDrops
+        # RFC 9069 Loc-RIB events lost at the RIB/PeerManager→BmpManager
+        # channel. A dropped route_monitoring event diverges every Loc-RIB
+        # collector until its next reconnect-triggered table dump; a dropped
+        # stats event only skips one periodic report.
+        expr: increase(bmp_loc_rib_source_drops_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            BMP Loc-RIB events dropped ({{ $labels.event }},
+            {{ $labels.reason }})
+          description: >-
+            bmp_loc_rib_source_drops_total{event="{{ $labels.event }}",
+            reason="{{ $labels.reason }}"} on {{ $labels.instance }}
+            increased by {{ $value | printf "%.0f" }} in the last 10 minutes.
+            Connected Loc-RIB collectors may hold a stale table until their
+            next reconnect; correlate with bmp_collector_drops_total and the
+            bmp_loc_rib_dump_live_buffer_* gauges to find the slow consumer.
+
+      - alert: BmpCollectorDrops
+        # Messages discarded toward one collector, in fan_out (its outbound
+        # channel is full or closed) or loc_rib_dump (the bounded live buffer
+        # overflowed or the dump failed). The collector's view is incomplete
+        # until it reconnects and receives a fresh dump.
+        expr: increase(bmp_collector_drops_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            BMP messages dropped toward collector {{ $labels.collector }}
+            ({{ $labels.phase }})
+          description: >-
+            bmp_collector_drops_total for collector {{ $labels.collector }}
+            on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 10 minutes
+            (phase={{ $labels.phase }}, reason={{ $labels.reason }}). The
+            collector is not keeping up or its connection failed; its BMP
+            view is incomplete until it reconnects and is re-fed.

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -1295,3 +1295,171 @@ tests:
       - eval_time: 21m
         alertname: BgpEventStreamLagged
         exp_alerts: []
+
+  # ── BmpSourceDrops ────────────────────────────────────────
+  # Same shape as the other loss alerts: the old increment pins 10m versus
+  # 5m, the same-evaluation increment pins for: 0m, a flat counter stays
+  # quiet, and the late evaluation pins recovery. Native peer/reason labels
+  # are preserved; a different loss family must not satisfy the rule.
+  - interval: 1m
+    input_series:
+      - series: 'bmp_source_drops_total{peer="192.0.2.60", reason="channel_full", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bmp_source_drops_total{peer="192.0.2.61", reason="channel_closed", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bmp_source_drops_total{peer="192.0.2.62", reason="channel_full", instance="edge1:9179"}'
+        values: "3x22"
+      - series: 'bgp_outbound_route_drops_total{peer="192.0.2.63", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BmpSourceDrops
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BmpSourceDrops
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.60
+              reason: channel_full
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BMP events dropped for 192.0.2.60 (channel_full)"
+              description: >-
+                bmp_source_drops_total for peer 192.0.2.60 on edge1:9179
+                increased by 1 in the last 10 minutes (reason=channel_full).
+                The BMP manager is not draining the per-peer event channel as
+                fast as the session produces events; collectors receive a
+                peer-state reset and rebuild this peer's view. Find the slow
+                collector via bmp_collector_drops_total and the
+                bmp_loc_rib_dump_live_buffer_* gauges.
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.61
+              reason: channel_closed
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BMP events dropped for 192.0.2.61 (channel_closed)"
+              description: >-
+                bmp_source_drops_total for peer 192.0.2.61 on edge1:9179
+                increased by 1 in the last 10 minutes (reason=channel_closed).
+                The BMP manager is not draining the per-peer event channel as
+                fast as the session produces events; collectors receive a
+                peer-state reset and rebuild this peer's view. Find the slow
+                collector via bmp_collector_drops_total and the
+                bmp_loc_rib_dump_live_buffer_* gauges.
+      - eval_time: 21m
+        alertname: BmpSourceDrops
+        exp_alerts: []
+
+  # ── BmpLocRibSourceDrops ──────────────────────────────────
+  # Process-global series keyed by event/reason only. The per-peer source
+  # counter must not satisfy the Loc-RIB rule.
+  - interval: 1m
+    input_series:
+      - series: 'bmp_loc_rib_source_drops_total{event="route_monitoring", reason="channel_full", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bmp_loc_rib_source_drops_total{event="stats", reason="channel_full", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bmp_loc_rib_source_drops_total{event="route_monitoring", reason="channel_closed", instance="edge1:9179"}'
+        values: "5x22"
+      - series: 'bmp_source_drops_total{peer="192.0.2.64", reason="channel_full", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BmpLocRibSourceDrops
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BmpLocRibSourceDrops
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              event: route_monitoring
+              reason: channel_full
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BMP Loc-RIB events dropped (route_monitoring, channel_full)"
+              description: >-
+                bmp_loc_rib_source_drops_total{event="route_monitoring",
+                reason="channel_full"} on edge1:9179 increased by 1 in the
+                last 10 minutes. Connected Loc-RIB collectors may hold a stale
+                table until their next reconnect; correlate with
+                bmp_collector_drops_total and the
+                bmp_loc_rib_dump_live_buffer_* gauges to find the slow
+                consumer.
+          - exp_labels:
+              severity: warning
+              event: stats
+              reason: channel_full
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BMP Loc-RIB events dropped (stats, channel_full)"
+              description: >-
+                bmp_loc_rib_source_drops_total{event="stats",
+                reason="channel_full"} on edge1:9179 increased by 1 in the
+                last 10 minutes. Connected Loc-RIB collectors may hold a stale
+                table until their next reconnect; correlate with
+                bmp_collector_drops_total and the
+                bmp_loc_rib_dump_live_buffer_* gauges to find the slow
+                consumer.
+      - eval_time: 21m
+        alertname: BmpLocRibSourceDrops
+        exp_alerts: []
+
+  # ── BmpCollectorDrops ─────────────────────────────────────
+  # Per-collector identity is the listener socket address; phase/reason are
+  # the bounded vocabularies from the BMP manager. The reset-then-increment
+  # vector pins reset-safe increase versus delta. Replay attempts are a
+  # reconnect signal, not loss, and must not satisfy the rule.
+  - interval: 1m
+    input_series:
+      - series: 'bmp_collector_drops_total{collector="192.0.2.10:11019", phase="fan_out", reason="channel_full", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bmp_collector_drops_total{collector="192.0.2.11:11019", phase="loc_rib_dump", reason="live_buffer_full", instance="edge1:9179"}'
+        values: "10 10 10 10 10 10 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bmp_collector_drops_total{collector="192.0.2.12:11019", phase="fan_out", reason="channel_closed", instance="edge1:9179"}'
+        values: "2x22"
+      - series: 'bmp_replay_attempts_total{collector="192.0.2.12:11019", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BmpCollectorDrops
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BmpCollectorDrops
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              collector: 192.0.2.10:11019
+              phase: fan_out
+              reason: channel_full
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                BMP messages dropped toward collector 192.0.2.10:11019
+                (fan_out)
+              description: >-
+                bmp_collector_drops_total for collector 192.0.2.10:11019 on
+                edge1:9179 increased by 1 in the last 10 minutes
+                (phase=fan_out, reason=channel_full). The collector is not
+                keeping up or its connection failed; its BMP view is
+                incomplete until it reconnects and is re-fed.
+          - exp_labels:
+              severity: warning
+              collector: 192.0.2.11:11019
+              phase: loc_rib_dump
+              reason: live_buffer_full
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                BMP messages dropped toward collector 192.0.2.11:11019
+                (loc_rib_dump)
+              description: >-
+                bmp_collector_drops_total for collector 192.0.2.11:11019 on
+                edge1:9179 increased by 1 in the last 10 minutes
+                (phase=loc_rib_dump, reason=live_buffer_full). The collector
+                is not keeping up or its connection failed; its BMP view is
+                incomplete until it reconnects and is re-fed.
+      - eval_time: 21m
+        alertname: BmpCollectorDrops
+        exp_alerts: []


### PR DESCRIPTION
## Summary

- Add three rules to the Prometheus alert pack, each firing on any 10-minute increase of the corresponding BMP drop counter with its native label set preserved (same shape and `for: 0m` as the existing loss alerts):
  - `BmpSourceDrops` — `bmp_source_drops_total{peer,reason}` (per-peer PeerSession→BmpManager channel; a dropped RouteMonitoring also forces the synthetic PeerDown/PeerUp collector reset)
  - `BmpLocRibSourceDrops` — `bmp_loc_rib_source_drops_total{event,reason}` (RFC 9069 Loc-RIB path)
  - `BmpCollectorDrops` — `bmp_collector_drops_total{collector,phase,reason}` (per-collector fan-out / Loc-RIB dump loss)
- promtool unit tests per rule: pending, firing (old and same-evaluation increments, reset-safe increase), flat counter, cross-family negative, recovery after the window.
- Document the rules in `docs/GRAFANA.md` and the BMP metrics section of `docs/OPERATIONS.md`; CHANGELOG entry.

No Rust changes. The stream-divergence latch (`PeerSession::bmp_stream_diverged`) is not exported as a metric family today, so there is no divergence rule; its only scrape-visible trace is `bmp_source_drops_total{reason="channel_full"}`, which `BmpSourceDrops` covers.

## Gates

- `promtool check rules examples/prometheus/rustbgpd-alerts.yml` (31 rules)
- `promtool test rules rustbgpd-alerts_test.yml`
- `python3 scripts/check_public_tracker_ids.py`
- `python3 scripts/check-grafana-dashboard.py`