### PR TITLE
release: prep v0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   client logs the clamp of a cache-advertised expire down to
   `max_expire_interval` at `warn` rather than `debug`, matching its sibling
   End of Data timer adjustments.
+- `rustbgpd-wire` 0.17.1 → 0.17.2 (additive): `PathAttribute` gains the
+  `AtomicAggregate` variant on the `#[non_exhaustive]` enum, a zero-length
+  `ATOMIC_AGGREGATE` decodes to it instead of `Unknown`, and the attribute
+  decode path returns typed `DecodeError`s where it carried `unreachable!`
+  arms. `rustbgpd-fsm` stays at 0.4.1; its `^0.17.1` requirement admits the
+  patch.
+
 - `rs-config-render` now uses one exit-code table across every subcommand
   (render, IXP Manager candidate, `activate`, `ixp-manager-lifecycle`): each
   code has exactly one meaning. This renumbers codes that previously meant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.66.0] — 2026-08-22
+
 ### Added
 
 - `bench/scale/compare-rrharness.sh` now compares any two refs: `--base`/`--head`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "birdwatcher-adapter"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "axum",
  "clap",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "event-bridge"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "clap",
  "rustbgpd-api",
@@ -2928,7 +2928,7 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rs-config-render"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "clap",
  "rustbgpd-policy",
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpctl"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "axum",
  "bgpkit-parser",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-api"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bfd"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-event-history"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "rusqlite",
  "rustbgpd-telemetry",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.20",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-linux"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "futures",
  "libc",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-mrt"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "criterion",
  "rustbgpd-wire",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.20",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-rustbgpd-wire = { path = "crates/wire", version = "0.17.1" }
