### PR TITLE
ci: gate release-checklist trigger paths on existence

### DIFF
--- a/.github/workflows/public-docs-contract.yml
+++ b/.github/workflows/public-docs-contract.yml
@@ -1,28 +1,15 @@
 # The main CI lane ignores `**/*.md`, so a doc-only pull request — exactly
 # the change that reintroduces an unresolvable tracker citation — would skip
-# the gate entirely. This lane runs on the published doc surface itself.
+# the gate entirely. This lane runs unfiltered: the release-checklist path
+# gate cross-references source paths from the doc surface, so a pure source
+# rename — exactly the drift that silenced four EVPN interop triggers — must
+# fire it too, and every step here is a seconds-cheap python check.
 name: Public docs contract
 
 on:
   push:
     branches: [main]
-    paths: &paths
-      - docs/**
-      - README.md
-      - ARCHITECTURE.md
-      - CONTRIBUTING.md
-      - KNOWN_ISSUES.md
-      - SECURITY.md
-      - SUPPORT.md
-      - scripts/check_public_tracker_ids.py
-      - scripts/test_check_public_tracker_ids.py
-      - examples/birdwatcher-adapter/README.md
-      - tests/compat/ixp-manager-birdseye/contract.json
-      - scripts/check_ixp_manager_docs.py
-      - scripts/test_check_ixp_manager_docs.py
-      - .github/workflows/public-docs-contract.yml
   pull_request:
-    paths: *paths
 
 permissions:
   contents: read
@@ -40,3 +27,7 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_ixp_manager_docs.py
           python3 scripts/check_ixp_manager_docs.py
+      - name: Check release-checklist trigger paths exist
+        run: |
+          python3 -m unittest -v scripts/test_check_release_checklist_paths.py
+          python3 scripts/check_release_checklist_paths.py

--- a/scripts/check_release_checklist_paths.py
+++ b/scripts/check_release_checklist_paths.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Assert every repo path named in docs/RELEASE_CHECKLIST.md exists in the tree.
+
+A trigger list that names a path which no longer exists never fires: the
+release gate it guards silently passes. This extracts every path-shaped
+token from the document -- backticked prose paths in the trigger lists, and
+bare paths inside the fenced reproduction blocks -- and checks each against
+the working tree. Bare tokens are read only inside fenced code blocks, so
+prose such as "docs/test improvements" is not mistaken for a path.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOTS = r"(?:src|crates|tests|docs|scripts|bench|examples|\.github|fuzz)"
+BACKTICKED = re.compile(r"`([^`\s]+)`")
+BARE = re.compile(rf"(?<![\w/`.-])({ROOTS}/[\w./-]*[\w/])")
+IS_PATH = re.compile(rf"^{ROOTS}/")
+
+DOCUMENT = Path("docs") / "RELEASE_CHECKLIST.md"
+
+
+def named_paths(document: str) -> dict[str, list[int]]:
+    """Map each path-shaped token in `document` to the lines naming it."""
+    found: dict[str, list[int]] = {}
+    in_fence = False
+    for number, line in enumerate(document.splitlines(), start=1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        tokens = [match.group(1) for match in BACKTICKED.finditer(line)]
+        if in_fence:
+            tokens += [match.group(1) for match in BARE.finditer(line)]
+        for token in tokens:
+            if IS_PATH.match(token):
+                found.setdefault(token, []).append(number)
+    return found
+
+
+def check(root: Path) -> tuple[int, list[str]]:
+    """Return (paths checked, errors) for the checklist under `root`."""
+    document = (root / DOCUMENT).read_text(encoding="utf-8")
+    found = named_paths(document)
+    if not found:
+        return 0, [
+            f"no paths were extracted from {DOCUMENT.as_posix()}, "
+            "so the parse is broken"
+        ]
+    errors = []
+    for token, lines in sorted(found.items()):
+        if not (root / token.rstrip("/")).exists():
+            where = ",".join(str(number) for number in lines)
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{where} names `{token}`, which does "
+                "not exist in the tree; the gate it triggers can never fire"
+            )
+    return len(found), errors
+
+
+def main() -> int:
+    if len(sys.argv) > 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} [REPO_ROOT]")
+    default = Path(__file__).resolve().parents[1]
+    root = Path(sys.argv[1]) if len(sys.argv) == 2 else default
+    checked, errors = check(root)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print(
+        f"release checklist path check passed: all {checked} named "
+        "trigger paths exist"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_release_checklist_paths.py
+++ b/scripts/test_check_release_checklist_paths.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Mutation proofs for the release-checklist path-existence gate."""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_release_checklist_paths.py"
+
+CHECKLIST = """\
+# Release checklist
+
+If the release touches the parser (`src/parser.rs`) or the
+originator (`src/evpn_originator/`), run M-01:
+
+```sh
+containerlab deploy -t tests/interop/m01.clab.yml
+bash tests/interop/scripts/test-m01.sh
+```
+
+Unfenced prose such as docs/test improvements is not a path, and a
+prefixed `$PWD/tests/prefixed.rs` token is not a repo path.
+"""
+
+FIXTURE_PATHS = (
+    "src/parser.rs",
+    "src/evpn_originator/",
+    "tests/interop/m01.clab.yml",
+    "tests/interop/scripts/test-m01.sh",
+)
+
+
+class ReleaseChecklistPathTests(unittest.TestCase):
+    def run_checker(
+        self, checklist: str, paths: tuple[str, ...]
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "docs").mkdir()
+            (root / "docs" / "RELEASE_CHECKLIST.md").write_text(
+                checklist, encoding="utf-8"
+            )
+            for relative in paths:
+                target = root / relative
+                if relative.endswith("/"):
+                    target.mkdir(parents=True, exist_ok=True)
+                else:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text("", encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, str(CHECKER), str(root)],
+                capture_output=True,
+                text=True,
+            )
+
+    def assert_fails(self, paths: tuple[str, ...], missing: str) -> None:
+        result = self.run_checker(CHECKLIST, paths)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(missing, result.stderr)
+
+    def test_passes_when_every_named_path_exists(self) -> None:
+        """Green with all named paths present; prose tokens are not extracted."""
+        result = self.run_checker(CHECKLIST, FIXTURE_PATHS)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_fails_on_missing_backticked_trigger_path(self) -> None:
+        """Red when a backticked trigger-list file is gone."""
+        remaining = tuple(p for p in FIXTURE_PATHS if p != "src/parser.rs")
+        self.assert_fails(remaining, "src/parser.rs")
+
+    def test_fails_on_missing_trigger_directory(self) -> None:
+        """Red when a trailing-slash trigger directory is gone."""
+        remaining = tuple(p for p in FIXTURE_PATHS if p != "src/evpn_originator/")
+        self.assert_fails(remaining, "src/evpn_originator/")
+
+    def test_fails_on_missing_fenced_reproduction_path(self) -> None:
+        """Red when a bare path inside a fenced block is gone."""
+        remaining = tuple(
+            p for p in FIXTURE_PATHS if p != "tests/interop/scripts/test-m01.sh"
+        )
+        self.assert_fails(remaining, "tests/interop/scripts/test-m01.sh")
+
+    def test_fails_when_no_paths_are_extracted(self) -> None:
+        """Red when the parse yields nothing: a gate that cannot fail is broken."""
+        result = self.run_checker("# Empty\n\nNo paths named here.\n", ())
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no paths were extracted", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -66,7 +66,9 @@ pub fn journal_path(runtime_state_dir: &Path) -> PathBuf {
 }
 
 /// Refuse a retired locator-free v1/v2 authority without opening, changing, or
-/// removing it. Its terminal state cannot be proven by the v0.65 daemon.
+/// removing it. Its terminal state cannot be proven by v0.65.0 or any later
+/// release, so every one of them refuses boot untouched; finish or recover the
+/// transaction before upgrading past v0.64.0.
 pub fn refuse_retired_journal(path: &Path) -> Result<(), String> {
     match fs::symlink_metadata(path) {
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),


### PR DESCRIPTION
Two items (LAN-1253):

**1. Release-checklist trigger-path existence gate.** `docs/RELEASE_CHECKLIST.md` names source paths in its trigger lists ("if the release touches X, run M-NN") and in fenced reproduction blocks. When `src/evpn_originator.rs` became a directory, four EVPN interop gates silently could never fire — the trigger path no longer existed, so the condition never matched. New `scripts/check_release_checklist_paths.py`:

- extracts every backticked path in the document plus bare paths inside fenced code blocks, and asserts each resolves in the tree (trailing-slash directory forms included);
- scopes bare-token matching to fenced blocks so prose like "docs/test improvements" is not mistaken for a path;
- fails closed when the parse extracts nothing (a gate that cannot fail is broken);
- exit 0 clean, non-zero with a listing of unresolved paths and the lines naming them.

`scripts/test_check_release_checklist_paths.py` proves both directions on self-contained fixtures: green with every named path present, red for a missing backticked file, a missing trailing-slash directory, a missing fenced-block bare path, and an empty extraction.

Wired into `.github/workflows/public-docs-contract.yml` next to the other doc-surface contract checks, same step shape (unittest then checker). The lane's paths filter is dropped: the checklist gate cross-references source paths from the doc surface, so a pure source rename — the founding incident's exact shape — must fire it, and the trigger prefixes the checklist names (`src/`, `crates/`, `tests/`, `docs/`, `scripts/`, `examples/`, `.github/`) are effectively the whole tree. Every step in the lane is a seconds-cheap python check. On the current tree the checker passes: 92 named paths, none dead, so no checklist fixes were needed.

**2. `refuse_retired_journal` doc comment rescoped** (`src/confirm_journal.rs`): "cannot be proven by the v0.65 daemon" read as a v0.65-specific event; the refusal is a floor from v0.65.0 onward. Rephrased to match `docs/OPERATIONS.md` / `docs/deployment.md` ("v0.65.0 or any later release ... refuses boot untouched; finish or recover ... before upgrading past v0.64.0"). No behavior change.

Gates (all green): new unittest, checker vs real tree, `check_public_tracker_ids`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace --no-fail-fast`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `check-clippy-reasons`, workflow YAML parse.

No CHANGELOG entry: internal tooling plus a doc comment, not operator-visible.
