### PR TITLE
docs: correct the crate graph, crate READMEs, and the missing renderer entry in the release notes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ fsm            ──► wire
 policy         ──► wire
 rpki           ──► wire
 bmp            ──► telemetry, wire
-mrt            ──► wire, rib
+mrt            ──► wire, rib, telemetry
 telemetry      (no internal deps)
 event-history  ──► telemetry
 evpn           ──► wire
@@ -41,7 +41,7 @@ unicast Linux FIB, the BFD socket actor, and the EVPN dataplane glue).
 | `rustbgpd-policy` | Policy engine: prefix/community/AS_PATH matching, route modifications. |
 | `rustbgpd-rpki` | RPKI origin validation: RTR client, VRP table, multi-cache aggregation. |
 | `rustbgpd-bmp` | BMP exporter: RFC 7854 codec, collector clients, manager fan-out. |
-| `rustbgpd-mrt` | MRT dump: RFC 6396 TABLE_DUMP_V2 codec, atomic writer, periodic manager. |
+| `rustbgpd-mrt` | MRT dump: RFC 6396 TABLE_DUMP_V2 codec, atomic writer, periodic manager. Depends on `telemetry` to export the dump-health gauges and counters (`mrt_dump_*`); see the crate README for the metric list. |
 | `rustbgpd-event-history` | Durable local event outbox (ADR-0072): SQLite WAL store with monotonic `event_id`, `EventHistoryManager` actor + storage thread, in-process `subscribe_live()` broadcast, retention by count + bytes, payload-opaque (producer-encoded bytes are persisted and broadcast byte-identically). Producers (RIB, EVPN, PeerManager session lifecycle, policy, BFD bridge, dataplane FIB / blackhole) enqueue prost-encoded `BgpEvent` envelopes; the gRPC `SubscribeFromEvent` cursor in `api` does the replay → live handoff. |
 | `rustbgpd-evpn` | EVPN local VTEP domain model: `EvpnInstance` / `EvpnInstanceTable` / `RouteTarget` / `IpVrf` / `IpVrfTable` (RFC 7432 / RFC 8365 / RFC 9136). Includes the `LocalMacOriginator` / `LocalMacIpOriginator` / `LocalEsOriginator` / `LocalEadPerEs*` state machines (RFC 7432 §15.1 mobility + §8 multi-homing), the `DataplaneIntent` / `RemoteMacTable` snapshot types with `RemoteMacEntry::alias_group_key` for ADR-0059 aliasing-ECMP wire intent, the IP-VRF readiness probe (Gate 9), and the pure-logic Type 5 origination + projection helpers (RFC 9136 §4.4.2 Interface-less IRB). Aliasing module (`aliasing::group_members`) produces the canonical alias VTEP set for a multi-homed Type 2. Domain-only, kernel-free. See ADR-0052, ADR-0054, ADR-0055, ADR-0057, ADR-0058, ADR-0059. |
 | `rustbgpd-evpn-linux` | Linux kernel dataplane for EVPN VTEP mode (`cfg(target_os = "linux")`). Reconciles remote-MAC FDB programming via rtnetlink, surfaces local-MAC observations from `RTNLGRP_NEIGH` upward (plus `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` for slice 6a sub-second IP-VRF route observation), supplies Linux rtnetlink dumps for VRF / L3VXLAN inventory (Gate 9), implements the `Dataplane::probe_ip_vrfs` IRB readiness call, and programs FDB nexthop groups via `NDA_NH_ID` / `NHA_FDB` for aliasing-ECMP receive paths (ADR-0059). `linux::nexthop_raw` is the raw-netlink primitive (rtnetlink 0.22 still exposes no nexthop API); `linux::fdb_nhg` is the apply primitive with the CVE-2025-39851 guard; `group_state` + `nh_id_alloc` carry the refcount + NHID-tagging state the reconcile coordinator uses. Consumes domain types from `rustbgpd-evpn`; never imports `rib` or `transport`. See ADR-0054, ADR-0055, ADR-0058, ADR-0059. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   panic enters the same coordinated peer teardown and exits 1; live bound-listener
   and accepted-connection fault proofs preserve signal and Shutdown RPC exit 0.
   This does not add PeerManager supervision or in-process respawn. (LAN-1207)
