### PR TITLE
feat: add rs-config-render recover verbs for manual-recovery state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   0 for any readable state (manual recovery included) and 1 only when the state
   directory is unreadable. The manual-recovery runbook's "is the candidate
   live?" step now reads its output. (LAN-1229)
+- `rs-config-render recover keep-current|rollback|release-lock|clear` resolve
+  manual-recovery (exit 5) state as commands: each refuses outside that state,
+  plans and prints its steps, performs nothing without `--apply`, journals
+  callback intent before the request, and leaves its record in the activation
+  receipt (`kept`, `rolled_back`) and the journal it clears. `keep-current` is
+  health-gated (`--force` overrides) and delivers `updated`; `rollback`
+  re-stages the previous generation through the activation path and delivers
+  `release-update-lock`; `release-lock --kept|--rolled-back` delivers one
+  callback standalone and retryably; `clear` removes fence and journal only
+  once no upstream lock is owed. The runbook's steps 2–5 now show the verbs'
+  exact output and keep the hand procedures as an appendix. (LAN-1229)
 - `rs-config-render prune --keep N` removes activation generations that no
   retention rule keeps: the `current` target, the last activation receipt's
   candidate and predecessor, anything a pending lifecycle journal names, and

--- a/docs/cookbook/activation-manual-recovery.md
+++ b/docs/cookbook/activation-manual-recovery.md
@@ -103,32 +103,88 @@ re-point first (step 2) and diff again.
 Pick by what step 1 showed. Neither `resume` nor `activate` will do this for
 you: `resume` refuses the `manual_recovery` phase, `activate` refuses while the
 fence stands and refuses again ("current runtime is not known-good") until
-`current` and the daemon agree. Re-pointing `current` is not currently
-supported as a command; the manual procedure is an atomic symlink swap, using
-the `previous_generation` value from the receipt:
+`current` and the daemon agree. The `recover` verbs do it. Every verb takes the
+binding flags `status` takes, is a dry run unless `--apply`, prints the exact
+steps it would perform, refuses (exit 2, nothing changed) outside this state,
+and — for a lifecycle run, whose journal owes the upstream lock — needs the
+same connection `resume` takes:
 
 ```bash
-PREV=generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a
-ln -s $PREV $STATE/.current.rollback && mv -T $STATE/.current.rollback $STATE/current && sync $STATE
-readlink $STATE/current
+BIND="--router-handle rs1-ipv4 --runtime-state-dir /var/lib/rustbgpd/rs1-ipv4 \
+  --state-dir $STATE --host-state-dir $HOST --rbgp-addr $UDS"
+IXP="--ixp-origin https://ixp.example.net --api-key-file /var/lib/rustbgpd/ixp-manager/api-key"
+```
+
+Without `$IXP` a journal-holding recovery refuses before planning (`lifecycle
+journal owes the upstream lock; pass --ixp-origin and --api-key-file`); a
+plain `activate` exit 5 has no journal and needs no connection.
+
+**Keep the candidate** (step 1 read `daemon: healthy` and
+`runtime_equals_current: yes`):
+
+```bash
+rs-config-render recover keep-current --rbgp /usr/bin/rbgp $BIND $IXP
 ```
 
 ```text
-generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a
+recover keep-current: probe: daemon healthy, runtime equals current
+recover keep-current: write activation receipt: status kept, candidate 53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c, previous generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a
+recover keep-current: deliver updated callback to https://ixp.example.net for rs1-ipv4 (attempt 1)
+recover keep-current: remove lifecycle journal
+recover keep-current: remove host fence
+recover keep-current: dry run — 5 step(s) planned; pass --apply to perform them
 ```
 
-| Step 1 said | Keep the candidate | Roll back |
-|---|---|---|
-| Live and equal | Nothing to do to the daemon. | Re-point, then run your activation command by hand (the exact `--activation-command`/`--activation-arg` line, normally `systemctl reload-or-restart rustbgpd@rs1-ipv4`). |
-| Live on the previous generation | Run your activation command by hand. | Re-point only; the daemon already runs it. |
-| Down | Run your activation command by hand (`reload-or-restart` starts a stopped unit on `current`). | Re-point, then run your activation command by hand. |
+Add `--apply` to perform exactly those steps; the last line becomes `recover
+keep-current: applied 5 step(s)` and the exit is 0. The verb is health-gated:
+when the probe does not read healthy and equal it refuses with `daemon is not
+settled on current; fix the daemon by hand or pass --force`. In the "live on
+the previous generation" and "down" rows that means either running your
+activation command by hand (`reload-or-restart` starts a stopped unit on
+`current`) and re-running `keep-current`, or rolling back. `--force` declares
+the candidate kept regardless (the probe line then ends `(overridden by
+--force)` and the receipt records `runtime_equal: false`).
 
-Then repeat `status --rbgp` until it reads `daemon: healthy` and
-`runtime_equals_current: yes` — that is the "current and daemon agree" state
-every later helper run requires.
+**Roll back** (step 1 read live-on-previous, down, or broken):
 
-Whichever you chose decides the callback in step 3: kept means `updated`,
-rolled back means `release-update-lock`.
+```bash
+rs-config-render recover rollback --rbgp /usr/bin/rbgp \
+  --activation-command /usr/bin/sudo --activation-arg=-n --activation-arg /usr/bin/systemctl \
+  --activation-arg reload-or-restart --activation-arg rustbgpd@rs1-ipv4 $BIND $IXP
+```
+
+```text
+recover rollback: re-point current generations/53fa45222b96917cac847a870e16a6a29da9195adf5db717a4bd3b305f9e1d9c -> generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a, run `/usr/bin/sudo -n /usr/bin/systemctl reload-or-restart rustbgpd@rs1-ipv4`, settle within 30s
+recover rollback: deliver release-update-lock callback to https://ixp.example.net for rs1-ipv4 (attempt 1)
+recover rollback: remove lifecycle journal
+recover rollback: remove host fence
+recover rollback: dry run — 4 step(s) planned; pass --apply to perform them
+```
+
+The target is the receipt's `previous_generation` when step 1 read
+`advisory_receipt: matches-current`; otherwise pass `--to
+generations/<digest>` — the generation `current` pointed at before the failed
+run, confirmed by the hand diff in appendix A. Rollback goes through the same
+publish → activation command → settle path as a first activation (not a bare
+symlink swap) and writes the activation receipt as `rolled_back`. If the daemon
+does not settle on the target within `--settle-seconds`, the verb exits 5
+(`rollback did not settle`): `current` is re-pointed, the receipt reads
+`recovery_required`, fence and journal stay — run `status` again and work from
+step 1. It refuses when the journal shows no candidate was activated (the
+lock-ambiguous case: use `release-lock --rolled-back` and `clear`), when the
+target is the current generation, or when the target is not a published
+generation.
+
+In both verbs the callback is the one step that can fail on its own (step 3):
+the local work is then done, the exit is 5, and the message names the retry
+(`updated callback was not delivered; upstream lock retained — retry with
+recover release-lock --kept`, or the `--rolled-back` twin). With a
+lock-ambiguous journal `keep-current` delivers `release-update-lock` instead of
+`updated`, since nothing was updated.
+
+Then `status --rbgp` reads `daemon: healthy` and `runtime_equals_current:
+yes` — that is the "current and daemon agree" state every later helper run
+requires.
 
 ## 3. Release the retained IXP Manager update lock (lifecycle runs only)
 
@@ -141,70 +197,74 @@ you clear local state in step 5 stops at the lock:
 rs-config-render: IXP Manager lifecycle: IXP Manager update lock was not acquired
 ```
 
-(exit 2, from a 423 Locked). Releasing it is not currently supported by
-`rs-config-render`; the manual procedure is to deliver, yourself, the callback
-the helper would have sent — the same v7.4 endpoint, same handle, same API key
-in the same header. Keep the key out of argv with a mode-0600 header file:
+(exit 2, from a 423 Locked). `keep-current` and `rollback` deliver the
+callback themselves; `release-lock` is for when that delivery failed, or when
+you resolved step 2 by hand ([appendix B](#b-the-hand-procedures)). It
+delivers one callback, standalone and retryable, and touches nothing else:
 
 ```bash
-umask 077
-printf 'X-IXP-Manager-API-Key: %s\n' "$(cat /var/lib/rustbgpd/ixp-manager/api-key)" \
-  > /var/lib/rustbgpd/ixp-manager/api-key-header
-# rolled back:
-curl -sS -X POST -H @/var/lib/rustbgpd/ixp-manager/api-key-header -w '\nHTTP %{http_code}\n' \
-  https://ixp.example.net/admin/api/v4/router/release-update-lock/rs1-ipv4
-# kept the candidate instead:
-curl -sS -X POST -H @/var/lib/rustbgpd/ixp-manager/api-key-header -w '\nHTTP %{http_code}\n' \
-  https://ixp.example.net/admin/api/v4/router/updated/rs1-ipv4
+rs-config-render recover release-lock --kept $BIND $IXP          # kept the candidate
+rs-config-render recover release-lock --rolled-back $BIND $IXP   # rolled back, or nothing was activated
 ```
 
 ```text
-{"last_update_started": "2026-08-22T15:05:00+00:00", "last_update_started_unix": 1787411100, "last_updated": "2026-08-22T15:05:00+00:00", "last_updated_unix": 1787411100}
-HTTP 200
+recover release-lock: deliver updated callback to https://ixp.example.net for rs1-ipv4 (attempt 2)
+recover release-lock: mark the upstream lock released in the lifecycle journal
+recover release-lock: dry run — 2 step(s) planned; pass --apply to perform them
 ```
 
-`release-update-lock` resets `last_update_started` to `last_updated`; `updated`
-stamps a new `last_updated`. Either way the lock is free. Delivery is
-at-least-once by design, so sending one twice is harmless; sending the wrong
-one is not — `updated` tells IXP Manager a configuration is live that you
-rolled away from.
+With `--apply` the intent is journaled before the request (`status` shows
+`callback` and `callback_attempts`); a failed delivery exits 5 and the same
+command retries it. Once delivered, `status` reads `lock: released`, and
+`keep-current`/`rollback` defer to `clear`. `release-update-lock` resets
+`last_update_started` to `last_updated`; `updated` stamps a new
+`last_updated`. Either way the lock is free. Delivery is at-least-once by
+design, so sending one twice is harmless; sending the wrong one is not —
+`updated` tells IXP Manager a configuration is live that you rolled away from.
 
 ## 4. The activation receipt may be absent or stale
 
 Exit 5 also covers "the receipt's final write or directory sync failed", so
-before re-running anything check the `advisory_receipt` line of `status`.
-`matches-current` means the receipt describes this attempt (its
-`candidate_sha256` equals the generation `current` pointed at when you
-arrived). `stale` (a receipt naming an older generation, or `"status":
-"activated"` for the previous run) or `absent` means the write never landed,
-and `previous_generation` is then whatever generation `current` pointed at
-*before* the failed run — confirm it by the hand diff in appendix A rather than
-the receipt. After a rollback the receipt is stale by construction
-(it still names the candidate). Leave it alone: the helper never reads it back
-— it verifies the render receipt inside each generation instead — and the next
-successful run rewrites it.
+the `advisory_receipt` line of `status` tells you whether the receipt describes
+this attempt: `matches-current` (its `candidate_sha256` equals the generation
+`current` pointed at when you arrived) or `stale`/`absent` (the write never
+landed; `previous_generation` is then whatever generation `current` pointed at
+*before* the failed run — confirm it by the hand diff in appendix A, and pass
+it to `rollback --to`). `keep-current` and `rollback` rewrite the receipt
+(`kept`, `rolled_back`) so it describes what you decided; the helper never
+reads it back — it verifies the render receipt inside each generation
+instead.
 
 ## 5. When automation may resume
 
 The fence and the journal are the helper's own proof that a human has not yet
-decided; clearing them is not currently supported as a command. The manual
-procedure, once steps 1–4 are done and `status --rbgp` reads `daemon: healthy`
-and `runtime_equals_current: yes`:
+decided. `keep-current` and `rollback` remove both as their last steps; `clear`
+does only that, for when you released the lock with `release-lock` or did
+step 2 by hand:
 
 ```bash
