### PR TITLE
feat(adapter): Bird's Eye wildcard semantics for ordinary lc-zwild pairs and a deterministic backend-failure journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   instead of the table variant's HTTP 400. Genuinely malformed input remains
   HTTP 400. The two matching `must_match` runtime-divergence allow-list
   entries are removed. (LAN-1232)
+- The Bird's Eye adapter's `lc-zwild` endpoint follows Bird's Eye's wildcard
+  semantics for ordinary `(x, y)` pairs: the member's accepted routes
+  carrying a large community `(x, y, *)`, scanned from the paged received
+  view with truthful `primary` and the generic route cap applied to the
+  matched rows. The daemon's own rejection namespace (`{daemon ASN}:1101:*`)
+  keeps serving the session's retained rejects with the retention envelope,
+  unchanged. The last `must_match` runtime-divergence allow-list entry is
+  removed, and the populated compat gate gains a deterministic
+  backend-failure journey pinning the adapter's HTTP 502 against Bird's
+  Eye's HTTP 503, allow-listed as `intentional`. (LAN-1232)
 
 ### Removed
 

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -47,7 +47,8 @@ partial runtime support: the ten reasons active in the pinned v7.4 route-server
 templates are mapped, while IDs 2, 4, 11, 12, and 15 are display-only and
 remain fallback 0 rather than gaining invented semantics. The full-table view
 and longest-prefix table search are served; full-table counts are not, other
