### PR TITLE
docs: repair the dead EVPN interop triggers and correct stale runner, troubleshooting, and use-case claims

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -388,19 +388,26 @@ measured shape gives a tighter or wider figure, pass
 > investigation.
 
 `bench/compare-criterion.sh --fail-on-regression` codifies the confident
-regression branch for unattended use. The nightly release-baseline workflow
-enables it with the default `--verdict-min-attempts 3` and
-`--regression-threshold-pct 3` plus `--regression-max-stddev-pct 10`: rows
-whose `min..max` straddles zero remain advisory/noise, high-stddev rows remain
-inconclusive, all-positive rows whose last-run 95% CI straddles zero stay
-advisory (`ci-straddles-zero`), and a confirmed row at or above the threshold
-whose last-run 95% CI is entirely above zero makes the workflow fail for human
-review. On scheduled nightly runs one further filter applies: a confident row
-fails the workflow only when the same row was also confident on the previous
-nightly. With ~53 rows per run on the VPS a single all-positive row clears the
-per-row bar by chance roughly nightly and is contradicted the next night,
-while real regressions repeat identically; first-night rows are surfaced as
-advisory in the run summary instead of failing the run.
+regression branch for unattended use. It exits non-zero only for a confirmed
+row: at least `--verdict-min-attempts` (default 3) completed attempts,
+`min..max` entirely above zero, `stddev` below `--regression-max-stddev-pct`
+(default 10), a mean delta at or above `--regression-threshold-pct`
+(default 3), and a last-run 95% CI entirely above zero. Rows whose `min..max`
+straddles zero stay advisory/noise, high-stddev rows stay inconclusive, and
+all-positive rows that clear the delta but whose last-run 95% CI straddles
+zero stay advisory (`ci-straddles-zero`).
+
+Nothing runs those flags on a schedule any more. The removed nightly
+release-baseline workflow layered one further filter on top of the per-row
+bar: a confident row failed the run only when the same row was also confident
+on the previous night. That filter was load-bearing — at ~53 rows per run a
+single all-positive row cleared the per-row bar by chance roughly nightly and
+was contradicted the next night, while real regressions repeated identically;
+first-night rows were surfaced as advisory in the run summary instead of
+failing the run. Until a replacement runner exists, accumulated regressions
+are caught only when someone runs `bench/compare-criterion.sh` by hand, and
+any replacement should re-add an equivalent repeat-confirmation filter before
+it is trusted unattended.
 
 **Worked example** — the first multi-attempt comparison on the VPS
 runner (`rib_ops`, `v0.30.0` → `main`, 3 attempts; the span includes

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -406,7 +406,7 @@ If the release includes EVPN changes (any commit touching
 `crates/wire/src/evpn.rs`, `crates/wire/src/pmsi.rs`, EVPN paths in
 `crates/rib/src/`, the EVPN gRPC surface, `crates/evpn-linux/src/`,
 `crates/evpn/src/origination.rs`, `src/evpn_dataplane.rs`,
-`src/evpn_originator.rs`, or `src/evpn_imet.rs`), run at least one of
+`src/evpn_originator/`, or `src/evpn_imet.rs`), run at least one of
 M29 (capability sanity) or M30 (real Type 2 reflection). Run M33
 (scale) before any release that claims new performance numbers:
 
@@ -429,7 +429,7 @@ containerlab destroy -t tests/interop/m33-evpn-scale.clab.yml --cleanup
 
 If the release touches the **VTEP dataplane** (`crates/evpn-linux/`)
 or **local-MAC origination** (`crates/evpn/src/origination.rs`,
-`src/evpn_originator.rs`, `src/evpn_imet.rs`,
+`src/evpn_originator/`, `src/evpn_imet.rs`,
 `crates/wire/src/pmsi.rs`), additionally run M36 (downward, Gate 7b)
 and M37 (upward, Gate 7b+1) before tagging. If it touches the
 **ADR-0079 adoption/reap sweep** (`crates/evpn-linux/src/reconcile.rs`),

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -901,6 +901,20 @@ Be honest about where rustbgpd isn't the right tool:
   full SP PE.
 - **CLI-first operations** — The CLI is a thin gRPC wrapper, not a full
   interactive shell. If you want IOS-style CLI, use FRR.