+rustbgpd-wire = { path = "crates/wire", version = "0.17.2" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.65.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.4.1" }
 rustbgpd-transport = { path = "crates/transport", version = "0.65.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -35,19 +35,19 @@ categories = ["network-programming"]
 [workspace.dependencies]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire", version = "0.17.2" }
-rustbgpd-bfd = { path = "crates/bfd", version = "0.65.0" }
+rustbgpd-bfd = { path = "crates/bfd", version = "0.66.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.4.1" }
-rustbgpd-transport = { path = "crates/transport", version = "0.65.0" }
-rustbgpd-rib = { path = "crates/rib", version = "0.65.0" }
-rustbgpd-policy = { path = "crates/policy", version = "0.65.0" }
-rustbgpd-api = { path = "crates/api", version = "0.65.0" }
-rustbgpd-telemetry = { path = "crates/telemetry", version = "0.65.0" }
-rustbgpd-rpki = { path = "crates/rpki", version = "0.65.0" }
-rustbgpd-bmp = { path = "crates/bmp", version = "0.65.0" }
-rustbgpd-mrt = { path = "crates/mrt", version = "0.65.0" }
-rustbgpd-evpn = { path = "crates/evpn", version = "0.65.0" }
-rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.65.0" }
-rustbgpd-event-history = { path = "crates/event-history", version = "0.65.0" }
+rustbgpd-transport = { path = "crates/transport", version = "0.66.0" }
+rustbgpd-rib = { path = "crates/rib", version = "0.66.0" }
+rustbgpd-policy = { path = "crates/policy", version = "0.66.0" }
+rustbgpd-api = { path = "crates/api", version = "0.66.0" }
+rustbgpd-telemetry = { path = "crates/telemetry", version = "0.66.0" }
+rustbgpd-rpki = { path = "crates/rpki", version = "0.66.0" }
+rustbgpd-bmp = { path = "crates/bmp", version = "0.66.0" }
+rustbgpd-mrt = { path = "crates/mrt", version = "0.66.0" }
+rustbgpd-evpn = { path = "crates/evpn", version = "0.66.0" }
+rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.66.0" }
+rustbgpd-event-history = { path = "crates/event-history", version = "0.66.0" }
 
 # External dependencies — pinned across workspace
 bytes = "1"

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ cargo build --release -p rustbgpd -p rustbgpctl -p rs-config-render -p birdwatch
 ### Docker
 
 Release images are published to GHCR (versioned tags, e.g.
-`ghcr.io/lance0/rustbgpd:0.65.0`), or build locally:
+`ghcr.io/lance0/rustbgpd:0.66.0`), or build locally:
 
 ```bash
 docker build -t rustbgpd .                    # daemon + rbgp + birdwatcher-adapter, nonroot
@@ -471,7 +471,7 @@ evolving API.**
 | Dimension | Current state |
 |-----------|---------------|
 | **Target use case** | Data-center fabric pilots, IXP route servers, programmable BGP control planes, lab/test environments |
-| **Maturity** | Public alpha (v0.65.0) |
+| **Maturity** | Public alpha (v0.66.0) |
 | **Adopter support** | Reporting channels, compatibility boundaries, and proof limits are documented in [SUPPORT.md](SUPPORT.md). |
 | **Narrow stable contract** | The machine-pinned [route-server / route-reflector v1 contract](docs/v1-stable-contract.md) covers only its inventoried control-plane roles and surfaces; the project and all unlisted features remain alpha. |
 | **Implemented** | Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full gRPC/CLI management. Linux FIB integration is default-off and scoped to RFC 7999 discard routes and configured unicast tables (including ECMP and weighted multipath); broader routing-suite features remain future work. |

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "rustbgpd-wire",
  "rustc-hash",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.20",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bytes",
  "libc",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "bytes",
  "thiserror 2.0.20",

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-wire"
-version = "0.17.1"
+version = "0.17.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -67,6 +67,33 @@ analyzers, test harnesses, MRT readers, etc.
 | 10005 | Link Bandwidth Extended Community receiver subset: decode exact transitive/non-transitive types 0x00/0x40, subtype 0x04, as raw AS + IEEE-754 bytes/second; the constructor remains non-transitive type 0x40 |
 | draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |
 
+### 0.17.2 compatibility note
+
+`rustbgpd-wire` 0.17.2 is **additive**. `PathAttribute` (a `#[non_exhaustive]`
+enum) gains `PathAttribute::AtomicAggregate`, and one decode classification
+changes:
+
+- **ATOMIC_AGGREGATE (type 6) decodes as `PathAttribute::AtomicAggregate`**
+  (zero-length, well-known discretionary, RFC 4271 §5.1.6) instead of
+  `PathAttribute::Unknown`. Under 0.17.1 the `Unknown` value tripped the
+  unrecognized-well-known validation and the UPDATE was treat-as-withdrawn
+  (subcode 2); it now validates, and the encoder re-emits the attribute with
+  the transitive flag and a zero-length value. A non-zero length is an
+  attribute-length error — attribute-discard on the revised decode path
+  (RFC 7606 §7.6). On the legacy strict path (`decode_path_attributes`, used
+  by the MRT reader) that error fails the whole decode, so an MRT RIB entry
+  carrying a non-zero-length ATOMIC_AGGREGATE is rejected where it previously
+  read back as `PathAttribute::Unknown`. Code matching on `Unknown` for type
+  code 6 no longer sees it.
+
+The attribute decode path also replaces its `unreachable!` arms (`AS4_PATH`
+segment types, the `COMMUNITIES` / `EXTENDED_COMMUNITIES` / `CLUSTER_LIST` /
+`LARGE_COMMUNITIES` length checks, and the BGP-LS and VPN `MP_REACH_NLRI`
+next-hop lengths) with the typed `DecodeError` the surrounding validation
+already produces. Acceptance is unchanged for every input those guards
+already rejected. No signature changed and nothing was removed; code that
+builds against 0.17.1 builds unchanged against 0.17.2.
+
 ### 0.17.1 compatibility note
 
 `rustbgpd-wire` 0.17.1 is a **documentation-only patch**. There is no public
@@ -119,15 +146,6 @@ before upgrading a consumer that asserts on acceptance or typed variants:
 - **AGGREGATOR decodes as a typed `PathAttribute::Aggregator` value** instead
   of falling through to `PathAttribute::Unknown`. Code matching on `Unknown`
   for type code 7 no longer sees it.
