### PR TITLE
feat(mrt): expose dump health metrics and alert on stale dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The Prometheus alert pack gains `BmpSourceDrops`, `BmpLocRibSourceDrops`,
   and `BmpCollectorDrops`, firing on any 10-minute increase of the BMP drop
   counters so a lossy BMP feed is no longer silent. (LAN-1189)
+- MRT dump health is exported as `mrt_dump_interval_seconds`,
+  `mrt_last_dump_success_timestamp_seconds`, `mrt_last_dump_duration_milliseconds`,
+  `mrt_dump_bytes_written_total`, and `mrt_dump_failures_total{stage}`; the
+  alert pack gains `MrtDumpStale` (newest dump older than twice the configured
+  interval) and the Grafana dashboard a last-successful-dump stat. (LAN-1189)
 - A `semver-checks` CI workflow runs `cargo-semver-checks` for every
   publishable workspace crate (re-derived from the manifests; today
   `rustbgpd-wire` and `rustbgpd-fsm`) against its latest crates.io release on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,6 +3213,7 @@ dependencies = [
  "flate2",
  "nix 0.31.3",
  "rustbgpd-rib",
+ "rustbgpd-telemetry",
  "rustbgpd-wire",
  "serde",
  "serde_json",

--- a/crates/mrt/Cargo.toml
+++ b/crates/mrt/Cargo.toml
@@ -29,6 +29,7 @@ tokio.workspace = true
 tracing.workspace = true
 rustbgpd-wire = { workspace = true }
 rustbgpd-rib = { workspace = true }
+rustbgpd-telemetry.workspace = true
 flate2.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 

--- a/crates/mrt/src/manager.rs
+++ b/crates/mrt/src/manager.rs
@@ -2,13 +2,14 @@
 
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info};
 
 use rustbgpd_rib::RibUpdate;
+use rustbgpd_telemetry::BgpMetrics;
 
 use crate::codec;
 use crate::types::{MrtSnapshotData, MrtWriterConfig};
@@ -20,12 +21,37 @@ fn periodic_interval(period: Duration) -> tokio::time::Interval {
     interval
 }
 
