### PR TITLE
test: fuzz policy ID remapping and explain walks

### DIFF
--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     # A cold run without stored corpus artifacts spent about 6m42s per target
     # waiting for each missing artifact before fuzzing. Leave enough room for
-    # all 19 targets plus the observed 14-minute ASan build.
+    # all 21 targets plus the observed 14-minute ASan build.
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v7

--- a/crates/policy/fuzz/Cargo.toml
+++ b/crates/policy/fuzz/Cargo.toml
@@ -8,10 +8,13 @@ edition = "2024"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 
 [dependencies.rustbgpd-policy]
 path = ".."
+
+[dependencies.rustbgpd-wire]
+path = "../../wire"
 
 [[bin]]
 name = "rpol_compile"
@@ -24,5 +27,17 @@ doc = false
 [[bin]]
 name = "dataset_parse"
 path = "fuzz_targets/dataset_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "compile_chain"
+path = "fuzz_targets/compile_chain.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "explain_walk"
+path = "fuzz_targets/explain_walk.rs"
 test = false
 doc = false

--- a/crates/policy/fuzz/fuzz_targets/compile_chain.rs
+++ b/crates/policy/fuzz/fuzz_targets/compile_chain.rs
@@ -1,0 +1,21 @@
+#![no_main]
+//! Structure-aware mixed TOML/`.rpol` chain compiler fuzzing.
+
+// The shared support module also contains the route-walk recipe used by the
+// sibling target.
+#[allow(dead_code)]
+#[path = "../support.rs"]
+mod support;
+
+use libfuzzer_sys::fuzz_target;
+use rustbgpd_policy::compile::compile_chain;
+use rustbgpd_policy::sets::SetStore;
+use support::{ChainRecipe, assert_ids_resolve, mixed_chain};
+
+fuzz_target!(|recipe: ChainRecipe| {
+    let Some(chain) = mixed_chain(&recipe) else {
+        return;
+    };
+    let compiled = compile_chain(&chain, &mut SetStore::new());
+    assert_ids_resolve(&compiled);
+});

--- a/crates/policy/fuzz/fuzz_targets/compile_chain.rs
+++ b/crates/policy/fuzz/fuzz_targets/compile_chain.rs
@@ -10,12 +10,10 @@ mod support;
 use libfuzzer_sys::fuzz_target;
 use rustbgpd_policy::compile::compile_chain;
 use rustbgpd_policy::sets::SetStore;
-use support::{ChainRecipe, assert_ids_resolve, mixed_chain};
+use support::{assert_ids_resolve, mixed_chain, ChainRecipe};
 
 fuzz_target!(|recipe: ChainRecipe| {
-    let Some(chain) = mixed_chain(&recipe) else {
-        return;
-    };
+    let chain = mixed_chain(&recipe);
     let compiled = compile_chain(&chain, &mut SetStore::new());
     assert_ids_resolve(&compiled);
 });

--- a/crates/policy/fuzz/fuzz_targets/explain_walk.rs
+++ b/crates/policy/fuzz/fuzz_targets/explain_walk.rs
@@ -1,0 +1,54 @@
+#![no_main]
+//! Bounded explain-walk agreement fuzzing over valid TOML policy chains.
+
+// The shared support module also contains the mixed-chain compiler recipe
+// used by the sibling target.
+#[allow(dead_code)]
+#[path = "../support.rs"]
+mod support;
+
+use libfuzzer_sys::fuzz_target;
+use rustbgpd_policy::{evaluate_chain, explain_chain_statements};
+use support::{ChainRecipe, OwnedRoute, RouteRecipe, mixed_chain};
+
+fuzz_target!(|bytes: [u8; 8]| {
+    let chain_recipe = ChainRecipe {
+        policies: bytes[0],
+        statements: bytes[1],
+        deny_at: bytes[2],
+        selector: bytes[3],
+    };
+    let route_recipe = RouteRecipe {
+        address: [
+            if bytes[4] & 1 == 0 { 10 } else { bytes[4] },
+            bytes[3],
+            bytes[6],
+            bytes[7],
+        ],
+        prefix_len: 16 + bytes[5] % 17,
+        community: if bytes[4] & 2 == 0 {
+            u16::from(bytes[3])
+        } else {
+            u16::from_be_bytes([bytes[6], bytes[7]])
+        },
+        local_pref: u16::from_be_bytes([bytes[0], bytes[6]]),
+        med: u16::from_be_bytes([bytes[1], bytes[7]]),
+    };
+    let Some(chain) = mixed_chain(&chain_recipe) else {
+        return;
+    };
+    let route = OwnedRoute::from_recipe(&route_recipe);
+    let context = route.context();
+    let trace = explain_chain_statements(Some(&chain), &context);
+    let live = evaluate_chain(Some(&chain), &context);
+
+    assert!(trace.steps.len() <= chain.policies.len());
+    if let Some(deny_index) = trace
+        .steps
+        .iter()
+        .position(|step| step.action == rustbgpd_policy::PolicyAction::Deny)
+    {
+        assert_eq!(deny_index + 1, trace.steps.len());
+    }
+    assert_eq!(trace.action, live.action);
+});