-- **BIRD replacement at established IXPs** — BIRD + ARouteServer + IXP Manager
-  is a deep ecosystem. Migrating away requires tooling integration, not just
-  a better daemon.
+- **Drop-in BIRD replacement at established IXPs — bounded.** BIRD +
+  ARouteServer + IXP Manager is a deep ecosystem, and the integration work is
+  now partly done rather than absent: an IXP Manager v7.4 native target
+  (Foil render → atomic activate → lock/update lifecycle, see
+  [cookbook/ixp-manager-route-server.md](cookbook/ixp-manager-route-server.md)),
+  the `birdwatcher-adapter` looking-glass binary, ARouteServer-shaped
+  reject-reason tagging, and `rs-config-render` for member data that lives in
+  arouteserver's `general.yml`/`clients.yml`. The boundary is pinned rather
+  than claimed: `runtime_compatibility` in
+  [`tests/compat/ixp-manager-birdseye/contract.json`](../tests/compat/ixp-manager-birdseye/contract.json)
+  is still `false`, and the adapter covers only the enumerated IXP Manager
+  v7.4 journeys — the route-count endpoints, the table-less
+  `api/route/{net}` lookup, and the whole `lg/` looking-glass surface are out
+  of scope, and arbitrary Alice-LG clients are not a target. No external
+  production pilot has run. Treat it as a shadow-pilot path
+  ([cookbook/route-server-shadow-pilot.md](cookbook/route-server-shadow-pilot.md)),
+  not a swap-in.

--- a/docs/adr/0073-import-policy-explain.md
+++ b/docs/adr/0073-import-policy-explain.md
@@ -173,7 +173,7 @@ Response carries one of eight outcomes:
 |---|---|
 | `PERMIT` | Cached entry, route was permitted |
 | `DENY` | Cached entry, route was denied (the load-bearing case) |
-| `NOT_SEEN` | Peer has never sent this prefix (or it has been withdrawn — distinguished from `WITHDRAWN` below) |
+| `NOT_SEEN` | Peer has never sent this prefix — no entry was ever recorded under this key. A prefix that was seen and then withdrawn returns `WITHDRAWN`, not `NOT_SEEN` |
 | `WITHDRAWN` | Was permitted, withdrawn after; entry retained for visibility |
 | `EVICTED` | Was in the cache; pushed out by the per-peer bound |
 | `STALE` | Cached entry's `policy_generation` is older than current; result no longer represents current policy |

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -501,14 +501,26 @@ or installs remote prefixes.
 **Triage**:
 
 1. `rbgp evpn vrfs <name>` and read the `not_ready_reasons`
-   list. Common entries:
-   - `vrf_device_missing` / `not_up` — the VRF master device must
-     exist and be UP before the probe runs.
-   - `vrf_table_id_mismatch` — the kernel's VRF `table` must
-     match the configured `table_id`.
-   - `l3vxlan_device_missing` / `not_up` / `vni_mismatch` /
-     `local_ip_mismatch` / `not_enslaved_to_vrf` /
-     `router_mac_mismatch` — covers the L3VXLAN device side.
+   list. The entries are short English lines, one per failing
+   ADR-0058 §3 predicate:
+   - `vrf device missing` / `vrf device down` — the VRF master
+     device must exist and be UP before the probe runs.
+   - `vrf table_id mismatch (observed N, configured M)` — the
+     kernel's VRF `table` must match the configured `table_id`.
+   - `l3vxlan device missing` / `l3vxlan device down` /
+     `l3vxlan vni mismatch (observed N, configured M)` /
+     `l3vxlan local mismatch (observed X, configured Y)` (or
+     `l3vxlan local missing (configured Y)`) /
+     `l3vxlan not in vrf (observed master ifindex N, expected M)`
+     (or `l3vxlan unenslaved (expected master ifindex M)`) /
+     `router_mac mismatch (observed X, configured Y)` (or
+     `router_mac missing (configured Y)`) — covers the L3VXLAN
+     device side.
+
+   These lines are for humans and are not a stable machine
+   interface. A structured consumer should match the proto
+   `readiness_state` variants and their field values instead of
+   parsing the strings.
 2. `ip link show type vrf` + `ip -d link show type vxlan` to
    confirm the kernel side matches the rustbgpd config.
 3. If the probe is `Ready` but `originated_routes_count == 0`,

