### PR TITLE
fix: surface the RPKI expire clamp and floor it above retry; pin BMP drop phase, DeadlineMap ties, and the MRT ATOMIC_AGGREGATE length rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `expire_interval`) is clamped down to it, so that cache's VRPs are discarded
   once older than the ceiling no matter what the cache advertises, on the same
   expiry path as the RFC 8210 two-day maximum. Rejected unless <= 172800 and
-  > `refresh_interval`; unset changes nothing. The new
+  > both `refresh_interval` and `retry_interval`; unset changes nothing. The new
   `bgp_rpki_cache_effective_expire_seconds{cache}` gauge shows the effective
   expire per cache.
 - `rs-config-render status` reports the activation and lifecycle state of one
@@ -227,6 +227,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `[[rpki.cache_servers]] max_expire_interval` is now rejected at config
+  validation unless it is also above the cache's `retry_interval` (it was
+  already required to exceed `refresh_interval`), so the ceiling alone never
+  forces the RTR client to lower retry below its configured value. The RTR
+  client logs the clamp of a cache-advertised expire down to
+  `max_expire_interval` at `warn` rather than `debug`, matching its sibling
+  End of Data timer adjustments.
 - `rs-config-render` now uses one exit-code table across every subcommand
   (render, IXP Manager candidate, `activate`, `ixp-manager-lifecycle`): each
   code has exactly one meaning. This renumbers codes that previously meant

--- a/crates/mrt/src/reader.rs
+++ b/crates/mrt/src/reader.rs
@@ -1199,6 +1199,45 @@ mod tests {
         assert!(matches!(err, Some(ReadError::Truncated { .. })));
     }
 
+    /// The reader decodes entry attributes on the legacy strict path, so a
+    /// non-zero-length `ATOMIC_AGGREGATE` (RFC 4271 §5.1.6 says zero) is an
+    /// attribute-length error that fails the record instead of reading back
+    /// as `PathAttribute::Unknown`.
+    #[test]
+    fn nonzero_length_atomic_aggregate_is_attribute_length_error() {
+        use rustbgpd_wire::notification::update_subcode::ATTRIBUTE_LENGTH_ERROR;
+        let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
+        let mut data =
+            encode_snapshot(COLLECTOR, std::slice::from_ref(&peer), &[], &[], TS).unwrap();
+        // ATOMIC_AGGREGATE with flags 0x40, length 1, one value byte.
+        let attr = [attr_flags::TRANSITIVE, attr_type::ATOMIC_AGGREGATE, 1, 0];
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&0u32.to_be_bytes());
+        payload.push(24);
+        payload.extend_from_slice(&[192, 168, 1]);
+        payload.extend_from_slice(&1u16.to_be_bytes());
+        payload.extend_from_slice(&0u16.to_be_bytes()); // peer index
+        payload.extend_from_slice(&TS.to_be_bytes()); // originated
+        payload.extend_from_slice(&u16::try_from(attr.len()).unwrap().to_be_bytes());
+        payload.extend_from_slice(&attr);
+        data.extend_from_slice(&raw_record(13, 2, &payload));
+        let mut reader = SnapshotReader::new(&data).unwrap();
+        let (entries, err) = drain(&mut reader);
+        assert!(entries.is_empty());
+        assert!(
+            matches!(
+                err,
+                Some(ReadError::AttributeDecode(
+                    DecodeError::UpdateAttributeError {
+                        subcode: ATTRIBUTE_LENGTH_ERROR,
+                        ..
+                    }
+                ))
+            ),
+            "{err:?}"
+        );
+    }
+
     #[test]
     fn bad_prefix_length_is_malformed() {
         let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);

