### PR TITLE
fix(ixp-compat): mask BIRD route_changes counters in the populated oracle fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The IXP Manager / Bird's Eye populated oracle fixtures now mask BIRD's
+  timing-dependent `route_changes` counters (shape still compared), so the
+  pinned-contract job no longer fails on announcer arrival order.
 - Routes carrying `ATOMIC_AGGREGATE` were treat-as-withdrawn: the zero-length
   well-known attribute was decoded as an unrecognized well-known attribute
   and rejected with UPDATE error subcode 2. It is now a first-class

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -115,7 +115,8 @@ consumer through all eleven in-scope endpoints (24 journeys, including a
 covering-only prefix, a host address, host-bit input, and a foreign
 large-community wildcard) against each leg, and `verify_capture.py
 --populated` normalizes both captures (timestamps, the rustbgpd version,
-countdowns, each leg's own route-server addresses, route and symbol order),
+countdowns, each leg's own route-server addresses, BIRD's `route_changes`
+counters, route and symbol order),
 pins them as `fixtures/populated-oracle.json` and
 `fixtures/populated-live.json`, diffs oracle against live through the
 `runtime_divergences` allow-list in `contract.json`, proves the allow-list
@@ -348,8 +349,10 @@ predicted eight more that the diff did not show, listed after the table.
 
 Normalization applied to both legs before the diff (recorded in each
 fixture's `provenance.normalization`): timestamps, the rustbgpd version,
-`hold_timer_now`/`keepalive_now`, each leg's own route-server addresses, and
-route and symbol list order. The two route servers cannot share one address
+`hold_timer_now`/`keepalive_now`, each leg's own route-server addresses,
+route and symbol list order, and BIRD's `route_changes` counters (they follow
+announcer arrival order; the block's shape is still compared). The two route
+servers cannot share one address
 on one segment, so `source_address` is compared as `<route-server>`; BIRD's
 default hold time is mirrored in the rustbgpd config so the negotiated timers
 match.

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
@@ -1331,7 +1331,8 @@
       "rustbgpd <semver> -> rustbgpd <version>",
       "hold_timer_now and keepalive_now -> <countdown>",
       "each leg's own route-server addresses -> <route-server>",
-      "routes sorted by network, symbol lists sorted"
+      "routes sorted by network, symbol lists sorted",
+      "route_changes counters -> <counter>"
     ],
     "software": "rustbgpd + birdwatcher-adapter"
   }

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-oracle.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-oracle.json
@@ -554,27 +554,27 @@
           "protocol": "pb_as64496",
           "route_changes": {
             "export_updates": {
-              "accepted": 1,
-              "filtered": 0,
-              "received": 4,
-              "rejected": 3
+              "accepted": "<counter>",
+              "filtered": "<counter>",
+              "received": "<counter>",
+              "rejected": "<counter>"
             },
             "export_withdraws": {
-              "accepted": 0,
-              "received": 0
+              "accepted": "<counter>",
+              "received": "<counter>"
             },
             "import_updates": {
-              "accepted": 3,
-              "filtered": 0,
-              "ignored": 0,
-              "received": 3,
-              "rejected": 0
+              "accepted": "<counter>",
+              "filtered": "<counter>",
+              "ignored": "<counter>",
+              "received": "<counter>",
+              "rejected": "<counter>"
             },
             "import_withdraws": {
-              "accepted": 0,
-              "ignored": 0,
-              "received": 0,
-              "rejected": 0
+              "accepted": "<counter>",
+              "ignored": "<counter>",
+              "received": "<counter>",
+              "rejected": "<counter>"
             }
           },
           "route_limit_at": 3,
@@ -621,27 +621,27 @@
           "protocol": "pb6_as64496",
           "route_changes": {
             "export_updates": {
-              "accepted": 1,
-              "filtered": 0,
-              "received": 3,
-              "rejected": 2
+              "accepted": "<counter>",
+              "filtered": "<counter>",
+              "received": "<counter>",
+              "rejected": "<counter>"
             },
             "export_withdraws": {
-              "accepted": 0,
-              "received": 0
+              "accepted": "<counter>",
+              "received": "<counter>"
             },
             "import_updates": {
-              "accepted": 2,
-              "filtered": 0,
-              "ignored": 0,
-              "received": 2,
-              "rejected": 0
+              "accepted": "<counter>",
+              "filtered": "<counter>",
+              "ignored": "<counter>",
+              "received": "<counter>",
+              "rejected": "<counter>"
             },
             "import_withdraws": {
-              "accepted": 0,
-              "ignored": 0,
-              "received": 0,
-              "rejected": 0
+              "accepted": "<counter>",
+              "ignored": "<counter>",
+              "received": "<counter>",
+              "rejected": "<counter>"
             }
           },
           "route_limit_at": 2,