--- a/crates/policy/fuzz/fuzz_targets/explain_walk.rs
+++ b/crates/policy/fuzz/fuzz_targets/explain_walk.rs
@@ -1,5 +1,5 @@
 #![no_main]
-//! Bounded explain-walk agreement fuzzing over valid TOML policy chains.
+//! Bounded explain-walk agreement fuzzing over valid mixed policy chains.
 
 // The shared support module also contains the mixed-chain compiler recipe
 // used by the sibling target.
@@ -9,7 +9,7 @@ mod support;
 
 use libfuzzer_sys::fuzz_target;
 use rustbgpd_policy::{evaluate_chain, explain_chain_statements};
-use support::{ChainRecipe, OwnedRoute, RouteRecipe, mixed_chain};
+use support::{mixed_chain, ChainRecipe, OwnedRoute, RouteRecipe};
 
 fuzz_target!(|bytes: [u8; 8]| {
     let chain_recipe = ChainRecipe {
@@ -34,9 +34,7 @@ fuzz_target!(|bytes: [u8; 8]| {
         local_pref: u16::from_be_bytes([bytes[0], bytes[6]]),
         med: u16::from_be_bytes([bytes[1], bytes[7]]),
     };
-    let Some(chain) = mixed_chain(&chain_recipe) else {
-        return;
-    };
+    let chain = mixed_chain(&chain_recipe);
     let route = OwnedRoute::from_recipe(&route_recipe);
     let context = route.context();
     let trace = explain_chain_statements(Some(&chain), &context);

--- a/crates/policy/fuzz/support.rs
+++ b/crates/policy/fuzz/support.rs
@@ -1,0 +1,190 @@
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary};
+use rustbgpd_policy::engine::{
+    CommunityMatch, NamedPolicy, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteContext,
+    RouteModifications,
+};
+use rustbgpd_policy::ir::MatchExpr;
+use rustbgpd_policy::rpol::compile_rpol;
+use rustbgpd_policy::sets::SetStore;
+use rustbgpd_wire::{AspaValidation, Ipv4Prefix, Prefix, RpkiValidation};
+
+pub const MAX_POLICIES: usize = 8;
+const MAX_STATEMENTS: usize = 6;
+
+#[derive(Arbitrary, Debug)]
+pub struct ChainRecipe {
+    pub policies: u8,
+    pub statements: u8,
+    pub deny_at: u8,
+    pub selector: u8,
+}
+
+#[derive(Debug)]
+pub struct RouteRecipe {
+    pub address: [u8; 4],
+    pub prefix_len: u8,
+    pub community: u16,
+    pub local_pref: u16,
+    pub med: u16,
+}
+
+pub fn toml_chain(recipe: &ChainRecipe) -> PolicyChain {
+    let policy_count = usize::from(recipe.policies) % MAX_POLICIES + 1;
+    let statement_count = usize::from(recipe.statements) % MAX_STATEMENTS + 1;
+    let mut policies = Vec::with_capacity(policy_count);
+    for policy_index in 0..policy_count {
+        let mut entries = Vec::with_capacity(statement_count);
+        for statement_index in 0..statement_count {
+            let discriminator =
+                (policy_index + statement_index + usize::from(recipe.selector)) as u32;
+            entries.push(PolicyStatement {
+                prefix: Some(v4([10, discriminator as u8, 0, 0], 16)),
+                ge: Some(16),
+                le: Some(28),
+                action: if policy_index == usize::from(recipe.deny_at) % policy_count
+                    && statement_index == usize::from(recipe.deny_at) % statement_count
+                {
+                    PolicyAction::Deny
+                } else {
+                    PolicyAction::Permit
+                },
+                match_community: vec![CommunityMatch::Standard {
+                    value: 65_000_u32 << 16 | discriminator,
+                }],
+                match_as_path: None,
+                match_neighbor_set: None,
+                match_route_type: None,
+                match_evpn_route_type: None,
+                match_rpki_validation: None,
+                match_aspa_validation: None,
+                match_as_path_length_ge: None,
+                match_as_path_length_le: None,
+                match_local_pref_ge: Some(discriminator),
+                match_local_pref_le: None,
+                match_med_ge: None,
+                match_med_le: Some(u32::from(u16::MAX)),
+                match_next_hop: None,
+                modifications: RouteModifications {
+                    set_local_pref: Some(100 + discriminator),
+                    ..RouteModifications::default()
+                },
+            });
+        }
+        policies.push(NamedPolicy {
+            name: Some(format!("toml-{policy_index}")),
+            policy: Policy {
+                entries,
+                default_action: PolicyAction::Permit,
+            },
+            rpol: None,
+        });
+    }
+    let mut chain = PolicyChain::default();
+    chain.policies = policies;
+    chain
+}
+
+pub fn mixed_chain(recipe: &ChainRecipe) -> Option<PolicyChain> {
+    let source = r#"
+prefix-set p { 10.0.0.0/8 ge 16 le 28 }
+community-set c { 65000:1, 65000:2 }
+asn-set a { 64512, 64513 }
+dataset asn-set external_asns
+policy donor {
+  term indexed {
+    if route.prefix in p && route.communities in c && route.origin-as in a
+       && route.as-path matches "^64512" && route.origin-as in external_asns { accept }
+  }
+  term fallback { accept }
+}
+"#;
+    let donor = compile_rpol(source, &mut SetStore::new()).ok()?;
+    assert_ids_resolve(&donor);
+    let mut chain = toml_chain(recipe);
+    let count = usize::from(recipe.policies).min(3) + 1;
+    for index in 0..count {
+        chain.policies.push(NamedPolicy::from_rpol(
+            format!("rpol-{index}"),
+            Arc::new(donor.clone()),
+        ));
+    }
+    Some(chain)
+}
+
+pub fn assert_ids_resolve(compiled: &rustbgpd_policy::ir::CompiledChain) {
+    for policy in &compiled.policies {
+        for term in &policy.terms {
+            assert!(all_ids_resolve(&term.guard, compiled));
+        }
+    }
+}
+
+fn all_ids_resolve(expr: &MatchExpr, compiled: &rustbgpd_policy::ir::CompiledChain) -> bool {
+    let valid = std::cell::Cell::new(true);
+    expr.any_node(&|node| {
+        let resolved = match node {
+            MatchExpr::PrefixInSet(id) => (id.0 as usize) < compiled.prefix_sets.len(),
+            MatchExpr::CommunityInSet(id) | MatchExpr::LocalInCommunitySet { set: id, .. } => {
+                (id.0 as usize) < compiled.community_sets.len()
+            }
+            MatchExpr::OriginAsInSet(id)
+            | MatchExpr::PeerAsInSet(id)
+            | MatchExpr::LocalInAsnSet { set: id, .. } => (id.0 as usize) < compiled.asn_sets.len(),
+            MatchExpr::AsPathMatches(id) => (id.0 as usize) < compiled.as_path_regexes.len(),
+            MatchExpr::InDataset { id, .. } => (id.0 as usize) < compiled.datasets.len(),
+            _ => true,
+        };
+        valid.set(valid.get() && resolved);
+        false
+    });
+    valid.get()
+}
+
+pub struct OwnedRoute {
+    prefix: Prefix,
+    communities: Vec<u32>,
+    local_pref: u32,
+    med: u32,
+}
+
+impl OwnedRoute {
+    pub fn from_recipe(recipe: &RouteRecipe) -> Self {
+        Self {
+            prefix: v4(recipe.address, recipe.prefix_len.min(32)),
+            communities: vec![65_000_u32 << 16 | u32::from(recipe.community)],
+            local_pref: u32::from(recipe.local_pref),
+            med: u32::from(recipe.med),
+        }
+    }
+
+    pub fn context(&self) -> RouteContext<'_> {
+        RouteContext {
+            prefix: Some(self.prefix),
+            next_hop: None,
+            extended_communities: &[],
+            communities: &self.communities,
+            large_communities: &[],
+            as_path_str: "",
+            as_path: None,
+            as_path_len: 0,
+            origin_asn: None,
+            validation_state: RpkiValidation::NotFound,
+            aspa_state: AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            family: None,
+            evpn_route_type: None,
+            local_pref: Some(self.local_pref),
+            med: Some(self.med),
+        }
+    }
+}
+
+fn v4(address: [u8; 4], prefix_len: u8) -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(address), prefix_len))
+}

