### PR TITLE
feat(rpki): operator freshness floor on cache-advertised expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   --summary`). `bench/compare-criterion.sh` prints an explicit noise line in
   its verdict and `bench/README.md` documents it as the local replacement for
   the removed CI bench workflows. (LAN-1234)
+- `[[rpki.cache_servers]] max_expire_interval` caps the effective RTR expire
+  interval per cache: the cache-advertised End of Data expire (and
+  `expire_interval`) is clamped down to it, so that cache's VRPs are discarded
+  once older than the ceiling no matter what the cache advertises, on the same
+  expiry path as the RFC 8210 two-day maximum. Rejected unless <= 172800 and
+  > `refresh_interval`; unset changes nothing. The new
+  `bgp_rpki_cache_effective_expire_seconds{cache}` gauge shows the effective
+  expire per cache.
 - `rs-config-render prune --keep N` removes activation generations that no
   retention rule keeps: the `current` target, the last activation receipt's
   candidate and predecessor, anything a pending lifecycle journal names, and

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -59,7 +59,9 @@ use std::sync::Arc;
 
 pub use aspa::{AspaRecord, AspaTable};
 pub use aspa_verify::{AspaInvalidHop, AspaVerificationResult};
-pub use rtr_client::{RtrClient, RtrClientConfig, VrpUpdate};
+pub use rtr_client::{
+    EXPIRE_MAX_SECS as RTR_EXPIRE_MAX_SECS, RtrClient, RtrClientConfig, VrpUpdate,
+};
 pub use vrp::{VrpEntry, VrpTable};
 pub use vrp_manager::{AspaTableUpdate, RpkiTableUpdate, VrpManager};
 

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -48,7 +48,10 @@ const MAX_PDU_LEN: usize = 65_535;
 const REFRESH_MAX_SECS: u64 = 86_400;
 const RETRY_MAX_SECS: u64 = 7_200;
 const EXPIRE_MIN_SECS: u64 = 600;
-const EXPIRE_MAX_SECS: u64 = 172_800;
+/// §6 maximum Expire Interval (two days): the longest a router may
+/// retain a cache's data without a fresh End of Data. Also the upper
+/// bound for an operator `max_expire_interval`.
+pub const EXPIRE_MAX_SECS: u64 = 172_800;
 
 /// Wall-clock budget for one RTR transaction (query → End of Data).
 /// A full production table transfers in seconds; a cache that cannot
@@ -183,6 +186,12 @@ pub struct RtrClientConfig {
     pub retry_interval: u64,
     /// Seconds after which cached VRPs are considered stale.
     pub expire_interval: u64,
+    /// Operator ceiling on the effective expire interval in seconds.
+    /// The cache-advertised End of Data expire (and `expire_interval`)
+    /// is clamped down to it, so data older than this is discarded
+    /// regardless of what the cache says. `None`: only the §6 two-day
+    /// maximum applies.
+    pub max_expire_interval: Option<u64>,
 }
 
 /// Per-cache-server RTR client.
@@ -213,6 +222,9 @@ pub struct RtrClient {
     transaction_deadline: Duration,
     max_transaction_records: usize,
     max_transaction_bytes: usize,
+    /// Told the effective expire interval (seconds) at start and after
+    /// every End of Data; see [`Self::with_expire_observer`].
+    expire_observer: Option<Box<dyn Fn(u64) + Send + Sync>>,
 }
 
 impl RtrClient {
@@ -222,7 +234,13 @@ impl RtrClient {
         Self {
             refresh_interval: Duration::from_secs(config.refresh_interval),
             retry_interval: Duration::from_secs(config.retry_interval),
-            expire_interval: Duration::from_secs(config.expire_interval),
+            expire_interval: Duration::from_secs(
+                config
+                    .max_expire_interval
+                    .map_or(config.expire_interval, |max| {
+                        config.expire_interval.min(max)
+                    }),
+            ),
             last_end_of_data_at: None,
             data_expires_at: None,
             vrp_tx,
@@ -233,12 +251,29 @@ impl RtrClient {
             transaction_deadline: TRANSACTION_DEADLINE,
             max_transaction_records: MAX_TRANSACTION_RECORDS,
             max_transaction_bytes: MAX_TRANSACTION_BYTES,
+            expire_observer: None,
+        }
+    }
+
+    /// Report the effective expire interval (seconds) to `observer` at
+    /// start and after every End of Data — the hook behind the
+    /// `bgp_rpki_cache_effective_expire_seconds` gauge.
+    #[must_use]
+    pub fn with_expire_observer(mut self, observer: impl Fn(u64) + Send + Sync + 'static) -> Self {
+        self.expire_observer = Some(Box::new(observer));
+        self
+    }
+
+    fn observe_expire(&self) {
+        if let Some(observer) = &self.expire_observer {
+            observer(self.expire_interval.as_secs());
         }
     }
 
     /// Main event loop — connects, keeps the RTR session open, and reconnects
     /// on failure.
     pub async fn run(mut self) {
+        self.observe_expire();
         loop {
             self.prepare_fresh_connection_attempt();
             if let Err(e) = self.connect_and_run().await {
@@ -523,6 +558,9 @@ impl RtrClient {
     /// * An expire below the §6 minimum of 600 s is used as-is with a
     ///   warning: expiring early is always safe, while raising it would
     ///   retain data longer than the cache said.
+    /// * An operator `max_expire_interval` is a stricter ceiling applied
+    ///   the same way: the expire is clamped down to it, never raised,
+    ///   and the data takes the ordinary expiry path at that point.
     /// * §6: "Caches MUST set Expire Interval to a value larger than
     ///   both the Refresh Interval and the Retry Interval." On
     ///   violation the effective refresh/retry are lowered below the
@@ -541,7 +579,7 @@ impl RtrClient {
                 Duration::from_secs(self.bounded_timer("retry", u64::from(retry), RETRY_MAX_SECS));
         }
         if expire > 0 {
-            let expire = self.bounded_timer("expire", u64::from(expire), EXPIRE_MAX_SECS);
+            let mut expire = self.bounded_timer("expire", u64::from(expire), EXPIRE_MAX_SECS);
             if expire < EXPIRE_MIN_SECS {
                 warn!(
                     server = %self.config.server_addr,
@@ -549,6 +587,17 @@ impl RtrClient {
                     minimum = EXPIRE_MIN_SECS,
                     "RTR End of Data expire interval below the §6 minimum (using as-is: expiring early is safe)"
                 );
+            }
+            if let Some(max) = self.config.max_expire_interval
+                && expire > max
+            {
+                debug!(
+                    server = %self.config.server_addr,
+                    expire,
+                    max_expire_interval = max,
+                    "RTR End of Data expire interval above the configured max_expire_interval, clamped"
+                );
+                expire = max;
             }
             self.expire_interval = Duration::from_secs(expire);
         }
@@ -574,6 +623,7 @@ impl RtrClient {
             );
             self.retry_interval = floor;
         }
+        self.observe_expire();
     }
 
     /// Clamp one End of Data timer to its §6 maximum, warning with both
@@ -1366,6 +1416,7 @@ mod tests {
             refresh_interval: refresh,
             retry_interval: retry,
             expire_interval: expire,
+            max_expire_interval: None,
         }
     }
 
@@ -3251,6 +3302,95 @@ mod tests {
 
         client_handle.abort();
         let _ = client_handle.await;
+    }
+
+    /// An operator `max_expire_interval` is a stricter expire and takes
+    /// the same expiry path as the §6 maximum: with the cache advertising
+    /// 7,200 s and a 1,800 s ceiling, the data dies at the 1,800 s mark —
+    /// `ServerDown`, exactly as at any other expiry. The observer sees
+    /// the effective value at start (configured expire, under the
+    /// ceiling) and after End of Data (the ceiling).
+    #[tokio::test(start_paused = true)]
+    async fn operator_max_expire_interval_expires_before_the_cache_advertised_expire() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (vrp_tx, mut vrp_rx) = mpsc::channel(8);
+        let mut config = test_config(addr, 60, 5, 120);
+        config.max_expire_interval = Some(1_800);
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&seen);
+        let client = RtrClient::new(config, vrp_tx)
+            .with_expire_observer(move |secs| sink.lock().unwrap().push(secs));
+        let client_handle = tokio::spawn(client.run());
+
+        let (mut stream, _) = listener.accept().await.unwrap();
+        establish_epoch_with_timers(&mut stream, &mut vrp_rx, 5, 7_200).await;
+        let eod_at = TokioInstant::now();
+        assert_eq!(*seen.lock().unwrap(), vec![120, 1_800]);
+
+        drop(stream);
+        tokio::spawn(async move {
+            while let Ok((conn, _)) = listener.accept().await {
+                drop(conn);
+            }
+        });
+
+        let update = vrp_rx.recv().await.unwrap();
+        assert_eq!(update, VrpUpdate::ServerDown { server: addr });
+        let elapsed = TokioInstant::now().duration_since(eod_at).as_secs();
+        // As in the two-day test above: the paused clock auto-advances
+        // past pending timers (here up to one transaction deadline)
+        // while the client is in real socket I/O, so the flush lands
+        // shortly after — not exactly at — the ceiling. The claim under
+        // test is the cap: expiry at ~1,800 s, far below the
+        // cache-supplied 7,200 s.
+        assert!(
+            (1_800..2_400).contains(&elapsed),
+            "expected expiry at the 1,800 s operator ceiling, got {elapsed} s"
+        );
+
+        client_handle.abort();
+        let _ = client_handle.await;
+    }
+
+    /// `max_expire_interval` caps the configured expire at construction
+    /// and the cache-advertised expire at End of Data, never raises a
+    /// lower one, and — being an expire like any other — drags
+    /// refresh/retry below it through the existing §6 relationship
+    /// rule. Unset leaves the §6 bounds as the only limit.
+    #[test]
+    fn operator_max_expire_interval_caps_the_effective_expire() {
+        let addr: SocketAddr = "127.0.0.1:323".parse().unwrap();
+        let with_max = |max| {
+            let mut config = test_config(addr, 3600, 600, 7200);
+            config.max_expire_interval = max;
+            RtrClient::new(config, mpsc::channel(1).0)
+        };
+        let secs = |client: &RtrClient| {
+            (
+                client.refresh_interval.as_secs(),
+                client.retry_interval.as_secs(),
+                client.expire_interval.as_secs(),
+            )
+        };
+
+        // The configured expire is capped at construction.
+        assert_eq!(secs(&with_max(Some(1_800))), (3600, 600, 1_800));
+
+        // The advertised expire is capped; refresh drops below the cap.
+        let mut client = with_max(Some(1_800));
+        client.apply_eod_timers(3600, 600, 7200);
+        assert_eq!(secs(&client), (1_799, 600, 1_800));
+
+        // An advertised expire under the cap is honoured as-is.
+        let mut client = with_max(Some(1_800));
+        client.apply_eod_timers(0, 0, 900);
+        assert_eq!(secs(&client), (899, 600, 900));
+
+        // Unset: the advertised expire lands verbatim.
+        let mut client = with_max(None);
+        client.apply_eod_timers(3600, 600, 7200);
+        assert_eq!(secs(&client), (3600, 600, 7200));
     }
 
     /// §6 timer acceptance rules, asserted on the effective intervals:

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -317,6 +317,7 @@ struct BgpMetricsInner {
 
     // ── RPKI ───────────────────────────────────────────────────
     rpki_vrp_count: IntGaugeVec,
+    rpki_cache_effective_expire_seconds: IntGaugeVec,
 
     // ── ASPA ───────────────────────────────────────────────────
     aspa_records: IntGauge,
@@ -1434,6 +1435,15 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let rpki_cache_effective_expire_seconds = IntGaugeVec::new(
+            Opts::new(
+                "bgp_rpki_cache_effective_expire_seconds",
+                "Effective RTR expire interval per cache: the cache-advertised End of Data expire after the RFC 8210 two-day maximum and the configured max_expire_interval ceiling",
+            ),
+            &["cache"],
+        )
+        .expect("valid metric definition");
+
         let aspa_records = IntGauge::new(
             "bgp_aspa_records",
             "Number of ASPA customer records in the merged table",
@@ -2314,6 +2324,9 @@ impl BgpMetrics {
             .register(Box::new(rpki_vrp_count.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(rpki_cache_effective_expire_seconds.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(aspa_records.clone()))
             .expect("metric not already registered");
         registry
@@ -2628,6 +2641,7 @@ impl BgpMetrics {
             selection_deferral_timeouts,
             selection_deferral_ledger_overflows,
             rpki_vrp_count,
+            rpki_cache_effective_expire_seconds,
             aspa_records,
             validation_import_refreshes,
             policy_dataset_refresh_errors,
@@ -3999,6 +4013,15 @@ impl BgpMetrics {
     /// Set RPKI VRP count by address family.
     pub fn set_rpki_vrp_count(&self, af: &str, count: i64) {
         self.0.rpki_vrp_count.with_label_values(&[af]).set(count);
+    }
+
+    /// Set the effective RTR expire interval (seconds) for one cache,
+    /// labelled by its canonical `IP:port`.
+    pub fn set_rpki_cache_effective_expire_seconds(&self, cache: &str, secs: u64) {
+        self.0
+            .rpki_cache_effective_expire_seconds
+            .with_label_values(&[cache])
+            .set(i64::try_from(secs).unwrap_or(i64::MAX));
     }
 
     /// Set ASPA record count.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2161,7 +2161,10 @@ rustbgpd connects to one or more RPKI cache validators and uses their VRP
 The RTR session stays connected after `EndOfData`, uses `SerialNotify` for
 immediate refreshes when the cache sends them, falls back to periodic serial
 polling at `refresh_interval`, and expires cached VRPs if no fresh `EndOfData`
-arrives before the effective expiry timer.
+arrives before the effective expiry timer. That timer is the cache's advertised
+End of Data expire (capped at the RFC 8210 two-day maximum), or
+`expire_interval` until the cache supplies one; `max_expire_interval` lets the
+operator cap it lower.
 
 ### Prerequisites
 
@@ -2208,7 +2211,8 @@ address = "[2001:db8::10]:3323"
 | `address` | string | yes | -- | Numeric cache server `IP:port`; bracket IPv6 addresses |
 | `refresh_interval` | u64 | no | 3600 | Seconds between Serial Queries |
 | `retry_interval` | u64 | no | 600 | Seconds before reconnect on failure |
-| `expire_interval` | u64 | no | 7200 | Seconds before discarding stale VRPs |
+| `expire_interval` | u64 | no | 7200 | Seconds before discarding stale VRPs, until the cache's End of Data supplies its own expire |
+| `max_expire_interval` | u64 | no | unset | Ceiling on the effective expire, in seconds: the cache-advertised expire (and `expire_interval`) is clamped down to it, so this cache's VRPs are discarded once older than this no matter what the cache advertises. Must be <= 172800 and > `refresh_interval`. Unset: only the two-day maximum applies |
 
 ### Validation states
 
@@ -2259,6 +2263,7 @@ Prometheus metrics exposed at the configured metrics endpoint:
 | Metric | Description |
 |--------|-------------|
 | `bgp_rpki_vrp_count{af="ipv4\|ipv6"}` | Current VRP entries by address family |
+| `bgp_rpki_cache_effective_expire_seconds{cache}` | Effective expire interval per cache after the two-day maximum and `max_expire_interval` are applied |
 
 See [ADR-0034](adr/0034-rpki-origin-validation.md) for design details.
 
@@ -4234,6 +4239,7 @@ starting:
 | RT/RO local administrator must be <= 65535 for a 4-octet ASN or dotted IPv4 administrator; numeric ASNs <= 65535 carry a u32 local value | `local admin ... exceeds 65535 for ...` |
 | RPKI `refresh_interval`, `retry_interval`, `expire_interval` must be > 0 | `must be > 0` |
 | RPKI `expire_interval` must be >= `refresh_interval` | `expire_interval must be >= refresh_interval` |
+| RPKI `max_expire_interval`, when set, must be <= 172800 and > `refresh_interval` | `max_expire_interval ... must be <= 172800` / `must be > refresh_interval` |
 | RPKI cache addresses must be unique numeric `IP:port` endpoints (bracketed for IPv6) | `invalid address` / `duplicate address` |
 | Named policy referenced in chain must exist in `[policy.definitions]` | `undefined policy` |
 | Inline policy and policy chain cannot both be set for the same neighbor/direction | `mutually exclusive` |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -712,9 +712,10 @@ part of the ordered teardown and exits 0.
 ### RPKI cache unreachable
 
 Each RTR client reconnects independently after a fixed `retry_interval`
-(default 600s). If no fresh `EndOfData` arrives before
-`expire_interval` (default 7200s), cached VRPs for that server are discarded.
-Routes are re-validated against the remaining VRP table.
+(default 600s). If no fresh `EndOfData` arrives before the effective expire
+(the cache-advertised expire, `expire_interval` (default 7200s) until one
+arrives, both capped by `max_expire_interval` when set), cached VRPs for that
+server are discarded. Routes are re-validated against the remaining VRP table.
 
 When all caches are down, the VRP table is empty and all routes have
 validation state `NotFound`. If your policy denies `NotFound` routes, this
@@ -1532,6 +1533,7 @@ details stay in the structured daemon log and RPC status.
 |--------|-------------------|
 | `bgp_rpki_vrp_count{af="ipv4"}` | IPv4 VRP entries loaded |
 | `bgp_rpki_vrp_count{af="ipv6"}` | IPv6 VRP entries loaded |
+| `bgp_rpki_cache_effective_expire_seconds{cache}` | Effective RTR expire per cache (`IP:port`): the cache-advertised expire after the RFC 8210 two-day maximum and the configured `max_expire_interval` ceiling. Set at client start and after every End of Data |
 | `bgp_aspa_records` | ASPA customer records loaded in the merged table. Renamed from `bgp_aspa_records_total` (a gauge must not carry the counter `_total` suffix) |
 | `bgp_validation_import_refreshes_total{dependency, outcome}` | Inbound Route Refresh work triggered by VRP / ASPA cache updates for peers whose import policy matches validation state. `dependency` is `rpki` or `aspa`; `outcome` is `eligible`, `refreshed`, `skipped_not_established`, or `failed`. |
 

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -431,6 +431,15 @@
           "default": 7200,
           "minimum": 0
         },
+        "max_expire_interval": {
+          "description": "Operator ceiling on the effective expire interval in seconds. The\ncache-advertised End of Data expire (and `expire_interval`) is clamped\ndown to it, so this cache's VRPs are discarded once older than this\nregardless of what the cache advertises. Must be <= 172800 (the\nRFC 8210 two-day maximum) and > `refresh_interval`. Unset: only the\ntwo-day maximum applies.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
         "refresh_interval": {
           "description": "RTR refresh interval in seconds. Default 3600.",
           "type": "integer",

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -557,6 +557,14 @@ pub struct CacheServer {
     /// RTR expire interval in seconds. Default 7200.
     #[serde(default = "default_rpki_expire")]
     pub expire_interval: u64,
+    /// Operator ceiling on the effective expire interval in seconds. The
+    /// cache-advertised End of Data expire (and `expire_interval`) is clamped
+    /// down to it, so this cache's VRPs are discarded once older than this
+    /// regardless of what the cache advertises. Must be <= 172800 (the
+    /// RFC 8210 two-day maximum) and > `refresh_interval`. Unset: only the
+    /// two-day maximum applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_expire_interval: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/src/config/tests/rpki.rs
+++ b/src/config/tests/rpki.rs
@@ -26,6 +26,7 @@ address = "127.0.0.1:3323"
     assert_eq!(rpki.cache_servers[0].refresh_interval, 3600);
     assert_eq!(rpki.cache_servers[0].retry_interval, 600);
     assert_eq!(rpki.cache_servers[0].expire_interval, 7200);
+    assert_eq!(rpki.cache_servers[0].max_expire_interval, None);
 }
 
 #[test]
@@ -264,4 +265,38 @@ fn rpki_valid_custom_timers_accepted() {
     assert_eq!(rpki.cache_servers[0].refresh_interval, 1800);
     assert_eq!(rpki.cache_servers[0].retry_interval, 300);
     assert_eq!(rpki.cache_servers[0].expire_interval, 3600);
+}
+
+#[test]
+fn rpki_max_expire_interval_accepted_and_parsed() {
+    let config = parse(&rpki_toml(
+        "refresh_interval = 600\nmax_expire_interval = 1800",
+    ))
+    .unwrap();
+    let rpki = config.rpki.as_ref().unwrap();
+    assert_eq!(rpki.cache_servers[0].max_expire_interval, Some(1800));
+}
+
+#[test]
+fn rpki_max_expire_interval_above_two_day_maximum_rejected() {
+    let err = parse(&rpki_toml("max_expire_interval = 172801"))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("cache_servers[0]: max_expire_interval (172801) must be <= 172800"),
+        "{err}"
+    );
+}
+
+#[test]
+fn rpki_max_expire_interval_not_above_refresh_rejected() {
+    let err = parse(&rpki_toml("max_expire_interval = 3600"))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains(
+            "cache_servers[0]: max_expire_interval (3600) must be > refresh_interval (3600)"
+        ),
+        "{err}"
+    );
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -4,6 +4,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 
 use rustbgpd_api::authz::{LOCAL_OPERATOR_PRINCIPAL, uds_mode_is_owner_only};
+use rustbgpd_rpki::RTR_EXPIRE_MAX_SECS;
 use rustbgpd_transport::TCP_AO_MAX_INSPECT_KEYS;
 
 use super::parse::{
@@ -948,6 +949,25 @@ impl Config {
                             server.expire_interval, server.refresh_interval
                         ),
                     });
+                }
+                if let Some(max) = server.max_expire_interval {
+                    if max > RTR_EXPIRE_MAX_SECS {
+                        return Err(ConfigError::InvalidRpkiConfig {
+                            reason: format!(
+                                "cache_servers[{i}]: max_expire_interval ({max}) must be <= \
+                                 {RTR_EXPIRE_MAX_SECS} (the RFC 8210 two-day maximum)"
+                            ),
+                        });
+                    }
+                    if max <= server.refresh_interval {
+                        return Err(ConfigError::InvalidRpkiConfig {
+                            reason: format!(
+                                "cache_servers[{i}]: max_expire_interval ({max}) must be > \
+                                 refresh_interval ({})",
+                                server.refresh_interval
+                            ),
+                        });
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3857,8 +3857,14 @@ async fn run<T>(
                 refresh_interval: server.refresh_interval,
                 retry_interval: server.retry_interval,
                 expire_interval: server.expire_interval,
+                max_expire_interval: server.max_expire_interval,
             };
-            let client = rustbgpd_rpki::RtrClient::new(client_config, vrp_update_tx.clone());
+            let expire_metrics = metrics.clone();
+            let cache_label = addr.to_string();
+            let client = rustbgpd_rpki::RtrClient::new(client_config, vrp_update_tx.clone())
+                .with_expire_observer(move |secs| {
+                    expire_metrics.set_rpki_cache_effective_expire_seconds(&cache_label, secs);
+                });
             info!(server = %addr, "spawning RTR client for RPKI cache");
             tokio::spawn(client.run());
         }


### PR DESCRIPTION
## Summary

Inside the RFC 8210 two-day maximum, the cache alone controls how long its VRPs stay authoritative: `apply_eod_timers` adopts the End of Data expire verbatim (clamped only at 172,800 s), and the configured `expire_interval` is used only until the first End of Data. A misconfigured or hostile cache advertising 48 h gets it silently.

This adds an operator ceiling, `[[rpki.cache_servers]] max_expire_interval`, on the effective expire.

## Knob

- `max_expire_interval: Option<u64>` (seconds), per cache server, next to `refresh_interval` / `retry_interval` / `expire_interval`. Default unset: no behaviour change for existing configs.
- Validation (`src/config/validation.rs`): when set, it must be `<= 172800` (the RFC 8210 two-day maximum, now exported as `rustbgpd_rpki::RTR_EXPIRE_MAX_SECS`) and `> refresh_interval`; otherwise the config is rejected with `cache_servers[i]: max_expire_interval (N) must be <= 172800 (the RFC 8210 two-day maximum)` or `... must be > refresh_interval (R)`.
- `[rpki]` stays restart-required as a section (reload matrix unchanged). The JSON schema is regenerated; the field is an additive optional sibling, so the v1 stable-surface digest for `CacheServer` is unchanged and the inventory was not edited.

## Semantics (implemented: the consistent option)

The ceiling is literally a stricter expire, not a new state. `RtrClient` clamps the configured `expire_interval` at construction and the cache-advertised End of Data expire in `apply_eod_timers` down to the ceiling (debug log when it bites); the existing §6 rule then lowers refresh/retry below it as for any expire, and at the ceiling the data takes exactly the existing expiry path: `ServerDown`, the cache's VRPs/ASPAs leave the merged tables, routes are revalidated. A cache expire below the ceiling is honoured as-is (expiring early is always safe).

**Alternative not taken — keep serving past the ceiling and emit a loud staleness signal.** Under flush, a lying or stuck cache becomes a validation blackout for that cache's VRPs (routes fall to `NotFound` against the remaining caches); under keep-serving, stale VRPs keep driving `Invalid`/`Valid` decisions past the age the operator configured, which is the integrity problem the ceiling exists to close, and it would introduce a state the rest of the pipeline has no notion of. The consistent option is kept: multi-cache deployments already make the blackout partial, and the new gauge makes the ceiling observable. Revisiting this is a separate decision.

**Not in scope — pre-sync/flushed state vs `NotFound` (tracked as LAN-1242):** before the first End of Data and after a flush, a prefix validates as `NotFound`, the same state as "covered by no ROA". A policy that denies `NotFound` therefore drops traffic during cache startup and expiry, and a policy that permits it cannot tell "no ROA exists" from "no data yet". Distinguishing the two is a policy-language change (a new match state or an "RPKI data present" predicate) and is out of scope for this change.

## Observability

- New gauge `bgp_rpki_cache_effective_expire_seconds{cache="IP:port"}` (label value = the canonical parsed `SocketAddr`, the same identity `rbgp doctor` uses for `rpki.cache.<addr>`): the effective expire after the two-day maximum and the ceiling. Fed by a new `RtrClient::with_expire_observer` hook from `main.rs` at client start and after every End of Data. Documented in `docs/CONFIGURATION.md` and `docs/OPERATIONS.md`.
- `rbgp doctor` does not report RPKI freshness today, so no doctor line was added.

## Tests

- `rtr_client`: `operator_max_expire_interval_caps_the_effective_expire` (construction + End of Data clamp, under-ceiling honoured, unset verbatim) and `operator_max_expire_interval_expires_before_the_cache_advertised_expire` (paused clock: cache advertises 7,200 s, ceiling 1,800 s, `ServerDown` lands at ~1,800 s; observer sees `[120, 1800]`). Existing `eod_expire_*` / `eod_timer_bounds_and_relationships` untouched.
- config: `rpki_max_expire_interval_accepted_and_parsed`, `..._above_two_day_maximum_rejected`, `..._not_above_refresh_rejected`; default `None` asserted in `rpki_single_cache_server_parses`.

## Gates (rc 0 unless noted)

`cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`; `scripts/check-clippy-reasons.py`; `scripts/check_public_tracker_ids.py`; `scripts/check-v1-stable-surface.py`; `scripts/check-grafana-dashboard.py`. `cargo test --workspace --no-fail-fast`: one failure, the known load-sensitive `rs-config-render` activation 4 s wall-clock bound (`started_failure_timeout_and_unsettled_retain_candidate_without_rollback`, host load ~20); passes in isolation (2.99 s).
