### PR TITLE
fix(alerts): guard MrtDumpStale on a configured dump interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `MrtDumpStale` in the shipped alert pack no longer fires on instances
+  without `[mrt]` configured: the `mrt_*` gauges are exported as 0 on every
+  instance, so the unguarded rule anchored dump age on process start with a
+  zero threshold and fired five minutes after every start. The rule now
+  requires a configured interval (`mrt_dump_interval_seconds > 0`); the
+  OPERATIONS.md MRT metrics table no longer claims the series exists only
+  when `[mrt]` is configured.
 - The IXP Manager / Bird's Eye populated oracle fixtures now mask BIRD's
   timing-dependent `route_changes` counters (shape still compared), so the
   pinned-contract job no longer fails on announcer arrival order.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1136,7 +1136,7 @@ any 10-minute increase of these two counters and of
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `mrt_dump_interval_seconds` | The configured `[mrt] dump_interval`; the series exists only when `[mrt]` is configured. The alert pack's `MrtDumpStale` fires once the newest dump is older than twice this value |
+| `mrt_dump_interval_seconds` | The configured `[mrt] dump_interval`. Exported on every instance: 0 when `[mrt]` is not configured, otherwise always > 0. The alert pack's `MrtDumpStale` guards on a value > 0 and fires once the newest dump is older than twice it |
 | `mrt_last_dump_success_timestamp_seconds` | Unix time the last periodic or on-demand dump was published successfully; 0 until the first success after start. A failed dump does not advance it, so `time() - <this>` is the age of the newest dump file |
 | `mrt_last_dump_duration_milliseconds` | Wall-clock duration of the last successful dump from trigger to published file (RIB snapshot, encode, write, rename) |
 | `mrt_dump_bytes_written_total` | Bytes of dump files published on disk (after compression) |

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -305,8 +305,10 @@ groups:
         # mrt_last_dump_success_timestamp_seconds stays 0 until the first
         # successful dump, so dump age is anchored on process start until
         # then: a daemon whose dumps have never succeeded alerts after the
-        # same 2x interval as one whose dumps stopped. Both mrt_* gauges
-        # exist only when [mrt] is configured, so this cannot fire elsewhere.
+        # same 2x interval as one whose dumps stopped. The mrt_* gauges are
+        # exported (as 0) on every instance, [mrt] configured or not; the
+        # `mrt_dump_interval_seconds > 0` guard is what keeps a 0 interval
+        # (no [mrt]) from firing 5m after every start.
         expr: >-
           time()
           - (
@@ -315,6 +317,7 @@ groups:
             or process_start_time_seconds{job="rustbgpd"}
           )
           > 2 * mrt_dump_interval_seconds
+          and mrt_dump_interval_seconds > 0
         for: 5m
         labels:
           severity: warning

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -693,7 +693,9 @@ tests:
   # Age is anchored on process start until the first success: edge1 never
   # succeeds after starting at 5m and fires 2x interval later; edge2
   # succeeded once at 10m then stalled; edge3's fresh success at 32m clears
-  # a pending alert; edge4's longer interval scales the threshold. All
+  # a pending alert; edge4's longer interval scales the threshold; edge5 has
+  # no [mrt] configured (interval and timestamp both exported as 0) and must
+  # never fire, which every exhaustive exp_alerts list below asserts. All
   # timestamps are promtool's epoch-relative clock.
   - interval: 1m
     input_series:
@@ -720,6 +722,12 @@ tests:
       - series: 'mrt_last_dump_success_timestamp_seconds{job="rustbgpd", instance="edge4:9179"}'
         values: "0x60"
       - series: 'process_start_time_seconds{job="rustbgpd", instance="edge4:9179"}'
+        values: "0x60"
+      - series: 'mrt_dump_interval_seconds{job="rustbgpd", instance="edge5:9179"}'
+        values: "0x60"
+      - series: 'mrt_last_dump_success_timestamp_seconds{job="rustbgpd", instance="edge5:9179"}'
+        values: "0x60"
+      - series: 'process_start_time_seconds{job="rustbgpd", instance="edge5:9179"}'
         values: "0x60"
       # A process-start series from another job must not anchor anything.
       - series: 'process_start_time_seconds{job="node", instance="edge1:9100"}'


### PR DESCRIPTION
## Mechanism

`crates/telemetry/src/metrics.rs` registers all five `mrt_*` metrics unconditionally in `Metrics::with_registry`; `mrt_dump_interval_seconds` and `mrt_last_dump_success_timestamp_seconds` are plain `IntGauge`s that only `crates/mrt/src/manager.rs` sets, and only when `[mrt]` is configured. Every instance without `[mrt]` therefore exports both as `0` from process start.

`MrtDumpStale` anchored dump age on `process_start_time_seconds` whenever the success timestamp was not newer than process start, and compared it against `2 * mrt_dump_interval_seconds`. Without `[mrt]` that is `time() - process_start > 0`, true from the first scrape, so the rule fired five minutes after every start on every non-MRT instance. The rule comment and the OPERATIONS.md MRT table row both claimed the series exist only when `[mrt]` is configured, and every fixture instance in the MrtDumpStale test group had a non-zero interval, so the tests could not catch it.

## Guard

```
          > 2 * mrt_dump_interval_seconds
+         and mrt_dump_interval_seconds > 0
```

Same plain `and <gauge> > 0` idiom `BgpDynamicNeighborSlotsNearLimit` already uses; both sides carry the same `job`/`instance` labels from one scrape. `[mrt] dump_interval` is validated `> 0`, so the guard is exactly "MRT configured".

## Docs

- Rule comment rewritten: the `mrt_*` gauges are exported (as 0) on every instance; the `> 0` guard is what keeps the rule from firing without `[mrt]`.
- `docs/OPERATIONS.md` MRT table row for `mrt_dump_interval_seconds`: exported on every instance, 0 when `[mrt]` is not configured, the pack guards on `> 0`. The other MRT rows, the MRT-failure prose, and `docs/CONFIGURATION.md` `[mrt]` make no "exists only when" claim and are unchanged. The RPKI `IntGaugeVec` claims are true and untouched.
- CHANGELOG `[Unreleased]` / `### Fixed` bullet.

## Deliberate-red proof

`examples/prometheus/rustbgpd-alerts_test.yml` gains `edge5:9179` in the MrtDumpStale group: `mrt_dump_interval_seconds 0`, `mrt_last_dump_success_timestamp_seconds 0`, `process_start_time_seconds 0` across the 60-minute range. The group's `exp_alerts` lists are exhaustive per eval time, so edge5 must be absent at 20m, 30m, 31m and 36m (all beyond `for: 5m`).

- Against the unguarded expr: `promtool test rules` rc 1 — edge5 fires at 20m, 30m, 31m, 36m.
- With the guard: rc 0 — edge1/edge2 still fire as before, edge5 never does.

## Gates (promtool 3.4.1, run as `.github/workflows/alert-rules.yml` does)

- `cd examples/prometheus && promtool test rules rustbgpd-alerts_test.yml` — rc 0 (rc 1 on the pre-guard run, as intended)
- `promtool check rules examples/prometheus/rustbgpd-alerts.yml` — rc 0, 32 rules
- `python3 scripts/check_public_tracker_ids.py` — rc 0
- `python3 scripts/check_ixp_manager_docs.py` — rc 0
- relative links in `docs/OPERATIONS.md` — 18 checked, 0 missing

No Rust changes. The `mrt_dump_interval_seconds` HELP string in `crates/telemetry/src/metrics.rs` carries the same "exists only when [mrt] is configured" wording and is left for a Rust-side follow-up.

LAN-1246
