### PR TITLE
fix: emit RFC 9384 BFD Down notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Genuine BFD Down transitions now tear established BGP sessions down with
+  RFC 9384 Cease/BFD Down; peers that negotiated Notification GR receive an
+  RFC 8538 Hard Reset carrying the original BFD Down reason. (LAN-1261)
+
 - Runtime behavior is unchanged; the supervised-shutdown proof now injects a
   BGP accept-forwarder panic after inbound dispatch and verifies bounded
   teardown of both the configured peer and its half-admitted candidate before

--- a/crates/fsm/src/action.rs
+++ b/crates/fsm/src/action.rs
@@ -161,7 +161,11 @@ pub enum Action {
     /// Boxed: `NegotiatedSession` is by far the largest `Action` variant, so
     /// inlining it would bloat every `Action` (clippy `large_enum_variant`).
     SessionEstablished(Box<NegotiatedSession>),
-    /// The session left the Established state.
+    /// Run authoritative session-down cleanup.
+    ///
+    /// Normally emitted when leaving `Established`. A BFD-triggered teardown
+    /// in `OpenSent` or `OpenConfirm` also emits it after queuing the typed
+    /// Cease notification so transport-side notification state is cleared.
     SessionDown,
     /// A timer-expired event arrived for a timer that should not be
     /// running in the current state. The FSM ignores it instead of

--- a/crates/fsm/src/event.rs
+++ b/crates/fsm/src/event.rs
@@ -16,6 +16,8 @@ pub enum Event {
         /// Optional shutdown reason for RFC 8203 Cease NOTIFICATION.
         reason: Option<Bytes>,
     },
+    /// A genuine BFD Down transition requests session teardown (RFC 9384).
+    BfdDown,
 
     // ── Timer ─────────────────────────────────────────
     /// The connect-retry timer has expired.
@@ -62,6 +64,7 @@ impl Event {
         match self {
             Self::ManualStart => "ManualStart",
             Self::ManualStop { .. } => "ManualStop",
+            Self::BfdDown => "BfdDown",
             Self::ConnectRetryTimerExpires => "ConnectRetryTimerExpires",
             Self::HoldTimerExpires => "HoldTimerExpires",
             Self::KeepaliveTimerExpires => "KeepaliveTimerExpires",

--- a/crates/fsm/src/session.rs
+++ b/crates/fsm/src/session.rs
@@ -147,7 +147,9 @@ impl Session {
     )]
     fn handle_connect(&mut self, event: Event) -> Vec<Action> {
         match event {
-            Event::ManualStop { .. } | Event::DecodeError(_) => self.enter_idle_silent(),
+            Event::ManualStop { .. } | Event::BfdDown | Event::DecodeError(_) => {
+                self.enter_idle_silent()
+            }
 
             Event::ConnectRetryTimerExpires => {
                 let mut actions = vec![
@@ -197,7 +199,9 @@ impl Session {
     )]
     fn handle_active(&mut self, event: Event) -> Vec<Action> {
         match event {
-            Event::ManualStop { .. } | Event::DecodeError(_) => self.enter_idle_silent(),
+            Event::ManualStop { .. } | Event::BfdDown | Event::DecodeError(_) => {
+                self.enter_idle_silent()
+            }
 
             Event::ConnectRetryTimerExpires => {
                 let mut actions = vec![
@@ -246,6 +250,11 @@ impl Session {
                 NotificationCode::Cease,
                 cease_subcode::ADMINISTRATIVE_SHUTDOWN,
                 reason.unwrap_or_default(),
+            ),
+            Event::BfdDown => self.enter_idle_with_notification(
+                NotificationCode::Cease,
+                cease_subcode::BFD_DOWN,
+                Bytes::new(),
             ),
 
             Event::HoldTimerExpires => self.enter_idle_with_notification(
@@ -343,6 +352,11 @@ impl Session {
                 cease_subcode::ADMINISTRATIVE_SHUTDOWN,
                 reason.unwrap_or_default(),
             ),
+            Event::BfdDown => self.enter_idle_with_notification(
+                NotificationCode::Cease,
+                cease_subcode::BFD_DOWN,
+                Bytes::new(),
+            ),
 
             Event::HoldTimerExpires => self.enter_idle_with_notification(
                 NotificationCode::HoldTimerExpired,
@@ -414,6 +428,17 @@ impl Session {
         }
     }
 
+    fn enter_idle_bfd_down(&mut self) -> Vec<Action> {
+        let mut actions = self.enter_idle_with_notification(
+            NotificationCode::Cease,
+            cease_subcode::BFD_DOWN,
+            Bytes::new(),
+        );
+        // Cache the exact on-wire NOTIFICATION before BMP Peer Down is emitted.
+        actions.insert(1, Action::SessionDown);
+        actions
+    }
+
     fn handle_established(&mut self, event: Event) -> Vec<Action> {
         match event {
             Event::ManualStop { reason } => {
@@ -425,6 +450,7 @@ impl Session {
                 ));
                 actions
             }
+            Event::BfdDown => self.enter_idle_bfd_down(),
 
             Event::HoldTimerExpires => {
                 let mut actions = vec![Action::SessionDown];
@@ -1232,6 +1258,24 @@ mod tests {
         assert!(has_action(&actions, |a| matches!(
             a,
             Action::SendNotification(n) if n.code == NotificationCode::Cease
+        )));
+    }
+
+    #[test]
+    fn established_bfd_down_sends_typed_cease_and_session_down() {
+        let mut session = reach_established();
+        let actions = session.handle_event(Event::BfdDown);
+        assert!(
+            actions
+                .iter()
+                .any(|action| matches!(action, Action::SessionDown))
+        );
+        assert!(actions.iter().any(|action| matches!(
+            action,
+            Action::SendNotification(notification)
+                if notification.code == NotificationCode::Cease
+                    && notification.subcode == cease_subcode::BFD_DOWN
+                    && notification.data.is_empty()
         )));
     }
 

--- a/crates/fsm/src/session.rs
+++ b/crates/fsm/src/session.rs
@@ -251,11 +251,7 @@ impl Session {
                 cease_subcode::ADMINISTRATIVE_SHUTDOWN,
                 reason.unwrap_or_default(),
             ),
-            Event::BfdDown => self.enter_idle_with_notification(
-                NotificationCode::Cease,
-                cease_subcode::BFD_DOWN,
-                Bytes::new(),
-            ),
+            Event::BfdDown => self.enter_idle_bfd_down(),
 
             Event::HoldTimerExpires => self.enter_idle_with_notification(
                 NotificationCode::HoldTimerExpired,
@@ -352,11 +348,7 @@ impl Session {
                 cease_subcode::ADMINISTRATIVE_SHUTDOWN,
                 reason.unwrap_or_default(),
             ),
-            Event::BfdDown => self.enter_idle_with_notification(
-                NotificationCode::Cease,
-                cease_subcode::BFD_DOWN,
-                Bytes::new(),
-            ),
+            Event::BfdDown => self.enter_idle_bfd_down(),
 
             Event::HoldTimerExpires => self.enter_idle_with_notification(
                 NotificationCode::HoldTimerExpired,
@@ -1277,6 +1269,34 @@ mod tests {
                     && notification.subcode == cease_subcode::BFD_DOWN
                     && notification.data.is_empty()
         )));
+    }
+
+    #[test]
+    fn handshake_bfd_down_sends_typed_cease_and_session_down() {
+        let mut open_sent = Session::new(test_config());
+        open_sent.handle_event(Event::ManualStart);
+        open_sent.handle_event(Event::TcpConnectionConfirmed);
+        assert_eq!(open_sent.state(), SessionState::OpenSent);
+
+        let mut open_confirm = Session::new(test_config());
+        open_confirm.handle_event(Event::ManualStart);
+        open_confirm.handle_event(Event::TcpConnectionConfirmed);
+        open_confirm.handle_event(Event::OpenReceived(peer_open()));
+        assert_eq!(open_confirm.state(), SessionState::OpenConfirm);
+
+        for session in [&mut open_sent, &mut open_confirm] {
+            let actions = session.handle_event(Event::BfdDown);
+            assert!(has_action(&actions, |action| matches!(
+                action,
+                Action::SessionDown
+            )));
+            assert!(has_action(&actions, |action| matches!(
+                action,
+                Action::SendNotification(notification)
+                    if notification.code == NotificationCode::Cease
+                        && notification.subcode == cease_subcode::BFD_DOWN
+            )));
+        }
     }
 
     #[test]

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -348,6 +348,8 @@ pub enum PeerCommand {
         /// Shutdown communication reason (pre-encoded), or None.
         reason: Option<Bytes>,
     },
+    /// Tear down an established session because BFD transitioned to Down.
+    BfdDown,
     /// Shut down the task entirely.
     Shutdown,
     /// Query the current session state.
@@ -1319,6 +1321,17 @@ impl PeerHandle {
         deadline: Duration,
     ) -> Result<(), PeerCommandError> {
         self.send_simple_command_timeout(PeerCommand::Stop { reason }, "stop", deadline)
+            .await
+    }
+
+    /// Send a typed BFD-down command with a bounded deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session task has exited or the command is not
+    /// accepted before `deadline`.
+    pub async fn bfd_down_timeout(&self, deadline: Duration) -> Result<(), PeerCommandError> {
+        self.send_simple_command_timeout(PeerCommand::BfdDown, "BFD down", deadline)
             .await
     }
 

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1119,6 +1119,12 @@ impl PeerSession {
                 self.drive_fsm(Event::ManualStop { reason }).await;
                 ControlFlow::Continue(())
             }
+            PeerCommand::BfdDown => {
+                self.stop_requested = true;
+                self.reconnect_timer = None;
+                self.drive_fsm(Event::BfdDown).await;
+                ControlFlow::Continue(())
+            }
             PeerCommand::Shutdown => {
                 self.stop_requested = true;
                 self.reconnect_timer = None;

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -159,13 +159,14 @@ impl PeerSession {
                 event = event.name(),
                 "FSM event"
             );
-            let mut actions = self.fsm.handle_event(event.clone());
-            if matches!(event, Event::BfdDown)
+            let bfd_notification_gr = matches!(event, Event::BfdDown)
                 && self
                     .negotiated
-                    .as_ref()
-                    .is_some_and(|negotiated| negotiated.peer_notification_gr)
-            {
+                    .as_deref()
+                    .or(self.fsm.negotiated())
+                    .is_some_and(|negotiated| negotiated.peer_notification_gr);
+            let mut actions = self.fsm.handle_event(event.clone());
+            if bfd_notification_gr {
                 for action in &mut actions {
                     if let Action::SendNotification(notification) = action
                         && notification.code == NotificationCode::Cease

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -5,6 +5,20 @@ use super::{
     cease_subcode, debug, info, mpsc, warn,
 };
 
+pub(super) fn notification_description(
+    notification: &rustbgpd_wire::NotificationMessage,
+) -> String {
+    if notification.code == NotificationCode::Cease
+        && notification.subcode == cease_subcode::HARD_RESET
+        && notification
+            .data
+            .starts_with(&[NotificationCode::Cease.as_u8(), cease_subcode::BFD_DOWN])
+    {
+        return "Hard Reset: BFD Down".to_string();
+    }
+    rustbgpd_wire::notification::description(notification.code, notification.subcode).to_string()
+}
+
 impl PeerSession {
     /// Retain a bounded, secret-free reset cause for snapshots, without
     /// replacing an actionable error during intentional local maintenance.
@@ -30,7 +44,7 @@ impl PeerSession {
             "{direction} NOTIFICATION {}/{} ({})",
             notification.code.as_u8(),
             notification.subcode,
-            rustbgpd_wire::notification::description(notification.code, notification.subcode)
+            notification_description(notification)
         );
     }
 
@@ -145,7 +159,29 @@ impl PeerSession {
                 event = event.name(),
                 "FSM event"
             );
-            let actions = self.fsm.handle_event(event.clone());
+            let mut actions = self.fsm.handle_event(event.clone());
+            if matches!(event, Event::BfdDown)
+                && self
+                    .negotiated
+                    .as_ref()
+                    .is_some_and(|negotiated| negotiated.peer_notification_gr)
+            {
+                for action in &mut actions {
+                    if let Action::SendNotification(notification) = action
+                        && notification.code == NotificationCode::Cease
+                        && notification.subcode == cease_subcode::BFD_DOWN
+                    {
+                        *notification = rustbgpd_wire::NotificationMessage::new(
+                            NotificationCode::Cease,
+                            cease_subcode::HARD_RESET,
+                            Bytes::from(vec![
+                                NotificationCode::Cease.as_u8(),
+                                cease_subcode::BFD_DOWN,
+                            ]),
+                        );
+                    }
+                }
+            }
             if notification_teardown_event(&event, &actions) {
                 self.notification_teardown = true;
             }

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -1566,11 +1566,7 @@ impl PeerSession {
             direction,
             code: notification.code.as_u8(),
             subcode: notification.subcode,
-            description: rustbgpd_wire::notification::description(
-                notification.code,
-                notification.subcode,
-            )
-            .to_string(),
+            description: fsm::notification_description(notification),
             shutdown_reason,
             failure_cause: (direction == SessionNotificationDirection::Sent
                 && notification.code == NotificationCode::Cease

--- a/crates/transport/src/session/tests/bmp.rs
+++ b/crates/transport/src/session/tests/bmp.rs
@@ -69,6 +69,39 @@ async fn session_down_emits_bmp_peer_down() {
 }
 
 #[tokio::test]
+async fn bfd_down_hard_reset_bmp_reason_carries_the_full_notification_pdu() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    Arc::make_mut(session.negotiated.as_mut().expect("negotiated")).peer_notification_gr = true;
+    while bmp_rx.try_recv().is_ok() {}
+
+    assert_eq!(
+        session.handle_command(PeerCommand::BfdDown).await,
+        ControlFlow::Continue(())
+    );
+
+    match bmp_rx.recv().await.expect("BMP Peer Down") {
+        BmpEvent::PeerDown {
+            reason: PeerDownReason::LocalNotification(pdu),
+            ..
+        } => {
+            assert_eq!(
+                &pdu[19..],
+                &[
+                    NotificationCode::Cease.as_u8(),
+                    cease_subcode::HARD_RESET,
+                    NotificationCode::Cease.as_u8(),
+                    cease_subcode::BFD_DOWN,
+                ]
+            );
+        }
+        other => panic!("expected local-notification BMP Peer Down, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn inbound_update_emits_bmp_route_monitoring() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
     let negotiated = negotiated_session(65002, false);

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -307,6 +307,70 @@ async fn bfd_down_command_sends_direct_or_hard_reset_and_retains_inner_cause() {
     }
 }
 
+#[tokio::test]
+async fn open_sent_bfd_down_clears_a_stale_down_reason() {
+    let mut session = make_test_session(65001, 65002);
+    session.last_down_reason = Some(PeerDownReason::RemoteNoNotification);
+    session.fsm.handle_event(Event::ManualStart);
+    session.fsm.handle_event(Event::TcpConnectionConfirmed);
+    assert_eq!(session.fsm.state(), SessionState::OpenSent);
+
+    session.drive_fsm(Event::BfdDown).await;
+
+    assert_eq!(session.fsm.state(), SessionState::Idle);
+    assert!(session.last_down_reason.is_none());
+}
+
+#[tokio::test]
+async fn open_confirm_bfd_down_uses_negotiated_notification_gr() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.peer.graceful_restart = true;
+    session.fsm = Session::new(session.config.peer.clone());
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    session.drive_fsm(Event::ManualStart).await;
+    session
+        .drive_fsm(Event::OpenReceived(rustbgpd_wire::OpenMessage {
+            version: 4,
+            my_as: 65002,
+            hold_time: 90,
+            bgp_identifier: Ipv4Addr::new(10, 0, 0, 2),
+            capabilities: vec![
+                Capability::MultiProtocol {
+                    afi: Afi::Ipv4,
+                    safi: Safi::Unicast,
+                },
+                Capability::FourOctetAs { asn: 65002 },
+                Capability::GracefulRestart {
+                    restart_state: false,
+                    notification: true,
+                    restart_time: 120,
+                    families: vec![rustbgpd_wire::GracefulRestartFamily {
+                        afi: Afi::Ipv4,
+                        safi: Safi::Unicast,
+                        forwarding_preserved: false,
+                    }],
+                },
+            ],
+        }))
+        .await;
+    assert_eq!(session.fsm.state(), SessionState::OpenConfirm);
+    assert!(session.negotiated.is_none());
+
+    session.drive_fsm(Event::BfdDown).await;
+
+    let notification = read_until_notification(&mut server).await;
+    assert_eq!(notification.code, NotificationCode::Cease);
+    assert_eq!(notification.subcode, cease_subcode::HARD_RESET);
+    assert_eq!(
+        notification.data,
+        Bytes::from(vec![
+            NotificationCode::Cease.as_u8(),
+            cease_subcode::BFD_DOWN,
+        ])
+    );
+}
+
 /// Mutant: removing the sent-admin guard mislabels intentional local maintenance.
 #[test]
 fn administrative_notifications_keep_directional_maintenance_semantics() {

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -261,6 +261,52 @@ async fn stop_command_sends_and_reports_exact_shutdown_communication() {
     assert_eq!(notification.data, encoded_reason);
 }
 
+#[tokio::test]
+async fn bfd_down_command_sends_direct_or_hard_reset_and_retains_inner_cause() {
+    for notification_gr in [false, true] {
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let (client, mut server) = connected_stream_pair().await;
+        session.test_install_stream(client);
+        establish_test_session(&mut session, 65002).await;
+        while rib_rx.try_recv().is_ok() {}
+        Arc::make_mut(session.negotiated.as_mut().expect("negotiated")).peer_notification_gr =
+            notification_gr;
+        let (event_tx, mut event_rx) = mpsc::channel(2);
+        session.session_event_tx = Some(event_tx);
+
+        assert_eq!(
+            session.handle_command(PeerCommand::BfdDown).await,
+            ControlFlow::Continue(())
+        );
+
+        let notification = read_until_notification(&mut server).await;
+        assert_eq!(notification.code, NotificationCode::Cease);
+        let event = event_rx.try_recv().expect("one sent notification event");
+        if notification_gr {
+            assert_eq!(notification.subcode, cease_subcode::HARD_RESET);
+            assert_eq!(
+                notification.data,
+                Bytes::from(vec![
+                    NotificationCode::Cease.as_u8(),
+                    cease_subcode::BFD_DOWN,
+                ])
+            );
+            assert_eq!(event.description, "Hard Reset: BFD Down");
+            assert_eq!(
+                session.last_error,
+                "sent NOTIFICATION 6/9 (Hard Reset: BFD Down)"
+            );
+        } else {
+            assert_eq!(notification.subcode, cease_subcode::BFD_DOWN);
+            assert!(notification.data.is_empty());
+            assert_eq!(event.description, "BFD Down");
+            assert_eq!(session.last_error, "sent NOTIFICATION 6/10 (BFD Down)");
+        }
+        assert!(matches!(rib_rx.try_recv(), Ok(RibUpdate::PeerDown { .. })));
+        assert_eq!(session.fsm.state(), SessionState::Idle);
+    }
+}
+
 /// Mutant: removing the sent-admin guard mislabels intentional local maintenance.
 #[test]
 fn administrative_notifications_keep_directional_maintenance_semantics() {

--- a/crates/wire/src/notification.rs
+++ b/crates/wire/src/notification.rs
@@ -143,6 +143,8 @@ pub mod cease_subcode {
     pub const CONNECTION_COLLISION_RESOLUTION: u8 = 7;
     /// RFC 8538
     pub const HARD_RESET: u8 = 9;
+    /// Subcode 10: BFD Down (RFC 9384).
+    pub const BFD_DOWN: u8 = 10;
 }
 
 /// Encode a shutdown communication reason string (RFC 9003).
@@ -315,6 +317,7 @@ pub fn description(code: NotificationCode, subcode: u8) -> &'static str {
         (NotificationCode::Cease, 8) => "Out of Resources",
         (NotificationCode::Cease, 7) => "Connection Collision Resolution",
         (NotificationCode::Cease, 9) => "Hard Reset",
+        (NotificationCode::Cease, 10) => "BFD Down",
         // Unknown code
         (NotificationCode::Unknown(_), _) => "Unknown Error Code",
         // Fallback for known code with unknown subcode
@@ -345,6 +348,25 @@ mod tests {
         );
         // Raw byte survives roundtrip
         assert_eq!(NotificationCode::from_u8(42).as_u8(), 42);
+    }
+
+    #[test]
+    fn bfd_down_cease_round_trips_and_displays() {
+        let notification = crate::NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::BFD_DOWN,
+            bytes::Bytes::new(),
+        );
+        let mut encoded = crate::encode_message(&crate::Message::Notification(notification))
+            .unwrap()
+            .freeze();
+        let decoded = crate::decode_message(&mut encoded, 4096).unwrap();
+        let crate::Message::Notification(decoded) = decoded else {
+            panic!("expected notification");
+        };
+        assert_eq!(decoded.code, NotificationCode::Cease);
+        assert_eq!(decoded.subcode, cease_subcode::BFD_DOWN);
+        assert_eq!(description(decoded.code, decoded.subcode), "BFD Down");
     }
 
     #[test]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -320,8 +320,11 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 - `handle_event` never returns `Result` — every (State, Event) pair
   produces a well-defined output. Invalid events in any state produce a
   NOTIFICATION (FSM Error) and transition to Idle.
-- `SessionDown` action only emitted when leaving Established state.
-  Failed handshakes are not surfaced as session-down events.
+- `SessionDown` is normally emitted when leaving Established state. A BFD
+  Down event in OpenSent or OpenConfirm also emits it after the typed Cease
+  notification so the shared transport teardown path clears cached
+  notification state; other failed handshakes are not surfaced as
+  session-down events.
 - `StateChanged` action emitted on every state transition for telemetry.
 
 ### §8.2 — Timers (transport implementation)

--- a/docs/adr/0046-notification-gr.md
+++ b/docs/adr/0046-notification-gr.md
@@ -59,14 +59,23 @@ if neg.peer_gr_capable
 
 If either hard reset flag is set, the session falls through to `PeerDown` (routes purged immediately) instead of `PeerGracefulRestart`.
 
-### No New Config
+### Automatic BFD hard reset
 
-N-bit advertisement is unconditional. Hard Reset sending is not automated in this change — it's primarily a reactive feature (honoring peer's Hard Reset). Future work could add a `hard_reset` flag to the `DisablePeer` gRPC command.
+N-bit advertisement is unconditional. When BFD drives a local BGP teardown,
+the typed `BfdDown` FSM event first creates Cease/BFD Down (6/10). If
+Notification GR was negotiated, the transport wraps that exact notification
+as Cease/Hard Reset (6/9) with the original 6/10 code and subcode in the data,
+as required by RFC 8538. Other local administrative teardown paths do not send
+Hard Reset automatically; a future change could expose that separately.
+
+This behavior adds no configuration knob or gRPC field.
 
 ## Consequences
 
 - Peers that support RFC 8538 will see the N-bit in our GR capability.
 - Cease/Hard Reset from a peer now correctly bypasses GR, preventing stale route preservation when the peer explicitly requests a hard teardown.
+- A BFD-triggered local teardown sends Cease/BFD Down, wrapped in Cease/Hard
+  Reset when Notification GR was negotiated.
 - No new configuration knobs or gRPC fields.
 - The `HARD_RESET` constant (Cease subcode 9) was already defined in the wire crate.
 - Backward compatible: peers without N-bit support ignore the bit per RFC.

--- a/docs/adr/0067-bfd-single-hop.md
+++ b/docs/adr/0067-bfd-single-hop.md
@@ -139,9 +139,12 @@ actor consumes) and consumes `BfdStateChange` events; the actor never learns BGP
 internals. This keeps the actor as the sole session owner while letting BGP
 drive which sessions should exist.
 
-- **Non-strict:** BFD **down** → `PeerHandle::stop` (FSM `ManualStop` →
-  session down), i.e. teardown **before** the hold timer expires. BFD **up**
-  clears the BFD hold and the existing reconnect path proceeds.
+- **Non-strict:** BFD **down** → `PeerCommand::BfdDown` → typed FSM
+  `Event::BfdDown` → Cease/BFD Down (RFC 9384 subcode 10) and session down,
+  i.e. teardown **before** the hold timer expires. When Notification GR was
+  negotiated, the transport sends the RFC 8538 Hard Reset envelope carrying
+  the original 6/10 notification. BFD **up** clears the BFD hold and the
+  existing reconnect path proceeds.
 - **Strict:** `add_peer` currently spawns **and immediately starts** the
   `PeerHandle`. Strict mode requires splitting that into **create managed peer →
   register BFD session → start BGP only after BFD reaches Up**. The

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -290,10 +290,9 @@ impl PeerManager {
                     info!(%peer, "BFD down — shut down pending inbound collision candidate");
                 }
                 if let Some(managed) = peer_key.as_ref().and_then(|key| self.peers.get(key)) {
-                    let reason = bytes::Bytes::from_static(b"BFD session down");
                     if let Err(e) = managed
                         .handle
-                        .stop_timeout(Some(reason), PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                        .bfd_down_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
                         .await
                     {
                         warn!(%peer, error = %e, "BFD down: failed to stop BGP session");

--- a/src/peer_manager/tests/bfd.rs
+++ b/src/peer_manager/tests/bfd.rs
@@ -9,6 +9,7 @@ use super::*;
 #[derive(Default)]
 struct BfdCouplingCounters {
     stop: AtomicU32,
+    bfd_down: AtomicU32,
     start: AtomicU32,
 }
 
@@ -22,6 +23,10 @@ fn fake_bfd_peer_handle(counters: Arc<BfdCouplingCounters>) -> PeerHandle {
             match cmd {
                 PeerCommand::Stop { .. } => {
                     counters.stop.fetch_add(1, Ordering::SeqCst);
+                }
+                PeerCommand::BfdDown => {
+                    counters.stop.fetch_add(1, Ordering::SeqCst);
+                    counters.bfd_down.fetch_add(1, Ordering::SeqCst);
                 }
                 PeerCommand::Start => {
                     counters.start.fetch_add(1, Ordering::SeqCst);
@@ -107,6 +112,7 @@ async fn bfd_down_then_up_tears_down_and_restores_enabled_peer() {
 
     mgr.handle_bfd_state_change(down(peer)).await;
     wait_counter(&counters.stop, 1).await; // BFD down must stop BGP
+    assert_eq!(counters.bfd_down.load(Ordering::SeqCst), 1);
     // A duplicate Down while already held must not re-stop.
     mgr.handle_bfd_state_change(down(peer)).await;
     assert_eq!(counters.stop.load(Ordering::SeqCst), 1);
@@ -378,6 +384,23 @@ async fn ack_is_release_only_never_tears_down() {
     // A real Down transition still does.
     mgr.handle_bfd_state_change(down(peer)).await;
     wait_counter(&counters.stop, 1).await;
+}
+
+#[tokio::test]
+async fn genuine_init_transition_does_not_tear_bgp_down() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+    mgr.handle_bfd_state_change(crate::bfd_runtime::BfdStateChange {
+        peer,
+        state: rustbgpd_bfd::SessionState::Init,
+        diagnostic: rustbgpd_bfd::Diagnostic::None,
+        remote_admin_down: false,
+        resync: false,
+    })
+    .await;
+    assert_eq!(counters.stop.load(Ordering::SeqCst), 0);
+    assert_eq!(counters.bfd_down.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- carry BFD-triggered teardown as a typed command and FSM event instead of inferring it from a shutdown string
- emit RFC 9384 Cease/BFD Down (6/10), or RFC 8538 Hard Reset (6/9) with inner `06 0a` when Notification GR is negotiated
- preserve the inner BFD Down diagnosis in last-error, session-event, and full BMP local-notification PDU surfaces while bypassing graceful retention
- keep BFD Init, resync reports, remote AdminDown, and administrative Stop/Shutdown behavior unchanged

## Validation

- wire 6/10 encode/decode/display regression passes
- focused FSM, transport notification/BMP, and 21 peer-manager BFD tests pass
- full wire, FSM, and transport suites pass
- strict workspace Clippy passes
- complete `cargo test --workspace --all-features` rerun passes
- final-head pre-push fmt, Clippy, workspace library tests, and rustdoc pass

Linear: LAN-1261
