### PR TITLE
feat: add a read-only rs-config-render status verb for activation and lifecycle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   > `refresh_interval`; unset changes nothing. The new
   `bgp_rpki_cache_effective_expire_seconds{cache}` gauge shows the effective
   expire per cache.
+- `rs-config-render status` reports the activation and lifecycle state of one
+  handle without changing it: the host fence, the lifecycle journal (phase,
+  callback, outcome, error class, upstream-lock disposition), the `current`
+  generation versus the journal's candidate, the advisory activation receipt,
+  and, with `--rbgp`, the settle path's own health and config-diff probe. It
+  prints one `key: value` line per field in a fixed order, takes no lock, exits
+  0 for any readable state (manual recovery included) and 1 only when the state
+  directory is unreadable. The manual-recovery runbook's "is the candidate
+  live?" step now reads its output. (LAN-1229)
 - `rs-config-render prune --keep N` removes activation generations that no
   retention rule keeps: the `current` target, the last activation receipt's
   candidate and predecessor, anything a pending lifecycle journal names, and

--- a/docs/cookbook/activation-manual-recovery.md
+++ b/docs/cookbook/activation-manual-recovery.md
@@ -29,118 +29,74 @@ rs-config-render: IXP Manager lifecycle: manual recovery required; upstream lock
 rs-config-render: activation: recovery required; inspect private activation state
 ```
 
-`current` points at the candidate generation, not the one that was live
-before, and an owner fence stands in the shared host-state directory:
+Then read the state with `status`. It takes the same binding flags as
+`activate`, changes nothing (no lock, nothing written), and with `--rbgp` runs
+the helper's own settlement probe against the daemon:
 
 ```bash
-readlink $STATE/current
-ls -la $HOST
+rs-config-render status --router-handle rs1-ipv4 \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 --state-dir $STATE \
+  --host-state-dir $HOST --rbgp-addr $UDS --rbgp /usr/bin/rbgp
 ```
 
 ```text
-generations/53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c
--rw------- 1 rustbgpd rustbgpd  274 Aug 22 15:01 ixp-manager-host-fence.json
--rw------- 1 rustbgpd rustbgpd    0 Aug 22 15:01 ixp-manager-host.lock
+fence: present
+journal: present
+phase: manual_recovery
+callback: none
+callback_attempts: 0
+activation_outcome: recovery_required
+error_class: activation
+lock: retained
+current: generations/53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c
+candidate: generations/53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c
+current_is_candidate: yes
+advisory_receipt: matches-current
+advisory_receipt_status: recovery_required
+advisory_receipt_previous_generation: generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a
+daemon: healthy
+runtime_equals_current: no
 ```
 
-If the receipt was written, it says so (the next step covers when it was not):
-
-```bash
-grep -E '"(status|candidate_sha256|previous_generation|runtime_equal)"' $STATE/activation-receipt.json
-```
-
-```text
-  "candidate_sha256": "53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c",
-    "runtime_equal": false
-  "previous_generation": "generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a",
-  "status": "recovery_required",
-```
-
-A lifecycle run additionally leaves a journal with the lock still owed:
-
-```bash
-grep -E '"(phase|callback|activation_outcome|error_class)"' $STATE/ixp-manager-lifecycle.json
-```
-
-```text
-  "phase": "manual_recovery",
-  "callback": null,
-  "activation_outcome": "recovery_required",
-  "error_class": "activation"
-```
+`fence: present` is the owner fence standing in the shared host-state
+directory: while it stands, `resume` and every new `run` or `activate` answer
+with the same exit 5 line and touch nothing (`resume` has no action for this
+phase). `current_is_candidate: yes` says `current` was moved onto the candidate
+and `advisory_receipt_previous_generation` names what was live before.
 
 `error_class` tells you how far it got. `activation` (the case this runbook
 walks) means the candidate was rendered, `current` was moved, and the
-activation command started. `transport`, `status`, or `control_body` mean the
-*lock request itself* was ambiguous: nothing was rendered or moved, `current`
-is unchanged, and you can go straight to steps 3 and 5. A plain `activate`
-leaves no journal and holds no upstream lock — skip step 3.
+activation command started; `lock: retained` means the IXP Manager update lock
+is still owed. `transport`, `status`, or `control_body` mean the *lock request
+itself* was ambiguous: the output then reads `activation_outcome: none`,
+`lock: unknown`, `candidate: none`, `current_is_candidate: no` — nothing was
+rendered or moved — and you can go straight to steps 3 and 5. A plain
+`activate` leaves no journal (`journal: absent`, `lock: none`) and holds no
+upstream lock — skip step 3.
 
-While the fence stands, `resume` and every new `run` or `activate` answer with
-the same exit 5 line and touch nothing; `resume` has no action for this phase.
+The activation receipt is advisory: `advisory_receipt: stale` or `absent`
+means its final write never landed (step 4). The journal, the fence, and the
+generation tree are the state; the receipt is not.
 
 ## 1. Is the candidate live and healthy, live and broken, or down?
 
-The helper's settlement test is `rbgp health` plus `rbgp config diff` against
-the candidate; run the same two by hand. The generation's `config.toml` names
-its policy files relatively, and the daemon resolves those against its own
-working directory, so diff a copy with the paths rewritten to the live
-`current/` prefix (exactly what the helper compares):
+The last two `status` lines are the helper's own settlement test — `rbgp
+health`, then `rbgp config diff` against the `current` generation with its
+policy paths rewritten to the live `current/` prefix (exactly what the helper
+compares). Read them together:
 
-```bash
-rbgp --addr $UDS health
-umask 077
-sed 's#"policy/#"'"$STATE"'/current/policy/#' $STATE/current/config.toml > $STATE/.compare.toml
-rbgp --addr $UDS config diff $STATE/.compare.toml; echo "rc=$?"
-rm $STATE/.compare.toml
-```
+| `daemon` | `runtime_equals_current` | Meaning |
+|---|---|---|
+| `healthy` | `yes` | **Live and equal**: the reload landed; the helper only ran out of settle budget, or the receipt write failed afterwards. |
+| `healthy` | `no` | **Live but still on the previous generation**: the activation command ran and failed without reloading (a sudoers denial, a wrong unit name) or the daemon rejected the reload. The daemon log has no `config reload complete` line for the attempt. |
+| `unreachable` | `unknown` | **Down**: a restart took the old process out and the new one never came up. |
+| `unhealthy`, or `invalid` | any | **Live and broken**: treat it as the down case and prefer the previous generation. |
 
-**Live and equal** (the reload landed; the helper only ran out of settle
-budget, or the receipt write failed afterwards):
-
-```text
-Status:  healthy
-Uptime:  00:00:05
-Peers:   0
-Routes:  0
-No changes.
-rc=0
-```
-
-**Live but still on the previous generation** (the activation command ran and
-failed without reloading — a sudoers denial, a wrong unit name — or the daemon
-rejected the reload). The diff lists exactly what the daemon is missing:
-
-```text
-Status:  healthy
-Reload-applied changes:
-
-  Neighbors:
-    ~ 10.1.0.10:
-        max_prefixes_ipv4: 900 → 1000  [hot-applied]
-
-Plan: 1 to change · no session resets expected
-rc=2
-```
-
-Confirm by diffing the previous generation from the receipt the same way
-(`sed … $STATE/generations/<previous_generation>/config.toml`, still rewriting
-to the `current/` prefix): `No changes.` / `rc=0` means the daemon runs the
-previous generation. If the two generations differ only in policy files this
-comparison reads them through `current/`, so re-point first (step 2) and diff
-again. The daemon log has no `config reload complete` line for the attempt.
-
-**Down** (a restart took the old process out and the new one never came up):
-
-```text
-Error: cannot reach rustbgpd at unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock (socket does not exist)
-  hint: is the daemon running? if it uses a different endpoint, pass -s or set RUSTBGPD_ADDR
-rc=1
-```
-
-`healthy: false` from `rbgp --json health`, or a diff that errors on a reachable
-daemon, is "live and broken": treat it as the down case and prefer the previous
-generation.
+To see *what* the daemon is missing in the second row, or to confirm it runs
+the previous generation, run the diff by hand
+([appendix A](#a-reading-the-state-by-hand)). If the two generations differ
+only in policy files that comparison reads them through `current/`, so
+re-point first (step 2) and diff again.
 
 ## 2. Keep the candidate or roll back
 
@@ -167,14 +123,9 @@ generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a
 | Live on the previous generation | Run your activation command by hand. | Re-point only; the daemon already runs it. |
 | Down | Run your activation command by hand (`reload-or-restart` starts a stopped unit on `current`). | Re-point, then run your activation command by hand. |
 
-Then repeat step 1 until it reads `No changes.` / `rc=0` — that is the
-"current and daemon agree" state every later helper run requires:
-
-```text
-Status:  healthy
-No changes.
-rc=0
-```
+Then repeat `status --rbgp` until it reads `daemon: healthy` and
+`runtime_equals_current: yes` — that is the "current and daemon agree" state
+every later helper run requires.
 
 Whichever you chose decides the callback in step 3: kept means `updated`,
 rolled back means `release-update-lock`.
@@ -221,19 +172,14 @@ rolled away from.
 ## 4. The activation receipt may be absent or stale
 
 Exit 5 also covers "the receipt's final write or directory sync failed", so
-before re-running anything check whether `activation-receipt.json` describes
-this attempt at all:
-
-```bash
-grep -E '"(status|candidate_sha256)"' $STATE/activation-receipt.json; readlink $STATE/current
-```
-
-It describes this attempt when `candidate_sha256` equals the generation
-`current` pointed at when you arrived. A receipt naming an older generation
-(or `"status": "activated"` for the previous run, or no file) is stale: the
-write never landed, and `previous_generation` is then whatever generation
-`current` pointed at *before* the failed run — confirm it by the diff in step 1
-rather than the receipt. After a rollback the receipt is stale by construction
+before re-running anything check the `advisory_receipt` line of `status`.
+`matches-current` means the receipt describes this attempt (its
+`candidate_sha256` equals the generation `current` pointed at when you
+arrived). `stale` (a receipt naming an older generation, or `"status":
+"activated"` for the previous run) or `absent` means the write never landed,
+and `previous_generation` is then whatever generation `current` pointed at
+*before* the failed run — confirm it by the hand diff in appendix A rather than
+the receipt. After a rollback the receipt is stale by construction
 (it still names the candidate). Leave it alone: the helper never reads it back
 — it verifies the render receipt inside each generation instead — and the next
 successful run rewrites it.
@@ -242,7 +188,8 @@ successful run rewrites it.
 
 The fence and the journal are the helper's own proof that a human has not yet
 decided; clearing them is not currently supported as a command. The manual
-procedure, once steps 1–4 are done and step 1 reads `No changes.`:
+procedure, once steps 1–4 are done and `status --rbgp` reads `daemon: healthy`
+and `runtime_equals_current: yes`:
 
 ```bash
 rm $STATE/ixp-manager-lifecycle.json $HOST/ixp-manager-host-fence.json && sync $STATE $HOST