+- `rs-config-render` now renders an effective ARouteServer `reject_policy:
+  tag_and_reject` instead of refusing it: each client policy emits ordered
+  IRRDB origin- and prefix-reject terms, and the candidate gains a startup
+  `birdwatcher-reject-communities.json` artifact carrying the resolved
+  reject-cause communities. `birdwatcher-adapter` consumes that artifact
+  through `--arouteserver-reject-communities-file`, validating its schema,
+  peer ordering, and community shape strictly and refusing a file over 1 MiB
+  or over 4096 peers rather than starting on a downgraded view. `tag` stays
+  refused, as do `communities.reject_cause.ext` and
+  `rejected_route_announced_by`. (LAN-1178)
 - BLACKHOLE kernel ownership now survives crashes through a private,
   descriptor-relative `blackhole-owned.json` exact-prefix receipt. Adoption
   and deletion require both receipt authority and the kernel marker; install

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -10,7 +10,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 ### Runtime Snapshot
 
 ```bash
-rbgp global       # ASN, router ID, families, TCP-AO support
+rbgp global       # ASN, router ID, listen port, TCP-AO support
 rbgp health       # daemon health check
 rbgp doctor       # triage checks + redacted support bundle (tar.gz)
 rbgp metrics      # Prometheus metrics snapshot

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -49,6 +49,15 @@ returns `Result` and rejects routes it previously encoded silently altered)
 — see the "0.17.0 compatibility note" in the `rustbgpd-wire` README.
 Upgrade both crates together so the re-exported types unify.
 
+`rustbgpd-fsm 0.4.1` keeps its public API backward-compatible with 0.4.0 — its
+source is unchanged since that publish. Its `^0.17.1` wire requirement admits
+`rustbgpd-wire` 0.17.2, whose **decode acceptance changed**: ATOMIC_AGGREGATE
+(type 6) now decodes to `PathAttribute::AtomicAggregate` instead of
+`PathAttribute::Unknown`, so an UPDATE carrying it is no longer
+treat-as-withdrawn by unrecognized-well-known validation — see the "0.17.2
+compatibility note" in the `rustbgpd-wire` README, since the FSM surfaces wire
+decode results to its callers.
+
 ## Key types
 
 - **`Session`** — the state machine: `handle_event(&mut self, Event) -> Vec<Action>` (state is mutated in place on `&mut self`)

--- a/crates/mrt/README.md
+++ b/crates/mrt/README.md
@@ -18,6 +18,13 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
   `RIB_IPV4_UNICAST` / `RIB_IPV6_UNICAST` records into
   `SnapshotEntry` / `SnapshotNlri`, with gzip auto-detection
   (`decompress_if_gzip`)
+- **Dump health metrics** — `MrtManager` records `mrt_dump_interval_seconds`,
+  `mrt_last_dump_success_timestamp_seconds`,
+  `mrt_last_dump_duration_milliseconds`, `mrt_dump_bytes_written_total`, and
+  `mrt_dump_failures_total{stage}` (`preflight` / `snapshot` / `encode` /
+  `write`; a caller-canceled on-demand dump is not counted). The shipped alert
+  pack's `MrtDumpStale` guards on a non-zero `mrt_dump_interval_seconds` and
+  fires once the newest dump is older than twice it
 
 ## Warm bundle
 

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -43,12 +43,14 @@ docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 \
 docker compose exec rustbgpd cat /var/lib/rustbgpd/config.toml
 ```
 
-`rustbgpd.toml` in this directory is a **template**. The daemon copies it into
-its writable state volume on first start and runs from
+`rustbgpd.toml` in this directory is a **template**. The service's start
+command copies it into the writable state volume on first start (`cp -n`, see
+`command:` in `docker-compose.yml`) and the daemon then runs from
 `/var/lib/rustbgpd/config.toml` — a read-only bind mount cannot accept the
 temp-file + rename write that config persistence uses, and every mutating
-command would fail. Edit the template and `docker compose down -v` to start
-over from it.
+command would fail. The daemon itself has no template-seeding behavior, so a
+port of this pattern to another supervisor has to carry the copy. Edit the
+template and `docker compose down -v` to start over from it.
 
 The service has a 32-minute stop grace so an explicit Compose stop does not
 kill a runtime-config owner before its fixed 30-minute settlement watchdog.


### PR DESCRIPTION
Six documentation corrections found by the pre-release audit. Each claim was
re-verified against the current tree before editing.

## `ARCHITECTURE.md` — crate dependency graph missed the MRT telemetry edge

The graph recorded `mrt ──► wire, rib`. `crates/mrt/Cargo.toml` declares
`rustbgpd-wire`, `rustbgpd-rib`, and `rustbgpd-telemetry`; `crates/mrt/src/manager.rs`
imports `rustbgpd_telemetry::BgpMetrics` and `MrtManager` holds one. The edge is
now `mrt ──► wire, rib, telemetry`, and the `rustbgpd-mrt` crate-summary row
names telemetry as the reason.

Every other edge in the graph was re-derived from the fifteen `crates/*/Cargo.toml`
manifests (dependencies plus dev-dependencies, including the
`cfg(target_os = "linux")` section in `evpn-linux`). All fourteen match the file
as written; no other stale edge exists.

## `CHANGELOG.md` — the ARouteServer reject-tag surface had no `[0.66.0]` entry

Commit `05189440` shipped a user-facing renderer and adapter surface with no
entry: the file had zero occurrences of `tag_and_reject`,
`birdwatcher-reject-communities`, or the change's tracker id. What the code says:

