### PR TITLE
docs: correct the log-level instruction, the GetGlobal surface, listen_addresses validation, and commit-confirm version scoping

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,8 +71,8 @@ input from the network. It runs under continuous fuzzing in CI.
   locator unlink plus parent `fsync` is terminal; only later verified exact
   metadata/raw cleanup and pending-directory `fsync` can fail warning-only.
   Locator absence carries no v3 authority. A retired v2 locator or locator-free
-  v1/v2 journal makes v0.65 refuse boot before candidate mutation and remains
-  untouched for recovery with rustbgpd v0.64.0.
+  v1/v2 journal makes v0.65.0 and every later release refuse boot before
+  candidate mutation, and remains untouched for recovery with rustbgpd v0.64.0.
 - **No `unsafe` code in shipped paths, with two scoped exceptions.** Every
   workspace crate root carries `#![deny(unsafe_code)]`, so `unsafe` cannot enter
   a crate without a visible, reviewed opt-out. There are two:

--- a/docs/API.md
+++ b/docs/API.md
@@ -279,13 +279,23 @@ Daemon identity and configuration.
 
 | RPC | Description |
 |-----|-------------|
-| `GetGlobal` | Returns ASN, router ID, listen port, and host TCP-AO capability probe status |
+| `GetGlobal` | Returns ASN, router ID, listen port, host TCP-AO capability probe status and detail, and the Unix-epoch-seconds timestamp of the last successfully accepted full policy generation |
 
 ```bash
 # Get daemon identity
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.GlobalService/GetGlobal
 ```
+
+`policy_generation_loaded_timestamp_seconds` is the Unix epoch second at which
+the daemon last accepted a complete policy generation — initial load, SIGHUP, or
+a config transaction. It is `0` until the first generation is accepted, and a
+rejected load never advances it (the prior generation stays live and the
+timestamp freezes), so a caller can prove a reload was *accepted* rather than
+merely attempted. It is the same value the
+`bgp_policy_generation_loaded_timestamp_seconds` Prometheus gauge exports; see
+"Policy artifact freshness" in [`OPERATIONS.md`](OPERATIONS.md) for the staleness
+alert expressions.
 
 `tcp_ao_support` is a read-only Linux capability probe for RFC 5925 TCP-AO. It
 reports whether the host kernel accepts the TCP-AO socket primitive that
@@ -296,6 +306,9 @@ attempt without falling back to unauthenticated TCP. Dynamic-range keys are
 config-file-only: runtime range CRUD rejects protected ranges and overlaps.
 SIGHUP can append a non-preferred successor generation; selection,
 deprecation, deletion, and protected-owner CRUD are not exposed.
+`tcp_ao_detail` carries human-readable probe detail alongside it, populated only
+when `tcp_ao_support` is `TCP_AO_SUPPORT_UNSUPPORTED` or
+`TCP_AO_SUPPORT_PROBE_FAILED`, and empty otherwise.
 
 `NeighborState.authentication` reports the effective protected transport as
 `PLAINTEXT`, `MD5`, or `TCP_AO`. For direct dynamic-prefix TCP-AO sessions,
@@ -612,8 +625,9 @@ parent-directory `fsync`. Subsequent verified exact metadata/raw cleanup and
 pending-directory `fsync` are warning-only; locator-free residue cannot re-arm
 the transaction.
 Production reads and writes v3 authority only. A v2 locator or locator-free
-v1/v2 journal makes v0.65 refuse untouched. Recover with rustbgpd v0.64.0, or delete only
-after proving it terminal and intended. Status reports pending/terminal state.
+v1/v2 journal makes v0.65.0 and every later release refuse untouched. Recover
+with rustbgpd v0.64.0, or delete only after proving it terminal and intended.
+Status reports pending/terminal state.
 A failed abort/auto-revert rollback is not terminal: the transaction stays
 pending with an `ABORT_FAILED`/`AUTO_REVERT_FAILED` status and the mutation
 fence stays closed until the abort is retried successfully, the candidate is

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -190,7 +190,7 @@ Required. Defines the local BGP speaker identity.
 | `asn`               | u32    | yes      | --                   | Local autonomous system number; AS 0 is rejected at startup |
 | `router_id`         | string | yes      | --                   | Non-zero BGP Identifier in IPv4 dotted-quad form; `0.0.0.0` is rejected at startup |
 | `listen_port`       | u16    | yes      | --                   | TCP port to listen on (typically 179). When `listen_addresses` is absent, the daemon uses `0.0.0.0` and `[::]`; an unavailable family is skipped while the other keeps serving, and startup fails only when neither binds. Explicit endpoints instead bind atomically |