-- **ATOMIC_AGGREGATE decodes as `PathAttribute::AtomicAggregate`** (zero-length,
-  well-known discretionary) instead of `PathAttribute::Unknown`, so the
-  unrecognized-well-known validation no longer treat-as-withdraws routes that
-  carry it. A non-zero length is an attribute-length error (RFC 7606 §7.6
-  attribute-discard on the revised decode path). On the legacy strict path
-  (`decode_path_attributes`, used by the MRT reader) that error fails the
-  whole decode, so an MRT RIB entry carrying a non-zero-length
-  ATOMIC_AGGREGATE is rejected where it previously read back as
-  `PathAttribute::Unknown`.
 - **OPEN and KEEPALIVE over 4096 bytes are rejected** at header peek, before a
   framing caller buffers the declared body, regardless of a negotiated RFC 8654
   extended message length.

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -76,7 +76,7 @@ Public surface (re-exported at crate root — `crates/wire/src/lib.rs`):
 - **`UpdateMessage`** — raw wire framing + `parse()` → `ParsedUpdate`
   (decoded NLRI + `Vec<PathAttribute>`).
 - **`PathAttribute`** — typed variants + `Unknown` pass-through (`AsPath`,
-  `Aggregator`, `NextHop`, `Communities`, `MpReachNlri`, `LargeCommunities`,
+  `Aggregator`, `AtomicAggregate`, `NextHop`, `Communities`, `MpReachNlri`, `LargeCommunities`,
   `PmsiTunnel`, `OnlyToCustomer`, ...).
 - **`Prefix`** (`V4(Ipv4Prefix)` / `V6(Ipv6Prefix)`), `NlriEntry`, Add-Path IDs.
 - **`Afi` / `Safi`** — IANA address-family identifiers.
@@ -153,7 +153,7 @@ This is the "MRT reader / monitor / analyzer" consumer. Links only
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.17.1"
+rustbgpd-wire = "0.17.2"
 bytes = "1"
 ```
 
@@ -213,7 +213,7 @@ intentional split (ADR-0002: inherent methods, no I/O in the FSM).
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.17.1"
+rustbgpd-wire = "0.17.2"
 rustbgpd-fsm = "0.4.1"
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "time", "rt"] }
@@ -312,7 +312,7 @@ once that crate is published.
 **Status: `wire` → `fsm` are published; `rpki` is next; `rib`, `bmp`, `mrt`,
 and `policy` are later.**
 
-1. **`rustbgpd-wire` (published as `0.17.1`).** This is the
+1. **`rustbgpd-wire` (published as `0.17.2`).** This is the
    foundation — dependent crate versions cannot publish before their wire
    dependency exists on crates.io. `0.15.0` brought `Capability::PathsLimit`
    with its `PathsLimitFamily` entry type (experimental capability code 76),
@@ -338,7 +338,21 @@ and `policy` are later.**
    RFC 7432 §7.8 citation, and the FlowSpec next-hop citation to RFC 8955 §4).
    There is no public API, wire-format, or decoder/encoder behavior change,
    and therefore nothing to migrate — code that builds against `0.17.0`
-   builds and behaves identically against `0.17.1`.
+   builds and behaves identically against `0.17.1`. `0.17.2` is
+   **additive**: `PathAttribute` (a `#[non_exhaustive]` enum) gains the
+   `AtomicAggregate` variant, and a zero-length `ATOMIC_AGGREGATE` (type 6)
+   now decodes to it instead of `PathAttribute::Unknown`. Under `0.17.1` that
+   `Unknown` value tripped the unrecognized-well-known-attribute validation,
+   so the UPDATE was treat-as-withdrawn with subcode 2; under `0.17.2` the
+   route validates and the encoder re-emits the attribute. A non-zero length
+   stays an attribute-length error — attribute-discard on the revised decode
+   path per RFC 7606 §7.6. Code matching `PathAttribute::Unknown` for type
+   code 6 no longer sees it; no signature changed and nothing was removed, so
+   `cargo semver-checks` reports no required bump and consumers compiled
+   against `0.17.1` build unchanged. The same release replaces the
+   `unreachable!` arms on the attribute decode path with the typed
+   `DecodeError` the surrounding validation already produces; acceptance is
+   unchanged for every input those guards already rejected.
 
 2. **`rustbgpd-fsm` (published as `0.4.1`).** The `0.4.0` release makes no
    FSM API changes of its own — it exists because the FSM's public surface
@@ -352,7 +366,9 @@ and `policy` are later.**
    boundary while the session is live. `Session::negotiated()` keeps its
    `Option<&NegotiatedSession>` signature, nothing was removed or changed,
    and `0.4.1` re-pins `rustbgpd-wire ^0.17.1` — a patch-level wire move with
