### PR TITLE
test: gate heartbeat renders in the gNMI removal-presence rearm test

### DIFF
--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -5890,9 +5890,20 @@ mod tests {
         };
 
         let manager = event_history_manager().await;
-        let service =
-            GnmiService::with_peer_snapshot(65001, "192.0.2.1", || async { Ok(Vec::new()) })
-                .with_event_history(Some(manager.handle()));
+        // Heartbeat renders block on this gate. Without it, any wall-clock
+        // stall that leaves a heartbeat due while the peer is Present lets
+        // the render reconcile presence against the always-empty snapshot
+        // and interleave a delete ahead of the awaited update.
+        let render_permits = Arc::new(tokio::sync::Semaphore::new(0));
+        let render_gate = Arc::clone(&render_permits);
+        let service = GnmiService::with_peer_snapshot(65001, "192.0.2.1", move || {
+            let gate = Arc::clone(&render_gate);
+            async move {
+                gate.acquire_owned().await.unwrap().forget();
+                Ok(Vec::new())
+            }
+        })
+        .with_event_history(Some(manager.handle()));
         let path = neighbor_session_state_path("10.0.0.2");
         let mut list = stream_on_change_list(path.clone());
         list.updates_only = true;
@@ -5938,6 +5949,7 @@ mod tests {
             manager.handle().sender().try_send(envelope).unwrap();
         }
         let updates = subscribe_updates(next_bounded(&mut stream).await.unwrap().unwrap());
+        assert_eq!(updates.len(), 1);
         let gnmi::typed_value::Value::JsonIetfVal(value) =
             updates[0].val.as_ref().unwrap().value.as_ref().unwrap()
         else {
@@ -5954,6 +5966,8 @@ mod tests {
             subscribe_deletes(next_bounded(&mut stream).await.unwrap().unwrap()),
             vec![path.clone()]
         );
+        // One permit: the absent-phase heartbeat this sleep proves silent.
+        render_permits.add_permits(1);
         tokio::time::sleep(Duration::from_millis(1_100)).await;
         manager
             .handle()
@@ -5966,6 +5980,9 @@ mod tests {
         );
         drop(stream);
 
+        // The second stream's initial snapshot renders once; a straggling
+        // first-stream heartbeat pending at drop can consume at most one.
+        render_permits.add_permits(2);
         let mut stream = harness
             .client
             .subscribe(tokio_stream::iter(vec![subscribe_msg(
@@ -6090,6 +6107,7 @@ mod tests {
 
         let heartbeat = next_bounded(&mut stream).await.unwrap().unwrap();
         let replacement = subscribe_updates(heartbeat);
+        assert_eq!(replacement.len(), 1);
         let gnmi::typed_value::Value::JsonIetfVal(value) =
             replacement[0].val.as_ref().unwrap().value.as_ref().unwrap()
         else {


### PR DESCRIPTION
Fixes the LAN-1250 flake: `gnmi_service::tests::tcp_removal_presence_is_bounded_and_rearms_after_add` panicked once under full-workspace load with `index out of bounds: the len is 0 but the index is 0` at `gnmi_service.rs:5942:20`, while staying green in isolation.

## Root cause

The test's peer-snapshot closure always returns an empty vec, while the live session events mark the peer Present, and the first subscription runs with a 1s `heartbeat_interval`. Heartbeat renders reconcile presence against that snapshot: any wall-clock stall that leaves a heartbeat due while the peer is Present lets the render observe the always-empty snapshot and emit a delete-only notification. That delete lands ahead of the awaited ESTABLISHED update, and the read indexed `updates[0]` blind — an empty `update` vec, hence the index panic.

The contract at fault is the test fixture's, not the product's: heartbeat reconciliation deleting a path the snapshot no longer reports is the designed behavior (in production the snapshot and the event stream share one source of truth and cannot disagree persistently). The test choreography implicitly assumed the whole Present phase fits inside one heartbeat interval.

## Fix

Gate the snapshot closure on a zero-permit `tokio::sync::Semaphore`, following the held-render pattern `subscribe_on_change_streams_session_transitions` already uses. A heartbeat that comes due mid-choreography now pends harmlessly on the gate (the select loop keeps servicing live events, and a covering event cancels the pending render), so no spurious delete can interleave regardless of scheduling stalls. The test grants exactly one permit before the 1.1s sleep — the absent-phase heartbeat whose silence the test proves — and two before the second subscription (its non-`updates_only` initial snapshot renders once; a straggling first-stream heartbeat pending at drop can consume at most one). All five documented load-bearing breaks keep firing exactly as before, including the PeerDisabled-as-removal probe, which now fails through an explicit `assert_eq!(updates.len(), 1)` instead of an index panic.

## Seam sweep

Checked every `[0]` index and every heartbeat-bearing test in the file:

- `tcp_removal_presence_is_bounded_and_rearms_after_add` — the only test driving heartbeats plus live events over real TCP with real time; fixed as above.
- The other heartbeat lifecycle tests (`on_change_heartbeats_batch_co_due_paths_and_skip_late_periods`, `on_change_heartbeat_deletes_only_due_absent_present_paths`, `on_change_updates_only_reads_first_snapshot_at_heartbeat`, `on_change_heartbeat_preserves_actor_error_status`) run under `start_paused` with direct channel drive — deterministic, no exposure.
- `subscribe_on_change_streams_session_transitions` indexes `replacement[0]` without a length assert; its snapshot always returns the peer so a delete cannot arrive there, but the same blind-index shape got the same one-line `assert_eq!(replacement.len(), 1)` hardening for a readable failure on any future regression.
- `tcp_on_change_dispatches_accepted_heartbeat` asserts an exact snapshot-call count that a >1s stall could in principle bump; different shape (counter, not index), not touched here.

## Proof

Reproducer: no load generators — each run gets a 1.25s `SIGSTOP`/`SIGCONT` at a swept 10-160ms offset, simulating the scheduler stall surgically.

- Pre-fix: 11/60 runs failed, all with the exact panic at `gnmi_service.rs:5942:20`; brute core-pinning alone (48 runs at 8-way contention on 2 cores, plus 48 runs single-core against a concurrent suite) never reproduced it.
- Post-fix, same 60-run SIGSTOP sweep: 60/60 ok.
- Post-fix, spec recipe `chrt -b 0 taskset -c 0,1 <bin> --exact <test> --test-threads=1`: 20/20 ok.
- Post-fix, unconstrained `cargo test -p rustbgpd-api gnmi`: 3/3 ok (92 tests per run).

## Gates

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` rc=0
- `cargo test --workspace --no-fail-fast` rc=0
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` rc=0
- `python3 scripts/check-clippy-reasons.py` rc=0
