### PR TITLE
build: refresh the bench/scale lockfile after the thiserror dependency removal

### DIFF
--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1013,7 +1013,6 @@ dependencies = [
  "bytes",
  "rustbgpd-telemetry",
  "rustbgpd-wire",
- "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -1054,7 +1053,6 @@ dependencies = [
  "rustbgpd-wire",
  "rustc-hash",
  "sha2",
- "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1073,7 +1071,6 @@ dependencies = [
  "rustbgpd-wire",
  "rustc-hash",
  "smallvec",
- "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",


### PR DESCRIPTION
The standalone `bench/scale` workspace path-depends on the `rustbgpd-rib`, `rustbgpd-policy`, and `rustbgpd-bmp` crates. #1798 removed their unused `thiserror` dependencies, which left `bench/scale/Cargo.lock` recording three edges that no longer exist; the CI `scale / receipt checks` job runs every harness with `--locked` and has refused since `808914e9`.

Regenerated with `cargo update --workspace --manifest-path bench/scale/Cargo.toml`. The only change is the three removed `thiserror 2.0.20` edges.

Verified locally with the job's own shape: `cargo test --manifest-path bench/scale/{rrharness,rrtransport,reloadstall,enhanced-route-refresh}/Cargo.toml --locked` build rc 0 each, and `cargo metadata --locked --manifest-path bench/scale/Cargo.toml` rc 0.