--- a/crates/rib/src/manager/tests/gr_llgr.rs
+++ b/crates/rib/src/manager/tests/gr_llgr.rs
@@ -2160,6 +2160,28 @@ mod deadline_map {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn removing_one_of_tied_minima_rescans_to_the_survivor() {
+        let mut map = DeadlineMap::default();
+        map.insert("a", at(10));
+        map.insert("b", at(10));
+        map.insert("c", at(30));
+        assert_eq!(map.min(), Some(at(10)));
+        assert_eq!(map.remove("a"), Some(at(10)));
+        assert!(
+            map.is_stale(),
+            "removing a value equal to the cached minimum invalidates it"
+        );
+        assert_eq!(
+            map.min(),
+            Some(at(10)),
+            "the tied survivor is still the minimum"
+        );
+        assert!(!map.is_stale());
+        assert_eq!(map.remove("b"), Some(at(10)));
+        assert_eq!(map.min(), Some(at(30)));
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn overwriting_the_minimum_rescans_to_the_new_value() {
         let mut map = DeadlineMap::default();
         map.insert("a", at(10));

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -591,7 +591,7 @@ impl RtrClient {
             if let Some(max) = self.config.max_expire_interval
                 && expire > max
             {
-                debug!(
+                warn!(
                     server = %self.config.server_addr,
                     expire,
                     max_expire_interval = max,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -6773,21 +6773,16 @@ mod tests {
         let m = BgpMetrics::new();
         m.record_bmp_collector_drop("127.0.0.1:5000", "fan_out", "channel_full", 1);
         m.record_bmp_collector_drop("127.0.0.1:5000", "fan_out", "channel_full", 1);
-        // Replay abort: count every cached-PeerUp message that was
-        // skipped, not just one.
-        m.record_bmp_collector_drop("127.0.0.1:5000", "replay", "channel_full", 7);
+        // A batched drop counts every message that was skipped, not just
+        // one; `phase` is one of the documented values (fan_out,
+        // loc_rib_dump).
+        m.record_bmp_collector_drop("127.0.0.1:5000", "fan_out", "channel_full", 7);
 
         let fan_out =
             m.0.bmp_collector_drops
                 .with_label_values(&["127.0.0.1:5000", "fan_out", "channel_full"])
                 .get();
-        assert_eq!(fan_out, 2);
-
-        let replay =
-            m.0.bmp_collector_drops
-                .with_label_values(&["127.0.0.1:5000", "replay", "channel_full"])
-                .get();
-        assert_eq!(replay, 7);
+        assert_eq!(fan_out, 9);
     }
 
     #[test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1908,7 +1908,7 @@ impl BgpMetrics {
         let mrt_dump_interval_seconds = IntGauge::new(
             "mrt_dump_interval_seconds",
             "Configured seconds between periodic MRT TABLE_DUMP_V2 dumps \
-             ([mrt] dump_interval). Exists only when [mrt] is configured.",
+             ([mrt] dump_interval); 0 when [mrt] is not configured.",
         )
         .expect("valid metric definition");
         let mrt_last_dump_success_timestamp = IntGauge::new(

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -123,7 +123,11 @@ before upgrading a consumer that asserts on acceptance or typed variants:
   well-known discretionary) instead of `PathAttribute::Unknown`, so the
   unrecognized-well-known validation no longer treat-as-withdraws routes that
   carry it. A non-zero length is an attribute-length error (RFC 7606 §7.6
-  attribute-discard on the revised decode path).
+  attribute-discard on the revised decode path). On the legacy strict path
+  (`decode_path_attributes`, used by the MRT reader) that error fails the
+  whole decode, so an MRT RIB entry carrying a non-zero-length
+  ATOMIC_AGGREGATE is rejected where it previously read back as
+  `PathAttribute::Unknown`.
 - **OPEN and KEEPALIVE over 4096 bytes are rejected** at header peek, before a
   framing caller buffers the declared body, regardless of a negotiated RFC 8654
   extended message length.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2212,7 +2212,7 @@ address = "[2001:db8::10]:3323"
 | `refresh_interval` | u64 | no | 3600 | Seconds between Serial Queries |
 | `retry_interval` | u64 | no | 600 | Seconds before reconnect on failure |
 | `expire_interval` | u64 | no | 7200 | Seconds before discarding stale VRPs, until the cache's End of Data supplies its own expire |
-| `max_expire_interval` | u64 | no | unset | Ceiling on the effective expire, in seconds: the cache-advertised expire (and `expire_interval`) is clamped down to it, so this cache's VRPs are discarded once older than this no matter what the cache advertises. Must be <= 172800 and > `refresh_interval`. Unset: only the two-day maximum applies |
+| `max_expire_interval` | u64 | no | unset | Ceiling on the effective expire, in seconds: the cache-advertised expire (and `expire_interval`) is clamped down to it, so this cache's VRPs are discarded once older than this no matter what the cache advertises. Must be <= 172800 and > both `refresh_interval` and `retry_interval`. Unset: only the two-day maximum applies |
 
 ### Validation states
 
@@ -4239,7 +4239,7 @@ starting:
 | RT/RO local administrator must be <= 65535 for a 4-octet ASN or dotted IPv4 administrator; numeric ASNs <= 65535 carry a u32 local value | `local admin ... exceeds 65535 for ...` |
 | RPKI `refresh_interval`, `retry_interval`, `expire_interval` must be > 0 | `must be > 0` |
 | RPKI `expire_interval` must be >= `refresh_interval` | `expire_interval must be >= refresh_interval` |
-| RPKI `max_expire_interval`, when set, must be <= 172800 and > `refresh_interval` | `max_expire_interval ... must be <= 172800` / `must be > refresh_interval` |
+| RPKI `max_expire_interval`, when set, must be <= 172800 and > both `refresh_interval` and `retry_interval` | `max_expire_interval ... must be <= 172800` / `must be > refresh_interval` / `must be > retry_interval` |
 | RPKI cache addresses must be unique numeric `IP:port` endpoints (bracketed for IPv6) | `invalid address` / `duplicate address` |
 | Named policy referenced in chain must exist in `[policy.definitions]` | `undefined policy` |
 | Inline policy and policy chain cannot both be set for the same neighbor/direction | `mutually exclusive` |

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -432,7 +432,7 @@
           "minimum": 0
         },
         "max_expire_interval": {
-          "description": "Operator ceiling on the effective expire interval in seconds. The\ncache-advertised End of Data expire (and `expire_interval`) is clamped\ndown to it, so this cache's VRPs are discarded once older than this\nregardless of what the cache advertises. Must be <= 172800 (the\nRFC 8210 two-day maximum) and > `refresh_interval`. Unset: only the\ntwo-day maximum applies.",
+          "description": "Operator ceiling on the effective expire interval in seconds. The\ncache-advertised End of Data expire (and `expire_interval`) is clamped\ndown to it, so this cache's VRPs are discarded once older than this\nregardless of what the cache advertises. Must be <= 172800 (the\nRFC 8210 two-day maximum) and > both `refresh_interval` and\n`retry_interval`. Unset: only the two-day maximum applies.",
           "type": [
             "integer",
             "null"

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -561,8 +561,8 @@ pub struct CacheServer {
     /// cache-advertised End of Data expire (and `expire_interval`) is clamped
     /// down to it, so this cache's VRPs are discarded once older than this
     /// regardless of what the cache advertises. Must be <= 172800 (the
-    /// RFC 8210 two-day maximum) and > `refresh_interval`. Unset: only the
-    /// two-day maximum applies.
+    /// RFC 8210 two-day maximum) and > both `refresh_interval` and
+    /// `retry_interval`. Unset: only the two-day maximum applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_expire_interval: Option<u64>,
 }

--- a/src/config/tests/rpki.rs
+++ b/src/config/tests/rpki.rs
@@ -300,3 +300,16 @@ fn rpki_max_expire_interval_not_above_refresh_rejected() {
         "{err}"
     );
 }
+
+#[test]
+fn rpki_max_expire_interval_not_above_retry_rejected() {
+    let err = parse(&rpki_toml(
+        "refresh_interval = 300\nmax_expire_interval = 600",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("cache_servers[0]: max_expire_interval (600) must be > retry_interval (600)"),
+        "{err}"
+    );
+}

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -968,6 +968,15 @@ impl Config {
                             ),
                         });
                     }
+                    if max <= server.retry_interval {
+                        return Err(ConfigError::InvalidRpkiConfig {
+                            reason: format!(
+                                "cache_servers[{i}]: max_expire_interval ({max}) must be > \
+                                 retry_interval ({})",
+                                server.retry_interval
+                            ),
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
Five small, independent pre-release fixes, one commit each.

## RPKI `max_expire_interval`: clamp log level and retry floor

**Mechanism.** When a cache's End of Data expire exceeds the configured `max_expire_interval`, the RTR client clamps it and logged the clamp at `debug`, while its sibling timer adjustments (the §6 minimum, refresh/retry lowering) log at `warn`. Config validation required `max_expire_interval > refresh_interval` but not `> retry_interval`, so a ceiling at or below `retry_interval` was accepted and then silently forced the retry interval down at every End of Data.

**Change.** The clamp logs at `warn` with the same fields. Validation rejects `max_expire_interval <= retry_interval` with a message in the same shape as the refresh rule (`cache_servers[i]: max_expire_interval (N) must be > retry_interval (M)`). The rule is mirrored in `docs/CONFIGURATION.md` (option table and validation table), the config struct doc comment, the regenerated JSON schema, and the CHANGELOG.

**Test.** `rpki_max_expire_interval_not_above_retry_rejected` in `src/config/tests/rpki.rs`.

## BMP collector drop counter: test phase

**Mechanism.** `bmp_collector_drops_total` documents its `phase` label as `fan_out` or `loc_rib_dump`; the unit test recorded a third value, `replay`, that no producer emits.

**Change.** The test records the batched drop under `fan_out` and asserts the summed series. No metric or alert change (`BmpCollectorDrops` is phase-agnostic).

**Test.** `bmp_collector_drop_counter` in `crates/telemetry/src/metrics.rs`.

## `DeadlineMap`: tied minima

**Mechanism.** `DeadlineMap` caches its minimum and invalidates on value equality, so removing either of two keys that share the minimum deadline forces a rescan which must land on the survivor.

**Change.** None to the code; the documented semantics were untested.

**Test.** `removing_one_of_tied_minima_rescans_to_the_survivor` in `crates/rib/src/manager/tests/gr_llgr.rs` (`mod deadline_map`).

## MRT reader: strict `ATOMIC_AGGREGATE` length

**Mechanism.** The MRT reader decodes entry attributes through the legacy strict `decode_path_attributes`, which returns an attribute-length error for a non-zero-length `ATOMIC_AGGREGATE`. Such a RIB entry is therefore rejected where it previously read back as `PathAttribute::Unknown`.

**Change.** No behavior change. One sentence in the `rustbgpd-wire` README next to the existing `ATOMIC_AGGREGATE` note states the consequence for the strict path and the MRT reader.

**Test.** `nonzero_length_atomic_aggregate_is_attribute_length_error` in `crates/mrt/src/reader.rs` builds a minimal `RIB_IPV4_UNICAST` record with a length-1 `ATOMIC_AGGREGATE` and asserts `ReadError::AttributeDecode(UpdateAttributeError { subcode: ATTRIBUTE_LENGTH_ERROR, .. })`.

## `mrt_dump_interval_seconds` HELP string

**Mechanism.** The gauge is registered unconditionally and exports 0 until the MRT manager sets it, but its HELP string claimed the series exists only when `[mrt]` is configured. (The operations table and the `MrtDumpStale` guard were corrected on `main` separately; this branch carries only the HELP text.)

**Change.** HELP now reads: configured `[mrt] dump_interval` in seconds; 0 when `[mrt]` is not configured. The sibling MRT gauge HELP strings do not carry the claim.

**Test.** Covered by the existing `cargo test -p rustbgpd-telemetry` run; string-only change.
