### PR TITLE
test: carry the stub OPEN-loop leftover into the session reader so a coalesced KEEPALIVE is not dropped

### DIFF
--- a/tests/atomic_aggregate_passthrough.rs
+++ b/tests/atomic_aggregate_passthrough.rs
@@ -191,19 +191,13 @@ async fn establish(ctx: Arc<Ctx>, i: usize) -> Result<mpsc::Sender<Message>, Str
 
     let reader_ctx = Arc::clone(&ctx);
     tokio::spawn(async move {
-        let mut frame = BytesMut::with_capacity(1 << 16);
+        // Start from the OPEN loop's leftover: on loopback the daemon's
+        // first KEEPALIVE often shares a read with its OPEN, so parse
+        // what is already buffered before the first read instead of
+        // dropping it.
+        let mut frame = buf;
         let mut tmp = vec![0u8; 1 << 16];
         loop {
-            let n = match reader.read(&mut tmp).await {
-                Ok(0) | Err(_) => {
-                    reader_ctx.obs[i]
-                        .established
-                        .store(false, Ordering::Release);
-                    return;
-                }
-                Ok(n) => n,
-            };
-            frame.extend_from_slice(&tmp[..n]);
             loop {
                 if frame.len() < HEADER_LEN {
                     break;
@@ -255,6 +249,16 @@ async fn establish(ctx: Arc<Ctx>, i: usize) -> Result<mpsc::Sender<Message>, Str
                     }
                 }
             }
+            let n = match reader.read(&mut tmp).await {
+                Ok(0) | Err(_) => {
+                    reader_ctx.obs[i]
+                        .established
+                        .store(false, Ordering::Release);
+                    return;
+                }
+                Ok(n) => n,
+            };
+            frame.extend_from_slice(&tmp[..n]);
         }
     });
 

--- a/tests/config_persistence_lifecycle.rs
+++ b/tests/config_persistence_lifecycle.rs
@@ -426,14 +426,13 @@ async fn establish(ctx: Arc<Ctx>, i: usize) -> Result<mpsc::Sender<Message>, Str
 
     let reader_ctx = Arc::clone(&ctx);
     tokio::spawn(async move {
-        let mut frame = BytesMut::with_capacity(1 << 16);
+        // Start from the OPEN loop's leftover: on loopback the daemon's
+        // first KEEPALIVE often shares a read with its OPEN, so parse
+        // what is already buffered before the first read instead of
+        // dropping it.
+        let mut frame = buf;
         let mut tmp = vec![0u8; 1 << 16];
         loop {
-            let n = match reader.read(&mut tmp).await {
-                Ok(0) | Err(_) => break,
-                Ok(n) => n,
-            };
-            frame.extend_from_slice(&tmp[..n]);
             loop {
                 if frame.len() < HEADER_LEN {
                     break;
@@ -537,6 +536,11 @@ async fn establish(ctx: Arc<Ctx>, i: usize) -> Result<mpsc::Sender<Message>, Str
                     _ => {}
                 }
             }
+            let n = match reader.read(&mut tmp).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            frame.extend_from_slice(&tmp[..n]);
         }
         record_link_drop(&reader_ctx, i);
     });

--- a/tests/outbound_prefix_limits.rs
+++ b/tests/outbound_prefix_limits.rs
@@ -340,19 +340,13 @@ async fn establish(ctx: Arc<Ctx>, i: usize) -> Result<mpsc::Sender<Message>, Str
 
     let reader_ctx = Arc::clone(&ctx);
     tokio::spawn(async move {
-        let mut frame = BytesMut::with_capacity(1 << 16);
+        // Start from the OPEN loop's leftover: on loopback the daemon's
+        // first KEEPALIVE often shares a read with its OPEN, so parse
+        // what is already buffered before the first read instead of
+        // dropping it.
+        let mut frame = buf;
         let mut tmp = vec![0u8; 1 << 16];
         loop {
-            let n = match reader.read(&mut tmp).await {
-                Ok(0) | Err(_) => {
-                    reader_ctx.obs[i]
-                        .established
-                        .store(false, Ordering::Release);
-                    return;
-                }
-                Ok(n) => n,
-            };
-            frame.extend_from_slice(&tmp[..n]);
             loop {
                 if frame.len() < HEADER_LEN {
                     break;
@@ -445,6 +439,16 @@ async fn establish(ctx: Arc<Ctx>, i: usize) -> Result<mpsc::Sender<Message>, Str
                     }
                 }
             }
+            let n = match reader.read(&mut tmp).await {
+                Ok(0) | Err(_) => {
+                    reader_ctx.obs[i]
+                        .established
+                        .store(false, Ordering::Release);
+                    return;
+                }
+                Ok(n) => n,
+            };
+            frame.extend_from_slice(&tmp[..n]);
         }
     });
 