-   no API change, so there is nothing to migrate. (History: `0.3.1` added
+   no API change, so there is nothing to migrate. The FSM does not move for
+   wire `0.17.2`: its `^0.17.1` requirement already resolves to the new patch
+   and the FSM's own source is unchanged since `0.4.1`. (History: `0.3.1` added
    `min_hold_time` and `required_families` to the `#[non_exhaustive]`
    `PeerConfig`, made the last duplicate Graceful Restart capability win, and
    rejected invalid OPEN identities.) Why the FSM was the second published crate:
@@ -444,7 +460,7 @@ To be the de facto Rust BGP codec, the concrete gaps:
 
 ## 7. Published-crate release boundary
 
-`rustbgpd-wire 0.17.1` and `rustbgpd-fsm 0.4.1` are published and are the
+`rustbgpd-wire 0.17.2` and `rustbgpd-fsm 0.4.1` are published and are the
 versions the §3 dependency examples name. The ordering rules that govern every
 future publish are:
 

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "rustbgpd-rs-rr-v1",
-  "baseline_release": "v0.65.0",
+  "baseline_release": "v0.66.0",
   "scope": "Narrow route-server and route-reflector product contract; unlisted surfaces are not stable by implication.",
   "roles": [
     {
@@ -373,6 +373,20 @@
       "semantic_toml_sha256": "c95411fc1f1b08f3e9370ea8aaa6ac405d8302fe42cddb6038c559c5ba0a5927",
       "validation_source": "src/config/tests/mod.rs",
       "validation_test": "config::tests::v1_stable_v0_64_route_server_fixture_parses",
+      "result": "accepted_without_config_migration"
+    },
+    {
+      "from_release": "v0.65.0",
+      "to_release": "v0.66.0",
+      "fixture_directory": "tests/fixtures/v1-stable/v0.65.0/route-server",
+      "source_directory": "examples/route-server",
+      "files": [
+        {"path": "config.toml", "sha256": "51376c81219f5e3d7a185adf0aaa9344de5dee241302a7d2f0b8ec12d14a301c"},
+        {"path": "hygiene.rpol", "sha256": "9035313c7813273a64856780be66d790f25cafcb8a7f04e44ada16efb083e515"}
+      ],
+      "semantic_toml_sha256": "c95411fc1f1b08f3e9370ea8aaa6ac405d8302fe42cddb6038c559c5ba0a5927",
+      "validation_source": "src/config/tests/mod.rs",
+      "validation_test": "config::tests::v1_stable_v0_65_route_server_fixture_parses",
       "result": "accepted_without_config_migration"
     }
   ]

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -38,7 +38,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
 
     def test_each_wire_snippet_is_guarded(self) -> None:
         """Red if either wire dependency example drifts to 0.15.0."""
-        old = 'rustbgpd-wire = "0.17.1"'
+        old = 'rustbgpd-wire = "0.17.2"'
         for occurrence in (0, 1):
             with self.subTest(occurrence=occurrence):
                 self.assert_fails(
@@ -55,7 +55,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
 
     def test_publish_statuses_are_guarded(self) -> None:
         """Red if either numbered publish heading names an old version."""
-        mutations = (("wire", "0.17.1", "0.17.0"), ("fsm", "0.4.1", "0.4.0"))
+        mutations = (("wire", "0.17.2", "0.17.1"), ("fsm", "0.4.1", "0.4.0"))
         for package, current, old in mutations:
             with self.subTest(package=package):
                 self.assert_fails(
@@ -76,7 +76,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
         """Red if an actual publish status changes from published to prepared."""
         self.assert_fails(
             self.replace_nth(
-                "(published as `0.17.1`)", "(prepared as `0.17.1`)"
+                "(published as `0.17.2`)", "(prepared as `0.17.2`)"
             ),
             "publish-status-version",
         )

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -342,6 +342,27 @@ fn v1_stable_v0_64_route_server_fixture_parses() {
         .unwrap_or_else(|err| panic!("v0.64.0 route-server config no longer validates: {err}"));
 }
 
+#[test]
+fn v1_stable_v0_65_route_server_fixture_parses() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/v1-stable/v0.65.0/route-server");
+    let config_path = fixture.join("config.toml");
+    let source = fs::read_to_string(&config_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read immutable v0.65.0 route-server fixture {}: {err}",
+            config_path.display()
+        );
+    });
+    let mut config: Config = toml::from_str(&source)
+        .unwrap_or_else(|err| panic!("v0.65.0 route-server config no longer parses: {err}"));
+    config
+        .load_rpol_files(Some(&fixture))
+        .unwrap_or_else(|err| panic!("v0.65.0 route-server rpol no longer loads: {err}"));
+    config
+        .validate()
+        .unwrap_or_else(|err| panic!("v0.65.0 route-server config no longer validates: {err}"));
+}
+
 const V1_EFFECTIVE_DEFAULTS_TOML: &str = r#"
 [global]
 asn = 65001

