### PR TITLE
test: scope the tight settlement budget to armed rows and keep fail-stop evidence on panic

### DIFF
--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -36,7 +36,10 @@ pub mod settlement_test_control {
     const RECEIPT: &str = "receipt.v1";
     const RELEASE: &str = "release.v1";
     const MIN_BUDGET_MS: u64 = 250;
-    const MAX_BUDGET_MS: u64 = 10_000;
+    // Wide enough that a test can grant its un-armed setup mutations a
+    // budget its own harness timeouts always undercut, while the armed
+    // settlement keeps a tight one (see `registration_budget`).
+    const MAX_BUDGET_MS: u64 = 60_000;
     const MIN_GRACE_MS: u64 = 100;
     const MAX_GRACE_MS: u64 = 5_000;
     const MAX_CONTROL_FILE_BYTES: usize = 1_024;
@@ -227,6 +230,19 @@ pub mod settlement_test_control {
         ControlDirectory::from_environment(true)
             .unwrap_or_else(|error| panic!("settlement_test_control setup error: {error}"))
             .map(|control| (control.settings.budget, control.settings.grace))
+    }
+
+    /// Budget for a settlement registered right now, re-read from the
+    /// control directory. Tests rewrite `settings.v1` between their setup
+    /// mutations and the armed checkpoint so that only the armed settlement
+    /// runs under the tight budget; a loaded box therefore cannot fail-stop
+    /// an un-held setup mutation. Grace is intentionally not re-read: it
+    /// stays fixed at watchdog start.
+    #[must_use]
+    pub fn registration_budget() -> Option<Duration> {
+        ControlDirectory::from_environment(false)
+            .unwrap_or_else(|error| panic!("settlement_test_control error: {error}"))
+            .map(|control| control.settings.budget)
     }
 
     pub async fn hold(checkpoint: Checkpoint) {
@@ -455,6 +471,7 @@ pub mod settlement_test_control {
             for invalid in [
                 "version=wrong\nbudget_ms=250\ngrace_ms=100\n",
                 &format!("version={CONTROL_VERSION}\nbudget_ms=249\ngrace_ms=100\n"),
+                &format!("version={CONTROL_VERSION}\nbudget_ms=60001\ngrace_ms=100\n"),
                 &format!("version={CONTROL_VERSION}\nbudget_ms=250\ngrace_ms=5001\n"),
                 &format!("version={CONTROL_VERSION}\nbudget_ms=250\nbudget_ms=251\ngrace_ms=100\n"),
             ] {
@@ -810,6 +827,14 @@ impl OperationInner {
         fence_reason_from_state(self.state.load(Ordering::Acquire))
     }
 
+    /// Budget granted at registration, derived from the immutable deadline.
+    /// Debug builds may register under a control-directory budget that
+    /// differs from the watchdog default, so display sites must not read
+    /// the registry value.
+    fn budget(&self) -> Duration {
+        self.deadline.saturating_duration_since(self.registered_at)
+    }
+
     /// Elapsed ownership time, derived on every call from the stored
     /// `registered_at` instant. Nothing stores an elapsed value at phase
     /// transitions, so a wedged owner still reads a growing elapsed on a
@@ -1034,7 +1059,7 @@ impl Collector for RuntimeConfigSettlementCollector {
             .set(operation.elapsed().as_secs_f64());
         self.budget
             .with_label_values(&labels)
-            .set(self.registry.budget.as_secs_f64());
+            .set(operation.budget().as_secs_f64());
         // The sole recovery-fenced owner cannot settle, and its fatal clock
         // exits this process. The process-lifetime counter therefore moves
         // only from 0 to 1; a fence-reason label change is a distinct series.
@@ -1114,6 +1139,18 @@ impl RuntimeConfigSettlementWatchdog {
             .expect("runtime-config settlement metric definitions must be unique");
     }
 
+    /// Budget for a settlement registered right now. Debug builds re-read
+    /// the settlement-test control directory so a test can tighten the
+    /// budget for exactly the settlement it arms; everything else uses the
+    /// fixed watchdog budget.
+    fn registration_budget(&self) -> Duration {
+        #[cfg(all(debug_assertions, not(test)))]
+        if let Some(budget) = settlement_test_control::registration_budget() {
+            return budget;
+        }
+        self.registry.budget
+    }
+
     #[expect(
         clippy::too_many_arguments,
         reason = "the closed ownership registration lists every retained fail-stop resource explicitly"
@@ -1134,7 +1171,7 @@ impl RuntimeConfigSettlementWatchdog {
         response_attached: Arc<AtomicBool>,
     ) -> (OwnedRuntimeConfigOperation, RuntimeConfigExecutorGuard) {
         let registered_at = Instant::now();
-        let deadline = registered_at + self.registry.budget;
+        let deadline = registered_at + self.registration_budget();
         let id = self.registry.next_id.fetch_add(1, Ordering::Relaxed);
         let operation = Arc::new(OperationInner {
             id,
@@ -1172,7 +1209,7 @@ impl RuntimeConfigSettlementWatchdog {
             kind = operation.kind.as_str(),
             phase = operation.phase().as_str(),
             elapsed_seconds = operation.elapsed().as_secs(),
-            budget_seconds = self.registry.budget.as_secs(),
+            budget_seconds = operation.budget().as_secs(),
             "runtime config settlement ownership registered"
         );
         self.registry.wake.notify_one();
@@ -1382,7 +1419,7 @@ impl OwnedRuntimeConfigOperation {
                         kind = self.inner.kind.as_str(),
                         phase = phase.as_str(),
                         elapsed_seconds = self.inner.elapsed().as_secs(),
-                        budget_seconds = self.inner.registry.budget.as_secs(),
+                        budget_seconds = self.inner.budget().as_secs(),
                         "runtime config settlement phase advanced"
                     );
                     return;
@@ -1436,7 +1473,7 @@ impl OwnedRuntimeConfigOperation {
             kind = self.inner.kind.as_str(),
             phase = self.inner.phase().as_str(),
             elapsed_seconds = self.inner.elapsed().as_secs(),
-            budget_seconds = self.inner.registry.budget.as_secs(),
+            budget_seconds = self.inner.budget().as_secs(),
             "runtime config settlement settled"
         );
         self.inner.registry.current.store(None);
@@ -1538,7 +1575,7 @@ fn propagate_fence(operation: &OperationInner) {
         kind = operation.kind.as_str(),
         phase = operation.phase().as_str(),
         elapsed_seconds = operation.elapsed().as_secs(),
-        budget_seconds = operation.registry.budget.as_secs(),
+        budget_seconds = operation.budget().as_secs(),
         response_attached = if operation.response_attached.load(Ordering::Acquire) {
             "attached"
         } else {
@@ -1607,7 +1644,7 @@ fn emit_due_warnings(operation: &OperationInner, now: Instant) {
                 kind = operation.kind.as_str(),
                 phase = operation.phase().as_str(),
                 elapsed_seconds = elapsed.as_secs(),
-                budget_seconds = operation.registry.budget.as_secs(),
+                budget_seconds = operation.budget().as_secs(),
                 response_attached = if operation.response_attached.load(Ordering::Acquire) {
                     "attached"
                 } else {

--- a/tests/runtime_config_persistence_failstop.rs
+++ b/tests/runtime_config_persistence_failstop.rs
@@ -1,5 +1,7 @@
 //! Real-daemon proof for typed config-publication failures.
 
+mod support;
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -11,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;
+
+use support::{RetainOnPanic, rbgp_binary};
 
 const FIRST_NEIGHBOR: &str = "192.0.2.1";
 const SECOND_NEIGHBOR: &str = "192.0.2.2";
@@ -91,14 +95,7 @@ impl Drop for Daemon {
 }
 
 fn rbgp_command(grpc_addr: &str, args: &[&str]) -> Command {
-    let mut command = if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
-        Command::new(path)
-    } else {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let mut command = Command::new(cargo);
-        command.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"]);
-        command
-    };
+    let mut command = Command::new(rbgp_binary());
     command.arg("--addr").arg(grpc_addr).args(args);
     command
 }
@@ -224,12 +221,12 @@ fn wait_until_ready(addr: SocketAddr, daemon: &mut Daemon, expected: u16) {
     );
 }
 
-fn wait_output(mut child: Child, timeout: Duration) -> Output {
+fn wait_output(mut child: Child, timeout: Duration, context: &str) -> Output {
     let deadline = Instant::now() + timeout;
     while child.try_wait().expect("query rbgp status").is_none() {
         if Instant::now() >= deadline {
             let _ = child.kill();
-            panic!("rbgp did not finish before fail-stop deadline");
+            panic!("rbgp ({context}) did not finish within {timeout:?}");
         }
         thread::sleep(Duration::from_millis(20));
     }
@@ -265,7 +262,7 @@ principal = "rustbgpd://operator/persistence-failstop-test"
 }
 
 fn exercise(fault: &str, published: bool) {
-    let dir = tempfile::tempdir().expect("create test dir");
+    let dir = RetainOnPanic::new(tempfile::tempdir().expect("create test dir"));
     std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
     let runtime_dir = dir.path().join("runtime");
     std::fs::create_dir(&runtime_dir).unwrap();
@@ -314,7 +311,11 @@ fn exercise(fault: &str, published: bool) {
     .spawn()
     .expect("start rejected mutation");
 
-    let second = wait_output(second, Duration::from_secs(2));
+    let second = wait_output(
+        second,
+        Duration::from_secs(2),
+        "grace-window rejected mutation",
+    );
     assert!(
         !second.status.success(),
         "second mutation unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
@@ -333,7 +334,15 @@ fn exercise(fault: &str, published: bool) {
         recovery_fenced_at.elapsed() <= FAILSTOP_GRACE_WITH_JITTER,
         "exit 70 exceeded the five-second grace plus test jitter"
     );
-    assert!(!wait_output(first, Duration::from_secs(2)).status.success());
+    assert!(
+        !wait_output(
+            first,
+            Duration::from_secs(10),
+            "settling mutation after fail-stop"
+        )
+        .status
+        .success()
+    );
 
     let bytes = std::fs::read(&config_path).expect("read persisted config");
     assert!(!bytes.is_empty(), "published config must never be empty");
@@ -367,7 +376,7 @@ fn post_rename_failure_fences_and_restart_loads_complete_candidate() {
 }
 
 fn exercise_sighup_ack_loss(fault: &str) {
-    let dir = tempfile::tempdir().expect("create test dir");
+    let dir = RetainOnPanic::new(tempfile::tempdir().expect("create test dir"));
     let runtime_dir = dir.path().join("runtime");
     std::fs::create_dir(&runtime_dir).unwrap();
     let config_path = dir.path().join("rustbgpd.toml");

--- a/tests/runtime_config_settlement_matrix.rs
+++ b/tests/runtime_config_settlement_matrix.rs
@@ -1,5 +1,7 @@
 //! Real-daemon matrix for deterministic settlement-budget fail-stop coverage.
 
+mod support;
+
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -7,7 +9,7 @@ use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
-use std::sync::{OnceLock, mpsc};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -19,6 +21,8 @@ use rustbgpd_api::proto::{
 };
 use tonic::{Code, Request, Status, transport::Endpoint};
 
+use support::{RetainOnPanic, rbgp_binary};
+
 const CONTROL_ENV: &str = "RUSTBGPD_TEST_SETTLEMENT_CONTROL_DIR";
 const CONTROL_VERSION: &str = "settlement-control-v1";
 const SETTINGS: &str = "settings.v1";
@@ -27,6 +31,12 @@ const CLAIMED: &str = "claimed.v1";
 const RECEIPT: &str = "receipt.v1";
 const RELEASE: &str = "release.v1";
 const BUDGET: Duration = Duration::from_secs(2);
+// Budget in force for every settlement registered before a row arms its
+// checkpoint. Strictly larger than every harness command timeout, so the
+// watchdog can never fail-stop an un-held setup mutation on a starved box:
+// a stalled setup hits the harness's own bound (with the directory
+// retained) instead of killing the daemon mid-RPC.
+const SETUP_BUDGET: Duration = Duration::from_secs(30);
 const GRACE: Duration = Duration::from_millis(500);
 const EXIT_JITTER: Duration = Duration::from_secs(2);
 const MATRIX_LIMIT: Duration = Duration::from_secs(120);
@@ -262,20 +272,25 @@ impl Control {
         let dir = root.join("settlement-control");
         std::fs::create_dir(&dir).expect("create settlement control directory");
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let control = Self {
+            dir,
+            nonce: format!("{ordinal:032x}"),
+        };
+        control.write_settings(SETUP_BUDGET);
+        control
+    }
+
+    fn write_settings(&self, budget: Duration) {
         atomic_write(
-            &dir,
+            &self.dir,
             SETTINGS,
             format!(
                 "version={CONTROL_VERSION}\nbudget_ms={}\ngrace_ms={}\n",
-                BUDGET.as_millis(),
+                budget.as_millis(),
                 GRACE.as_millis()
             )
             .as_bytes(),
         );
-        Self {
-            dir,
-            nonce: format!("{ordinal:032x}"),
-        }
     }
 
     fn command(&self, checkpoint: &str) -> String {
@@ -289,13 +304,17 @@ impl Control {
         for forbidden in [ARM, CLAIMED, RECEIPT, RELEASE] {
             assert!(!self.dir.join(forbidden).exists());
         }
+        // The daemon re-reads the budget at every settlement registration,
+        // so tightening here scopes the 2 s budget to exactly the armed
+        // settlement; everything registered earlier ran under SETUP_BUDGET.
+        self.write_settings(BUDGET);
         atomic_write(&self.dir, ARM, self.command(checkpoint).as_bytes());
     }
 
     fn wait_for_receipt(&self, checkpoint: &str, pid: u32, daemon: &mut Daemon) {
         let expected_command = self.command(checkpoint);
         let expected_receipt = format!("{expected_command}pid={pid}\n");
-        let deadline = Instant::now() + Duration::from_secs(4);
+        let deadline = Instant::now() + Duration::from_secs(10);
         loop {
             if let Ok(receipt) = std::fs::read_to_string(self.dir.join(RECEIPT)) {
                 assert_eq!(receipt, expected_receipt);
@@ -354,7 +373,7 @@ fn atomic_write(directory: &Path, name: &str, bytes: &[u8]) {
 }
 
 struct Lab {
-    _root: tempfile::TempDir,
+    root: RetainOnPanic,
     config: PathBuf,
     grpc: String,
     grpc_tcp: SocketAddr,
@@ -384,7 +403,7 @@ impl Lab {
         Self {
             grpc: format!("unix://{}", runtime.join("grpc.sock").display()),
             grpc_tcp,
-            _root: root,
+            root: RetainOnPanic::new(root),
             config,
             metrics,
             control,
@@ -395,7 +414,7 @@ impl Lab {
     fn spawn(&self, name: &str, controlled: bool) -> Daemon {
         Daemon::spawn(
             &self.config,
-            self._root.path().join(format!("{name}.log")),
+            self.root.path().join(format!("{name}.log")),
             controlled.then_some(self.control.dir.as_path()),
         )
     }
@@ -422,7 +441,7 @@ impl Lab {
     }
 
     fn candidate(&self, name: &str) -> PathBuf {
-        let path = self._root.path().join(format!("{name}.toml"));
+        let path = self.root.path().join(format!("{name}.toml"));
         std::fs::write(
             &path,
             format!(
@@ -471,27 +490,6 @@ fn rbgp_command(grpc: &str, args: &[&str]) -> Command {
     let mut command = Command::new(rbgp_binary());
     command.arg("--addr").arg(grpc).args(args);
     command
-}
-
-fn rbgp_binary() -> &'static Path {
-    static RBGP: OnceLock<PathBuf> = OnceLock::new();
-    RBGP.get_or_init(|| {
-        let path = std::env::var_os("CARGO_BIN_EXE_rbgp").map_or_else(
-            || {
-                Path::new(env!("CARGO_BIN_EXE_rustbgpd"))
-                    .parent()
-                    .expect("rustbgpd binary has a profile directory")
-                    .join("rbgp")
-            },
-            PathBuf::from,
-        );
-        assert!(
-            path.is_file(),
-            "build rbgp before this matrix; missing {}",
-            path.display()
-        );
-        path
-    })
 }
 
 fn unused_loopback_addr() -> SocketAddr {
@@ -830,7 +828,7 @@ fn apply_confirmed(lab: &Lab, candidate: &Path) {
         "--confirm-id",
         "matrix-auto-revert",
         "--confirm-timeout",
-        "2",
+        "4",
     ]);
     assert!(
         output.status.success(),
@@ -878,7 +876,7 @@ fn wait_metrics_idle(addr: SocketAddr, daemon: &mut Daemon) {
 }
 
 fn exercise_peer_group(lab: &Lab, daemon: &mut Daemon) -> RowResult {
-    let definition = lab._root.path().join("peer-group.json");
+    let definition = lab.root.path().join("peer-group.json");
     std::fs::write(
         &definition,
         r#"{"families":["ipv4_unicast"],"route_server_client":true}"#,
@@ -907,7 +905,7 @@ fn exercise_peer_group(lab: &Lab, daemon: &mut Daemon) -> RowResult {
 }
 
 fn exercise_policy(lab: &Lab, daemon: &mut Daemon) -> RowResult {
-    let definition = lab._root.path().join("policy.json");
+    let definition = lab.root.path().join("policy.json");
     std::fs::write(
         &definition,
         r#"{"default_action":"permit","statements":[]}"#,
@@ -984,7 +982,7 @@ fn finish_row(lab: &Lab, row: MatrixRow, daemon: &mut Daemon, result: RowResult)
             wait_ready_and_idle(lab.metrics, &mut restarted);
             lab.assert_disk("auto-candidate", false);
             assert!(
-                std::fs::read_to_string(lab._root.path().join("rustbgpd.toml.unconfirmed"))
+                std::fs::read_to_string(lab.root.path().join("rustbgpd.toml.unconfirmed"))
                     .unwrap()
                     .contains("auto-candidate")
             );

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,72 @@
+//! Shared harness pieces for the real-daemon fail-stop integration tests.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Temporary test directory that survives on panic.
+///
+/// The daemon under test writes its log inside the test's temporary
+/// directory, so dropping that directory on an assertion failure destroys
+/// the only evidence of why the daemon misbehaved. This guard disarms
+/// cleanup while the thread is panicking and names the retained path in the
+/// captured test output.
+pub struct RetainOnPanic {
+    dir: Option<tempfile::TempDir>,
+}
+
+impl RetainOnPanic {
+    pub fn new(dir: tempfile::TempDir) -> Self {
+        Self { dir: Some(dir) }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.dir
+            .as_ref()
+            .expect("temporary directory is held until drop")
+            .path()
+    }
+}
+
+impl Drop for RetainOnPanic {
+    fn drop(&mut self) {
+        let Some(dir) = self.dir.take() else {
+            return;
+        };
+        if std::thread::panicking() {
+            let path = dir.keep();
+            eprintln!(
+                "test panicked: daemon logs and state retained at {}",
+                path.display()
+            );
+        }
+    }
+}
+
+/// Resolve the `rbgp` CLI binary next to the daemon binary under test.
+///
+/// `CARGO_BIN_EXE_rbgp` is honoured when the invoker exports it; otherwise
+/// the binary must already sit next to `rustbgpd` in the build profile
+/// directory, which `cargo test --workspace` guarantees. Falling back to
+/// `cargo run` instead would put a build lock and a workspace freshness
+/// check on the hot path of grace-window assertions, where seconds of
+/// build-load stall turn a live-daemon rejection into a missed deadline.
+pub fn rbgp_binary() -> &'static Path {
+    static RBGP: OnceLock<PathBuf> = OnceLock::new();
+    RBGP.get_or_init(|| {
+        let path = std::env::var_os("CARGO_BIN_EXE_rbgp").map_or_else(
+            || {
+                Path::new(env!("CARGO_BIN_EXE_rustbgpd"))
+                    .parent()
+                    .expect("rustbgpd binary has a profile directory")
+                    .join("rbgp")
+            },
+            PathBuf::from,
+        );
+        assert!(
+            path.is_file(),
+            "build rbgp before this test (cargo test --workspace builds it); missing {}",
+            path.display()
+        );
+        path
+    })
+}


### PR DESCRIPTION
Fixes the two tight-settlement-budget flakes tracked in LAN-1240. Both are required-path workspace integration tests that fail-stopped mid-RPC under build load; both are root-caused below, neither settlement budget is widened, and the harnesses now keep their evidence on panic.

### Root causes

**`tests/runtime_config_settlement_matrix.rs:835` — `daemon error: transport error` after a successful `config plan`.** The watchdog reads the control-directory budget once at startup and stamps `deadline = registered_at + budget` on **every** settlement it registers (`register_owned`), then `fatal_clock_loop` fences on expiry and `_exit(70)` after the 500 ms grace. The matrix's 2 s budget therefore also gated the auto-revert row's **un-held setup apply** (`apply_confirmed`), whose settlement does real fsyncs on the temp directory; under 4 fsync writers + 48 spinners it can exceed 2 s, the daemon exits 70 mid-apply, and the CLI surfaces the dead socket as `daemon error: transport error`. The hypothesis on the ticket is confirmed.

**`tests/runtime_config_persistence_failstop.rs:232` — "rbgp did not finish before fail-stop deadline".** `CARGO_BIN_EXE_rbgp` is a compile-time-only variable, so the harness's runtime `env::var` fallback ran **every** `rbgp` invocation as `cargo run -p rustbgpctl --bin rbgp`: a target-dir build lock plus a workspace freshness check inside the 2 s bound on the grace-window rejection (and inside the 4 s fence-readiness wait). Under a looping release build that stalls past the bound; rc 0 in isolation because the freshness check is cheap on an idle box.

### Per-test determination

* **Settlement matrix: (b), and it already was.** The fail-stop under test is induced deterministically (armed checkpoint holds the settlement past the budget; exit code 70 and the single `runtime config settlement fail-stop armed` log line are asserted). The defect was collateral: the tight budget also applied to un-armed setup. The debug-only settlement test control now re-reads `budget_ms` at **each settlement registration**; the matrix writes a 30 s setup budget at spawn and tightens to 2 s inside `Control::arm`, scoping the tight budget to exactly the armed settlement. Every harness command timeout (15 s `rbgp` bound) undercuts the setup budget, so the watchdog can no longer fire on un-held setup before the harness's own bound does — an ordering guarantee, not a margin. The armed budget stays 2 s and `budget_seconds == 2.0` is still asserted on the fenced tuple; if the per-registration re-read ever regresses, the armed row runs under the 30 s setup budget and `wait_fenced` fails its 4 s deadline, so the matrix itself pins the mechanism.
* **Persistence fail-stop: neither — the harness was the flake.** The test's fences are already deterministic typed injections (`RUSTBGPD_TEST_CONFIG_PUBLISH_FAILURE`) under the production 1800 s budget (asserted in its metrics) and 5 s grace. `rbgp` now resolves directly next to the `rustbgpd` binary (shared `tests/support::rbgp_binary`), removing cargo from the RPC path. The grace-window rejection keeps its 2 s bound — it must land well inside the daemon's 5 s exit grace, and with direct execution it is a ~ms round-trip — while the wait on the pre-fence mutation after exit 70, which nothing races, widens to a 10 s hang bound. Both waits now name their callsite in the panic.

Supporting harness changes in the matrix: `--confirm-timeout` 2 s → 4 s (the arm is two fsyncing control-file writes that must land before the auto-revert timer starts the armed settlement) and the receipt wait 4 s → 10 s (the auto-revert row's receipt only arrives when that timer fires). The settlement budget, grace, exit-jitter, and the 120 s matrix limit are unchanged.

### Fail-stop evidence retention

Both harnesses previously dropped their `TempDir` during unwind, destroying the daemon log that would have confirmed or refuted any of this. `tests/support/mod.rs` adds `RetainOnPanic`: it disarms cleanup while the thread is panicking, keeps the directory (daemon logs, operator config, control dir, staged files), and prints the retained path into the captured test output. Verified by injecting a panic after the fence: the run prints `retained at /tmp/.tmpXXXXXX` and the directory holds `fault-daemon.log` plus the full test state.

### Daemon-side change (debug-only)

`register_owned` consults `settlement_test_control::registration_budget()` under `cfg(all(debug_assertions, not(test)))`; without the control environment variable the consult returns `None` and the fixed watchdog budget applies, so release builds and every daemon outside this harness are byte-for-byte on the previous behavior. Display sites (metrics gauge and lifecycle logs) derive the budget from the operation's own immutable deadline instead of the registry. The control protocol's budget cap rises from 10 s to 60 s to admit the setup budget, with a new over-cap rejection case in the parser test. Grace is deliberately not re-read.

### Reproduction and proof

Load recipe as in #1806: 48 CPU spinners + 4 `dd conv=fsync` writers in a recorded process group, plus a looping clean `cargo build --release --workspace` in a second worktree.

* Pre-fix (base commit, same box, same recipe): the settlement matrix failed **1/20** — run 19 died at `runtime_config_settlement_matrix.rs:835` with exactly `confirmed apply failed: … "daemon error: transport error"`; the persistence binary failed **1/10** — run 3 died at `:221` (`daemon never reported readiness 503`, both `exercise` tests), the same `cargo run`-on-the-fence-path seam as the ticket's `:232`, stalled at a different bound. Load average 57–68 on 64 cores during the failing runs.
* Post-fix under the same recipe: settlement matrix **10/10**, persistence fail-stop **10/10** (matrix wall time 44–58 s against its 120 s limit).
* Post-fix unloaded: **3/3** and **3/3**.

### Gates

| gate | rc |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace --no-fail-fast` | 0 (8062 passed, 0 failed) |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |
| `scripts/check-clippy-reasons.py` | 0 |

No CHANGELOG entry (test-only; the daemon delta is confined to the debug-only test control path).
