### PR TITLE
test: prove post-dispatch BGP teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Runtime behavior is unchanged; the supervised-shutdown proof now injects a
+  BGP accept-forwarder panic after inbound dispatch and verifies bounded
+  teardown of both the configured peer and its half-admitted candidate before
+  the daemon exits non-zero. (LAN-1258)
+
 - The IXP Manager Bird's Eye compatibility contract
   (`tests/compat/ixp-manager-birdseye/contract.json`) flips
   `runtime_compatibility` to `true`: verified IXP Manager 7.4 Bird's Eye API

--- a/src/main.rs
+++ b/src/main.rs
@@ -2971,8 +2971,8 @@ const RIB_CHANNEL_CAPACITY: usize = 4096;
 const TEST_RIB_CHANNEL_CAPACITY_ENV: &str = "RUSTBGPD_TEST_RIB_CHANNEL_CAPACITY";
 
 /// Test-only fault injection; never set this in production. The only accepted
-/// values are `listener_panic` and `forwarder_return`; all others are ignored
-/// with a sanitized warning.
+/// values are `listener_panic`, `forwarder_return`, and `forwarder_panic`; all
+/// others are ignored with a sanitized warning.
 const TEST_BGP_INGRESS_EXIT_ENV: &str = "RUSTBGPD_TEST_BGP_INGRESS_EXIT";
 
 /// Test-only one-based configured-peer ordinal that forces the real
@@ -2999,6 +2999,7 @@ fn resolve_test_peer_manager_panic() -> bool {
 enum TestBgpIngressExit {
     ListenerPanic,
     ForwarderReturn,
+    ForwarderPanic,
 }
 
 fn parse_test_bgp_ingress_exit(raw: Option<&str>) -> Result<Option<TestBgpIngressExit>, ()> {
@@ -3006,6 +3007,7 @@ fn parse_test_bgp_ingress_exit(raw: Option<&str>) -> Result<Option<TestBgpIngres
         None => Ok(None),
         Some("listener_panic") => Ok(Some(TestBgpIngressExit::ListenerPanic)),
         Some("forwarder_return") => Ok(Some(TestBgpIngressExit::ForwarderReturn)),
+        Some("forwarder_panic") => Ok(Some(TestBgpIngressExit::ForwarderPanic)),
         Some(_) => Err(()),
     }
 }
@@ -3016,13 +3018,13 @@ fn resolve_test_bgp_ingress_exit() -> Option<TestBgpIngressExit> {
         Err(std::env::VarError::NotPresent) => None,
         Err(std::env::VarError::NotUnicode(_)) => {
             warn!(
-                "ignoring invalid {TEST_BGP_INGRESS_EXIT_ENV}; expected listener_panic or forwarder_return"
+                "ignoring invalid {TEST_BGP_INGRESS_EXIT_ENV}; expected listener_panic, forwarder_return, or forwarder_panic"
             );
             return None;
         }
     };
     parse_test_bgp_ingress_exit(raw.as_deref()).unwrap_or_else(|()| {
-        warn!("ignoring invalid {TEST_BGP_INGRESS_EXIT_ENV}; expected listener_panic or forwarder_return");
+        warn!("ignoring invalid {TEST_BGP_INGRESS_EXIT_ENV}; expected listener_panic, forwarder_return, or forwarder_panic");
         None
     })
 }
@@ -5070,16 +5072,22 @@ async fn run<T>(
             if test_bgp_ingress_exit == Some(TestBgpIngressExit::ForwarderReturn) {
                 return;
             }
-            if let Err(e) = listener_peer_mgr_tx
+            let result = listener_peer_mgr_tx
                 .send(PeerManagerCommand::AcceptInbound {
                     stream: conn.stream,
                     peer_addr: conn.peer_addr,
                     tcp_ao_info: conn.tcp_ao_info,
                     tcp_ao_generation: conn.tcp_ao_generation,
                 })
-                .await
-            {
+                .await;
+            if let Err(e) = result {
                 warn!(error = %e, "failed to forward inbound connection to peer manager");
+            } else {
+                assert_ne!(
+                    test_bgp_ingress_exit,
+                    Some(TestBgpIngressExit::ForwarderPanic),
+                    "injected BGP accept-forwarding task panic after inbound dispatch"
+                );
             }
         }
     });
@@ -5961,7 +5969,17 @@ mod tests {
             parse_test_bgp_ingress_exit(Some("forwarder_return")),
             Ok(Some(TestBgpIngressExit::ForwarderReturn))
         );
