### PR TITLE
feat(adapter): longest-prefix route lookups and host-bit query semantics for Bird's Eye parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and exact-route views (joined against `ListBestRoutes`; the table views
   already read it). The five matching `must_match` runtime-divergence
   allow-list entries are removed. (LAN-1232)
+- The Bird's Eye adapter's route lookups converge on the pinned oracle's
+  lookup semantics: `route/{net}/protocol/{protocol}` and
+  `route/{net}/export/{protocol}` are longest-match (`show route for`) — a
+  covering-only prefix or a host address answers with the view's
+  most-specific covering prefix instead of an empty array — and
+  syntactically valid input with host bits set, which BIRD rejects, returns
+  HTTP 200 with an empty route array on all three `route/{net}` lookups
+  instead of the table variant's HTTP 400. Genuinely malformed input remains
+  HTTP 400. The two matching `must_match` runtime-divergence allow-list
+  entries are removed. (LAN-1232)
 
 ### Removed
 

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -87,8 +87,8 @@ listener beyond loopback only with the mTLS controls in `docs/SECURITY.md`.
 | `GET /routes/protocol/{id}`  | `RibService.ListReceivedRoutes` (paged, all unicast families) + `ListBestRoutes` identity join for truthful `primary` |
 | `GET /routes/export/{id}`    | `RibService.ListAdvertisedRoutes` (paged, all unicast families) + `ListBestRoutes` identity join for truthful `primary` |
 | `GET /routes/table/{table}`  | One `NeighborService.ListNeighbors` snapshot, then global `RibService.ListReceivedRoutes` + `ListBestRoutes` paged under one generation |
