### PR TITLE
bench: parameterise the rrharness A/B runner and document the local criterion A/B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `bench/scale/compare-rrharness.sh` now compares any two refs: `--base`/`--head`
+  are the only required inputs, the original grouped exact-export pin is
+  opt-in via `--pin FILE --diff-path PATH`, and unpinned runs write an
+  advisory `comparison.csv` plus a per-rung `summary.csv` instead of applying
+  the pinned throughput gates (`parse_rrharness.py compare --no-gates
+  --summary`). `bench/compare-criterion.sh` prints an explicit noise line in
+  its verdict and `bench/README.md` documents it as the local replacement for
+  the removed CI bench workflows. (LAN-1234)
 - `rs-config-render prune --keep N` removes activation generations that no
   retention rule keeps: the `current` target, the last activation receipt's
   candidate and predecessor, anything a pending lifecycle journal names, and

--- a/bench/README.md
+++ b/bench/README.md
@@ -207,6 +207,47 @@ bench/compare-criterion.sh \
   --bench codec
 ```
 
+### Local A/B recipe (the former CI workflow)
+
+There is no CI benchmark lane: the self-hosted runner behind the
+`Criterion Bench Compare` / `Criterion Bench Nightly` workflows was retired
+and both workflows were removed. They were thin wrappers around this script,
+so the recipe they ran is simply the local invocation below. Run it on a
+quiet host.
+
+```bash
+bench/compare-criterion.sh \
+  --base origin/main \
+  --head HEAD \
+  --package rustbgpd-rib \
+  --bench rib_ops \
+  --core 8 \
+  --attempts 4 \
+  --harness-ref HEAD \
+  --harness-path crates/rib/benches/rib_ops.rs \
+  --require-performance
+```
+
+- `--attempts` ≥ 3, always; even N cancels first-vs-second order bias. One
+  attempt cannot separate a delta from the host's own spread, and the summary
+  says so in its verdict block.
+- Pin one core (`--core`) and check the governor (`--require-performance`
+  where the host exposes cpufreq; on a virtualised host it cannot).
+- `--harness-ref HEAD --harness-path crates/rib/benches/rib_ops.rs` overlays
+  one benchmark source on both sides so a bench-file edit is not measured as a
+  code change; drop it when the benchmark itself is what changed.
+- Criterion takes `--save-baseline` *or* `--baseline`, never both in one run;
+  the script saves a baseline per ref and attempt and computes deltas from the
+  saved medians. `--bench NAME` is required per target because the libtest
+  lib target rejects `--save-baseline`.
+
+Honesty rule for anything pasted into a PR: interleaved samples, every run
+reported (no dropping the inconvenient attempt), no receipt claim from a busy
+host, and the noise floor is whatever a same-SHA control on *this* host at
+*this* shape measured — never a number carried over from another machine. The
+retired runner's ~11% spread was that runner's figure and transfers to
+nothing.
+
 ## VPN query campaign
 
 `run-vpn-query-campaign.sh` drives the retained VPN query benchmark
@@ -244,7 +285,9 @@ harnesses are excluded by name.
 
 See `bench/scale/README.md` for the manager-level `rrharness` and
 real-transport `rrtransport` scale drivers plus their scenario
-directories.
+directories. `bench/scale/compare-rrharness.sh` is the A/B runner for the
+rrharness flood/churn matrix between any two refs (usage and the pinned
+exact-export form are in `bench/scale/rrharness/README.md`).
 
 ## RIB memory compare
 

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -272,7 +272,9 @@ if [[ -n $lan395_gate_out ]]; then
     exit 2
   }
   "$repo/bench/scale/compare-rrharness.sh" \
-    --validate-only --base "$base_sha" --head "$head_sha"
+    --validate-only --base "$base_sha" --head "$head_sha" \
+    --pin "$repo/bench/scale/rebaseline/lan395-run-pin.env" \
+    --diff-path crates/rib/src/manager/distribution/mod.rs
 fi
 
 if [[ "$use_taskset" -eq 1 ]] && ! command -v taskset >/dev/null 2>&1; then
@@ -611,6 +613,7 @@ import json
 import os
 import statistics
 import sys
+from collections import Counter
 from pathlib import Path
 
 criterion_dir = Path(os.environ["CRITERION_DIR"])
@@ -846,6 +849,24 @@ elif rows:
     lines.append("No confident regressions by the configured verdict rule.")
 else:
     lines.append("No benchmark rows were discovered.")
+if rows:
+    counts = Counter(row[-1] for row in rows)
+    lines.append(
+        "Row verdicts: " + ", ".join(f"{name}={count}" for name, count in sorted(counts.items()))
+    )
+    if attempts < verdict_min_attempts:
+        lines.append(
+            f"Noise: {attempts} attempt(s) is below the {verdict_min_attempts} needed to "
+            "measure the across-attempt spread, so no row here is a regression or an "
+            f"improvement — rerun with --attempts >= {verdict_min_attempts} (interleaved) "
+            "before reading any delta as a result."
+        )
+    else:
+        lines.append(
+            "Noise: read stddev and min..max before mean delta; a row whose min..max "
+            "brackets zero is noise whatever its mean, and a same-SHA control on this host "
+            "at this shape is the only honest floor."
+        )
 
 summary_file.write_text("\n".join(lines) + "\n")
 print(summary_file.read_text())

--- a/bench/scale/compare-rrharness.sh
+++ b/bench/scale/compare-rrharness.sh
@@ -4,39 +4,49 @@ export PYTHONDONTWRITEBYTECODE=1
 
 usage() {
   cat <<'EOF'
-Run the pinned LAN-395 rrharness A/B matrix with fail-closed receipt gates.
+Run the rrharness flood/churn A/B matrix between two refs with fail-closed
+receipt mechanics.
 
 Usage: bench/scale/compare-rrharness.sh [options]
 
-  --base REF              Baseline ref (required; must resolve to pinned base)
-  --head REF              Candidate ref (required; must resolve to pinned head)
+  --base REF              Baseline ref (required)
+  --head REF              Candidate ref (required)
+  --pin FILE              Opt-in exactness: base/head must resolve to the
+                          pin's commits and the base..head diff of every
+                          --diff-path must hash to the pin's digest; the
+                          pinned throughput gates are then applied
+  --diff-path PATH        Repository-relative path hashed against --pin;
+                          repeatable; required with --pin
   --core N                CPU pinned with taskset (default: 5)
   --output-dir DIR        New, empty receipt directory
   --preflight-wait N      Per-cell idle wait in seconds (default: 120)
   --timeout N             Per-cell outer timeout in seconds (default: 600)
-  --validate-only         Verify pinned refs/tooling and exit before host access
+  --validate-only         Verify refs/tooling and exit before host access
   -h, --help              Show this help
 
 The matrix is fixed: flood 256/1000 x 100k and churn 256x256/1000x1000 x
-3000, each for 20 seconds, with two counterbalanced repetitions. The driver
-requires a clean invoking checkout, exact reviewed refs and production diff,
-the shared host lock, a performance-governor pinned CPU, load below 2.0, and
-no competing build/performance process before every fresh-process cell.
+3000, each for 20 seconds, with two counterbalanced repetitions of every
+shape (repetition 1 base-first, repetition 2 head-first). The driver requires
+a clean invoking checkout, an identical bench/scale/rrharness tree at both
+refs, the shared host lock, a performance-governor pinned CPU, load below
+2.0, and no competing build/performance process before every fresh-process
+cell. Both sides are built with `cargo build --release --locked` into
+separate target directories and launched as prebuilt binaries.
 
-The receipt is marked complete only if all 16 cells parse, every folded
-profile reclassifies exactly, every LAN-395 throughput gate passes, privacy
-checks pass, and the final checksum manifest verifies.
+Without --pin the receipt is advisory: comparison.csv (per cell) and
+summary.csv (per rung) report head-vs-base throughput with no pass/fail
+gate. With --pin the receipt is marked complete only if every pinned
+throughput gate passes.
 EOF
 }
 
-readonly expected_base_commit=b2ec55f21364978f26662b1ec35fd47ddcfce9a6
-readonly expected_head_commit=ea579bea4ad6602dc719a1664441f04330c5ef64
-readonly expected_production_diff_sha256=363ca576015ced26223b72b109acede0b88c1859db4cffb5c702d3d95ba236c4
 readonly load_one_max=2.0
 readonly required_governor=performance
 
 base_ref=
 head_ref=
+pin_path=
+diff_paths=()
 core=5
 output_dir=
 preflight_wait_seconds=120
@@ -47,6 +57,8 @@ while (($#)); do
   case "$1" in
     --base) base_ref=${2:?--base requires a ref}; shift 2 ;;
     --head) head_ref=${2:?--head requires a ref}; shift 2 ;;
+    --pin) pin_path=${2:?--pin requires a path}; shift 2 ;;
+    --diff-path) diff_paths+=("${2:?--diff-path requires a path}"); shift 2 ;;
     --core) core=${2:?--core requires a value}; shift 2 ;;
     --output-dir) output_dir=${2:?--output-dir requires a path}; shift 2 ;;
     --preflight-wait)
@@ -67,6 +79,18 @@ for value_name in preflight_wait_seconds cell_timeout_seconds; do
   value=${!value_name}
   [[ $value =~ ^[1-9][0-9]*$ ]] || {
     printf '%s must be a positive integer\n' "$value_name" >&2
+    exit 2
+  }
+done
+if [[ -n $pin_path ]]; then
+  ((${#diff_paths[@]})) || { printf '%s requires at least one --diff-path\n' --pin >&2; exit 2; }
+elif ((${#diff_paths[@]})); then
+  printf '%s requires --pin\n' --diff-path >&2
+  exit 2
+fi
+for diff_path in "${diff_paths[@]}"; do
+  [[ $diff_path != /* && "/${diff_path}/" != *"/../"* && "/${diff_path}/" != *"/./"* ]] || {
+    printf 'diff path must be repository-relative: %s\n' "$diff_path" >&2
     exit 2
   }
 done
@@ -93,7 +117,6 @@ canonical_criterion_driver="$repo_root/bench/compare-criterion.sh"
 canonical_parser="$repo_root/bench/scale/rebaseline/parse_rrharness.py"
 canonical_classifier="$repo_root/bench/scale/rebaseline/classify_cpu.py"
 canonical_criterion_validator="$repo_root/bench/scale/rebaseline/validate_lan395_criterion.py"
-pin_path="$repo_root/bench/scale/rebaseline/lan395-run-pin.env"
 driver_path=$0
 [[ $driver_path == */* ]] || driver_path=$(command -v -- "$driver_path")
 actual_driver=$(realpath "$driver_path")
@@ -101,69 +124,44 @@ actual_driver=$(realpath "$driver_path")
   printf 'driver must run from the canonical repository path: %s\n' "$canonical_driver" >&2
   exit 2
 }
-for source in \
-  "$canonical_driver" "$canonical_criterion_driver" "$canonical_parser" \
-  "$canonical_classifier" "$canonical_criterion_validator" "$pin_path"; do
+measurement_sources=(
+  "$canonical_driver" "$canonical_criterion_driver" "$canonical_parser"
+  "$canonical_classifier" "$canonical_criterion_validator"
+)
+if [[ -n $pin_path ]]; then
+  pin_path=$(realpath -- "$pin_path")
+  measurement_sources+=("$pin_path")
+fi
+for source in "${measurement_sources[@]}"; do
   [[ -f $source && ! -L $source ]] || {
-    printf 'pinned measurement source missing or not regular: %s\n' "$source" >&2
+    printf 'measurement source missing or not regular: %s\n' "$source" >&2
     exit 2
   }
 done
-
-mapfile -t invoking_parents < <(
-  git -C "$repo_root" rev-list --parents -n 1 "$invoking_head"
-)
-read -r -a invoking_parent_fields <<<"${invoking_parents[0]}"
-[[ ${#invoking_parent_fields[@]} -eq 2 ]] || {
-  printf 'measurement pin commit must have exactly one parent\n' >&2
-  exit 2
-}
-tooling_commit=${invoking_parent_fields[1]}
-tooling_parent_line=$(git -C "$repo_root" rev-list --parents -n 1 "$tooling_commit")
-read -r -a tooling_parent_fields <<<"$tooling_parent_line"
-[[ ${#tooling_parent_fields[@]} -eq 2 ]] || {
-  printf 'reviewed tooling commit must have exactly one parent\n' >&2
-  exit 2
-}
-[[ ${tooling_parent_fields[1]} == "$expected_head_commit" ]] || {
-  printf 'reviewed tooling must be a direct child of pinned production head\n' >&2
-  exit 2
-}
-mapfile -t pin_changed_files < <(
-  git -C "$repo_root" diff --name-only "$tooling_commit..$invoking_head"
-)
-[[ ${#pin_changed_files[@]} -eq 1 \
-  && ${pin_changed_files[0]} == bench/scale/rebaseline/lan395-run-pin.env ]] || {
-  printf 'invoking commit must add only the LAN-395 run pin over reviewed tooling\n' >&2
-  exit 2
-}
-git -C "$repo_root" diff --quiet "$tooling_commit..$invoking_head" -- \
-  bench/scale/compare-rrharness.sh \
-  bench/compare-criterion.sh \
-  bench/scale/rebaseline/parse_rrharness.py \
-  bench/scale/rebaseline/classify_cpu.py \
-  bench/scale/rebaseline/validate_lan395_criterion.py || {
-  printf 'measurement tooling differs from the reviewed tooling parent\n' >&2
-  exit 2
-}
 
 pin_value() {
   local key=$1
   awk -F= -v key="$key" '$1 == key { count += 1; value = substr($0, length(key) + 2) }
     END { if (count != 1 || value == "") exit 1; print value }' "$pin_path"
 }
-[[ $(wc -l <"$pin_path") -eq 5 ]] || {
-  printf 'LAN-395 run pin must contain exactly five canonical rows\n' >&2
-  exit 2
-}
-[[ $(pin_value schema) == rustbgpd.lan395-run-pin.v1 \
-  && $(pin_value base_commit) == "$expected_base_commit" \
-  && $(pin_value head_commit) == "$expected_head_commit" \
-  && $(pin_value production_diff_sha256) == "$expected_production_diff_sha256" \
-  && $(pin_value tooling_commit) == "$tooling_commit" ]] || {
-  printf 'LAN-395 run pin does not bind the exact reviewed refs and tooling\n' >&2
-  exit 2
-}
+pin_base_commit=
+pin_head_commit=
+pin_diff_sha256=
+pin_tooling_commit=
+if [[ -n $pin_path ]]; then
+  [[ $(wc -l <"$pin_path") -eq 5 ]] || {
+    printf 'run pin must contain exactly five canonical rows\n' >&2
+    exit 2
+  }
+  [[ $(pin_value schema) == rustbgpd.lan395-run-pin.v1 ]] || {
+    printf 'run pin schema is not rustbgpd.lan395-run-pin.v1\n' >&2
+    exit 2
+  }
+  pin_base_commit=$(pin_value base_commit)
+  pin_head_commit=$(pin_value head_commit)
+  pin_diff_sha256=$(pin_value production_diff_sha256)
+  pin_tooling_commit=$(pin_value tooling_commit)
+fi
 
 base_commit=$(git -C "$repo_root" rev-parse --verify "${base_ref}^{commit}") || {
   printf 'baseline ref does not resolve: %s\n' "$base_ref" >&2
@@ -173,71 +171,67 @@ head_commit=$(git -C "$repo_root" rev-parse --verify "${head_ref}^{commit}") || 
   printf 'candidate ref does not resolve: %s\n' "$head_ref" >&2
   exit 2
 }
-[[ $base_commit == "$expected_base_commit" ]] || {
-  printf 'baseline drift: expected %s, got %s\n' "$expected_base_commit" "$base_commit" >&2
-  exit 2
-}
-[[ $head_commit == "$expected_head_commit" ]] || {
-  printf 'candidate drift: expected %s, got %s\n' "$expected_head_commit" "$head_commit" >&2
-  exit 2
-}
-git -C "$repo_root" merge-base --is-ancestor "$base_commit" "$head_commit" || {
-  printf 'baseline is not an ancestor of candidate\n' >&2
+[[ $base_commit != "$head_commit" ]] || {
+  printf 'baseline and candidate resolve to the same commit\n' >&2
   exit 2
 }
 
-mapfile -t changed_files < <(git -C "$repo_root" diff --name-only "$base_commit..$head_commit")
-for changed_file in "${changed_files[@]}"; do
-  case "$changed_file" in
-    crates/rib/src/manager/distribution/mod.rs|\
-    crates/rib/src/manager/tests/exportability.rs|\
-    bench/scale/rebaseline/README.md|\
-    bench/scale/rebaseline/classify_cpu.py|\
-    bench/scale/rebaseline/fixtures/cpu.expected.tsv|\
-    bench/scale/rebaseline/fixtures/cpu.folded)
-      ;;
-    *)
-      printf 'base..head contains an unexpected change: %s\n' "$changed_file" >&2
-      exit 2
-      ;;
-  esac
-done
-[[ ${#changed_files[@]} -eq 6 ]] || {
-  printf 'base..head change set is incomplete: expected 6 paths, got %s\n' "${#changed_files[@]}" >&2
-  exit 2
-}
-
-production_diff_sha256=$(
+normalized_diff() {
   LC_ALL=C git -C "$repo_root" -c diff.algorithm=myers --no-pager diff \
     --no-ext-diff --no-textconv --no-color --abbrev=8 \
     --src-prefix=a/ --dst-prefix=b/ --indent-heuristic \
-    "$base_commit..$head_commit" -- crates/rib/src/manager/distribution/mod.rs \
-    | sha256sum | awk '{print $1}'
-)
-[[ $production_diff_sha256 == "$expected_production_diff_sha256" ]] || {
-  printf 'production diff drift: expected %s, got %s\n' \
-    "$expected_production_diff_sha256" "$production_diff_sha256" >&2
-  exit 2
+    "$base_commit..$head_commit" -- "$@"
 }
+
+production_diff_sha256=
+if [[ -n $pin_path ]]; then
+  [[ $base_commit == "$pin_base_commit" ]] || {
+    printf 'baseline drift: pin expects %s, got %s\n' "$pin_base_commit" "$base_commit" >&2
+    exit 2
+  }
+  [[ $head_commit == "$pin_head_commit" ]] || {
+    printf 'candidate drift: pin expects %s, got %s\n' "$pin_head_commit" "$head_commit" >&2
+    exit 2
+  }
+  git -C "$repo_root" merge-base --is-ancestor "$base_commit" "$head_commit" || {
+    printf 'baseline is not an ancestor of candidate\n' >&2
+    exit 2
+  }
+  production_diff_sha256=$(normalized_diff "${diff_paths[@]}" | sha256sum | awk '{print $1}')
+  [[ $production_diff_sha256 == "$pin_diff_sha256" ]] || {
+    printf 'production diff drift: pin expects %s, got %s\n' \
+      "$pin_diff_sha256" "$production_diff_sha256" >&2
+    exit 2
+  }
+fi
+
+mapfile -t changed_files < <(git -C "$repo_root" diff --name-only "$base_commit..$head_commit")
 
 git -C "$repo_root" diff --quiet "$base_commit..$head_commit" -- \
   bench/scale/rrharness || {
-  printf 'rrharness source, manifest, or lock differs between base and candidate\n' >&2
+  printf 'rrharness source or manifest differs between base and candidate; the instrument must be identical\n' >&2
   exit 2
 }
 
 if ((validate_only)); then
-  printf 'validated LAN-395 refs and tooling: pin=%s tooling=%s base=%s head=%s\n' \
-    "$invoking_head" "$tooling_commit" "$base_commit" "$head_commit"
+  if [[ -n $pin_path ]]; then
+    printf 'validated pinned refs and tooling: pin=%s base=%s head=%s diff=%s\n' \
+      "$pin_path" "$base_commit" "$head_commit" "$production_diff_sha256"
+  else
+    printf 'validated refs and tooling: base=%s head=%s changed_files=%s\n' \
+      "$base_commit" "$head_commit" "${#changed_files[@]}"
+  fi
   exit 0
 fi
-git -C "$repo_root" diff --quiet "$base_commit..$head_commit" -- \
-  Cargo.toml Cargo.lock .cargo rust-toolchain rust-toolchain.toml \
-  ':(glob)**/Cargo.toml' ':(glob)**/Cargo.lock' ':(glob)**/build.rs' \
-  ':(glob)**/.cargo/config' ':(glob)**/.cargo/config.toml' || {
-  printf 'Cargo, toolchain, build-script, or configuration input drifted\n' >&2
-  exit 2
-}
+if [[ -n $pin_path ]]; then
+  git -C "$repo_root" diff --quiet "$base_commit..$head_commit" -- \
+    Cargo.toml Cargo.lock .cargo rust-toolchain rust-toolchain.toml \
+    ':(glob)**/Cargo.toml' ':(glob)**/Cargo.lock' ':(glob)**/build.rs' \
+    ':(glob)**/.cargo/config' ':(glob)**/.cargo/config.toml' || {
+    printf 'Cargo, toolchain, build-script, or configuration input drifted under --pin\n' >&2
+    exit 2
+  }
+fi
 
 taskset -c "$core" true >/dev/null 2>&1 || {
   printf 'selected CPU cannot be used by taskset: %s\n' "$core" >&2
@@ -294,18 +288,28 @@ cp "$canonical_criterion_driver" "$source_dir/compare-criterion.sh"
 cp "$canonical_parser" "$source_dir/parse_rrharness.py"
 cp "$canonical_classifier" "$source_dir/classify_cpu.py"
 cp "$canonical_criterion_validator" "$source_dir/validate_lan395_criterion.py"
-cp "$pin_path" "$source_dir/lan395-run-pin.env"
-LC_ALL=C git -C "$repo_root" -c diff.algorithm=myers --no-pager diff \
-  --no-ext-diff --no-textconv --no-color --abbrev=8 \
-  --src-prefix=a/ --dst-prefix=b/ --indent-heuristic \
-  "$base_commit..$head_commit" -- crates/rib/src/manager/distribution/mod.rs \
-  >"$source_dir/production.patch"
-printf '%s  %s\n' "$production_diff_sha256" production.patch \
-  >"$source_dir/production-diff.sha256"
-(
-  cd "$source_dir"
-  sha256sum --check production-diff.sha256 >/dev/null
+expected_measurement_sources=(
+  classify_cpu.py
+  compare-criterion.sh
+  compare-rrharness.sh
+  compile-inputs.sha256
+  parse_rrharness.py
+  validate_lan395_criterion.py
 )
+pin_sha256=
+if [[ -n $pin_path ]]; then
+  cp "$pin_path" "$source_dir/run-pin.env"
+  pin_sha256=$(sha256sum "$source_dir/run-pin.env" | awk '{print $1}')
+  normalized_diff "${diff_paths[@]}" >"$source_dir/production.patch"
+  printf '%s  %s\n' "$production_diff_sha256" production.patch \
+    >"$source_dir/production-diff.sha256"
+  (
+    cd "$source_dir"
+    sha256sum --check production-diff.sha256 >/dev/null
+  )
+  expected_measurement_sources+=(production-diff.sha256 production.patch run-pin.env)
+fi
+printf '%s\n' "${changed_files[@]}" >"$output_dir/changed-files.txt"
 
 default_tmp='/'"tmp"
 scratch_root=${TMPDIR:-$default_tmp}
@@ -325,18 +329,23 @@ git -C "$repo_root" worktree add --detach "$base_tree" "$base_commit" >/dev/null
 git -C "$repo_root" worktree add --detach "$head_tree" "$head_commit" >/dev/null
 mkdir "$base_target" "$head_target"
 
+# Record every compile input that exists on either side. The rrharness tree is
+# already required to be identical; root and bench/scale lockfiles may differ
+# between refs (that is part of what a candidate changes) and are retained per
+# side so the receipt says exactly what each binary was built from.
 compile_input_manifest="$source_dir/compile-inputs.sha256"
 : >"$compile_input_manifest"
 for tracked_path in \
-  Cargo.toml Cargo.lock \
+  Cargo.toml Cargo.lock bench/scale/Cargo.toml bench/scale/Cargo.lock \
   bench/scale/rrharness/Cargo.toml bench/scale/rrharness/Cargo.lock \
   bench/scale/rrharness/src/main.rs; do
-  cmp --silent "$base_tree/$tracked_path" "$head_tree/$tracked_path" || {
-    printf 'base/candidate compile input mismatch: %s\n' "$tracked_path" >&2
-    exit 2
-  }
-  printf '%s  %s\n' "$(sha256sum "$base_tree/$tracked_path" | awk '{print $1}')" \
-    "$tracked_path" >>"$compile_input_manifest"
+  for side in base head; do
+    tree_var="${side}_tree"
+    file="${!tree_var}/$tracked_path"
+    [[ -f $file ]] || continue
+    printf '%s  %s/%s\n' "$(sha256sum "$file" | awk '{print $1}')" \
+      "$side" "$tracked_path" >>"$compile_input_manifest"
+  done
 done
 
 run_utc_start=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -383,6 +392,7 @@ done
 
 results="$output_dir/results.csv"
 comparison="$output_dir/comparison.csv"
+summary="$output_dir/summary.csv"
 preflight="$output_dir/preflight.tsv"
 execution="$output_dir/execution.tsv"
 printf '%s\n' \
@@ -518,8 +528,11 @@ for repetition in 1 2; do
   run_pair churn 1000 1000 3000 20 "$repetition"
 done
 
+gate_args=()
+[[ -n $pin_path ]] || gate_args=(--no-gates)
 python3 "$source_dir/parse_rrharness.py" compare \
-  --input "$results" --raw-dir "$raw_dir" --output "$comparison"
+  --input "$results" --raw-dir "$raw_dir" --output "$comparison" \
+  --summary "$summary" "${gate_args[@]}"
 
 (
   cd "$output_dir"
@@ -546,23 +559,49 @@ python3 "$source_dir/parse_rrharness.py" compare \
 
 run_utc_finish=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 cpu_model=$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)
+if [[ -n $pin_path ]]; then
+  receipt_status=all-throughput-gates-passed
+  receipt_gates=pinned
+else
+  receipt_status=advisory-no-gates
+  receipt_gates=none
+fi
+RRH_PIN_PATH_SHA256="$pin_sha256" \
+RRH_PIN_BASE="$pin_base_commit" RRH_PIN_HEAD="$pin_head_commit" \
+RRH_PIN_DIFF="$pin_diff_sha256" RRH_PIN_TOOLING="$pin_tooling_commit" \
+RRH_DIFF_PATHS="$(printf '%s\n' "${diff_paths[@]}")" \
+RRH_CHANGED_FILES="$output_dir/changed-files.txt" \
+RRH_STATUS="$receipt_status" RRH_GATES="$receipt_gates" \
 python3 - "$output_dir/manifest.json" <<PY
 import json
+import os
 from pathlib import Path
 
+env = os.environ
+pin = None
+if env["RRH_PIN_PATH_SHA256"]:
+    pin = {
+        "base_commit": env["RRH_PIN_BASE"],
+        "diff_paths": env["RRH_DIFF_PATHS"].split("\n"),
+        "head_commit": env["RRH_PIN_HEAD"],
+        "pin_sha256": env["RRH_PIN_PATH_SHA256"],
+        "production_diff_sha256": env["RRH_PIN_DIFF"],
+        "tooling_commit": env["RRH_PIN_TOOLING"],
+    }
+changed_files = Path(env["RRH_CHANGED_FILES"]).read_text(encoding="utf-8").split("\n")
 manifest = {
     "schema": "rustbgpd.rrharness-comparison.v1",
-    "status": "all-throughput-gates-passed",
+    "status": env["RRH_STATUS"],
+    "gates": env["RRH_GATES"],
     "run_utc_start": "$run_utc_start",
     "run_utc_finish": "$run_utc_finish",
     "invoking_commit": "$invoking_head",
-    "pin_commit": "$invoking_head",
-    "tooling_commit": "$tooling_commit",
+    "pin": pin,
     "base_commit": "$base_commit",
     "head_commit": "$head_commit",
     "base_tree": "$(git -C "$repo_root" rev-parse "${base_commit}^{tree}")",
     "head_tree": "$(git -C "$repo_root" rev-parse "${head_commit}^{tree}")",
-    "production_diff_sha256": "$production_diff_sha256",
+    "changed_files": [path for path in changed_files if path],
     "base_binary_sha256": "$base_binary_sha256",
     "head_binary_sha256": "$head_binary_sha256",
     "driver_sha256": "$(sha256sum "$source_dir/compare-rrharness.sh" | awk '{print $1}')",
@@ -570,7 +609,6 @@ manifest = {
     "parser_sha256": "$(sha256sum "$source_dir/parse_rrharness.py" | awk '{print $1}')",
     "classifier_sha256": "$(sha256sum "$source_dir/classify_cpu.py" | awk '{print $1}')",
     "criterion_validator_sha256": "$(sha256sum "$source_dir/validate_lan395_criterion.py" | awk '{print $1}')",
-    "run_pin_sha256": "$(sha256sum "$source_dir/lan395-run-pin.env" | awk '{print $1}')",
     "compile_inputs_sha256": "$(sha256sum "$compile_input_manifest" | awk '{print $1}')",
     "host_lock_source": "$host_lock_source",
     "host_lock_path_sha256": "$host_lock_sha256",
@@ -600,10 +638,16 @@ rm -rf "$rows_dir"
 # later raw-file drift cannot be blessed by a new top-level checksum while
 # results.csv still names the earlier bytes.
 final_comparison="$scratch/final-comparison.csv"
+final_summary="$scratch/final-summary.csv"
 python3 "$source_dir/parse_rrharness.py" compare \
-  --input "$results" --raw-dir "$raw_dir" --output "$final_comparison"
+  --input "$results" --raw-dir "$raw_dir" --output "$final_comparison" \
+  --summary "$final_summary" "${gate_args[@]}" >/dev/null
 cmp --silent "$comparison" "$final_comparison" || {
   printf 'final comparison differs from the gated matrix\n' >&2
+  exit 1
+}
+cmp --silent "$summary" "$final_summary" || {
+  printf 'final summary differs from the gated matrix\n' >&2
   exit 1
 }
 
@@ -611,26 +655,16 @@ cmp --silent "$comparison" "$final_comparison" || {
 # the complete reviewed source inventory here, after the last parser process,
 # so ignored caches, sidecars, symlinks, or other generated files cannot enter
 # the checksum envelope after review.
-expected_measurement_sources=(
-  classify_cpu.py
-  compare-criterion.sh
-  compare-rrharness.sh
-  compile-inputs.sha256
-  lan395-run-pin.env
-  parse_rrharness.py
-  production-diff.sha256
-  production.patch
-  validate_lan395_criterion.py
-)
+mapfile -t sorted_expected_sources < <(printf '%s\n' "${expected_measurement_sources[@]}" | LC_ALL=C sort)
 mapfile -d '' -t actual_measurement_sources < <(
   find "$source_dir" -mindepth 1 -maxdepth 1 -printf '%f\0' | LC_ALL=C sort -z
 )
-[[ ${#actual_measurement_sources[@]} -eq ${#expected_measurement_sources[@]} ]] || {
+[[ ${#actual_measurement_sources[@]} -eq ${#sorted_expected_sources[@]} ]] || {
   printf 'measurement-source inventory differs from the reviewed exact set\n' >&2
   exit 1
 }
-for source_index in "${!expected_measurement_sources[@]}"; do
-  [[ ${actual_measurement_sources[$source_index]} == "${expected_measurement_sources[$source_index]}" ]] || {
+for source_index in "${!sorted_expected_sources[@]}"; do
+  [[ ${actual_measurement_sources[$source_index]} == "${sorted_expected_sources[$source_index]}" ]] || {
     printf 'measurement-source inventory differs from the reviewed exact set\n' >&2
     exit 1
   }
@@ -687,7 +721,8 @@ final_manifest_tmp="$scratch/final-SHA256SUMS"
   sha256sum --check SHA256SUMS >/dev/null
   printf 'schema=rustbgpd.rrharness-comparison.v1\n' >COMPLETED
   printf 'sha256sums_sha256=%s\n' "$(sha256sum SHA256SUMS | awk '{print $1}')" >>COMPLETED
-  printf 'matrix_complete=1\nthroughput_gates_passed=1\n' >>COMPLETED
+  printf 'matrix_complete=1\ngates=%s\n' "$receipt_gates" >>COMPLETED
+  [[ $receipt_gates != pinned ]] || printf 'throughput_gates_passed=1\n' >>COMPLETED
 )
 
-printf 'complete LAN-395 rrharness receipt: %s\n' "$output_dir"
+printf 'complete rrharness receipt (%s): %s\n' "$receipt_status" "$output_dir"

--- a/bench/scale/rebaseline/parse_rrharness.py
+++ b/bench/scale/rebaseline/parse_rrharness.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Parse and gate the pinned LAN-395 rrharness comparison matrix."""
+"""Parse, summarise, and optionally gate the rrharness comparison matrix.
+
+`compare` applies the pinned throughput gates by default; `--no-gates` keeps
+every row advisory and `--summary PATH` adds a per-rung table.
+"""
 
 from __future__ import annotations
 
@@ -53,6 +57,21 @@ COMPARISON_FIELDS = (
     "required_improvement_percent",
     "maximum_regression_percent",
     "verdict",
+)
+
+SUMMARY_FIELDS = (
+    "mode",
+    "clients",
+    "candidates",
+    "prefixes",
+    "rate_name",
+    "repetitions",
+    "base_rate_mean",
+    "head_rate_mean",
+    "head_improvement_percent_mean",
+    "head_improvement_percent_min",
+    "head_improvement_percent_max",
+    "reading",
 )
 
 EXPECTED_SHAPES = {
@@ -397,14 +416,19 @@ def compare_command(args: argparse.Namespace) -> None:
         base_rate = finite_number(variants["base"]["rate"], "base rate")
         head_rate = finite_number(variants["head"]["rate"], "head rate")
         improvement = (head_rate / base_rate - 1.0) * 100.0
-        required_improvement = 15.0 if mode == "churn" or clients == 1000 else 0.0
-        maximum_regression = 5.0 if clients == 256 else 0.0
-        verdict = "pass"
-        if required_improvement and improvement + 1e-9 < required_improvement:
-            verdict = "fail-improvement"
-        elif maximum_regression and improvement < -maximum_regression - 1e-9:
-            verdict = "fail-regression"
-        failed |= verdict != "pass"
+        if args.no_gates:
+            required_improvement = 0.0
+            maximum_regression = 0.0
+            verdict = "advisory"
+        else:
+            required_improvement = 15.0 if mode == "churn" or clients == 1000 else 0.0
+            maximum_regression = 5.0 if clients == 256 else 0.0
+            verdict = "pass"
+            if required_improvement and improvement + 1e-9 < required_improvement:
+                verdict = "fail-improvement"
+            elif maximum_regression and improvement < -maximum_regression - 1e-9:
+                verdict = "fail-regression"
+            failed |= verdict != "pass"
         comparisons.append(
             {
                 "mode": mode,
@@ -426,8 +450,68 @@ def compare_command(args: argparse.Namespace) -> None:
         writer = csv.DictWriter(handle, fieldnames=COMPARISON_FIELDS, lineterminator="\n")
         writer.writeheader()
         writer.writerows(comparisons)
+    if args.summary is not None:
+        write_summary(args.summary, comparisons)
     if failed:
         raise ValueError("one or more LAN-395 throughput gates failed")
+
+
+def write_summary(path: Path, comparisons: list[dict[str, object]]) -> None:
+    """One row per rung across its repetitions, plus a printed table.
+
+    `reading` is deliberately coarse: with two counterbalanced repetitions a
+    rung is `noise` when the per-repetition deltas straddle zero and only
+    `head-faster` / `head-slower` when both agree in sign. It is a reading of
+    this run, not a pass/fail verdict.
+    """
+    rungs: dict[tuple[object, ...], list[dict[str, object]]] = {}
+    for row in comparisons:
+        key = (row["mode"], row["clients"], row["candidates"], row["prefixes"])
+        rungs.setdefault(key, []).append(row)
+    summary_rows: list[dict[str, object]] = []
+    for (mode, clients, candidates, prefixes), rows in rungs.items():
+        deltas = [float(row["head_improvement_percent"]) for row in rows]
+        base_mean = sum(float(row["base_rate"]) for row in rows) / len(rows)
+        head_mean = sum(float(row["head_rate"]) for row in rows) / len(rows)
+        if min(deltas) <= 0.0 <= max(deltas):
+            reading = "noise"
+        elif min(deltas) > 0.0:
+            reading = "head-faster"
+        else:
+            reading = "head-slower"
+        summary_rows.append(
+            {
+                "mode": mode,
+                "clients": clients,
+                "candidates": candidates,
+                "prefixes": prefixes,
+                "rate_name": "blocks_per_s" if mode == "flood" else "waves_per_s",
+                "repetitions": len(rows),
+                "base_rate_mean": f"{base_mean:.6f}",
+                "head_rate_mean": f"{head_mean:.6f}",
+                "head_improvement_percent_mean": f"{sum(deltas) / len(deltas):.3f}",
+                "head_improvement_percent_min": f"{min(deltas):.3f}",
+                "head_improvement_percent_max": f"{max(deltas):.3f}",
+                "reading": reading,
+            }
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=SUMMARY_FIELDS, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(summary_rows)
+    print(
+        f"{'rung':<22} {'reps':>4} {'base rate':>14} {'head rate':>14} "
+        f"{'delta% mean':>11} {'min..max':>18}  reading"
+    )
+    for row in summary_rows:
+        rung = f"{row['mode']} {row['clients']}x{row['candidates']}x{row['prefixes']}"
+        print(
+            f"{rung:<22} {row['repetitions']:>4} {row['base_rate_mean']:>14} "
+            f"{row['head_rate_mean']:>14} {row['head_improvement_percent_mean']:>11} "
+            f"{row['head_improvement_percent_min']:>8}..{row['head_improvement_percent_max']:<8}  "
+            f"{row['reading']}"
+        )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -449,6 +533,12 @@ def build_parser() -> argparse.ArgumentParser:
     compare.add_argument("--input", type=Path, required=True)
     compare.add_argument("--raw-dir", type=Path, required=True)
     compare.add_argument("--output", type=Path, required=True)
+    compare.add_argument("--summary", type=Path, help="per-rung summary CSV (also printed)")
+    compare.add_argument(
+        "--no-gates",
+        action="store_true",
+        help="keep every row advisory instead of applying the pinned throughput gates",
+    )
     compare.set_defaults(run=compare_command)
     return parser
 

--- a/bench/scale/rebaseline/test_parse_rrharness.py
+++ b/bench/scale/rebaseline/test_parse_rrharness.py
@@ -310,6 +310,38 @@ rss_end_mib 210
             )
             self.assertFalse(comparison.exists())
 
+    def test_no_gates_keeps_rows_advisory_and_writes_rung_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory_text:
+            directory = Path(directory_text)
+            matrix = directory / "matrix.csv"
+            raw_dir = directory / "raw"
+            comparison = directory / "comparison.csv"
+            summary = directory / "summary.csv"
+            # 1.14 misses the pinned 15% gate; without gates it is just a reading.
+            self.write_matrix(matrix, raw_dir, head_multiplier=1.14)
+            result = self.run_parser(
+                "compare",
+                "--input",
+                str(matrix),
+                "--raw-dir",
+                str(raw_dir),
+                "--output",
+                str(comparison),
+                "--summary",
+                str(summary),
+                "--no-gates",
+            )
+            with comparison.open(newline="", encoding="utf-8") as handle:
+                rows = list(csv.DictReader(handle))
+            self.assertEqual({row["verdict"] for row in rows}, {"advisory"})
+            with summary.open(newline="", encoding="utf-8") as handle:
+                rungs = list(csv.DictReader(handle))
+            self.assertEqual(len(rungs), 4)
+            self.assertEqual({row["reading"] for row in rungs}, {"head-faster"})
+            self.assertEqual({row["repetitions"] for row in rungs}, {"2"})
+            self.assertEqual({row["head_improvement_percent_mean"] for row in rungs}, {"14.000"})
+            self.assertIn("head-faster", result.stdout)
+
     def test_matrix_rejects_tampered_numeric_and_hash_evidence(self) -> None:
         mutations = {
             "nonfinite rate": ("rate", "NaN"),

--- a/bench/scale/rrharness/README.md
+++ b/bench/scale/rrharness/README.md
@@ -96,18 +96,50 @@ rrharness churn 256  256  3000 20 churn-256-{a,b}
 rrharness churn 1000 1000 3000 20 churn-1000-{a,b}
 ```
 