@@ -689,27 +689,27 @@
             "protocol": "pb6_as64496",
             "route_changes": {
               "export_updates": {
-                "accepted": 1,
-                "filtered": 0,
-                "received": 3,
-                "rejected": 2
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "export_withdraws": {
-                "accepted": 0,
-                "received": 0
+                "accepted": "<counter>",
+                "received": "<counter>"
               },
               "import_updates": {
-                "accepted": 2,
-                "filtered": 0,
-                "ignored": 0,
-                "received": 2,
-                "rejected": 0
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "import_withdraws": {
-                "accepted": 0,
-                "ignored": 0,
-                "received": 0,
-                "rejected": 0
+                "accepted": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               }
             },
             "route_limit_at": 2,
@@ -746,27 +746,27 @@
             "protocol": "pb6_as64497",
             "route_changes": {
               "export_updates": {
-                "accepted": 2,
-                "filtered": 0,
-                "received": 3,
-                "rejected": 1
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "export_withdraws": {
-                "accepted": 0,
-                "received": 0
+                "accepted": "<counter>",
+                "received": "<counter>"
               },
               "import_updates": {
-                "accepted": 1,
-                "filtered": 0,
-                "ignored": 0,
-                "received": 1,
-                "rejected": 0
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "import_withdraws": {
-                "accepted": 0,
-                "ignored": 0,
-                "received": 0,
-                "rejected": 0
+                "accepted": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               }
             },
             "route_limit_at": 1,
@@ -803,27 +803,27 @@
             "protocol": "pb_as64496",
             "route_changes": {
               "export_updates": {
-                "accepted": 1,
-                "filtered": 0,
-                "received": 4,
-                "rejected": 3
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "export_withdraws": {
-                "accepted": 0,
-                "received": 0
+                "accepted": "<counter>",
+                "received": "<counter>"
               },
               "import_updates": {
-                "accepted": 3,
-                "filtered": 0,
-                "ignored": 0,
-                "received": 3,
-                "rejected": 0
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "import_withdraws": {
-                "accepted": 0,
-                "ignored": 0,
-                "received": 0,
-                "rejected": 0
+                "accepted": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               }
             },
             "route_limit_at": 3,
@@ -860,27 +860,27 @@
             "protocol": "pb_as64497",
             "route_changes": {
               "export_updates": {
-                "accepted": 3,
-                "filtered": 0,
-                "received": 4,
-                "rejected": 1
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "export_withdraws": {
-                "accepted": 0,
-                "received": 0
+                "accepted": "<counter>",
+                "received": "<counter>"
               },
               "import_updates": {
-                "accepted": 1,
-                "filtered": 0,
-                "ignored": 0,
-                "received": 1,
-                "rejected": 0
+                "accepted": "<counter>",
+                "filtered": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               },
               "import_withdraws": {
-                "accepted": 0,
-                "ignored": 0,
-                "received": 0,
-                "rejected": 0
+                "accepted": "<counter>",
+                "ignored": "<counter>",
+                "received": "<counter>",
+                "rejected": "<counter>"
               }
             },
             "route_limit_at": 1,
@@ -1618,7 +1618,8 @@
       "rustbgpd <semver> -> rustbgpd <version>",
       "hold_timer_now and keepalive_now -> <countdown>",
       "each leg's own route-server addresses -> <route-server>",
-      "routes sorted by network, symbol lists sorted"
+      "routes sorted by network, symbol lists sorted",
+      "route_changes counters -> <counter>"
     ],
     "software": "BIRD 2.0.12 + Bird's Eye 2.1.0"
   }

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -454,6 +454,7 @@ POPULATED_NORMALIZATION = [
     "hold_timer_now and keepalive_now -> <countdown>",
     "each leg's own route-server addresses -> <route-server>",
     "routes sorted by network, symbol lists sorted",
+    "route_changes counters -> <counter>",
 ]
 TIMESTAMP = re.compile(
     r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\+00:00)?$|^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$"
@@ -461,7 +462,27 @@ TIMESTAMP = re.compile(
 PRODUCT_VERSION = re.compile(r"^rustbgpd \d+\.\d+\.\d+\S*$")
 
 
+def mask_counters(value):
+    """Keep the shape of BIRD's per-channel route change statistics, drop the
+    numbers: they count how many times BIRD processed updates, which depends
+    on announcer arrival order."""
+    if isinstance(value, dict):
+        return {k: mask_counters(v) for k, v in value.items()}
+    return "<counter>"
+
+
+def raw_counters(document):
+    """Numeric leaves under any route_changes key: a fixture still carrying
+    them is itself a bug."""
+    return [
+        path for path, value in flatten(document).items()
+        if ".route_changes." in path and json_type(value) == "number"
+    ]
+
+
 def normalize_value(value, key, own_addresses):
+    if key == "route_changes" and isinstance(value, dict):
+        return mask_counters(value)
     if isinstance(value, dict):
         return {k: normalize_value(v, k, own_addresses) for k, v in value.items()}
     if isinstance(value, list):
@@ -625,12 +646,16 @@ def verify_populated(capture_dir: Path, web_php: Path) -> None:
             output = Path(os.environ["CAPTURE_OUTPUT"])
             output.mkdir(parents=True, exist_ok=True)
             (output / fixture.name).write_text(text)
-        elif fixture.read_text() != text:
-            sys.stderr.writelines(difflib.unified_diff(
-                fixture.read_text().splitlines(True), text.splitlines(True),
-                fromfile=str(fixture), tofile=f"populated-{leg}-capture",
-            ))
-            fail(f"populated {leg} capture drifted from its fixture")
+        else:
+            pinned = fixture.read_text()
+            if raw_counters(json.loads(pinned)):
+                fail(f"{fixture.name} carries raw route_changes counters; re-capture it")
+            if pinned != text:
+                sys.stderr.writelines(difflib.unified_diff(
+                    pinned.splitlines(True), text.splitlines(True),
+                    fromfile=str(fixture), tofile=f"populated-{leg}-capture",
+                ))
+                fail(f"populated {leg} capture drifted from its fixture")
 
     unlisted, stale = check_divergences(docs["oracle"], docs["live"], RUNTIME_DIVERGENCES)
     for item in unlisted:


### PR DESCRIPTION
## Failure

`IXP Manager / Bird's Eye contract oracle` (`pinned-contract`) failed on main `6d91444b` (run 32600554523) with `populated oracle capture drifted from its fixture`: two protocols' `route_changes.export_updates.received/rejected` were `4/3` in `fixtures/populated-oracle.json` and `7/6` in the capture. The job passed on the commits before and after (`29289e51`, `ee812955`, `ac7bb6eb`).

## Why it is timing

BIRD's per-protocol `Route change stats` count how many times BIRD processed import/export updates, which follows the arrival order of the two ExaBGP announcers' sessions and routes. Nothing in the harness pins that order. `verify_capture.py::normalize_value` already masks the other timing-dependent values before the byte-for-byte fixture comparison (`<timestamp>`, `<countdown>`, `<route-server>`, sorted routes/symbols) but not these counters; `route_changes.*.*` was already on the oracle-vs-live `runtime_divergences` allow-list, so the fixture identity check was the only place it still bit.

## Fix

- `normalize_value`: a dict under key `route_changes` is passed through `mask_counters`, which keeps the keys and replaces every leaf with `"<counter>"` (shape drift still fails). Nothing outside `route_changes` is masked; `routes.imported/filtered/exported/preferred` stay exact.
- `POPULATED_NORMALIZATION` gains `route_changes counters -> <counter>` (embedded in both fixtures' `provenance.normalization`).
- Self-check at the fixture comparison: if either pinned populated fixture still carries a numeric leaf under a `route_changes` key, `fail("<fixture> carries raw route_changes counters; re-capture it")`.
- Both populated fixtures re-captured from the real leg (`CAPTURE_FIXTURES=1 CAPTURE_OUTPUT=… run.sh`, rc 0). Fixture diff:
  - `populated-oracle.json`: 90 counter leaves (6 `route_changes` blocks × 15) changed from numbers to `"<counter>"`, plus the one new `provenance.normalization` line. Nothing else moved.
  - `populated-live.json`: the new `provenance.normalization` line only (the live leg emits no `route_changes`).
  - The other captured fixtures (`birdseye-contract.json`, `ixp-manager-consumer.json`, `ixp-manager-v7.4-rustbgpd.json`) came back byte-identical to the tree.
- README normalization list and CHANGELOG `[Unreleased]` / `### Fixed` updated.

## Gates

- `tests/compat/ixp-manager-birdseye/run.sh` (exactly as CI runs it) × 3 after the re-capture: rc 0, 0, 0 (29 s, 28 s, 28 s).
- Deliberate red: one `route_changes` leaf in `fixtures/populated-oracle.json` put back to `7`, `run.sh` → rc 1 with `populated-oracle.json carries raw route_changes counters; re-capture it`; fixture restored from the capture and re-verified identical.
- `python3 scripts/check_public_tracker_ids.py` rc 0; `python3 -m py_compile tests/compat/ixp-manager-birdseye/verify_capture.py` rc 0.
