### PR TITLE
feat(api): serve effective local-pref and match Bird's Eye route shapes in the adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   BIRD 2.0.12 + Bird's Eye oracle prints them, closing the two matching
   runtime-divergence allow-list entries. (LAN-1232)
 
+### Changed
+
+- **Operator-visible:** `Route.local_pref` in the gRPC route projection
+  (`ListReceivedRoutes` / `ListBestRoutes` / `ListAdvertisedRoutes` rows and
+  the explain/lookup responses) now carries the effective local preference —
+  the LOCAL_PREF attribute when present, otherwise the default 100 best-path
+  selection applies. It previously encoded an absent attribute as 0,
+  indistinguishable from an explicit LOCAL_PREF 0. Wire-level presence stays
+  on the optional `Route.local_pref_attr` field, unchanged, and `rbgp rib`
+  (table and JSON) accordingly shows 100 instead of 0 for routes without the
+  attribute. (LAN-1232)
+- The Bird's Eye adapter route views converge on the pinned oracle's route
+  shapes: `bgp.as_path` elements are strings, `bgp.local_pref` is the
+  effective value as a string, `bgp.med` is emitted only when the route
+  carries the attribute, `type` is BIRD 2's `["BGP", "univ"]` pair, and
+  `primary` truthfully marks the Loc-RIB selection in the received, export,
+  and exact-route views (joined against `ListBestRoutes`; the table views
+  already read it). The five matching `must_match` runtime-divergence
+  allow-list entries are removed. (LAN-1232)
+
 ### Removed
 
 - **Breaking:** `RibService.WatchRoutes` and `RibService.WatchRouteEvents`

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1182,7 +1182,11 @@ fn explain_best_path_to_proto(explain: ExplainBestPath) -> proto::ExplainBestPat
 fn route_to_proto(route: &Route, best: bool) -> proto::Route {
     let mut origin = 0u32;
     let mut as_path = Vec::new();
-    let mut local_pref = 0u32;
+    // Effective LOCAL_PREF: the attribute value when present, otherwise
+    // the default 100 the RIB applies (`Route::local_pref()`), which is
+    // what best-path selection actually compares. Wire-level presence is
+    // `local_pref_attr` below.
+    let mut local_pref = 100u32;
     let mut med = 0u32;
     let mut communities = Vec::new();
     let mut extended_communities = Vec::new();
@@ -4619,6 +4623,33 @@ mod tests {
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
             aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
+    }
+
+    #[test]
+    fn route_to_proto_serves_effective_local_pref_with_presence_marker() {
+        let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+
+        // No LOCAL_PREF attribute (the eBGP wire): the effective default
+        // 100 is served, and the presence marker stays absent.
+        let absent = route_to_proto(&test_route(prefix, vec![]), false);
+        assert_eq!(absent.local_pref, 100);
+        assert_eq!(absent.local_pref_attr, None);
+
+        // Explicit LOCAL_PREF 0 (e.g. RFC 8326 demotion) must not be
+        // conflated with the default.
+        let zero = route_to_proto(
+            &test_route(prefix, vec![PathAttribute::LocalPref(0)]),
+            false,
+        );
+        assert_eq!(zero.local_pref, 0);
+        assert_eq!(zero.local_pref_attr, Some(0));
+
+        let explicit = route_to_proto(
+            &test_route(prefix, vec![PathAttribute::LocalPref(200)]),
+            false,
+        );
+        assert_eq!(explicit.local_pref, 200);
+        assert_eq!(explicit.local_pref_attr, Some(200));
     }
 
     #[test]

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -84,13 +84,13 @@ listener beyond loopback only with the mTLS controls in `docs/SECURITY.md`.
 | `GET /protocols/bgp`         | One `NeighborService.ListNeighbors` request, including actor-authoritative per-neighbor `routes.filtered` counts |
 | `GET /protocol/{id}`         | Same live neighbor object exposed by `GET /protocols/bgp`              |
 | `GET /symbols`               | Sorted live protocol and routing-table identities from `NeighborService.ListNeighbors` |
-| `GET /routes/protocol/{id}`  | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
-| `GET /routes/export/{id}`    | `RibService.ListAdvertisedRoutes` (paged, all unicast families) |
+| `GET /routes/protocol/{id}`  | `RibService.ListReceivedRoutes` (paged, all unicast families) + `ListBestRoutes` identity join for truthful `primary` |
+| `GET /routes/export/{id}`    | `RibService.ListAdvertisedRoutes` (paged, all unicast families) + `ListBestRoutes` identity join for truthful `primary` |
 | `GET /routes/table/{table}`  | One `NeighborService.ListNeighbors` snapshot, then global `RibService.ListReceivedRoutes` + `ListBestRoutes` paged under one generation |
-| `GET /route/{prefix}/protocol/{id}` | `RibService.ListReceivedRoutes` (paged, exact IPv4/IPv6 unicast prefix) |
-| `GET /route/{prefix}/export/{id}` | `RibService.ListAdvertisedRoutes` (paged, exact IPv4/IPv6 unicast prefix) |
+| `GET /route/{prefix}/protocol/{id}` | `RibService.ListReceivedRoutes` (paged, exact IPv4/IPv6 unicast prefix) + prefix-filtered `ListBestRoutes` for truthful `primary` |
+| `GET /route/{prefix}/export/{id}` | `RibService.ListAdvertisedRoutes` (paged, exact IPv4/IPv6 unicast prefix) + prefix-filtered `ListBestRoutes` for truthful `primary` |
 | `GET /route/{prefix}/table/{table}` | `RibService.LookupBestPath` (bounded longest-prefix match with one matched-prefix candidate set) |
-| `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
+| `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families) + `ListBestRoutes` identity join for truthful `primary` |
 | `GET /routes/filtered/{id}`  | `PolicyService.ListRejectedRoutes` (unpaged — the store is bounded at the `[policy.reject_retention]` capacity, default 1024/peer) |
 | `GET /routes/lc-zwild/protocol/{id}/{x}/{y}` | `GlobalService.GetGlobal` + `PolicyService.ListRejectedRoutes` for IXP Manager's `{daemon ASN}:1101:*` filtered-prefix query |
 | `GET /routes/noexport/{id}`  | `RibService.ListBestRoutes` − `RibService.ListAdvertisedRoutes` (both paged), each missing prefix explained by `RibService.ExplainAdvertisedRoute` |