-rm $STATE/ixp-manager-lifecycle.json $HOST/ixp-manager-host-fence.json && sync $STATE $HOST
-ls -la $HOST
+rs-config-render recover clear $BIND
 ```
 
 ```text
--rw------- 1 rustbgpd rustbgpd    0 Aug 22 15:01 ixp-manager-host.lock
+recover clear: remove lifecycle journal
+recover clear: remove host fence
+recover clear: dry run — 2 step(s) planned; pass --apply to perform them
 ```
 
-Remove both as a pair. The fence belongs to the handle named inside it; a
-lifecycle for another handle sharing the host-state directory is refused while
-it stands. Then fix the cause (the sudoers rule, the unit name, the settle
-budget, the crashed restart) and run the lifecycle once by hand with the
-production arguments before handing back to cron:
+`clear` accepts exactly two states: no lifecycle journal at all (a plain
+`activate` exit 5, or a journal you removed by hand), or a journal whose
+callback `release-lock` delivered (`status` reads `lock: released`). Any other
+journal means the upstream lock is still owed and it refuses (`upstream lock
+still owed; run recover keep-current, recover rollback, or recover release-lock
+first`). It does not probe the daemon: make sure step 1 reads healthy and equal
+first, because every later helper run requires `current` and the daemon to
+agree. The fence belongs to the handle named inside it; a lifecycle for another
+handle sharing the host-state directory is refused while it stands.
+
+Then fix the cause (the sudoers rule, the unit name, the settle budget, the
+crashed restart) and run the lifecycle once by hand with the production
+arguments before handing back to cron:
 
 ```text
 IXP Manager lifecycle activated
@@ -321,6 +381,69 @@ rc=1
 
 `healthy: false` from `rbgp --json health` (`daemon: unhealthy`), or a diff
 that errors on a reachable daemon, is "live and broken".
+
+## B. The hand procedures
+
+What the `recover` verbs do, by hand, for a host without the binary or a state
+the verbs refuse (an unreadable or foreign fence or journal: inspect who wrote
+them before removing anything).
+
+**Re-point `current`** (rollback) is an atomic symlink swap using the
+`previous_generation` value from the receipt, followed by your activation
+command:
+
+```bash
+PREV=generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a
+ln -s $PREV $STATE/.current.rollback && mv -T $STATE/.current.rollback $STATE/current && sync $STATE
+readlink $STATE/current
+```
+
+```text
+generations/55de8d9cf767c58ce9b197129f69b2a776aa54bad6542385c4e5be924d8e460a
+```
+
+| Step 1 said | Keep the candidate | Roll back |
+|---|---|---|
+| Live and equal | Nothing to do to the daemon. | Re-point, then run your activation command by hand (the exact `--activation-command`/`--activation-arg` line, normally `systemctl reload-or-restart rustbgpd@rs1-ipv4`). |
+| Live on the previous generation | Run your activation command by hand. | Re-point only; the daemon already runs it. |
+| Down | Run your activation command by hand (`reload-or-restart` starts a stopped unit on `current`). | Re-point, then run your activation command by hand. |
+
+Whichever you chose decides the callback: kept means `updated`, rolled back
+means `release-update-lock`.
+
+**The callbacks** are the same v7.4 endpoints, same handle, same API key in
+the same header. Keep the key out of argv with a mode-0600 header file:
+
+```bash
+umask 077
+printf 'X-IXP-Manager-API-Key: %s\n' "$(cat /var/lib/rustbgpd/ixp-manager/api-key)" \
+  > /var/lib/rustbgpd/ixp-manager/api-key-header
+# rolled back:
+curl -sS -X POST -H @/var/lib/rustbgpd/ixp-manager/api-key-header -w '\nHTTP %{http_code}\n' \
+  https://ixp.example.net/admin/api/v4/router/release-update-lock/rs1-ipv4
+# kept the candidate instead:
+curl -sS -X POST -H @/var/lib/rustbgpd/ixp-manager/api-key-header -w '\nHTTP %{http_code}\n' \
+  https://ixp.example.net/admin/api/v4/router/updated/rs1-ipv4
+```
+
+```text
+{"last_update_started": "2026-08-22T15:05:00+00:00", "last_update_started_unix": 1787411100, "last_updated": "2026-08-22T15:05:00+00:00", "last_updated_unix": 1787411100}
+HTTP 200
+```
+
+**Clearing** is removing the fence and the journal as a pair:
+
+```bash
+rm $STATE/ixp-manager-lifecycle.json $HOST/ixp-manager-host-fence.json && sync $STATE $HOST
+ls -la $HOST
+```
+
+```text
+-rw------- 1 rustbgpd rustbgpd    0 Aug 22 15:01 ixp-manager-host.lock
+```
+
+After a hand rollback the receipt is stale by construction (it still names the
+candidate); leave it alone, the next successful run rewrites it.
 
 ## What this runbook does not cover
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -166,8 +166,10 @@ runtime is verified unchanged. Once it starts, a nonzero exit, timeout, or
 unsettled result leaves `current` on the candidate and returns exit 5. Leave
 retained state untouched and inspect the current private receipt if present;
 recovery or receipt durability is unproven, and the receipt may be absent or