--- a/tests/fixtures/v1-stable/v0.65.0/route-server/config.toml
+++ b/tests/fixtures/v1-stable/v0.65.0/route-server/config.toml
@@ -1,0 +1,172 @@
+# IXP route server configuration
+#
+# rustbgpd as an IX route server with two members. Every member gets:
+# - transparent route-server mode (preserve original NEXT_HOP, no AS prepend)
+# - local BGP role "route_server" (RFC 9234: OTC attached on egress,
+#   role capability negotiated when the member also sets its role)
+# - dual-stack (IPv4 + IPv6 unicast)
+# - RPKI origin validation (drop invalid, prefer valid) and import
+#   hygiene (reject AS_SET, ASPA-invalid, and a dated dual-stack
+#   special-purpose prefix snapshot — see hygiene.rpol)
+#
+# Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
+# - member-alpha negotiates Add-Path send: it sees up to the eight best
+#   export-permitted candidates, subject to configured and negotiated
+#   Paths-Limit, and runs its own selection (the preferred mitigation);
+# - member-beta cannot do Add-Path, so it opts into per_client_best:
+#   when its export policy denies the best path, the route server
+#   advertises the best *permitted* candidate instead of hiding the
+#   prefix (the BIRD-`secondary` equivalent).
+#
+# Add more [[neighbors]] blocks for additional IXP members, or manage
+# them dynamically via gRPC at runtime.
+
+[global]
+asn = 65500
+router_id = "198.51.100.1"
+listen_port = 179
+# RFC 8212: a member session with no explicit policy carries nothing in
+# that direction. The export chain below is deliberately permit-all, and
+# this knob is what keeps that a decision: delete the chain and members
+# stop receiving routes, loudly, instead of inheriting the same permit-all
+# by omission. Startup-only — SIGHUP keeps the running value, so changing
+# it takes a daemon restart.
+ebgp_requires_policy = true
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# For remote management, prefer an mTLS proxy (see examples/envoy-mtls/).
+# For a loopback-only bearer listener, create the token file and uncomment
+# this complete principal-to-role mapping:
+# [global.telemetry.grpc_tcp]
+# address = "127.0.0.1:50051"
+# token_file = "/etc/rustbgpd/grpc-token"
+# principal = "remote-operator"
+# [security.grpc.roles]
+# remote-operator = "operator"
+
+# Local gRPC uses the implicit owner-only socket at
+# <runtime_state_dir>/grpc.sock and the local-operator identity.
+
+# --- RPKI origin validation ---
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"       # Routinator, rpki-client, etc.
+
+# --- Named policy definitions ---
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.reject-long-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "0.0.0.0/0"
+ge = 25
+le = 32
+action = "deny"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "::/0"
+ge = 49
+le = 128
+action = "deny"
+
+[policy.definitions.prefer-rpki-valid]
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "valid"
+action = "permit"
+set_local_pref = 200
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "not_found"
+action = "permit"
+set_local_pref = 100
+
+# --- Export policy: permit-all, on purpose ---
+#
+# An IX route server is transparent by design (RFC 7947): it hands each
+# member what that member's own filters selected, without imposing the
+# route server's opinion on top. So permit-all is the correct export
+# posture here — but it is *declared*, not inherited. A route server that
+# is permit-all because nobody wrote an export chain behaves identically
+# on the wire; only this chain, and this comment, record that it was a
+# choice rather than an omission.
+#
+# Per-member filtering (a member that wants a subset, or a bilateral
+# arrangement) belongs in that neighbor's `export_policy_chain`, which
+# overrides this globally applied one. member-beta's `per_client_best`
+# below is what makes such a per-member denial advertise the best
+# permitted candidate rather than hide the prefix.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
+[policy]
+# ixp-hygiene and reject-special-purpose live in hygiene.rpol; rpol and
+# TOML policies share one namespace and compose in one ordered chain.
+rpol_files = ["hygiene.rpol"]
+import_chain = [
+    "reject-rpki-invalid",
+    "ixp-hygiene",
+    "reject-special-purpose",
+    "reject-long-prefixes",
+    "prefer-rpki-valid",
+]
+export_chain = ["rs-transparent-export"]
+
+# Import-decision explain, off — stated rather than inherited, because on
+# a route server it is the memory decision that matters most. The cache is
+# per session, so its cost is multiplied by member count, and 4096 entries
+# cannot retain a member's full table anyway: a query for an arbitrary
+# prefix would be a coin-flip against an evicted answer. On a 1000-member
+# fleet whose members each announce more than 4096 prefixes, an enabled
+# cache at the default size saturates in the low gigabytes.
+#
+# For the member-facing "why is my route filtered?" question, prefer
+# `[policy.reject_retention]` (on by default) and
+# `rbgp rib received <member> --rejected` — it enumerates rejections with
+# reasons and does not need the prefix known in advance.
+#
+# Turn this on deliberately, with `cache_size` raised toward the member's
+# retained-prefix count, while you are diagnosing — not as a standing cost.
+[policy.explain]
+enabled = false
+
+# --- IXP member peers ---
+
+# Add-Path-capable member: sees up to the eight best export-permitted
+# candidates, subject to configured and negotiated Paths-Limit (preferred
+# path-hiding mitigation). Like `per_client_best`, Add-Path send places
+# the member on the per-peer distribution path (the `add_path_send`
+# fallback reason); update-group sharing applies to members using
+# neither mitigation.
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64501
+description = "member-alpha"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+role = "route_server"
+max_prefixes = 50000
+
+[neighbors.add_path]
+send = true
+send_max = 8
+
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied
+# (RFC 7947 §2.3.2 per-client best-path). Requires route_server_client.
+[[neighbors]]
+address = "198.51.100.3"
+remote_asn = 64502
+description = "member-beta"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+per_client_best = true
+role = "route_server"
+max_prefixes = 50000