- `tools/rs-config-render/src/lib.rs` `check_reject_policy` accepts
  `"reject" | "tag_and_reject"`; before this change it accepted only `"reject"`
  and refused `tag` and `tag_and_reject` together. `tag` is still refused.
- The `tag_and_reject` client policy emits `reject-irrdb-origin-as-filtered`
  then `reject-irrdb-prefix-filtered`, in that order, before `accept-authorized`.
- `render_reject_communities` writes `birdwatcher-reject-communities.json`
  (schema `rustbgpd.arouteserver-reject-communities.v1`) into the candidate, and
  refuses `communities.reject_cause.ext`, a configured
  `rejected_route_announced_by`, and malformed or out-of-range cause maps.
- `examples/birdwatcher-adapter/src/main.rs`
  `load_arouteserver_reject_communities` validates schema, strictly ascending
  peers, and community shape, and errors on a file over `MAX_ALIAS_FILE_BYTES`
  (1 MiB) or over `MAX_ALIAS_FILE_ENTRIES` (4096) peers rather than starting on a
  partial view.

The bullet is added inside `## [0.66.0]` → `### Added`, in the slot the section's
existing ordering puts it (between the `LAN-1207` and `LAN-1195` entries), so
`.github/workflows/release.yml` picks it up in the extracted release body.
`[Unreleased]` stays empty. It carries a `(LAN-1178)` suffix, matching how every
sibling bullet in this section cites its change.

## `crates/cli/README.md` — `rbgp global` field list wrong on both ends

The comment advertised `families` and omitted the listen port.
`crates/cli/src/commands/global.rs` prints `ASN`, `Router ID`, `Listen Port`, and
`TCP-AO`; `GlobalState` in `proto/rustbgpd.proto` has no families field. The
comment now reads `# ASN, router ID, listen port, TCP-AO support`.

## `crates/fsm/README.md` — compatibility ladder stopped at 0.4.0

`crates/fsm/Cargo.toml` is `version = "0.4.1"` and that version is published, so a
reader on 0.4.1 found no rung. The last rung also paired the FSM with
`rustbgpd-wire` 0.17.0 while 0.17.2 is now current, and 0.17.2 changed decode
acceptance — exactly what this README's own 0.16.0 paragraph promises to flag.

A 0.4.1 rung is added: the API is backward-compatible with 0.4.0 (`git diff
v0.65.0..HEAD -- crates/fsm/` is empty), and the published `^0.17.1` wire
requirement admits 0.17.2, whose ATOMIC_AGGREGATE (type 6) decode moved from
`PathAttribute::Unknown` to `PathAttribute::AtomicAggregate`, so an UPDATE
carrying it is no longer treat-as-withdrawn. It points at the existing "0.17.2
compatibility note" in the `rustbgpd-wire` README.

## `crates/mrt/README.md` — dump-health metrics undocumented

The metrics shipped this release and the crate README did not mention them. The
five names and the `stage` label values were read from
`crates/telemetry/src/metrics.rs` (registration at `mrt_dump_interval_seconds`,
`mrt_last_dump_success_timestamp_seconds`, `mrt_last_dump_duration_milliseconds`,
`mrt_dump_bytes_written_total`, `mrt_dump_failures_total{stage}`) and from the
`DumpError::at` call sites in `crates/mrt/src/manager.rs` (`preflight`,
`snapshot`, `encode`, `write`; `DumpError::canceled` carries no stage and is not
counted). A Features bullet now records them and the `MrtDumpStale` guard.

## `examples/docker-compose/README.md` — template copy attributed to the daemon

The text said the daemon copies the template into its state volume on first
start. rustbgpd has no template-seeding behavior: the copy is in the service's
start command in `docker-compose.yml`
(`cp -n /etc/rustbgpd/config.template.toml /var/lib/rustbgpd/config.toml && exec
rustbgpd /var/lib/rustbgpd/config.toml`). The paragraph now names the start
command as the actor, points at `command:` in the compose file, and states that a
port of this pattern to another supervisor has to carry the copy itself.

## Gates

- `python3 scripts/check_public_tracker_ids.py` — rc 0
- `python3 -m unittest scripts/test_check_embedding_crate_map.py` — rc 0
- `python3 scripts/check_embedding_crate_map.py` — rc 0
- `python3 scripts/check_embedding_versions.py` — rc 0
- `python3 scripts/reflow-release-notes.py --selftest` — rc 0
- `python3 scripts/check_ixp_manager_docs.py` — rc 0
- `python3 scripts/check_release_install_contract.py` — rc 0
- Release-notes extraction mirror (`.github/workflows/release.yml` awk for
  `0.66.0`, then `reflow-release-notes.py`) — rc 0, new bullet present in the
  extracted section
- Relative links in all six touched files resolve (19 checked, 0 broken)
