### PR TITLE
docs: correct the embedding crate map for the MRT telemetry dependency

### DIFF
--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -29,7 +29,7 @@ This document is the contract for embedders: which crate to depend on, what the
 | `rustbgpd-evpn-linux` | Disabled | `rustbgpd-evpn` | Linux netlink EVPN dataplane reconciler. |
 | `rustbgpd-evpn-load` | Disabled | `rustbgpd-wire` | EVPN route-reflector benchmark load generator. |
 | `rustbgpd-fsm` | Enabled | `rustbgpd-wire` | Pure RFC 4271 FSM; no I/O. |
-| `rustbgpd-mrt` | Disabled | `rustbgpd-rib`, `rustbgpd-wire` | RFC 6396 MRT dump export. |
+| `rustbgpd-mrt` | Disabled | `rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-wire` | RFC 6396 MRT dump export. |
 | `rustbgpd-policy` | Disabled | `rustbgpd-wire` | Import/export policy engine. |
 | `rustbgpd-rib` | Disabled | `rustbgpd-bmp`, `rustbgpd-policy`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-wire` | Adj-RIB and Loc-RIB best-path data structures. |
 | `rustbgpd-rpki` | Disabled | `rustbgpd-wire` | VRP table, RTR client, and origin validation. |


### PR DESCRIPTION
## Problem

The `Embedding docs contract` workflow is red on `main` at `ae1d199e`
([run 32604680175](https://github.com/lance0/rustbgpd/actions/runs/32604680175)),
job `embedding-doc-contract`, step `Check embedding crate map`:

```
EMBEDDING_CRATE_MAP_DEPS: rustbgpd-mrt documented=[`rustbgpd-rib`, `rustbgpd-wire`] metadata=[`rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-wire`]
FAILED (failures=2)
```

## Mechanism

`crates/mrt` gained a normal dependency on `rustbgpd-telemetry` (dump-health
metrics), but the `rustbgpd-mrt` row in the `docs/EMBEDDING.md` crate map was
not updated alongside it. `scripts/check_embedding_crate_map.py` derives the
expected dependency set for every workspace package from
`cargo metadata --locked --offline --format-version 1 --no-deps` and compares it
to the documented row, so the stale row fails the contract.

Both failing unit tests
(`test_dependency_kind_scope_is_load_bearing`, `test_scope_paragraph_may_be_reworded`)
read the live `docs/EMBEDDING.md` and live Cargo metadata and assert the checker
returns no diagnostics; they were failing for this one reason. No test fixture
encodes the old dependency set, so no change to `scripts/` was needed.

`crates/mrt/Cargo.toml` confirms the real edge set:
`rustbgpd-wire`, `rustbgpd-rib`, `rustbgpd-telemetry`.

## Rows changed

One row, `rustbgpd-mrt`:

```diff
-| `rustbgpd-mrt` | Disabled | `rustbgpd-rib`, `rustbgpd-wire` | RFC 6396 MRT dump export. |
+| `rustbgpd-mrt` | Disabled | `rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-wire` | RFC 6396 MRT dump export. |
```

Every other row in the map was checked against the same metadata in the same
pass; `rustbgpd-mrt` was the only stale one. The surrounding prose needed no
change: the scope paragraph is generic, and §4's note about `mrt` naming
`prefix-trie`/`ipnet`/`flate2`/`chrono` describes external dependencies only.

## Checker output

Before:

```
EMBEDDING_CRATE_MAP_DEPS: rustbgpd-mrt documented=[`rustbgpd-rib`, `rustbgpd-wire`] metadata=[`rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-wire`]
```
`python3 -m unittest scripts/test_check_embedding_crate_map.py` → `FAILED (failures=2)`, rc 1;
`python3 scripts/check_embedding_crate_map.py` → rc 1.

After:

```
Ran 10 tests in 0.026s

OK
```
`python3 scripts/check_embedding_crate_map.py` → no output, rc 0.

## Gates

All rc 0: both `Embedding docs contract` steps
(`test_check_embedding_versions.py` + `check_embedding_versions.py`,
`test_check_embedding_crate_map.py` + `check_embedding_crate_map.py`),
`scripts/check_public_tracker_ids.py`, and a relative-link resolution check
over `docs/EMBEDDING.md` (3 links, 0 broken).

No CHANGELOG entry: this is a one-cell correction to a machine-checked
topology table, not a behavior change.