-For the pinned LAN-395 A/B campaign, use
-[`../compare-rrharness.sh`](../compare-rrharness.sh). It builds the exact base
-and candidate in detached worktrees, launches prebuilt binaries directly on a
-performance-governor CPU, counterbalances two repetitions of every shape, and
-refuses to complete a receipt unless every log/profile parses and every
-throughput gate passes. The companion parser and its adversarial tests live in
+To A/B that matrix between two refs, use
+[`../compare-rrharness.sh`](../compare-rrharness.sh). It builds base and
+candidate in detached worktrees with `cargo build --release --locked` into
+separate target directories, launches the prebuilt binaries directly on a
+`taskset`-pinned performance-governor CPU behind the shared host lock, waits
+for an idle host before every cell, and runs two counterbalanced repetitions
+of every shape (repetition 1 base-first, repetition 2 head-first). The
+rrharness tree must be identical at both refs — the instrument cannot be part
+of the change.
+
+```text
+bench/scale/compare-rrharness.sh \
+  --base origin/main \
+  --head my-branch \
+  --core 5 \
+  --output-dir target/rrharness-compare/my-branch
+```
+
+Without `--pin` the receipt is advisory: `comparison.csv` has one row per
+cell, `summary.csv` one row per rung (mean/min/max head-vs-base throughput
+and a `noise` / `head-faster` / `head-slower` reading), and the manifest
+records `"gates": "none"`. Two repetitions are a reading, not a verdict;
+report every run.
+
+`--pin FILE --diff-path PATH` is the opt-in exact form used for the original
+grouped exact-export A/B: base and head must resolve to the pin's commits, the
+normalized `base..head` diff of every `--diff-path` must hash to the pin's
+digest, Cargo/toolchain inputs may not drift, and the pinned throughput gates
+are applied. That campaign reproduces as:
+
+```text
+bench/scale/compare-rrharness.sh \
+  --base b2ec55f21364978f26662b1ec35fd47ddcfce9a6 \
+  --head ea579bea4ad6602dc719a1664441f04330c5ef64 \
+  --pin bench/scale/rebaseline/lan395-run-pin.env \
+  --diff-path crates/rib/src/manager/distribution/mod.rs \
+  --core 5 \
+  --output-dir target/rrharness-compare/reproduction
+```
+
+The companion parser and its adversarial tests live in
 [`../rebaseline/parse_rrharness.py`](../rebaseline/parse_rrharness.py) and