--- a/docs/kernel-dataplane-runner.md
+++ b/docs/kernel-dataplane-runner.md
@@ -98,10 +98,15 @@ issue #187) so reviewers can distinguish real stability from flake masking.
 - M70: ADR-0089 VLAN-aware bridge FDB attribution against FRR.
 - M71: RFC 9136 §4.3 ESI overlay-index Type 5 single-active receive against GoBGP.
 - M72: RFC 9136 §4.3 ESI overlay-index Type 5 all-active receive against GoBGP.
-- Docker netns selectors: `fdb_nhg`, `fib_runtime`, `bfd_runtime`,
-  `dataplane_vlan_fdb`, `macip_vlan_attribution`, `svd_fdb_vni`,
-  `managed_bridge`, `managed_vxlan`, `managed_svd_vxlan`, `managed_vlan_upper`, `managed_ready`,
-  `managed_ip_vrf_ready`, `l3_multipath`, and `l3_all_active_writer`.
+- Docker netns selectors, in job order — `fdb_nhg`, `fib_runtime`,
+  `bfd_runtime`, `dataplane_vlan_fdb`, `macip_vlan_attribution`,
+  `svd_fdb_vni`, `managed_bridge`, `managed_vxlan`, `managed_svd_vxlan`,
+  `managed_vlan_upper`, `managed_ready`, `link_carrier`, `ac_gate`,
+  `nexthop_raw`, `foreign_state_l2`, and `foreign_state_nhid`. Five further
+  L3 selectors run only when the job's `vrf-available` probe loads the `vrf`
+  kernel module, and skip otherwise: `l3_multipath`,
+  `managed_ip_vrf_ready`, `l3_all_active_writer`, `foreign_state_l3`, and
+  `l3_route_event`.
 
 The `Privileged Interop (netns)` workflow (`privileged-interop.yml`) is a
 manual (`workflow_dispatch`) on-demand harness for the non-docker direct-`cargo


### PR DESCRIPTION
A pre-release audit of the v0.66.0 doc surface found six factual defects in
this cluster. Each was re-verified against the current tree before editing.

## `docs/RELEASE_CHECKLIST.md` — two EVPN interop triggers named a path that no longer exists

**Wrong:** both EVPN trigger lists gated on a commit touching
`src/evpn_originator.rs` — line 409 for M29/M30 (capability sanity / real
Type 2 reflection), line 432 for M36/M37 (VTEP downward/upward, Gate 7b and
7b+1).

**Evidence:** `git ls-tree HEAD src/` reports `040000 tree … src/evpn_originator`.
The module split turned the flat file into a directory (`mod.rs`,
`lifecycle.rs`, `duplicate_mac.rs`, `observation.rs`, `rib_polling.rs`,
`rib_write.rs`, `tests.rs`); the `.rs` path has not existed since. A release
changing local-MAC origination inside the split module matched no trigger, so
four interop gates silently never fired — a check pointed at something that
cannot fail.

**Changed:** both lines now name `src/evpn_originator/`. Every other repo path
in the document was swept the same way, backticked trigger paths and bare
paths in the reproduction command blocks alike: 92 paths checked, this was the
only dead one.

## `docs/evpn-vtep-troubleshooting.md` — IP-VRF triage listed reason tokens the daemon never emits

**Wrong:** the "IP-VRF stuck in `NotReady`" step told operators to look for
snake_case `not_ready_reasons` values — `vrf_device_missing`, `not_up`,
`vrf_table_id_mismatch`, `l3vxlan_device_missing`, `vni_mismatch`,
`local_ip_mismatch`, `not_enslaved_to_vrf`, `router_mac_mismatch`.

**Evidence:** `format_not_ready_reason` in `crates/api/src/evpn_service.rs`
renders short English lines — `vrf device missing`, `vrf device down`,
`vrf table_id mismatch (observed N, configured M)`, and so on — and
`crates/api/src/evpn_service.rs` pins them
(`list_ip_vrfs_surfaces_not_ready_reasons` asserts `vrf device missing`).
No documented token appears in any output, so grepping for one finds nothing.

**Changed:** the bullets now carry the strings the API actually produces,
including both arms of each optional-observed variant, keeping the ADR-0058 §3
predicate grouping. Added the function's own caveat: these lines are for
humans, and structured consumers should match the proto `readiness_state`
variants rather than parse them.

## `docs/kernel-dataplane-runner.md` — the netns selector inventory under-listed by seven

**Wrong:** the "Docker netns selectors" bullet read as a complete enumeration
of 14 selectors.

**Evidence:** `.github/workflows/kernel-dataplane.yml` invokes
`run-netns-tests.sh` 21 times. Missing from the doc: `link_carrier`,
`ac_gate`, `nexthop_raw`, `foreign_state_l2`, `foreign_state_nhid`,
`foreign_state_l3`, and `l3_route_event`. The `foreign_state_*` trio (foreign
static FDB / NHID / L3 ownership preservation) was entirely undocumented. The
doc also flattened the vrf gating, listing `managed_ip_vrf_ready`,
`l3_multipath`, and `l3_all_active_writer` alongside the unconditional ones.

**Changed:** the bullet lists all 21 in job order and separates the five L3
selectors that run only when the job's `vrf-available` probe loads the `vrf`
kernel module and skip otherwise.

## `docs/BENCHMARKS.md` — the removed nightly bench workflow described in the present tense

**Wrong:** the grading section said "The nightly release-baseline workflow
enables it with…", "makes the workflow fail for human review", and "On
scheduled nightly runs one further filter applies". A contributor reading only
that section believes accumulated regressions are still caught nightly.

**Evidence:** `git ls-files .github/workflows/` lists no bench workflow, and
the "Manual CI Workflow" section of this same document already says both were
removed on 2026-08-22 with the retired runner. The page contradicted itself.

**Changed:** the grading rules are kept — they still describe how a figure is
judged — but stated as flag semantics on `bench/compare-criterion.sh` rather
than as workflow behavior, with the defaults verified against the script
(`--verdict-min-attempts 3`, `--regression-threshold-pct 3`,
`--regression-max-stddev-pct 10`). The nightly two-run confirmation filter is
described in the past tense, with why it was load-bearing (at ~53 rows per run
a single all-positive row cleared the per-row bar by chance roughly nightly),
and the section now states plainly that nothing runs on a schedule today and
that a replacement runner should re-add an equivalent filter.

## `docs/USE_CASES.md` — a "Not a Good Fit" entry this release invalidated

**Wrong:** "**BIRD replacement at established IXPs** — BIRD + ARouteServer +
IXP Manager is a deep ecosystem. Migrating away requires tooling integration,
not just a better daemon." This release ships that tooling integration, so an
operator evaluating rustbgpd for an IXP concluded no IXP Manager path exists.

**Evidence:** the IXP Manager v7.4 native target (Foil render → atomic
activate → lock/update lifecycle, `docs/cookbook/ixp-manager-route-server.md`,
proven by M96/M97), the `birdwatcher-adapter` binary in the release tarball,
and `tools/rs-config-render`.

**Changed:** re-scoped rather than removed, and the limits come from the
pinned contract, not from prose. `runtime_compatibility` in
`tests/compat/ixp-manager-birdseye/contract.json` is still `false`; its
`birdseye_routes.out_of_scope` list names the route-count endpoints, the
table-less `api/route/{net}` lookup, and the whole `lg/` surface. The entry
records that no external production pilot has run and points at the
shadow-pilot recipe. It stays in the "Not a Good Fit" section.

## `docs/adr/0073-import-policy-explain.md` — the `NOT_SEEN` row contradicted itself and the code

**Wrong:** "Peer has never sent this prefix (or it has been withdrawn —
distinguished from `WITHDRAWN` below)". The parenthetical says a withdrawn
prefix returns `NOT_SEEN` and in the same breath that it is distinguished from
`WITHDRAWN`.

**Evidence:** `ImportDecisionCache::mark_withdrawn`
(`crates/transport/src/session/import_decision_cache.rs`) converts the entry's
outcome to `Withdrawn` and retains it as a tombstone; it is a no-op only when
the key is absent. The pinning test `mark_withdrawn_converts_outcome_to_withdrawn`
asserts exactly that. The only routes to `NOT_SEEN` are a key the cache never
held, and eviction returns `EVICTED`.

**Changed:** the one table cell. The ADR's decision and narrative are
untouched — it remains a historical record.

## Gates

- `python3 scripts/check_public_tracker_ids.py` — rc 0 (606 public documents,
  no private tracker IDs).
- `python3 scripts/check_ixp_manager_docs.py` — rc 0.
- Every relative link and same-document anchor in the six touched files
  resolves — 55 links, 0 broken.
- Every repo path named in `docs/RELEASE_CHECKLIST.md` exists — 92 paths, 0
  dead after the fix, 1 dead before it.