--- a/crates/policy/fuzz/support.rs
+++ b/crates/policy/fuzz/support.rs
@@ -2,13 +2,14 @@ use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 use libfuzzer_sys::arbitrary::{self, Arbitrary};
+use rustbgpd_policy::datasets::{DatasetBindings, DatasetData, DatasetHandle, DatasetKind};
 use rustbgpd_policy::engine::{
     CommunityMatch, NamedPolicy, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteContext,
     RouteModifications,
 };
 use rustbgpd_policy::ir::MatchExpr;
-use rustbgpd_policy::rpol::compile_rpol;
-use rustbgpd_policy::sets::SetStore;
+use rustbgpd_policy::rpol::RpolFile;
+use rustbgpd_policy::sets::{AsnSet, SetStore};
 use rustbgpd_wire::{AspaValidation, Ipv4Prefix, Prefix, RpkiValidation};
 
 pub const MAX_POLICIES: usize = 8;
@@ -87,7 +88,7 @@ pub fn toml_chain(recipe: &ChainRecipe) -> PolicyChain {
     chain
 }
 
-pub fn mixed_chain(recipe: &ChainRecipe) -> Option<PolicyChain> {
+pub fn mixed_chain(recipe: &ChainRecipe) -> PolicyChain {
     let source = r#"
 prefix-set p { 10.0.0.0/8 ge 16 le 28 }
 community-set c { 65000:1, 65000:2 }
@@ -101,7 +102,17 @@ policy donor {
   term fallback { accept }
 }
 "#;
-    let donor = compile_rpol(source, &mut SetStore::new()).ok()?;
+    let file = RpolFile::parse(source).expect("fixed donor source must parse");
+    let mut bindings = DatasetBindings::new();
+    bindings.insert(Arc::new(DatasetHandle::new(
+        "external_asns",
+        DatasetKind::Asn,
+        DatasetData::Asn(AsnSet::new([64_512, 64_513])),
+    )));
+    let donor = file
+        .compile_policy_bound("donor", &[], &mut SetStore::new(), &bindings)
+        .expect("fixed donor policy must exist")
+        .expect("fixed donor dataset must be bound");
     assert_ids_resolve(&donor);
     let mut chain = toml_chain(recipe);
     let count = usize::from(recipe.policies).min(3) + 1;
@@ -111,7 +122,7 @@ policy donor {
             Arc::new(donor.clone()),
         ));
     }