-[`../rebaseline/test_parse_rrharness.py`](../rebaseline/test_parse_rrharness.py).
-Retained runs must execute from the canonical driver in a clean pin commit;
-that commit may add only `lan395-run-pin.env` over the reviewed tooling parent.
-This binds the driver, parser, classifier, production refs, and normalized
-production diff before the shared host lock or any build begins.
+[`../rebaseline/test_parse_rrharness.py`](../rebaseline/test_parse_rrharness.py);
+`bench/tests/test-rrharness-driver.sh` covers the driver's refusals.
 
 A tiny smoke shape (`flood 4 100 2 /tmp/smoke`) runs in a couple of seconds and
 emits a folded profile.

--- a/bench/tests/test-rrharness-driver.sh
+++ b/bench/tests/test-rrharness-driver.sh
@@ -1,31 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo=$(git rev-parse --show-toplevel)
-driver="$repo/bench/scale/compare-rrharness.sh"
-pin_rel=bench/scale/rebaseline/lan395-run-pin.env
-pin="$repo/$pin_rel"
-
-# The retained driver deliberately refuses to measure from any descendant of
-# the exact pin commit. Once the receipt documentation is added above that
-# commit, run the mechanics suite from a clean detached pin worktree instead
-# of weakening the measurement fence for ordinary CI checkouts.
-pin_commit=$(git -C "$repo" log -1 --format=%H -- "$pin_rel")
-current_commit=$(git -C "$repo" rev-parse --verify HEAD)
-if [[ $current_commit != "$pin_commit" ]]; then
-  pin_worktree=$(mktemp -d "${TMPDIR:-/tmp}/lan395-pin-worktree.XXXXXX")
-  rmdir "$pin_worktree"
+# The driver requires a clean invoking checkout, so exercise it from a fresh
+# detached worktree at HEAD rather than trusting the caller's tree (CI leaves
+# build output around; a developer may have edits in flight).
+if [[ -z ${RRHARNESS_DRIVER_TEST_WORKTREE:-} ]]; then
+  origin=$(git rev-parse --show-toplevel)
+  worktree=$(mktemp -d "${TMPDIR:-/tmp}/rrharness-driver-test.XXXXXX")
+  rmdir "$worktree"
   # shellcheck disable=SC2317 # Invoked indirectly by the trap below.