-| `listen_addresses`  | array of IP strings | no | -- | Exact local BGP endpoints and active-open source addresses. Omission preserves the tolerant dual-wildcard listener. When present, the list must be nonempty with at most one address per family; every configured peer and dynamic range must use a listed family, and every bind is atomic. **Restart-required.** |
+| `listen_addresses`  | array of IP strings | no | -- | Exact local BGP endpoints and active-open source addresses. Omission preserves the tolerant dual-wildcard listener. When present, the list must be nonempty with at most one address per family; every listed address must be a usable unicast endpoint (unspecified, multicast, IPv4 broadcast, IPv4-mapped IPv6, and IPv6 link-local are rejected); every configured peer and dynamic range must use a listed family; and every bind is atomic. Scoped IPv6 link-local `[[neighbors]]` and `[[dynamic_neighbors]]` entries are not supported alongside an explicit list — keep those deployments on the default dual-wildcard listener. **Restart-required.** |
 | `dynamic_neighbor_limit` | u32 | no     | `100`                | Maximum number of auto-accepted dynamic peers (must be > 0) |
 | `worker_threads`    | usize  | no       | `min(cores, 8)`      | Tokio runtime worker threads. Unset caps to `min(CPU parallelism, 8)` to avoid over-provisioning the async runtime (one worker + stack reservation per core) on a high-core host for this I/O-bound daemon — reduces virtual-address reservation and scheduler footprint (RSS-neutral in benchmarks). `0` means unset. `RUSTBGPD_WORKER_THREADS` overrides. **Restart-required** (runtime built once at startup). |
 | `runtime_state_dir` | string | no       | `"/var/lib/rustbgpd"` | Directory for daemon-owned runtime state (GR restart marker, optional warm checkpoint, FIB and BLACKHOLE ownership receipts, and gRPC socket) |
@@ -3381,9 +3381,10 @@ daemon-owned real parents that are not group- or world-writable. Locator
 absence carries no authority and does not impose this storage policy on an
 ordinary launch path.
 
-Production reads and writes v3 authority only. Before v0.65, finish every v1/v2
-transaction. Retired authority makes boot refuse untouched; recover with rustbgpd v0.64.0
-or delete only after proving it terminal/intended. Retired TOML history is
+Production reads and writes v3 authority only. Finish every v1/v2 transaction
+before upgrading past v0.64.0: from v0.65.0 on, retired authority makes boot
+refuse untouched; recover with rustbgpd v0.64.0 or delete only after proving it
+terminal/intended. Retired TOML history is
 ignored/retained; v2 JSON remains listable and restorable.
 See `docs/OPERATIONS.md` (config transactions) for the boot-revert and storage
 semantics.
@@ -4204,6 +4205,8 @@ starting:
 |------|-------|
 | Local `asn` must not be AS 0 | `invalid local ASN` |
 | `router_id` must be a valid IPv4 dotted quad and must not be `0.0.0.0` | `invalid router_id` |
+| `listen_addresses`, when present, must be non-empty, carry at most one address per family, and list only usable unicast endpoints (unspecified, multicast, IPv4 broadcast, IPv4-mapped IPv6, and IPv6 link-local are rejected) | `invalid global.listen_addresses` |
+| With explicit `listen_addresses`, every `[[neighbors]]` address and `[[dynamic_neighbors]]` prefix must use a listed family, and scoped IPv6 link-local peers and ranges are not supported | `invalid global.listen_addresses` |
 | Each `address` in `[[neighbors]]` must be a valid IP address (IPv4 or IPv6) | `invalid neighbor address` |
 | IPv6 link-local `[[neighbors]]` must set `interface`; numbered neighbors must not | `invalid neighbor config` |
 | `[[neighbors]]` identity must be unique by address for numbered peers and by `(address, interface)` for IPv6 link-local peers | `duplicate neighbor address/interface` |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -337,9 +337,10 @@ paths; failure there is a warning and locator-free residue cannot re-arm the
 transaction. A later confirmed apply removes only verified residue at those
 two fixed v3 names.
 