--- a/tests/fixtures/v1-stable/v0.65.0/route-server/hygiene.rpol
+++ b/tests/fixtures/v1-stable/v0.65.0/route-server/hygiene.rpol
@@ -1,0 +1,166 @@
+# IXP import hygiene (rpol policy language, ADR-0096).
+#
+# Referenced from config.toml via `[policy] rpol_files` and the import
+# chain; edits hot-apply via SIGHUP. Run the in-language tests below
+# with `rbgp policy check hygiene.rpol`.
+
+# Dated starter snapshot of the IANA IPv4 and IPv6 Special-Purpose Address
+# Registries (both updated 2025-10-09; reviewed here 2026-07-15). The reject
+# set contains the two default routes plus active rows whose "Globally
+# Reachable" value is False. It is deliberately not a complete bogon feed:
+# terminated rows, unallocated space, multicast, and True/N/A rows outside a
+# rejected parent are omitted. Active True/N/A children of a rejected parent
+# must stay in this first set so the policy accepts them before the broad deny.
+prefix-set special-purpose-parent-exceptions {
+    192.0.0.9/32,
+    192.0.0.10/32,
+    2001::/32 le 128,
+    2001:1::1/128,
+    2001:1::2/128,
+    2001:1::3/128,
+    2001:3::/32 le 128,
+    2001:4:112::/48 le 128,
+    2001:20::/28 le 128,
+    2001:30::/28 le 128,
+}
+
+prefix-set non-global-special-purpose {
+    0.0.0.0/0,
+    0.0.0.0/8 le 32,
+    10.0.0.0/8 le 32,
+    100.64.0.0/10 le 32,
+    127.0.0.0/8 le 32,
+    169.254.0.0/16 le 32,
+    172.16.0.0/12 le 32,
+    192.0.0.0/24 le 32,
+    192.0.2.0/24 le 32,
+    192.88.99.2/32,
+    192.168.0.0/16 le 32,
+    198.18.0.0/15 le 32,
+    198.51.100.0/24 le 32,
+    203.0.113.0/24 le 32,
+    240.0.0.0/4 le 32,
+    ::/0,
+    ::/128,
+    ::1/128,
+    ::ffff:0:0/96 le 128,
+    64:ff9b:1::/48 le 128,
+    100::/64 le 128,
+    100:0:0:1::/64 le 128,
+    2001::/23 le 128,
+    2001:db8::/32 le 128,
+    3fff::/20 le 128,
+    5f00::/16 le 128,
+    fc00::/7 le 128,
+    fe80::/10 le 128,
+}
+
+policy reject-special-purpose {
+    term preserve-active-parent-exception {
+        if route.prefix in special-purpose-parent-exceptions { accept }
+    }
+    term reject-non-global { if route.prefix in non-global-special-purpose { reject } }
+}
+
+policy ixp-hygiene {
+    # Reject routes carrying an AS_SET (deprecated by RFC 9774; common
+    # IXP hygiene, arouteserver rejects them too). AS_PATHs render
+    # AS_SETs in braces — "65001 {65002 65003}" — so a literal `{`
+    # (escaped for the regex) matches any AS_SET segment.
+    term reject-as-set { if route.as-path matches "\\{" { reject } }
+    # Reject ASPA-invalid AS paths (draft-ietf-sidrops-aspa-verification).
+    # Inert (state = unknown) until ASPA objects are loaded from the
+    # RPKI cache; activates automatically once they are.
+    term reject-aspa-invalid { if route.aspa == invalid { reject } }
+    # Tag the RPKI origin-validation outcome as an RFC 8097 extended
+    # community (non-transitive opaque, type 0x43) so route-server
+    # clients can act on it without running their own validator.
+    # OV_INVALID never reaches clients here — the TOML import chain
+    # drops rpki-invalid routes — but tagging is harmless and keeps
+    # the terms uniform if that drop is ever relaxed.
+    term tag-ov-valid { if route.rpki == valid { add ext-community OV_VALID } }
+    term tag-ov-not-found { if route.rpki == not-found { add ext-community OV_NOT_FOUND } }
+    term tag-ov-invalid { if route.rpki == invalid { add ext-community OV_INVALID } }
+}
+
+test as-set-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501 {64502 64503}" }
+    expect ixp-hygiene == reject
+}
+
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
+test clean-route-falls-through {
+    route { prefix 203.0.113.0/24; as-path "64501 64510" }
+    expect ixp-hygiene == accept
+}
+
+test rpki-valid-is-tagged-ov-valid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki valid }
+    expect ixp-hygiene == accept with ext-community OV_VALID
+}
+
+test rpki-not-found-is-tagged-ov-not-found {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
+}
+
+test rpki-invalid-is-tagged-ov-invalid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki invalid }
+    expect ixp-hygiene == accept with ext-community OV_INVALID
+}
+
+test ipv4-default-is-rejected {
+    route { prefix 0.0.0.0/0 }
+    expect reject-special-purpose == reject
+}
+
+test ipv6-default-is-rejected {
+    route { prefix ::/0 }
+    expect reject-special-purpose == reject
+}
+
+test shared-address-more-specific-is-rejected {
+    route { prefix 100.65.0.0/24 }
+    expect reject-special-purpose == reject
+}
+
+test unique-local-more-specific-is-rejected {
+    route { prefix fd00:1::/48 }
+    expect reject-special-purpose == reject
+}
+
+test pcp-parent-exception-is-preserved {
+    route { prefix 192.0.0.9/32 }
+    expect reject-special-purpose == accept
+}
+
+test teredo-parent-exception-is-preserved {
+    route { prefix 2001:0:1234::/48 }
+    expect reject-special-purpose == accept
+}
+
+test as112-parent-exception-is-preserved {
+    route { prefix 2001:4:112::/48 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv4-falls-through {
+    route { prefix 8.8.8.0/24 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv6-falls-through {
+    route { prefix 2001:4860::/32 }
+    expect reject-special-purpose == accept
+}
+
+# This policy only classifies the dated special-purpose snapshot. The later
+# reject-long-prefixes chain member remains responsible for prefix-length caps.
+test too-long-parent-exception-falls-through {
+    route { prefix 2001:4:112::1/128 }
+    expect reject-special-purpose == accept
+}


### PR DESCRIPTION
Release preparation for v0.66.0 (release date 2026-08-22). Two commits: the decoupled wire crate bump first, then the workspace bump and CHANGELOG roll. No tag is created here.

## Version moves

| Package | From | To | Why |
|---|---|---|---|
| workspace (`rustbgpd`, twelve internal pins) | 0.65.0 | 0.66.0 | release |
| `rustbgpd-wire` | 0.17.1 | 0.17.2 | additive: `PathAttribute::AtomicAggregate` on the `#[non_exhaustive]` enum; zero-length `ATOMIC_AGGREGATE` decodes to it instead of `Unknown` (no more treat-as-withdraw); typed `DecodeError`s replace `unreachable!` arms. `cargo semver-checks` against v0.65.0: 196 pass, 0 required bumps |
| `rustbgpd-fsm` | 0.4.1 | 0.4.1 | unchanged source since publish; `^0.17.1` admits the wire patch |
| `rustbgpd-rpki` | — | — | `publish = false` |

## Files swept

**Wire bump (`release: bump rustbgpd-wire to 0.17.2`)**
- `crates/wire/Cargo.toml`, root `Cargo.toml` `[workspace.dependencies]` wire pin, `Cargo.lock` (wire line)
- `docs/EMBEDDING.md`: both dependency snippets, publish-status heading, §2.1 type list, §4 0.17.1 → 0.17.2 transition prose and FSM non-bump note, §7 boundary
- `scripts/test_check_embedding_versions.py`: expected published versions
- `crates/wire/README.md`: new "0.17.2 compatibility note"; the ATOMIC_AGGREGATE bullet that had been filed under the 0.16.0 note moves into it (restoring that note's six-item list). RFC table re-checked against `git grep 'RFC [0-9]+' crates/wire/src/` (remaining unlisted mentions — 5398/6996/7947/9107 — are doc-comment references, not features), key-types list re-checked against the `pub use` block in `lib.rs` (unchanged since v0.65.0), usage examples match the current `decode_message` / `UpdateMessage::parse` / `encode_message` signatures
- `CHANGELOG.md`: `rustbgpd-wire` entry under `### Changed`

**Release commit (`release: prep v0.66.0 — bump workspace, roll CHANGELOG`)**
- root `Cargo.toml` `[workspace.package] version` + twelve internal `rustbgpd-*` pins; `Cargo.lock` (18 version lines); `bench/scale/Cargo.lock` (8 lines)
- `README.md`: Maturity row and GHCR image example → 0.66.0
- `docs/v1-stable-surface.json`: `baseline_release` → v0.66.0; consecutive v0.65.0 → v0.66.0 upgrade exercise appended; `tests/fixtures/v1-stable/v0.65.0/route-server/{config.toml,hygiene.rpol}` archived from the v0.65.0 tag; `src/config/tests/mod.rs` gains `v1_stable_v0_65_route_server_fixture_parses`
- `CHANGELOG.md`: `[Unreleased]` rolled to `## [0.66.0] — 2026-08-22`, fresh empty `[Unreleased]` above it (rebased onto #1815 so its `### Fixed` bullet sits inside 0.66.0)
- `ROADMAP.md` / `KNOWN_ISSUES.md`: no `(post-v0.65.0)` annotations exist and no open ROADMAP item landed this cycle; unchanged

v1 surface rows added since v0.65.0 (none stable): `Global.listen_addresses` → alpha, `RibService.LookupBestPath` → outside v1; `GetGlobal` / `NeighborService` / `RibService` message-graph digests refreshed for additive fields.

## Gates (all rc 0, run on the branch head's Rust tree)

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`: 113 suites, 8061 passed, 0 failed, 15 ignored
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo audit` (509 dependencies, no advisories)
- `cargo test -p rustbgpd-api authz`: 50 passed
- `cargo test -p rustbgpctl checked_in_completions_match_current_cli`: 1 passed
- `cargo semver-checks check-release -p rustbgpd-wire --baseline-rev v0.65.0`: 196 pass, 58 skip
- `cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked`: 11 passed
- `cargo publish -p rustbgpd-wire --dry-run --allow-dirty`: reached "aborting upload due to dry run"
- `python3 scripts/check-clippy-reasons.py`, `check_public_tracker_ids.py` (606 documents clean), `check-v1-stable-surface.py` (OK), `python3 -m unittest scripts/test_check_embedding_versions.py` (9 tests OK)
- Wire README freshness gate mirrored locally against origin/main: version moved and README touched
- `release.yml` notes extraction mirrored locally for 0.66.0: 320-line section extracted, `reflow-release-notes.py` rc 0
