### PR TITLE
docs: add the IXP Manager receipts to the operational proof and correct the served-table statement

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -45,9 +45,10 @@ exact `{daemon ASN}:1101:*` filtered-prefix query reads only retained rejects,
 scrubs that reserved namespace, and adds one conservative reason. This remains
 partial runtime support: the ten reasons active in the pinned v7.4 route-server
 templates are mapped, while IDs 2, 4, 11, 12, and 15 are display-only and
-remain fallback 0 rather than gaining invented semantics. Global table lists,
-full-table counts, and other
-wildcard-community endpoints are not served. The adapter's table identity is a
+remain fallback 0 rather than gaining invented semantics. The full-table view
+and longest-prefix table search are served; full-table counts are not, other
+wildcard-community pairs return empty, and the contract's
+`runtime_compatibility` stays `false`. The adapter's table identity is a
 validated view over one global Loc-RIB, and `api.version` is rustbgpd product
 identity, not a Bird's Eye version claim; the adapter is not described as fully
 IXP Manager / Bird's Eye compatible.

--- a/docs/OPERATIONAL_PROOF.md
+++ b/docs/OPERATIONAL_PROOF.md
@@ -28,7 +28,7 @@ operator-facing index that answers "what has actually been proved?"
 | BIRD / GoBGP / StayRTR diversity | Mixed CI/manual | BIRD TCP-AO and GoBGP coverage are documented. The RTR-dependent RPKI/ASPA cases are hosted in `interop.yml`: M84 multi-cache RTR/ASPA epoch conformance against Routinator and StayRTR, M27/M59 ASPA against the RTR v2 mock, and M83's route-server StayRTR fixture. The earlier M21 origin-validation lab and broader platform-diversity runs remain local/manual where extra fixtures are required. |
 | Long-wall-clock gates | Manual/local | GR/LLGR soak-style gates and M33 scale churn are intentionally not PR-CI jobs because they consume substantial wall-clock. |
 