@@ -274,6 +221,106 @@ on a 2 whose message is `IXP Manager update lock was not acquired` meaning step
 (the [tool README](../../tools/rs-config-render/README.md#exit-codes)), so a
 wrapper can branch on the code alone: 7 is always the benign, already-released
 lifecycle rollback and 4 is always arouteserver shape drift.
+
+## A. Reading the state by hand
+
+Everything `status` prints comes from four files; when the binary is not at
+hand, or to see the diff itself, read them directly.
+
+`current` points at the candidate generation, not the one that was live
+before, and an owner fence stands in the shared host-state directory:
+
+```bash
+readlink $STATE/current
+ls -la $HOST
+```
+
+```text
+generations/53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c
+-rw------- 1 rustbgpd rustbgpd  274 Aug 22 15:01 ixp-manager-host-fence.json
+-rw------- 1 rustbgpd rustbgpd    0 Aug 22 15:01 ixp-manager-host.lock
+```
+
+If the receipt was written, it says so:
+
+```bash
+grep -E '"(status|candidate_sha256|previous_generation|runtime_equal)"' $STATE/activation-receipt.json
+```
+
+```text
+  "candidate_sha256": "53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c",
+    "runtime_equal": false
+  "previous_generation": "generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a",
+  "status": "recovery_required",
+```
+
+A lifecycle run additionally leaves a journal with the lock still owed:
+
+```bash
+grep -E '"(phase|callback|activation_outcome|error_class)"' $STATE/ixp-manager-lifecycle.json
+```
+
+```text
+  "phase": "manual_recovery",
+  "callback": null,
+  "activation_outcome": "recovery_required",
+  "error_class": "activation"
+```
+
+The settlement test by hand is `rbgp health` plus `rbgp config diff` against
+the candidate. The generation's `config.toml` names its policy files
+relatively, and the daemon resolves those against its own working directory,
+so diff a copy with the paths rewritten to the live `current/` prefix:
+
+```bash
+rbgp --addr $UDS health
+umask 077
+sed 's#"policy/#"'"$STATE"'/current/policy/#' $STATE/current/config.toml > $STATE/.compare.toml
+rbgp --addr $UDS config diff $STATE/.compare.toml; echo "rc=$?"
+rm $STATE/.compare.toml
+```
+
+**Live and equal** (`runtime_equals_current: yes`):
+
+```text
+Status:  healthy
+Uptime:  00:00:05
+Peers:   0
+Routes:  0
+No changes.
+rc=0
+```
+
+**Live but still on the previous generation** (`runtime_equals_current: no`);
+the diff lists exactly what the daemon is missing:
+
+```text
+Status:  healthy
+Reload-applied changes:
+
+  Neighbors:
+    ~ 10.1.0.10:
+        max_prefixes_ipv4: 900 → 1000  [hot-applied]
+
+Plan: 1 to change · no session resets expected
+rc=2
+```
+
+Confirm by diffing the previous generation from the receipt the same way
+(`sed … $STATE/generations/<previous_generation>/config.toml`, still rewriting
+to the `current/` prefix): `No changes.` / `rc=0` means the daemon runs the
+previous generation.
+
+**Down** (`daemon: unreachable`):
+
+```text
+Error: cannot reach rustbgpd at unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock (socket does not exist)
+  hint: is the daemon running? if it uses a different endpoint, pass -s or set RUSTBGPD_ADDR
+rc=1
+```
+
+`healthy: false` from `rbgp --json health` (`daemon: unhealthy`), or a diff
+that errors on a reachable daemon, is "live and broken".
 
 ## What this runbook does not cover
 

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -296,6 +296,46 @@ route server spends about 2.3 MiB per distinct generation; an hourly lifecycle
 whose render differs every run (the worst case) would retain about 20 GiB a
 year unpruned, and `--keep 48` bounds it to about 110 MiB.
 
+### Inspecting activation and lifecycle state
+
+`status` reads the three durable artifacts that define an exit 5 — the host
+fence, the lifecycle journal, and the generation tree with its `current` link —
+plus the advisory activation receipt, and prints one `key: value` line per
+field in a fixed order. It takes the same binding flags as `activate` and
+changes nothing; with `--rbgp` it also runs the settle path's own probe
+(`rbgp health`, then `rbgp config diff` against the `current` generation):
+
+```console
+sudo -u rustbgpd /usr/bin/rs-config-render status \
+  --router-handle rs1-ipv4 \
+  --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir /var/lib/rustbgpd/rs1-ipv4/activation \
+  --host-state-dir /var/lib/rustbgpd/ixp-manager-host \
+  --rbgp-addr unix:///var/lib/rustbgpd/rs1-ipv4/grpc.sock \
+  --rbgp /usr/bin/rbgp
+```
+
+| Key | Values |
+|---|---|
+| `fence` | `absent`, `present` (this binding's; automation may not resume), `foreign` (another handle's), `unreadable` |
+| `journal` | `absent`, `present`, `unreadable` |
+| `phase`, `callback`, `callback_attempts`, `activation_outcome`, `error_class` | the journal's own values; `none`/`0` without a journal |
+| `lock` | the upstream update lock as the journal proves it: `none` (no journal), `retained`, `unknown` (the lock request itself was ambiguous) |
+| `current` | the `current` target, `none`, or `invalid (<reason>)` |
+| `candidate` | the generation the journal's render receipt names; without a journal, `current` when the receipt describes it; `none` when the journal proves no candidate was rendered; else `unknown` |
+| `current_is_candidate` | `yes`, `no`, `unknown` |
+| `advisory_receipt` | `matches-current` (its `candidate_sha256` is the `current` target), `stale`, `absent`, `unreadable`; the receipt is advisory and may be absent or stale after an exit 5 |
+| `advisory_receipt_status`, `advisory_receipt_previous_generation` | the receipt's values or `none` |
+| `daemon` | `not-probed` (no `--rbgp`), `healthy`, `unhealthy`, `unreachable`, `invalid` |
+| `runtime_equals_current` | `yes`, `no`, `unknown` (not probed, unreachable, or no valid `current`) |
+
+Exit 0 whenever the state could be read — manual recovery is a report, not an
+error — and 1 only when the state directory is unreadable. `status` takes no
+lock and writes nothing durable; the comparison file it hands to `rbgp config
+diff` is created and removed inside the state directory. The
+[manual-recovery runbook](../../docs/cookbook/activation-manual-recovery.md)
+reads its output field by field.
+
 Release tarballs (`rustbgpd-<arch>.tar.gz` on the [releases
 page](https://github.com/lance0/rustbgpd/releases)) ship the
 `rs-config-render` binary alongside `rustbgpd` and `rbgp`; from
@@ -371,7 +411,7 @@ stuck for more than a couple of refresh intervals should page, not rot.
 ## Exit codes
 
 One table for every subcommand (`render`, `--input-format ixp-manager-*`,
-`activate`, `ixp-manager-lifecycle run|resume`): each code has exactly one
+`activate`, `ixp-manager-lifecycle run|resume`, `prune`, `status`): each code has exactly one
 meaning, so a cron or systemd wrapper can branch on the code alone without
 knowing which subcommand ran. The mapping is asserted by
 `tests/exit_codes.rs` against this table and its mirror in
@@ -392,7 +432,9 @@ knowing which subcommand ran. The mapping is asserted by
 
 Codes 1–4 and 8–9 leave the previous configuration running untouched
 (fail-stale); 5 and 6 need an operator; 7 is safe to retry. `prune` uses 0, 2
-(fenced, busy, or unreadable forensic state — nothing removed), and 8.
+(fenced, busy, or unreadable forensic state — nothing removed), and 8. `status`
+uses 0 (any readable state, manual recovery included), 1 (unreadable state
+directory), and 2 (invalid binding).
 
 Refused knobs: RTT-based communities and `rtt_thresholds` (the daemon
 has no RTT source; permanent), configured

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -81,12 +81,12 @@ mod unix {
     const REFUSAL_KEYS: &[&str] = &["status", "active_ui_filters", SKINS, MULTI];
     type AResult<T> = Result<T, Error>;
 
-    struct Verified {
-        digest: String,
+    pub(crate) struct Verified {
+        pub(crate) digest: String,
         files: BTreeMap<String, String>,
         directories: Vec<String>,
         checker_version: String,
-        config: Vec<u8>,
+        pub(crate) config: Vec<u8>,
     }
 
     pub(crate) fn private(path: &Path, directory: bool, mode: u32) -> bool {
@@ -162,7 +162,7 @@ mod unix {
         Ok(())
     }
 
-    fn verify_candidate(root: &Path, binding: &Binding) -> AResult<Verified> {
+    pub(crate) fn verify_candidate(root: &Path, binding: &Binding) -> AResult<Verified> {
         if !private(root, true, 0o700) || !private(&root.join(RECEIPT), false, 0o600) {
             return Err(Error::Refused(
                 "candidate and receipt must be private regular paths",
@@ -371,7 +371,7 @@ mod unix {
         }
     }
 
-    struct Comparison(PathBuf);
+    pub(crate) struct Comparison(PathBuf);
 
     impl AsRef<Path> for Comparison {
         fn as_ref(&self) -> &Path {
@@ -452,7 +452,7 @@ mod unix {
         Ok((final_path, true))
     }
 
-    fn current_target(state: &Path, binding: &Binding) -> AResult<Option<String>> {
+    pub(crate) fn current_target(state: &Path, binding: &Binding) -> AResult<Option<String>> {
         let current = state.join("current");
         let metadata = match fs::symlink_metadata(&current) {
             Ok(metadata) => metadata,
@@ -519,7 +519,7 @@ mod unix {
         }
     }
 
-    fn normalized_toml(config: &[u8], state: &Path) -> AResult<Vec<u8>> {
+    pub(crate) fn normalized_toml(config: &[u8], state: &Path) -> AResult<Vec<u8>> {
         let current = fs::canonicalize(state)
             .map_err(|_| Error::Refused("state path is invalid"))?
             .join("current");
@@ -562,7 +562,7 @@ mod unix {
         Ok(bytes)
     }
 
-    fn comparison_file(bytes: &[u8], state: &Path, label: &str) -> AResult<Comparison> {
+    pub(crate) fn comparison_file(bytes: &[u8], state: &Path, label: &str) -> AResult<Comparison> {
         let path = state.join(unique_name(&format!(".compare-{label}")));
         let mut file = OpenOptions::new()
             .write(true)
@@ -591,16 +591,16 @@ mod unix {
         }
     }
 
-    #[derive(PartialEq, Eq)]
-    enum Health {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) enum Health {
         Reachable(bool),
         Unreachable,
         Invalid,
     }
 
-    fn health_probe(options: &Options<'_>, deadline: Instant) -> Health {
-        let Ok(child) = Command::new(options.rbgp)
-            .args(["--json", "--addr", options.rbgp_addr, "health"])
+    pub(crate) fn health_probe(rbgp: &Path, rbgp_addr: &str, deadline: Instant) -> Health {
+        let Ok(child) = Command::new(rbgp)
+            .args(["--json", "--addr", rbgp_addr, "health"])
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()
@@ -627,9 +627,14 @@ mod unix {
         }
     }
 
-    fn equal_runtime(options: &Options<'_>, comparison: &Path, deadline: Instant) -> bool {
-        let Ok(child) = Command::new(options.rbgp)
-            .args(["--addr", options.rbgp_addr, "config", "diff"])
+    pub(crate) fn equal_runtime(
+        rbgp: &Path,
+        rbgp_addr: &str,
+        comparison: &Path,
+        deadline: Instant,
+    ) -> bool {
+        let Ok(child) = Command::new(rbgp)
+            .args(["--addr", rbgp_addr, "config", "diff"])
             .arg(comparison)
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -642,8 +647,8 @@ mod unix {
 
     fn settle(options: &Options<'_>, comparison: &Path, deadline: Instant) -> bool {
         loop {
-            if health_probe(options, deadline) == Health::Reachable(true)
-                && equal_runtime(options, comparison, deadline)
+            if health_probe(options.rbgp, options.rbgp_addr, deadline) == Health::Reachable(true)
+                && equal_runtime(options.rbgp, options.rbgp_addr, comparison, deadline)
             {
                 return true;
             }
@@ -811,7 +816,11 @@ mod unix {
             ));
         }
         if options.initial
-            && health_probe(options, Instant::now() + options.settle) != Health::Unreachable
+            && health_probe(
+                options.rbgp,
+                options.rbgp_addr,
+                Instant::now() + options.settle,
+            ) != Health::Unreachable
         {
             return Err(Error::Refused("--initial requires no reachable daemon"));
         }
@@ -871,8 +880,14 @@ mod unix {
                 "prior",
             )?;
             let known_good_deadline = Instant::now() + options.settle;
-            if health_probe(options, known_good_deadline) != Health::Reachable(true)
-                || !equal_runtime(options, prior_comparison.as_ref(), known_good_deadline)
+            if health_probe(options.rbgp, options.rbgp_addr, known_good_deadline)
+                != Health::Reachable(true)
+                || !equal_runtime(
+                    options.rbgp,
+                    options.rbgp_addr,
+                    prior_comparison.as_ref(),
+                    known_good_deadline,
+                )
             {
                 return Err(Error::Refused("current runtime is not known-good"));
             }
@@ -907,8 +922,14 @@ mod unix {
                     }
                     let deadline = Instant::now() + options.settle;
                     if rollback == Publication::Durable
-                        && health_probe(options, deadline) == Health::Reachable(true)
-                        && equal_runtime(options, prior_comparison.as_ref(), deadline)
+                        && health_probe(options.rbgp, options.rbgp_addr, deadline)
+                            == Health::Reachable(true)
+                        && equal_runtime(
+                            options.rbgp,
+                            options.rbgp_addr,
+                            prior_comparison.as_ref(),
+                            deadline,
+                        )
                     {
                         phases.runtime_equal = true;
                         drop(prior_comparison);
@@ -973,4 +994,7 @@ mod unix {
 #[cfg(unix)]
 pub use unix::activate;
 #[cfg(unix)]
-pub(crate) use unix::{activate_guarded, private, state_lock, valid_digest};
+pub(crate) use unix::{
+    Comparison, Health, activate_guarded, comparison_file, current_target, equal_runtime,
+    health_probe, normalized_toml, private, state_lock, valid_digest, verify_candidate,
+};

--- a/tools/rs-config-render/src/ixp_manager_host.rs
+++ b/tools/rs-config-render/src/ixp_manager_host.rs
@@ -142,7 +142,9 @@ mod unix {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound
         )
     }
-    fn read_fence(state: &Path) -> Result<Option<Binding>, Error> {
+    /// The fence's owner binding: `Ok(None)` when no fence exists, `Err` when
+    /// one exists but is not a private, well-formed fence.
+    pub(crate) fn read_fence(state: &Path) -> Result<Option<Binding>, Error> {
         let path = state.join(FENCE);
         let metadata = match fs::symlink_metadata(&path) {
             Ok(metadata) => metadata,
@@ -227,4 +229,4 @@ mod unix {
 #[cfg(unix)]
 pub use unix::Guard;
 #[cfg(unix)]
-pub(crate) use unix::fence_present;
+pub(crate) use unix::{fence_present, read_fence};

--- a/tools/rs-config-render/src/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/src/ixp_manager_lifecycle.rs
@@ -127,7 +127,7 @@ mod unix {
 
     #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(rename_all = "snake_case")]
-    enum Phase {
+    pub(crate) enum Phase {
         LockRequestPending,
         Locked,
         ActivationStarted,
@@ -136,27 +136,50 @@ mod unix {
         ManualRecovery,
     }
 
+    impl Phase {
+        /// The journal's own spelling of the phase.
+        pub(crate) const fn name(self) -> &'static str {
+            match self {
+                Self::LockRequestPending => "lock_request_pending",
+                Self::Locked => "locked",
+                Self::ActivationStarted => "activation_started",
+                Self::UpdatedPending => "updated_pending",
+                Self::ReleasePending => "release_pending",
+                Self::ManualRecovery => "manual_recovery",
+            }
+        }
+    }
+
     #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(rename_all = "snake_case")]
-    enum Callback {
+    pub(crate) enum Callback {
         Updated,
         Release,
     }
 
+    impl Callback {
+        pub(crate) const fn name(self) -> &'static str {
+            match self {
+                Self::Updated => "updated",
+                Self::Release => "release",
+            }
+        }
+    }
+
     #[derive(Debug, Deserialize, Serialize)]
     #[serde(deny_unknown_fields)]
-    struct Journal {
+    pub(crate) struct Journal {
         schema: String,
         ixp_manager_version: String,
         origin: String,
         router_handle: String,
         host: Binding,
-        phase: Phase,
-        callback: Option<Callback>,
-        callback_attempts: u32,
-        candidate_sha256: Option<String>,
-        activation_outcome: Option<String>,
-        error_class: Option<String>,
+        pub(crate) phase: Phase,
+        pub(crate) callback: Option<Callback>,
+        pub(crate) callback_attempts: u32,
+        pub(crate) candidate_sha256: Option<String>,
+        pub(crate) activation_outcome: Option<String>,
+        pub(crate) error_class: Option<String>,
     }
 
     struct Client {
@@ -516,6 +539,16 @@ mod unix {
         Ok(())
     }
 
+    /// The journal as a read-only inspection: `Ok(None)` when none exists,
+    /// `Err(())` when one exists but is not a private, well-formed journal.
+    pub(crate) fn inspect_journal(state: &Path) -> std::result::Result<Option<Journal>, ()> {
+        match read_journal(state) {
+            Ok(journal) => Ok(Some(journal)),
+            Err(Error::Refused(_)) => Ok(None),
+            Err(_) => Err(()),
+        }
+    }
+
     fn read_journal(state: &Path) -> Result<Journal> {
         let path = journal_path(state);
         match fs::symlink_metadata(&path) {
@@ -578,7 +611,7 @@ mod unix {
         }
     }
 
-    fn candidate_digest(path: &Path) -> Option<String> {
+    pub(crate) fn candidate_digest(path: &Path) -> Option<String> {
         let bytes = fs::read(path.join("render-receipt.json")).ok()?;
         Some(
             Sha256::digest(bytes)
@@ -815,6 +848,6 @@ mod unix {
 }
 
 #[cfg(unix)]
-pub(crate) use unix::journal_candidate;
+pub(crate) use unix::{Journal, Phase, candidate_digest, inspect_journal, journal_candidate};
 #[cfg(unix)]
 pub use unix::{resume, run};

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -49,6 +49,8 @@ pub mod ixp_manager_host;
 pub mod ixp_manager_lifecycle;
 #[cfg(unix)]
 pub mod prune;
+#[cfg(unix)]
+pub mod recover;
 
 /// Top-level keys of the supported `template-context` shape, sorted.
 ///

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -69,6 +69,20 @@ struct PruneArgs {
     apply: bool,
 }
 
+#[derive(Parser)]
+#[command(
+    name = "rs-config-render status",
+    about = "Report activation and lifecycle state for one handle without changing it"
+)]
+struct StatusArgs {
+    #[command(flatten)]
+    host: HostBindingArgs,
+    /// Exact rbgp executable; when given, probe the daemon and compare its
+    /// runtime with `current`
+    #[arg(long)]
+    rbgp: Option<PathBuf>,
+}
+
 #[derive(clap::Args)]
 struct HostBindingArgs {
     #[arg(long)]
@@ -270,6 +284,13 @@ fn parse_activation() -> Option<ActivateArgs> {
         .then(|| ActivateArgs::parse_from(std::iter::once(binary).chain(args)))
 }
 
+fn parse_status() -> Option<StatusArgs> {
+    let mut args = std::env::args_os();
+    let binary = args.next()?;
+    (args.next().as_deref() == Some(OsStr::new("status")))
+        .then(|| StatusArgs::parse_from(std::iter::once(binary).chain(args)))
+}
+
 fn parse_prune() -> Option<PruneArgs> {
     let mut args = std::env::args_os();
     let binary = args.next()?;
@@ -309,6 +330,26 @@ fn lifecycle_exit(
 }
 
 fn main() -> ExitCode {
+    if let Some(args) = parse_status() {
+        let binding = match args.host.binding() {
+            Ok(binding) => binding,
+            Err(reason) => {
+                eprintln!("rs-config-render: status: {reason}");
+                return Exit::Refused.into();
+            }
+        };
+        return match rs_config_render::recover::status(&rs_config_render::recover::StatusOptions {
+            state_dir: &args.host.state_dir,
+            binding: &binding,
+            rbgp: args.rbgp.as_deref(),
+        }) {
+            Ok(report) => stdout_exit(write_stdout(|writer| write!(writer, "{report}"))),
+            Err(error) => {
+                eprintln!("rs-config-render: status: {error}");
+                error.exit_code().into()
+            }
+        };
+    }
     if let Some(args) = parse_prune() {
         let binding = match args.host.binding() {
             Ok(binding) => binding,

--- a/tools/rs-config-render/src/recover.rs
+++ b/tools/rs-config-render/src/recover.rs
@@ -1,0 +1,323 @@
+//! Operator inspection of the durable activation and lifecycle state.
+//!
+//! An exit 5 is characterised by three durable artifacts: the host fence, the
+//! lifecycle journal, and the generation tree with its `current` link. The
+//! activation receipt is advisory (it can be absent or stale after an exit 5).
+//! `status` reads all of them, probes the daemon when asked, and changes
+//! nothing; it is step 1 of the manual-recovery runbook.
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+use crate::Exit;
+use crate::ixp_manager_host::{self, Binding};
+use crate::ixp_manager_lifecycle::{self as lifecycle, Journal, Phase};
+use crate::{activation, activation::Health};
+
+const ACTIVATION_RECEIPT: &str = "activation-receipt.json";
+/// rbgp gets this long per probe before `status` reports it as invalid.
+const PROBE: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+pub struct StatusOptions<'a> {
+    pub state_dir: &'a Path,
+    pub binding: &'a Binding,
+    /// Exact rbgp executable; `None` skips the daemon probe.
+    pub rbgp: Option<&'a Path>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The state directory cannot be read at all; nothing can be reported.
+    Unreadable(&'static str),
+    /// The options do not describe one handle's state.
+    Refused(&'static str),
+}
+
+impl Error {
+    pub const fn exit_code(&self) -> Exit {
+        match self {
+            Self::Unreadable(_) => Exit::InvalidInput,
+            Self::Refused(_) => Exit::Refused,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unreadable(reason) | Self::Refused(reason) => formatter.write_str(reason),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// The status report: one `key: value` line per field, in a fixed order.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Report {
+    pub fields: Vec<(&'static str, String)>,
+}
+
+impl Report {
+    fn push(&mut self, key: &'static str, value: impl Into<String>) {
+        self.fields.push((key, value.into()));
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|(name, _)| *name == key)
+            .map(|(_, value)| value.as_str())
+    }
+}
+
+impl fmt::Display for Report {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (key, value) in &self.fields {
+            writeln!(formatter, "{key}: {value}")?;
+        }
+        Ok(())
+    }
+}
+
+enum Receipt {
+    Absent,
+    Unreadable,
+    Present {
+        status: String,
+        candidate: String,
+        previous: Option<String>,
+    },
+}
+
+fn read_receipt(state: &Path) -> Receipt {
+    let bytes = match fs::read(state.join(ACTIVATION_RECEIPT)) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Receipt::Absent,
+        Err(_) => return Receipt::Unreadable,
+    };
+    let receipt: Value = match serde_json::from_slice(&bytes) {
+        Ok(receipt) => receipt,
+        Err(_) => return Receipt::Unreadable,
+    };
+    match (
+        receipt["status"].as_str(),
+        receipt["candidate_sha256"]
+            .as_str()
+            .filter(|digest| activation::valid_digest(digest)),
+    ) {
+        (Some(status), Some(candidate)) => Receipt::Present {
+            status: status.to_owned(),
+            candidate: candidate.to_owned(),
+            previous: receipt["previous_generation"].as_str().map(str::to_owned),
+        },
+        _ => Receipt::Unreadable,
+    }
+}
+
+/// The generation whose render receipt a lifecycle journal names.
+fn journal_generation(state: &Path, receipt_sha256: &str) -> Option<String> {
+    let generations = state.join("generations");
+    fs::read_dir(&generations).ok()?.find_map(|entry| {
+        let name = entry.ok()?.file_name().into_string().ok()?;
+        (activation::valid_digest(&name)
+            && lifecycle::candidate_digest(&generations.join(&name)).as_deref()
+                == Some(receipt_sha256))
+        .then(|| format!("generations/{name}"))
+    })
+}
+
+/// What the journal proves about the upstream router lock.
+fn upstream_lock(journal: &Journal) -> &'static str {
+    match journal.phase {
+        Phase::LockRequestPending => "unknown",
+        Phase::Locked
+        | Phase::ActivationStarted
+        | Phase::UpdatedPending
+        | Phase::ReleasePending => "retained",
+        // An activation outcome means the lock request succeeded; without one
+        // the lock request itself was the ambiguous step.
+        Phase::ManualRecovery if journal.activation_outcome.is_some() => "retained",
+        Phase::ManualRecovery => "unknown",
+    }
+}
+
+/// The generation's config, normalised the way the settle path compares it,
+/// staged as a private comparison file (removed on drop).
+fn comparison(
+    state: &Path,
+    target: &str,
+    binding: &Binding,
+) -> Result<activation::Comparison, activation::Error> {
+    let verified = activation::verify_candidate(&state.join(target), binding)?;
+    let bytes = activation::normalized_toml(&verified.config, state)?;
+    activation::comparison_file(&bytes, state, "status")
+}
+
+/// Report the activation and lifecycle state of one handle without changing
+/// it. Manual-recovery state is a successful report; only an unreadable
+/// state directory is an error.
+pub fn status(options: &StatusOptions<'_>) -> Result<Report, Error> {
+    let binding = options.binding;
+    let state = options.state_dir;
+    if state != binding.activation_state_dir {
+        return Err(Error::Refused("state directory must match host binding"));
+    }
+    if !state.is_absolute() || !fs::metadata(state).is_ok_and(|metadata| metadata.is_dir()) {
+        return Err(Error::Unreadable(
+            "state directory is not a readable directory",
+        ));
+    }
+    let mut report = Report::default();
+    report.push(
+        "fence",
+        match ixp_manager_host::read_fence(&binding.host_state_dir) {
+            Ok(None) => "absent",
+            Ok(Some(owner)) if owner == *binding => "present",
+            Ok(Some(_)) => "foreign",
+            Err(_) => "unreadable",
+        },
+    );
+    let journal = lifecycle::inspect_journal(state);
+    report.push(
+        "journal",
+        match &journal {
+            Ok(None) => "absent",
+            Ok(Some(_)) => "present",
+            Err(()) => "unreadable",
+        },
+    );
+    let journal = journal.ok().flatten();
+    let journal = journal.as_ref();
+    report.push(
+        "phase",
+        journal.map_or("none", |journal| journal.phase.name()),
+    );
+    report.push(
+        "callback",
+        journal
+            .and_then(|journal| journal.callback)
+            .map_or("none", |callback| callback.name()),
+    );
+    report.push(
+        "callback_attempts",
+        journal
+            .map_or(0, |journal| journal.callback_attempts)
+            .to_string(),
+    );
+    report.push(
+        "activation_outcome",
+        journal
+            .and_then(|journal| journal.activation_outcome.as_deref())
+            .unwrap_or("none"),
+    );
+    report.push(
+        "error_class",
+        journal
+            .and_then(|journal| journal.error_class.as_deref())
+            .unwrap_or("none"),
+    );
+    report.push("lock", journal.map_or("none", upstream_lock));
+    let current = activation::current_target(state, binding);
+    report.push(
+        "current",
+        match &current {
+            Ok(None) => "none".to_owned(),
+            Ok(Some(target)) => target.clone(),
+            Err(activation::Error::Refused(reason)) => format!("invalid ({reason})"),
+            Err(_) => "invalid".to_owned(),
+        },
+    );
+    let current = current.ok().flatten();
+    let receipt = read_receipt(state);
+    let receipt_matches = matches!(
+        (&receipt, &current),
+        (Receipt::Present { candidate, .. }, Some(target)) if *target == format!("generations/{candidate}")
+    );
+    // The candidate: proven by the journal when there is one; otherwise only
+    // a receipt that describes the current attempt can name it.
+    let candidate = match journal {
+        Some(journal) => match &journal.candidate_sha256 {
+            None => Some("none".to_owned()),
+            Some(sha256) => journal_generation(state, sha256),
+        },
+        None if receipt_matches => current.clone(),
+        None => None,
+    };
+    report.push("candidate", candidate.as_deref().unwrap_or("unknown"));
+    report.push(
+        "current_is_candidate",
+        match (&candidate, &current) {
+            (Some(candidate), _) if candidate == "none" => "no",
+            (Some(candidate), Some(target)) => {
+                if candidate == target {
+                    "yes"
+                } else {
+                    "no"
+                }
+            }
+            _ => "unknown",
+        },
+    );
+    report.push(
+        "advisory_receipt",
+        match &receipt {
+            Receipt::Absent => "absent",
+            Receipt::Unreadable => "unreadable",
+            Receipt::Present { .. } if receipt_matches => "matches-current",
+            Receipt::Present { .. } => "stale",
+        },
+    );
+    let (status, previous) = match &receipt {
+        Receipt::Present {
+            status, previous, ..
+        } => (status.as_str(), previous.as_deref()),
+        _ => ("none", None),
+    };
+    report.push("advisory_receipt_status", status);
+    report.push(
+        "advisory_receipt_previous_generation",
+        previous.unwrap_or("none"),
+    );
+    let (daemon, equal) = match options.rbgp {
+        None => ("not-probed", "unknown"),
+        Some(rbgp) => {
+            let addr = binding.rbgp_addr();
+            let health = activation::health_probe(rbgp, addr, Instant::now() + PROBE);
+            let daemon = match health {
+                Health::Reachable(true) => "healthy",
+                Health::Reachable(false) => "unhealthy",
+                Health::Unreachable => "unreachable",
+                Health::Invalid => "invalid",
+            };
+            let equal = match (health, &current) {
+                (Health::Reachable(_), Some(target)) => match comparison(state, target, binding) {
+                    Ok(file) => {
+                        if activation::equal_runtime(
+                            rbgp,
+                            addr,
+                            file.as_ref(),
+                            Instant::now() + PROBE,
+                        ) {
+                            "yes"
+                        } else {
+                            "no"
+                        }
+                    }
+                    Err(_) => "unknown",
+                },
+                _ => "unknown",
+            };
+            (daemon, equal)
+        }
+    };
+    report.push("daemon", daemon);
+    report.push("runtime_equals_current", equal);
+    Ok(report)
+}

--- a/tools/rs-config-render/tests/exit_codes.rs
+++ b/tools/rs-config-render/tests/exit_codes.rs
@@ -2,7 +2,9 @@
 //! source of numbers, every error type maps into it, and the README table
 //! (plus its `docs/deployment.md` mirror) must list exactly those codes.
 
-use rs_config_render::{Exit, RenderError, activation, ixp_manager, ixp_manager_lifecycle, prune};
+use rs_config_render::{
+    Exit, RenderError, activation, ixp_manager, ixp_manager_lifecycle, prune, recover,
+};
 
 fn table_rows(markdown: &str) -> Vec<String> {
     let mut lines = markdown.lines();
@@ -168,6 +170,17 @@ fn every_error_variant_maps_to_the_shared_table() {
     for (error, exit) in &pruning {
         match error {
             prune::Error::Refused(_) => {}
+        }
+        assert_eq!(error.exit_code(), *exit, "{error:?}");
+    }
+
+    let recovery = [
+        (recover::Error::Unreadable(""), Exit::InvalidInput),
+        (recover::Error::Refused(""), Exit::Refused),
+    ];
+    for (error, exit) in &recovery {
+        match error {
+            recover::Error::Unreadable(_) | recover::Error::Refused(_) => {}
         }
         assert_eq!(error.exit_code(), *exit, "{error:?}");
     }

--- a/tools/rs-config-render/tests/recover.rs
+++ b/tools/rs-config-render/tests/recover.rs
@@ -1,0 +1,755 @@
+//! `status` (and the `recover` verbs) against the durable state a real
+//! lifecycle leaves behind: a bootstrapped handle, a loopback stand-in for the
+//! IXP Manager v7.4 router API, and fake `rustbgpd`/`rbgp`/activation
+//! executables whose outcomes the test controls through mode files.
+
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use rs_config_render::activation;
+use rs_config_render::ixp_manager;
+use rs_config_render::ixp_manager_host::{Binding, Guard};
+use rs_config_render::ixp_manager_lifecycle::{self as lifecycle, Error as LifecycleError};
+
+const FIXTURE: &[u8] = include_bytes!("fixtures/ixp-manager-v2-supported.json");
+const API_KEY: &str = "recover-api-key-must-not-leak";
+const HANDLE: &str = "b2-rs1-lan1-ipv4";
+// Serialize the binary: a foreign child can inherit another test's flock descriptor.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+    TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+fn mode(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+}
+
+fn private_dir(path: &Path) {
+    fs::create_dir(path).unwrap();
+    mode(path, 0o700);
+}
+
+fn executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    mode(path, 0o700);
+}
+
+#[derive(Clone)]
+struct Response {
+    status: u16,
+    content_type: &'static str,
+    body: Vec<u8>,
+}
+
+impl Response {
+    fn json(status: u16) -> Self {
+        Self {
+            status,
+            content_type: "application/json",
+            body: br#"{"last_update_started":"2026-08-20T00:00:00+00:00","last_update_started_unix":1787184000,"last_updated":null,"last_updated_unix":null}"#.to_vec(),
+        }
+    }
+
+    fn config(body: &[u8]) -> Self {
+        Self {
+            status: 200,
+            content_type: "text/plain; charset=UTF-8",
+            body: body.to_vec(),
+        }
+    }
+}
+
+struct Server {
+    origin: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    join: thread::JoinHandle<()>,
+}
+
+fn read_request(mut stream: &TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .unwrap();
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 2048];
+    while !bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+        let count = stream.read(&mut chunk).unwrap();
+        assert_ne!(count, 0, "HTTP request ended before its headers");
+        bytes.extend_from_slice(&chunk[..count]);
+        assert!(bytes.len() <= 32 * 1024, "test request headers too large");
+    }
+    String::from_utf8(bytes).unwrap()
+}
+
+impl Server {
+    fn start(responses: Vec<Response>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let origin = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&requests);
+        let join = thread::spawn(move || {
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                captured.lock().unwrap().push(read_request(&stream));
+                stream
+                    .set_write_timeout(Some(Duration::from_secs(3)))
+                    .unwrap();
+                let reason = match response.status {
+                    200 => "OK",
+                    423 => "Locked",
+                    500 => "Server Error",
+                    _ => "Error",
+                };
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 {} {reason}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    response.status,
+                    response.content_type,
+                    response.body.len()
+                );
+                let _ = stream.write_all(&response.body);
+            }
+        });
+        Self {
+            origin,
+            requests,
+            join,
+        }
+    }
+
+    fn finish(self) -> Vec<String> {
+        self.join.join().unwrap();
+        Arc::try_unwrap(self.requests)
+            .unwrap()
+            .into_inner()
+            .unwrap()
+    }
+}
+
+fn assert_request(request: &str, method: &str, action: &str) {
+    assert!(
+        request.starts_with(&format!(
+            "{method} /admin/api/v4/router/{action}/{HANDLE} HTTP/1.1\r\n"
+        )),
+        "unexpected request: {request}"
+    );
+    assert!(
+        request
+            .to_ascii_lowercase()
+            .contains(&format!("\r\nx-ixp-manager-api-key: {API_KEY}\r\n"))
+    );
+}
+
+struct Rig {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    state: PathBuf,
+    runtime: PathBuf,
+    host: PathBuf,
+    candidate: PathBuf,
+    key: PathBuf,
+    checker: PathBuf,
+    rbgp: PathBuf,
+    activation: PathBuf,
+    binding: Binding,
+}
+
+impl Rig {
+    /// A bootstrapped handle: one activated generation, `current` on it, the
+    /// fake daemon "running" it, no fence, no journal.
+    fn new() -> Self {
+        let current = std::env::current_dir().unwrap();
+        let temp = tempfile::Builder::new()
+            .prefix("recover-")
+            .tempdir_in(current)
+            .unwrap();
+        let root = temp.path().to_path_buf();
+        let runtime = root.join(HANDLE);
+        let state = runtime.join("activation");
+        let candidate = root.join("candidate");
+        let host = root.join("host-state");
+        private_dir(&runtime);
+        private_dir(&state);
+        private_dir(&candidate);
+        private_dir(&host);
+        let key = root.join("api-key");
+        fs::write(&key, format!("{API_KEY}\n")).unwrap();
+        mode(&key, 0o600);
+        fs::write(root.join("health-mode"), "ok").unwrap();
+        fs::write(root.join("activation-mode"), "ok").unwrap();
+        let checker = root.join("rustbgpd");
+        executable(
+            &checker,
+            "#!/bin/sh\n[ \"$1\" = --version ] && { echo 'rustbgpd 0.65.0'; exit 0; }\nexit 0\n",
+        );
+        // The fake daemon "runs" whatever generation the activation command
+        // last loaded (`runtime`); `config diff` is equal iff that is what
+        // `current` points at now. `health-mode` is ok | unhealthy | down.
+        let rbgp = root.join("rbgp");
+        executable(
+            &rbgp,
+            &format!(
+                r#"#!/bin/sh
+root=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+printf '%s\n' "$*" >> "$root/rbgp.log"
+case "$*" in
+  *" health")
+    health_mode=$(cat "$root/health-mode")
+    if [ "$health_mode" = down ] || [ ! -f "$root/runtime" ]; then
+      printf 'Error: cannot reach rustbgpd at test (connection refused)\n' >&2
+      exit 1
+    fi
+    [ "$health_mode" = unhealthy ] && healthy=false || healthy=true
+    printf '{{"healthy":%s}}\n' "$healthy"
+    exit 0
+    ;;
+esac
+[ "$(cat "$root/runtime" 2>/dev/null)" = "$(readlink "$root/{HANDLE}/activation/current")" ] && exit 0
+exit 2
+"#
+            ),
+        );
+        // `activation-mode`: ok (load and succeed) | load-then-fail (the
+        // daemon loads the new current but the command exits nonzero) | fail
+        // (nothing loaded, nonzero exit).
+        let activation = root.join("activate");
+        executable(
+            &activation,
+            &format!(
+                r#"#!/bin/sh
+root=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+target=$(readlink "$root/{HANDLE}/activation/current") || exit 7
+printf '%s\n' "$target" >> "$root/activation.log"
+case "$(cat "$root/activation-mode")" in
+  ok) printf '%s\n' "$target" > "$root/runtime"; exit 0 ;;
+  load-then-fail) printf '%s\n' "$target" > "$root/runtime"; exit 9 ;;
+  *) exit 9 ;;
+esac
+"#
+            ),
+        );
+        let binding = Binding::new(
+            HANDLE,
+            &runtime,
+            &state,
+            &host,
+            &format!("unix://{}", runtime.join("grpc.sock").display()),
+        )
+        .unwrap();
+        let rig = Self {
+            _temp: temp,
+            root,
+            state,
+            runtime,
+            host,
+            candidate,
+            key,
+            checker,
+            rbgp,
+            activation,
+            binding,
+        };
+        rig.bootstrap();
+        rig
+    }
+
+    fn bootstrap(&self) {
+        let candidate = self.root.join("bootstrap");
+        private_dir(&candidate);
+        ixp_manager::write_checked_candidate_bytes(
+            FIXTURE,
+            &candidate,
+            300,
+            &self.checker,
+            &self.binding.render_binding(),
+        )
+        .unwrap();
+        assert_eq!(
+            activation::activate(&activation::Options {
+                candidate: &candidate,
+                state_dir: &self.state,
+                checker: &self.checker,
+                rbgp: &self.rbgp,
+                rbgp_addr: self.binding.rbgp_addr(),
+                settle: Duration::from_secs(2),
+                initial: true,
+                activation_command: &self.activation,
+                activation_args: &[],
+                binding: &self.binding,
+            }),
+            Ok(activation::Status::Activated)
+        );
+    }
+
+    fn set(&self, name: &str, value: &str) {
+        fs::write(self.root.join(name), value).unwrap();
+    }
+
+    fn current(&self) -> String {
+        fs::read_link(self.state.join("current"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn journal(&self) -> PathBuf {
+        self.state.join("ixp-manager-lifecycle.json")
+    }
+
+    fn fence(&self) -> PathBuf {
+        self.host.join("ixp-manager-host-fence.json")
+    }
+
+    fn receipt(&self) -> PathBuf {
+        self.state.join("activation-receipt.json")
+    }
+
+    fn options<'a>(&'a self, origin: &'a str) -> lifecycle::Options<'a> {
+        lifecycle::Options {
+            ixp_origin: origin,
+            router_handle: HANDLE,
+            api_key_file: &self.key,
+            candidate_dir: &self.candidate,
+            state_dir: &self.state,
+            checker: &self.checker,
+            // 301 differs from the bootstrap's 300, so the candidate is a new
+            // generation rather than a no-op.
+            max_prefix_restart_seconds: 301,
+            rbgp: &self.rbgp,
+            rbgp_addr: self.binding.rbgp_addr(),
+            activation_command: &self.activation,
+            activation_args: &[],
+            settle: Duration::from_secs(2),
+            timeout: Duration::from_secs(2),
+            initial: false,
+            allow_http_loopback: true,
+            binding: &self.binding,
+        }
+    }
+
+    /// Drive one lifecycle run into exit 5 with the activation command in
+    /// `activation_mode`; the upstream lock is retained and no callback sent.
+    fn induce_exit_5(&self, activation_mode: &str) {
+        self.set("activation-mode", activation_mode);
+        let server = Server::start(vec![Response::json(200), Response::config(FIXTURE)]);
+        assert_eq!(
+            lifecycle::run(&self.options(&server.origin)),
+            Err(LifecycleError::ManualRecovery)
+        );
+        assert_eq!(server.finish().len(), 2, "exit 5 must not callback");
+        self.set("activation-mode", "ok");
+        assert!(self.fence().exists());
+        assert!(self.journal().exists());
+    }
+
+    /// One failed `updated` callback after a successful activation: exit 6.
+    fn induce_exit_6(&self) {
+        let server = Server::start(vec![
+            Response::json(200),
+            Response::config(FIXTURE),
+            Response::json(500),
+        ]);
+        assert_eq!(
+            lifecycle::run(&self.options(&server.origin)),
+            Err(LifecycleError::CallbackPending)
+        );
+        assert_request(&server.finish()[2], "POST", "updated");
+    }
+
+    fn binding_args(&self, command: &mut Command) {
+        command
+            .args(["--router-handle", HANDLE])
+            .arg("--runtime-state-dir")
+            .arg(&self.runtime)
+            .arg("--state-dir")
+            .arg(&self.state)
+            .arg("--host-state-dir")
+            .arg(&self.host)
+            .arg("--rbgp-addr")
+            .arg(self.binding.rbgp_addr());
+    }
+
+    /// `status` through the binary, asserting it changed nothing: the state,
+    /// runtime, and host-state trees are byte-for-byte identical afterwards.
+    fn status_cli(&self, probe: bool) -> (i32, BTreeMap<String, String>, String) {
+        let before = snapshot(&self.root);
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rs-config-render"));
+        command.arg("status");
+        self.binding_args(&mut command);
+        if probe {
+            command.arg("--rbgp").arg(&self.rbgp);
+        }
+        let output = command.output().unwrap();
+        assert_eq!(snapshot(&self.root), before, "status changed state");
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let fields = stdout
+            .lines()
+            .map(|line| {
+                let (key, value) = line
+                    .split_once(": ")
+                    .unwrap_or_else(|| panic!("not `key: value`: {line}"));
+                (key.to_owned(), value.to_owned())
+            })
+            .collect();
+        (
+            output.status.code().unwrap(),
+            fields,
+            String::from_utf8(output.stderr).unwrap(),
+        )
+    }
+}
+
+/// Every path under `root` with its type, mode, and content (or link target),
+/// excluding the fake executables' own logs.
+fn snapshot(root: &Path) -> BTreeMap<String, (u32, Vec<u8>)> {
+    fn walk(root: &Path, directory: &Path, out: &mut BTreeMap<String, (u32, Vec<u8>)>) {
+        for entry in fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            let relative = path
+                .strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            if relative.ends_with(".log") {
+                continue;
+            }
+            let metadata = fs::symlink_metadata(&path).unwrap();
+            let mode = metadata.permissions().mode();
+            let content = if metadata.file_type().is_symlink() {
+                fs::read_link(&path)
+                    .unwrap()
+                    .into_os_string()
+                    .into_encoded_bytes()
+            } else if metadata.is_dir() {
+                walk(root, &path, out);
+                Vec::new()
+            } else {
+                fs::read(&path).unwrap()
+            };
+            out.insert(relative, (mode, content));
+        }
+    }
+    let mut out = BTreeMap::new();
+    walk(root, root, &mut out);
+    out
+}
+
+const STATUS_KEYS: [&str; 16] = [
+    "fence",
+    "journal",
+    "phase",
+    "callback",
+    "callback_attempts",
+    "activation_outcome",
+    "error_class",
+    "lock",
+    "current",
+    "candidate",
+    "current_is_candidate",
+    "advisory_receipt",
+    "advisory_receipt_status",
+    "advisory_receipt_previous_generation",
+    "daemon",
+    "runtime_equals_current",
+];
+
+fn assert_fields(fields: &BTreeMap<String, String>, expected: &[(&str, &str)]) {
+    for (key, value) in expected {
+        assert_eq!(
+            fields.get(*key).map(String::as_str),
+            Some(*value),
+            "{key} in {fields:#?}"
+        );
+    }
+}
+
+#[test]
+fn status_on_a_healthy_handle_reports_no_state_and_a_settled_daemon() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let current = rig.current();
+    let (code, fields, stderr) = rig.status_cli(true);
+    assert_eq!(code, 0, "{stderr}");
+    let keys: Vec<&str> = fields.keys().map(String::as_str).collect();
+    let mut expected: Vec<&str> = STATUS_KEYS.to_vec();
+    expected.sort_unstable();
+    expected.dedup();
+    assert_eq!(keys, expected, "status keys drifted");
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "absent"),
+            ("journal", "absent"),
+            ("phase", "none"),
+            ("callback", "none"),
+            ("callback_attempts", "0"),
+            ("activation_outcome", "none"),
+            ("error_class", "none"),
+            ("lock", "none"),
+            ("current", &current),
+            ("candidate", &current),
+            ("current_is_candidate", "yes"),
+            ("advisory_receipt", "matches-current"),
+            ("advisory_receipt_status", "activated"),
+            ("advisory_receipt_previous_generation", "none"),
+            ("daemon", "healthy"),
+            ("runtime_equals_current", "yes"),
+        ],
+    );
+    let (code, fields, _) = rig.status_cli(false);
+    assert_eq!(code, 0);
+    assert_fields(
+        &fields,
+        &[
+            ("daemon", "not-probed"),
+            ("runtime_equals_current", "unknown"),
+        ],
+    );
+}
+
+#[test]
+fn status_reports_a_pending_callback_as_resumable_lifecycle_state() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let previous = rig.current();
+    rig.induce_exit_6();
+    let current = rig.current();
+    assert_ne!(current, previous);
+    let (code, fields, _) = rig.status_cli(true);
+    assert_eq!(code, 0);
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "present"),
+            ("journal", "present"),
+            ("phase", "updated_pending"),
+            ("callback", "updated"),
+            ("callback_attempts", "1"),
+            ("activation_outcome", "activated"),
+            ("error_class", "none"),
+            ("lock", "retained"),
+            ("current", &current),
+            ("candidate", &current),
+            ("current_is_candidate", "yes"),
+            ("advisory_receipt", "matches-current"),
+            ("advisory_receipt_status", "activated"),
+            ("advisory_receipt_previous_generation", &previous),
+            ("daemon", "healthy"),
+            ("runtime_equals_current", "yes"),
+        ],
+    );
+}
+
+#[test]
+fn status_reports_manual_recovery_with_the_candidate_live() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let previous = rig.current();
+    rig.induce_exit_5("load-then-fail");
+    let current = rig.current();
+    assert_ne!(current, previous);
+    let (code, fields, _) = rig.status_cli(true);
+    assert_eq!(code, 0, "manual recovery is a report, not an error");
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "present"),
+            ("journal", "present"),
+            ("phase", "manual_recovery"),
+            ("callback", "none"),
+            ("callback_attempts", "0"),
+            ("activation_outcome", "recovery_required"),
+            ("error_class", "activation"),
+            ("lock", "retained"),
+            ("current", &current),
+            ("candidate", &current),
+            ("current_is_candidate", "yes"),
+            ("advisory_receipt", "matches-current"),
+            ("advisory_receipt_status", "recovery_required"),
+            ("advisory_receipt_previous_generation", &previous),
+            ("daemon", "healthy"),
+            ("runtime_equals_current", "yes"),
+        ],
+    );
+}
+
+#[test]
+fn status_reports_manual_recovery_with_the_candidate_not_live() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    rig.induce_exit_5("fail");
+    let (code, fields, _) = rig.status_cli(true);
+    assert_eq!(code, 0);
+    assert_fields(
+        &fields,
+        &[
+            ("phase", "manual_recovery"),
+            ("lock", "retained"),
+            ("current_is_candidate", "yes"),
+            ("daemon", "healthy"),
+            ("runtime_equals_current", "no"),
+        ],
+    );
+    rig.set("health-mode", "unhealthy");
+    let (_, fields, _) = rig.status_cli(true);
+    assert_fields(
+        &fields,
+        &[("daemon", "unhealthy"), ("runtime_equals_current", "no")],
+    );
+    rig.set("health-mode", "down");
+    let (_, fields, _) = rig.status_cli(true);
+    assert_fields(
+        &fields,
+        &[
+            ("daemon", "unreachable"),
+            ("runtime_equals_current", "unknown"),
+        ],
+    );
+}
+
+#[test]
+fn status_marks_an_absent_or_stale_receipt_and_still_names_the_candidate() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let bootstrap_receipt = fs::read(rig.receipt()).unwrap();
+    rig.induce_exit_5("fail");
+    let current = rig.current();
+    fs::remove_file(rig.receipt()).unwrap();
+    let (code, fields, _) = rig.status_cli(false);
+    assert_eq!(code, 0);
+    assert_fields(
+        &fields,
+        &[
+            ("advisory_receipt", "absent"),
+            ("advisory_receipt_status", "none"),
+            ("advisory_receipt_previous_generation", "none"),
+            ("candidate", &current),
+            ("current_is_candidate", "yes"),
+        ],
+    );
+    // The previous run's receipt survived an unlanded final write.
+    fs::write(rig.receipt(), &bootstrap_receipt).unwrap();
+    mode(&rig.receipt(), 0o600);
+    let (code, fields, _) = rig.status_cli(false);
+    assert_eq!(code, 0);
+    assert_fields(
+        &fields,
+        &[
+            ("advisory_receipt", "stale"),
+            ("advisory_receipt_status", "activated"),
+            ("candidate", &current),
+            ("current_is_candidate", "yes"),
+        ],
+    );
+    fs::write(rig.receipt(), b"{not json").unwrap();
+    let (code, fields, _) = rig.status_cli(false);
+    assert_eq!(code, 0);
+    assert_fields(&fields, &[("advisory_receipt", "unreadable")]);
+}
+
+#[test]
+fn status_reports_an_ambiguous_lock_request_as_no_candidate_and_unknown_lock() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let current = rig.current();
+    let server = Server::start(vec![Response::json(500)]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&server.origin)),
+        Err(LifecycleError::ManualRecovery)
+    );
+    server.finish();
+    let (code, fields, _) = rig.status_cli(true);
+    assert_eq!(code, 0);
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "present"),
+            ("phase", "manual_recovery"),
+            ("activation_outcome", "none"),
+            ("error_class", "status"),
+            ("lock", "unknown"),
+            ("current", &current),
+            ("candidate", "none"),
+            ("current_is_candidate", "no"),
+            ("advisory_receipt", "matches-current"),
+            ("daemon", "healthy"),
+            ("runtime_equals_current", "yes"),
+        ],
+    );
+}
+
+#[test]
+fn status_distinguishes_foreign_and_unreadable_fences_and_journals() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let foreign_runtime = rig.root.join("foreign-ipv4");
+    private_dir(&foreign_runtime);
+    let foreign_state = foreign_runtime.join("activation");
+    private_dir(&foreign_state);
+    let foreign = Binding::new(
+        "foreign-ipv4",
+        &foreign_runtime,
+        &foreign_state,
+        &rig.host,
+        &format!("unix://{}/grpc.sock", foreign_runtime.display()),
+    )
+    .unwrap();
+    let held = Guard::claim_new(&foreign).unwrap();
+    let (code, fields, _) = rig.status_cli(false);
+    assert_eq!(code, 0);
+    assert_fields(&fields, &[("fence", "foreign"), ("journal", "absent")]);
+    held.clear().unwrap();
+    drop(held);
+    fs::write(rig.fence(), b"{}").unwrap();
+    mode(&rig.fence(), 0o644);
+    fs::write(rig.journal(), b"{}").unwrap();
+    let (code, fields, _) = rig.status_cli(false);
+    assert_eq!(code, 0);
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "unreadable"),
+            ("journal", "unreadable"),
+            ("phase", "none"),
+            ("lock", "none"),
+        ],
+    );
+}
+
+#[test]
+fn status_exits_1_for_an_unreadable_state_directory_and_2_for_a_bad_binding() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    fs::remove_dir_all(&rig.state).unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rs-config-render"));
+    command.arg("status");
+    rig.binding_args(&mut command);
+    let output = command.output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8(output.stderr).unwrap(),
+        "rs-config-render: status: state directory is not a readable directory\n"
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args(["status", "--router-handle", HANDLE])
+        .arg("--runtime-state-dir")
+        .arg(&rig.runtime)
+        .arg("--state-dir")
+        .arg(&rig.state)
+        .arg("--host-state-dir")
+        .arg(&rig.host)
+        .args(["--rbgp-addr", "unix:///wrong/grpc.sock"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+}


### PR DESCRIPTION
## Summary

`rs-config-render status` reads the three durable artifacts that define an exit 5 — the host fence, the lifecycle journal, and the generation tree with its `current` link — plus the advisory activation receipt, and prints one `key: value` line per field in a fixed order. With `--rbgp` it runs the settle path's own probe (`rbgp health`, then `rbgp config diff` against the `current` generation). It takes the same binding flags as `activate`, takes no lock, and writes nothing durable (the comparison file it hands to `rbgp config diff` is created and removed inside the state directory).

```
rs-config-render status --router-handle … --runtime-state-dir … --state-dir … --host-state-dir … --rbgp-addr … [--rbgp PATH]
```

The 16 keys, in order: `fence` (absent | present | foreign | unreadable), `journal` (absent | present | unreadable), `phase`, `callback`, `callback_attempts`, `activation_outcome`, `error_class` (the journal's values; `none`/`0` without a journal), `lock` (none | retained | unknown), `current` (target | none | invalid (<reason>)), `candidate` (generations/<digest> | none | unknown), `current_is_candidate` (yes | no | unknown), `advisory_receipt` (matches-current | stale | absent | unreadable), `advisory_receipt_status`, `advisory_receipt_previous_generation`, `daemon` (not-probed | healthy | unhealthy | unreachable | invalid), `runtime_equals_current` (yes | no | unknown).

Exit semantics: 0 whenever the state could be read (manual recovery is a report, not an error); 1 only when the state directory is unreadable; 2 for an invalid binding. No new exit-table rows; `recover::Error` is added to `tests/exit_codes.rs`.

## Changes

- `activation.rs`: `health_probe`/`equal_runtime` take the rbgp executable and address explicitly (the settle path is unchanged); `Verified`, `verify_candidate`, `current_target`, `normalized_toml`, `comparison_file`, `Health` exposed crate-internally.
- `ixp_manager_lifecycle.rs`: `Journal`/`Phase` crate-internal with `name()`, `inspect_journal()`, `candidate_digest` crate-internal. `ixp_manager_host.rs`: `read_fence` crate-internal.
- New `recover.rs` (`status` + `Report`); `main.rs` `status` subcommand.
- New `tests/recover.rs`: a bootstrapped handle driven through real lifecycle runs against a loopback IXP Manager v7.4 stand-in, with mode-controlled `rbgp`/activation fakes. Eight tests: healthy/no-state, callback pending (exit 6), manual recovery with the candidate live, manual recovery with the candidate not live (+unhealthy/down), receipt absent/stale/unreadable, ambiguous lock request, foreign/unreadable fence and journal, exit 1/2. Every `status` invocation snapshots the state, runtime, and host-state trees (type, mode, content, link target) before and after and asserts them byte-for-byte equal.
- README: "Inspecting activation and lifecycle state" section and exit-table notes. Runbook: "How to recognise it" and step 1 now read the exact `status` output; the hand procedure moves to appendix A. CHANGELOG.

## Gates

`cargo fmt --check` 0 · `cargo clippy --workspace --all-targets -D warnings` 0 · `cargo test -p rs-config-render --test exit_codes` 0 · `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` 0 · `check-clippy-reasons.py` 0 · `check_public_tracker_ids.py` 0 · `cargo test --workspace --no-fail-fast`: one failure, `tests/activation.rs::started_failure_timeout_and_unsettled_retain_candidate_without_rollback` (the `elapsed < 4 s` bound), which reproduces identically on pristine `origin/main` (`ee812955`) on the same host and is addressed by #1806; `tests/activation.rs` is not touched here.
