### PR TITLE
feat: supervise the PeerManager task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Loc-RIB → Adj-RIB-Out, and is re-emitted on export, BMP, and MRT. A
   non-zero length stays attribute-discard (RFC 7606 §7.6). (LAN-1235)
 
+- The peer manager task is now supervised beside the RIB, gRPC, and BGP
+  ingress tasks: a panic or unexpected return enters the same coordinated
+  teardown and exits 1 instead of leaving a daemon that can no longer admit,
+  tear down, mutate, or shut down peers. Intentional shutdown (signals, the
+  Shutdown RPC) still joins the task after the ordered teardown and exits 0;
+  live fault and Shutdown RPC proofs pin both paths. (LAN-1237)
 - The `AS4_PATH`, `COMMUNITIES`, `EXTENDED_COMMUNITIES`, `CLUSTER_LIST`,
   `LARGE_COMMUNITIES`, BGP-LS next-hop, and VPN next-hop decoders return typed
   `DecodeError`s on every malformed-length and unknown-segment-type branch

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -700,12 +700,14 @@ coordinated shutdown (NOTIFICATION to all peers, GR marker write). This is
 deliberate: losing the control plane means losing the ability to shut down
 cleanly later. See [ADR-0022](adr/0022-grpc-server-supervision.md).
 
-### RIB manager exits unexpectedly
+### RIB manager or peer manager exits unexpectedly
 
-The daemon likewise treats any RIB manager return or panic as fatal. It logs
-`RIB manager exited unexpectedly`, performs the ordinary coordinated shutdown
-(including peer NOTIFICATIONs), and exits 1 for `Restart=on-failure`. The
-daemon does not claim active supervision of the PeerManager itself.
+The daemon likewise treats any RIB manager or peer manager return or panic as
+fatal. It logs `RIB manager exited unexpectedly` or `peer manager task exited
+unexpectedly`, performs the ordinary coordinated shutdown (including peer
+NOTIFICATIONs where the actor that sends them is still alive), and exits 1 for
+`Restart=on-failure`. An intentional shutdown still stops the peer manager as
+part of the ordered teardown and exits 0.
 
 ### RPKI cache unreachable
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -445,8 +445,8 @@ Notes on the sandbox:
   immediately if legacy BGP mode binds neither family, explicit
   `listen_addresses` cannot bind every configured endpoint, or a configured
   `prometheus_addr` health listener cannot bind. An unexpected gRPC server,
-  RIB manager, BGP listener task, or inbound accept-forwarding task exit instead
-  runs the coordinated peer teardown before exit 1. These components are not
+  RIB manager, peer manager, BGP listener task, or inbound accept-forwarding
+  task exit instead runs the coordinated peer teardown before exit 1. These components are not
   respawned in place; the supervisor is the recovery path.
   Exit 70 is also a failure: it is the runtime-config settlement watchdog's
   fail-stop recovery request and must remain restartable. `RestartSec=5`

--- a/src/main.rs
+++ b/src/main.rs
@@ -2376,8 +2376,8 @@ reported at least one warning. For
 neither family; explicit
 .B listen_addresses
 mode could not bind every configured endpoint; a configured metrics/readiness
-listener failed to bind; or the RIB manager, gRPC server, BGP listener task,
-or BGP accept-forwarding task exited unexpectedly),
+listener failed to bind; or the RIB manager, peer manager, gRPC server,
+BGP listener task, or BGP accept-forwarding task exited unexpectedly),
 so that a supervisor configured
 with
 .B Restart=on\-failure