@@ -423,9 +423,8 @@ load_on_demand = true
 | protocol `routes.preferred` | omitted | No per-peer Loc-RIB best count exists on the gRPC surface; deriving one would page the whole Loc-RIB on every poll. The field is left out rather than served as a wrong `0` — a client that defaults absent fields still reads zero, but nothing here asserts it. |
 | route `interface` | `""` | Interface identity is not exposed for these routes. |
 | route `metric` | `0` | Sentinel only; this is not an IGP metric. |
-| route `primary` | `false` | Sentinel only; primary-route status is not exposed. |
 | filtered route `bgp.origin` | `""` | ORIGIN is not retained for rejected routes. |
-| filtered route `bgp.local_pref`, `bgp.med` | `0` | Not retained for rejected routes. |
+| filtered route `bgp.local_pref`, `bgp.med` | `"100"`, omitted | Not retained for rejected routes: `local_pref` renders the effective default (the same rule the accepted views apply to a route without the attribute) and `med` is omitted. An explicit wire value on the rejected announcement is lost. |
 
 Error behavior differs only on failure: when the daemon is unreachable
 the adapter returns `502 Bad Gateway` (the in-daemon server returned

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -901,6 +901,54 @@ fn symbol_names(
 //                            →  RibService.ListReceivedRoutes
 // ---------------------------------------------------------------------------
 
+/// Identity key of one route row across the paged route scopes:
+/// (prefix, prefix length, source peer, Add-Path id). Advertised rows
+/// keep their source identity, so the same key joins every scope.
+fn route_key(route: &proto::Route) -> (String, u32, String, u32) {
+    (
+        route.prefix.clone(),
+        route.prefix_length,
+        route.peer_address.clone(),
+        route.path_id,
+    )
+}
+
+/// Loc-RIB best-route identity keys, used to report `primary` truthfully
+/// in the received and export views (Bird's Eye marks the selected route
+/// in every view). `prefix` narrows the walk to one exact prefix for the
+/// exact-route lookups; `None` walks the whole table — the same
+/// per-request full-table read the atomic table view already performs.
+async fn best_route_keys(
+    state: &AppState,
+    prefix: Option<ExactPrefix>,
+) -> Result<HashSet<(String, u32, String, u32)>, HttpError> {
+    let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
+    let mut keys = HashSet::new();
+    let mut page_token = String::new();
+    loop {
+        let response = client
+            .list_best_routes(proto::ListRoutesRequest {
+                afi_safi: proto::AddressFamily::Unspecified as i32,
+                page_size: 1000,
+                page_token,
+                prefix_filter: prefix.map(|p| p.address.to_string()).unwrap_or_default(),
+                prefix_filter_length: prefix.map_or(0, |p| p.length),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| bad_gateway("ListBestRoutes", &error))?
+            .into_inner();
+        // Marker set, not a served view: the max-routes cap applies to
+        // the view being rendered, not to this lookup.
+        keys.extend(response.routes.iter().map(route_key));
+        if response.next_page_token.is_empty() {
+            break;
+        }
+        page_token = response.next_page_token;
+    }
+    Ok(keys)
+}
+
 async fn routes_protocol(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -920,6 +968,7 @@ async fn routes_peer(
 }
 
 async fn serve_routes_for_peer(state: &AppState, peer: IpAddr) -> Result<Json<Value>, HttpError> {
+    let best = best_route_keys(state, None).await?;
     let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
     let mut routes: Vec<Value> = Vec::new();
     let mut page_token = String::new();
@@ -940,11 +989,13 @@ async fn serve_routes_for_peer(state: &AppState, peer: IpAddr) -> Result<Json<Va
         if page_token.is_empty() {
             enforce_max(resp.total_count, state.max_routes)?;
         }
-        routes.extend(
-            resp.routes
-                .iter()
-                .map(|route| route_to_birdwatcher(route, &state.identities)),
-        );
+        routes.extend(resp.routes.iter().map(|route| {
+            route_to_birdwatcher_with_primary(
+                route,
+                &state.identities,
+                best.contains(&route_key(route)),
+            )
+        }));
         enforce_max(routes.len() as u64, state.max_routes)?;
         if resp.next_page_token.is_empty() {
             break;
@@ -1137,6 +1188,7 @@ async fn routes_export(
     Path(id): Path<String>,
 ) -> Result<Json<Value>, HttpError> {
     let peer = state.identities.resolve(&id)?;
+    let best = best_route_keys(&state, None).await?;
     let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
     let mut routes = Vec::new();
     let mut page_token = String::new();
@@ -1155,11 +1207,13 @@ async fn routes_export(
         if page_token.is_empty() {
             enforce_max(resp.total_count, state.max_routes)?;
         }
-        routes.extend(
-            resp.routes
-                .iter()
-                .map(|route| route_to_birdwatcher(route, &state.identities)),
-        );
+        routes.extend(resp.routes.iter().map(|route| {
+            route_to_birdwatcher_with_primary(
+                route,
+                &state.identities,
+                best.contains(&route_key(route)),
+            )
+        }));
         enforce_max(routes.len() as u64, state.max_routes)?;
         if resp.next_page_token.is_empty() {
             break;
@@ -1337,11 +1391,18 @@ async fn serve_exact_route(
         page_token = response.next_page_token;
     }
 
+    let best = best_route_keys(state, Some(prefix)).await?;
     Ok(Json(serde_json::json!({
         "api": api_block(state.max_routes),
         "routes": routes
             .iter()
-            .map(|route| route_to_birdwatcher(route, &state.identities))
+            .map(|route| {
+                route_to_birdwatcher_with_primary(
+                    route,
+                    &state.identities,
+                    best.contains(&route_key(route)),
+                )
+            })
             .collect::<Vec<_>>(),
     })))
 }
@@ -1796,12 +1857,14 @@ fn render_rejected_route(
 
     // The retained AS_PATH is a lossless display string ("65001 {65002
     // 65003}"); birdwatcher wants an ASN array, so flatten it (AS_SET
-    // members included) best-effort.
-    let as_path: Vec<u32> = route
+    // members included) best-effort. Elements are strings, the same
+    // Bird's Eye shape the accepted-route views emit.
+    let as_path: Vec<String> = route
         .as_path
         .split(|c: char| !c.is_ascii_digit())
         .filter(|p| !p.is_empty())
-        .filter_map(|p| p.parse().ok())
+        .filter_map(|p| p.parse::<u32>().ok())
+        .map(|asn| asn.to_string())
         .collect();
 
     let from_protocol = identities.identity(peer).protocol;
@@ -1818,7 +1881,7 @@ fn render_rejected_route(
         "interface": "",
         "metric": 0,
         "age": age,
-        "type": ["BGP", "unicast", "univ"],
+        "type": ["BGP", "univ"],
         "primary": false,
         "learnt_from": peer.to_string(),
         "reject_reason": route.reason,
@@ -1831,8 +1894,11 @@ fn render_rejected_route(
             "origin": "",
             "as_path": as_path,
             "next_hop": route.next_hop,
-            "local_pref": 0,
-            "med": 0,
+            // Retention keeps no LOCAL_PREF/MED: render the effective
+            // default local preference (the same rule as the accepted
+            // views on a route without the attribute) and omit `med`,
+            // matching BIRD's absence semantics.
+            "local_pref": "100",
             "communities": communities,
             "large_communities": large_communities,
         }
@@ -2069,8 +2135,12 @@ fn format_connection(state: i32) -> &'static str {
 /// `metric`, `age`, `type`, `primary`, `learnt_from`, and `bgp` sub-object
 /// with `origin`, `as_path`, `next_hop`, `local_pref`, `med`, `communities`,
 /// `large_communities`.
+///
+/// `primary` reports what the response itself carries (`Route.best`);
+/// views whose upstream scope never marks best-ness pass an explicit
+/// value from a Loc-RIB lookup instead.
 fn route_to_birdwatcher(route: &proto::Route, identities: &IdentityResolver) -> Value {
-    route_to_birdwatcher_with_primary(route, identities, false)
+    route_to_birdwatcher_with_primary(route, identities, route.best)
 }
 
 fn route_to_birdwatcher_with_primary(
@@ -2117,15 +2187,26 @@ fn route_to_birdwatcher_with_primary(
         String::new()
     };
 
+    // Bird's Eye splits BIRD's `BGP.as_path` text, so path elements are
+    // strings, and BIRD assigns its default local preference at import,
+    // so a (string) `local_pref` prints for every route — the gRPC field
+    // carries the same effective value (default 100 when the attribute
+    // is absent). Both shapes are pinned by the populated oracle leg.
+    let as_path: Vec<String> = route.as_path.iter().map(u32::to_string).collect();
     let mut bgp = serde_json::json!({
         "origin": origin,
-        "as_path": route.as_path,
+        "as_path": as_path,
         "next_hop": route.next_hop,
-        "local_pref": route.local_pref,
-        "med": route.med,
+        "local_pref": route.local_pref.to_string(),
         "communities": communities,
         "large_communities": large_communities,
     });
+    // BIRD omits `BGP.med` entirely when the route carries no MED
+    // attribute; mirror that presence semantics from the wire-presence
+    // field (the bare `med` encodes absent as 0).
+    if let Some(med) = route.med_attr {
+        bgp["med"] = med.into();
+    }
     // Bird's Eye prints AGGREGATOR as "<address> AS<asn>" and
     // ATOMIC_AGGREGATE as a bare key (empty value), each only when the
     // route carries the attribute; mirror that presence semantics.
@@ -2143,7 +2224,8 @@ fn route_to_birdwatcher_with_primary(
         "interface": "",
         "metric": 0,
         "age": age,
-        "type": ["BGP", "unicast", "univ"],
+        // BIRD 2's `Type: BGP univ` pair, as Bird's Eye splits it.
+        "type": ["BGP", "univ"],
         "primary": primary,
         "learnt_from": route.peer_address,
         "bgp": bgp
@@ -2491,6 +2573,7 @@ mod tests {
             as_path: vec![65010, 65020],
             local_pref: 200,
             med: 50,
+            med_attr: Some(50),
             communities: vec![(65001 << 16) | 100],
             large_communities: vec!["65001:1:2".to_string()],
             // 2026-01-02 03:04:05 UTC
@@ -2510,11 +2593,14 @@ mod tests {
         assert_eq!(json["learnt_from"], "192.0.2.1");
         assert_eq!(json["age"], "2026-01-02 03:04:05");
         assert_eq!(json["primary"], false);
-        assert_eq!(json["type"], serde_json::json!(["BGP", "unicast", "univ"]));
+        assert_eq!(json["type"], serde_json::json!(["BGP", "univ"]));
         assert_eq!(json["bgp"]["origin"], "Incomplete");
-        assert_eq!(json["bgp"]["as_path"], serde_json::json!([65010, 65020]));
+        assert_eq!(
+            json["bgp"]["as_path"],
+            serde_json::json!(["65010", "65020"])
+        );
         assert_eq!(json["bgp"]["next_hop"], "192.0.2.1");
-        assert_eq!(json["bgp"]["local_pref"], 200);
+        assert_eq!(json["bgp"]["local_pref"], "200");
         assert_eq!(json["bgp"]["med"], 50);
         assert_eq!(
             json["bgp"]["communities"],
@@ -2536,10 +2622,18 @@ mod tests {
             prefix_length: 32,
             next_hop: "2001:db8::1".to_string(),
             peer_address: "2001:db8::1".to_string(),
+            local_pref: 100,
+            best: true,
             ..Default::default()
         };
         let json = route_to_birdwatcher(&route, &IdentityResolver::default());
         assert_eq!(json["network"], "2001:db8::/32");
+        // The response's own best flag is the primary marker.
+        assert_eq!(json["primary"], true);
+        // Effective local preference prints for every route; an absent
+        // MED attribute omits the key, matching BIRD.
+        assert_eq!(json["bgp"]["local_pref"], "100");
+        assert!(json["bgp"].get("med").is_none());
         // No receive timestamp → empty age (Alice-LG zero-time fallback).
         assert_eq!(json["age"], "");
         assert_eq!(json["from_protocol"], "bgp_2001_db8__1");
@@ -2606,8 +2700,13 @@ mod tests {
         assert_eq!(json["aspa_validation"], "unverified");
         assert_eq!(
             json["bgp"]["as_path"],
-            serde_json::json!([65020, 65030, 65031])
+            serde_json::json!(["65020", "65030", "65031"])
         );
+        // Retained rejects render the effective default local preference
+        // and omit the unretained MED, in the BIRD 2 type pair.
+        assert_eq!(json["bgp"]["local_pref"], "100");
+        assert!(json["bgp"].get("med").is_none());
+        assert_eq!(json["type"], serde_json::json!(["BGP", "univ"]));
         assert_eq!(
             json["bgp"]["communities"],
             serde_json::json!([[65001, 666]])
@@ -3041,8 +3140,8 @@ mod tests {
         assert_eq!(json["network"], "10.1.0.0/24");
         assert_eq!(json["gateway"], "192.0.2.9");
         assert_eq!(json["learnt_from"], "192.0.2.9");
-        assert_eq!(json["bgp"]["as_path"], serde_json::json!([65010]));
-        assert_eq!(json["bgp"]["local_pref"], 100);
+        assert_eq!(json["bgp"]["as_path"], serde_json::json!(["65010"]));
+        assert_eq!(json["bgp"]["local_pref"], "100");
         // …the stopping gate is surfaced as the reason…
         assert_eq!(json["noexport_reason"], "export_policy");
         assert_eq!(json["noexport_reason_detail"], "denied by term no-transit");
@@ -3320,6 +3419,7 @@ mod tests {
             prefix_length: 24,
             path_id,
             med,
+            med_attr: Some(med),
             ..Default::default()
         };
         for source in [ExactRouteSource::Received, ExactRouteSource::Advertised] {
@@ -3358,6 +3458,7 @@ mod tests {
             prefix_length: 24,
             peer_address: peer.to_string(),
             med,
+            med_attr: Some(med),
             ..Default::default()
         };
         let response = proto::ExplainBestPathResponse {

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2433,6 +2433,9 @@ message Route {
   string peer_address = 4;
   uint32 origin = 5;
   repeated uint32 as_path = 6;
+  // Effective local preference: the LOCAL_PREF attribute value when the
+  // route carries one, otherwise the default 100 the RIB applies during
+  // best-path selection. Wire-level presence is `local_pref_attr`.
   uint32 local_pref = 7;
   // Deprecated for absence-sensitive consumers: a bare integer cannot
   // distinguish "no MED attribute" from "MED 0" (absent encodes as 0).

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -1064,7 +1064,6 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     for route in live["routes"].as_array().unwrap() {
         assert_eq!(route["network"], "10.99.0.0/24", "{live}");
         assert_eq!(route["from_protocol"], "pb_0001_as65020", "{live}");
-        assert_eq!(route["primary"], false, "received views stay non-primary");
     }
     assert_eq!(
         live["routes"]
@@ -1075,6 +1074,16 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .collect::<Vec<_>>(),
         [10, 20],
         "Add-Path candidates must remain in daemon order: {live}"
+    );
+    assert_eq!(
+        live["routes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|route| route["primary"].as_bool().unwrap())
+            .collect::<Vec<_>>(),
+        [true, false],
+        "received view must mark the Loc-RIB winner primary: {live}"
     );
     let aliased_live = get_json(adapter_port, "/routes/protocol/pb_0001_as65020", "adapter");
     assert_eq!(

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -196,8 +196,8 @@ the adapter serves at `/` where Bird's Eye serves under `/api/` (IXP Manager's
 | `GET /api/symbols` | `symbols()` | `symbols` | served, divergent | only `protocol` and `routing table` classes; Bird's Eye emits every `show symbols` class |
 | `GET /api/symbols/tables` | — | — | not served | out of scope |
 | `GET /api/symbols/protocols` | — | — | not served | out of scope |
-| `GET /api/routes/protocol/{protocol}` | `routesForProtocol()` | `routes_protocol` | served, divergent | route shape: `bgp.as_path` integers (strings upstream), `bgp.local_pref` number (string upstream), `gateway` = next hop, `interface` `""`, `metric` `0`, `primary` `false`, `learnt_from` = peer address, `age` from receive time |
-| `GET /api/routes/table/{table}` | `routesForTable()` | `routes_table` | served, divergent | route shape as above but `primary` is real; table is a validated alias over one global Loc-RIB, not a BIRD table |
+| `GET /api/routes/protocol/{protocol}` | `routesForProtocol()` | `routes_protocol` | served, divergent | route shape: `gateway` = next hop, `interface` `""`, `metric` `0`, `learnt_from` = peer address, `age` from receive time |
+| `GET /api/routes/table/{table}` | `routesForTable()` | `routes_table` | served, divergent | route shape as above; table is a validated alias over one global Loc-RIB, not a BIRD table |
 | `GET /api/routes/export/{protocol}` | `routesForExport()` | `routes_export` | served, divergent | route shape as above |
 | `GET /api/routes/count/protocol/{protocol}` | — | — | not served | out of scope (`total_count` exists on the first RIB page, so it is a cheap add if scope grows) |
 | `GET /api/routes/count/table/{table}` | — | — | not served | out of scope; standing `full-table-count` blocker |
@@ -274,18 +274,18 @@ refuses any `runtime_compatibility` value other than `false` while any entry
 is classified `must_match`. The flag therefore flips only when zero
 `must_match` entries remain, and the post-flip claim language is "verified
 IXP Manager 7.4 Bird's Eye API compatibility with documented BIRD-internal
-divergences". The eight open `must_match` entries are the route-shape
-cluster (`bgp.as_path` element type, `bgp.local_pref`, `bgp.med` emitted
-when absent, `primary` outside the table view, the `type` triple), the two
-lookup-semantics entries (exact-versus-longest protocol/export match and the
-table lookup's HTTP 400 for host-bit input), and the ordinary-`(x, y)`
-lc-zwild scope.
+divergences". The open `must_match` entries are the two lookup-semantics
+entries (exact-versus-longest protocol/export match and the table lookup's
+HTTP 400 for host-bit input) and the ordinary-`(x, y)` lc-zwild scope; the
+route-shape cluster (`bgp.as_path` element type, `bgp.local_pref`,
+`bgp.med` emitted when absent, `primary` outside the table view, the `type`
+triple) converged on the oracle and its entries are removed.
 
 ### Work list
 
-Each line names the gap and the evidence that closes it. Items 1, 2, 6, 15,
+Each line names the gap and the evidence that closes it. Items 1 to 6, 15,
 and 16 are done; items 3 to 14 record what the oracle diff showed, with the
-observed JSON paths, and now carry their decisions: `must_match` entries
+observed JSON paths, and carry their decisions: `must_match` entries
 stay open and gate the flip, while `intentional`, `unsupported`, and
 `extension` entries are closed decisions that stay on the allow-list. Every
 observed
@@ -302,16 +302,19 @@ predicted eight more that the diff did not show, listed after the table.
    adapter shape, rationale, `consumer_visible`), pinned to a constant in
    `verify_capture.py`; the gate fails on an unlisted difference and on a stale
    entry, and re-proves both on every run.
-3. `bgp.as_path` element type: observed on every route view,
+3. Done. `bgp.as_path` element type: observed on every route view,
    `routes.*.bgp.as_path.*` strings upstream, integers from the adapter.
-   Decided: classified `must_match`; the adapter converges on the oracle's
-   element type and the entry is then removed.
-4. `bgp.local_pref`: observed as a type and meaning difference,
+   Was `must_match`; the adapter now emits string elements (the split
+   `BGP.as_path` text shape) and the entry is removed.
+4. Done. `bgp.local_pref`: observed as a type and meaning difference,
    `routes.*.bgp.local_pref` is the string `"100"` upstream (BIRD's default
    local preference assigned at import, also for the route announced with
    LOCAL_PREF 200, which both route servers ignore on the eBGP session) and the
-   number `0` from the adapter (the received attribute). Decided:
-   classified `must_match`.
+   number `0` from the adapter (the received attribute). Was `must_match`;
+   the gRPC projection now serves the effective local preference — the
+   attribute when present, otherwise the default 100 best-path selection
+   applies, with wire presence on `Route.local_pref_attr` — and the adapter
+   prints it as Bird's Eye's string; the entry is removed.
 5. Route sentinels: observed `routes.*.interface` (`"eth0"` vs `""`),
    `routes.*.metric` (BIRD preference `100` vs `0`), `routes.*.primary`
    (`true` for the best route in every upstream view, `false` from the adapter
@@ -324,8 +327,13 @@ predicted eight more that the diff did not show, listed after the table.
    `fixtures/birdseye-contract.json` come from `fake-birdc`'s BIRD 1 line
    format, not from BIRD 2. Decided: `interface`, `learnt_from`, and `metric`
    are `intentional` (BIRD-internal kernel and preference values a route
-   server cannot honestly fabricate); `primary` and the `type` triple are
-   `must_match`, as is the always-emitted `bgp.med`.
+   server cannot honestly fabricate); `primary`, the `type` triple, and the
+   always-emitted `bgp.med` were `must_match` and are done: `primary` now
+   reports the Loc-RIB selection in every view (the received, export, and
+   exact-route views join a `ListBestRoutes` identity set; the table views
+   already read it), `type` is the BIRD 2 `["BGP", "univ"]` pair, and
+   `bgp.med` is emitted only when the route carries the attribute
+   (`Route.med_attr` presence). Their entries are removed.
 6. Done. `bgp.aggregator` and `bgp.atomic_aggr`: the gRPC route detail
    carries the stored AGGREGATOR and ATOMIC_AGGREGATE path attributes
    (`Route.aggregator`, `Route.atomic_aggregate`) and the adapter renders

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -347,60 +347,6 @@
         "api/route/{net}/export/{protocol}",
         "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
       ],
-      "path": "routes.*.bgp.as_path.*",
-      "kind": "type",
-      "classification": "must_match",
-      "birdseye": "strings",
-      "adapter": "integers",
-      "rationale": "Bird's Eye splits the BGP.as_path text; the adapter emits the numeric path; the pinned route views implode either",
-      "consumer_visible": true
-    },
-    {
-      "endpoint": [
-        "api/routes/protocol/{protocol}",
-        "api/routes/table/{table}",
-        "api/routes/export/{protocol}",
-        "api/route/{net}/protocol/{protocol}",
-        "api/route/{net}/table/{table}",
-        "api/route/{net}/export/{protocol}",
-        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
-      ],
-      "path": "routes.*.bgp.local_pref",
-      "kind": "type",
-      "classification": "must_match",
-      "birdseye": "string \"100\" (BIRD's default local preference assigned at import)",
-      "adapter": "number 0 (the received attribute, absent on an eBGP session)",
-      "rationale": "type and meaning differ: BIRD prints a local preference for every route, the adapter prints the attribute that arrived",
-      "consumer_visible": true
-    },
-    {
-      "endpoint": [
-        "api/routes/protocol/{protocol}",
-        "api/routes/table/{table}",
-        "api/routes/export/{protocol}",
-        "api/route/{net}/protocol/{protocol}",
-        "api/route/{net}/table/{table}",
-        "api/route/{net}/export/{protocol}",
-        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
-      ],
-      "path": "routes.*.bgp.med",
-      "kind": "extra",
-      "classification": "must_match",
-      "birdseye": "absent when the route carries no MED",
-      "adapter": "0 when absent",
-      "rationale": "the adapter always emits med; equal whenever the attribute is present",
-      "consumer_visible": true
-    },
-    {
-      "endpoint": [
-        "api/routes/protocol/{protocol}",
-        "api/routes/table/{table}",
-        "api/routes/export/{protocol}",
-        "api/route/{net}/protocol/{protocol}",
-        "api/route/{net}/table/{table}",
-        "api/route/{net}/export/{protocol}",
-        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
-      ],
       "path": "routes.*.interface",
       "kind": "value",
       "classification": "intentional",
@@ -443,40 +389,6 @@
       "birdseye": "BIRD route preference (100)",
       "adapter": "0",
       "rationale": "BIRD-internal preference; the pinned route view prints metric",
-      "consumer_visible": true
-    },
-    {
-      "endpoint": [
-        "api/routes/protocol/{protocol}",
-        "api/routes/export/{protocol}",
-        "api/route/{net}/protocol/{protocol}",
-        "api/route/{net}/export/{protocol}",
-        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
-      ],
-      "path": "routes.*.primary",
-      "kind": "value",
-      "classification": "must_match",
-      "birdseye": "true for the best route in every view",
-      "adapter": "false outside the table view",
-      "rationale": "the adapter reports primary only where it reads the Loc-RIB; the pinned route view prints it",
-      "consumer_visible": true
-    },
-    {
-      "endpoint": [
-        "api/routes/protocol/{protocol}",
-        "api/routes/table/{table}",
-        "api/routes/export/{protocol}",
-        "api/route/{net}/protocol/{protocol}",
-        "api/route/{net}/table/{table}",
-        "api/route/{net}/export/{protocol}",
-        "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
-      ],
-      "path": "routes.*.type.*",
-      "kind": "semantics",
-      "classification": "must_match",
-      "birdseye": "[\"BGP\", \"univ\"] (BIRD 2 Type: BGP univ)",
-      "adapter": "[\"BGP\", \"unicast\", \"univ\"] (BIRD 1 shape)",
-      "rationale": "the adapter keeps the BIRD 1 type triple; the pinned route view prints the list",
       "consumer_visible": true
     },
     {

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
@@ -28,7 +28,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64497
+                "64497"
               ],
               "communities": [
                 [
@@ -43,8 +43,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "198.51.100.4",
               "origin": "IGP"
             },
@@ -54,10 +53,9 @@
             "learnt_from": "198.51.100.4",
             "metric": 0,
             "network": "192.0.2.0/24",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -79,8 +77,8 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64497,
-                64530
+                "64497",
+                "64530"
               ],
               "communities": [
                 [
@@ -95,7 +93,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 5,
               "next_hop": "2001:db8:5100::4",
               "origin": "IGP"
@@ -106,10 +104,9 @@
             "learnt_from": "2001:db8:5100::4",
             "metric": 0,
             "network": "2001:db8:c::/48",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -144,9 +141,9 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496,
-                64510,
-                64520
+                "64496",
+                "64510",
+                "64520"
               ],
               "communities": [
                 [
@@ -170,7 +167,7 @@
                   2
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 10,
               "next_hop": "198.51.100.2",
               "origin": "IGP"
@@ -181,10 +178,9 @@
             "learnt_from": "198.51.100.2",
             "metric": 0,
             "network": "203.0.113.0/24",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -219,8 +215,8 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496,
-                64510
+                "64496",
+                "64510"
               ],
               "communities": [
                 [
@@ -235,7 +231,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 20,
               "next_hop": "2001:db8:5100::2",
               "origin": "IGP"
@@ -246,10 +242,9 @@
             "learnt_from": "2001:db8:5100::2",
             "metric": 0,
             "network": "2001:db8:a::/48",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -271,7 +266,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496
+                "64496"
               ],
               "communities": [
                 [
@@ -286,8 +281,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "198.51.100.2",
               "origin": "IGP"
             },
@@ -300,7 +294,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -322,7 +315,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496
+                "64496"
               ],
               "communities": [
                 [
@@ -337,8 +330,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "198.51.100.2",
               "origin": "IGP"
             },
@@ -351,7 +343,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -377,8 +368,8 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64497,
-                64530
+                "64497",
+                "64530"
               ],
               "communities": [
                 [
@@ -393,7 +384,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 5,
               "next_hop": "2001:db8:5100::4",
               "origin": "IGP"
@@ -407,7 +398,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -647,7 +637,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64497
+                "64497"
               ],
               "communities": [
                 [
@@ -662,8 +652,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "198.51.100.4",
               "origin": "IGP"
             },
@@ -673,10 +662,9 @@
             "learnt_from": "198.51.100.4",
             "metric": 0,
             "network": "192.0.2.0/24",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -698,8 +686,8 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64497,
-                64530
+                "64497",
+                "64530"
               ],
               "communities": [
                 [
@@ -714,7 +702,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 5,
               "next_hop": "2001:db8:5100::4",
               "origin": "IGP"
@@ -725,10 +713,9 @@
             "learnt_from": "2001:db8:5100::4",
             "metric": 0,
             "network": "2001:db8:c::/48",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -750,9 +737,9 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496,
-                64510,
-                64520
+                "64496",
+                "64510",
+                "64520"
               ],
               "communities": [
                 [
@@ -776,7 +763,7 @@
                   2
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 10,
               "next_hop": "198.51.100.2",
               "origin": "IGP"
@@ -787,10 +774,9 @@
             "learnt_from": "198.51.100.2",
             "metric": 0,
             "network": "203.0.113.0/24",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -798,7 +784,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496
+                "64496"
               ],
               "communities": [
                 [
@@ -813,8 +799,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "198.51.100.2",
               "origin": "IGP"
             },
@@ -824,10 +809,9 @@
             "learnt_from": "198.51.100.2",
             "metric": 0,
             "network": "203.0.113.128/25",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -836,12 +820,12 @@
             "bgp": {
               "aggregator": "203.0.113.1 AS64496",
               "as_path": [
-                64496
+                "64496"
               ],
               "atomic_aggr": "",
               "communities": [],
               "large_communities": [],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 30,
               "next_hop": "198.51.100.2",
               "origin": "Incomplete"
@@ -852,10 +836,9 @@
             "learnt_from": "198.51.100.2",
             "metric": 0,
             "network": "203.0.113.64/26",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -877,8 +860,8 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496,
-                64510
+                "64496",
+                "64510"
               ],
               "communities": [
                 [
@@ -893,7 +876,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 20,
               "next_hop": "2001:db8:5100::2",
               "origin": "IGP"
@@ -904,10 +887,9 @@
             "learnt_from": "2001:db8:5100::2",
             "metric": 0,
             "network": "2001:db8:a::/48",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -915,7 +897,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496
+                "64496"
               ],
               "communities": [
                 [
@@ -930,8 +912,7 @@
                   2
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "2001:db8:5100::2",
               "origin": "EGP"
             },
@@ -941,10 +922,9 @@
             "learnt_from": "2001:db8:5100::2",
             "metric": 0,
             "network": "2001:db8:b::/48",
-            "primary": false,
+            "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -966,7 +946,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64497
+                "64497"
               ],
               "communities": [
                 [
@@ -981,8 +961,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "198.51.100.4",
               "origin": "IGP"
             },
@@ -995,7 +974,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -1003,9 +981,9 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496,
-                64510,
-                64520
+                "64496",
+                "64510",
+                "64520"
               ],
               "communities": [
                 [
@@ -1029,7 +1007,7 @@
                   2
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 10,
               "next_hop": "198.51.100.2",
               "origin": "IGP"
@@ -1043,7 +1021,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -1051,7 +1028,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496
+                "64496"
               ],
               "communities": [
                 [
@@ -1066,8 +1043,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "198.51.100.2",
               "origin": "IGP"
             },
@@ -1080,7 +1056,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -1089,12 +1064,12 @@
             "bgp": {
               "aggregator": "203.0.113.1 AS64496",
               "as_path": [
-                64496
+                "64496"
               ],
               "atomic_aggr": "",
               "communities": [],
               "large_communities": [],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 30,
               "next_hop": "198.51.100.2",
               "origin": "Incomplete"
@@ -1108,7 +1083,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }
@@ -1130,8 +1104,8 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496,
-                64510
+                "64496",
+                "64510"
               ],
               "communities": [
                 [
@@ -1146,7 +1120,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 20,
               "next_hop": "2001:db8:5100::2",
               "origin": "IGP"
@@ -1160,7 +1134,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -1168,7 +1141,7 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64496
+                "64496"
               ],
               "communities": [
                 [
@@ -1183,8 +1156,7 @@
                   2
                 ]
               ],
-              "local_pref": 0,
-              "med": 0,
+              "local_pref": "100",
               "next_hop": "2001:db8:5100::2",
               "origin": "EGP"
             },
@@ -1197,7 +1169,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           },
@@ -1205,8 +1176,8 @@
             "age": "<timestamp>",
             "bgp": {
               "as_path": [
-                64497,
-                64530
+                "64497",
+                "64530"
               ],
               "communities": [
                 [
@@ -1221,7 +1192,7 @@
                   1
                 ]
               ],
-              "local_pref": 0,
+              "local_pref": "100",
               "med": 5,
               "next_hop": "2001:db8:5100::4",
               "origin": "IGP"
@@ -1235,7 +1206,6 @@
             "primary": true,
             "type": [
               "BGP",
-              "unicast",
               "univ"
             ]
           }

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -179,11 +179,6 @@ ROUTE_VIEWS = [
     "api/route/{net}/table/{table}", "api/route/{net}/export/{protocol}",
     "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
 ]
-NON_TABLE_ROUTE_VIEWS = [
-    "api/routes/protocol/{protocol}", "api/routes/export/{protocol}",
-    "api/route/{net}/protocol/{protocol}", "api/route/{net}/export/{protocol}",
-    "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
-]
 LC_ZWILD = "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}"
 
 
@@ -294,28 +289,6 @@ RUNTIME_DIVERGENCES = [
         "consumer_visible": True,
     },
     {
-        "endpoint": ROUTE_VIEWS, "path": "routes.*.bgp.as_path.*", "kind": "type",
-        "classification": "must_match",
-        "birdseye": "strings", "adapter": "integers",
-        "rationale": "Bird's Eye splits the BGP.as_path text; the adapter emits the numeric path; the pinned route views implode either",
-        "consumer_visible": True,
-    },
-    {
-        "endpoint": ROUTE_VIEWS, "path": "routes.*.bgp.local_pref", "kind": "type",
-        "classification": "must_match",
-        "birdseye": "string \"100\" (BIRD's default local preference assigned at import)",
-        "adapter": "number 0 (the received attribute, absent on an eBGP session)",
-        "rationale": "type and meaning differ: BIRD prints a local preference for every route, the adapter prints the attribute that arrived",
-        "consumer_visible": True,
-    },
-    {
-        "endpoint": ROUTE_VIEWS, "path": "routes.*.bgp.med", "kind": "extra",
-        "classification": "must_match",
-        "birdseye": "absent when the route carries no MED", "adapter": "0 when absent",
-        "rationale": "the adapter always emits med; equal whenever the attribute is present",
-        "consumer_visible": True,
-    },
-    {
         "endpoint": ROUTE_VIEWS, "path": "routes.*.interface", "kind": "value",
         "classification": "intentional",
         "birdseye": "BIRD egress interface (eth0)", "adapter": "\"\"",
@@ -334,20 +307,6 @@ RUNTIME_DIVERGENCES = [
         "classification": "intentional",
         "birdseye": "BIRD route preference (100)", "adapter": "0",
         "rationale": "BIRD-internal preference; the pinned route view prints metric",
-        "consumer_visible": True,
-    },
-    {
-        "endpoint": NON_TABLE_ROUTE_VIEWS, "path": "routes.*.primary", "kind": "value",
-        "classification": "must_match",
-        "birdseye": "true for the best route in every view", "adapter": "false outside the table view",
-        "rationale": "the adapter reports primary only where it reads the Loc-RIB; the pinned route view prints it",
-        "consumer_visible": True,
-    },
-    {
-        "endpoint": ROUTE_VIEWS, "path": "routes.*.type.*", "kind": "semantics",
-        "classification": "must_match",
-        "birdseye": "[\"BGP\", \"univ\"] (BIRD 2 Type: BGP univ)", "adapter": "[\"BGP\", \"unicast\", \"univ\"] (BIRD 1 shape)",
-        "rationale": "the adapter keeps the BIRD 1 type triple; the pinned route view prints the list",
         "consumer_visible": True,
     },
     {


### PR DESCRIPTION
Closes the Bird's Eye compatibility profile's route-shape `must_match` cluster (LAN-1232): the five pinned oracle/live route-shape divergences converge on the oracle's byte shapes and their allow-list entries are removed (29 → 24; the 3 remaining `must_match` entries are the two lookup-semantics gaps and the ordinary-`(x, y)` lc-zwild scope).

## The five gaps

| Gap | Before (live) | After (live = oracle) |
|---|---|---|
| `bgp.as_path` element type | `"as_path": [64496, 64510, 64520]` | `"as_path": ["64496", "64510", "64520"]` |
| `bgp.local_pref` | `"local_pref": 0` (received attribute; absent on eBGP) | `"local_pref": "100"` (effective value as Bird's Eye's string) |
| `bgp.med` absence | `"med": 0` when the attribute is absent | key omitted when absent (`"med": 10` unchanged when present) |
| route `type` | `"type": ["BGP", "unicast", "univ"]` (BIRD 1 triple) | `"type": ["BGP", "univ"]` (BIRD 2 pair) |
| `primary` | `false` outside the table view | `true` for the Loc-RIB selection in every view |

## gRPC projection change (operator-visible)

`route_to_proto` in `crates/api/src/rib_service.rs` initialized `local_pref = 0` when the attribute is absent, while the RIB's `Route::local_pref()` documents (and best-path selection uses) the effective default 100. The projection now serves the EFFECTIVE value: the attribute when present, otherwise 100. Wire-level presence was already carried by the existing `optional uint32 local_pref_attr = 16` (and MED absence by `optional uint32 med_attr = 18`), so **no new proto fields were needed** — both absence markers shipped earlier (M35 / LAN-313). The `local_pref = 7` field's doc comment now records the effective semantics; comments are stripped before the stable-surface `message_graph_sha256`, so the digest is unchanged (`check-v1-stable-surface.py` green, no textual digest edit required).

Consumer sweep of `Route.local_pref` (visible impact):

- `rbgp rib` table (`crates/cli/src/output.rs`) and JSON (`crates/cli/src/commands/rib.rs`): display `local_pref` directly with no 0-as-absent special case — eBGP routes without the attribute now show `100` instead of `0`. `local_pref_attr` rendering is unchanged (JSON emits it only when present).
- TUI (`crates/cli/src/tui/ui.rs`): reads `local_pref_attr`, not `local_pref` — unaffected.
- `ribsnap` / `ribsnap_bmp`: decode BMP/wire data into their own `Option<u32>` — unaffected.
- Interop scripts asserting `local_pref` via the API (e.g. M83) do so under explicit `set_local_pref` policy — value unchanged. M35 asserts through `local_pref_attr` — unaffected.
- No consumer special-cased 0-as-absent, so no consumer display logic changed.

## Adapter changes (`examples/birdwatcher-adapter`)

- `route_to_birdwatcher` renders as_path elements as strings, `local_pref` as the effective value's string, `med` only when `Route.med_attr` is present, and the BIRD 2 `["BGP", "univ"]` type pair.
- `primary`: the received (`/routes/protocol`, `/routes/peer`), export, and exact-route views join a `ListBestRoutes` identity set (`(prefix, prefix_length, source peer, path_id)`; prefix-filtered for the exact lookups) and mark the Loc-RIB selection; the table views already read it. `route_to_birdwatcher` otherwise reports the response's own `Route.best` flag, which also makes the Alice-LG noexport view (built from `ListBestRoutes`) truthful.
- Retained-reject renders (filtered / lc-zwild views) use the same shapes: string as_path, type pair, `"local_pref": "100"` (the effective-default rule; the retention store keeps no LOCAL_PREF/MED), `med` omitted.

## Oracle proof

Baseline (unmodified tree, `tests/compat/ixp-manager-birdseye/run.sh`, rc 0):

```
populated oracle proof: 24 journeys over 11 endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; 29 allow-listed divergences (8 must_match, 12 intentional, 2 unsupported, 7 extension), 0 unlisted, 0 stale; 27 pinned routes/web.php routes accounted for
```

Post-change (rc 0):

```
populated oracle proof: 24 journeys over 11 endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; 24 allow-listed divergences (3 must_match, 12 intentional, 2 unsupported, 7 extension), 0 unlisted, 0 stale; 27 pinned routes/web.php routes accounted for
```

`fixtures/populated-live.json` regenerated via the harness's `CAPTURE_FIXTURES=1` mode; `populated-oracle.json`, `birdseye-contract.json`, and `ixp-manager-consumer.json` captures verified byte-identical to their pinned copies. The allow-list is updated in both `contract.json` and the pinned `verify_capture.py` constant (the gate proves them equal, fail-closed per entry).

## Gates

| Gate | Result |
|---|---|
| baseline `run.sh` (pre-change) | rc 0, 29 (8 must_match), 0 unlisted, 0 stale |
| post-change `run.sh` | rc 0, 24 (3 must_match), 0 unlisted, 0 stale |
| `cargo fmt --all -- --check` | rc 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | rc 0 |
| `cargo test --workspace --no-fail-fast` | rc 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | rc 0 |
| `scripts/check-clippy-reasons.py` | rc 0 |
| `scripts/check_public_tracker_ids.py` | rc 0 |
| `scripts/check-v1-stable-surface.py` | rc 0 (digest unchanged — no proto field changes) |
| `cargo test -p rustbgpd-api authz` | rc 0 |