-        for raw in ["", "listener", " listener_panic", "forwarder_return "] {
+        assert_eq!(
+            parse_test_bgp_ingress_exit(Some("forwarder_panic")),
+            Ok(Some(TestBgpIngressExit::ForwarderPanic))
+        );
+        for raw in [
+            "",
+            "listener",
+            " listener_panic",
+            "forwarder_return ",
+            "forwarder_panic ",
+        ] {
             assert_eq!(parse_test_bgp_ingress_exit(Some(raw)), Err(()));
         }
         assert_eq!(parse_test_initial_peer_rejection_at(None), Ok(None));

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -313,7 +313,7 @@ fn rbgp(grpc_addr: &str, args: &[&str]) -> std::process::Output {
     .expect("failed to spawn rbgp subprocess")
 }
 
-fn run_bgp_ingress_fault(mode: &str, connect: bool) -> (ExitStatus, String) {
+fn run_bgp_ingress_fault(mode: &str, connect: bool) -> (ExitStatus, String, Vec<String>) {
     let temp = private_tempdir();
     let config_path = write_rib_fault_config(temp.path());
     let mut daemon = spawn_daemon_with_env(
@@ -326,7 +326,16 @@ fn run_bgp_ingress_fault(mode: &str, connect: bool) -> (ExitStatus, String) {
         TcpStream::connect(("127.0.0.1", port)).expect("connect to real bound BGP listener")
     });
     let status = daemon.wait_within(Duration::from_secs(30));
-    (status, daemon.logs())
+    let logs = daemon.logs();
+    let reports = match std::fs::read_dir(temp.path().join("runtime/crash")) {
+        Ok(entries) => entries
+            .map(|entry| entry.expect("read panic report directory entry"))
+            .map(|entry| std::fs::read_to_string(entry.path()).expect("read panic report"))
+            .collect(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => panic!("read panic report directory: {error}"),
+    };
+    (status, logs, reports)
 }
 
 #[test]
@@ -643,7 +652,7 @@ fn bgp_ingress_tasks_are_retained_unconditionally_supervised_and_torn_down() {
 
 #[test]
 fn bound_bgp_listener_panic_uses_common_shutdown_and_exits_nonzero() {
-    let (status, logs) = run_bgp_ingress_fault("listener_panic", false);
+    let (status, logs, _reports) = run_bgp_ingress_fault("listener_panic", false);
     assert_eq!(
         status.code(),
         Some(1),
@@ -665,7 +674,7 @@ fn bound_bgp_listener_panic_uses_common_shutdown_and_exits_nonzero() {
 
 #[test]
 fn accepted_connection_forwarder_return_uses_common_shutdown_and_exits_nonzero() {
-    let (status, logs) = run_bgp_ingress_fault("forwarder_return", true);
+    let (status, logs, reports) = run_bgp_ingress_fault("forwarder_return", true);
     assert_eq!(
         status.code(),
         Some(1),
@@ -679,6 +688,53 @@ fn accepted_connection_forwarder_return_uses_common_shutdown_and_exits_nonzero()
         logs.contains("initiating shutdown due to BGP accept-forwarding task failure"),
         "{logs}"
     );
+    assert_eq!(logs.matches("shutdown requested").count(), 1, "{logs}");
+    assert!(reports.is_empty(), "unexpected panic reports: {reports:?}");
+}
+
+#[test]
+fn accepted_connection_forwarder_panic_drains_half_admitted_candidate_and_exits_nonzero() {
+    let (status, logs, reports) = run_bgp_ingress_fault("forwarder_panic", true);
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "forwarder panic must exit 1\n{logs}"
+    );
+    assert_eq!(reports.len(), 1, "one durable panic report: {reports:?}");
+    assert!(
+        reports[0].contains("injected BGP accept-forwarding task panic after inbound dispatch"),
+        "{reports:?}"
+    );
+    for message in [
+        "BGP accept-forwarding task exited unexpectedly",
+        "initiating shutdown due to BGP accept-forwarding task failure",
+        "initiating coordinated shutdown",
+        "peer manager shutting down 1 peers",
+        "rustbgpd exiting",
+    ] {
+        assert!(logs.contains(message), "missing {message:?}\n{logs}");
+    }
+    let peer_shutdown = logs.find("peer manager shutting down 1 peers").unwrap();
+    let exit = logs.find("rustbgpd exiting").unwrap();
+    let shutdowns = logs
+        .match_indices("shutdown requested")
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    assert_eq!(shutdowns.len(), 2, "{logs}");
+    assert!(
+        shutdowns
+            .iter()
+            .all(|index| peer_shutdown < *index && *index < exit),
+        "{logs}"
+    );
+    for absent in [
+        "rustbgpd did not exit within timeout",
+        "JoinHandle polled after completion",
+        "peer shutdown timed out",
+        "peer task join error during shutdown",
+    ] {
+        assert!(!logs.contains(absent), "unexpected {absent:?}\n{logs}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a test-only BGP accept-forwarder panic after a successful inbound dispatch
- prove coordinated shutdown drains both the configured peer and its half-admitted inbound candidate
- preserve runtime behavior while tightening durable panic and teardown-order coverage

## Verification

- `cargo fmt --all --check`
- focused parser, forwarder-return, and forwarder-panic tests
- `cargo test --locked -p rustbgpd --test grpc_failure_exit_code`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace`
- `cargo +1.95.0 check --locked --workspace --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --lib --no-deps`
- `python3 scripts/check_public_tracker_ids.py`

Linear: LAN-1258