-wildcard-community pairs return empty, and the contract's
+wildcard-community pairs follow Bird's Eye's accepted-route wildcard
+semantics (every member route carrying `(x, y, *)`), and the contract's
 `runtime_compatibility` stays `false` — every allow-listed oracle divergence
 carries a classification, and the gate refuses the flip while any
 `must_match` entry remains open. The adapter's table identity is a

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -92,7 +92,7 @@ listener beyond loopback only with the mTLS controls in `docs/SECURITY.md`.
 | `GET /route/{prefix}/table/{table}` | `RibService.LookupBestPath` (bounded longest-prefix match with one matched-prefix candidate set) |
 | `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families) + `ListBestRoutes` identity join for truthful `primary` |
 | `GET /routes/filtered/{id}`  | `PolicyService.ListRejectedRoutes` (unpaged — the store is bounded at the `[policy.reject_retention]` capacity, default 1024/peer) |
-| `GET /routes/lc-zwild/protocol/{id}/{x}/{y}` | `GlobalService.GetGlobal` + `PolicyService.ListRejectedRoutes` for IXP Manager's `{daemon ASN}:1101:*` filtered-prefix query |
+| `GET /routes/lc-zwild/protocol/{id}/{x}/{y}` | `GlobalService.GetGlobal` to dispatch: `PolicyService.ListRejectedRoutes` for IXP Manager's `{daemon ASN}:1101:*` filtered-prefix query, or the paged `RibService.ListReceivedRoutes` + `ListBestRoutes` accepted-route scan for any other `(x, y)` wildcard |
 | `GET /routes/noexport/{id}`  | `RibService.ListBestRoutes` − `RibService.ListAdvertisedRoutes` (both paged), each missing prefix explained by `RibService.ExplainAdvertisedRoute` |
 
 There are no placeholder 501 responses. Route `age` is served from the
@@ -195,7 +195,7 @@ silently:
 |---|---|---|
 | `exact-protocol-route` | supported | `/route/{prefix}/protocol/{id}`: exact prefix on every gRPC page, falling back to the view's most-specific covering prefix (`show route for` semantics), every Add-Path candidate in daemon order |
 | `exact-export-route` | supported | `/route/{prefix}/export/{id}`: the same discipline over the Adj-RIB-Out |
-| `filtered-prefix-wildcard` | supported | `/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`, answered from the session's retained rejects only |
+| `filtered-prefix-wildcard` | supported | `/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`, answered from the session's retained rejects; ordinary `(x, y)` pairs scan the member's accepted routes instead (Bird's Eye wildcard semantics) |
 | `less-specific-longest-prefix-match` | supported | `/route/{prefix}/table/{table}`: one bounded longest-prefix lookup |
 | `atomic-full-table-snapshot` | supported | `/routes/table/{table}`: accepted candidates joined with installed winners under one Received/Best generation; refuses rather than truncates |
 | `atomic-all-candidate-prefix-snapshot` | supported | the table lookup returns the installed winner first and every same-prefix alternative in one response |
@@ -208,17 +208,19 @@ silently:
 | `defined-only-rejected-route-reason-emission` | unsupported | the five display-only reason ids are never emitted; such causes fall back to `0` |
 | `full-ixp-manager-ui-filter-policy-engine` | unsupported | only the bounded `rs-config-render` manual-export subset exists |
 
-Other large-community wildcard queries return an empty route array. The table
+The table
 name validates the live routing-table identity over rustbgpd's one global
 Loc-RIB; it is not an independent table selector. The adapter does not claim
 full Bird's Eye compatibility.
 
 IXP Manager v7.4 queries member-filtered prefixes through
-`/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`. The adapter answers only
-that exact daemon-owned namespace and returns an empty route array for other
-`x` or `y` values. It never scans accepted routes: the response comes only from
-the selected session's retained rejects and preserves the usual no-session
-empty answer. Successful filtered replies use the daemon-reported retention
+`/routes/lc-zwild/protocol/{id}/{daemon ASN}/1101`. The daemon-owned
+namespace is answered only from the selected session's retained rejects and
+preserves the usual no-session empty answer. Any other `(x, y)` pair follows
+Bird's Eye's wildcard semantics instead: the member's accepted routes
+carrying a large community `(x, y, *)`, served in the accepted-route shape
+(no retention envelope) with the generic route cap applied to the matched
+rows. Successful filtered replies use the daemon-reported retention
 capacity as `api.max_routes` and are exempt from the generic RIB-derived cap.
 Both add `retention.enabled`, `capacity`, `evictions_since_reset`, and
 `may_be_incomplete`; the last two are `null` against an older daemon, while a

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -22,7 +22,9 @@
 //!   session (`PolicyService.ListRejectedRoutes`), tagged with a synthesized
 //!   reject-reason large community (see the README mapping table)
 //! - `GET /routes/lc-zwild/protocol/{id}/{x}/{y}` — the IXP Manager v7.4
-//!   filtered-prefix query for this daemon's `{asn}:1101:*` reason namespace
+//!   filtered-prefix query for this daemon's `{asn}:1101:*` reason namespace;
+//!   any other `(x, y)` follows Bird's Eye wildcard semantics over the
+//!   member's accepted routes carrying `(x, y, *)`
 //! - `GET /routes/noexport/{id}` — Loc-RIB best routes NOT advertised to the
 //!   peer (`ListBestRoutes` minus `ListAdvertisedRoutes`), each explained by
 //!   the live export gate ladder (`RibService.ExplainAdvertisedRoute`) and
@@ -954,7 +956,7 @@ async fn routes_protocol(
     Path(id): Path<String>,
 ) -> Result<Json<Value>, HttpError> {
     let peer_addr = state.identities.resolve(&id)?;
-    serve_routes_for_peer(&state, peer_addr).await
+    serve_routes_for_peer(&state, peer_addr, None).await
 }
 
 async fn routes_peer(
@@ -964,10 +966,17 @@ async fn routes_peer(
     let peer_addr: IpAddr = peer
         .parse()
         .map_err(|_| json_error(StatusCode::BAD_REQUEST, "Invalid peer address"))?;
-    serve_routes_for_peer(&state, peer_addr).await
+    serve_routes_for_peer(&state, peer_addr, None).await
 }
 
-async fn serve_routes_for_peer(state: &AppState, peer: IpAddr) -> Result<Json<Value>, HttpError> {
+/// One member's accepted-route view; with `wildcard: Some((x, y))` only the
+/// routes carrying a large community `(x, y, *)` are rendered (Bird's Eye's
+/// `lc-zwild` semantics, an O(n) scan over the member's paged view).
+async fn serve_routes_for_peer(
+    state: &AppState,
+    peer: IpAddr,
+    wildcard: Option<(u64, u64)>,
+) -> Result<Json<Value>, HttpError> {
     let best = best_route_keys(state, None).await?;
     let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
     let mut routes: Vec<Value> = Vec::new();
@@ -986,16 +995,24 @@ async fn serve_routes_for_peer(state: &AppState, peer: IpAddr) -> Result<Json<Va
             .await
             .map_err(|e| bad_gateway("ListReceivedRoutes", &e))?
             .into_inner();
-        if page_token.is_empty() {
+        // The generic cap applies to the rows this view renders: the whole
+        // received view, or only the wildcard matches (Bird's Eye's
+        // MAX_ROUTES likewise counts parsed result rows).
+        if page_token.is_empty() && wildcard.is_none() {
             enforce_max(resp.total_count, state.max_routes)?;
         }
-        routes.extend(resp.routes.iter().map(|route| {
-            route_to_birdwatcher_with_primary(
-                route,
-                &state.identities,
-                best.contains(&route_key(route)),
-            )
-        }));
+        routes.extend(
+            resp.routes
+                .iter()
+                .filter(|route| wildcard.is_none_or(|(x, y)| carries_large_community(route, x, y)))
+                .map(|route| {
+                    route_to_birdwatcher_with_primary(
+                        route,
+                        &state.identities,
+                        best.contains(&route_key(route)),
+                    )
+                }),
+        );
         enforce_max(routes.len() as u64, state.max_routes)?;
         if resp.next_page_token.is_empty() {
             break;
@@ -1612,17 +1629,16 @@ async fn routes_filtered(
 
 const IXP_MANAGER_REJECT_FUNCTION: u64 = 1101;
 
-/// IXP Manager v7.4's member-facing filtered-prefix query. Only the daemon's
-/// own rejection namespace is meaningful; a different `(x, y)` is a valid
-/// query with no matches.
+/// IXP Manager v7.4's member-facing filtered-prefix query, with Bird's Eye
+/// wildcard semantics for every ordinary pair: the daemon's own rejection
+/// namespace `({daemon ASN}, 1101)` serves the session's retained rejects,
+/// and any other `(x, y)` returns the member's accepted routes carrying a
+/// large community `(x, y, *)`.
 async fn routes_protocol_large_community_wild_xy(
     State(state): State<AppState>,
     Path((id, x, y)): Path<(String, u64, u64)>,
 ) -> Result<Json<Value>, HttpError> {
     let peer = state.identities.resolve(&id)?;
-    if y != IXP_MANAGER_REJECT_FUNCTION {
-        return Ok(Json(empty_filtered_routes_body(state.max_routes)));
-    }
     let mut global = proto::global_service_client::GlobalServiceClient::new(state.upstream.clone());
     let daemon_asn = u64::from(
         global
@@ -1632,8 +1648,10 @@ async fn routes_protocol_large_community_wild_xy(
             .into_inner()
             .asn,
     );
+    // Hybrid dispatch: only the daemon's own rejection namespace reads the
+    // retained rejects; every other pair is an accepted-route wildcard scan.
     if !ixp_manager_reason_namespace_matches(daemon_asn, x, y) {
-        return Ok(Json(empty_filtered_routes_body(state.max_routes)));
+        return serve_routes_for_peer(&state, peer, Some((x, y))).await;
     }
     let mut policy = proto::policy_service_client::PolicyServiceClient::new(state.upstream.clone());
     let response = match policy
@@ -1686,6 +1704,16 @@ fn retention_metadata(resp: Option<&proto::ListRejectedRoutesResponse>) -> Value
 
 fn ixp_manager_reason_namespace_matches(daemon_asn: u64, x: u64, y: u64) -> bool {
     x == daemon_asn && y == IXP_MANAGER_REJECT_FUNCTION
+}
+
+/// True when the route carries a large community `(x, y, *)` — the Bird's
+/// Eye `lc-zwild` wildcard. gRPC encodes each large community as
+/// `"global_admin:data1:data2"`; anything else never matches.
+fn carries_large_community(route: &proto::Route, x: u64, y: u64) -> bool {
+    route.large_communities.iter().any(|lc| {
+        let parts: Vec<u64> = lc.split(':').filter_map(|p| p.parse().ok()).collect();
+        parts.len() == 3 && parts[0] == x && parts[1] == y
+    })
 }
 
 /// Build the filtered-view response body from a `ListRejectedRoutes`
@@ -3036,7 +3064,7 @@ mod tests {
     }
 
     #[test]
-    fn ixp_manager_filtered_handler_uses_only_retained_rejects() {
+    fn ixp_manager_filtered_handler_dispatches_rejects_and_wildcard_scan() {
         let source = include_str!("main.rs");
         assert!(source.contains(".route(\n            \"/routes/lc-zwild/protocol/{id}/{x}/{y}\""));
         let body = source
@@ -3046,10 +3074,22 @@ mod tests {
             .split_once("fn empty_routes_body(")
             .unwrap()
             .0;
-        assert!(body.contains(".list_rejected_routes("), "{body}");
-        assert!(!body.contains("list_received_routes"), "{body}");
-        assert!(!body.contains("list_best_routes"), "{body}");
-        assert!(!body.contains("serve_routes_for_peer"), "{body}");
+        // The daemon ASN is read before the dispatch, and an ordinary pair
+        // hands off to the accepted-route wildcard scan before any
+        // rejected-route sourcing happens.
+        assert!(
+            body.find(".get_global(").unwrap()
+                < body.find("ixp_manager_reason_namespace_matches").unwrap(),
+            "{body}"
+        );
+        assert!(
+            body.find("serve_routes_for_peer(&state, peer, Some((x, y)))")
+                .unwrap()
+                < body.find(".list_rejected_routes(").unwrap(),
+            "{body}"
+        );
+        // The retained-rejects tail keeps its capacity-based api block and
+        // never trips the generic RIB cap.
         assert!(!body.contains("enforce_max("), "{body}");
         assert!(
             body.contains("api_block(u64::from(response.capacity))"),
@@ -3063,14 +3103,30 @@ mod tests {
             .unwrap()
             .0;
         assert!(!ordinary.contains("enforce_max("), "{ordinary}");
-        assert!(
-            body.find("if y != IXP_MANAGER_REJECT_FUNCTION").unwrap()
-                < body.find(".get_global(").unwrap(),
-            "{body}"
-        );
         assert!(ixp_manager_reason_namespace_matches(65001, 65001, 1101));
         assert!(!ixp_manager_reason_namespace_matches(65001, 65002, 1101));
         assert!(!ixp_manager_reason_namespace_matches(65001, 65001, 1102));
+    }
+
+    #[test]
+    fn wildcard_scan_matches_only_x_y_star_large_communities() {
+        let route = |lcs: &[&str]| proto::Route {
+            large_communities: lcs.iter().map(|lc| lc.to_string()).collect(),
+            ..Default::default()
+        };
+        assert!(carries_large_community(&route(&["64496:1:1"]), 64496, 1));
+        assert!(carries_large_community(
+            &route(&["65001:999:7", "64496:1:2"]),
+            64496,
+            1
+        ));
+        // A different admin or function, short encodings, and malformed
+        // parts never match.
+        assert!(!carries_large_community(&route(&["64497:1:1"]), 64496, 1));
+        assert!(!carries_large_community(&route(&["64496:2:1"]), 64496, 1));
+        assert!(!carries_large_community(&route(&["64496:1"]), 64496, 1));
+        assert!(!carries_large_community(&route(&["64496:one:1"]), 64496, 1));
+        assert!(!carries_large_community(&route(&[]), 64496, 1));
     }
 
     /// Retention disabled and enabled-but-empty both produce the full

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -509,6 +509,7 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
 }
 
 fn announce_additional_route(stream: &mut TcpStream) {
+    use rustbgpd_wire::LargeCommunity;
     use rustbgpd_wire::attribute::{AsPath, AsPathSegment, Origin, PathAttribute};
     use rustbgpd_wire::message::{Message, encode_message};
     use rustbgpd_wire::update::UpdateMessage;
@@ -522,6 +523,9 @@ fn announce_additional_route(stream: &mut TcpStream) {
             }),
             PathAttribute::NextHop("192.0.2.99".parse().unwrap()),
             PathAttribute::Med(31),
+            // An ordinary (non-reserved) large community, so the accepted
+            // route is visible to the lc-zwild wildcard scan.
+            PathAttribute::LargeCommunities(vec![LargeCommunity::new(65020, 100, 1)]),
         ],
         &mut attrs,
         true,
@@ -1204,10 +1208,11 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         "ARouteServer presentation must scrub both configured namespaces: {filtered}"
     );
 
-    // IXP Manager v7.4 asks for `{daemon ASN}:1101:*`. This view uses only
-    // retained rejects, strips the peer's forged value in that reserved
-    // namespace, preserves unrelated communities, and synthesizes one
-    // conservative reason (as_path_loop is deliberately generic here).
+    // IXP Manager v7.4 asks for `{daemon ASN}:1101:*`. The daemon's own
+    // rejection namespace uses only retained rejects, strips the peer's
+    // forged value in that reserved namespace, preserves unrelated
+    // communities, and synthesizes one conservative reason (as_path_loop
+    // is deliberately generic here).
     let ixp_filtered = get_json(
         adapter_port,
         "/routes/lc-zwild/protocol/pb_0001_as65020/65001/1101",
@@ -1228,14 +1233,16 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .collect::<Vec<_>>(),
         [&serde_json::json!([65001, 1101, 0])]
     );
+    // An ordinary pair follows Bird's Eye wildcard semantics: the member's
+    // accepted routes carrying (x, y, *). Nothing accepted carries these
+    // pairs, and the accepted-route shape has no retention envelope.
     for path in [
         "/routes/lc-zwild/protocol/pb_0001_as65020/65002/1101",
         "/routes/lc-zwild/protocol/pb_0001_as65020/65001/1102",
     ] {
-        assert_eq!(
-            get_json(adapter_port, path, "adapter")["routes"],
-            serde_json::json!([])
-        );
+        let ordinary = get_json(adapter_port, path, "adapter");
+        assert_eq!(ordinary["routes"], serde_json::json!([]), "{ordinary}");
+        assert!(ordinary.get("retention").is_none(), "{ordinary}");
     }
 
     // /protocols/bgp — the neighbor summary serves the real filtered
@@ -1413,6 +1420,23 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         403,
         over_limit,
     );
+    // Ordinary-pair wildcard scan: the accepted 10.97.0.0/24 carries
+    // 65020:100:1, and nonmatching routes are filtered before the cap, so
+    // the scan answers 200 while the full received view is over limit.
+    let wildcard = get_json(
+        adapter_port,
+        "/routes/lc-zwild/protocol/pb_0001_as65020/65020/100",
+        "adapter",
+    );
+    let wildcard_routes = wildcard["routes"].as_array().unwrap();
+    assert_eq!(wildcard_routes.len(), 1, "{wildcard}");
+    assert_eq!(wildcard_routes[0]["network"], "10.97.0.0/24", "{wildcard}");
+    assert_eq!(
+        wildcard_routes[0]["bgp"]["large_communities"],
+        serde_json::json!([[65020, 100, 1]]),
+        "{wildcard}"
+    );
+    assert!(wildcard.get("retention").is_none(), "{wildcard}");
     announce_additional_rejected_route(&mut bgp_session);
     let deadline = Instant::now() + Duration::from_secs(60);
     let overflow = loop {

--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -113,7 +113,12 @@ large communities, an aggregate carrying ATOMIC_AGGREGATE and AGGREGATOR, and
 a more-specific inside a covering prefix. `oracle-consumer.php` drives the pinned IXP Manager `BirdsEye`
 consumer through all eleven in-scope endpoints (24 journeys, including a
 covering-only prefix, a host address, host-bit input, and a foreign
-large-community wildcard) against each leg, and `verify_capture.py
+large-community wildcard) against each leg. The harness then appends a 25th,
+deterministic backend-failure journey captured directly with status and body
+(the pinned consumer collapses every non-2xx to an empty string): rustbgpd is
+stopped under the still-running adapter and BIRD under the still-running
+Bird's Eye, and one `api/status` probe per leg records the adapter's HTTP 502
+against Bird's Eye's own HTTP 503. `verify_capture.py
 --populated` normalizes both captures (timestamps, the rustbgpd version,
 countdowns, each leg's own route-server addresses, BIRD's `route_changes`
 counters, route and symbol order),