-  cleanup_pin_worktree() {
-    git -C "$repo" worktree remove --force "$pin_worktree" >/dev/null 2>&1 || true
+  cleanup_worktree() {
+    git -C "$origin" worktree remove --force "$worktree" >/dev/null 2>&1 || true
   }
-  trap cleanup_pin_worktree EXIT INT TERM
-  git -C "$repo" worktree add --detach "$pin_worktree" "$pin_commit" >/dev/null
-  (cd "$pin_worktree" && bench/tests/test-rrharness-driver.sh)
+  trap cleanup_worktree EXIT INT TERM
+  git -C "$origin" worktree add --detach "$worktree" HEAD >/dev/null
+  (cd "$worktree" && RRHARNESS_DRIVER_TEST_WORKTREE=1 bench/tests/test-rrharness-driver.sh)
   exit
 fi
 
-marker="$repo/.lan395-dirty-probe"
+repo=$(git rev-parse --show-toplevel)
+driver="$repo/bench/scale/compare-rrharness.sh"
+pin="$repo/bench/scale/rebaseline/lan395-run-pin.env"
+diff_path=crates/rib/src/manager/distribution/mod.rs
+
+marker="$repo/.rrharness-dirty-probe"
 external_driver=$(mktemp "${TMPDIR:-/tmp}/compare-rrharness.XXXXXX")
 privacy_fixture=$(mktemp -d "${TMPDIR:-/tmp}/rrharness-privacy.XXXXXX")
 cleanup() {
@@ -39,43 +37,46 @@ pin_value() {
   awk -F= -v key="$key" '$1 == key { print substr($0, length(key) + 2) }' "$pin"
 }
 
+expect_rc() {
+  local expected=$1 label=$2 rc=0
+  shift 2
+  "$@" >/dev/null 2>&1 || rc=$?
+  [[ $rc -eq $expected ]] || {
+    printf '%s returned %s instead of %s\n' "$label" "$rc" "$expected" >&2
+    exit 1
+  }
+}
+
 base=$(pin_value base_commit)
 head=$(pin_value head_commit)
 [[ -n $base && -n $head ]]
+git -C "$repo" cat-file -e "${base}^{commit}"
+git -C "$repo" cat-file -e "${head}^{commit}"
 
+"$driver" --help >/dev/null
 "$driver" --validate-only --base "$base" --head "$head" >/dev/null
+"$driver" --validate-only --base "$base" --head "$head" \
+  --pin "$pin" --diff-path "$diff_path" >/dev/null
 
-set +e
-"$driver" --validate-only --base "$head" --head "$head" >/dev/null 2>&1
-wrong_ref_rc=$?
-set -e
-[[ $wrong_ref_rc -eq 2 ]] || {
-  printf 'wrong pinned ref returned %s instead of 2\n' "$wrong_ref_rc" >&2
-  exit 1
-}
+expect_rc 2 'missing --base' "$driver" --validate-only --head "$head"
+expect_rc 2 'identical refs' "$driver" --validate-only --base "$head" --head "$head"
+expect_rc 2 'pinned ref drift' "$driver" --validate-only \
+  --base "${base}~1" --head "$head" --pin "$pin" --diff-path "$diff_path"
+expect_rc 2 '--pin without --diff-path' "$driver" --validate-only \
+  --base "$base" --head "$head" --pin "$pin"
+expect_rc 2 '--diff-path without --pin' "$driver" --validate-only \
+  --base "$base" --head "$head" --diff-path "$diff_path"
+expect_rc 2 'pinned diff drift' "$driver" --validate-only \
+  --base "$base" --head "$head" --pin "$pin" --diff-path bench/scale/rrharness/README.md
 
 cp "$driver" "$external_driver"
 chmod +x "$external_driver"
-set +e
-"$external_driver" --validate-only --base "$base" --head "$head" >/dev/null 2>&1
-external_rc=$?
-set -e
-[[ $external_rc -eq 2 ]] || {
-  printf 'external driver returned %s instead of 2\n' "$external_rc" >&2
-  exit 1
-}
+expect_rc 2 'external driver' "$external_driver" --validate-only --base "$base" --head "$head"
 
 [[ ! -e $marker ]]
 touch "$marker"
-set +e
-"$driver" --validate-only --base "$base" --head "$head" >/dev/null 2>&1
-dirty_rc=$?
-set -e
+expect_rc 1 'dirty checkout' "$driver" --validate-only --base "$base" --head "$head"
 rm -f "$marker"
-[[ $dirty_rc -eq 1 ]] || {
-  printf 'dirty checkout returned %s instead of 1\n' "$dirty_rc" >&2
-  exit 1
-}
 
 mkdir -p "$privacy_fixture/measurement-sources" "$privacy_fixture/raw"
 printf 'pid vocabulary belongs in retained reviewed source\n' \
@@ -110,9 +111,12 @@ rg -F 'privacy scan failed while inspecting' "$driver" >/dev/null || {
   printf 'rrharness driver does not fail closed on privacy scanner errors\n' >&2
   exit 1
 }
-
 rg -F 'export PYTHONDONTWRITEBYTECODE=1' "$driver" >/dev/null || {
   printf 'rrharness driver does not disable retained Python bytecode writes\n' >&2
+  exit 1
+}
+rg -F 'cargo build --release --locked' "$driver" >/dev/null || {
+  printf 'rrharness driver does not build both sides with --release --locked\n' >&2
   exit 1
 }
 mkdir "$privacy_fixture/python-import"
@@ -124,4 +128,4 @@ PYTHONPATH="$privacy_fixture/python-import" PYTHONDONTWRITEBYTECODE=1 \
   exit 1
 }
 
-printf 'LAN-395 rrharness driver mechanics passed\n'
+printf 'rrharness driver mechanics passed\n'


### PR DESCRIPTION
## Summary

Keeps the A/B method alive locally now that the CI bench workflows are gone.

- `bench/scale/compare-rrharness.sh` compares any two refs. `--base`/`--head` are the only required inputs. The driver keeps its fail-closed mechanics — clean invoking checkout, identical `bench/scale/rrharness` tree at both refs, `cargo build --release --locked` into separate target directories, prebuilt binaries under `taskset` on a performance-governor CPU behind the shared host lock, per-cell idle preflight, two counterbalanced repetitions of every shape (rep 1 base-first, rep 2 head-first), privacy scan, checksum envelope — and drops the hard-coded historical refs, diff digest, and tooling-chain ancestry fence that bound it to one commit. The original grouped exact-export A/B is opt-in via `--pin FILE --diff-path PATH` (same five-row pin file; base/head must match, the normalized `base..head` diff of the `--diff-path` set must hash to the pin, Cargo/toolchain inputs may not drift, pinned throughput gates applied). Unpinned runs are advisory: `comparison.csv` per cell, a new per-rung `summary.csv` (mean/min/max head-vs-base throughput + `noise`/`head-faster`/`head-slower` reading, also printed as a table), manifest `"gates": "none"`.
- `bench/scale/rebaseline/parse_rrharness.py compare` gains `--no-gates` and `--summary PATH`; one unit test added.
- `bench/compare-criterion.sh` — already the recipe the deleted `bench.yml` wrapped, so no duplicate script is added — now ends its summary with a verdict histogram and an explicit noise line (with fewer than `--verdict-min-attempts` attempts no row is called a regression or an improvement). Its pinned-receipt mode passes `--pin`/`--diff-path` to the rrharness driver.
- `bench/tests/test-rrharness-driver.sh` now runs against HEAD (fresh detached worktree) instead of the historical pin commit, covering free + pinned validate-only, ref drift, diff-digest drift, missing/extra pin flags, external-copy and dirty-checkout refusals, and the privacy-scan fixtures.
- `bench/README.md` documents the local Criterion A/B recipe (the former workflow invocation, the `--save-baseline`/`--baseline` exclusivity and per-target `--bench` rules, the honesty rule); `bench/scale/rrharness/README.md` documents the generic and pinned rrharness invocations.

## Usage

```
bench/scale/compare-rrharness.sh --base REF --head REF [--pin FILE --diff-path PATH ...] [--core N] [--output-dir DIR] [--preflight-wait N] [--timeout N] [--validate-only]
bench/compare-criterion.sh --base REF --head REF --package NAME --bench NAME [--filter TEXT] [--core CPU] [--attempts N] [--require-performance] [--harness-ref REF --harness-path PATH] ...
```

## Gates (all exit 0)

`bash -n` + `shellcheck` on the three changed shell scripts; `--help` dry-runs of both drivers and the parser; `python3 -m unittest discover -s bench/scale/rebaseline -p 'test_*.py'` (38 tests); `bench/tests/test-rrharness-driver.sh`; `bench/tests/test-compare-criterion-harness.sh`; `scripts/check_public_tracker_ids.py`; one real plumbing smoke `bench/compare-criterion.sh --base HEAD --head HEAD --attempts 1 --package rustbgpd-policy --bench explain_snapshot --core 60` — both rows `insufficient-attempts`, verdict block prints the noise line (base==head measured −1.57% / −3.43% on a single attempt, which is exactly why the line exists).