-| `GET /route/{prefix}/protocol/{id}` | `RibService.ListReceivedRoutes` (paged, exact IPv4/IPv6 unicast prefix) + prefix-filtered `ListBestRoutes` for truthful `primary` |
-| `GET /route/{prefix}/export/{id}` | `RibService.ListAdvertisedRoutes` (paged, exact IPv4/IPv6 unicast prefix) + prefix-filtered `ListBestRoutes` for truthful `primary` |
+| `GET /route/{prefix}/protocol/{id}` | `RibService.ListReceivedRoutes` (paged; exact prefix, else the view's most-specific covering prefix) + prefix-filtered `ListBestRoutes` for truthful `primary` |
+| `GET /route/{prefix}/export/{id}` | `RibService.ListAdvertisedRoutes` (paged; exact prefix, else the view's most-specific covering prefix) + prefix-filtered `ListBestRoutes` for truthful `primary` |
 | `GET /route/{prefix}/table/{table}` | `RibService.LookupBestPath` (bounded longest-prefix match with one matched-prefix candidate set) |
 | `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families) + `ListBestRoutes` identity join for truthful `primary` |
 | `GET /routes/filtered/{id}`  | `PolicyService.ListRejectedRoutes` (unpaged — the store is bounded at the `[policy.reject_retention]` capacity, default 1024/peer) |
@@ -169,13 +169,19 @@ IXP Manager's `protocolRoute()`, `exportRoute()`, and `protocolTable()` journeys
 use `/route/<prefix>%2F<mask>/protocol/{id}`,
 `/route/<prefix>%2F<mask>/export/{id}`, and
 `/route/<prefix>%2F<mask>/table/{table}`.
-The protocol and export views request an exact prefix on every gRPC page,
-retain every Add-Path candidate in daemon order, and apply `--max-routes` only
-after exact filtering.
+The protocol and export views are longest-match, like Bird's Eye's
+`show route for`: they request an exact prefix on every gRPC page, retain
+every Add-Path candidate in daemon order, and when the queried prefix has no
+entry they answer with the view's most-specific covering prefix (a linear
+scan over that member's paged view — there is no covering-prefix RPC filter);
+`--max-routes` applies only to the routes of the one matched prefix.
 The table view instead performs one bounded longest-prefix lookup and atomically
 returns the installed winner first followed by every same-prefix alternative;
-it applies `--max-routes` before rendering. Malformed prefixes return HTTP 400,
-unknown identities return 404, and daemon failures return a sanitized 502.
+it applies `--max-routes` before rendering. Syntactically valid input with
+host bits set — which BIRD rejects, so Bird's Eye answers with no routes —
+returns HTTP 200 with an empty route array on all three lookups. Genuinely
+malformed prefixes return HTTP 400, unknown identities return 404, and daemon
+failures return a sanitized 502.
 
 This is deliberately partial IXP Manager support: status, live BGP inventory
 and detail, protocol symbols, member received routes, and member exported
@@ -187,7 +193,7 @@ silently:
 
 | Contract capability | Status | Adapter surface |
 |---|---|---|
-| `exact-protocol-route` | supported | `/route/{prefix}/protocol/{id}`: exact prefix on every gRPC page, every Add-Path candidate in daemon order |
+| `exact-protocol-route` | supported | `/route/{prefix}/protocol/{id}`: exact prefix on every gRPC page, falling back to the view's most-specific covering prefix (`show route for` semantics), every Add-Path candidate in daemon order |
 | `exact-export-route` | supported | `/route/{prefix}/export/{id}`: the same discipline over the Adj-RIB-Out |
 | `filtered-prefix-wildcard` | supported | `/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`, answered from the session's retained rejects only |
 | `less-specific-longest-prefix-match` | supported | `/route/{prefix}/table/{table}`: one bounded longest-prefix lookup |

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -14,8 +14,8 @@
 //! - `GET /symbols` — sorted live protocol identities
 //! - `GET /routes/protocol/{id}` — received routes by neighbor address
 //! - `GET /routes/export/{id}` — routes advertised to a neighbor
-//! - `GET /route/{prefix}/protocol/{id}` — exact received-route candidates
-//! - `GET /route/{prefix}/export/{id}` — exact advertised-route candidates
+//! - `GET /route/{prefix}/protocol/{id}` — received-route candidates, longest match
+//! - `GET /route/{prefix}/export/{id}` — advertised-route candidates, longest match
 //! - `GET /route/{prefix}/table/{table}` — global Loc-RIB LPM winner and alternatives
 //! - `GET /routes/peer/{peer}` — received routes by peer IP
 //! - `GET /routes/filtered/{id}` — rejected routes retained by the peer's
@@ -1227,8 +1227,8 @@ async fn routes_export(
 }
 
 // ---------------------------------------------------------------------------
-// GET /route/{prefix}/protocol/{id} — exact received-route candidates
-// GET /route/{prefix}/export/{id}   — exact advertised-route candidates
+// GET /route/{prefix}/protocol/{id} — received-route candidates, longest match
+// GET /route/{prefix}/export/{id}   — advertised-route candidates, longest match
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1244,7 +1244,12 @@ struct ExactPrefix {
 }
 
 impl ExactPrefix {
-    fn parse(value: &str) -> Result<Self, HttpError> {
+    /// `Ok(Some)` is a network-aligned prefix. `Ok(None)` is a well-formed
+    /// address/length whose host bits are set: BIRD rejects that literal in
+    /// `show route for`, so Bird's Eye answers HTTP 200 with no routes and
+    /// the lookup handlers do the same. Anything else is HTTP 400, matching
+    /// Bird's Eye's own parameter validation.
+    fn parse(value: &str) -> Result<Option<Self>, HttpError> {
         let invalid = || json_error(StatusCode::BAD_REQUEST, "Invalid route prefix");
         let (address, length) = value.split_once('/').ok_or_else(invalid)?;
         if address.is_empty() || length.is_empty() || length.contains('/') {
@@ -1253,10 +1258,10 @@ impl ExactPrefix {
         let address: IpAddr = address.parse().map_err(|_| invalid())?;
         let length: u32 = length.parse().map_err(|_| invalid())?;
         let width = if address.is_ipv4() { 32 } else { 128 };
-        if length > width || !network_aligned(address, length) {
+        if length > width {
             return Err(invalid());
         }
-        Ok(Self { address, length })
+        Ok(network_aligned(address, length).then_some(Self { address, length }))
     }
 
     fn from_route(address: &str, length: u32) -> Option<Self> {
@@ -1310,6 +1315,18 @@ fn network_aligned(address: IpAddr, length: u32) -> bool {
     }
 }
 
+/// Most-specific network among `routes` that covers `query` — the selection
+/// Bird's Eye's `show route for` makes when the query has no exact entry.
+/// The RPC surface offers exact and longer-prefix filters only, so covering
+/// prefixes come from a linear scan over one member's paged view.
+fn longest_match(routes: &[proto::Route], query: ExactPrefix) -> Option<ExactPrefix> {
+    routes
+        .iter()
+        .filter_map(|route| ExactPrefix::from_route(&route.prefix, route.prefix_length))
+        .filter(|network| network.covers(query))
+        .max_by_key(|network| network.length)
+}
+
 #[allow(
     clippy::match_same_arms,
     reason = "separate arms keep each exact IXP consumer journey mutation-testable"
@@ -1360,6 +1377,43 @@ async fn route_export(
     serve_exact_route(&state, &prefix, &id, ExactRouteSource::Advertised).await
 }
 
+/// One member's complete received or advertised view, paged unfiltered.
+/// Backs the longest-match fallback of the exact-route lookups.
+async fn view_routes(
+    client: &mut proto::rib_service_client::RibServiceClient<Upstream>,
+    peer: IpAddr,
+    source: ExactRouteSource,
+) -> Result<Vec<proto::Route>, HttpError> {
+    let mut view = Vec::new();
+    let mut page_token = String::new();
+    loop {
+        let request = proto::ListRoutesRequest {
+            neighbor_address: peer.to_string(),
+            afi_safi: proto::AddressFamily::Unspecified as i32,
+            page_size: 1000,
+            page_token,
+            ..Default::default()
+        };
+        let response = match source {
+            ExactRouteSource::Received => client
+                .list_received_routes(request)
+                .await
+                .map_err(|error| bad_gateway("ListReceivedRoutes", &error))?,
+            ExactRouteSource::Advertised => client
+                .list_advertised_routes(request)
+                .await
+                .map_err(|error| bad_gateway("ListAdvertisedRoutes", &error))?,
+        }
+        .into_inner();
+        view.extend(response.routes);
+        if response.next_page_token.is_empty() {
+            break;
+        }
+        page_token = response.next_page_token;
+    }
+    Ok(view)
+}
+
 async fn serve_exact_route(
     state: &AppState,
     raw_prefix: &str,
@@ -1368,6 +1422,9 @@ async fn serve_exact_route(
 ) -> Result<Json<Value>, HttpError> {
     let prefix = ExactPrefix::parse(raw_prefix)?;
     let peer = state.identities.resolve(id)?;
+    let Some(prefix) = prefix else {
+        return Ok(Json(empty_routes_body(state.max_routes)));
+    };
     let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
     let mut routes = Vec::new();
     let mut page_token = String::new();
@@ -1391,7 +1448,26 @@ async fn serve_exact_route(
         page_token = response.next_page_token;
     }
 
-    let best = best_route_keys(state, Some(prefix)).await?;
+    // Bird's Eye's `show route for` is longest-match: with no exact entry it
+    // answers with the view's most-specific covering prefix, and with no
+    // covering prefix it answers with no routes. The cap applies to the one
+    // matched prefix's candidates, not to the scanned view.
+    let mut matched = prefix;
+    if routes.is_empty() {
+        let view = view_routes(&mut client, peer, source).await?;
+        if let Some(covering) = longest_match(&view, prefix) {
+            routes = view
+                .into_iter()
+                .filter(|route| {
+                    ExactPrefix::from_route(&route.prefix, route.prefix_length) == Some(covering)
+                })
+                .collect();
+            enforce_max(routes.len() as u64, state.max_routes)?;
+            matched = covering;
+        }
+    }
+
+    let best = best_route_keys(state, Some(matched)).await?;
     Ok(Json(serde_json::json!({
         "api": api_block(state.max_routes),
         "routes": routes
@@ -1421,6 +1497,9 @@ async fn route_table(
     if tables.binary_search(&table).is_err() {
         return Err(json_error(StatusCode::NOT_FOUND, "Table not found"));
     }
+    let Some(prefix) = prefix else {
+        return Ok(Json(empty_routes_body(state.max_routes)));
+    };
 
     let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
     let response = match client
@@ -3357,16 +3436,21 @@ mod tests {
     }
 
     #[test]
-    fn exact_prefix_parser_accepts_networks_and_rejects_malformed_or_host_values() {
+    fn exact_prefix_parser_distinguishes_networks_host_bit_input_and_malformed_input() {
         for (input, address, length) in [
             ("192.0.2.0/24", "192.0.2.0", 24),
             ("0.0.0.0/0", "0.0.0.0", 0),
             ("2001:db8::/32", "2001:db8::", 32),
             ("::/0", "::", 0),
         ] {
-            let parsed = ExactPrefix::parse(input).unwrap();
+            let parsed = ExactPrefix::parse(input).unwrap().unwrap();
             assert_eq!(parsed.address.to_string(), address);
             assert_eq!(parsed.length, length);
+        }
+        // Well-formed but with host bits set: BIRD rejects the literal, so
+        // the lookups answer HTTP 200 with no routes rather than HTTP 400.
+        for input in ["192.0.2.1/24", "2001:db8::1/64"] {
+            assert_eq!(ExactPrefix::parse(input).unwrap(), None, "{input}");
         }
         for input in [
             "192.0.2.0",
@@ -3375,9 +3459,7 @@ mod tests {
             "not-an-ip/24",
             "192.0.2.0/nope",
             "192.0.2.0/33",
-            "192.0.2.1/24",
             "2001:db8::/129",
-            "2001:db8::1/64",
         ] {
             let (status, Json(body)) = ExactPrefix::parse(input).unwrap_err();
             assert_eq!(status, StatusCode::BAD_REQUEST, "{input}");
@@ -3387,9 +3469,91 @@ mod tests {
     }
 
     #[test]
+    fn longest_match_selects_the_most_specific_covering_view_prefix() {
+        let route = |prefix: &str, length: u32| proto::Route {
+            prefix: prefix.to_string(),
+            prefix_length: length,
+            ..Default::default()
+        };
+        let view = vec![
+            route("203.0.113.0", 24),
+            route("203.0.113.128", 25),
+            route("203.0.113.64", 26),
+            route("2001:db8:a::", 48),
+        ];
+        let query = |value: &str| ExactPrefix::parse(value).unwrap().unwrap();
+        // An exact entry is its own longest match.
+        assert_eq!(
+            longest_match(&view, query("203.0.113.128/25")),
+            Some(query("203.0.113.128/25"))
+        );
+        // A covering-only prefix and a host address fall back to the cover.
+        assert_eq!(
+            longest_match(&view, query("203.0.113.0/25")),
+            Some(query("203.0.113.0/24"))
+        );
+        assert_eq!(
+            longest_match(&view, query("203.0.113.1/32")),
+            Some(query("203.0.113.0/24"))
+        );
+        // The most specific covering entry wins over a shorter one.
+        assert_eq!(
+            longest_match(&view, query("203.0.113.192/26")),
+            Some(query("203.0.113.128/25"))
+        );
+        // Nothing covering, and never across address families.
+        assert_eq!(longest_match(&view, query("198.51.100.0/24")), None);
+        assert_eq!(longest_match(&view, query("2001:db8:c::/48")), None);
+    }
+
+    #[tokio::test]
+    async fn host_bit_lookups_answer_empty_success_without_an_upstream_call() {
+        let store = Arc::new(ResolverStore::new(
+            IdentityResolver::parse(&["pb_as64496=192.0.2.1@master4".to_string()]).unwrap(),
+        ));
+        let state = AppState {
+            upstream: InterceptedService::new(
+                Endpoint::from_static("http://127.0.0.1:50051").connect_lazy(),
+                BearerInterceptor::default(),
+            ),
+            identities: store.snapshot(),
+            identity_store: store,
+            max_routes: 7,
+            arouteserver_reject_communities: None,
+        };
+        for source in [ExactRouteSource::Received, ExactRouteSource::Advertised] {
+            let Json(body) = serve_exact_route(&state, "192.0.2.1/24", "pb_as64496", source)
+                .await
+                .unwrap();
+            assert_eq!(body["routes"], serde_json::json!([]), "{source:?}");
+            assert_eq!(body["api"]["max_routes"], 7, "{source:?}");
+        }
+        // Identity resolution still precedes the host-bit answer, and
+        // genuinely malformed input is still rejected.
+        let (status, _) = serve_exact_route(
+            &state,
+            "192.0.2.1/24",
+            "missing",
+            ExactRouteSource::Received,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        let (status, _) = serve_exact_route(
+            &state,
+            "not-an-ip/24",
+            "pb_as64496",
+            ExactRouteSource::Received,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
     fn exact_route_requests_pin_every_filter_on_every_page_and_unknown_id_is_404() {
         let peer: IpAddr = "192.0.2.1".parse().unwrap();
-        let prefix = ExactPrefix::parse("2001:db8::/32").unwrap();
+        let prefix = ExactPrefix::parse("2001:db8::/32").unwrap().unwrap();
         for source in [ExactRouteSource::Received, ExactRouteSource::Advertised] {
             for token in ["", "opaque-page-2"] {
                 let request = exact_route_request(peer, prefix, token.to_string(), source);
@@ -3413,7 +3577,7 @@ mod tests {
 
     #[test]
     fn exact_route_pages_preserve_add_path_order_and_cap_only_exact_candidates() {
-        let prefix = ExactPrefix::parse("192.0.2.0/24").unwrap();
+        let prefix = ExactPrefix::parse("192.0.2.0/24").unwrap().unwrap();
         let route = |network: &str, path_id: u32, med: u32| proto::Route {
             prefix: network.to_string(),
             prefix_length: 24,
@@ -3471,7 +3635,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let query = ExactPrefix::parse("192.0.2.128/25").unwrap();
+        let query = ExactPrefix::parse("192.0.2.128/25").unwrap().unwrap();
         let body = table_lookup_body(&response, query, &IdentityResolver::default(), 2).unwrap();
         assert_eq!(body["routes"][0]["bgp"]["med"], 10);
         assert_eq!(body["routes"][1]["bgp"]["med"], 20);
@@ -3507,7 +3671,11 @@ mod tests {
             .prefix
             .clone_from(&unrelated.prefix);
         rejects(&unrelated, query, 2);
-        rejects(&response, ExactPrefix::parse("192.0.2.0/23").unwrap(), 2);
+        rejects(
+            &response,
+            ExactPrefix::parse("192.0.2.0/23").unwrap().unwrap(),
+            2,
+        );
         let mut missing = response.clone();
         missing.best_route = None;
         rejects(&missing, query, 2);

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -1099,6 +1099,27 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         exact_received, live,
         "exact protocol route must preserve every candidate and its order"
     );
+    let covering_received = get_json(
+        adapter_port,
+        "/route/10.99.0.1%2F32/protocol/pb_0001_as65020",
+        "adapter",
+    );
+    assert_eq!(
+        covering_received, live,
+        "a lookup without an exact entry must answer with the view's most-specific covering prefix"
+    );
+    for path in [
+        "/route/10.99.0.1%2F24/protocol/pb_0001_as65020",
+        "/route/10.99.0.1%2F24/export/pb_0002_as65030",
+        "/route/10.99.0.1%2F24/table/master4",
+    ] {
+        let host_bits = get_json(adapter_port, path, "adapter");
+        assert_eq!(
+            host_bits["routes"],
+            serde_json::json!([]),
+            "host-bit input must be an empty successful lookup: {path}"
+        );
+    }
     let table_lookup = get_json(
         adapter_port,
         "/route/10.99.0.128%2F25/table/master4",

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -29,7 +29,7 @@ and body are all part of the reviewed fixture. Composer validation is strict;
 the harness permits only IXP Manager's pinned deprecated `GPL-2.0` identifier
 warning and rejects any additional warning.
 
-The live-adapter leg intentionally uses a configured, down peer, so the exact
+The live-adapter leg intentionally uses a configured, down peer, so the route
 lookups, table longest-prefix match, and filtered-prefix query return honest
 empty route arrays. The pinned protocol-detail consumer also proves its
 unconditional `connection` field is the empty string while `source_address`,
@@ -143,7 +143,10 @@ diff -u tests/compat/ixp-manager-birdseye/fixtures/birdseye-contract.json \
 
 `contract.json` deliberately keeps the unsupported runtime matrix executable.
 Exact protocol-route, exact export-route, filtered-prefix wildcard, bounded
-less-specific lookup, and atomic full-table journeys are runtime-supported. The LPM lookup
+less-specific lookup, and atomic full-table journeys are runtime-supported;
+the protocol and export lookups follow Bird's Eye's `show route for`
+longest-match semantics, answering a covering-only prefix or host address
+with the view's most-specific covering prefix. The LPM lookup
 returns one matched prefix atomically with its installed winner first and every
 same-prefix Add-Path alternative. The full-table view joins Received and Best
 under one generation, caps before truncation, and does not add counts. All ten
@@ -204,8 +207,8 @@ the adapter serves at `/` where Bird's Eye serves under `/api/` (IXP Manager's
 | `GET /api/routes/count/export/{protocol}` | — | — | not served | out of scope (same note as protocol count) |
 | `GET /api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` | `routesProtocolLargeCommunityWildXYRoutes()` | `routes_protocol_large_community_wild_xy` | served, divergent | answers only `{daemon ASN}:1101:*` from retained rejects, empty for any other `(x, y)`; adds `retention.*`; `api.max_routes` is the retention capacity |
 | `GET /api/route/{net}` (default table `master`) | — | — | not served | out of scope |
-| `GET /api/route/{net}/table/{table}` | `protocolTable()` | `route_table` | served, divergent | requires a network-aligned `addr/len` (host or unmasked input is HTTP 400; Bird's Eye accepts `192.0.2.1` and runs `show route for`); returns the installed winner first plus same-prefix Add-Path alternatives; no per-minute throttle |
-| `GET /api/route/{net}/protocol/{protocol}` | `protocolRoute()` | `route_protocol` | served, divergent | **exact** prefix match where Bird's Eye's `show route for` is longest-match; network-aligned input only; all Add-Path candidates |
+| `GET /api/route/{net}/table/{table}` | `protocolTable()` | `route_table` | served, divergent | longest-prefix match; host-bit input is HTTP 200 with no routes (BIRD rejects the literal), genuinely malformed or unmasked input is HTTP 400 (Bird's Eye accepts a bare `192.0.2.1`); returns the installed winner first plus same-prefix Add-Path alternatives; no per-minute throttle |
+| `GET /api/route/{net}/protocol/{protocol}` | `protocolRoute()` | `route_protocol` | served, divergent | longest-prefix match like Bird's Eye's `show route for`: the exact entry when present, else the view's most-specific covering prefix; host-bit input is HTTP 200 with no routes; all Add-Path candidates |
 | `GET /api/route/{net}/export/{protocol}` | `exportRoute()` | `route_export` | served, divergent | same as the protocol lookup |
 | `GET /test`, `GET /`, `/lg/*` | — | — | not served | out of scope (non-API: hello-world, HTML index, HTML looking glass) |
 
@@ -274,12 +277,12 @@ refuses any `runtime_compatibility` value other than `false` while any entry
 is classified `must_match`. The flag therefore flips only when zero
 `must_match` entries remain, and the post-flip claim language is "verified
 IXP Manager 7.4 Bird's Eye API compatibility with documented BIRD-internal
-divergences". The open `must_match` entries are the two lookup-semantics
-entries (exact-versus-longest protocol/export match and the table lookup's
-HTTP 400 for host-bit input) and the ordinary-`(x, y)` lc-zwild scope; the
-route-shape cluster (`bgp.as_path` element type, `bgp.local_pref`,
-`bgp.med` emitted when absent, `primary` outside the table view, the `type`
-triple) converged on the oracle and its entries are removed.
+divergences". The one open `must_match` entry is the ordinary-`(x, y)`
+lc-zwild scope; the route-shape cluster (`bgp.as_path` element type,
+`bgp.local_pref`, `bgp.med` emitted when absent, `primary` outside the table
+view, the `type` triple) and the two lookup-semantics entries
+(exact-versus-longest protocol/export match and the table lookup's HTTP 400
+for host-bit input) converged on the oracle and their entries are removed.
 
 ### Work list
 
@@ -368,13 +371,16 @@ predicted eight more that the diff did not show, listed after the table.
    symbols` reports configuration keywords there) the adapter never emits.
    Decided: both are `intentional`; the daemon has no BIRD symbol table to
    reproduce.
-10. Exact versus longest match: observed on `route/{net}/protocol` and
+10. Done. Exact versus longest match: observed on `route/{net}/protocol` and
     `route/{net}/export` (a covering-only prefix and a host address return the
     covering route upstream, `routes: []` from the adapter) and on
     `route/{net}/table` for host-bit input (HTTP 200 `routes: []` upstream
     because BIRD rejects the lookup, HTTP 400 from the adapter, which the
-    consumer collapses to `""`). Decided: both entries are `must_match`; the
-    lookups converge on the oracle behavior before the flip.
+    consumer collapses to `""`). Were `must_match`; the protocol and export
+    lookups now fall back to the view's most-specific covering prefix when
+    the queried prefix has no entry, and host-bit input answers HTTP 200
+    with an empty route array on all three lookups. Both entries are
+    removed.
 11. `lc-zwild`: observed for a foreign `(x, y)` (the route carrying that large
     community upstream, `routes: []` from the adapter) plus the adapter's extra
     `retention.*` and `api.max_routes` as the retention capacity for the daemon

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -392,29 +392,6 @@
       "consumer_visible": true
     },
     {
-      "endpoint": [
-        "api/route/{net}/protocol/{protocol}",
-        "api/route/{net}/export/{protocol}"
-      ],
-      "path": "routes",
-      "kind": "semantics",
-      "classification": "must_match",
-      "birdseye": "show route for: longest match, so a covering-only prefix or a host address returns the covering route",
-      "adapter": "exact prefix match: the same inputs return []",
-      "rationale": "IXP Manager passes listed exact networks; the exact-vs-longest choice is recorded, not hidden",
-      "consumer_visible": true
-    },
-    {
-      "endpoint": "api/route/{net}/table/{table}",
-      "path": "<response>",
-      "kind": "semantics",
-      "classification": "must_match",
-      "birdseye": "HTTP 200 with routes: [] for host-bit input (BIRD rejects the lookup)",
-      "adapter": "HTTP 400, which the pinned consumer collapses to \"\"",
-      "rationale": "network-aligned input only; IXP Manager renders an empty page either way",
-      "consumer_visible": true
-    },
-    {
       "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
       "path": "routes",
       "kind": "semantics",

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
@@ -10,7 +10,43 @@
           "result_from_cache": false,
           "version": "rustbgpd <version>"
         },
-        "routes": []
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64497"
+              ],
+              "communities": [
+                [
+                  64497,
+                  100
+                ]
+              ],
+              "large_communities": [
+                [
+                  64497,
+                  1,
+                  1
+                ]
+              ],
+              "local_pref": "100",
+              "next_hop": "198.51.100.4",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64497",
+            "gateway": "198.51.100.4",
+            "interface": "",
+            "learnt_from": "198.51.100.4",
+            "metric": 0,
+            "network": "192.0.2.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
       }
     },
     "lookup_export_exact": {
@@ -123,7 +159,55 @@
           "result_from_cache": false,
           "version": "rustbgpd <version>"
         },
-        "routes": []
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
       }
     },
     "lookup_protocol_exact": {
@@ -197,7 +281,55 @@
           "result_from_cache": false,
           "version": "rustbgpd <version>"
         },
-        "routes": []
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
       }
     },
     "lookup_protocol_v6": {
@@ -351,7 +483,16 @@
     },
     "lookup_table_unaligned": {
       "endpoint": "api/route/{net}/table/{table}",
-      "response": ""
+      "response": {
+        "api": {
+          "Version": "rustbgpd <version>",
+          "from_cache": false,
+          "max_routes": 100,
+          "result_from_cache": false,
+          "version": "rustbgpd <version>"
+        },
+        "routes": []
+      }
     },
     "lookup_table_v6": {
       "endpoint": "api/route/{net}/table/{table}",

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -310,23 +310,6 @@ RUNTIME_DIVERGENCES = [
         "consumer_visible": True,
     },
     {
-        "endpoint": ["api/route/{net}/protocol/{protocol}", "api/route/{net}/export/{protocol}"],
-        "path": "routes", "kind": "semantics",
-        "classification": "must_match",
-        "birdseye": "show route for: longest match, so a covering-only prefix or a host address returns the covering route",
-        "adapter": "exact prefix match: the same inputs return []",
-        "rationale": "IXP Manager passes listed exact networks; the exact-vs-longest choice is recorded, not hidden",
-        "consumer_visible": True,
-    },
-    {
-        "endpoint": "api/route/{net}/table/{table}", "path": "<response>", "kind": "semantics",
-        "classification": "must_match",
-        "birdseye": "HTTP 200 with routes: [] for host-bit input (BIRD rejects the lookup)",
-        "adapter": "HTTP 400, which the pinned consumer collapses to \"\"",
-        "rationale": "network-aligned input only; IXP Manager renders an empty page either way",
-        "consumer_visible": True,
-    },
-    {
         "endpoint": LC_ZWILD, "path": "routes", "kind": "semantics",
         "classification": "must_match",
         "birdseye": "every route carrying (x, y, *) in the protocol's table",
@@ -622,7 +605,7 @@ def verify_populated(capture_dir: Path, web_php: Path) -> None:
         )
     for leg, document in docs.items():
         for name, journey in document["journeys"].items():
-            if journey["response"] == "" and name != "lookup_table_unaligned":
+            if journey["response"] == "":
                 fail(f"populated {leg} capture: {name} returned a collapsed non-2xx response")
     for leg, document in docs.items():
         text = json.dumps(document, indent=2, sort_keys=True) + "\n"


### PR DESCRIPTION
Closes the two lookup-semantics `must_match` divergences in the Bird's Eye
compatibility profile (LAN-1232), leaving the lc-zwild scope entry as the
single open `must_match` gate.

## Gap A — exact vs longest prefix match (`route/{net}/protocol`, `route/{net}/export`)

Bird's Eye runs `show route for {net} …`, a longest-match lookup: a
covering-only prefix (`203.0.113.0/25`) or a host address (`203.0.113.1/32`)
answers with the most-specific covering prefix's routes. The adapter answered
those inputs with an exact match only.

Before (live), `lookup_protocol_covering` / `lookup_protocol_host` /
`lookup_export_covering`:

```json
{ "api": { … }, "routes": [] }
```

After (matches the oracle byte-shape modulo the standing allow-listed
`interface` / `learnt_from` / `metric` sentinels):

```json
{ "api": { … }, "routes": [ { "network": "203.0.113.0/24", "from_protocol": "pb_as64496", "primary": true, … } ] }
```

When nothing in the view covers the query, the response stays the empty
200 body, which is also what Bird's Eye returns when BIRD reports no route.

**Implementation choice:** the gRPC surface has no covering-prefix lookup for
the per-peer views — `ListRoutesRequest` offers exact and `longer_prefixes`
filters only, and `RibService.LookupBestPath` searches the global Loc-RIB,
not a member's received/advertised view (recon: `proto/rustbgpd.proto`,
`LookupBestPathRequest` "canonical ancestors" of the installed table). So the
exact fast path is kept unchanged (server-side exact filter on every page),
and only on an empty result does the handler page the member's full view and
scan it for the most-specific covering prefix (`longest_match`). Complexity:
O(n) over one member's routes per fallback lookup, with a best-length
tie-break — the same full-view paging the `routes/protocol/{id}` and
`routes/export/{id}` journeys already perform per request; `--max-routes`
applies to the matched prefix's candidates, not the scanned view. `primary`
joins the matched prefix against `ListBestRoutes` exactly as the exact path
did.

## Gap B — host-bit table lookup: 400 → 200 with empty routes

BIRD rejects a prefix literal with host bits set (`203.0.113.1/24`), so
Bird's Eye answers HTTP 200 with no routes; the adapter returned HTTP 400,
which the pinned consumer collapses to `""`.

Before (live), `lookup_table_unaligned`: HTTP 400 → captured as `""`.
After: `{ "api": { … }, "routes": [] }`, byte-identical to the oracle modulo
the allow-listed `api.*` identity fields.

The prefix parser now distinguishes three cases: network-aligned (served),
well-formed with host bits (200 + empty routes — applied consistently on all
three `route/{net}` lookups, since BIRD's rejection is uniform across
`show route for` forms), and genuinely malformed (`not-an-ip/24`, `/33`,
missing mask — still HTTP 400, matching Bird's Eye's own validation, kept by
the `bad_prefix` oracle case). Unknown protocol/table still 404 first.

## Contract

- `contract.json` and the `RUNTIME_DIVERGENCES` constant in
  `verify_capture.py` both drop the two entries (24 → 22; `must_match`
  3 → 1); the harness self-checks the two copies stay equal and re-proves
  the allow-list fail-closed on every run.
- The `lookup_table_unaligned` collapsed-response exemption in
  `verify_capture.py` is removed — no journey may return a non-2xx now.
- `fixtures/populated-live.json` re-captured via the harness's
  `CAPTURE_FIXTURES=1` mode; `fixtures/populated-oracle.json` unchanged.

## Proof

Baseline (unmodified tree):

```
populated oracle proof: 24 journeys over 11 endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; 24 allow-listed divergences (3 must_match, 12 intentional, 2 unsupported, 7 extension), 0 unlisted, 0 stale; 27 pinned routes/web.php routes accounted for
```

Post-change:

```
populated oracle proof: 24 journeys over 11 endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; 22 allow-listed divergences (1 must_match, 12 intentional, 2 unsupported, 7 extension), 0 unlisted, 0 stale; 27 pinned routes/web.php routes accounted for
```

## Tests

- Adapter unit tests: parser tri-state (aligned / host-bit / malformed),
  `longest_match` selection (exact hit, covering fallback, most-specific
  wins, no cover, no cross-family), and host-bit lookups answering empty
  success without an upstream call (unknown protocol still 404, malformed
  still 400).
- Live smoke test: a `/32` lookup returns the covering `/24`'s full
  candidate set; host-bit input on all three lookups is an empty 200.

## Gates

| Gate | Result |
|---|---|
| baseline `run.sh` | rc 0, proof line above |
| post-change `run.sh` | rc 0, proof line above |
| `cargo fmt --all -- --check` | rc 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | rc 0 |
| `cargo test --workspace --no-fail-fast` | rc 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | rc 0 |
| `python3 scripts/check-clippy-reasons.py` | rc 0 |
| `python3 scripts/check_public_tracker_ids.py` | rc 0 |
| `python3 scripts/check-v1-stable-surface.py` | rc 0 |