-stale when its final write or directory sync failed. The operator procedure for
-exit 5 is the
+stale when its final write or directory sync failed. `rs-config-render status`
+reads that state without changing it and the `rs-config-render recover` verbs
+(`keep-current`, `rollback`, `release-lock`, `clear`; dry run unless `--apply`)
+resolve it; the operator procedure for exit 5 is the
 [activation manual-recovery runbook](cookbook/activation-manual-recovery.md).
 
 To drive the same path directly from IXP Manager v7.4, create a separate

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -336,6 +336,32 @@ diff` is created and removed inside the state directory. The
 [manual-recovery runbook](../../docs/cookbook/activation-manual-recovery.md)
 reads its output field by field.
 
+### Recovering from exit 5
+
+The `recover` verbs are the runbook's steps 2–5 as commands. Each takes the
+binding flags `status` takes, plans first and prints one `recover <verb>:
+<step>` line per step, performs nothing without `--apply` (with it, the lines
+are exactly the steps that completed), and refuses (exit 2, nothing changed)
+unless this binding's fence stands and the lifecycle journal, if any, is in
+manual recovery rather than resumable. A journal owes the upstream lock, so a
+journal-holding recovery also needs `--ixp-origin` and `--api-key-file` (the
+connection `resume` takes); a plain `activate` exit 5 needs neither.
+
+| Verb | Does | Refuses when |
+|---|---|---|
+| `keep-current --rbgp <PATH> [--force]` | probes the daemon (`rbgp health` + `config diff` against `current`), writes the receipt as `kept`, delivers `updated` (or `release-update-lock` when the journal shows nothing was activated), removes journal and fence | the probe is not healthy and equal (unless `--force`); the lock was already released |
+| `rollback --rbgp <PATH> --activation-command … [--activation-arg …] [--settle-seconds N] [--to generations/<digest>]` | re-points `current` at the previous generation and runs the activation command through the same publish-activate-settle path as a first activation, writes the receipt as `rolled_back`, delivers `release-update-lock`, removes journal and fence | the previous generation is unknown (receipt absent or stale) and `--to` is not given; the target is `current` or not a published generation; the journal shows nothing was activated; the lock was already released |
+| `release-lock --kept\|--rolled-back` | delivers that one callback and marks the journal `lock_released`; retryable | there is no journal |
+| `clear` | removes journal and fence | a journal exists whose callback no verb delivered |
+
+Callback intent is journaled before the request, exactly as the lifecycle does
+it. A step that does not complete under `--apply` — a callback not delivered, a
+rollback that does not settle — exits 5 with fence and journal retained and a
+message naming the retry (`recover release-lock --kept`, `status`); exit 5 keeps
+its single table meaning, "a human is needed". The
+[manual-recovery runbook](../../docs/cookbook/activation-manual-recovery.md)
+shows each verb's exact output and keeps the hand procedures as an appendix.
+
 Release tarballs (`rustbgpd-<arch>.tar.gz` on the [releases
 page](https://github.com/lance0/rustbgpd/releases)) ship the
 `rs-config-render` binary alongside `rustbgpd` and `rbgp`; from
@@ -411,7 +437,7 @@ stuck for more than a couple of refresh intervals should page, not rot.
 ## Exit codes
 
 One table for every subcommand (`render`, `--input-format ixp-manager-*`,
-`activate`, `ixp-manager-lifecycle run|resume`, `prune`, `status`): each code has exactly one
+`activate`, `ixp-manager-lifecycle run|resume`, `prune`, `status`, `recover`): each code has exactly one
 meaning, so a cron or systemd wrapper can branch on the code alone without
 knowing which subcommand ran. The mapping is asserted by
 `tests/exit_codes.rs` against this table and its mirror in
@@ -434,7 +460,10 @@ Codes 1–4 and 8–9 leave the previous configuration running untouched
 (fail-stale); 5 and 6 need an operator; 7 is safe to retry. `prune` uses 0, 2
 (fenced, busy, or unreadable forensic state — nothing removed), and 8. `status`
 uses 0 (any readable state, manual recovery included), 1 (unreadable state
-directory), and 2 (invalid binding).
+directory), and 2 (invalid binding). The `recover` verbs use 0, 2 (no fence for
+this binding, resumable or unreadable state, an unmet gate — nothing changed),
+and 5 (an `--apply` step did not complete; fence and journal retained, the
+message names the retry).
 
 Refused knobs: RTT-based communities and `rtt_thresholds` (the daemon
 has no RTT source; permanent), configured

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -54,6 +54,7 @@ mod unix {
     use serde_json::{Value, json};
     use sha2::{Digest, Sha256};
     use std::collections::{BTreeMap, BTreeSet};
+    use std::ffi::OsString;
     use std::fmt::Write as _;
     use std::fs::{self, File, OpenOptions};
     use std::io::Write as _;
@@ -85,7 +86,7 @@ mod unix {
         pub(crate) digest: String,
         files: BTreeMap<String, String>,
         directories: Vec<String>,
-        checker_version: String,
+        pub(crate) checker_version: String,
         pub(crate) config: Vec<u8>,
     }
 
@@ -645,10 +646,10 @@ mod unix {
         wait_output(child, deadline).is_some_and(|output| output.status.code() == Some(0))
     }
 
-    fn settle(options: &Options<'_>, comparison: &Path, deadline: Instant) -> bool {
+    fn settle(rbgp: &Path, rbgp_addr: &str, comparison: &Path, deadline: Instant) -> bool {
         loop {
-            if health_probe(options.rbgp, options.rbgp_addr, deadline) == Health::Reachable(true)
-                && equal_runtime(options.rbgp, options.rbgp_addr, comparison, deadline)
+            if health_probe(rbgp, rbgp_addr, deadline) == Health::Reachable(true)
+                && equal_runtime(rbgp, rbgp_addr, comparison, deadline)
             {
                 return true;
             }
@@ -666,10 +667,33 @@ mod unix {
         settled: bool,
     }
 
-    fn activate_and_settle(options: &Options<'_>, comparison: &Path) -> Attempt {
-        let deadline = Instant::now() + options.settle;
-        let Ok(child) = Command::new(options.activation_command)
-            .args(options.activation_args)
+    /// The activation command, then the settlement test; everything a
+    /// re-activation needs besides the generation itself.
+    #[derive(Clone, Copy)]
+    pub(crate) struct Activation<'a> {
+        pub(crate) command: &'a Path,
+        pub(crate) args: &'a [OsString],
+        pub(crate) rbgp: &'a Path,
+        pub(crate) rbgp_addr: &'a str,
+        pub(crate) settle: Duration,
+    }
+
+    impl<'a> From<&Options<'a>> for Activation<'a> {
+        fn from(options: &Options<'a>) -> Self {
+            Self {
+                command: options.activation_command,
+                args: options.activation_args,
+                rbgp: options.rbgp,
+                rbgp_addr: options.rbgp_addr,
+                settle: options.settle,
+            }
+        }
+    }
+
+    fn activate_and_settle(activation: Activation<'_>, comparison: &Path) -> Attempt {
+        let deadline = Instant::now() + activation.settle;
+        let Ok(child) = Command::new(activation.command)
+            .args(activation.args)
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
@@ -685,7 +709,7 @@ mod unix {
         Attempt {
             ran: true,
             health_checked: true,
-            settled: settle(options, comparison, deadline),
+            settled: settle(activation.rbgp, activation.rbgp_addr, comparison, deadline),
         }
     }
 
@@ -907,7 +931,8 @@ mod unix {
             unpublished.0.take();
             phases.candidate_publication = Some(publication);
             if publication == Publication::Durable {
-                phases.candidate = activate_and_settle(options, candidate_comparison.as_ref());
+                phases.candidate =
+                    activate_and_settle(options.into(), candidate_comparison.as_ref());
                 if phases.candidate.settled {
                     phases.runtime_equal = true;
                     drop(prior_comparison);
@@ -953,7 +978,7 @@ mod unix {
         unpublished.0.take();
         phases.candidate_publication = Some(publication);
         if publication == Publication::Durable {
-            phases.candidate = activate_and_settle(options, candidate_comparison.as_ref());
+            phases.candidate = activate_and_settle(options.into(), candidate_comparison.as_ref());
             phases.runtime_equal = phases.candidate.settled;
             if phases.candidate.settled {
                 drop(candidate_comparison);
@@ -964,6 +989,90 @@ mod unix {
         drop(candidate_comparison);
         finish("recovery_required", phases)?;
         Err(Error::RecoveryRequired)
+    }
+
+    /// The receipt a `recover keep-current` leaves: the exit-5 candidate stays
+    /// live (`kept`), with the probe result as `runtime_equal`.
+    pub(crate) fn write_kept_receipt(
+        state: &Path,
+        candidate: &str,
+        previous: Option<&str>,
+        runtime_equal: bool,
+        checker_version: &str,
+        binding: &Binding,
+    ) -> AResult<()> {
+        let attempt = Attempt {
+            ran: true,
+            health_checked: true,
+            settled: runtime_equal,
+        };
+        write_receipt(
+            state,
+            "kept",
+            candidate,
+            previous,
+            Phases {
+                candidate_publication: Some(Publication::Durable),
+                candidate: attempt,
+                runtime_equal,
+                ..Phases::default()
+            },
+            checker_version,
+            binding,
+        )
+    }
+
+    /// Re-point `current` at the already published generation `target` and run
+    /// the activation command through the same publish-activate-settle path a
+    /// first activation uses, then write the activation receipt for
+    /// `candidate` (the generation being rolled away from): `rolled_back` when
+    /// the daemon settled on `target`, `recovery_required` otherwise. The
+    /// caller holds the activation state lock. Returns whether it settled.
+    pub(crate) fn republish(
+        state: &Path,
+        target: &str,
+        candidate: &str,
+        activation: Activation<'_>,
+        binding: &Binding,
+    ) -> AResult<bool> {
+        let verified = verify_candidate(&state.join(target), binding)?;
+        let comparison =
+            comparison_file(&normalized_toml(&verified.config, state)?, state, "recover")?;
+        let mut phases = Phases {
+            candidate_publication: Some(Publication::Durable),
+            candidate: Attempt {
+                ran: true,
+                ..Attempt::default()
+            },
+            ..Phases::default()
+        };
+        let publication = publish_current(state, target);
+        if publication == Publication::UnchangedError {
+            return Err(Error::Refused(
+                "atomic current publication failed before rename",
+            ));
+        }
+        phases.rollback_publication = Some(publication);
+        if publication == Publication::Durable {
+            phases.rollback = activate_and_settle(activation, comparison.as_ref());
+            phases.runtime_equal = phases.rollback.settled;
+        }
+        drop(comparison);
+        let status = if phases.runtime_equal {
+            "rolled_back"
+        } else {
+            "recovery_required"
+        };
+        write_receipt(
+            state,
+            status,
+            candidate,
+            Some(target),
+            phases,
+            &verified.checker_version,
+            binding,
+        )?;
+        Ok(phases.runtime_equal)
     }
 
     fn host_error(error: ixp_manager_host::Error) -> Error {
@@ -995,6 +1104,7 @@ mod unix {
 pub use unix::activate;
 #[cfg(unix)]
 pub(crate) use unix::{
-    Comparison, Health, activate_guarded, comparison_file, current_target, equal_runtime,
-    health_probe, normalized_toml, private, state_lock, valid_digest, verify_candidate,
+    Activation, Comparison, Health, activate_guarded, comparison_file, current_target,
+    equal_runtime, health_probe, normalized_toml, private, republish, state_lock, valid_digest,
+    verify_candidate, write_kept_receipt,
 };

--- a/tools/rs-config-render/src/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/src/ixp_manager_lifecycle.rs
@@ -171,21 +171,62 @@ mod unix {
     pub(crate) struct Journal {
         schema: String,
         ixp_manager_version: String,
-        origin: String,
-        router_handle: String,
-        host: Binding,
+        pub(crate) origin: String,
+        pub(crate) router_handle: String,
+        pub(crate) host: Binding,
         pub(crate) phase: Phase,
         pub(crate) callback: Option<Callback>,
         pub(crate) callback_attempts: u32,
         pub(crate) candidate_sha256: Option<String>,
         pub(crate) activation_outcome: Option<String>,
         pub(crate) error_class: Option<String>,
+        /// Set by a `recover` verb once its terminal callback was delivered:
+        /// the upstream lock is no longer owed and `recover clear` may run.
+        #[serde(default)]
+        pub(crate) lock_released: bool,
     }
 
-    struct Client {
+    /// What `resume` would do with a journal; `None` is manual recovery.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum Pending {
+        Updated,
+        Release { rolled_back: bool },
+        ReleaseBeforeActivation,
+    }
+
+    pub(crate) fn pending(journal: &Journal) -> Option<Pending> {
+        match journal.phase {
+            Phase::UpdatedPending
+                if journal.callback == Some(Callback::Updated)
+                    && matches!(
+                        journal.activation_outcome.as_deref(),
+                        Some("activated" | "noop")
+                    ) =>
+            {
+                Some(Pending::Updated)
+            }
+            Phase::ReleasePending
+                if journal.callback == Some(Callback::Release)
+                    && matches!(
+                        journal.activation_outcome.as_deref(),
+                        Some("refused" | "rolled_back")
+                    ) =>
+            {
+                Some(Pending::Release {
+                    rolled_back: journal.activation_outcome.as_deref() == Some("rolled_back"),
+                })
+            }
+            Phase::Locked if journal.callback.is_none() && journal.activation_outcome.is_none() => {
+                Some(Pending::ReleaseBeforeActivation)
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) struct Client {
         agent: Agent,
-        origin: String,
-        handle: String,
+        pub(crate) origin: String,
+        pub(crate) handle: String,
         key: Zeroizing<String>,
     }
 
@@ -195,12 +236,12 @@ mod unix {
         Ambiguous(&'static str),
     }
 
-    enum RequestError {
+    pub(crate) enum RequestError {
         Definite,
         Ambiguous(&'static str),
     }
 
-    struct StateLock {
+    pub(crate) struct StateLock {
         _file: File,
     }
 
@@ -239,7 +280,7 @@ mod unix {
             .map_err(|_| Error::ManualRecovery)
     }
 
-    fn state_lock(state: &Path) -> Result<StateLock> {
+    pub(crate) fn state_lock(state: &Path) -> Result<StateLock> {
         if !state.is_absolute() || !private(state, true, 0o700) {
             return Err(Error::Refused(
                 "state directory must be a pre-created absolute mode-0700 directory",
@@ -381,7 +422,7 @@ mod unix {
     }
 
     impl Client {
-        fn new(
+        pub(crate) fn new(
             origin: &str,
             handle: &str,
             key_file: &Path,
@@ -473,7 +514,7 @@ mod unix {
             Ok(Zeroizing::new(body))
         }
 
-        fn callback(&self, callback: Callback) -> std::result::Result<(), RequestError> {
+        pub(crate) fn callback(&self, callback: Callback) -> std::result::Result<(), RequestError> {
             self.control(match callback {
                 Callback::Updated => "updated",
                 Callback::Release => "release-update-lock",
@@ -507,7 +548,7 @@ mod unix {
         state.join(JOURNAL)
     }
 
-    fn write_journal(state: &Path, journal: &Journal) -> Result<()> {
+    pub(crate) fn write_journal(state: &Path, journal: &Journal) -> Result<()> {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -590,7 +631,7 @@ mod unix {
             .map_err(|_| ())
     }
 
-    fn remove_journal(state: &Path) -> Result<()> {
+    pub(crate) fn remove_journal(state: &Path) -> Result<()> {
         fs::remove_file(journal_path(state)).map_err(|_| Error::ManualRecovery)?;
         sync_dir(state)
     }
@@ -608,6 +649,7 @@ mod unix {
             candidate_sha256: None,
             activation_outcome: None,
             error_class: None,
+            lock_released: false,
         }
     }
 
@@ -807,25 +849,12 @@ mod unix {
         let finish = |journal: &mut Journal, callback| {
             callback_pending(options.state_dir, &client, journal, callback, &guard)
         };
-        match journal.phase {
-            Phase::UpdatedPending
-                if journal.callback == Some(Callback::Updated)
-                    && matches!(
-                        journal.activation_outcome.as_deref(),
-                        Some("activated" | "noop")
-                    ) =>
-            {
+        match pending(&journal) {
+            Some(Pending::Updated) => {
                 finish(&mut journal, Callback::Updated)?;
                 Ok(Status::Updated)
             }
-            Phase::ReleasePending
-                if journal.callback == Some(Callback::Release)
-                    && matches!(
-                        journal.activation_outcome.as_deref(),
-                        Some("refused" | "rolled_back")
-                    ) =>
-            {
-                let rolled_back = journal.activation_outcome.as_deref() == Some("rolled_back");
+            Some(Pending::Release { rolled_back }) => {
                 finish(&mut journal, Callback::Release)?;
                 if rolled_back {
                     Err(Error::RolledBack)
@@ -833,21 +862,19 @@ mod unix {
                     Err(Error::Refused("lock released without activation"))
                 }
             }
-            Phase::Locked if journal.callback.is_none() && journal.activation_outcome.is_none() => {
+            Some(Pending::ReleaseBeforeActivation) => {
                 finish(&mut journal, Callback::Release)?;
                 Err(Error::Refused("lock released before activation"))
             }
-            Phase::LockRequestPending | Phase::ActivationStarted | Phase::ManualRecovery => {
-                Err(Error::ManualRecovery)
-            }
-            Phase::UpdatedPending | Phase::ReleasePending | Phase::Locked => {
-                Err(Error::ManualRecovery)
-            }
+            None => Err(Error::ManualRecovery),
         }
     }
 }
 
 #[cfg(unix)]
-pub(crate) use unix::{Journal, Phase, candidate_digest, inspect_journal, journal_candidate};
+pub(crate) use unix::{
+    Callback, Client, Journal, Phase, candidate_digest, inspect_journal, journal_candidate,
+    pending, remove_journal, state_lock, write_journal,
+};
 #[cfg(unix)]
 pub use unix::{resume, run};

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -83,6 +83,112 @@ struct StatusArgs {
     rbgp: Option<PathBuf>,
 }
 
+#[derive(Parser)]
+#[command(
+    name = "rs-config-render recover",
+    about = "Resolve manual-recovery (exit 5) state; every verb is a dry run unless --apply"
+)]
+struct RecoverArgs {
+    #[command(subcommand)]
+    command: RecoverCommand,
+}
+
+#[derive(Subcommand)]
+enum RecoverCommand {
+    /// Keep the live candidate: probe the daemon, deliver `updated`, clear fence and journal
+    KeepCurrent(KeepCurrentArgs),
+    /// Re-stage the previous generation through the activation path, deliver
+    /// `release-update-lock`, clear fence and journal
+    Rollback(RollbackArgs),
+    /// Deliver one callback standalone (retryable); the journal records delivery
+    ReleaseLock(ReleaseLockArgs),
+    /// Remove fence and journal once no upstream lock is owed
+    Clear(RecoverCommonArgs),
+}
+
+#[derive(clap::Args)]
+struct RecoverCommonArgs {
+    #[command(flatten)]
+    host: HostBindingArgs,
+    /// Perform the planned steps instead of only printing them
+    #[arg(long)]
+    apply: bool,
+    /// IXP Manager root origin; required with a lifecycle journal
+    #[arg(long, requires = "api_key_file")]
+    ixp_origin: Option<String>,
+    /// Absolute mode-0600 file containing the API key; required with a lifecycle journal
+    #[arg(long, requires = "ixp_origin")]
+    api_key_file: Option<PathBuf>,
+    /// Whole-request deadline in seconds
+    #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=300))]
+    request_timeout_seconds: u64,
+    /// Permit plaintext HTTP only to a numeric loopback origin
+    #[arg(long)]
+    allow_http_loopback: bool,
+}
+
+impl RecoverCommonArgs {
+    fn connection(&self) -> Option<rs_config_render::recover::Connection<'_>> {
+        Some(rs_config_render::recover::Connection {
+            ixp_origin: self.ixp_origin.as_deref()?,
+            api_key_file: self.api_key_file.as_deref()?,
+            timeout: Duration::from_secs(self.request_timeout_seconds),
+            allow_http_loopback: self.allow_http_loopback,
+        })
+    }
+}
+
+#[derive(clap::Args)]
+struct KeepCurrentArgs {
+    #[command(flatten)]
+    common: RecoverCommonArgs,
+    /// Exact rbgp executable used for the health and live config probe
+    #[arg(long)]
+    rbgp: PathBuf,
+    /// Proceed although the daemon is not proven healthy and settled on current
+    #[arg(long)]
+    force: bool,
+}
+
+#[derive(clap::Args)]
+struct RollbackArgs {
+    #[command(flatten)]
+    common: RecoverCommonArgs,
+    /// Exact rbgp executable used for settlement
+    #[arg(long)]
+    rbgp: PathBuf,
+    /// Maximum seconds for the rollback settlement
+    #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=120))]
+    settle_seconds: u64,
+    /// Exact activation executable; never evaluated by a shell
+    #[arg(long)]
+    activation_command: PathBuf,
+    /// Literal activation argument; repeatable and never shell-evaluated
+    #[arg(long, allow_hyphen_values = true)]
+    activation_arg: Vec<OsString>,
+    /// Generation to re-stage (`generations/<digest>`); defaults to the
+    /// activation receipt's previous_generation when that receipt describes
+    /// the current attempt
+    #[arg(long)]
+    to: Option<String>,
+}
+
+#[derive(clap::Args)]
+struct ReleaseLockArgs {
+    #[command(flatten)]
+    common: RecoverCommonArgs,
+    /// The candidate stays live: deliver `updated`
+    #[arg(
+        long,
+        conflicts_with = "rolled_back",
+        required_unless_present = "rolled_back"
+    )]
+    kept: bool,
+    /// The candidate was rolled away from or never activated: deliver `release-update-lock`
+    #[arg(long)]
+    rolled_back: bool,
+}
+
 #[derive(clap::Args)]
 struct HostBindingArgs {
     #[arg(long)]
@@ -291,6 +397,55 @@ fn parse_status() -> Option<StatusArgs> {
         .then(|| StatusArgs::parse_from(std::iter::once(binary).chain(args)))
 }
 
+fn parse_recover() -> Option<RecoverArgs> {
+    let mut args = std::env::args_os();
+    let binary = args.next()?;
+    (args.next().as_deref() == Some(OsStr::new("recover")))
+        .then(|| RecoverArgs::parse_from(std::iter::once(binary).chain(args)))
+}
+
+fn recover_exit(
+    common: &RecoverCommonArgs,
+    verb: &rs_config_render::recover::Verb<'_>,
+) -> ExitCode {
+    let name = verb.name();
+    let binding = match common.host.binding() {
+        Ok(binding) => binding,
+        Err(reason) => {
+            eprintln!("rs-config-render: recover {name}: {reason}");
+            return Exit::Refused.into();
+        }
+    };
+    let options = rs_config_render::recover::Options {
+        state_dir: &common.host.state_dir,
+        binding: &binding,
+        apply: common.apply,
+        connection: common.connection(),
+    };
+    match rs_config_render::recover::recover(&options, verb) {
+        Ok(outcome) => {
+            let count = outcome.steps.len();
+            let summary = if common.apply {
+                format!("recover {name}: applied {count} step(s)")
+            } else {
+                format!(
+                    "recover {name}: dry run — {count} step(s) planned; pass --apply to perform them"
+                )
+            };
+            stdout_exit(write_stdout(|writer| {
+                for step in &outcome.steps {
+                    writeln!(writer, "recover {name}: {step}")?;
+                }
+                writeln!(writer, "{summary}")
+            }))
+        }
+        Err(error) => {
+            eprintln!("rs-config-render: recover {name}: {error}");
+            error.exit_code().into()
+        }
+    }
+}
+
 fn parse_prune() -> Option<PruneArgs> {
     let mut args = std::env::args_os();
     let binary = args.next()?;
@@ -348,6 +503,39 @@ fn main() -> ExitCode {
                 eprintln!("rs-config-render: status: {error}");
                 error.exit_code().into()
             }
+        };
+    }
+    if let Some(args) = parse_recover() {
+        use rs_config_render::recover::{Released, RollbackActivation, Verb};
+        return match &args.command {
+            RecoverCommand::KeepCurrent(args) => recover_exit(
+                &args.common,
+                &Verb::KeepCurrent {
+                    rbgp: &args.rbgp,
+                    force: args.force,
+                },
+            ),
+            RecoverCommand::Rollback(args) => recover_exit(
+                &args.common,
+                &Verb::Rollback {
+                    activation: RollbackActivation {
+                        rbgp: &args.rbgp,
+                        settle: Duration::from_secs(args.settle_seconds),
+                        activation_command: &args.activation_command,
+                        activation_args: &args.activation_arg,
+                    },
+                    to: args.to.as_deref(),
+                },
+            ),
+            RecoverCommand::ReleaseLock(args) => recover_exit(
+                &args.common,
+                &Verb::ReleaseLock(if args.kept {
+                    Released::Kept
+                } else {
+                    Released::RolledBack
+                }),
+            ),
+            RecoverCommand::Clear(common) => recover_exit(common, &Verb::Clear),
         };
     }
     if let Some(args) = parse_prune() {

--- a/tools/rs-config-render/src/recover.rs
+++ b/tools/rs-config-render/src/recover.rs
@@ -1,11 +1,16 @@
-//! Operator inspection of the durable activation and lifecycle state.
+//! Operator inspection and recovery of the durable activation and lifecycle
+//! state.
 //!
 //! An exit 5 is characterised by three durable artifacts: the host fence, the
 //! lifecycle journal, and the generation tree with its `current` link. The
 //! activation receipt is advisory (it can be absent or stale after an exit 5).
 //! `status` reads all of them, probes the daemon when asked, and changes
-//! nothing; it is step 1 of the manual-recovery runbook.
+//! nothing; it is step 1 of the manual-recovery runbook. The `recover` verbs
+//! are steps 2–5: each refuses outside manual-recovery state, plans first,
+//! changes nothing without `--apply`, and leaves its record in the activation
+//! receipt and the journal it clears.
 
+use std::ffi::OsString;
 use std::fmt;
 use std::fs;
 use std::io;
@@ -15,8 +20,8 @@ use std::time::{Duration, Instant};
 use serde_json::Value;
 
 use crate::Exit;
-use crate::ixp_manager_host::{self, Binding};
-use crate::ixp_manager_lifecycle::{self as lifecycle, Journal, Phase};
+use crate::ixp_manager_host::{self, Binding, Guard};
+use crate::ixp_manager_lifecycle::{self as lifecycle, Callback, Journal, Phase};
 use crate::{activation, activation::Health};
 
 const ACTIVATION_RECEIPT: &str = "activation-receipt.json";
@@ -35,8 +40,12 @@ pub struct StatusOptions<'a> {
 pub enum Error {
     /// The state directory cannot be read at all; nothing can be reported.
     Unreadable(&'static str),
-    /// The options do not describe one handle's state.
+    /// The options do not describe one handle's state, or the state is not
+    /// one this verb may act on; nothing was changed.
     Refused(&'static str),
+    /// A `recover --apply` step did not complete: the state is still manual
+    /// recovery (fence and journal retained) and the message names the retry.
+    ManualRecovery(&'static str),
 }
 
 impl Error {
@@ -44,6 +53,7 @@ impl Error {
         match self {
             Self::Unreadable(_) => Exit::InvalidInput,
             Self::Refused(_) => Exit::Refused,
+            Self::ManualRecovery(_) => Exit::ManualRecovery,
         }
     }
 }
@@ -51,7 +61,9 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Unreadable(reason) | Self::Refused(reason) => formatter.write_str(reason),
+            Self::Unreadable(reason) | Self::Refused(reason) | Self::ManualRecovery(reason) => {
+                formatter.write_str(reason)
+            }
         }
     }
 }
@@ -135,6 +147,9 @@ fn journal_generation(state: &Path, receipt_sha256: &str) -> Option<String> {
 
 /// What the journal proves about the upstream router lock.
 fn upstream_lock(journal: &Journal) -> &'static str {
+    if journal.lock_released {
+        return "released";
+    }
     match journal.phase {
         Phase::LockRequestPending => "unknown",
         Phase::Locked
@@ -320,4 +335,493 @@ pub fn status(options: &StatusOptions<'_>) -> Result<Report, Error> {
     report.push("daemon", daemon);
     report.push("runtime_equals_current", equal);
     Ok(report)
+}
+
+/// The IXP Manager connection a journal-holding recovery needs for its
+/// callback; the same shape `ixp-manager-lifecycle resume` takes.
+#[derive(Debug)]
+pub struct Connection<'a> {
+    pub ixp_origin: &'a str,
+    pub api_key_file: &'a Path,
+    pub timeout: Duration,
+    pub allow_http_loopback: bool,
+}
+
+#[derive(Debug)]
+pub struct Options<'a> {
+    pub state_dir: &'a Path,
+    pub binding: &'a Binding,
+    /// Perform the plan; otherwise only print it.
+    pub apply: bool,
+    /// Required whenever a lifecycle journal owes the upstream lock.
+    pub connection: Option<Connection<'a>>,
+}
+
+/// Which callback a `release-lock` delivers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Released {
+    /// The candidate stays live: `updated`.
+    Kept,
+    /// The candidate was rolled away from (or never activated):
+    /// `release-update-lock`.
+    RolledBack,
+}
+
+#[derive(Debug)]
+pub enum Verb<'a> {
+    /// Keep the candidate that is live: health-gated, `updated` callback,
+    /// fence and journal cleared.
+    KeepCurrent { rbgp: &'a Path, force: bool },
+    /// Re-stage the previous generation through the activation path,
+    /// `release-update-lock` callback, fence and journal cleared.
+    Rollback {
+        activation: RollbackActivation<'a>,
+        /// The generation to re-stage; defaults to the activation receipt's
+        /// `previous_generation` when that receipt describes the current attempt.
+        to: Option<&'a str>,
+    },
+    /// One callback, standalone and retryable; the journal records delivery.
+    ReleaseLock(Released),
+    /// Fence and journal only; refuses while the upstream lock is still owed.
+    Clear,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RollbackActivation<'a> {
+    pub rbgp: &'a Path,
+    pub settle: Duration,
+    pub activation_command: &'a Path,
+    pub activation_args: &'a [OsString],
+}
+
+impl Verb<'_> {
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::KeepCurrent { .. } => "keep-current",
+            Self::Rollback { .. } => "rollback",
+            Self::ReleaseLock(_) => "release-lock",
+            Self::Clear => "clear",
+        }
+    }
+}
+
+/// What a verb did (`--apply`) or would do: one line per step, in order. On
+/// an `--apply` failure the lines are exactly the steps that completed.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Outcome {
+    pub steps: Vec<String>,
+}
+
+enum Step {
+    Probe(String),
+    Receipt {
+        status: &'static str,
+        candidate: String,
+        previous: Option<String>,
+        runtime_equal: bool,
+    },
+    Republish {
+        from: String,
+        to: String,
+    },
+    Callback(Callback),
+    MarkReleased,
+    RemoveJournal,
+    ClearFence,
+}
+
+impl Step {
+    fn describe(&self, session: &Session<'_>) -> String {
+        match self {
+            Self::Probe(result) => format!("probe: {result}"),
+            Self::Receipt {
+                status,
+                candidate,
+                previous,
+                ..
+            } => format!(
+                "write activation receipt: status {status}, candidate {candidate}, previous {}",
+                previous.as_deref().unwrap_or("none")
+            ),
+            Self::Republish { from, to } => {
+                let activation = session.activation.expect("rollback carries its activation");
+                let mut command = activation.activation_command.display().to_string();
+                for arg in activation.activation_args {
+                    command.push(' ');
+                    command.push_str(&arg.to_string_lossy());
+                }
+                format!(
+                    "re-point current {from} -> {to}, run `{command}`, settle within {}s",
+                    activation.settle.as_secs()
+                )
+            }
+            Self::Callback(callback) => {
+                let client = session.client.as_ref().expect("callbacks carry a client");
+                let journal = session.journal.as_ref().expect("callbacks carry a journal");
+                format!(
+                    "deliver {} callback to {} for {} (attempt {})",
+                    match callback {
+                        Callback::Updated => "updated",
+                        Callback::Release => "release-update-lock",
+                    },
+                    client.origin,
+                    client.handle,
+                    journal.callback_attempts + 1
+                )
+            }
+            Self::MarkReleased => "mark the upstream lock released in the lifecycle journal".into(),
+            Self::RemoveJournal => "remove lifecycle journal".into(),
+            Self::ClearFence => "remove host fence".into(),
+        }
+    }
+}
+
+struct Session<'a> {
+    options: &'a Options<'a>,
+    guard: Guard,
+    journal: Option<Journal>,
+    client: Option<lifecycle::Client>,
+    activation: Option<RollbackActivation<'a>>,
+    checker_version: String,
+}
+
+fn host_refusal(error: ixp_manager_host::Error) -> Error {
+    match error {
+        ixp_manager_host::Error::Refused("no pending host fence exists") => {
+            Error::Refused("no host fence for this binding; nothing to recover")
+        }
+        ixp_manager_host::Error::Refused(reason) => Error::Refused(reason),
+        ixp_manager_host::Error::RecoveryRequired => {
+            Error::Refused("host fence is unreadable; inspect it before recovering")
+        }
+    }
+}
+
+fn activation_refusal(error: activation::Error) -> Error {
+    match error {
+        activation::Error::Refused(reason) => Error::Refused(reason),
+        activation::Error::RolledBack | activation::Error::RecoveryRequired => {
+            Error::Refused("activation state is unusable")
+        }
+    }
+}
+
+fn lifecycle_refusal(error: lifecycle::Error) -> Error {
+    match error {
+        lifecycle::Error::Refused(reason) => Error::Refused(reason),
+        _ => Error::Refused("lifecycle state is unusable"),
+    }
+}
+
+fn probe(rbgp: &Path, binding: &Binding, state: &Path, current: &str) -> (bool, String) {
+    let health = activation::health_probe(rbgp, binding.rbgp_addr(), Instant::now() + PROBE);
+    let daemon = match health {
+        Health::Reachable(true) => "healthy",
+        Health::Reachable(false) => "unhealthy",
+        Health::Unreachable => "unreachable",
+        Health::Invalid => "invalid",
+    };
+    let equal = health == Health::Reachable(true)
+        && comparison(state, current, binding).is_ok_and(|file| {
+            activation::equal_runtime(
+                rbgp,
+                binding.rbgp_addr(),
+                file.as_ref(),
+                Instant::now() + PROBE,
+            )
+        });
+    (
+        equal,
+        format!(
+            "daemon {daemon}, runtime {} current",
+            if equal { "equals" } else { "differs from" }
+        ),
+    )
+}
+
+/// Plan and, with `apply`, perform one recovery verb. Every verb refuses
+/// (exit 2, nothing changed) unless this binding's fence stands and the
+/// lifecycle journal, if any, is in manual recovery rather than resumable.
+pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error> {
+    let binding = options.binding;
+    let state = options.state_dir;
+    if state != binding.activation_state_dir {
+        return Err(Error::Refused("state directory must match host binding"));
+    }
+    let guard = Guard::claim_existing(binding).map_err(host_refusal)?;
+    let _activation_lock = activation::state_lock(state).map_err(activation_refusal)?;
+    let _lifecycle_lock = lifecycle::state_lock(state).map_err(lifecycle_refusal)?;
+    let journal = lifecycle::inspect_journal(state).map_err(|()| {
+        Error::Refused("lifecycle journal is unreadable; inspect it before recovering")
+    })?;
+    if let Some(journal) = &journal {
+        if journal.host != *binding {
+            return Err(Error::Refused("lifecycle journal identity does not match"));
+        }
+        if lifecycle::pending(journal).is_some() {
+            return Err(Error::Refused(
+                "lifecycle state is resumable, not manual recovery; run ixp-manager-lifecycle resume",
+            ));
+        }
+    }
+    // A callback needs the connection; validate it (origin, key file) before
+    // planning so a dry run refuses exactly where --apply would.
+    let client = match (&journal, &options.connection) {
+        (Some(journal), Some(connection)) => {
+            let client = lifecycle::Client::new(
+                connection.ixp_origin,
+                &binding.router_handle,
+                connection.api_key_file,
+                connection.timeout,
+                connection.allow_http_loopback,
+            )
+            .map_err(lifecycle_refusal)?;
+            if journal.origin != client.origin || journal.router_handle != client.handle {
+                return Err(Error::Refused("lifecycle journal identity does not match"));
+            }
+            Some(client)
+        }
+        (Some(_), None) if !matches!(verb, Verb::Clear) => {
+            return Err(Error::Refused(
+                "lifecycle journal owes the upstream lock; pass --ixp-origin and --api-key-file",
+            ));
+        }
+        _ => None,
+    };
+    let current = activation::current_target(state, binding).map_err(activation_refusal)?;
+    let receipt = read_receipt(state);
+    let receipt_previous = match (&receipt, &current) {
+        (
+            Receipt::Present {
+                candidate,
+                previous,
+                ..
+            },
+            Some(target),
+        ) if *target == format!("generations/{candidate}") => previous.clone(),
+        _ => None,
+    };
+    let mut session = Session {
+        options,
+        guard,
+        journal,
+        client,
+        activation: None,
+        checker_version: String::new(),
+    };
+    let journal = session.journal.as_ref();
+    let lock_released = journal.is_some_and(|journal| journal.lock_released);
+    // Lifecycle journals without an activation outcome never staged a
+    // candidate: the lock request itself was the ambiguous step.
+    let activated = journal.is_none_or(|journal| journal.activation_outcome.is_some());
+    let mut plan = Vec::new();
+    match verb {
+        Verb::KeepCurrent { rbgp, force } => {
+            if lock_released {
+                return Err(Error::Refused(
+                    "upstream lock already released; run recover clear",
+                ));
+            }
+            let Some(current) = current.as_deref() else {
+                return Err(Error::Refused("no current generation to keep"));
+            };
+            let (equal, detail) = probe(rbgp, binding, state, current);
+            if !equal && !*force {
+                return Err(Error::Refused(
+                    "daemon is not settled on current; fix the daemon by hand or pass --force",
+                ));
+            }
+            plan.push(Step::Probe(if equal {
+                detail
+            } else {
+                format!("{detail} (overridden by --force)")
+            }));
+            session.checker_version = activation::verify_candidate(&state.join(current), binding)
+                .map_err(activation_refusal)?
+                .checker_version;
+            plan.push(Step::Receipt {
+                status: "kept",
+                candidate: current
+                    .strip_prefix("generations/")
+                    .expect("current_target validated the prefix")
+                    .to_owned(),
+                previous: receipt_previous,
+                runtime_equal: equal,
+            });
+            if journal.is_some() {
+                plan.push(Step::Callback(if activated {
+                    Callback::Updated
+                } else {
+                    Callback::Release
+                }));
+                plan.push(Step::RemoveJournal);
+            }
+            plan.push(Step::ClearFence);
+        }
+        Verb::Rollback { activation, to } => {
+            if lock_released {
+                return Err(Error::Refused(
+                    "upstream lock already released; run recover clear",
+                ));
+            }
+            if !activated {
+                return Err(Error::Refused(
+                    "no candidate was activated (the lock request was ambiguous); run recover release-lock --rolled-back, then recover clear",
+                ));
+            }
+            let Some(current) = current.as_deref() else {
+                return Err(Error::Refused("no current generation to roll back from"));
+            };
+            let target = match to {
+                Some(to) => to.to_string(),
+                None => receipt_previous.ok_or(Error::Refused(
+                    "previous generation unknown (activation receipt absent or stale); pass --to generations/<digest>",
+                ))?,
+            };
+            if target == current {
+                return Err(Error::Refused(
+                    "rollback target is the current generation; run recover keep-current",
+                ));
+            }
+            if !target
+                .strip_prefix("generations/")
+                .is_some_and(activation::valid_digest)
+                || activation::verify_candidate(&state.join(&target), binding).is_err()
+            {
+                return Err(Error::Refused(
+                    "rollback target is not a published generation",
+                ));
+            }
+            session.activation = Some(*activation);
+            plan.push(Step::Republish {
+                from: current.to_owned(),
+                to: target,
+            });
+            if journal.is_some() {
+                plan.push(Step::Callback(Callback::Release));
+                plan.push(Step::RemoveJournal);
+            }
+            plan.push(Step::ClearFence);
+        }
+        Verb::ReleaseLock(released) => {
+            if journal.is_none() {
+                return Err(Error::Refused(
+                    "no lifecycle journal; no upstream lock is owed",
+                ));
+            }
+            plan.push(Step::Callback(match released {
+                Released::Kept => Callback::Updated,
+                Released::RolledBack => Callback::Release,
+            }));
+            plan.push(Step::MarkReleased);
+        }
+        Verb::Clear => {
+            if journal.is_some() && !lock_released {
+                return Err(Error::Refused(
+                    "upstream lock still owed; run recover keep-current, recover rollback, or recover release-lock first",
+                ));
+            }
+            if journal.is_some() {
+                plan.push(Step::RemoveJournal);
+            }
+            plan.push(Step::ClearFence);
+        }
+    }
+    let mut outcome = Outcome::default();
+    for step in &plan {
+        let line = step.describe(&session);
+        if options.apply {
+            session.perform(step)?;
+        }
+        outcome.steps.push(line);
+    }
+    Ok(outcome)
+}
+
+impl Session<'_> {
+    fn perform(&mut self, step: &Step) -> Result<(), Error> {
+        let state = self.options.state_dir;
+        let binding = self.options.binding;
+        match step {
+            Step::Probe(_) => Ok(()),
+            Step::Receipt {
+                candidate,
+                previous,
+                runtime_equal,
+                ..
+            } => activation::write_kept_receipt(
+                state,
+                candidate,
+                previous.as_deref(),
+                *runtime_equal,
+                &self.checker_version,
+                binding,
+            )
+            .map_err(|_| Error::ManualRecovery("activation receipt could not be written")),
+            Step::Republish { from, to } => {
+                let activation = self.activation.expect("rollback carries its activation");
+                let candidate = from
+                    .strip_prefix("generations/")
+                    .expect("current_target validated the prefix");
+                let settled = activation::republish(
+                    state,
+                    to,
+                    candidate,
+                    activation::Activation {
+                        command: activation.activation_command,
+                        args: activation.activation_args,
+                        rbgp: activation.rbgp,
+                        rbgp_addr: binding.rbgp_addr(),
+                        settle: activation.settle,
+                    },
+                    binding,
+                )
+                .map_err(|error| match error {
+                    activation::Error::Refused(reason) => Error::Refused(reason),
+                    _ => Error::ManualRecovery("activation receipt could not be written"),
+                })?;
+                if settled {
+                    Ok(())
+                } else {
+                    Err(Error::ManualRecovery(
+                        "rollback did not settle: current is re-pointed but the daemon did not prove it; inspect with status",
+                    ))
+                }
+            }
+            Step::Callback(callback) => {
+                let client = self.client.as_ref().expect("callbacks carry a client");
+                let journal = self.journal.as_mut().expect("callbacks carry a journal");
+                // Intent before the request, like the lifecycle itself.
+                journal.callback = Some(*callback);
+                journal.callback_attempts = journal.callback_attempts.saturating_add(1);
+                lifecycle::write_journal(state, journal)
+                    .map_err(|_| Error::ManualRecovery("lifecycle journal could not be written"))?;
+                match client.callback(*callback) {
+                    Ok(()) => {
+                        journal.lock_released = true;
+                        lifecycle::write_journal(state, journal).map_err(|_| {
+                            Error::ManualRecovery("lifecycle journal could not be written")
+                        })
+                    }
+                    Err(_) => Err(Error::ManualRecovery(match callback {
+                        Callback::Updated => {
+                            "updated callback was not delivered; upstream lock retained — retry with recover release-lock --kept"
+                        }
+                        Callback::Release => {
+                            "release-update-lock callback was not delivered; upstream lock retained — retry with recover release-lock --rolled-back"
+                        }
+                    })),
+                }
+            }
+            // Delivery already marked the journal; the step exists so the plan
+            // names the durable effect.
+            Step::MarkReleased => Ok(()),
+            Step::RemoveJournal => lifecycle::remove_journal(state)
+                .map_err(|_| Error::ManualRecovery("lifecycle journal could not be removed")),
+            Step::ClearFence => self
+                .guard
+                .clear()
+                .map_err(|_| Error::ManualRecovery("host fence could not be removed")),
+        }
+    }
 }

--- a/tools/rs-config-render/tests/exit_codes.rs
+++ b/tools/rs-config-render/tests/exit_codes.rs
@@ -177,10 +177,13 @@ fn every_error_variant_maps_to_the_shared_table() {
     let recovery = [
         (recover::Error::Unreadable(""), Exit::InvalidInput),
         (recover::Error::Refused(""), Exit::Refused),
+        (recover::Error::ManualRecovery(""), Exit::ManualRecovery),
     ];
     for (error, exit) in &recovery {
         match error {
-            recover::Error::Unreadable(_) | recover::Error::Refused(_) => {}
+            recover::Error::Unreadable(_)
+            | recover::Error::Refused(_)
+            | recover::Error::ManualRecovery(_) => {}
         }
         assert_eq!(error.exit_code(), *exit, "{error:?}");
     }

--- a/tools/rs-config-render/tests/recover.rs
+++ b/tools/rs-config-render/tests/recover.rs
@@ -339,17 +339,83 @@ esac
 
     /// Drive one lifecycle run into exit 5 with the activation command in
     /// `activation_mode`; the upstream lock is retained and no callback sent.
-    fn induce_exit_5(&self, activation_mode: &str) {
+    /// The stand-in keeps serving `afterwards` to whatever recovery follows.
+    fn induce_exit_5(&self, activation_mode: &str, afterwards: Vec<Response>) -> Server {
         self.set("activation-mode", activation_mode);
-        let server = Server::start(vec![Response::json(200), Response::config(FIXTURE)]);
+        let mut responses = vec![Response::json(200), Response::config(FIXTURE)];
+        responses.extend(afterwards);
+        let server = Server::start(responses);
         assert_eq!(
             lifecycle::run(&self.options(&server.origin)),
             Err(LifecycleError::ManualRecovery)
         );
-        assert_eq!(server.finish().len(), 2, "exit 5 must not callback");
+        assert_eq!(
+            server.requests.lock().unwrap().len(),
+            2,
+            "exit 5 must not callback"
+        );
         self.set("activation-mode", "ok");
         assert!(self.fence().exists());
         assert!(self.journal().exists());
+        server
+    }
+
+    /// One `recover` verb through the binary. A dry run is asserted to change
+    /// nothing; the returned lines are the `recover <verb>: ` step lines
+    /// without the prefix, followed by the summary line.
+    fn recover_cli(
+        &self,
+        verb: &[&str],
+        apply: bool,
+        origin: Option<&str>,
+    ) -> (i32, Vec<String>, String) {
+        let before = snapshot(&self.root);
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rs-config-render"));
+        command.arg("recover").args(verb);
+        self.binding_args(&mut command);
+        if apply {
+            command.arg("--apply");
+        }
+        if let Some(origin) = origin {
+            command
+                .args(["--ixp-origin", origin, "--api-key-file"])
+                .arg(&self.key)
+                .args(["--request-timeout-seconds", "2", "--allow-http-loopback"]);
+        }
+        let output = command.output().unwrap();
+        if !apply {
+            assert_eq!(snapshot(&self.root), before, "dry run changed state");
+        }
+        let prefix = format!("recover {}: ", verb[0]);
+        let lines = String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .map(|line| {
+                line.strip_prefix(&prefix)
+                    .unwrap_or_else(|| panic!("unprefixed line: {line}"))
+                    .to_owned()
+            })
+            .collect();
+        (
+            output.status.code().unwrap(),
+            lines,
+            String::from_utf8(output.stderr).unwrap(),
+        )
+    }
+
+    fn runtime(&self) -> String {
+        fs::read_to_string(self.root.join("runtime"))
+            .unwrap()
+            .trim()
+            .to_owned()
+    }
+
+    fn journal_value(&self) -> serde_json::Value {
+        serde_json::from_slice(&fs::read(self.journal()).unwrap()).unwrap()
+    }
+
+    fn receipt_value(&self) -> serde_json::Value {
+        serde_json::from_slice(&fs::read(self.receipt()).unwrap()).unwrap()
     }
 
     /// One failed `updated` callback after a successful activation: exit 6.
@@ -555,7 +621,7 @@ fn status_reports_manual_recovery_with_the_candidate_live() {
     let _guard = test_guard();
     let rig = Rig::new();
     let previous = rig.current();
-    rig.induce_exit_5("load-then-fail");
+    rig.induce_exit_5("load-then-fail", vec![]);
     let current = rig.current();
     assert_ne!(current, previous);
     let (code, fields, _) = rig.status_cli(true);
@@ -587,7 +653,7 @@ fn status_reports_manual_recovery_with_the_candidate_live() {
 fn status_reports_manual_recovery_with_the_candidate_not_live() {
     let _guard = test_guard();
     let rig = Rig::new();
-    rig.induce_exit_5("fail");
+    rig.induce_exit_5("fail", vec![]);
     let (code, fields, _) = rig.status_cli(true);
     assert_eq!(code, 0);
     assert_fields(
@@ -622,7 +688,7 @@ fn status_marks_an_absent_or_stale_receipt_and_still_names_the_candidate() {
     let _guard = test_guard();
     let rig = Rig::new();
     let bootstrap_receipt = fs::read(rig.receipt()).unwrap();
-    rig.induce_exit_5("fail");
+    rig.induce_exit_5("fail", vec![]);
     let current = rig.current();
     fs::remove_file(rig.receipt()).unwrap();
     let (code, fields, _) = rig.status_cli(false);
@@ -752,4 +818,491 @@ fn status_exits_1_for_an_unreadable_state_directory_and_2_for_a_bad_binding() {
         .output()
         .unwrap();
     assert_eq!(output.status.code(), Some(2));
+}
+
+fn keep_args(rig: &Rig) -> Vec<String> {
+    vec![
+        "keep-current".into(),
+        "--rbgp".into(),
+        rig.rbgp.display().to_string(),
+    ]
+}
+
+fn rollback_args(rig: &Rig) -> Vec<String> {
+    vec![
+        "rollback".into(),
+        "--rbgp".into(),
+        rig.rbgp.display().to_string(),
+        "--settle-seconds".into(),
+        "2".into(),
+        "--activation-command".into(),
+        rig.activation.display().to_string(),
+    ]
+}
+
+fn strs(args: &[String]) -> Vec<&str> {
+    args.iter().map(String::as_str).collect()
+}
+
+#[test]
+fn every_recover_verb_refuses_outside_manual_recovery() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let keep = keep_args(&rig);
+    let rollback = rollback_args(&rig);
+    let verbs: [&[&str]; 4] = [
+        &strs(&keep),
+        &strs(&rollback),
+        &["release-lock", "--kept"],
+        &["clear"],
+    ];
+    // Healthy handle: no fence, nothing to recover.
+    for verb in verbs {
+        for apply in [false, true] {
+            let (code, lines, stderr) = rig.recover_cli(verb, apply, None);
+            assert_eq!(code, 2, "{verb:?}: {stderr}");
+            assert!(lines.is_empty());
+            assert_eq!(
+                stderr,
+                format!(
+                    "rs-config-render: recover {}: no host fence for this binding; nothing to recover\n",
+                    verb[0]
+                )
+            );
+        }
+    }
+    // Exit 6: the fence stands but the journal is resumable, not manual recovery.
+    let rig = Rig::new();
+    rig.induce_exit_6();
+    for verb in verbs {
+        let (code, _, stderr) = rig.recover_cli(verb, true, Some("http://127.0.0.1:9"));
+        assert_eq!(code, 2, "{verb:?}: {stderr}");
+        assert!(
+            stderr.contains("lifecycle state is resumable, not manual recovery"),
+            "{stderr}"
+        );
+    }
+    assert!(rig.journal().exists());
+    assert!(rig.fence().exists());
+}
+
+#[test]
+fn dry_runs_change_nothing_and_apply_performs_exactly_the_printed_steps() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let previous = rig.current();
+    let server = rig.induce_exit_5("load-then-fail", vec![Response::json(200)]);
+    let candidate = rig.current();
+    let keep = keep_args(&rig);
+    // Without the connection a journal-holding recovery refuses before planning.
+    let (code, _, stderr) = rig.recover_cli(&strs(&keep), false, None);
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("pass --ixp-origin and --api-key-file"),
+        "{stderr}"
+    );
+    let (code, dry, stderr) = rig.recover_cli(&strs(&keep), false, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(
+        dry,
+        vec![
+            "probe: daemon healthy, runtime equals current".to_owned(),
+            format!(
+                "write activation receipt: status kept, candidate {}, previous {previous}",
+                candidate.strip_prefix("generations/").unwrap()
+            ),
+            format!(
+                "deliver updated callback to {} for {HANDLE} (attempt 1)",
+                server.origin
+            ),
+            "remove lifecycle journal".to_owned(),
+            "remove host fence".to_owned(),
+            "dry run — 5 step(s) planned; pass --apply to perform them".to_owned(),
+        ]
+    );
+    assert!(rig.journal().exists() && rig.fence().exists());
+    let (code, applied, stderr) = rig.recover_cli(&strs(&keep), true, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(
+        applied[..5],
+        dry[..5],
+        "--apply must do what the dry run printed"
+    );
+    assert_eq!(applied[5], "applied 5 step(s)");
+    let requests = server.finish();
+    assert_eq!(requests.len(), 3);
+    assert_request(&requests[2], "POST", "updated");
+    assert!(!rig.journal().exists());
+    assert!(!rig.fence().exists());
+    assert_eq!(rig.current(), candidate);
+    let receipt = rig.receipt_value();
+    assert_eq!(receipt["status"], "kept");
+    assert_eq!(
+        format!(
+            "generations/{}",
+            receipt["candidate_sha256"].as_str().unwrap()
+        ),
+        candidate
+    );
+    assert_eq!(receipt["previous_generation"], previous);
+    assert_eq!(receipt["phases"]["runtime_equal"], true);
+    // The handle is usable again: status is clean and a new lifecycle runs.
+    let (_, fields, _) = rig.status_cli(true);
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "absent"),
+            ("journal", "absent"),
+            ("advisory_receipt", "matches-current"),
+            ("advisory_receipt_status", "kept"),
+            ("runtime_equals_current", "yes"),
+        ],
+    );
+    fs::remove_dir_all(&rig.candidate).unwrap();
+    private_dir(&rig.candidate);
+    let again = Server::start(vec![
+        Response::json(200),
+        Response::config(FIXTURE),
+        Response::json(200),
+    ]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&again.origin)),
+        Ok(lifecycle::Status::Noop)
+    );
+    again.finish();
+}
+
+#[test]
+fn keep_current_is_health_gated_unless_forced() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let server = rig.induce_exit_5("fail", vec![Response::json(200)]);
+    let keep = keep_args(&rig);
+    // The daemon still runs the previous generation: not settled on current.
+    let (code, lines, stderr) = rig.recover_cli(&strs(&keep), true, Some(&server.origin));
+    assert_eq!(code, 2);
+    assert!(lines.is_empty());
+    assert!(
+        stderr.contains("daemon is not settled on current"),
+        "{stderr}"
+    );
+    assert!(rig.journal().exists() && rig.fence().exists());
+    rig.set("health-mode", "down");
+    let (code, _, stderr) = rig.recover_cli(&strs(&keep), true, Some(&server.origin));
+    assert_eq!(code, 2, "{stderr}");
+    rig.set("health-mode", "ok");
+    let mut forced = keep.clone();
+    forced.push("--force".into());
+    let (code, lines, stderr) = rig.recover_cli(&strs(&forced), true, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(
+        lines[0],
+        "probe: daemon healthy, runtime differs from current (overridden by --force)"
+    );
+    assert_request(&server.finish()[2], "POST", "updated");
+    assert!(!rig.journal().exists() && !rig.fence().exists());
+    assert_eq!(rig.receipt_value()["phases"]["runtime_equal"], false);
+}
+
+#[test]
+fn rollback_re_stages_the_previous_generation_through_the_activation_path() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let previous = rig.current();
+    let server = rig.induce_exit_5("fail", vec![Response::json(200)]);
+    let candidate = rig.current();
+    assert_eq!(
+        rig.runtime(),
+        previous,
+        "the failed activation loaded nothing"
+    );
+    let rollback = rollback_args(&rig);
+    let (code, dry, stderr) = rig.recover_cli(&strs(&rollback), false, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(
+        dry[0],
+        format!(
+            "re-point current {candidate} -> {previous}, run `{}`, settle within 2s",
+            rig.activation.display()
+        )
+    );
+    assert_eq!(
+        dry[1],
+        format!(
+            "deliver release-update-lock callback to {} for {HANDLE} (attempt 1)",
+            server.origin
+        )
+    );
+    assert_eq!(
+        dry[2..],
+        [
+            "remove lifecycle journal",
+            "remove host fence",
+            "dry run — 4 step(s) planned; pass --apply to perform them"
+        ]
+    );
+    let activations = fs::read_to_string(rig.root.join("activation.log")).unwrap();
+    let (code, applied, stderr) = rig.recover_cli(&strs(&rollback), true, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(applied[..4], dry[..4]);
+    assert_eq!(rig.current(), previous);
+    assert_eq!(
+        rig.runtime(),
+        previous,
+        "the activation command ran and the daemon loaded it"
+    );
+    assert_eq!(
+        fs::read_to_string(rig.root.join("activation.log")).unwrap(),
+        format!("{activations}{previous}\n"),
+        "exactly one activation command run"
+    );
+    assert_request(&server.finish()[2], "POST", "release-update-lock");
+    assert!(!rig.journal().exists() && !rig.fence().exists());
+    let receipt = rig.receipt_value();
+    assert_eq!(receipt["status"], "rolled_back");
+    assert_eq!(
+        format!(
+            "generations/{}",
+            receipt["candidate_sha256"].as_str().unwrap()
+        ),
+        candidate
+    );
+    assert_eq!(receipt["previous_generation"], previous);
+    assert_eq!(receipt["phases"]["rollback_activation_ran"], true);
+    assert_eq!(receipt["phases"]["runtime_equal"], true);
+    let (_, fields, _) = rig.status_cli(true);
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "absent"),
+            ("current", &previous),
+            ("daemon", "healthy"),
+            ("runtime_equals_current", "yes"),
+        ],
+    );
+}
+
+#[test]
+fn rollback_needs_a_known_target_and_refuses_when_nothing_was_activated() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let previous = rig.current();
+    let server = rig.induce_exit_5("fail", vec![Response::json(200)]);
+    let candidate = rig.current();
+    let rollback = rollback_args(&rig);
+    // A stale receipt cannot name the previous generation: --to is required.
+    fs::remove_file(rig.receipt()).unwrap();
+    let (code, _, stderr) = rig.recover_cli(&strs(&rollback), true, Some(&server.origin));
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("pass --to generations/<digest>"),
+        "{stderr}"
+    );
+    let mut explicit = rollback.clone();
+    explicit.extend(["--to".to_owned(), candidate.clone()]);
+    let (code, _, stderr) = rig.recover_cli(&strs(&explicit), true, Some(&server.origin));
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("rollback target is the current generation"),
+        "{stderr}"
+    );
+    let mut bogus = rollback.clone();
+    bogus.extend(["--to".to_owned(), format!("generations/{}", "0".repeat(64))]);
+    let (code, _, stderr) = rig.recover_cli(&strs(&bogus), true, Some(&server.origin));
+    assert_eq!(code, 2);
+    assert!(stderr.contains("not a published generation"), "{stderr}");
+    explicit.pop();
+    explicit.push(previous.clone());
+    let (code, _, stderr) = rig.recover_cli(&strs(&explicit), true, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(rig.current(), previous);
+    server.finish();
+
+    // An ambiguous lock request staged nothing: rollback refuses, keep-current
+    // releases rather than claiming an update.
+    let rig = Rig::new();
+    let server = Server::start(vec![Response::json(500), Response::json(200)]);
+    assert_eq!(
+        lifecycle::run(&rig.options(&server.origin)),
+        Err(LifecycleError::ManualRecovery)
+    );
+    let rollback = rollback_args(&rig);
+    let (code, _, stderr) = rig.recover_cli(&strs(&rollback), true, Some(&server.origin));
+    assert_eq!(code, 2);
+    assert!(stderr.contains("no candidate was activated"), "{stderr}");
+    let keep = keep_args(&rig);
+    let (code, lines, stderr) = rig.recover_cli(&strs(&keep), true, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert!(
+        lines[2].starts_with("deliver release-update-lock callback"),
+        "{lines:?}"
+    );
+    assert_request(&server.finish()[1], "POST", "release-update-lock");
+    assert!(!rig.journal().exists() && !rig.fence().exists());
+}
+
+#[test]
+fn release_lock_is_retryable_and_clear_waits_for_it() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let server = rig.induce_exit_5(
+        "load-then-fail",
+        vec![Response::json(500), Response::json(200)],
+    );
+    // clear refuses while the journal still owes the lock.
+    let (code, _, stderr) = rig.recover_cli(&["clear"], true, None);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("upstream lock still owed"), "{stderr}");
+    // release-lock needs the connection and a direction.
+    let (code, _, stderr) = rig.recover_cli(&["release-lock", "--kept"], true, None);
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("pass --ixp-origin and --api-key-file"),
+        "{stderr}"
+    );
+    let (code, dry, _) = rig.recover_cli(&["release-lock", "--kept"], false, Some(&server.origin));
+    assert_eq!(code, 0);
+    assert_eq!(
+        dry,
+        vec![
+            format!(
+                "deliver updated callback to {} for {HANDLE} (attempt 1)",
+                server.origin
+            ),
+            "mark the upstream lock released in the lifecycle journal".to_owned(),
+            "dry run — 2 step(s) planned; pass --apply to perform them".to_owned(),
+        ]
+    );
+    // First delivery fails (injected 500): exit 5, intent journaled, retry named.
+    let (code, lines, stderr) =
+        rig.recover_cli(&["release-lock", "--kept"], true, Some(&server.origin));
+    assert_eq!(code, 5, "{stderr}");
+    assert!(lines.is_empty(), "{lines:?}");
+    assert!(
+        stderr.contains("updated callback was not delivered; upstream lock retained — retry with recover release-lock --kept"),
+        "{stderr}"
+    );
+    let journal = rig.journal_value();
+    assert_eq!(journal["callback"], "updated");
+    assert_eq!(journal["callback_attempts"], 1);
+    assert_eq!(journal["lock_released"], false);
+    assert_eq!(journal["phase"], "manual_recovery");
+    let (code, _, stderr) = rig.recover_cli(&["clear"], true, None);
+    assert_eq!(code, 2, "{stderr}");
+    // Retry succeeds; the journal records delivery and stays for clear.
+    let (code, lines, stderr) =
+        rig.recover_cli(&["release-lock", "--kept"], true, Some(&server.origin));
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(
+        lines[0],
+        format!(
+            "deliver updated callback to {} for {HANDLE} (attempt 2)",
+            server.origin
+        )
+    );
+    let origin = server.origin.clone();
+    let requests = server.finish();
+    assert_eq!(requests.len(), 4);
+    assert_request(&requests[2], "POST", "updated");
+    assert_request(&requests[3], "POST", "updated");
+    let journal = rig.journal_value();
+    assert_eq!(journal["callback_attempts"], 2);
+    assert_eq!(journal["lock_released"], true);
+    assert!(rig.fence().exists());
+    let (_, fields, _) = rig.status_cli(false);
+    assert_fields(
+        &fields,
+        &[("lock", "released"), ("phase", "manual_recovery")],
+    );
+    // keep-current and rollback now defer to clear.
+    let keep = keep_args(&rig);
+    let (code, _, stderr) = rig.recover_cli(&strs(&keep), true, Some(&origin));
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("upstream lock already released; run recover clear"),
+        "{stderr}"
+    );
+    let (code, dry, _) = rig.recover_cli(&["clear"], false, None);
+    assert_eq!(code, 0);
+    assert_eq!(
+        dry,
+        [
+            "remove lifecycle journal",
+            "remove host fence",
+            "dry run — 2 step(s) planned; pass --apply to perform them"
+        ]
+    );
+    let (code, applied, stderr) = rig.recover_cli(&["clear"], true, None);
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(applied[..2], dry[..2]);
+    assert!(!rig.journal().exists() && !rig.fence().exists());
+}
+
+#[test]
+fn a_plain_activate_exit_5_recovers_without_a_journal_or_connection() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let previous = rig.current();
+    // A second candidate through the bare activation path, failing after the
+    // command started: exit 5 with a fence and no journal.
+    let candidate = rig.root.join("second");
+    private_dir(&candidate);
+    let mut input: serde_json::Value = serde_json::from_slice(FIXTURE).unwrap();
+    input["clients"][0]["max_prefix"] = 12.into();
+    ixp_manager::write_checked_candidate_bytes(
+        &serde_json::to_vec(&input).unwrap(),
+        &candidate,
+        300,
+        &rig.checker,
+        &rig.binding.render_binding(),
+    )
+    .unwrap();
+    rig.set("activation-mode", "fail");
+    assert_eq!(
+        activation::activate(&activation::Options {
+            candidate: &candidate,
+            state_dir: &rig.state,
+            checker: &rig.checker,
+            rbgp: &rig.rbgp,
+            rbgp_addr: rig.binding.rbgp_addr(),
+            settle: Duration::from_secs(2),
+            initial: false,
+            activation_command: &rig.activation,
+            activation_args: &[],
+            binding: &rig.binding,
+        }),
+        Err(activation::Error::RecoveryRequired)
+    );
+    rig.set("activation-mode", "ok");
+    assert!(rig.fence().exists() && !rig.journal().exists());
+    let (_, fields, _) = rig.status_cli(true);
+    assert_fields(
+        &fields,
+        &[
+            ("fence", "present"),
+            ("journal", "absent"),
+            ("lock", "none"),
+            ("current_is_candidate", "yes"),
+            ("runtime_equals_current", "no"),
+        ],
+    );
+    // release-lock has nothing to release; clear is allowed (no lock owed)
+    // but the runbook's choice is rollback here.
+    let (code, _, stderr) = rig.recover_cli(&["release-lock", "--rolled-back"], true, None);
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("no lifecycle journal; no upstream lock is owed"),
+        "{stderr}"
+    );
+    let (code, dry, _) = rig.recover_cli(&["clear"], false, None);
+    assert_eq!(code, 0);
+    assert_eq!(dry[0], "remove host fence");
+    let rollback = rollback_args(&rig);
+    let (code, lines, stderr) = rig.recover_cli(&strs(&rollback), true, None);
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(lines.len(), 3, "{lines:?}");
+    assert_eq!(lines[1], "remove host fence");
+    assert_eq!(rig.current(), previous);
+    assert_eq!(rig.runtime(), previous);
+    assert!(!rig.fence().exists());
 }


### PR DESCRIPTION
Stacked on #1811 (`status`); the diff below includes that commit until it merges.

## Summary

The `recover` verbs are the manual-recovery runbook's steps 2–5 as commands. Each takes the binding flags `status` takes, plans first and prints one `recover <verb>: <step>` line per step, performs nothing without `--apply` (with it, the printed lines are exactly the steps that completed), journals callback intent before the request exactly as the lifecycle does, and refuses (exit 2, nothing changed) unless this binding's fence stands and the lifecycle journal, if any, is in manual recovery rather than resumable. A journal owes the upstream lock, so a journal-holding recovery also needs `--ixp-origin` and `--api-key-file` (the connection `resume` takes); a plain `activate` exit 5 needs neither.

```
rs-config-render recover keep-current --rbgp PATH [--force] [--apply] <binding> [<connection>]
rs-config-render recover rollback --rbgp PATH --activation-command PATH [--activation-arg …] [--settle-seconds N] [--to generations/<digest>] [--apply] <binding> [<connection>]
rs-config-render recover release-lock --kept|--rolled-back [--apply] <binding> <connection>
rs-config-render recover clear [--apply] <binding>
```

- `keep-current`: probes the daemon (`rbgp health` + `config diff` against `current`, the settle path's own test) and refuses unless healthy and equal (`--force` overrides; the receipt then records `runtime_equal: false`); writes the activation receipt as `kept`; delivers `updated` (or `release-update-lock` when the journal shows nothing was activated — the lock-ambiguous case); removes journal and fence.
- `rollback`: the target is the receipt's `previous_generation` when the receipt describes the current attempt, else `--to` is required; refuses when the target is `current`, not a published generation, or the journal shows nothing was activated; re-points `current` and runs the activation command through the same publish → activate → settle path as a first activation (`activation::republish`, not a symlink swap); writes the receipt as `rolled_back` (or `recovery_required` and exit 5 if the daemon does not settle); delivers `release-update-lock`; removes journal and fence.
- `release-lock --kept|--rolled-back`: one callback, standalone and retryable; the journal gets `callback`, `callback_attempts`, and a new `lock_released: true` (serde default, so older journals parse) on delivery. `status` then reads `lock: released`; `keep-current`/`rollback` defer to `clear`.
- `clear`: fence and journal only. Terminal states, the only ones it accepts: no journal (a plain `activate` exit 5, or one removed by hand), or a journal whose callback a verb delivered. Anything else: `upstream lock still owed`.

Exit table: no new rows. Verbs use 0, 2 (refused, nothing changed) and 5 (an `--apply` step did not complete — callback not delivered, rollback not settled; fence and journal retained; the message names the retry). `recover::Error::ManualRecovery` is added to `tests/exit_codes.rs`. `resume` keeps its single meaning; its three dispositions are factored into `lifecycle::pending()` so the verbs classify "resumable vs manual recovery" from one source.

## Tests (`tests/recover.rs`, against the loopback IXP Manager stand-in)

- every verb refuses on a healthy handle (no fence) and in exit-6 (resumable) state, dry-run and `--apply`;
- dry runs change nothing (state tree snapshot) and `--apply` performs exactly the printed steps (keep-current; the handle then runs a new lifecycle to `noop`);
- keep-current refuses on a red probe (runtime differs, daemon down) and proceeds with `--force`;
- rollback ends with `current` on the previous generation, the activation command run exactly once, and the daemon settled on it (`status`: healthy / equals current); receipt `rolled_back`;
- rollback needs a known target (`--to` when the receipt is absent), refuses the current or a bogus target, refuses when the lock request was ambiguous (keep-current then delivers `release-update-lock`);
- release-lock is retryable after an injected 500 (exit 5, intent journaled, attempt 2 succeeds), clear refuses until then and succeeds after;
- a plain `activate` exit 5 (no journal) recovers with no connection; release-lock refuses there.

Runbook steps 2–5 show each verb's exact output; the hand procedures move to appendix B. README section + exit notes; `docs/deployment.md` one pointer; CHANGELOG.