-Compact M36-M90 index (details and assertions stay in
+Compact M36-M98 index (details and assertions stay in
 [`INTEROP.md`](INTEROP.md#ci-coverage)):
 
 | Receipts | Coverage |
@@ -38,6 +38,9 @@ Compact M36-M90 index (details and assertions stay in
 | M39, M39b, M47, M48, M60, M61, M68, M70, M71, M72 | EVPN L3VNI / Type 5 / runtime convergence / adoption / VLAN-aware / overlay-index dataplane receipts. |
 | M42, M50, M51, M52, M53, M58, M62 | Non-EVPN kernel dataplane receipts in the same hosted span: FIB runtime/CRUD, BFD, BGP unnumbered, and BLACKHOLE adoption. |
 | M43 | Conditional TCP-AO queued-child receipt, uninterrupted no-flap add/select/deprecate/delete against BIRD with a 100 ms route-continuity oracle, and a separate three-phase SIGKILL/restart recovery gate requiring exact fresh-start inventory/auth/session state; probed and skipped only when the selected runner kernel lacks support. |
+| M96 | [IXP Manager local activation](INTEROP.md#ixp-manager-v74-manual-configuration-oracle) (local): the pinned v7.4 Foil capture through the real renderer/strict checker, then atomic initial, no-op, hot-reload, and pre-effect spawn-failure restoration against MD5-authenticated FRR with exact prior bytes, unchanged daemon PID, and route/session continuity. |
+| M97 | [IXP Manager authenticated lifecycle](INTEROP.md#ixp-manager-v74-manual-configuration-oracle) (local): pinned v7.4 API lock/fetch/callback state for two same-host IPv4/IPv6 handles with distinct PIDs, state/UDS endpoints, and TCP/179 listeners, plus a shared durable host fence, paired competing-423 behavior, sequential callbacks, and cross-handle failure containment. |
+| M98 | [IXP Manager Nagios monitoring](INTEROP.md#ixp-manager-v74-manual-configuration-oracle) (`ixp-compat.yml`): the pinned v7.4 `birdseye-daemons` and `birdseye-bgp-sessions` generators include the rustbgpd route server (host, service, hostgroup, both client session services with rendered alias names), and the pinned Bird's Eye daemon plugin reports `OK` with `Last Reconfigure` against the live adapter. |
 | Other M41-M90 rows in this span | Foundation interop receipts such as BLACKHOLE FIB discard, gRPC/gNMI, EVPN Type 5 injection, BGP Roles/ORF/ASPA, inbound backpressure, IPv6-only peering, BGP-LS reflection, VPNv4 route-reflection, RT-Constrain VPNv4 filtering, RFC 9107 ORR divergent-best, RR-family GR/LLGR stale preservation, multi-cluster ORR with inter-RR Add-Path, RFC 8277 labeled-unicast reflection + GR, ADR-0096 `.rpol` policy parity vs FRR route-maps (M80), BMP trio + BMPv4/path-marking against pmacct/gobmp/tshark (M81), EVPN VLAN-aware-bundle non-zero Ethernet Tag reflection (M82), RFC 7947 route-server profile transparency/path-hiding/ROV proof (M83), and the arouteserver/BIRD/rustbgpd filtering differential (M90) remain catalogued in `INTEROP.md`. |
 
 ## Scale and benchmark receipts

--- a/scripts/check_ixp_manager_docs.py
+++ b/scripts/check_ixp_manager_docs.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """Fail closed when the IXP Manager documentation drifts from its contract.
 
-Three documents restate facts that `tests/compat/ixp-manager-birdseye/contract.json`
+Four documents restate facts that `tests/compat/ixp-manager-birdseye/contract.json`
 pins executably, and each has drifted silently before:
 
 - the Birdwatcher adapter README's reason-id tables versus
   `reject_reasons.active_ids` / `defined_only_ids` / `fallback_id` / `display`;
 - the same README's capability table versus `runtime_supported` / `unsupported`;
-- `docs/RECEIPTS.md`, which must carry a row for every M-series receipt that
-  `docs/INTEROP.md` claims in its IXP Manager sections.
+- `docs/RECEIPTS.md` and `docs/OPERATIONAL_PROOF.md`, which must each carry a
+  row for every M-series receipt that `docs/INTEROP.md` claims in its IXP
+  Manager sections.
 
 The checks parse the markdown tables positively; an absent table or an empty
 M-number set is itself a failure, because a guard that cannot fail is worse
@@ -27,6 +28,7 @@ CONTRACT = ROOT / "tests" / "compat" / "ixp-manager-birdseye" / "contract.json"
 README = ROOT / "examples" / "birdwatcher-adapter" / "README.md"
 INTEROP = ROOT / "docs" / "INTEROP.md"
 RECEIPTS = ROOT / "docs" / "RECEIPTS.md"
+PROOF = ROOT / "docs" / "OPERATIONAL_PROOF.md"
 
 REASON_HEADER = ("Retained cause", "IXP Manager reason id", "Bird's Eye display")
 DEFINED_ONLY_HEADER = ("Defined-only id", "Bird's Eye display", "Emitted as")
@@ -155,8 +157,8 @@ def interop_ixp_receipts(interop: str) -> set[str]:
     return found
 
 
-def receipt_rows(receipts: str) -> set[str]:
-    """M-numbers in the first cell of every `| Receipt | ... |` table row."""
+def receipt_rows(receipts: str, header: str = "Receipt") -> set[str]:
+    """M-numbers in the first cell of every `| <header> | ... |` table row."""
     found: set[str] = set()
     in_table = False
     for line in receipts.splitlines():
@@ -164,29 +166,35 @@ def receipt_rows(receipts: str) -> set[str]:
             in_table = False
             continue
         first = _cells(line)[0]
-        if first == "Receipt":
+        if first == header:
             in_table = True
         elif in_table:
             found.update(M_NUMBER.findall(first))
     return found
 
 
-def check_receipts(interop: str, receipts: str) -> list[str]:
+def check_receipts(interop: str, receipts: str, proof: str) -> list[str]:
     claimed = interop_ixp_receipts(interop)
     if not claimed:
         return ["INTEROP.md IXP Manager sections name no M-series receipts; the walk is broken"]
-    missing = sorted(claimed - receipt_rows(receipts), key=lambda m: (len(m), m))
-    return [
-        f"INTEROP.md claims {m} in its IXP Manager sections but RECEIPTS.md has no row for it"
-        for m in missing
-    ]
+    errors: list[str] = []
+    # OPERATIONAL_PROOF.md keys its compact index by `| Receipts | Coverage |`.
+    for name, rows in (
+        ("RECEIPTS.md", receipt_rows(receipts)),
+        ("OPERATIONAL_PROOF.md", receipt_rows(proof, "Receipts")),
+    ):
+        for m in sorted(claimed - rows, key=lambda m: (len(m), m)):
+            errors.append(
+                f"INTEROP.md claims {m} in its IXP Manager sections but {name} has no row for it"
+            )
+    return errors
 
 
-def check(readme: str, contract: dict, interop: str, receipts: str) -> list[str]:
+def check(readme: str, contract: dict, interop: str, receipts: str, proof: str) -> list[str]:
     return (
         check_reason_ids(readme, contract)
         + check_capabilities(readme, contract)
-        + check_receipts(interop, receipts)
+        + check_receipts(interop, receipts, proof)
     )
 
 
@@ -197,6 +205,7 @@ def main() -> int:
             json.loads(CONTRACT.read_text(encoding="utf-8")),
             INTEROP.read_text(encoding="utf-8"),
             RECEIPTS.read_text(encoding="utf-8"),
+            PROOF.read_text(encoding="utf-8"),
         )
     except (OSError, KeyError, ValueError) as error:
         errors = [f"cannot load the IXP Manager contract surface: {error!r}"]

--- a/scripts/test_check_ixp_manager_docs.py
+++ b/scripts/test_check_ixp_manager_docs.py
@@ -15,6 +15,7 @@ README = checker.README.read_text(encoding="utf-8")
 CONTRACT = json.loads(checker.CONTRACT.read_text(encoding="utf-8"))
 INTEROP = checker.INTEROP.read_text(encoding="utf-8")
 RECEIPTS = checker.RECEIPTS.read_text(encoding="utf-8")
+PROOF = checker.PROOF.read_text(encoding="utf-8")
 
 
 def row(document: str, prefix: str) -> str:
@@ -27,12 +28,12 @@ def without(document: str, prefix: str) -> str:
 
 
 class IxpManagerDocsTests(unittest.TestCase):
-    def assert_red(self, needle: str, readme=README, interop=INTEROP, receipts=RECEIPTS) -> None:
-        errors = checker.check(readme, CONTRACT, interop, receipts)
+    def assert_red(self, needle: str, readme=README, interop=INTEROP, receipts=RECEIPTS, proof=PROOF) -> None:
+        errors = checker.check(readme, CONTRACT, interop, receipts, proof)
         self.assertTrue(any(needle in error for error in errors), errors)
 
     def test_tree_is_green(self) -> None:
-        self.assertEqual(checker.check(README, CONTRACT, INTEROP, RECEIPTS), [])
+        self.assertEqual(checker.check(README, CONTRACT, INTEROP, RECEIPTS, PROOF), [])
 
     def test_dropped_active_reason_row_is_red(self) -> None:
         self.assert_red("active_ids", readme=without(README, "| `.rpol` term `ixp-manager-hygiene:reject-as-path-too-long` |"))
@@ -62,12 +63,15 @@ class IxpManagerDocsTests(unittest.TestCase):
         self.assert_red("contract unsupported", readme=without(README, "| `full-table-count` |"))
 
     def test_missing_tables_are_red(self) -> None:
-        errors = checker.check("# empty\n", CONTRACT, INTEROP, RECEIPTS)
+        errors = checker.check("# empty\n", CONTRACT, INTEROP, RECEIPTS, PROOF)
         self.assertTrue(any("reason-id table" in e for e in errors), errors)
         self.assertTrue(any("capability table" in e for e in errors), errors)
 
     def test_receipt_row_removal_is_red(self) -> None:
-        self.assert_red("claims M96", receipts=without(RECEIPTS, "| M96 |"))
+        self.assert_red("claims M96 in its IXP Manager sections but RECEIPTS.md", receipts=without(RECEIPTS, "| M96 |"))
+
+    def test_proof_row_removal_is_red(self) -> None:
+        self.assert_red("claims M97 in its IXP Manager sections but OPERATIONAL_PROOF.md", proof=without(PROOF, "| M97 |"))
 
     def test_new_interop_claim_without_receipt_row_is_red(self) -> None:
         unreceipted = next(f"M{n}" for n in range(100, 10000) if f"| {f'M{n}'} " not in RECEIPTS)
@@ -80,6 +84,7 @@ class IxpManagerDocsTests(unittest.TestCase):
     def test_recipe_table_does_not_count_as_receipt_row(self) -> None:
         self.assertNotIn("M14", checker.receipt_rows("| Receipts | Recipe |\n|---|---|\n| M14, M76 | x |\n"))
         self.assertIn("M14", checker.receipt_rows("| Receipt | Proves |\n|---|---|\n| M14 | x |\n"))
+        self.assertIn("M14", checker.receipt_rows("| Receipts | Coverage |\n|---|---|\n| M14, M76 | x |\n", "Receipts"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two stale IXP-facing statements, plus the guard that keeps them from drifting again.

**`docs/OPERATIONAL_PROOF.md` — missing M96/M97/M98 rows.** `docs/RECEIPTS.md`'s "Adding a receipt" procedure says every receipt gets a row in `OPERATIONAL_PROOF.md` too; the three IXP Manager receipts had rows in `RECEIPTS.md` only. Added `| M96 |`, `| M97 |`, `| M98 |` rows to the compact `| Receipts | Coverage |` index (the table where the M-numbered interop rows live), worded from `INTEROP.md`'s M96/M97/M98 paragraphs and CI bullets, linking `INTEROP.md#ixp-manager-v74-manual-configuration-oracle`; the index heading now reads M36-M98.

**`docs/INTEROP.md` — "Global table lists … are not served".** Predates the atomic full-table view (#1771) and the LPM table search (#1751). Restated from `tests/compat/ixp-manager-birdseye/contract.json`: full-table view and longest-prefix table search served (`atomic-full-table-snapshot`, `less-specific-longest-prefix-match` under `runtime_supported`), full-table counts not (`full-table-count` under `unsupported`), other wildcard-community pairs empty, `runtime_compatibility` still `false`. One sentence, no restructuring.

**`scripts/check_ixp_manager_docs.py`** now also asserts `OPERATIONAL_PROOF.md` carries every IXP Manager M-number `INTEROP.md` claims, keyed on its `| Receipts | Coverage |` index (`receipt_rows` takes the first-cell header name; the `RECEIPTS.md` walk is unchanged). Existing checks and the `public-docs-contract.yml` wiring are untouched; `docs/**` is already in its path filter.

## Verification

- `python3 scripts/check_public_tracker_ids.py` — rc 0
- `python3 scripts/check_ixp_manager_docs.py` — rc 0
- `python3 -m unittest -v scripts/test_check_ixp_manager_docs.py` — 14 tests, rc 0 (new `test_proof_row_removal_is_red`)
- Deliberate red: the script run against a tree copy with the `| M97 |` row removed from `OPERATIONAL_PROOF.md` exits 1 with `INTEROP.md claims M97 in its IXP Manager sections but OPERATIONAL_PROOF.md has no row for it`
- All 62 relative links/anchors in the two touched docs resolve

Refs LAN-1243.
