### PR TITLE
feat(observability): expose BMP divergence health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- BMP divergence repair is now operator-visible through the lifecycle-correct
+  `bmp_stream_diverged{peer}` gauge, a sustained-divergence alert, a control
+  event-drop alert, and a focused Grafana panel. The gauge clears after repair
+  or genuine teardown and is reaped with the peer. (LAN-1241)
+
 - `RibService` route detail now carries the RFC 4271 AGGREGATOR and
   ATOMIC_AGGREGATE path attributes (`Route.aggregator` with AS number and
   router ID, `Route.atomic_aggregate`), and the Bird's Eye adapter renders

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -7059,8 +7059,8 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 53 peer-labeled series; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 53);
+        // 54 peer-labeled series; state transitions hold two series.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 54);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -7070,7 +7070,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 53);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 54);
     }
 
     /// Load-bearing finite/unlimited proof: removing either finite gauge

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -212,6 +212,7 @@ struct BgpMetricsInner {
     // ── Outbound queue (per-peer writer back-pressure) ─────────────
     peer_outbound_queue_depth: IntGaugeVec,
     peer_slow: IntGaugeVec,
+    bmp_stream_diverged: IntGaugeVec,
     rejected_routes_retained: IntGaugeVec,
     rejected_route_retention_evictions: IntCounterVec,
     rfc8212_missing_import_policy: IntGaugeVec,
@@ -664,6 +665,15 @@ impl BgpMetrics {
                  persistently not draining its outbound queue (backlog above \
                  the configured threshold for the configured duration). \
                  Cleared on drain and on session teardown.",
+            ),
+            &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let bmp_stream_diverged = IntGaugeVec::new(
+            Opts::new(
+                "bmp_stream_diverged",
+                "1 while a peer's BMP RouteMonitoring stream is known to have diverged and is awaiting a peer-state reset.",
             ),
             &["peer"],
         )
@@ -2078,6 +2088,9 @@ impl BgpMetrics {
             .register(Box::new(peer_slow.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(bmp_stream_diverged.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(rejected_routes_retained.clone()))
             .expect("metric not already registered");
         registry
@@ -2558,6 +2571,7 @@ impl BgpMetrics {
             messages_received,
             peer_outbound_queue_depth,
             peer_slow,
+            bmp_stream_diverged,
             rejected_routes_retained,
             rejected_route_retention_evictions,
             rfc8212_missing_import_policy,
@@ -2782,6 +2796,7 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.0.messages_received, peer);
         Self::reap_peer_series_from_vec(&self.0.peer_outbound_queue_depth, peer);
         Self::reap_peer_series_from_vec(&self.0.peer_slow, peer);
+        Self::reap_peer_series_from_vec(&self.0.bmp_stream_diverged, peer);
         Self::reap_peer_series_from_vec(&self.0.rejected_routes_retained, peer);
         Self::reap_peer_series_from_vec(&self.0.rejected_route_retention_evictions, peer);
         Self::reap_peer_series_from_vec(&self.0.rfc8212_missing_import_policy, peer);
@@ -3090,6 +3105,20 @@ impl BgpMetrics {
     #[must_use]
     pub fn peer_slow(&self, peer: &str) -> i64 {
         self.0.peer_slow.with_label_values(&[peer]).get()
+    }
+
+    /// Publish whether a peer's BMP stream is awaiting divergence repair.
+    pub fn set_bmp_stream_diverged(&self, peer: &str, diverged: bool) {
+        self.0
+            .bmp_stream_diverged
+            .with_label_values(&[peer])
+            .set(i64::from(diverged));
+    }
+
+    /// Read a peer's BMP divergence latch. Test/diagnostic helper.
+    #[must_use]
+    pub fn bmp_stream_diverged(&self, peer: &str) -> i64 {
+        self.0.bmp_stream_diverged.with_label_values(&[peer]).get()
     }
 
     /// Set a peer's retained rejected-route count
@@ -6958,6 +6987,7 @@ mod tests {
         m.set_adj_rib_out_prefixes(peer, "ipv4_unicast", 7);
         m.set_peer_outbound_queue_depth(peer, 3);
         m.set_peer_slow(peer, true);
+        m.set_bmp_stream_diverged(peer, true);
         m.set_rejected_routes_retained(peer, 4);
         m.record_rejected_route_eviction(peer);
         m.set_rfc8212_missing_policy(peer, true, true);
@@ -7284,7 +7314,7 @@ mod tests {
     // `gather()`, so no runtime check can catch one that is added and
     // left unpopulated; this list plus the struct doc comment is the
     // practical ceiling.
-    const PEER_LABELED_FAMILIES: [&str; 52] = [
+    const PEER_LABELED_FAMILIES: [&str; 53] = [
         "bfd_session_flaps_total",
         "bfd_session_up",
         "bgp_as_path_loop_detected_total",
@@ -7337,6 +7367,7 @@ mod tests {
         "bgp_session_state_transitions_total",
         "bgp_update_malformed_total",
         "bmp_source_drops_total",
+        "bmp_stream_diverged",
     ];
 
     #[test]

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -522,6 +522,8 @@ impl PeerSession {
     /// would then stack a real `PeerUp` on top of).
     fn clear_bmp_stream_repair(&mut self) {
         self.bmp_stream_diverged = false;
+        self.metrics
+            .set_bmp_stream_diverged(&self.peer_label, false);
         self.bmp_repair_timer = None;
     }
 

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -1475,6 +1475,8 @@ impl PeerSession {
         };
         if matches!(event, BmpEvent::PeerDown { .. }) {
             self.bmp_stream_diverged = false;
+            self.metrics
+                .set_bmp_stream_diverged(&self.peer_label, false);
             self.bmp_repair_timer = None;
         }
         if tx.send(event).await.is_err() {
@@ -1496,6 +1498,7 @@ impl PeerSession {
             );
         }
         self.bmp_stream_diverged = true;
+        self.metrics.set_bmp_stream_diverged(&self.peer_label, true);
         self.bmp_repair_timer = Some(Box::pin(tokio::time::sleep(BMP_STREAM_REPAIR_RETRY)));
     }
 
@@ -1520,6 +1523,8 @@ impl PeerSession {
             return false;
         }
         self.bmp_stream_diverged = false;
+        self.metrics
+            .set_bmp_stream_diverged(&self.peer_label, false);
         self.bmp_repair_timer = None;
         info!(
             peer = %self.peer_label,

--- a/crates/transport/src/session/tests/bmp.rs
+++ b/crates/transport/src/session/tests/bmp.rs
@@ -574,6 +574,7 @@ async fn rib_out_tap_full_channel_increments_source_drop_counter() {
         session.bmp_stream_diverged,
         "a dropped rib-out RouteMonitoring must latch the divergence"
     );
+    assert_eq!(session.metrics.bmp_stream_diverged(&session.peer_label), 1);
     assert!(
         session.bmp_repair_timer.is_some(),
         "the bounded-latency repair timer must be armed"
@@ -672,6 +673,7 @@ async fn bmp_channel_full_after_wire_send_forces_peer_state_reset() {
     update.next_hop_override = vec![None].into();
     session.send_route_update(update);
     assert!(!session.bmp_stream_diverged, "repair must clear the latch");
+    assert_eq!(session.metrics.bmp_stream_diverged(&session.peer_label), 0);
     assert!(session.bmp_repair_timer.is_none());
     match bmp_rx.try_recv().unwrap() {
         BmpEvent::PeerDown { reason, .. } => assert!(

--- a/crates/transport/src/session/tests/bmp.rs
+++ b/crates/transport/src/session/tests/bmp.rs
@@ -813,6 +813,7 @@ async fn tcp_disconnect_clears_bmp_repair_latch() {
         update_pdu: Bytes::from_static(&[0xde, 0xad]),
     });
     assert!(session.bmp_stream_diverged);
+    assert_eq!(session.metrics.bmp_stream_diverged(&session.peer_label), 1);
     assert!(session.bmp_repair_timer.is_some());
     // Drain so a stray repair *could* succeed if it fired.
     for _ in 0..16 {
@@ -825,6 +826,7 @@ async fn tcp_disconnect_clears_bmp_repair_latch() {
         !session.bmp_stream_diverged,
         "disconnect clears the divergence latch"
     );
+    assert_eq!(session.metrics.bmp_stream_diverged(&session.peer_label), 0);
     assert!(
         session.bmp_repair_timer.is_none(),
         "disconnect disarms the repair timer"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1122,16 +1122,20 @@ query with a new live watch.
 
 | Metric | What it tells you |
 |--------|-------------------|
+| `bmp_stream_diverged{peer}` | 1 while a dropped per-peer RouteMonitoring event has left collectors' live view incomplete and the session is awaiting its bounded synthetic PeerDown/PeerUp repair. It clears after a successful reset or genuine session teardown and is reaped when the peer is deleted |
 | `bmp_loc_rib_source_drops_total{event,reason}` | RFC 9069 Loc-RIB events dropped before they reached the BMP manager, at the internal RIB/PeerManager→BmpManager channel. `event` is `route_monitoring` (a Loc-RIB route install/withdraw that will never reach any collector's Loc-RIB view) or `stats` (one periodic Loc-RIB statistics report skipped; the next tick reports current totals). `reason` is `channel_full` (the BMP manager is not draining as fast as RIB churn produces events) or `channel_closed` (BMP teardown). Both label sets are bounded; the series is process-global, not per-collector. A dropped `route_monitoring` event silently diverges every connected Loc-RIB collector until its next reconnect-triggered table dump, so alert on any sustained `channel_full` increase and correlate with the per-collector `bmp_collector_drops_total` and the `bmp_loc_rib_dump_live_buffer_*` gauges to find the slow consumer; each increment also emits a warn log line |
+| `bmp_control_event_drops_total{collector,kind,reason}` | Collector lifecycle transitions that failed to reach the BMP manager. `kind` identifies connected, bootstrap-complete, or disconnected; `reason` is the bounded channel failure. Any increase means manager state may not match the collector connection lifecycle |
 
 The sibling `bmp_source_drops_total{peer,reason}` counts the same kind of
 loss on the per-peer PeerSession→BmpManager path (RFC 7854 Adj-RIB
 monitoring) with the same `reason` vocabulary.
 The shipped alert pack
 ([`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml))
-fires `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` on
-any 10-minute increase of these two counters and of
-`bmp_collector_drops_total`.
+fires `BmpSourceDrops`, `BmpLocRibSourceDrops`, `BmpCollectorDrops`, and
+`BmpControlEventDrops` on any 10-minute increase of the corresponding loss
+counters. `BmpStreamDiverged` fires when the new gauge remains 1 for five
+minutes, identifying a repair that has not completed rather than a historical
+drop that already recovered.
 
 ### MRT
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -1885,7 +1885,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 97
       },
@@ -1953,8 +1953,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 97
       },
       "fieldConfig": {
@@ -1993,6 +1993,58 @@
       ]
     },
     {
+      "id": 68,
+      "type": "timeseries",
+      "title": "BMP divergence repair",
+      "description": "Peers whose BMP RouteMonitoring stream is awaiting a synthetic PeerDown/PeerUp repair. A value pinned at 1 means the collector view remains incomplete.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 97
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bmp_stream_diverged{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "id": 31,
       "type": "timeseries",
       "title": "Event outbox (ADR-0072)",
@@ -2003,8 +2055,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 97
       },
       "fieldConfig": {

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -554,6 +554,36 @@ groups:
             Find the slow collector via bmp_collector_drops_total and the
             bmp_loc_rib_dump_live_buffer_* gauges.
 
+      - alert: BmpStreamDiverged
+        expr: bmp_stream_diverged == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BMP stream remains diverged for {{ $labels.peer }}"
+          description: >-
+            bmp_stream_diverged for peer {{ $labels.peer }} on
+            {{ $labels.instance }} has remained 1 for five minutes. The
+            session has not completed its synthetic PeerDown/PeerUp repair;
+            inspect BMP channel pressure and collector health.
+
+      - alert: BmpControlEventDrops
+        expr: increase(bmp_control_event_drops_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            BMP control event dropped for {{ $labels.collector }}
+            ({{ $labels.kind }})
+          description: >-
+            bmp_control_event_drops_total for collector
+            {{ $labels.collector }} on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 10 minutes
+            (kind={{ $labels.kind }}, reason={{ $labels.reason }}). The BMP
+            manager missed a collector lifecycle transition; inspect manager
+            channel pressure and reconnect state.
+
       - alert: BmpLocRibSourceDrops
         # RFC 9069 Loc-RIB events lost at the RIB/PeerManager→BmpManager
         # channel. A dropped route_monitoring event diverges every Loc-RIB

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -1442,6 +1442,54 @@ tests:
         alertname: BmpSourceDrops
         exp_alerts: []
 
+  # ── BmpStreamDiverged / BmpControlEventDrops ──────────────
+  - interval: 1m
+    input_series:
+      - series: 'bmp_stream_diverged{peer="192.0.2.60", instance="edge1:9179"}'
+        values: "0 1 1 1 1 1 1 0 0 0 0 0"
+      - series: 'bmp_control_event_drops_total{collector="192.0.2.10:11019", kind="collector_connected", reason="channel_full", instance="edge1:9179"}'
+        values: "0 0 0 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: BmpStreamDiverged
+        exp_alerts: []
+      - eval_time: 6m
+        alertname: BmpStreamDiverged
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.60
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BMP stream remains diverged for 192.0.2.60"
+              description: >-
+                bmp_stream_diverged for peer 192.0.2.60 on edge1:9179 has
+                remained 1 for five minutes. The session has not completed
+                its synthetic PeerDown/PeerUp repair; inspect BMP channel
+                pressure and collector health.
+      - eval_time: 7m
+        alertname: BmpStreamDiverged
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BmpControlEventDrops
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              collector: 192.0.2.10:11019
+              kind: collector_connected
+              reason: channel_full
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                BMP control event dropped for 192.0.2.10:11019
+                (collector_connected)
+              description: >-
+                bmp_control_event_drops_total for collector
+                192.0.2.10:11019 on edge1:9179 increased by 1 in the last 10
+                minutes (kind=collector_connected, reason=channel_full). The
+                BMP manager missed a collector lifecycle transition; inspect
+                manager channel pressure and reconnect state.
+
   # ── BmpLocRibSourceDrops ──────────────────────────────────
   # Process-global series keyed by event/reason only. The per-peer source
   # counter must not satisfy the Loc-RIB rule.


### PR DESCRIPTION
## Summary

- export the existing per-peer BMP divergence latch as the lifecycle-reaped `bmp_stream_diverged{peer}` gauge
- clear the gauge on successful synthetic repair or genuine teardown and cover latch, clear, and peer-reap behavior
- add sustained-divergence and control-event-drop alerts, promtool cases, one Grafana panel, operator guidance, and an Unreleased changelog entry

The existing BMP repair and wire behavior are unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p rustbgpd-transport session::tests::bmp` (20 passed)
- `cargo test --locked -p rustbgpd-telemetry` (103 passed)
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- Dockerized `promtool test rules examples/prometheus/rustbgpd-alerts_test.yml`
- `python3 scripts/check-grafana-dashboard.py`
- `git diff --check`
- pre-push Clippy, workspace tests, and docs

Linear: LAN-1241