@@ -205,7 +210,7 @@ the adapter serves at `/` where Bird's Eye serves under `/api/` (IXP Manager's
 | `GET /api/routes/count/protocol/{protocol}` | — | — | not served | out of scope (`total_count` exists on the first RIB page, so it is a cheap add if scope grows) |
 | `GET /api/routes/count/table/{table}` | — | — | not served | out of scope; standing `full-table-count` blocker |
 | `GET /api/routes/count/export/{protocol}` | — | — | not served | out of scope (same note as protocol count) |
-| `GET /api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` | `routesProtocolLargeCommunityWildXYRoutes()` | `routes_protocol_large_community_wild_xy` | served, divergent | answers only `{daemon ASN}:1101:*` from retained rejects, empty for any other `(x, y)`; adds `retention.*`; `api.max_routes` is the retention capacity |
+| `GET /api/routes/lc-zwild/protocol/{protocol}/{x}/{y}` | `routesProtocolLargeCommunityWildXYRoutes()` | `routes_protocol_large_community_wild_xy` | served, divergent | the daemon's rejection namespace `{daemon ASN}:1101:*` answers from retained rejects (adds `retention.*`; `api.max_routes` is the retention capacity); any other `(x, y)` scans the member's accepted routes for `(x, y, *)` with Bird's Eye's wildcard semantics |
 | `GET /api/route/{net}` (default table `master`) | — | — | not served | out of scope |
 | `GET /api/route/{net}/table/{table}` | `protocolTable()` | `route_table` | served, divergent | longest-prefix match; host-bit input is HTTP 200 with no routes (BIRD rejects the literal), genuinely malformed or unmasked input is HTTP 400 (Bird's Eye accepts a bare `192.0.2.1`); returns the installed winner first plus same-prefix Add-Path alternatives; no per-minute throttle |
 | `GET /api/route/{net}/protocol/{protocol}` | `protocolRoute()` | `route_protocol` | served, divergent | longest-prefix match like Bird's Eye's `show route for`: the exact entry when present, else the view's most-specific covering prefix; host-bit input is HTTP 200 with no routes; all Add-Path candidates |
@@ -223,7 +228,8 @@ Cross-cutting differences that belong on the allow-list once: the `api` block
 adds Birdwatcher's `Version` and `result_from_cache` and never emits
 `ttl_mins`; `from_cache` is always `false` because there is no cache to skip
 (`use_cache` is ignored); upstream failure is HTTP 502 where Bird's Eye
-returns 503 `Error querying bird`; the `/api/route/*` per-minute throttle
+returns 503 `Error querying bird` (captured by the backend-failure journey
+and allow-listed `intentional`); the `/api/route/*` per-minute throttle
 (`THROTTLE_PER_MIN`, HTTP 429) has no adapter equivalent; error bodies are
 always JSON `{"message": ...}` (Bird's Eye's error body format follows
 Lumen's default handler and the request's `Accept` header, which is why the
@@ -277,18 +283,19 @@ refuses any `runtime_compatibility` value other than `false` while any entry
 is classified `must_match`. The flag therefore flips only when zero
 `must_match` entries remain, and the post-flip claim language is "verified
 IXP Manager 7.4 Bird's Eye API compatibility with documented BIRD-internal
-divergences". The one open `must_match` entry is the ordinary-`(x, y)`
-lc-zwild scope; the route-shape cluster (`bgp.as_path` element type,
+divergences". Zero `must_match` entries remain open: the ordinary-`(x, y)`
+lc-zwild scope, the route-shape cluster (`bgp.as_path` element type,
 `bgp.local_pref`, `bgp.med` emitted when absent, `primary` outside the table
-view, the `type` triple) and the two lookup-semantics entries
+view, the `type` triple), and the two lookup-semantics entries
 (exact-versus-longest protocol/export match and the table lookup's HTTP 400
-for host-bit input) converged on the oracle and their entries are removed.
+for host-bit input) all converged on the oracle and their entries are
+removed.
 
 ### Work list
 
-Each line names the gap and the evidence that closes it. Items 1 to 6, 15,
-and 16 are done; items 3 to 14 record what the oracle diff showed, with the
-observed JSON paths, and carry their decisions: `must_match` entries
+Each line names the gap and the evidence that closes it. Items 1 to 6, 10 to
+12, 15, and 16 are done; items 3 to 14 record what the oracle diff showed,
+with the observed JSON paths, and carry their decisions: `must_match` entries
 stay open and gate the flip, while `intentional`, `unsupported`, and
 `extension` entries are closed decisions that stay on the allow-list. Every
 observed
@@ -381,15 +388,24 @@ predicted eight more that the diff did not show, listed after the table.
     the queried prefix has no entry, and host-bit input answers HTTP 200
     with an empty route array on all three lookups. Both entries are
     removed.
-11. `lc-zwild`: observed for a foreign `(x, y)` (the route carrying that large
-    community upstream, `routes: []` from the adapter) plus the adapter's extra
-    `retention.*` and `api.max_routes` as the retention capacity for the daemon
-    `(x, y)`; both legs return `routes: []` for the daemon `(x, y)`.
-    Decided: the ordinary-`(x, y)` scope is `must_match`; `retention.*` and
-    `api.max_routes` are `extension`.
-12. 502 versus 503: not observed; the populated leg has no upstream-failure
-    case (the existing `bird_failure` case stays on the `fake-birdc`
-    oracle); no allow-list entry exists, so there is nothing to classify.
+11. Done. `lc-zwild`: observed for a foreign `(x, y)` (the route carrying
+    that large community upstream, `routes: []` from the adapter). Was
+    `must_match`; the endpoint now dispatches on the pair — the daemon's own
+    rejection namespace keeps serving retained rejects, and every other
+    `(x, y)` scans the member's accepted routes for `(x, y, *)` with Bird's
+    Eye's wildcard semantics — and the entry is removed. The adapter's extra
+    `retention.*` and capacity-as-`api.max_routes` on the namespace pair
+    stay `extension`; both legs return `routes: []` for the daemon `(x, y)`.
+12. Done. 502 versus 503: the populated leg now ends with the deterministic
+    backend-failure journey described above (rustbgpd stopped under the
+    still-running adapter, BIRD stopped under Bird's Eye, one `api/status`
+    probe per leg captured with status and body since the pinned consumer
+    collapses every non-2xx to `""`). Observed: HTTP 503
+    `Error querying bird` upstream, HTTP 502 `Upstream daemon request
+    failed` from the adapter; the difference is one `intentional` allow-list
+    entry — a gateway honestly reports 502 where Bird's Eye reports its own
+    backend as 503. The existing `bird_failure` case stays on the
+    `fake-birdc` oracle.
 13. Throttle and cache: not observed as a body difference; `ttl_mins` is
     absent on both sides because `CACHE_DRIVER=array` strips it upstream and
     `from_cache` is `false` on both; the per-minute throttle is not hit by

--- a/tests/compat/ixp-manager-birdseye/contract.json
+++ b/tests/compat/ixp-manager-birdseye/contract.json
@@ -206,6 +206,19 @@
       "consumer_visible": false
     },
     {
+      "endpoint": "api/status",
+      "path": [
+        "http_status",
+        "body.message"
+      ],
+      "kind": "value",
+      "classification": "intentional",
+      "birdseye": "HTTP 503 {\"message\": \"Error querying bird\"} when birdc cannot reach BIRD",
+      "adapter": "HTTP 502 {\"message\": \"Upstream daemon request failed\"} when the gRPC backend is down",
+      "rationale": "backend-failure journey: Bird's Eye reports its own backend error as 503 while the adapter is a gateway and honestly reports 502; the pinned consumer collapses every non-2xx to \"\" either way",
+      "consumer_visible": false
+    },
+    {
       "endpoint": [
         "api/protocols/bgp",
         "api/protocol/{protocol}"
@@ -389,16 +402,6 @@
       "birdseye": "BIRD route preference (100)",
       "adapter": "0",
       "rationale": "BIRD-internal preference; the pinned route view prints metric",
-      "consumer_visible": true
-    },
-    {
-      "endpoint": "api/routes/lc-zwild/protocol/{protocol}/{x}/{y}",
-      "path": "routes",
-      "kind": "semantics",
-      "classification": "must_match",
-      "birdseye": "every route carrying (x, y, *) in the protocol's table",
-      "adapter": "retained rejects tagged <daemon asn>:1101:* only; [] for any other (x, y)",
-      "rationale": "the filtered-prefix view is the only pinned use; accepted routes are never scanned",
       "consumer_visible": true
     },
     {

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
@@ -1,5 +1,14 @@
 {
   "journeys": {
+    "backend_failure": {
+      "endpoint": "api/status",
+      "response": {
+        "body": {
+          "message": "Upstream daemon request failed"
+        },
+        "http_status": 502
+      }
+    },
     "lookup_export_covering": {
       "endpoint": "api/route/{net}/export/{protocol}",
       "response": {
@@ -1427,13 +1436,55 @@
           "result_from_cache": false,
           "version": "rustbgpd <version>"
         },
-        "retention": {
-          "capacity": null,
-          "enabled": null,
-          "evictions_since_reset": null,
-          "may_be_incomplete": null
-        },
-        "routes": []
+        "routes": [
+          {
+            "age": "<timestamp>",
+            "bgp": {
+              "as_path": [
+                "64496",
+                "64510",
+                "64520"
+              ],
+              "communities": [
+                [
+                  64496,
+                  100
+                ],
+                [
+                  64496,
+                  200
+                ]
+              ],
+              "large_communities": [
+                [
+                  64496,
+                  1,
+                  1
+                ],
+                [
+                  64496,
+                  1,
+                  2
+                ]
+              ],
+              "local_pref": "100",
+              "med": 10,
+              "next_hop": "198.51.100.2",
+              "origin": "IGP"
+            },
+            "from_protocol": "pb_as64496",
+            "gateway": "198.51.100.2",
+            "interface": "",
+            "learnt_from": "198.51.100.2",
+            "metric": 0,
+            "network": "203.0.113.0/24",
+            "primary": true,
+            "type": [
+              "BGP",
+              "univ"
+            ]
+          }
+        ]
       }
     }
   },

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-oracle.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-oracle.json
@@ -1,5 +1,14 @@
 {
   "journeys": {
+    "backend_failure": {
+      "endpoint": "api/status",
+      "response": {
+        "body": {
+          "message": "Error querying bird"
+        },
+        "http_status": 503
+      }
+    },
     "lookup_export_covering": {
       "endpoint": "api/route/{net}/export/{protocol}",
       "response": {

--- a/tests/compat/ixp-manager-birdseye/run-oracle-leg.sh
+++ b/tests/compat/ixp-manager-birdseye/run-oracle-leg.sh
@@ -192,4 +192,47 @@ run_consumer() {
 }
 run_consumer "$oracle_api" "$capture_output/populated-oracle.raw.json"
 run_consumer "$live_api" "$capture_output/populated-live.raw.json"
+
+# Deterministic backend-failure journey, captured last so every journey above
+# read a healthy backend: stop rustbgpd under the still-running adapter (its
+# next gRPC call fails, HTTP 502) and BIRD under the still-running Bird's Eye
+# (birdc fails, its own HTTP 503), then record one api/status probe per leg
+# directly — the pinned consumer collapses every non-2xx to "". Nothing after
+# this point reads either backend; teardown follows.
+kill "$daemon_pid"
+wait "$daemon_pid" 2>/dev/null || true
+daemon_pid=
+docker exec "$oracle" birdc -s /run/bird/bird.ctl down >/dev/null 2>&1 || true
+docker exec "$oracle" sh -c \
+  'for _ in $(seq 1 100); do [ ! -S /run/bird/bird.ctl ] && exit 0; sleep 0.1; done; exit 1'
+probe_failure() {
+  curl --silent --max-time 10 --header 'Accept: application/json' \
+    --output "$2" --write-out '%{http_code}' "$1/status"
+}
+live_failure_status=$(probe_failure "$live_api" "$tmp/live-failure-body.json")
+oracle_failure_status=$(probe_failure "$oracle_api" "$tmp/oracle-failure-body.json")
+merge_backend_failure() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import json
+import sys
+
+path, status, body_path = sys.argv[1:4]
+with open(path) as handle:
+    document = json.load(handle)
+with open(body_path) as handle:
+    body = json.load(handle)
+document["journeys"]["backend_failure"] = {
+    "endpoint": "api/status",
+    "response": json.dumps({"http_status": int(status), "body": body}),
+}
+with open(path, "w") as handle:
+    json.dump(document, handle, indent=4)
+    handle.write("\n")
+PY
+}
+merge_backend_failure "$capture_output/populated-live.raw.json" \
+  "$live_failure_status" "$tmp/live-failure-body.json"
+merge_backend_failure "$capture_output/populated-oracle.raw.json" \
+  "$oracle_failure_status" "$tmp/oracle-failure-body.json"
+echo "backend failure journey: live adapter answered HTTP $live_failure_status, oracle Bird's Eye answered HTTP $oracle_failure_status" >&2
 chmod 600 "$capture_output/populated-oracle.raw.json" "$capture_output/populated-live.raw.json"

--- a/tests/compat/ixp-manager-birdseye/verify_capture.py
+++ b/tests/compat/ixp-manager-birdseye/verify_capture.py
@@ -231,6 +231,14 @@ RUNTIME_DIVERGENCES = [
         "consumer_visible": False,
     },
     {
+        "endpoint": "api/status", "path": ["http_status", "body.message"], "kind": "value",
+        "classification": "intentional",
+        "birdseye": "HTTP 503 {\"message\": \"Error querying bird\"} when birdc cannot reach BIRD",
+        "adapter": "HTTP 502 {\"message\": \"Upstream daemon request failed\"} when the gRPC backend is down",
+        "rationale": "backend-failure journey: Bird's Eye reports its own backend error as 503 while the adapter is a gateway and honestly reports 502; the pinned consumer collapses every non-2xx to \"\" either way",
+        "consumer_visible": False,
+    },
+    {
         "endpoint": ROW, "path": row("connection"), "kind": "value",
         "classification": "intentional",
         "birdseye": "BIRD 2 info column with its padding (\"  Established   \")",
@@ -307,14 +315,6 @@ RUNTIME_DIVERGENCES = [
         "classification": "intentional",
         "birdseye": "BIRD route preference (100)", "adapter": "0",
         "rationale": "BIRD-internal preference; the pinned route view prints metric",
-        "consumer_visible": True,
-    },
-    {
-        "endpoint": LC_ZWILD, "path": "routes", "kind": "semantics",
-        "classification": "must_match",
-        "birdseye": "every route carrying (x, y, *) in the protocol's table",
-        "adapter": "retained rejects tagged <daemon asn>:1101:* only; [] for any other (x, y)",
-        "rationale": "the filtered-prefix view is the only pinned use; accepted routes are never scanned",
         "consumer_visible": True,
     },
     {
@@ -607,6 +607,24 @@ def verify_populated(capture_dir: Path, web_php: Path) -> None:
         for name, journey in document["journeys"].items():
             if journey["response"] == "":
                 fail(f"populated {leg} capture: {name} returned a collapsed non-2xx response")
+    # The deterministic backend-failure journey is captured directly (the
+    # pinned consumer collapses every non-2xx to ""), so status and body are
+    # asserted here rather than only pinned by the fixture bytes.
+    for leg, expected in (
+        ("live", {"http_status": 502, "body": {"message": "Upstream daemon request failed"}}),
+        ("oracle", {"http_status": 503, "body": {"message": "Error querying bird"}}),
+    ):
+        observed = docs[leg]["journeys"].get("backend_failure", {}).get("response")
+        if observed != expected:
+            fail(
+                f"backend-failure journey ({leg}): expected {expected}, "
+                f"captured {observed}"
+            )
+    print(
+        "backend failure proof: with both backends stopped the adapter answered "
+        "HTTP 502 and Bird's Eye HTTP 503, each with its pinned JSON error body",
+        file=sys.stderr,
+    )
     for leg, document in docs.items():
         text = json.dumps(document, indent=2, sort_keys=True) + "\n"
         fixture = root / "fixtures" / f"populated-{leg}.json"


### PR DESCRIPTION
Closes the last `must_match` divergence (LAN-1232) and adds the deterministic backend-failure proof journey to the populated compat gate.

## Hybrid dispatch rule (lc-zwild)

`GET /routes/lc-zwild/protocol/{id}/{x}/{y}` resolves the member, reads the daemon ASN (`GlobalService.GetGlobal`), then dispatches on the pair:

- `(x, y) == ({daemon ASN}, 1101)` — the daemon's own rejection namespace: unchanged retained-rejects behavior (`PolicyService.ListRejectedRoutes`, retention envelope, capacity as `api.max_routes`, no-session empty answer).
- any other `(x, y)` — Bird's Eye wildcard semantics: the member's accepted routes carrying a large community `(x, y, *)`.

## Wildcard scan shape

The scan reuses the accepted-route view path: `serve_routes_for_peer` gains a `wildcard: Option<(u64, u64)>` parameter — paged `RibService.ListReceivedRoutes` over one member plus the `ListBestRoutes` identity join for truthful `primary`, filtering rows on `(x, y, *)` before rendering (O(n) over the member's view, like the LPM lookups). The generic `--max-routes` cap applies to the matched rows, not the whole view, matching Bird's Eye's `MAX_ROUTES` on parsed result rows; the response is the plain accepted-route body (no retention envelope). Unit tests cover the `(x, y, *)` matcher (malformed/short encodings never match) and the dispatch structure; the live smoke test announces an accepted route carrying `65020:100:1` and asserts the ordinary-pair scan returns exactly it — with the full view over the cap, proving filter-before-cap — plus empty-result shape and namespace behavior.

## Backend-failure journey (502 proof)

The populated oracle leg now ends with a deterministic failure journey, captured directly with status and body because the pinned IXP Manager consumer collapses every non-2xx to `""`: after the 24 consumer journeys, `run-oracle-leg.sh` stops rustbgpd under the still-running adapter and BIRD (`birdc down`, socket-gone poll) under the still-running Bird's Eye, then records one `api/status` probe per leg as a 25th journey in both raw captures. Captured:

- live: HTTP 502 `{"message": "Upstream daemon request failed"}`
- oracle: HTTP 503 `{"message": "Error querying bird"}`

`verify_capture.py --populated` asserts both captures exactly and prints a `backend failure proof:` line; the status/message difference is one new `intentional` allow-list entry (a gateway honestly reports 502 where Bird's Eye reports its own backend as 503). The journey runs last, so every healthy journey reads a live backend and nothing after it needs one.

## Contract delta

- removed: the lc-zwild `routes` `must_match` entry (both `contract.json` and the `RUNTIME_DIVERGENCES` constant) — `must_match` count 1 → 0
- added: one `intentional` entry for the backend-failure journey (`http_status`, `body.message` on `api/status`)
- net: 22 entries → 22 entries (0 must_match, 13 intentional, 2 unsupported, 7 extension); `retention.*` and `api.max_routes` extension entries unchanged, still exercised by the namespace journey
- fixtures refreshed via `CAPTURE_FIXTURES=1`: `wildcard_foreign` live now serves the accepted route in the oracle's shape, and both legs pin the `backend_failure` journey

## Proof lines (verbatim)

Baseline (unmodified tree, rc 0):

```
populated oracle proof: 24 journeys over 11 endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; 22 allow-listed divergences (1 must_match, 12 intentional, 2 unsupported, 7 extension), 0 unlisted, 0 stale; 27 pinned routes/web.php routes accounted for
```

Post-change (rc 0):

```
backend failure proof: with both backends stopped the adapter answered HTTP 502 and Bird's Eye HTTP 503, each with its pinned JSON error body
populated oracle proof: 25 journeys over 11 endpoints diffed BIRD 2.0.12 + Bird's Eye against rustbgpd + adapter; 22 allow-listed divergences (0 must_match, 13 intentional, 2 unsupported, 7 extension), 0 unlisted, 0 stale; 27 pinned routes/web.php routes accounted for
```

## Gates

| Gate | Result |
|---|---|
| `tests/compat/ixp-manager-birdseye/run.sh` (baseline, unmodified) | rc 0, proof line reproduced |
| `tests/compat/ixp-manager-birdseye/run.sh` (post-change, pinned fixtures) | rc 0, 0 must_match |
| `cargo fmt --all -- --check` | rc 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | rc 0 |
| `cargo test --workspace --no-fail-fast` | rc 0 (113 suites; `birdwatcher_adapter_smoke` and `grpc_failure_exit_code` green on first run) |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | rc 0 |
| `scripts/check-clippy-reasons.py` | rc 0 |
| `scripts/check_public_tracker_ids.py` | rc 0 |
| `scripts/check-v1-stable-surface.py` | rc 0 |
| `scripts/check_ixp_manager_docs.py` | rc 0 |