### PR DESCRIPTION
## Why

`core tests / rustdoc` is red on both completed `main` runs since ee812955 (#1803):

- https://github.com/lance0/rustbgpd/actions/runs/32595294570
- https://github.com/lance0/rustbgpd/actions/runs/32600945001

`tests/atomic_aggregate_passthrough.rs:475: not every stub session reached Established` after ~87 s / ~106 s. The test passes on an idle many-core box.

## Mechanism

The stub's `establish()` reads the daemon's OPEN in a loop over a local `buf` and breaks on `Message::Open`. When the daemon's OPEN and its first KEEPALIVE arrive in one read (the daemon enqueues both before the stub is scheduled, which is the common case on a small or loaded runner), the loop breaks on OPEN and the KEEPALIVE bytes left in `buf` are dropped. The session reader then starts from an empty buffer and only sets `established` on a daemon KEEPALIVE; the next one is hold/3 = 60 s away, which is exactly `CONVERGE_TIMEOUT`, so the assertion cannot win.

`tests/outbound_prefix_limits.rs` and `tests/config_persistence_lifecycle.rs` share the stub shape (they mark `established` right after OPEN so they do not hang on this, but they drop the same post-OPEN bytes, so the first daemon message after OPEN can be lost).

## Fix (test harness only)

In all three stubs, the session reader starts from the OPEN loop's leftover `buf` and parses whatever is already buffered before its first `read`. No change to `CONVERGE_TIMEOUT`, `HOLD_TIME`, any assertion, or daemon/crate code.

## Red -> green

Recipe: test binary pinned to one CPU under `SCHED_BATCH` (no wakeup preemption, so the daemon writes OPEN and KEEPALIVE before the stub runs), `rbgp` prebuilt:

```
cargo build -p rustbgpctl --bin rbgp
cargo test --test atomic_aggregate_passthrough --no-run
CARGO_BIN_EXE_rbgp=target/debug/rbgp chrt -b 0 taskset -c 0 target/debug/deps/atomic_aggregate_passthrough-<hash> --nocapture --test-threads=1
```

A temporary stub-side print (removed before commit) confirmed the coalescing in the failing case: `OPEN decoded; 19 leftover byte(s) already read` (19 bytes = one KEEPALIVE).

| Stage | Runs | Result | Wall per run |
|---|---|---|---|
| Before the fix, `taskset -c 0` only (no `chrt -b`) | 5 | 5/5 pass, 0 leftover bytes in every session (the stub preempts the daemon between its two writes) | 0.2 s |
| Before the fix, `chrt -b 0 taskset -c 0` | 5 | **0/5 pass**, every run `not every stub session reached Established`; 9 of 10 stub sessions logged `19 leftover byte(s)` | 60.2 s |
| After the fix, same recipe, `atomic_aggregate_passthrough` | 10 | **10/10 pass**; 5 of 20 stub sessions logged `19 leftover byte(s)` and still established | 0.2–1.2 s |
| After the fix, same recipe, `outbound_prefix_limits` | 3 | 3/3 pass (5 tests each) | 16.4–16.6 s |
| After the fix, same recipe, `config_persistence_lifecycle` | 3 | 3/3 pass (10 tests each) | 26.1–27.3 s |
| Final committed binary (print removed), same recipe | 3 | 3/3 pass | 0.2 s |


## Gates

- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `cargo test --workspace --no-fail-fast`: 8060 passed, 0 failed, 15 ignored (113 suites)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`: pass
- `scripts/check-clippy-reasons.py`, `scripts/check_public_tracker_ids.py`: pass

Refs LAN-1245.