-Production reads and writes v3 only. Retired authority makes v0.65 refuse
-untouched. Finish before upgrade, recover with rustbgpd v0.64.0, or delete only after
-proving it terminal/intended. Never delete a live v3 locator.
+Production reads and writes v3 only. Retired authority makes v0.65.0 and every
+later release refuse boot untouched. Finish before upgrading past v0.64.0,
+recover with rustbgpd v0.64.0, or delete only after proving it
+terminal/intended. Never delete a live v3 locator.
 
 The boot-revert save-aside moves the unconfirmed candidate to
 `<config>.unconfirmed` with an atomic hard-link + unlink, so it never clobbers
@@ -655,12 +656,13 @@ the stop, stops rustbgpd cleanly so the restart marker is written, checks the
 package manager's preserved-config files, and verifies the restarted daemon.
 The package hooks do not stop or restart a running service.
 
-Before installing v0.65, finish any pending confirmed transaction and clear
-retired v1/v2 authority. The candidate binary's `--check` validates the config
-only; it cannot inspect `runtime_state_dir` or config-adjacent commit-confirm
-authority. If retired authority remains or is inaccessible, recover it with
-exactly rustbgpd v0.64.0. Delete it only after proving the transaction is
-terminal and the current config is intended.
+Finish any pending confirmed transaction before any upgrade. Before upgrading
+past v0.64.0, also clear retired v1/v2 authority — v0.65.0 and every later
+release refuse to boot while it is present. The candidate binary's `--check`
+validates the config only; it cannot inspect `runtime_state_dir` or
+config-adjacent commit-confirm authority. If retired authority remains or is
+inaccessible, recover it with exactly rustbgpd v0.64.0. Delete it only after
+proving the transaction is terminal and the current config is intended.
 
 Moving a config between RFC 8212 epochs is a separate, offline step:
 `rustbgpd --migrate-config pin-legacy|prepare-secure|downgrade-v0.64 --offline

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1009,14 +1009,17 @@ therefore own the graceful stop and the verification that follows it.
    This check validates candidate config bytes only: it does **not** inspect
    `runtime_state_dir` or config-adjacent commit-confirm authority.
 
-   Before installing v0.65, use the still-running v0.64.0 daemon to run
-   `rbgp config status` and confirm or abort every pending transaction. A
-   locator-free `commit-confirm-journal.json` or a retired v2
+   Before any upgrade, use the still-running daemon to run
+   `rbgp config status` and confirm or abort every pending transaction.
+
+   When the installed release is v0.64.0 or earlier, also clear retired
+   commit-confirm authority first: a locator-free
+   `commit-confirm-journal.json` or a retired v2
    `*.commit-confirm-locator.json` must be recovered with exactly rustbgpd
    v0.64.0. Do not proceed while either artifact is present or inaccessible;
    delete one only after proving the transaction terminal and the current
-   config intended. v0.65 otherwise refuses boot and leaves the authority
-   untouched.
+   config intended. v0.65.0 and every later release otherwise refuse boot and
+   leave the authority untouched.
 3. Stop the running daemon cleanly, then confirm it is down:
 
    ```sh
@@ -1111,7 +1114,7 @@ processes is unsupported even when their configuration files differ.
 |---|---|---|
 | `gr-restart.toml` | Graceful Restart coordination marker. Written on clean shutdown, read on startup to set the R-bit in OPEN. | Yes |
 | `warm-bundle-v1/` | Optional owner-private shutdown checkpoint (`manifest.json` plus a content-addressed MRT artifact). Published only when `warm_cache_checkpoint_on_shutdown = true`; not restored on startup. | Yes |
-| `<runtime_state_dir>/commit-confirm-journal.json` | Retired locator-free v1/v2 authority; secret-bearing normalized TOML. Its presence makes v0.65 refuse boot untouched. | Until recovery with rustbgpd v0.64.0 or operator-proven terminal deletion |
+| `<runtime_state_dir>/commit-confirm-journal.json` | Retired locator-free v1/v2 authority; secret-bearing normalized TOML. Its presence makes v0.65.0 and every later release refuse boot untouched. | Until recovery with rustbgpd v0.64.0 or operator-proven terminal deletion |
 | `<runtime_state_dir>/commit-confirm-v3-prior.toml` | Fixed v3 raw accepted prior; secret-bearing normalized TOML. Published first. | Until terminal cleanup; safe residue may remain |
 | `<runtime_state_dir>/commit-confirm-v3-metadata.json` | Fixed confidential provenance, digest, and file-identity metadata; no raw TOML. Published after the raw prior. | Until terminal cleanup; safe residue may remain |
 | `<absolute lexical config path>.commit-confirm-locator.json` | Confidential paths/digests and sole v3 pending boot authority; no raw TOML. Published last and checked before candidate contents. | Until durable unlink and parent sync make the transaction terminal |