+/// A failed or canceled dump: the operator-facing message plus the bounded
+/// `mrt_dump_failures_total{stage}` class. `stage` is `None` for a
+/// caller-canceled on-demand dump, which is not a writer failure.
+struct DumpError {
+    stage: Option<&'static str>,
+    message: String,
+}
+
+impl DumpError {
+    fn at(stage: &'static str, message: String) -> Self {
+        Self {
+            stage: Some(stage),
+            message,
+        }
+    }
+
+    fn canceled(message: &str) -> Self {
+        Self {
+            stage: None,
+            message: message.to_string(),
+        }
+    }
+}
+
 /// MRT dump manager. Periodically queries the RIB and writes `TABLE_DUMP_V2` files.
 pub struct MrtManager {
     config: MrtWriterConfig,
     rib_tx: mpsc::Sender<RibUpdate>,
     trigger_rx: mpsc::Receiver<oneshot::Sender<Result<PathBuf, String>>>,
     local_bgp_id: Ipv4Addr,
+    metrics: BgpMetrics,
 }
 
 impl MrtManager {
@@ -36,17 +62,21 @@ impl MrtManager {
         rib_tx: mpsc::Sender<RibUpdate>,
         trigger_rx: mpsc::Receiver<oneshot::Sender<Result<PathBuf, String>>>,
         local_bgp_id: Ipv4Addr,
+        metrics: BgpMetrics,
     ) -> Self {
         Self {
             config,
             rib_tx,
             trigger_rx,
             local_bgp_id,
+            metrics,
         }
     }
 
     /// Run the manager loop. Returns when the trigger channel closes.
     pub async fn run(mut self) {
+        self.metrics
+            .set_mrt_dump_interval_seconds(self.config.dump_interval);
         let mut interval = periodic_interval(Duration::from_secs(self.config.dump_interval));
         // Skip the immediate first tick — the first dump will fire after one interval.
         interval.tick().await;
@@ -89,18 +119,51 @@ impl MrtManager {
         info!("MRT manager shutting down");
     }
 
+    /// Run one dump and account for it: a published file stamps the
+    /// success gauges and bytes counter; a failure increments
+    /// `mrt_dump_failures_total{stage}`; a caller cancellation is neither.
     async fn do_dump(
         &self,
         cancel: Option<&mut oneshot::Sender<Result<PathBuf, String>>>,
     ) -> Result<PathBuf, String> {
+        let started = Instant::now();
+        match self.dump_once(cancel).await {
+            Ok((path, bytes_written)) => {
+                self.metrics
+                    .record_mrt_dump_success(bytes_written, started.elapsed());
+                Ok(path)
+            }
+            Err(DumpError { stage, message }) => {
+                if let Some(stage) = stage {
+                    self.metrics.record_mrt_dump_failure(stage);
+                }
+                Err(message)
+            }
+        }
+    }
+
+    async fn dump_once(
+        &self,
+        cancel: Option<&mut oneshot::Sender<Result<PathBuf, String>>>,
+    ) -> Result<(PathBuf, u64), DumpError> {
         // Reject structurally impossible output paths before asking the
         // RIB actor to clone a full snapshot. Permissions and storage can
         // still change before publication, so the write remains fallible.
         let config = self.config.clone();
         tokio::task::spawn_blocking(move || writer::prepare_output_dir(&config))
             .await
-            .map_err(|e| format!("output directory preflight join error: {e}"))?
-            .map_err(|e| format!("output directory preflight error: {e}"))?;
+            .map_err(|e| {
+                DumpError::at(
+                    "preflight",
+                    format!("output directory preflight join error: {e}"),
+                )
+            })?
+            .map_err(|e| {
+                DumpError::at(
+                    "preflight",
+                    format!("output directory preflight error: {e}"),
+                )
+            })?;
 
         let snapshot = self.query_snapshot(cancel).await?;
 
@@ -117,56 +180,57 @@ impl MrtManager {
             &snapshot.evpn_routes,
             ts32,
         )
-        .map_err(|e| format!("encode error: {e}"))?;
+        .map_err(|e| DumpError::at("encode", format!("encode error: {e}")))?;
 
         let config = self.config.clone();
-        tokio::task::spawn_blocking(move || writer::write_dump(&config, &data))
-            .await
-            .map_err(|e| format!("join error: {e}"))?
-            .map_err(|e| {
-                error!(error = %e, "MRT dump write failed");
-                format!("write error: {e}")
-            })
+        tokio::task::spawn_blocking(move || {
+            let path = writer::write_dump(&config, &data)?;
+            let bytes_written = std::fs::metadata(&path)?.len();
+            Ok::<_, std::io::Error>((path, bytes_written))
+        })
+        .await
+        .map_err(|e| DumpError::at("write", format!("join error: {e}")))?
+        .map_err(|e| {
+            error!(error = %e, "MRT dump write failed");
+            DumpError::at("write", format!("write error: {e}"))
+        })
     }
 
     async fn query_snapshot(
         &self,
         mut cancel: Option<&mut oneshot::Sender<Result<PathBuf, String>>>,
-    ) -> Result<MrtSnapshotData, String> {
+    ) -> Result<MrtSnapshotData, DumpError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let query = RibUpdate::QueryMrtSnapshot { reply: reply_tx };
+        let closed = |e| DumpError::at("snapshot", format!("RIB channel closed: {e}"));
+        let dropped = |e| DumpError::at("snapshot", format!("RIB reply dropped: {e}"));
 
         if let Some(cancel) = cancel.as_deref_mut() {
             tokio::select! {
                 biased;
                 () = cancel.closed() => {
-                    return Err("MRT dump canceled while queueing RIB snapshot".to_string());
+                    return Err(DumpError::canceled("MRT dump canceled while queueing RIB snapshot"));
                 }
                 result = self.rib_tx.send(query) => {
-                    result.map_err(|e| format!("RIB channel closed: {e}"))?;
+                    result.map_err(closed)?;
                 }
             }
         } else {
-            self.rib_tx
-                .send(query)
-                .await
-                .map_err(|e| format!("RIB channel closed: {e}"))?;
+            self.rib_tx.send(query).await.map_err(closed)?;
         }
 
         if let Some(cancel) = cancel {
             tokio::select! {
                 biased;
                 () = cancel.closed() => {
-                    Err("MRT dump canceled while awaiting RIB snapshot".to_string())
+                    Err(DumpError::canceled("MRT dump canceled while awaiting RIB snapshot"))
                 }
                 result = reply_rx => {
-                    result.map_err(|e| format!("RIB reply dropped: {e}"))
+                    result.map_err(dropped)
                 }
             }
         } else {
-            reply_rx
-                .await
-                .map_err(|e| format!("RIB reply dropped: {e}"))
+            reply_rx.await.map_err(dropped)
         }
     }
 }