-    Some(chain)
+    chain
 }
 
 pub fn assert_ids_resolve(compiled: &rustbgpd_policy::ir::CompiledChain) {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -567,13 +567,13 @@ containerlab is the test harness — not "where feasible," but the default. Ever
 
 ### Fuzzing
 
-19 libFuzzer targets across six crates, each with its own `fuzz/` workspace:
+21 libFuzzer targets across six crates, each with its own `fuzz/` workspace:
 
 - `crates/wire/fuzz` (12) — OPEN / UPDATE / message and Route Refresh
   decoding, Route Distinguisher parsing, and per-family NLRI decoders
   (FlowSpec, EVPN, BGP-LS, MPLS-VPN, labeled-unicast, RT-Constrain) plus an
   EVPN encode target.
-- `crates/policy/fuzz` (2) — `.rpol` compilation and dataset parsing.
+- `crates/policy/fuzz` (4) — `.rpol` compilation, dataset parsing, mixed-chain compilation, and mixed-chain explain/live-walk agreement.
 - `crates/mrt/fuzz` (2) — snapshot-reader drain and warm-bundle manifest.
 - `crates/bfd/fuzz` (1) — BFD control-packet decoding.
 - `crates/rpki/fuzz` (1) — RTR PDU decoding.

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -35,6 +35,8 @@ network — so it has no fuzz surface.
 | `parse_rd` | wire | Route Distinguisher `FromStr` | Display→FromStr lossless |
 | `rpol_compile` | policy | `.rpol` lexer, parser, typechecker, lowering, and the in-language `test`-block runner (eval engine on fuzzer-authored programs) | returns `Diagnostics`, never panics/aborts/hangs |
 | `dataset_parse` | policy | operator-fed prefix, ASN, and community dataset text, including comments and malformed lines | returns a result, never panics/aborts/hangs |
+| `compile_chain` | policy | bounded valid mixed TOML and `.rpol` chains with indexed sets, regexes, and datasets | compilation returns and every recursively remapped ID resolves in the merged tables |
+| `explain_walk` | policy | bounded valid mixed TOML and `.rpol` chains plus owned route recipes | trace length is bounded by the walkable policies, Deny is terminal, and the trace verdict agrees with live evaluation |
 | `parse_rt` | evpn | Route Target `FromStr` over arbitrary UTF-8 | Display→FromStr lossless |
 | `snapshot_reader_drain` | mrt | arbitrary MRT framing plus arbitrary records after a valid empty peer-index table | reader construction and full iteration never panic |
 | `warm_bundle_manifest` | mrt | real owner-checked `manifest.json` load through JSON decoding, V1 structure, boot identity, freshness, and safe snapshot lookup/error handling | loader never panics |
@@ -108,7 +110,7 @@ which cannot meet rustbgpd's fail-closed corpus-reuse rule. ClusterFuzzLite's
 Rust integration also documents AddressSanitizer as the only supported
 sanitizer, so the manual workflow does not claim unsupported coverage mode.
 
-`scripts/check_fuzz_target_inventory.py` gates the exact 19-target inventory in
+`scripts/check_fuzz_target_inventory.py` gates the exact 21-target inventory in
 the ordinary PR/push `CI / check` job, before a manual ClusterFuzzLite build,
 and again inside the shared fuzzer build path. It compares cargo metadata and
 `fuzz_targets/*.rs` against an explicit globally-unique inventory, including

--- a/scripts/check_fuzz_target_inventory.py
+++ b/scripts/check_fuzz_target_inventory.py
@@ -17,7 +17,7 @@ EXPECTED_TARGETS: dict[str, tuple[str, ...]] = {
     "crates/bfd": ("decode_bfd_control",),
     "crates/evpn": ("parse_rt",),
     "crates/mrt": ("snapshot_reader_drain", "warm_bundle_manifest"),
-    "crates/policy": ("dataset_parse", "rpol_compile"),
+    "crates/policy": ("compile_chain", "dataset_parse", "explain_walk", "rpol_compile"),
     "crates/rpki": ("decode_rtr_pdu",),
     "crates/wire": (
         "decode_bgpls",
@@ -34,7 +34,7 @@ EXPECTED_TARGETS: dict[str, tuple[str, ...]] = {
         "parse_rd",
     ),
 }
-EXPECTED_COUNT = 19
+EXPECTED_COUNT = 21
 CAMPAIGN_BOUNDS: dict[str, tuple[str, int]] = {
     "crates/bfd": ("decode_bfd_control", 256),
     "crates/rpki": ("decode_rtr_pdu", 65_535),


### PR DESCRIPTION
## Summary

- add structure-aware `compile_chain` fuzzing for mixed TOML and `.rpol` members, with recursive post-splice ID resolution checks
- add an `explain_walk` target that exercises mixed chains with compact route recipes and asserts bounded terminal traces agree with live evaluation
- extend the fail-closed inventory, hosted target count, and fuzzing/design documentation from 19 to 21 targets

## Validation

- both new targets built with the pinned nightly and completed 1,000-run sanitizer smokes with growing coverage
- exact 21-target inventory check and all 15 mutation tests pass
- `cargo test -p rustbgpd-policy` passes (405 unit tests plus integration receipts)
- strict workspace Clippy passes
- `cargo test --workspace --all-features` passes
- final-head pre-push fmt, Clippy, workspace library tests, and rustdoc pass
- root `Cargo.lock` and production manifests remain unchanged

Linear: LAN-1197