@@ -1211,13 +1214,30 @@ short version for first deployment:
 | EVPN-specific issues | [`evpn-vtep-troubleshooting.md`](evpn-vtep-troubleshooting.md) |
 | Anything not above | [`OPERATIONS.md`](OPERATIONS.md) "Debugging" section |
 
-For deeper investigation, raise the daemon log level globally via
-`[global.telemetry] log_format = "json"` and per-peer via
-`[[neighbors]] log_level = "debug"`. Restart required for the global
-setting; per-peer log_level is **live** — re-applied on SIGHUP via a
-tracing reload handle that rebuilds the filter (base level plus every
-per-peer directive), so a level edit takes effect without a restart (see
-the [reload matrix](reload-matrix.md)).
+For deeper investigation, raise the daemon log level globally with the
+`RUST_LOG` environment variable — there is no log-level key in
+`[global.telemetry]`; `log_format` selects the output format, not the
+verbosity. Under systemd, set it in the unit's `[Service]` section:
+
+```ini
+[Service]
+Environment=RUST_LOG=debug
+```
+
+`RUST_LOG` accepts the usual `tracing` filter syntax, so a targeted
+directive beats a daemon-wide `debug` — including the per-peer span form
+documented in
+[`OPERATIONS.md`](OPERATIONS.md#per-peer-log-filtering):
+
+```ini
+Environment=RUST_LOG=info,peer{peer_addr=10.0.0.1}=debug
+```
+
+Per-peer verbosity also comes from `[[neighbors]] log_level = "debug"`.
+Restart required for the global setting; per-peer log_level is **live** —
+re-applied on SIGHUP via a tracing reload handle that rebuilds the filter
+(base level plus every per-peer directive), so a level edit takes effect
+without a restart (see the [reload matrix](reload-matrix.md)).
 
 ## Related
 


### PR DESCRIPTION
Four documentation corrections found by the pre-release audit, verified against
the code at the current tree.

## docs/deployment.md — the global log-level instruction was factually wrong

The troubleshooting section told operators to "raise the daemon log level
globally via `[global.telemetry] log_format = \"json\"`". That key selects the
output format, not the verbosity: `src/config/schema.rs:911` declares
`pub log_format: String` with the doc comment "Log output format (`\"json\"`)",
and `[global.telemetry]` has no level field at all.

The base level comes from `RUST_LOG` only. `crates/telemetry/src/logging.rs:26`
builds the filter as `EnvFilter::try_from_default_env().unwrap_or_else(|_|
EnvFilter::new("info"))`, and `init_logging` (same file, line 66) is the sole
startup path; `docs/reload-matrix.md:146` already states the base level is read
once from `RUST_LOG`.

Replaced the instruction with `RUST_LOG`, including a systemd
`Environment=RUST_LOG=debug` example matching the `[Service]` section of
`examples/systemd/rustbgpd.service`, and a targeted per-peer span example
cross-linked to the "Per-peer log filtering" section of `OPERATIONS.md`. The
following clause about the per-peer `log_level` being live is unchanged — it
was already correct.

## docs/API.md — the `GetGlobal` surface omitted two fields

The `GlobalService` RPC row described only "ASN, router ID, listen port, and
host TCP-AO capability probe status". `proto/rustbgpd.proto:99` declares
`string tcp_ao_detail = 5` and `proto/rustbgpd.proto:103` declares
`int64 policy_generation_loaded_timestamp_seconds = 6`; neither field name
appeared anywhere in the document.

Semantics verified in the service implementation and the gauge behind it:
`crates/api/src/global_service.rs:72` populates the timestamp from
`BgpMetrics::policy_generation_loaded_timestamp_seconds()`, whose accessor at
`crates/telemetry/src/metrics.rs:4070` returns zero until the first acceptance,
and whose setter `record_policy_generation_loaded`
(`crates/telemetry/src/metrics.rs:4059`) is documented and tested as never
called on a rejected load. The service's own test asserts `0` before the first
generation and a positive value after
(`crates/api/src/global_service.rs:107`, `:115`). `tcp_ao_detail` is populated
only for the `UNSUPPORTED` and `PROBE_FAILED` variants
(`crates/api/src/global_service.rs:53-56`).

Updated the RPC row and added prose for both fields, cross-referencing the
`bgp_policy_generation_loaded_timestamp_seconds` gauge already documented in
`OPERATIONS.md`.

## docs/CONFIGURATION.md — `listen_addresses` validation was under-documented

The `[global] listen_addresses` row covered the non-empty, one-per-family, and
family-coverage rules but not the address-shape or scoped-link-local
rejections, and the rejected-configurations table had no
`invalid global.listen_addresses` row at all.

`validate_listen_addresses()` (`src/config/validation.rs:1480`) rejects, all as
`ConfigError::InvalidListenAddresses` (`src/config/schema.rs:2703`, rendered as
`invalid global.listen_addresses`):

- an empty list (`:1485`)
- a non-unicast IPv4 address — unspecified, multicast, or broadcast (`:1494`)
- a non-unicast IPv6 address — unspecified, multicast, IPv4-mapped, or
  link-local (`:1502`)
- more than one address of the same family (`:1515`)
- a scoped IPv6 link-local `[[neighbors]]` entry (`:1532`)
- a neighbor whose family is not listed (`:1540`)
- a scoped IPv6 link-local `[[dynamic_neighbors]]` range (`:1554`)
- a dynamic range whose family is not listed (`:1564`)

Extended the field row with the address-shape and scoped-link-local rules and
added two rows to the rejected-configurations table.

## Commit-confirm retired-authority guidance was scoped to v0.65 as a future install

`confirm_journal::refuse_retired_journal` (`src/confirm_journal.rs:68`) refuses
boot whenever a retired locator-free v1/v2 authority exists or is inaccessible.
That code is live in this tree at version 0.66.0, so the refusal is a version
floor, not a v0.65 event: an operator upgrading v0.64.0 to v0.66.0 who reads
"Before installing v0.65" concludes the step is not theirs, and the new daemon
then refuses to boot.

Re-scoped to a floor at the six sites that stated it as a v0.65 event:

- `docs/OPERATIONS.md` (commit-confirm storage): "makes v0.65 refuse untouched"
  to "makes v0.65.0 and every later release refuse boot untouched"; "finish
  before upgrade" to "finish before upgrading past v0.64.0".
- `docs/OPERATIONS.md` (Upgrading): "Before installing v0.65" split into the
  generic pending-transaction step and a "Before upgrading past v0.64.0" step
  for the retired authority.
- `docs/deployment.md` (package upgrade procedure): same split, with the
  retired-authority paragraph conditioned on "When the installed release is
  v0.64.0 or earlier"; "v0.65 otherwise refuses boot" to "v0.65.0 and every
  later release otherwise refuse boot".
- `docs/deployment.md` (runtime state table): "makes v0.65 refuse boot
  untouched" to "makes v0.65.0 and every later release refuse boot untouched".
- `docs/CONFIGURATION.md` (commit-confirm storage): "Before v0.65, finish every
  v1/v2 transaction" to "Finish every v1/v2 transaction before upgrading past
  v0.64.0: from v0.65.0 on, retired authority makes boot refuse untouched".
- `docs/API.md` (config transactions) and `SECURITY.md` (commit-confirm
  posture): "makes v0.65 refuse" to "makes v0.65.0 and every later release
  refuse".

Left unchanged, as verified correct:

- Every `rustbgpd v0.64.0` recovery-binary reference — that pin is exact.
- `docs/deployment.md` (runtime state prose, "Retired v1/v2 authority refuses
  boot untouched") — already version-neutral.
- The `downgrade-v0.64` migration action name and its exact-v0.64.0 validator
  requirement (`docs/CONFIGURATION.md`, `docs/OPERATIONS.md`,
  `docs/deployment.md`).
- `enforcement = "legacy"` removed "from the typed schema in v0.65"
  (`docs/API.md`, `docs/CONFIGURATION.md` twice) — a historical fact about
  where the removal landed.