@@ -2460,8 +2460,8 @@ fn main() -> ExitCode {
                   A running daemon exits 1 on a component failure that ends it\n     \
                   (legacy BGP mode bound neither family; an explicit listen_addresses\n     \
                   endpoint failed to bind; configured metrics/readiness bind failure;\n     \
-                  or unexpected RIB manager, gRPC server, BGP listener task,\n     \
-                  or BGP accept-forwarding task exit)\n  \
+                  or unexpected RIB manager, peer manager, gRPC server,\n     \
+                  BGP listener task, or BGP accept-forwarding task exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
                     env!("CARGO_PKG_VERSION")
@@ -2980,6 +2980,21 @@ const TEST_BGP_INGRESS_EXIT_ENV: &str = "RUSTBGPD_TEST_BGP_INGRESS_EXIT";
 /// without echoing the raw environment value.
 const TEST_INITIAL_PEER_REJECTION_AT_ENV: &str = "RUSTBGPD_TEST_INITIAL_PEER_REJECTION_AT";
 
+/// Test-only fault injection; never set this in production. The only accepted
+/// value is `1`; all others are ignored with a sanitized warning.
+const TEST_PEER_MANAGER_PANIC_ENV: &str = "RUSTBGPD_TEST_PEER_MANAGER_PANIC";
+
+fn resolve_test_peer_manager_panic() -> bool {
+    match std::env::var(TEST_PEER_MANAGER_PANIC_ENV) {
+        Err(std::env::VarError::NotPresent) => false,
+        Ok(value) if value == "1" => true,
+        Ok(_) | Err(std::env::VarError::NotUnicode(_)) => {
+            warn!("ignoring invalid {TEST_PEER_MANAGER_PANIC_ENV}; expected 1");
+            false
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TestBgpIngressExit {
     ListenerPanic,
@@ -3104,6 +3119,7 @@ async fn run<T>(
         .unwrap_or_else(|e| fatal_startup_error("failed to register SIGHUP handler", e));
     let test_bgp_ingress_exit = resolve_test_bgp_ingress_exit();
     let test_initial_peer_rejection_at = resolve_test_initial_peer_rejection_at();
+    let test_peer_manager_panic = resolve_test_peer_manager_panic();
 
     let mut config = accepted.config();
     // Snapshot the gRPC listener config as it was at process start.
@@ -3912,7 +3928,12 @@ async fn run<T>(
         drop(bfd_state_change_rx);
         peer_mgr
     };
-    let peer_mgr_handle = tokio::spawn(peer_mgr.run());
+    // Retained: supervised by the shutdown `select!` below and joined by the
+    // coordinated teardown after it.
+    let mut peer_mgr_handle = tokio::spawn(async move {
+        assert!(!test_peer_manager_panic, "injected peer manager task panic");
+        Box::pin(peer_mgr.run()).await;
+    });
 
     // Spawn config persister (converts gRPC config events → disk writes).
     //
@@ -5110,7 +5131,7 @@ async fn run<T>(
     }
 
     // Wait for shutdown signal, Shutdown RPC, SIGHUP, or an unexpected
-    // gRPC/RIB component exit.
+    // supervised-component exit (gRPC, RIB, BGP ingress, peer manager).
     //
     // SIGHUP runs `reload_config` on a dedicated tokio task so the
     // signal-arm dispatch returns immediately. Without this, the SIGHUP
@@ -5129,6 +5150,9 @@ async fn run<T>(
     let mut reload_in_flight: Option<
         tokio::task::JoinHandle<Result<SighupAuthority, SighupReloadError>>,
     > = None;
+    // Set only by the peer-manager supervision arm, which consumes the
+    // JoinHandle; the coordinated teardown below must not join it twice.
+    let mut peer_mgr_exited = false;
     loop {
         if initial_peer_boot_failed {
             break;
@@ -5170,6 +5194,16 @@ async fn run<T>(
             result = &mut bgp_forwarder_handle => {
                 error!(?result, "BGP accept-forwarding task exited unexpectedly");
                 info!("initiating shutdown due to BGP accept-forwarding task failure");
+                component_failed = true;
+                break;
+            }
+            // Intentional shutdown never reaches this arm: the signal and
+            // Shutdown RPC arms break first, and the peer manager only
+            // returns once the teardown below sends `PeerManagerCommand::Shutdown`.
+            result = &mut peer_mgr_handle => {
+                error!(?result, "peer manager task exited unexpectedly");
+                info!("initiating shutdown due to peer manager task failure");
+                peer_mgr_exited = true;
                 component_failed = true;
                 break;
             }
@@ -5625,8 +5659,9 @@ async fn run<T>(
 
     let _ = peer_mgr_tx.send(PeerManagerCommand::Shutdown).await;
 
-    // 2. Wait for PeerManager to finish draining all peers
-    if let Err(e) = peer_mgr_handle.await {
+    // 2. Wait for PeerManager to finish draining all peers (unless the
+    // supervision arm already observed its exit and consumed the handle).
+    if !peer_mgr_exited && let Err(e) = peer_mgr_handle.await {
         error!(error = %e, "peer manager task panicked");
     }
 

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -3,7 +3,8 @@
 //! Operator-initiated shutdown (SIGTERM) exits 0; a component failure
 //! exits non-zero, so supervisors like systemd with `Restart=on-failure`
 //! restart the daemon instead of treating it as a clean stop. Live proofs cover
-//! startup binds, the RIB manager, and both inbound-admission tasks.
+//! startup binds, the RIB manager, both inbound-admission tasks, and the peer
+//! manager; the Shutdown RPC proof pins the intentional exit-0 path beside them.
 
 use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
@@ -296,6 +297,22 @@ fn establish_bgp_and_observe_shutdown(port: u16) {
     }
 }
 
+fn rbgp(grpc_addr: &str, args: &[&str]) -> std::process::Output {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
+        let mut cmd = Command::new(path);
+        cmd.arg("--addr").arg(grpc_addr).args(args).output()
+    } else {
+        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        let mut cmd = Command::new(cargo);
+        cmd.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
+            .arg("--addr")
+            .arg(grpc_addr)
+            .args(args)
+            .output()
+    }
+    .expect("failed to spawn rbgp subprocess")
+}
+
 fn run_bgp_ingress_fault(mode: &str, connect: bool) -> (ExitStatus, String) {
     let temp = private_tempdir();
     let config_path = write_rib_fault_config(temp.path());
@@ -427,6 +444,151 @@ fn rib_supervision_is_fail_stop_and_uses_common_peer_teardown() {
 }
 
 #[test]
+fn peer_manager_panic_uses_common_shutdown_and_exits_nonzero() {
+    let temp = private_tempdir();
+    let config_path = write_config(temp.path(), DAEMON_CHOOSES, DAEMON_CHOOSES);
+    let mut daemon = spawn_daemon_with_env(
+        temp.path(),
+        &config_path,
+        Some(("RUSTBGPD_TEST_PEER_MANAGER_PANIC", "1")),
+    );
+    let status = daemon.wait_within(Duration::from_secs(30));
+    let logs = daemon.logs();
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "peer manager task panic must exit 1\n{logs}"
+    );
+    for message in [
+        "injected peer manager task panic",
+        "peer manager task exited unexpectedly",
+        "initiating shutdown due to peer manager task failure",
+        "initiating coordinated shutdown",
+        "rustbgpd exiting",
+    ] {
+        assert!(logs.contains(message), "missing {message:?}\n{logs}");
+    }
+    // The supervision arm consumed the JoinHandle; the teardown must not
+    // join it a second time (that would panic the daemon mid-teardown).
+    assert!(!logs.contains("peer manager task panicked"), "{logs}");
+    assert!(
+        !logs.contains("JoinHandle polled after completion"),
+        "{logs}"
+    );
+    let reports = std::fs::read_dir(temp.path().join("runtime/crash"))
+        .expect("panic report directory")
+        .flatten()
+        .map(|entry| std::fs::read_to_string(entry.path()).expect("read panic report"))
+        .collect::<Vec<_>>();
+    assert_eq!(reports.len(), 1, "one durable panic report: {reports:?}");
+    assert!(reports[0].contains("injected peer manager task panic"));
+}
+
+#[test]
+fn shutdown_rpc_exits_zero_with_peer_manager_supervised() {
+    let temp = private_tempdir();
+    let config_path = write_config(temp.path(), DAEMON_CHOOSES, DAEMON_CHOOSES);
+    let hidden = "unknown-value-must-not-be-echoed";
+    let mut daemon = spawn_daemon_with_env(
+        temp.path(),
+        &config_path,
+        Some(("RUSTBGPD_TEST_PEER_MANAGER_PANIC", hidden)),
+    );
+    // Startup is complete once the gRPC TCP listener is bound; the Shutdown
+    // RPC then rides the implicit owner-only local socket.
+    wait_for_bound_grpc_port(&mut daemon);
+    let grpc_addr = format!("unix://{}", temp.path().join("runtime/grpc.sock").display());
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        let output = rbgp(&grpc_addr, &["shutdown", "--reason", "exit-code test"]);
+        if output.status.success() {
+            break;
+        }
+        if let Ok(Some(status)) = daemon.child.try_wait() {
+            panic!(
+                "rustbgpd exited before accepting the Shutdown RPC: {status}\n{}",
+                daemon.logs()
+            );
+        }
+        assert!(
+            Instant::now() < deadline,
+            "rbgp shutdown never succeeded\nstderr:\n{}\n{}",
+            String::from_utf8_lossy(&output.stderr),
+            daemon.logs()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let status = daemon.wait_within(Duration::from_secs(120));
+    let logs = daemon.logs();
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "Shutdown RPC must exit 0, got {status}\n{logs}"
+    );
+    // The peer manager exited as part of the ordered teardown, not through
+    // the supervision arm.
+    assert!(logs.contains("shutdown initiated via gRPC"), "{logs}");
+    assert!(
+        logs.contains("peer manager shutting down 0 peers"),
+        "{logs}"
+    );
+    assert!(
+        !logs.contains("peer manager task exited unexpectedly"),
+        "{logs}"
+    );
+    assert!(
+        logs.contains("ignoring invalid RUSTBGPD_TEST_PEER_MANAGER_PANIC"),
+        "{logs}"
+    );
+    assert!(
+        !logs.contains(hidden),
+        "unknown environment value leaked: {logs}"
+    );
+}
+
+#[test]
+fn peer_manager_supervision_is_fail_stop_and_joins_once() {
+    let source = include_str!("../src/main.rs");
+    let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
+    let retained = production
+        .find("let mut peer_mgr_handle = tokio::spawn(async move {")
+        .expect("peer manager JoinHandle must be retained");
+    let arm = production
+        .find("result = &mut peer_mgr_handle => {")
+        .expect("shutdown select must supervise the peer manager task");
+    let body = production[arm..].split_once("\n            }").unwrap().0;
+    assert!(
+        body.contains("peer manager task exited unexpectedly"),
+        "{body}"
+    );
+    assert!(body.contains("peer_mgr_exited = true;"), "{body}");
+    assert!(body.contains("component_failed = true;"), "{body}");
+    assert!(body.contains("break;"), "{body}");
+    assert!(
+        !body.contains("is_ok") && !body.contains("is_err"),
+        "{body}"
+    );
+    let teardown = production
+        .find("send(PeerManagerCommand::Shutdown)")
+        .expect("component failure must retain coordinated peer shutdown");
+    let join = production
+        .find("if !peer_mgr_exited && let Err(e) = peer_mgr_handle.await {")
+        .expect("coordinated teardown must join the peer manager exactly once");
+    assert!(retained < arm && arm < teardown && teardown < join);
+    assert_eq!(production.matches("peer_mgr_handle.await").count(), 1);
+    let rpc = production
+        .split_once("changed = rpc_shutdown_rx.changed() => {")
+        .unwrap()
+        .1;
+    let rpc = rpc.split_once("\n            }").unwrap().0;
+    assert!(
+        !rpc.contains("peer_mgr"),
+        "Shutdown RPC arm must not touch the peer manager"
+    );
+}
+
+#[test]
 fn bgp_ingress_tasks_are_retained_unconditionally_supervised_and_torn_down() {
     let source = include_str!("../src/main.rs");
     let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
@@ -532,11 +694,11 @@ fn help_and_man_distinguish_bgp_bind_modes_and_supervised_exits() {
     let help = output("--help");
     assert!(help.contains("legacy BGP mode bound neither family; an explicit listen_addresses"));
     assert!(help.contains("endpoint failed to bind; configured metrics/readiness bind failure;"));
-    assert!(help.contains("or unexpected RIB manager, gRPC server, BGP listener task,"));
-    assert!(help.contains("or BGP accept-forwarding task exit"));
+    assert!(help.contains("or unexpected RIB manager, peer manager, gRPC server,"));
+    assert!(help.contains("BGP listener task, or BGP accept-forwarding task exit"));
     let man = output("--man");
     assert!(man.contains("legacy BGP listen mode could bind\nneither family; explicit\n.B listen_addresses\nmode could not bind every configured endpoint"));
-    assert!(man.contains("the RIB manager, gRPC server, BGP listener task,\nor BGP accept-forwarding task exited unexpectedly"));
+    assert!(man.contains("the RIB manager, peer manager, gRPC server,\nBGP listener task, or BGP accept-forwarding task exited unexpectedly"));
 }
 
 #[test]

--- a/tests/quickstart_dynamic_neighbor.rs
+++ b/tests/quickstart_dynamic_neighbor.rs
@@ -61,7 +61,15 @@ impl Daemon {
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline {
             match self.child.try_wait() {
-                Ok(Some(_)) => return,
+                Ok(Some(status)) => {
+                    assert_eq!(
+                        status.code(),
+                        Some(0),
+                        "rbgp shutdown must exit the daemon cleanly, got {status}\nstderr:\n{}",
+                        self.stderr()
+                    );
+                    return;
+                }
                 Ok(None) => thread::sleep(Duration::from_millis(50)),
                 Err(_) => break,
             }


### PR DESCRIPTION
## Summary

- retain the PeerManager `JoinHandle` and supervise it in the shutdown `select!` beside the existing RIB, gRPC, BGP listener, and accept-forwarding arms: a panic or unexpected return logs `peer manager task exited unexpectedly`, runs the same coordinated teardown, and exits 1
- keep intentional shutdown at exit 0: the signal and Shutdown RPC arms break first and the peer manager only returns after the teardown sends `PeerManagerCommand::Shutdown`, after which the handle is joined exactly once
- add a test-only `RUSTBGPD_TEST_PEER_MANAGER_PANIC=1` probe, a live injected-panic exit-1 proof, a Shutdown RPC exit-0 proof with the peer manager supervised, and a source-geometry check of the arm and the single join
- `--help`/`--man` EXIT STATUS text, `docs/OPERATIONS.md`, and `docs/deployment.md` now list the peer manager among the supervised components

## Mechanism verified at HEAD before the change

- `src/main.rs:3915` `let peer_mgr_handle = tokio::spawn(peer_mgr.run());` — the handle was awaited only at `src/main.rs:5629`, after the main `select!` and after the teardown's `send(PeerManagerCommand::Shutdown)`. No `select!` arm polled it, so a mid-life panic or early return left the daemon running: sessions and the RIB kept going while admission, teardown, peer RPCs, config mutations, max-prefix restarts, and shutdown sequencing all routed into a dead actor. A later operator `Shutdown` would have exited 0 with only `peer manager task panicked` logged.
- `PeerManager::run()` returns only on `PeerManagerCommand::Shutdown` or a closed command channel; `main` holds the sender for the daemon's life.
- The Shutdown RPC (`crates/api/src/control_service.rs:152`) only flips the `rpc_shutdown` watch and never sends to the peer manager (its source test pins that), so the peer manager cannot exit before the `select!` breaks on an intentional shutdown.

## After this change

- `src/main.rs:3933` retained handle; the wrapper asserts the test probe and awaits `Box::pin(peer_mgr.run())`
- `src/main.rs:5203` supervision arm: `error!` + `info!`, `peer_mgr_exited = true`, `component_failed = true`, `break`
- `src/main.rs:5660` teardown sends `PeerManagerCommand::Shutdown`; `src/main.rs:5664` joins the handle only when the arm did not already consume it (a `JoinHandle` polled after completion panics)

### How intentional shutdown is distinguished

By arm ordering, the same way #1777 handles the listener: SIGINT/SIGTERM and the Shutdown RPC arms break the loop while the peer manager is still running; it is then told to stop and joined outside the `select!`. The arm can only fire while the loop is live, which is exactly "the peer manager died on its own".

## Actor audit

| Actor (`src/main.rs`) | Supervised | Why |
| --- | --- | --- |
| RIB manager (`rib_handle`) | yes (#1772) | core actor; fail-stop arm |
| gRPC server (`grpc_handle`) | yes (ADR-0022) | losing the control plane means losing clean shutdown |
| BGP listener / accept-forwarder | yes (#1777) | admission path; fail-stop arms |
| PeerManager (`peer_mgr_handle`) | yes (this PR) | last core actor; its death wedged admission, teardown, RPCs, and shutdown |
| Event history manager | no | optional actor with its own bounded drain; `required = true` only gates startup, live-only degradation is the documented mode |
| BMP manager + collector clients | no | optional export; manager joined with a 2 s bound at teardown, clients reconnect on their own |
| RPKI VRP manager / RTR clients / VRP+ASPA forwarders | no | optional; RTR clients reconnect, forwarders exit only when their channels close |
| MRT dump manager | no | optional periodic writer |
| Config persister + config bridge | no | persistence side; failures surface as `FAILED_PRECONDITION` and the existing persistence fail-stop |
| EVPN dataplane, originators (local-MAC, SVI, L3), segment orchestrator, link-drain | no | optional feature; each owns a handle with a bounded shutdown drain |
| BLACKHOLE, FIB runtime, BFD runtime | no | optional kernel-side actors with bounded drains |
| Metrics/readiness server | no | bind failure is already fatal at startup; a post-bind serve failure is observability loss, not a control-plane loss |
| gNMI dial-out manager | no | optional, mutex-held manager with per-target tasks |
| Runtime-config settlement watchdog | no (not a `select!` arm) | it is itself a fail-stop owner (exit 70, ADR-0127) on OS threads |
| GR marker expiry sleeper | no | one-shot timer task |

Nothing beyond the PeerManager is supervised in this PR.

## Tests

- `peer_manager_panic_uses_common_shutdown_and_exits_nonzero` — live daemon, probe set, exit 1, both log lines, one durable crash report, no second-join message
- `shutdown_rpc_exits_zero_with_peer_manager_supervised` — live daemon, `rbgp shutdown` over the implicit owner-only local socket, exit 0, `shutdown initiated via gRPC` and `peer manager shutting down 0 peers` present, supervision line absent, invalid probe value ignored and not echoed
- `peer_manager_supervision_is_fail_stop_and_joins_once` — source geometry: retained handle < arm < teardown send < single join; the Shutdown RPC arm never touches the peer manager
- `help_and_man_distinguish_bgp_bind_modes_and_supervised_exits` updated for the new wording
- `tests/quickstart_dynamic_neighbor.rs`: `Daemon::shutdown` now asserts the daemon exits 0 after `rbgp shutdown` (both starter flows)

Note: when the peer manager dies its per-session command senders drop, so established sessions end with a TCP close rather than a Cease NOTIFICATION — the NOTIFICATION sender is the dead actor. The operations text says "where the actor that sends them is still alive".

## Gates

All rc 0, captured to files:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast` (111 suites, no failures)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `python3 scripts/check-clippy-reasons.py`
- `python3 scripts/check_public_tracker_ids.py`
- `cargo test --test grpc_failure_exit_code` three times in isolation (15/15 each)
- `cargo test --test quickstart_dynamic_neighbor` three times in isolation (2/2 each)
- fmt, clippy, both focused suites, and the tracker check re-run after the final rebase onto `main`

Tracks LAN-1237.
