### PR TITLE
test: replace load-sensitive wall-clock bounds with behavioural assertions and fix test isolation

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -625,6 +625,12 @@ mod tests {
     use tokio::sync::broadcast;
     use tokio_stream::StreamExt;
 
+    /// Only catches a hang: the tests below wait for an event to come back
+    /// through a `SynchronousMode::Full` (fsync per commit) event history
+    /// manager, and a commit that merely takes a few seconds under I/O
+    /// load is not a failure.
+    const DURABLE_COMMIT_HANG_BOUND: std::time::Duration = std::time::Duration::from_secs(30);
+
     #[derive(Clone, Copy, Debug)]
     enum ListEventRead {
         Evpn,
@@ -1384,9 +1390,9 @@ mod tests {
             ..Default::default()
         });
 
-        let committed = tokio::time::timeout(std::time::Duration::from_secs(2), ehm_live.recv())
+        let committed = tokio::time::timeout(DURABLE_COMMIT_HANG_BOUND, ehm_live.recv())
             .await
-            .expect("committed event within 2s with no WatchEvents subscriber")
+            .expect("committed event with no WatchEvents subscriber")
             .expect("EHM broadcast still attached");
         assert_eq!(
             committed.envelope.category,
@@ -1474,16 +1480,15 @@ mod tests {
         // channel first — confirm we see it there so the test
         // distinguishes "diff didn't fire" from "EHM enqueue
         // didn't fire" if it ever regresses.
-        let _broadcast_event =
-            tokio::time::timeout(std::time::Duration::from_secs(2), watch_rx.recv())
-                .await
-                .expect("WatchEvents broadcast within 2s")
-                .expect("WatchEvents receiver still attached");
+        let _broadcast_event = tokio::time::timeout(DURABLE_COMMIT_HANG_BOUND, watch_rx.recv())
+            .await
+            .expect("WatchEvents broadcast")
+            .expect("WatchEvents receiver still attached");
 
         // EHM commits it on the next batch interval (10ms).
-        let committed = tokio::time::timeout(std::time::Duration::from_secs(2), ehm_live.recv())
+        let committed = tokio::time::timeout(DURABLE_COMMIT_HANG_BOUND, ehm_live.recv())
             .await
-            .expect("committed event within 2s")
+            .expect("committed event")
             .expect("EHM broadcast still attached");
         assert_eq!(
             committed.envelope.category,
@@ -2857,9 +2862,9 @@ mod tests {
             .expect("subscribe_from_event must succeed");
         let mut stream = response.into_inner();
 
-        let event = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+        let event = tokio::time::timeout(DURABLE_COMMIT_HANG_BOUND, stream.next())
             .await
-            .expect("first event within 2s")
+            .expect("first event")
             .expect("stream still attached")
             .expect("no status error");
 

--- a/tests/config_migration.rs
+++ b/tests/config_migration.rs
@@ -892,59 +892,77 @@ fn downgrade_dry_run_invokes_validator_and_malicious_stage_mutation_refuses() {
 #[test]
 fn both_validator_deadlines_kill_reap_sanitize_and_clean_stage() {
     for phase in ["version", "check"] {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        fs::write(&path, CONFIG).unwrap();
-        let descendant_pid = dir.path().join("descendant.pid");
-        // The descendant sleeps 60s: far past every bound below, so "reaped
-        // within the poll deadline" can only mean the migrator killed it, and
-        // "returned within the hang stop" can only mean the migrator did not
-        // wait it out. The pid record is the script's first action because the
-        // whole script races the shrunk 100ms deadline kill.
-        let script = if phase == "version" {
-            format!(
-                "#!/bin/sh\nsleep 60 & echo $! > '{}'\nprintf DO_NOT_PRINT >&2\n",
-                descendant_pid.display()
-            )
-        } else {
-            format!(
-                "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'rustbgpd 0.64.0\\n'; else (sleep 60; printf malicious > \"$2\") & echo $! > '{}'; printf DO_NOT_PRINT >&2; fi\n",
-                descendant_pid.display()
-            )
-        };
-        let validator = validator(dir.path(), &script);
-        let started = Instant::now();
-        let output = run_env(
-            &[&validator, &path],
-            &["downgrade-v0.64", "--offline", "--validator"],
-            &[("RUSTBGPD_TEST_MIGRATION_TIMEOUT_PHASE", phase)],
-        );
-        assert_eq!(
-            output.status.code(),
-            Some(1),
-            "{phase}: {:?}",
-            text(&output)
-        );
-        // Hang stop: waiting out the descendant instead of killing at the
-        // deadline would take 60s. Generous so scheduler load cannot trip it.
-        assert!(started.elapsed() < Duration::from_secs(30), "{phase}");
-        assert!(!text(&output).1.contains("DO_NOT_PRINT"));
-        let pid = fs::read_to_string(&descendant_pid).unwrap();
-        let proc_entry = format!("/proc/{}", pid.trim());
-        // The kill precedes the migrator's exit, but the reap can lag it under
-        // load — poll instead of asserting instant /proc non-existence. The
-        // 60s descendant sleep keeps this a kill proof, not an exit race.
+        // The migrator arms the shrunk 100ms deadline when it spawns the
+        // validator, so the script's first action, recording the descendant's
+        // pid, races the kill itself: under load the kill can land before the
+        // record exists. Such an attempt left no descendant to reason about
+        // and proves nothing either way, so it is retried (bounded) rather
+        // than read as a survivor; a pass always needs a recorded pid.
+        let mut recorded = false;
+        for _ in 0..5 {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("config.toml");
+            fs::write(&path, CONFIG).unwrap();
+            let descendant_pid = dir.path().join("descendant.pid");
+            // The descendant sleeps 60s: far past every bound below, so
+            // "reaped within the poll deadline" can only mean the migrator
+            // killed it, and "returned within the hang stop" can only mean
+            // the migrator did not wait it out.
+            let script = if phase == "version" {
+                format!(
+                    "#!/bin/sh\nsleep 60 & echo $! > '{}'\nprintf DO_NOT_PRINT >&2\n",
+                    descendant_pid.display()
+                )
+            } else {
+                format!(
+                    "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'rustbgpd 0.64.0\\n'; else (sleep 60; printf malicious > \"$2\") & echo $! > '{}'; printf DO_NOT_PRINT >&2; fi\n",
+                    descendant_pid.display()
+                )
+            };
+            let validator = validator(dir.path(), &script);
+            let started = Instant::now();
+            let output = run_env(
+                &[&validator, &path],
+                &["downgrade-v0.64", "--offline", "--validator"],
+                &[("RUSTBGPD_TEST_MIGRATION_TIMEOUT_PHASE", phase)],
+            );
+            assert_eq!(
+                output.status.code(),
+                Some(1),
+                "{phase}: {:?}",
+                text(&output)
+            );
+            // Hang stop: waiting out the descendant instead of killing at the
+            // deadline would take 60s. Generous so scheduler load cannot trip it.
+            assert!(started.elapsed() < Duration::from_secs(30), "{phase}");
+            assert!(!text(&output).1.contains("DO_NOT_PRINT"));
+            assert!(!PathBuf::from(format!("{}.tmp", path.display())).exists());
+            let retry = run(&[&path], &["pin-legacy", "--offline"]);
+            assert!(
+                retry.status.success(),
+                "lock leaked after {phase}: {:?}",
+                text(&retry)
+            );
+            let pid = fs::read_to_string(&descendant_pid).unwrap_or_default();
+            let pid = pid.trim();
+            if pid.is_empty() {
+                continue;
+            }
+            let proc_entry = format!("/proc/{pid}");
+            // The kill precedes the migrator's exit, but the reap can lag it
+            // under load — poll instead of asserting instant /proc
+            // non-existence. The 60s descendant sleep keeps this a kill proof,
+            // not an exit race.
+            assert!(
+                poll_until(10, || !Path::new(&proc_entry).exists()),
+                "{phase}: descendant {pid} survived the deadline kill"
+            );
+            recorded = true;
+            break;
+        }
         assert!(
-            poll_until(10, || !Path::new(&proc_entry).exists()),
-            "{phase}: descendant {} survived the deadline kill",
-            pid.trim()
-        );
-        assert!(!PathBuf::from(format!("{}.tmp", path.display())).exists());
-        let retry = run(&[&path], &["pin-legacy", "--offline"]);
-        assert!(
-            retry.status.success(),
-            "lock leaked after {phase}: {:?}",
-            text(&retry)
+            recorded,
+            "{phase}: the validator never recorded its descendant before the deadline kill"
         );
     }
 }

--- a/tests/config_persistence_lifecycle.rs
+++ b/tests/config_persistence_lifecycle.rs
@@ -1534,7 +1534,18 @@ async fn phase_commit_confirm_timeout(
         reverted.is_some(),
         format!("elapsed={reverted:?} window={TIMEOUT_CONFIRM_SECONDS}s"),
     );
-    let status = lab.rbgp.run(&["-j", "config", "status"]).await?;
+    // The rollback re-persists the prior config first and becomes terminal
+    // only after the revert journal's locator is unlinked and its directory
+    // synced, so the disk can read reverted while status still says
+    // `pending`: poll for the terminal record instead of reading it once.
+    let started = Instant::now();
+    let mut status = lab.rbgp.run(&["-j", "config", "status"]).await?;
+    while json_str(&status, "status").as_deref() == Some("pending")
+        && started.elapsed() < CONVERGE_TIMEOUT
+    {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        status = lab.rbgp.run(&["-j", "config", "status"]).await?;
+    }
     checks.eq(
         "timeout.status_reports_auto_reverted",
         json_str(&status, "status").as_deref(),

--- a/tools/rs-config-render/tests/activation.rs
+++ b/tools/rs-config-render/tests/activation.rs
@@ -5,8 +5,8 @@ use std::fs;
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use rs_config_render::activation::{Error, Options, Status, activate};
@@ -15,6 +15,20 @@ use sha2::{Digest, Sha256};
 
 const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v1-supported.json");
 const SECRET: &str = "activation-secret-must-not-escape";
+/// Settle window every `Rig::run` activation is given.
+const SETTLE: Duration = Duration::from_secs(1);
+// Serialize the binary. `Command::spawn` in any thread copies every open
+// descriptor into its child until that child execs, and flock locks live on
+// the open file description: a host lock one test just dropped stays held by
+// the ghost copy inside a sibling test's not-yet-exec'd child, and the
+// sibling's next claim is refused with "another host command is active".
+static ACTIVATION_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn activation_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    ACTIVATION_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+}
 
 fn mode(path: &Path, mode: u32) {
     fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
@@ -128,7 +142,7 @@ case "$(cat "$root/activation-mode")" in
   fail-once)
     if [ ! -f "$root/failed-once" ]; then touch "$root/failed-once"; printf '{SECRET}\n'; exit 9; fi ;;
   hang-once)
-    if [ ! -f "$root/hung-once" ]; then touch "$root/hung-once"; sleep 30; fi ;;
+    if [ ! -f "$root/hung-once" ]; then touch "$root/hung-once"; exec sleep 120; fi ;;
   reject-current)
     [ -f "$root/reject" ] || printf '%s\n' "$target" > "$root/reject" ;;
 esac
@@ -212,7 +226,7 @@ exit 0
             checker: &self.checker,
             rbgp: &self.rbgp,
             rbgp_addr: self.binding(&self.state).rbgp_addr(),
-            settle: Duration::from_secs(1),
+            settle: SETTLE,
             initial,
             activation_command: command,
             activation_args: &args,
@@ -243,6 +257,7 @@ exit 0
 
 #[test]
 fn initial_activation_and_noop_are_private_exact_and_secret_free() {
+    let _serial = activation_test_guard();
     let rig = Rig::new();
     let candidate = rig.candidate("candidate-a", 100);
     fs::write(rig.root.join("version-stderr"), "").unwrap();
@@ -359,6 +374,7 @@ fn initial_activation_and_noop_are_private_exact_and_secret_free() {
 
 #[test]
 fn receipt_and_toml_runtime_bindings_are_independently_enforced() {
+    let _serial = activation_test_guard();
     let rig = Rig::new();
     let receipt_mismatch = rig.candidate("candidate-receipt-mismatch", 120);
     let receipt_path = receipt_mismatch.join("render-receipt.json");
@@ -390,6 +406,7 @@ fn receipt_and_toml_runtime_bindings_are_independently_enforced() {
 
 #[test]
 fn changed_candidate_rolls_back_exactly_and_refuses_mutable_aliases() {
+    let _serial = activation_test_guard();
     let rig = Rig::new();
     let first = rig.candidate_with_alias("candidate-a", 100, 3, 42, "10.1.0.36");
     rig.run(&first, true, &rig.activation).unwrap();
@@ -458,7 +475,12 @@ fn changed_candidate_rolls_back_exactly_and_refuses_mutable_aliases() {
 
 #[test]
 fn started_failure_timeout_and_unsettled_retain_candidate_without_rollback() {
-    let started = Instant::now();
+    let _serial = activation_test_guard();
+    // The only absolute bound, and it only catches a hang: the hang-once
+    // fixture sleeps 120 s, so an activation that is not killed at the settle
+    // deadline (or a settle loop that never gives up) overshoots this by far,
+    // while scheduler load cannot reach it.
+    const HANG_MARGIN: Duration = Duration::from_secs(30);
     for mode_name in ["fail-once", "hang-once", "reject-current"] {
         let rig = Rig::new();
         let first = rig.candidate("candidate-a", 110);
@@ -467,9 +489,24 @@ fn started_failure_timeout_and_unsettled_retain_candidate_without_rollback() {
         let prior = rig.current();
         let activations = fs::read_to_string(rig.root.join("activation.log")).unwrap();
         rig.set("activation-mode", mode_name);
+        let started = Instant::now();
         assert_eq!(
             rig.run(&candidate, false, &rig.activation),
             Err(Error::RecoveryRequired)
+        );
+        let elapsed = started.elapsed();
+        // A failed command is reported at once; a hung command is killed at
+        // the settle deadline and a never-settling runtime is polled until
+        // it, so those two are given the whole configured window and no more.
+        if mode_name != "fail-once" {
+            assert!(
+                elapsed >= SETTLE,
+                "{mode_name}: gave up before the settle window: {elapsed:?}"
+            );
+        }
+        assert!(
+            elapsed < SETTLE + HANG_MARGIN,
+            "{mode_name}: ran past the settle deadline: {elapsed:?}"
         );
         let receipt = rig.receipt();
         assert_ne!(rig.current(), prior);
@@ -481,6 +518,8 @@ fn started_failure_timeout_and_unsettled_retain_candidate_without_rollback() {
         assert_eq!(receipt["activation_runs"], 1);
         assert_eq!(receipt["phases"]["rollback_link"]["published"], false);
         assert_eq!(receipt["phases"]["rollback_activation_ran"], false);
+        assert_eq!(receipt["phases"]["candidate_activation_ran"], true);
+        assert_eq!(receipt["phases"]["runtime_equal"], false);
         assert_eq!(
             fs::read_to_string(rig.root.join("activation.log"))
                 .unwrap()
@@ -489,11 +528,11 @@ fn started_failure_timeout_and_unsettled_retain_candidate_without_rollback() {
             activations.lines().count() + 1
         );
     }
-    assert!(started.elapsed() < Duration::from_secs(4));
 }
 
 #[test]
 fn initial_failed_command_exits_five_with_last_recovery_receipt() {
+    let _serial = activation_test_guard();
     let rig = Rig::new();
     let candidate = rig.candidate("candidate-recovery", 105);
     rig.set("activation-mode", "fail-once");
@@ -533,6 +572,7 @@ fn initial_failed_command_exits_five_with_last_recovery_receipt() {
 
 #[test]
 fn cli_help_pins_the_additive_literal_command_contract() {
+    let _serial = activation_test_guard();
     let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
         .args(["activate", "--help"])
         .output()
@@ -554,6 +594,7 @@ fn cli_help_pins_the_additive_literal_command_contract() {
 
 #[test]
 fn recovery_boundaries_refuse_before_publication_and_clean_partial_staging() {
+    let _serial = activation_test_guard();
     let rig = Rig::new();
     let candidate = rig.candidate("candidate-boundaries", 106);
     let args = Vec::new();
@@ -687,6 +728,7 @@ fn snapshot(root: &Path) -> BTreeMap<String, String> {
 
 #[test]
 fn refused_after_generation_copy_leaves_the_state_directory_unchanged() {
+    let _serial = activation_test_guard();
     let rig = Rig::new();
     let first = rig.candidate("candidate-first", 100);
     assert_eq!(
@@ -725,6 +767,25 @@ fn refused_after_generation_copy_leaves_the_state_directory_unchanged() {
         Ok(Status::Activated)
     );
     assert_ne!(snapshot(&rig.state), before);
+}
+
+#[test]
+fn every_activation_test_acquires_the_process_guard_first() {
+    let _serial = activation_test_guard();
+    let lines: Vec<_> = include_str!("activation.rs").lines().collect();
+    let tests = lines
+        .windows(3)
+        .filter(|window| window[0].trim() == "#[test]")
+        .inspect(|window| {
+            assert_eq!(
+                window[2].trim(),
+                "let _serial = activation_test_guard();",
+                "{} must acquire the process guard before fixtures or children",
+                window[1].trim()
+            );
+        })
+        .count();
+    assert_eq!(tests, 11);
 }
 
 mod prune {
@@ -783,6 +844,7 @@ mod prune {
 
     #[test]
     fn prune_keeps_current_predecessor_receipt_and_journal_and_refuses_under_a_fence() {
+        let _serial = activation_test_guard();
         let rig = Rig::new();
         let g = rig.generations(5);
 
@@ -876,6 +938,7 @@ mod prune {
 
     #[test]
     fn prune_cli_dry_run_lists_exactly_what_apply_removes_and_is_idempotent() {
+        let _serial = activation_test_guard();
         let rig = Rig::new();
         let g = rig.generations(4);
         let run = |apply: bool| {


### PR DESCRIPTION
Four required-path tests failed under scheduler or I/O load because they asserted wall-clock bounds or read state that the daemon only reaches a moment later. Each is root-caused below and now asserts the behaviour it cares about, with timing expressed against the configured parameters; the one absolute bound that remains only catches a hang.

Load method for every "10×" below: 48 shell CPU spinners plus 4 `dd … conv=fsync` writers in their own process group, a looping clean `cargo build --release --workspace` in a second worktree, and other agents' builds on the same box (load average 40–62 on 64 cores). No product behaviour changes; no CHANGELOG entry.

### 1. `tools/rs-config-render/tests/activation.rs` — `started_failure_timeout_and_unsettled_retain_candidate_without_rollback`

**Root cause.** `assert!(started.elapsed() < 4 s)` over three rigs × two activations each (a dozen `sh` fixtures per rig, every one of them racing the rest of the binary's tests in parallel) was a proxy for two behaviours: the hung activation command is killed at the settle deadline instead of being waited out, and the never-settling runtime is polled until the deadline and then given up. On this box the bound was red 6/10 even unloaded at default parallelism.

**Now.** Timing is measured per activation run and stated against `SETTLE` (1 s, the `Rig::run` settle window): `hang-once` and `reject-current` must take `>= SETTLE` (the whole configured window is honoured, not cut short) and every mode must take `< SETTLE + 30 s` (the only absolute bound; the hang-once fixture now `exec sleep 120`, so a missed deadline kill overshoots it by 90 s). The receipt assertions add `candidate_activation_ran == true` and `runtime_equal == false` next to the existing retained-candidate / no-rollback / `recovery_required` / `activation_runs == 1` checks.

**Regression proof.** With `wait_output` made to ignore its deadline the test fails after 122 s with `hang-once: ran past the settle deadline`; with `settle()` returning on the first failed probe it fails in 2.6 s with `reject-current: gave up before the settle window: 331 ms`.

**10× under load:** 10/10 green (8–29 s per whole-binary run).

### 2. `activation.rs` — `Refused("another host command is active")` from a sibling test

**Root cause.** The host lock is path-keyed (each `Rig` has its own `host-state`), so it is not contention on the lock file. `Command::spawn` in any thread copies every open descriptor into its child until that child `exec`s, and flock locks belong to the open file description: when test A drops its `Guard` while test B's freshly forked child still holds a copy of A's lock fd, A's next `claim_new` on the same path gets `EWOULDBLOCK`. Reproduced deterministically with a scratch program (lock, foreign thread spawns a child that sleeps in `pre_exec`, drop, re-`try_lock` → `WouldBlock`). This is the same mechanism `ixp_manager_lifecycle.rs` already serialises against.

**Now.** A module `Mutex` (`activation_test_guard()`) is taken first in every test in the binary, including the two `mod prune` tests added by #1792, and `every_activation_test_acquires_the_process_guard_first` pins that every `#[test]` in the file does so (count 11). Not `--test-threads=1`: the serialisation is local to this binary.

**Regression proof.** Removing one guard line makes the self-check fail: `fn cli_help_pins_the_additive_literal_command_contract() { must acquire the process guard before fixtures or children`.

**10× under load, default parallelism:** 10/10 green (plus 10/10 lightly loaded and 10/10 unloaded).

### 3. `tests/config_persistence_lifecycle.rs` — `timeout.status_reports_auto_reverted` read `pending`

**Determination: (a), the test.** The auto-revert path is `rollback_pending_locked` (re-applies and persists the prior snapshot, `src/config_transaction_control.rs:1757`) then `remove_pending_after_rollback` (`:1857`): unlink the revert journal's locator and sync its directory (`:1866–1877`), and only then take `state.pending` and write the terminal `AutoReverted` record (`:1892`). That order is documented — `docs/API.md` ("Confirm and successful rollback become terminal only after locator unlink and parent-directory fsync") and `docs/OPERATIONS.md` ("The fence clears only after the transaction is terminal, including durable locator removal and parent-directory sync") — and it is the crash-safe order, so the disk legitimately reads reverted while status still says `pending`.

**Now.** After observing the on-disk revert the phase polls `config status` (50 ms, bounded by the harness's `CONVERGE_TIMEOUT`) until it leaves `pending`, then asserts `auto_reverted`; the journal-consumed check follows it (the locator is unlinked before the record flips, so it is deterministic once status is terminal).

**Regression proof.** A daemon that never reaches the terminal record leaves the poll at `pending` for `CONVERGE_TIMEOUT` and the check fails with `status=pending`; a wrong terminal state fails the `eq` directly.

**10× under load:** 10/10 green (35–47 s each), plus 10/10 lightly loaded.

### 4. `tests/config_migration.rs` — `both_validator_deadlines_kill_reap_sanitize_and_clean_stage`

**Root cause.** The migrator arms the shrunk 100 ms deadline (`RUSTBGPD_TEST_MIGRATION_TIMEOUT_PHASE`) when it spawns the validator, so the script's first statement — `sleep 60 & echo $! > pidfile` — races the kill itself; under load the kill can land first, leaving an absent or empty pidfile, and `/proc/` (empty pid) "exists" forever, read as a survivor. Nothing the test does before spawning can record a pid that only exists after spawning, and after the migrator returns the pidfile is final (the whole group was SIGKILLed), so polling it cannot help.

**Now.** An attempt whose pidfile is absent or empty proved nothing either way and is retried (at most five attempts); every attempt still asserts exit 1, the 30 s hang stop, the sanitised stderr, the clean stage and the released lock. A pass requires a recorded, non-empty pid and `/proc/<pid>` gone within the poll; if no attempt records one the test fails with `the validator never recorded its descendant before the deadline kill`.

**Regression proof.** Replacing `killpg` with `child.kill()` fails the test in 11 s with `version: descendant <pid> survived the deadline kill`.

**10× under load:** 10/10 green (8–15 s per whole-binary run).

### 5. Seen once each today

- `crates/api/src/event_service.rs` — `dataplane_summary_durable_without_any_watch_events_subscriber`, `subscribe_from_event_route_durable_id_overrides_nested_field`: **same class.** The 2 s `timeout`s are positive waits for an event to come back through a `SynchronousMode::Full` (fsync per commit) event history manager; a commit that takes a few seconds under I/O load is not a failure. The four durable-path waits (the two named tests plus the identical pair in `dataplane_summary_enqueued_to_ehm_handle_alongside_broadcast`) now use one generous hang bound, `DURABLE_COMMIT_HANG_BOUND = 30 s`; the 1 s waits on in-memory broadcast streams are untouched. 10× under load: 10/10 green.
- `tests/grpc_failure_exit_code.rs` — `bound_bgp_listener_panic_uses_common_shutdown_and_exits_nonzero`: **not the same class; seen, not reproduced** (5/5 green under load, 5/5 lightly loaded). Mechanism on inspection: the injected listener panic drops `accept_tx`, so the forwarder's `accept_rx.recv()` returns `None` and both supervised handles complete; the supervisor's unbiased `tokio::select!` (`src/main.rs:5136`) can then report the accept-forwarding task first. Attribution only (exit code and shutdown are unchanged); left for a product decision (`biased;` or a test that accepts either attribution).
- `tests/runtime_config_settlement_matrix.rs:415/:835` — **not the same class; reproduced 1/3 under light load** at `:835` (`confirmed apply failed: … "daemon error: transport error"`, after `config plan` on the same socket succeeded, so not readiness). Hypothesis: the matrix configures a 2 s settlement `BUDGET` + 500 ms `GRACE` for its fail-stop rows, and under load the row's own un-held setup apply exceeds it, so the daemon fail-stops mid-RPC. The harness drops its `TempDir` on panic, so the daemon log was not retained; needs its own ticket.

### Gates

Locally, all rc 0: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `scripts/check_public_tracker_ids.py` — all rc 0. In the full `cargo test --workspace --no-fail-fast` run the four targets above were green; two unrelated targets flaked on the still-loaded box (`runtime_config_persistence_failstop::post_rename_failure_fences_and_restart_loads_complete_candidate`, `rbgp did not finish before fail-stop deadline`, and the settlement matrix's `:835` transport error again) and both passed when rerun in isolation — the same tight-settlement-budget family noted under item 5.
