### PR TITLE
test: resolve remaining rbgp test binaries directly

### DIFF
--- a/tests/atomic_aggregate_passthrough.rs
+++ b/tests/atomic_aggregate_passthrough.rs
@@ -9,6 +9,9 @@
 //!
 //! Stub mechanics follow `tests/outbound_prefix_limits.rs`.
 
+#[allow(dead_code)]
+mod support;
+
 use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -265,36 +268,22 @@ async fn establish(ctx: Arc<Ctx>, i: usize) -> Result<mpsc::Sender<Message>, Str
     Ok(tx)
 }
 
-/// `rbgp` against the spawned daemon. `CARGO_BIN_EXE_rbgp` is not set for a
-/// dev-dependency's binary, so fall back to `cargo run -p rustbgpctl`.
+/// `rbgp` against the spawned daemon.
 struct Rbgp {
-    argv: Vec<String>,
+    bin: PathBuf,
     addr: String,
 }
 
 impl Rbgp {
     fn new(addr: String) -> Self {
-        let argv = if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
-            vec![path]
-        } else {
-            let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-            vec![
-                cargo,
-                "run".into(),
-                "--quiet".into(),
-                "-p".into(),
-                "rustbgpctl".into(),
-                "--bin".into(),
-                "rbgp".into(),
-                "--".into(),
-            ]
-        };
-        Self { argv, addr }
+        Self {
+            bin: support::rbgp_binary().to_path_buf(),
+            addr,
+        }
     }
 
     async fn run(&self, args: &[&str]) -> Result<String, String> {
-        let out = tokio::process::Command::new(&self.argv[0])
-            .args(&self.argv[1..])
+        let out = tokio::process::Command::new(&self.bin)
             .arg("--addr")
             .arg(&self.addr)
             .args(args)

--- a/tests/config_persistence_lifecycle.rs
+++ b/tests/config_persistence_lifecycle.rs
@@ -34,6 +34,9 @@
 //! test fails at the end if any check failed, so one failure does not hide the
 //! rest of the picture.
 
+#[allow(dead_code)]
+mod support;
+
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
@@ -792,39 +795,25 @@ fn sum_samples(scrape: &str, name: &str, labels: &[(&str, &str)]) -> Option<f64>
     total
 }
 
-/// `rbgp` against the spawned daemon. `CARGO_BIN_EXE_rbgp` is not set for a
-/// dev-dependency's binary, so fall back to `cargo run -p rustbgpctl`.
+/// `rbgp` against the spawned daemon.
 struct Rbgp {
-    argv: Vec<String>,
+    bin: PathBuf,
     addr: String,
 }
 
 impl Rbgp {
     fn new(addr: String) -> Self {
-        let argv = if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
-            vec![path]
-        } else {
-            let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-            vec![
-                cargo,
-                "run".into(),
-                "--quiet".into(),
-                "-p".into(),
-                "rustbgpctl".into(),
-                "--bin".into(),
-                "rbgp".into(),
-                "--".into(),
-            ]
-        };
-        Self { argv, addr }
+        Self {
+            bin: support::rbgp_binary().to_path_buf(),
+            addr,
+        }
     }
 
     /// Exit status plus both streams. `config plan` and `config diff` use
     /// terraform-style exits (2 = changes present), so a nonzero status is not
     /// automatically a failure.
     async fn try_run(&self, args: &[&str]) -> Result<(i32, String, String), String> {
-        let out = tokio::process::Command::new(&self.argv[0])
-            .args(&self.argv[1..])
+        let out = tokio::process::Command::new(&self.bin)
             .arg("--addr")
             .arg(&self.addr)
             .args(args)

--- a/tests/outbound_prefix_limits.rs
+++ b/tests/outbound_prefix_limits.rs
@@ -28,6 +28,9 @@
 //! test fails at the end if any check failed, so one failure does not hide the
 //! rest of the picture.
 
+#[allow(dead_code)]
+mod support;
+
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
@@ -495,36 +498,22 @@ fn sample(scrape: &str, name: &str, labels: &[(&str, &str)]) -> Option<f64> {
     })
 }
 
-/// `rbgp` against the spawned daemon. `CARGO_BIN_EXE_rbgp` is not set for a
-/// dev-dependency's binary, so fall back to `cargo run -p rustbgpctl`.
+/// `rbgp` against the spawned daemon.
 struct Rbgp {
-    argv: Vec<String>,
+    bin: PathBuf,
     addr: String,
 }
 
 impl Rbgp {
     fn new(addr: String) -> Self {
-        let argv = if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
-            vec![path]
-        } else {
-            let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-            vec![
-                cargo,
-                "run".into(),
-                "--quiet".into(),
-                "-p".into(),
-                "rustbgpctl".into(),
-                "--bin".into(),
-                "rbgp".into(),
-                "--".into(),
-            ]
-        };
-        Self { argv, addr }
+        Self {
+            bin: support::rbgp_binary().to_path_buf(),
+            addr,
+        }
     }
 
     async fn run(&self, args: &[&str]) -> Result<String, String> {
-        let out = tokio::process::Command::new(&self.argv[0])
-            .args(&self.argv[1..])
+        let out = tokio::process::Command::new(&self.bin)
             .arg("--addr")
             .arg(&self.addr)
             .args(args)


### PR DESCRIPTION
## Summary

- replace the final three integration-test cargo-run fallbacks with the shared direct rbgp binary resolver
- preserve command arguments, address handling, exit status, captured output, and diagnostics
- remove build-lock and workspace freshness checks from timing-bounded command paths

## Verification

- `cargo fmt --all -- --check`
- `cargo build --locked -p rustbgpctl --bin rbgp`
- `cargo test --locked --test atomic_aggregate_passthrough`
- `cargo test --locked --test outbound_prefix_limits`
- `cargo test --locked --test config_persistence_lifecycle`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`
- pre-push workspace library tests

Linear: LAN-1257
