### PR TITLE
refactor(config): isolate test-only serializer probe

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -24,6 +24,22 @@ pub(super) const BGP_PORT: u16 = 179;
 pub(super) static PERSISTENCE_PROBE_DIRECT_MAPS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+fn serialize_hash_map_sorted<K, V, S>(map: &HashMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize,
+    V: Serialize,
+    S: Serializer,
+{
+    let mut entries: Vec<_> = map.iter().collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+    let mut map_out = serializer.serialize_map(Some(entries.len()))?;
+    for (key, value) in entries {
+        map_out.serialize_entry(key, value)?;
+    }
+    map_out.end()
+}
+
+#[cfg(not(test))]
 pub(super) fn serialize_sorted_hash_map<K, V, S>(
     map: &HashMap<K, V>,
     serializer: S,
@@ -33,7 +49,19 @@ where
     V: Serialize,
     S: Serializer,
 {
-    #[cfg(test)]
+    serialize_hash_map_sorted(map, serializer)
+}
+
+#[cfg(test)]
+pub(super) fn serialize_sorted_hash_map<K, V, S>(
+    map: &HashMap<K, V>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize,
+    V: Serialize,
+    S: Serializer,
+{
     if matches!(
         std::env::var("RUSTBGPD_PERSISTENCE_PROBE_ARM").as_deref(),
         Ok("direct")
@@ -45,13 +73,7 @@ where
         }
         return map_out.end();
     }
-    let mut entries: Vec<_> = map.iter().collect();
-    entries.sort_unstable_by_key(|(key, _)| *key);
-    let mut map_out = serializer.serialize_map(Some(entries.len()))?;
-    for (key, value) in entries {
-        map_out.serialize_entry(key, value)?;
-    }
-    map_out.end()
+    serialize_hash_map_sorted(map, serializer)
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
## Summary

- extract deterministic HashMap serialization into an environment-free helper
- keep the direct-map persistence probe behind a test-only wrapper
- preserve the five existing serde bindings and serialized output

This is item 1 of LAN-1206. The separate renderer refusal review remains open.

## Validation

- focused deterministic persistence tests in lib and bin targets
- full config test suites in lib and bin targets
- isolated 3.2M-statement release probe with identical direct/sorted bytes and hashes
- strict workspace Clippy, full all-feature workspace tests, and warning-denied docs
- pre-push formatting, Clippy, tests, and docs

Linear: LAN-1206