@@ -177,6 +241,33 @@ mod tests {
 
     use super::*;
     use crate::types::MrtPeerEntry;
+
+    /// Read one exported sample (gauge or counter) by family name and an
+    /// optional label match; 0 when the family or series is absent.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the sampled families are integral gauges and counters"
+    )]
+    fn metric_sample(metrics: &BgpMetrics, name: &str, label: Option<(&str, &str)>) -> i64 {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|f| f.name() == name)
+            .and_then(|mut f| {
+                f.take_metric().into_iter().find(|m| match label {
+                    None => true,
+                    Some((k, v)) => m.label.iter().any(|l| l.name() == k && l.value() == v),
+                })
+            })
+            .map_or(0, |m| {
+                if m.gauge.is_some() {
+                    m.gauge.value() as i64
+                } else {
+                    m.counter.value() as i64
+                }
+            })
+    }
 
     fn test_config(output_dir: PathBuf) -> MrtWriterConfig {
         MrtWriterConfig {
@@ -220,7 +311,13 @@ mod tests {
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         let (trigger_tx, trigger_rx) = mpsc::channel(16);
 
-        let mgr = MrtManager::new(config, rib_tx, trigger_rx, Ipv4Addr::new(1, 2, 3, 4));
+        let mgr = MrtManager::new(
+            config,
+            rib_tx,
+            trigger_rx,
+            Ipv4Addr::new(1, 2, 3, 4),
+            BgpMetrics::new(),
+        );
         let handle = tokio::spawn(mgr.run());
 
         drop(trigger_tx);
@@ -242,8 +339,22 @@ mod tests {
 
         let (rib_tx, mut rib_rx) = mpsc::channel(16);
         let (trigger_tx, trigger_rx) = mpsc::channel(16);
+        let metrics = BgpMetrics::new();
+        let before = i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
 
-        let mgr = MrtManager::new(config, rib_tx, trigger_rx, Ipv4Addr::new(1, 2, 3, 4));
+        let mgr = MrtManager::new(
+            config,
+            rib_tx,
+            trigger_rx,
+            Ipv4Addr::new(1, 2, 3, 4),
+            metrics.clone(),
+        );
         let handle = tokio::spawn(mgr.run());
 
         // Spawn a task to reply to the RIB query
@@ -273,6 +384,24 @@ mod tests {
         assert!(path.exists());
         assert!(path.to_string_lossy().ends_with(".mrt"));
 
+        // Dump health metrics: the success stamps the timestamp, the bytes
+        // counter matches the published file, and nothing counts as a failure.
+        let on_disk = i64::try_from(std::fs::metadata(&path).unwrap().len()).unwrap();
+        assert!(on_disk > 0, "PEER_INDEX_TABLE must produce bytes");
+        assert_eq!(
+            metric_sample(&metrics, "mrt_dump_interval_seconds", None),
+            86400
+        );
+        assert!(
+            metric_sample(&metrics, "mrt_last_dump_success_timestamp_seconds", None) >= before,
+            "success timestamp must be stamped"
+        );
+        assert_eq!(
+            metric_sample(&metrics, "mrt_dump_bytes_written_total", None),
+            on_disk
+        );
+        assert_eq!(metric_sample(&metrics, "mrt_dump_failures_total", None), 0);
+
         rib_handler.await.unwrap();
         drop(trigger_tx);
         handle.await.unwrap();
@@ -291,7 +420,13 @@ mod tests {
         let (rib_tx, mut rib_rx) = mpsc::channel(16);
         let (trigger_tx, trigger_rx) = mpsc::channel(16);
 
-        let mgr = MrtManager::new(config, rib_tx, trigger_rx, Ipv4Addr::new(1, 2, 3, 4));
+        let mgr = MrtManager::new(
+            config,
+            rib_tx,
+            trigger_rx,
+            Ipv4Addr::new(1, 2, 3, 4),
+            BgpMetrics::new(),
+        );
         let handle = tokio::spawn(mgr.run());
 
         // Count RIB snapshot queries: the canceled trigger must never
@@ -339,11 +474,13 @@ mod tests {
 
         let (rib_tx, mut rib_rx) = mpsc::channel(16);
         let (trigger_tx, trigger_rx) = mpsc::channel(16);
+        let metrics = BgpMetrics::new();
         let manager = MrtManager::new(
             test_config(output_file.clone()),
             rib_tx,
             trigger_rx,
             Ipv4Addr::LOCALHOST,
+            metrics.clone(),
         );
         let handle = tokio::spawn(manager.run());
 
@@ -359,6 +496,19 @@ mod tests {
             rib_rx.try_recv().is_err(),
             "structurally impossible output must emit zero RIB queries"
         );
+        assert_eq!(
+            metric_sample(
+                &metrics,
+                "mrt_dump_failures_total",
+                Some(("stage", "preflight"))
+            ),
+            1
+        );
+        assert_eq!(
+            metric_sample(&metrics, "mrt_last_dump_success_timestamp_seconds", None),
+            0,
+            "a failed dump must not stamp a success"
+        );
 
         drop(trigger_tx);
         handle.await.unwrap();
@@ -370,11 +520,13 @@ mod tests {
         let output_dir = dir.path().join("lazy-output");
         let (rib_tx, mut rib_rx) = mpsc::channel(16);
         let (trigger_tx, trigger_rx) = mpsc::channel(16);
+        let metrics = BgpMetrics::new();
         let manager = MrtManager::new(
             test_config(output_dir.clone()),
             rib_tx,
             trigger_rx,
             Ipv4Addr::LOCALHOST,
+            metrics.clone(),
         );
         let handle = tokio::spawn(manager.run());
 
@@ -413,6 +565,11 @@ mod tests {
         drop(snapshot_reply);
         drop(trigger_tx);
         handle.await.unwrap();
+        assert_eq!(
+            metric_sample(&metrics, "mrt_dump_failures_total", None),
+            0,
+            "a caller-canceled dump is not a writer failure"
+        );
     }
 
     #[tokio::test]
@@ -433,6 +590,7 @@ mod tests {
             rib_tx,
             trigger_rx,
             Ipv4Addr::LOCALHOST,
+            BgpMetrics::new(),
         );
         let handle = tokio::spawn(manager.run());
 

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -387,6 +387,13 @@ struct BgpMetricsInner {
     bmp_loc_rib_dump_live_buffer_depth: IntGaugeVec,
     bmp_loc_rib_dump_live_buffer_high_watermark: IntGaugeVec,
 
+    // ── MRT dump export ────────────────────────────────────────
+    mrt_dump_interval_seconds: IntGauge,
+    mrt_last_dump_success_timestamp: IntGauge,
+    mrt_last_dump_duration_milliseconds: IntGauge,
+    mrt_dump_bytes_written: IntCounter,
+    mrt_dump_failures: IntCounterVec,
+
     // ── Event history outbox (ADR-0072) ───────────────────────
     event_outbox_committed: IntCounterVec,
     event_outbox_dropped: IntCounterVec,
@@ -1887,6 +1894,43 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        // ── MRT dump export ──────────────────────────────────────
+        let mrt_dump_interval_seconds = IntGauge::new(
+            "mrt_dump_interval_seconds",
+            "Configured seconds between periodic MRT TABLE_DUMP_V2 dumps \
+             ([mrt] dump_interval). Exists only when [mrt] is configured.",
+        )
+        .expect("valid metric definition");
+        let mrt_last_dump_success_timestamp = IntGauge::new(
+            "mrt_last_dump_success_timestamp_seconds",
+            "Unix time the last MRT dump (periodic or on-demand) was written \
+             and published successfully. 0 until the first success after \
+             start; a failed dump does NOT advance it, so `time() - <this>` \
+             is the age of the newest dump file.",
+        )
+        .expect("valid metric definition");
+        let mrt_last_dump_duration_milliseconds = IntGauge::new(
+            "mrt_last_dump_duration_milliseconds",
+            "Wall-clock duration of the last successful MRT dump from trigger \
+             to published file (RIB snapshot, encode, write, rename).",
+        )
+        .expect("valid metric definition");
+        let mrt_dump_bytes_written = IntCounter::new(
+            "mrt_dump_bytes_written_total",
+            "Bytes of MRT dump files published on disk (post-compression).",
+        )
+        .expect("valid metric definition");
+        let mrt_dump_failures = IntCounterVec::new(
+            Opts::new(
+                "mrt_dump_failures_total",
+                "MRT dumps that failed, by bounded stage (preflight, snapshot, \
+                 encode, write). Caller-canceled on-demand dumps are not \
+                 counted.",
+            ),
+            &["stage"],
+        )
+        .expect("valid metric definition");
+
         // ── Event history outbox (ADR-0072) ─────────────────────
         let event_outbox_committed = IntCounterVec::new(
             Opts::new(
@@ -2431,6 +2475,21 @@ impl BgpMetrics {
             ))
             .expect("metric not already registered");
         registry
+            .register(Box::new(mrt_dump_interval_seconds.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(mrt_last_dump_success_timestamp.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(mrt_last_dump_duration_milliseconds.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(mrt_dump_bytes_written.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(mrt_dump_failures.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(event_outbox_committed.clone()))
             .expect("metric not already registered");
         registry
@@ -2622,6 +2681,11 @@ impl BgpMetrics {
             bmp_control_event_drops,
             bmp_loc_rib_dump_live_buffer_depth,
             bmp_loc_rib_dump_live_buffer_high_watermark,
+            mrt_dump_interval_seconds,
+            mrt_last_dump_success_timestamp,
+            mrt_last_dump_duration_milliseconds,
+            mrt_dump_bytes_written,
+            mrt_dump_failures,
             event_outbox_committed,
             event_outbox_dropped,
             event_outbox_queue_depth,
@@ -4517,6 +4581,33 @@ impl BgpMetrics {
     /// retargeted at their backup PE.
     pub fn set_evpn_single_active_backup_active(&self, value: i64) {
         self.0.evpn_single_active_backup_active.set(value);
+    }
+
+    /// Publish the configured MRT dump cadence so dump age can be
+    /// alerted on relative to it (`MrtDumpStale` in the alert pack).
+    pub fn set_mrt_dump_interval_seconds(&self, seconds: u64) {
+        self.0
+            .mrt_dump_interval_seconds
+            .set(i64::try_from(seconds).unwrap_or(i64::MAX));
+    }
+
+    /// Record a successfully published MRT dump: stamp the current unix
+    /// time, the end-to-end duration, and the bytes put on disk.
+    pub fn record_mrt_dump_success(&self, bytes_written: u64, duration: std::time::Duration) {
+        self.0
+            .mrt_last_dump_success_timestamp
+            .set(unix_now_seconds());
+        self.0
+            .mrt_last_dump_duration_milliseconds
+            .set(i64::try_from(duration.as_millis()).unwrap_or(i64::MAX));
+        self.0.mrt_dump_bytes_written.inc_by(bytes_written);
+    }
+
+    /// Record a failed MRT dump by bounded `stage` (`preflight`,
+    /// `snapshot`, `encode`, `write`). Never called for a caller-canceled
+    /// on-demand dump.
+    pub fn record_mrt_dump_failure(&self, stage: &str) {
+        self.0.mrt_dump_failures.with_label_values(&[stage]).inc();
     }
 
     /// Record a BMP event dropped at the PeerSession→BmpManager channel.
@@ -6524,6 +6615,41 @@ mod tests {
 
         let families = m.registry().gather();
         assert!(!families.is_empty());
+    }
+
+    #[test]
+    fn mrt_dump_metrics_record_success_failure_and_interval() {
+        let m = BgpMetrics::new();
+        assert_eq!(m.0.mrt_last_dump_success_timestamp.get(), 0);
+
+        m.set_mrt_dump_interval_seconds(7200);
+        assert_eq!(m.0.mrt_dump_interval_seconds.get(), 7200);
+
+        let before = unix_now_seconds();
+        m.record_mrt_dump_success(1234, std::time::Duration::from_millis(250));
+        assert!(m.0.mrt_last_dump_success_timestamp.get() >= before);
+        assert_eq!(m.0.mrt_last_dump_duration_milliseconds.get(), 250);
+        assert_eq!(m.0.mrt_dump_bytes_written.get(), 1234);
+
+        let stamp = m.0.mrt_last_dump_success_timestamp.get();
+        m.record_mrt_dump_failure("write");
+        m.record_mrt_dump_failure("write");
+        m.record_mrt_dump_failure("snapshot");
+        assert_eq!(m.0.mrt_dump_failures.with_label_values(&["write"]).get(), 2);
+        assert_eq!(
+            m.0.mrt_dump_failures.with_label_values(&["snapshot"]).get(),
+            1
+        );
+        assert_eq!(
+            m.0.mrt_last_dump_success_timestamp.get(),
+            stamp,
+            "a failure must not advance the success timestamp"
+        );
+
+        let text = gather_text(&m);
+        assert!(text.contains("mrt_dump_interval_seconds 7200"));
+        assert!(text.contains("mrt_dump_bytes_written_total 1234"));
+        assert!(text.contains("mrt_dump_failures_total{stage=\"write\"} 2"));
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3103,7 +3103,10 @@ changed targets redial; unchanged targets keep their live connection).
 
 Optional. Configures periodic MRT TABLE_DUMP_V2 (RFC 6396) RIB snapshots for
 offline analysis and archival. Dumps can also be triggered on demand via the
-gRPC `TriggerMrtDump` RPC or the `rbgp mrt-dump` CLI command.
+gRPC `TriggerMrtDump` RPC or the `rbgp mrt-dump` CLI command. Dump health is
+exported as the `mrt_*` Prometheus metrics (see the MRT table in
+[OPERATIONS.md](OPERATIONS.md)); the shipped alert pack's `MrtDumpStale` fires
+once the newest dump is older than twice `dump_interval`.
 
 ```toml
 [mrt]

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -77,7 +77,7 @@ dynamic-neighbor admission near-limit and rejection,
 actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
 selection-deferral timeout and ledger overflow, outbound route loss, RFC 9687
 send-hold teardown, live event-stream lag/desynchronization, BMP feed loss,
-and daemon down)
+stale MRT dumps, and daemon down)
 ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
 with per-rule unit tests in

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -763,7 +763,12 @@ fails later, a periodic dump logs the error and skips that cycle. An on-demand
 `TriggerMrtDump` failure is returned to its caller while the RPC remains
 connected; only write failures also emit a manager error log. Periodic dumps
 continue on the next interval without replaying missed intervals in a catch-up
-burst. The daemon does not crash on MRT failures.
+burst. The daemon does not crash on MRT failures. Dump health is exported as
+the `mrt_*` metrics (see the MRT table under Metrics below):
+`mrt_dump_failures_total{stage}` names the failing stage and
+`mrt_last_dump_success_timestamp_seconds` stops advancing, which the shipped
+`MrtDumpStale` alert turns into a page once the newest dump is older than twice
+`dump_interval`.
 
 If an on-demand request is already canceled when the RIB actor handles it, the
 actor skips route materialization. Cancellation observed while the manager
@@ -851,7 +856,8 @@ Metric names are split by prefix on purpose: `bgp_*` covers the BGP core
 (sessions, RIB, policy, RPKI/ASPA, GR, event stream/outbox, FIB) and
 `evpn_*` covers the EVPN/VTEP dataplane surface — the two subsystems have
 different cardinality profiles and are typically dashboarded and alerted
-separately. `bfd_*` names the BFD liveness metrics. A ready-to-load
+separately. `bfd_*` names the BFD liveness metrics; `bmp_*` and `mrt_*`
+cover the BMP exporter and MRT dump export. A ready-to-load
 Prometheus alert-rule pack covering the high-signal `bgp_*` metrics ships
 at [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml).
 
@@ -1124,6 +1130,16 @@ The shipped alert pack
 fires `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` on
 any 10-minute increase of these two counters and of
 `bmp_collector_drops_total`.
+
+### MRT
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `mrt_dump_interval_seconds` | The configured `[mrt] dump_interval`; the series exists only when `[mrt]` is configured. The alert pack's `MrtDumpStale` fires once the newest dump is older than twice this value |
+| `mrt_last_dump_success_timestamp_seconds` | Unix time the last periodic or on-demand dump was published successfully; 0 until the first success after start. A failed dump does not advance it, so `time() - <this>` is the age of the newest dump file |
+| `mrt_last_dump_duration_milliseconds` | Wall-clock duration of the last successful dump from trigger to published file (RIB snapshot, encode, write, rename) |
+| `mrt_dump_bytes_written_total` | Bytes of dump files published on disk (after compression) |
+| `mrt_dump_failures_total{stage}` | Failed dumps by bounded stage: `preflight` (output directory), `snapshot` (RIB actor query), `encode`, `write`. A caller-canceled on-demand dump is not counted; a periodic failure also logs at error level, an on-demand failure is returned to its caller |
 
 ### Durable Event Cursor (ADR-0072)
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2822,6 +2822,39 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 66,
+      "type": "row",
+      "title": "MRT dump export",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 177 },
+      "panels": []
+    },
+    {
+      "id": 67,
+      "type": "stat",
+      "title": "Last successful MRT dump",
+      "description": "mrt_last_dump_success_timestamp_seconds rendered as an age. 'never' means no dump has been published since start; the MrtDumpStale alert fires once the age exceeds twice mrt_dump_interval_seconds. Check mrt_dump_failures_total by stage when stale.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 178 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dateTimeFromNow",
+          "mappings": [ { "type": "value", "options": { "0": { "text": "never", "index": 0 } } } ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "mrt_last_dump_success_timestamp_seconds{instance=~\"$instance\"} * 1000",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
     }
   ]
 }

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -8,7 +8,7 @@
 # Every expression references only metrics the daemon actually exports
 # (crates/telemetry/src/metrics.rs). The rules assume the scrape config
 # from docs/GRAFANA.md (`job_name: rustbgpd`) — adjust the `job` label
-# in RustbgpdDown if yours differs.
+# in RustbgpdDown, RustbgpdRestarted, and MrtDumpStale if yours differs.
 #
 # Current peer health uses the level gauges
 # `bgp_peer_admin_enabled{peer,interface}` and
@@ -300,6 +300,32 @@ groups:
             a durability-impacting drop, decode failure, or open failure
             since start. Check bgp_event_outbox_dropped_total and
             bgp_event_outbox_open_failures_total, then the daemon log.
+
+      - alert: MrtDumpStale
+        # mrt_last_dump_success_timestamp_seconds stays 0 until the first
+        # successful dump, so dump age is anchored on process start until
+        # then: a daemon whose dumps have never succeeded alerts after the
+        # same 2x interval as one whose dumps stopped. Both mrt_* gauges
+        # exist only when [mrt] is configured, so this cannot fire elsewhere.
+        expr: >-
+          time()
+          - (
+            mrt_last_dump_success_timestamp_seconds
+            > process_start_time_seconds{job="rustbgpd"}
+            or process_start_time_seconds{job="rustbgpd"}
+          )
+          > 2 * mrt_dump_interval_seconds
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "MRT dump stale on {{ $labels.instance }}"
+          description: >-
+            No MRT TABLE_DUMP_V2 file has been published on
+            {{ $labels.instance }} for more than twice the configured
+            mrt_dump_interval_seconds. Check mrt_dump_failures_total by stage
+            and the daemon log for the failing dump; `rbgp mrt-dump` runs one
+            on demand.
 
       - alert: BgpUpdateGroupResidueGrowing
         # Withdrawal residue is bounded by the resync timer; a climb

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -689,6 +689,89 @@ tests:
                 bgp_event_outbox_open_failures_total, then the daemon
                 log.
 
+  # ── MrtDumpStale ──────────────────────────────────────────
+  # Age is anchored on process start until the first success: edge1 never
+  # succeeds after starting at 5m and fires 2x interval later; edge2
+  # succeeded once at 10m then stalled; edge3's fresh success at 32m clears
+  # a pending alert; edge4's longer interval scales the threshold. All
+  # timestamps are promtool's epoch-relative clock.
+  - interval: 1m
+    input_series:
+      - series: 'mrt_dump_interval_seconds{job="rustbgpd", instance="edge1:9179"}'
+        values: "600x60"
+      - series: 'mrt_last_dump_success_timestamp_seconds{job="rustbgpd", instance="edge1:9179"}'
+        values: "0x60"
+      - series: 'process_start_time_seconds{job="rustbgpd", instance="edge1:9179"}'
+        values: "300x60"
+      - series: 'mrt_dump_interval_seconds{job="rustbgpd", instance="edge2:9179"}'
+        values: "600x60"
+      - series: 'mrt_last_dump_success_timestamp_seconds{job="rustbgpd", instance="edge2:9179"}'
+        values: "0x10 600x50"
+      - series: 'process_start_time_seconds{job="rustbgpd", instance="edge2:9179"}'
+        values: "0x60"
+      - series: 'mrt_dump_interval_seconds{job="rustbgpd", instance="edge3:9179"}'
+        values: "600x60"
+      - series: 'mrt_last_dump_success_timestamp_seconds{job="rustbgpd", instance="edge3:9179"}'
+        values: "0x10 600x20 1920x30"
+      - series: 'process_start_time_seconds{job="rustbgpd", instance="edge3:9179"}'
+        values: "0x60"
+      - series: 'mrt_dump_interval_seconds{job="rustbgpd", instance="edge4:9179"}'
+        values: "86400x60"
+      - series: 'mrt_last_dump_success_timestamp_seconds{job="rustbgpd", instance="edge4:9179"}'
+        values: "0x60"
+      - series: 'process_start_time_seconds{job="rustbgpd", instance="edge4:9179"}'
+        values: "0x60"
+      # A process-start series from another job must not anchor anything.
+      - series: 'process_start_time_seconds{job="node", instance="edge1:9100"}'
+        values: "0x60"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: MrtDumpStale
+        exp_alerts: []
+      # edge1 crossed 2x interval at 25m30s and is still pending (for: 5m).
+      - eval_time: 30m
+        alertname: MrtDumpStale
+        exp_alerts: []
+      - eval_time: 31m
+        alertname: MrtDumpStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: rustbgpd
+              instance: edge1:9179
+            exp_annotations:
+              summary: "MRT dump stale on edge1:9179"
+              description: >-
+                No MRT TABLE_DUMP_V2 file has been published on edge1:9179 for
+                more than twice the configured mrt_dump_interval_seconds. Check
+                mrt_dump_failures_total by stage and the daemon log for the
+                failing dump; `rbgp mrt-dump` runs one on demand.
+      - eval_time: 36m
+        alertname: MrtDumpStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: rustbgpd
+              instance: edge1:9179
+            exp_annotations:
+              summary: "MRT dump stale on edge1:9179"
+              description: >-
+                No MRT TABLE_DUMP_V2 file has been published on edge1:9179 for
+                more than twice the configured mrt_dump_interval_seconds. Check
+                mrt_dump_failures_total by stage and the daemon log for the
+                failing dump; `rbgp mrt-dump` runs one on demand.
+          - exp_labels:
+              severity: warning
+              job: rustbgpd
+              instance: edge2:9179
+            exp_annotations:
+              summary: "MRT dump stale on edge2:9179"
+              description: >-
+                No MRT TABLE_DUMP_V2 file has been published on edge2:9179 for
+                more than twice the configured mrt_dump_interval_seconds. Check
+                mrt_dump_failures_total by stage and the daemon log for the
+                failing dump; `rbgp mrt-dump` runs one on demand.
+
   # ── BgpUpdateGroupResidueGrowing ──────────────────────────────
   - interval: 1m
     input_series:

--- a/src/main.rs
+++ b/src/main.rs
@@ -3874,8 +3874,13 @@ async fn run<T>(
                 file_prefix: mrt_config.file_prefix.clone(),
             };
             let (trigger_tx, trigger_rx) = mpsc::channel(16);
-            let mgr =
-                rustbgpd_mrt::MrtManager::new(writer_config, rib_tx.clone(), trigger_rx, router_id);
+            let mgr = rustbgpd_mrt::MrtManager::new(
+                writer_config,
+                rib_tx.clone(),
+                trigger_rx,
+                router_id,
+                metrics.clone(),
+            );
             info!(
                 output_dir = %mrt_config.output_dir,
                 interval = mrt_config.dump_interval,


### PR DESCRIPTION
## Summary

MRT dump health was invisible: zero `mrt_*` families, so a stalled periodic dump went unnoticed for as long as the interval. This registers the minimal set that answers "is MRT working", emits it from the real sites in the MRT manager, and alerts on staleness.

### Metrics (all registered in `crates/telemetry/src/metrics.rs`, emitted by `crates/mrt/src/manager.rs`)

| Family | Type | Labels | Meaning |
|---|---|---|---|
| `mrt_dump_interval_seconds` | gauge | — | configured `[mrt] dump_interval`; set when the manager starts, exists only with `[mrt]` configured |
| `mrt_last_dump_success_timestamp_seconds` | gauge | — | unix time of the last published dump (periodic or on-demand); 0 until the first success; a failure never advances it |
| `mrt_last_dump_duration_milliseconds` | gauge | — | trigger-to-published-file duration of the last successful dump |
| `mrt_dump_bytes_written_total` | counter | — | bytes of dump files on disk (post-compression) |
| `mrt_dump_failures_total` | counter | `stage` ∈ {`preflight`, `snapshot`, `encode`, `write`} | failed dumps by bounded stage; caller-canceled on-demand dumps are not counted |

`do_dump` now wraps `dump_once`, whose error carries the stage; `MrtManager::new` takes a `BgpMetrics` (the only caller is `src/main.rs`). Duration uses the registry's existing integer-millisecond "last duration" convention rather than a histogram; a dump fires a handful of times a day.

### Alert (`examples/prometheus/rustbgpd-alerts.yml`)

`MrtDumpStale` (warning, `for: 5m`):

```
time() - (mrt_last_dump_success_timestamp_seconds > process_start_time_seconds{job="rustbgpd"}
          or process_start_time_seconds{job="rustbgpd"})
  > 2 * mrt_dump_interval_seconds
```

Age is anchored on process start until the first success, so a daemon whose dumps have never succeeded fires after the same 2× interval as one whose dumps stopped, without a false alarm during the first interval after boot. promtool tests cover never-succeeded, succeeded-then-stalled, recovery clearing a pending alert, and a longer interval scaling the threshold.

### Dashboard / docs

- `docs/grafana/rustbgpd-overview.json`: new row "MRT dump export" with a "Last successful MRT dump" stat (`dateTimeFromNow`, 0 rendered as "never").
- `docs/OPERATIONS.md`: `### MRT` metrics table after the BMP table, the MRT-dump-failure runbook points at the metrics, and the prefix paragraph now names `bmp_*`/`mrt_*`; `docs/GRAFANA.md`, `docs/CONFIGURATION.md` (`[mrt]` section), CHANGELOG.

Correction to the ticket text: the default `[mrt] dump_interval` is 7200 s (`src/config/schema.rs`), not 86400 s.

## Gates

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `python3 scripts/check-clippy-reasons.py`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --workspace --no-fail-fast`: two known load-sensitive failures unrelated to this change (`rs-config-render` activation 4 s bound, `config_migration` deadline-kill pid race; host load average 16–26 at the time); both pass on isolated rerun.
- `promtool check rules` / `promtool test rules`, `python3 scripts/check-grafana-dashboard.py` (+ its unittest), `python3 scripts/check_public_tracker_ids.py`