### PR TITLE
ci: publish netns selector execution receipts

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -805,8 +805,13 @@ jobs:
     name: Privileged netns selectors (kernel dataplane inventory)
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    env:
+      NETNS_SELECTOR_RECEIPT: ${{ runner.temp }}/netns-selector-receipt.log
     steps:
       - uses: actions/checkout@v7
+
+      - name: Initialize netns selector receipt
+        run: : > "$NETNS_SELECTOR_RECEIPT"
 
       # The Docker netns harness builds its own image and runs the privileged
       # tests inside `docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN`, so the
@@ -916,6 +921,30 @@ jobs:
       - name: Route-event wake latency netns test
         if: steps.vrf.outputs.vrf-available == 'true'
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh l3_route_event
+
+      - name: Finalize netns selector receipt
+        if: always()
+        env:
+          VRF_AVAILABLE: ${{ steps.vrf.outputs.vrf-available }}
+        run: |
+          set +e
+          python3 scripts/check_netns_selector_receipt.py \
+            --receipt "$NETNS_SELECTOR_RECEIPT" \
+            --output "$RUNNER_TEMP/netns-selector-receipt.json" \
+            --summary "$RUNNER_TEMP/netns-selector-summary.md" \
+            --vrf-available "${VRF_AVAILABLE:-false}"
+          rc=$?
+          cat "$RUNNER_TEMP/netns-selector-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"
+
+      - name: Upload netns selector receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: netns-selector-receipt
+          path: ${{ runner.temp }}/netns-selector-receipt.json
+          if-no-files-found: error
+          retention-days: 14
 
   check:
     name: check

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -805,13 +805,14 @@ jobs:
     name: Privileged netns selectors (kernel dataplane inventory)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    env:
-      NETNS_SELECTOR_RECEIPT: ${{ runner.temp }}/netns-selector-receipt.log
     steps:
       - uses: actions/checkout@v7
 
       - name: Initialize netns selector receipt
-        run: : > "$NETNS_SELECTOR_RECEIPT"
+        run: |
+          receipt="$RUNNER_TEMP/netns-selector-receipt.log"
+          : > "$receipt"
+          printf 'NETNS_SELECTOR_RECEIPT=%s\n' "$receipt" >> "$GITHUB_ENV"
 
       # The Docker netns harness builds its own image and runs the privileged
       # tests inside `docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN`, so the

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -271,3 +271,4 @@ docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" "${TEST_ARGS[@]}"
 if [ -n "${NETNS_SELECTOR_RECEIPT:-}" ]; then
     printf '%s\n' "$SELECTOR" >> "$NETNS_SELECTOR_RECEIPT"
 fi
+exit 0

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -105,6 +105,7 @@ DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 # lifecycle/readiness proofs.
 TEST_BIN="netns_bum_filter"
 EXACT_FILTER=1
+SELECTOR="${1:-all}"
 # Module-path filter for `-p rustbgpd` daemon netns tests (fib/bfd);
 # empty means the default `netns_*` evpn-linux integration binary.
 RUSTBGPD_TEST_FILTER=""
@@ -263,4 +264,10 @@ else
 fi
 
 echo "[harness] running: ${TEST_ARGS[*]}"
-exec docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" "${TEST_ARGS[@]}"
+docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" "${TEST_ARGS[@]}"
+
+# CI uses this append-only log to prove which inventory selectors actually
+# completed. Never record an invocation that did not return successfully.
+if [ -n "${NETNS_SELECTOR_RECEIPT:-}" ]; then
+    printf '%s\n' "$SELECTOR" >> "$NETNS_SELECTOR_RECEIPT"
+fi

--- a/docs/kernel-dataplane-runner.md
+++ b/docs/kernel-dataplane-runner.md
@@ -108,6 +108,13 @@ issue #187) so reviewers can distinguish real stability from flake masking.
   `managed_ip_vrf_ready`, `l3_all_active_writer`, `foreign_state_l3`, and
   `l3_route_event`.
 
+The job always publishes a stable `netns-selector-receipt` JSON artifact and a
+concise job summary. A selector is recorded only after its harness invocation
+succeeds. The finalizer requires all 21 selectors when VRF is available; when
+VRF is unavailable it requires the 16 unconditional selectors and records the
+five L3 omissions with reason `vrf_unavailable`. Missing, duplicate, or
+unexpected required selectors fail the job.
+
 The `Privileged Interop (netns)` workflow (`privileged-interop.yml`) is a
 manual (`workflow_dispatch`) on-demand harness for the non-docker direct-`cargo
 test` netns binaries (`netns_dataplane` / `netns_fdb_nhg` / `netns_l3_install` /

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -781,8 +781,9 @@ def check(root: Path) -> list[str]:
         if gated != (selector in NETNS_VRF_SELECTORS):
             errors.append(f"kernel-dataplane.yml:netns {selector} VRF gate drifted")
     receipt_seams = (
-        "NETNS_SELECTOR_RECEIPT: ${{ runner.temp }}/netns-selector-receipt.log",
-        'run: : > "$NETNS_SELECTOR_RECEIPT"',
+        'receipt="$RUNNER_TEMP/netns-selector-receipt.log"',
+        ': > "$receipt"',
+        "printf 'NETNS_SELECTOR_RECEIPT=%s\\n' \"$receipt\" >> \"$GITHUB_ENV\"",
         "if: always()\n        env:\n          VRF_AVAILABLE:",
         "python3 scripts/check_netns_selector_receipt.py",
         '--vrf-available "${VRF_AVAILABLE:-false}"',

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -127,7 +127,7 @@ PINS = collections.Counter(
         "docker/setup-buildx-action@v4": 45,
         "docker/build-push-action@v7": 46,
         "actions/cache@v6": 7,
-        "actions/upload-artifact@v7": 8,
+        "actions/upload-artifact@v7": 9,
         "actions/download-artifact@v8": 6,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
@@ -780,6 +780,25 @@ def check(root: Path) -> list[str]:
         )
         if gated != (selector in NETNS_VRF_SELECTORS):
             errors.append(f"kernel-dataplane.yml:netns {selector} VRF gate drifted")
+    receipt_seams = (
+        "NETNS_SELECTOR_RECEIPT: ${{ runner.temp }}/netns-selector-receipt.log",
+        'run: : > "$NETNS_SELECTOR_RECEIPT"',
+        "if: always()\n        env:\n          VRF_AVAILABLE:",
+        "python3 scripts/check_netns_selector_receipt.py",
+        '--vrf-available "${VRF_AVAILABLE:-false}"',
+        'cat "$RUNNER_TEMP/netns-selector-summary.md" >> "$GITHUB_STEP_SUMMARY"',
+        "uses: actions/upload-artifact@v7",
+        "name: netns-selector-receipt",
+        "path: ${{ runner.temp }}/netns-selector-receipt.json",
+        "if-no-files-found: error",
+    )
+    for seam in receipt_seams:
+        if seam not in netns:
+            errors.append(f"kernel-dataplane.yml:netns receipt seam drifted: {seam}")
+    if netns.count("if: always()") != 2:
+        errors.append("kernel-dataplane.yml:netns receipt finalizer and upload must always run")
+    if 'printf \'%s\\n\' "$SELECTOR" >> "$NETNS_SELECTOR_RECEIPT"' not in harness:
+        errors.append("netns harness must append the successful selector receipt")
 
     action = (
         root / ".github" / "actions" / "setup-dataplane-host" / "action.yml"

--- a/scripts/check_netns_selector_receipt.py
+++ b/scripts/check_netns_selector_receipt.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate and publish the executed kernel-netns selector inventory."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+from pathlib import Path
+
+BASE = (
+    "fdb_nhg", "fib_runtime", "bfd_runtime", "dataplane_vlan_fdb",
+    "macip_vlan_attribution", "svd_fdb_vni", "managed_bridge",
+    "managed_vxlan", "managed_svd_vxlan", "managed_vlan_upper",
+    "managed_ready", "link_carrier", "ac_gate", "nexthop_raw",
+    "foreign_state_l2", "foreign_state_nhid",
+)
+VRF = (
+    "l3_multipath", "managed_ip_vrf_ready", "l3_all_active_writer",
+    "foreign_state_l3", "l3_route_event",
+)
+
+
+def finalize(receipt: Path, output: Path, summary: Path, vrf_available: bool) -> list[str]:
+    seen = receipt.read_text().splitlines() if receipt.is_file() else []
+    counts = collections.Counter(seen)
+    expected = BASE + VRF if vrf_available else BASE
+    errors: list[str] = []
+    errors += [f"missing selector: {item}" for item in expected if counts[item] == 0]
+    errors += [f"duplicate selector: {item}" for item, count in counts.items() if count > 1]
+    errors += [f"unexpected selector: {item}" for item in counts if item not in expected]
+    executed = [item for item in expected if counts[item] == 1]
+    omitted = [] if vrf_available else [
+        {"selector": item, "reason": "vrf_unavailable"} for item in VRF
+    ]
+    payload = {
+        "errors": sorted(errors),
+        "executed_selectors": executed,
+        "omitted_selectors": omitted,
+        "schema_version": 1,
+        "vrf_available": vrf_available,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    status = "PASS" if not errors else "FAIL"
+    summary.write_text(
+        f"### Netns selector receipt: {status}\n\n"
+        f"Executed **{len(executed)}** selectors; published **{len(omitted)}** VRF omissions.\n"
+    )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--summary", type=Path, required=True)
+    parser.add_argument("--vrf-available", choices=("true", "false"), required=True)
+    args = parser.parse_args()
+    errors = finalize(
+        args.receipt, args.output, args.summary, args.vrf_available == "true"
+    )
+    for error in errors:
+        print(error)
+    return bool(errors)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_netns_selector_receipt.py
+++ b/scripts/check_netns_selector_receipt.py
@@ -29,12 +29,13 @@ def finalize(receipt: Path, output: Path, summary: Path, vrf_available: bool) ->
     errors += [f"missing selector: {item}" for item in expected if counts[item] == 0]
     errors += [f"duplicate selector: {item}" for item, count in counts.items() if count > 1]
     errors += [f"unexpected selector: {item}" for item in counts if item not in expected]
+    errors.sort()
     executed = [item for item in expected if counts[item] == 1]
     omitted = [] if vrf_available else [
         {"selector": item, "reason": "vrf_unavailable"} for item in VRF
     ]
     payload = {
-        "errors": sorted(errors),
+        "errors": errors,
         "executed_selectors": executed,
         "omitted_selectors": omitted,
         "schema_version": 1,
@@ -62,7 +63,7 @@ def main() -> int:
     )
     for error in errors:
         print(error)
-    return bool(errors)
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -912,7 +912,27 @@ class PrimerContractTests(unittest.TestCase):
             (root / harness).unlink()
             workflow_path = root / workflow
             workflow_path.write_text(workflow_path.read_text().replace("        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier", "        run: true"))
-            self.assertEqual(["netns harness is missing", "kernel-dataplane.yml:netns must invoke link_carrier once"], check(root))
+            self.assertEqual(
+                [
+                    "netns harness is missing",
+                    "kernel-dataplane.yml:netns must invoke link_carrier once",
+                    "netns harness must append the successful selector receipt",
+                ],
+                check(root),
+            )
+
+    def test_kernel_netns_receipt_contract_is_load_bearing(self):
+        workflow = ".github/workflows/kernel-dataplane.yml"
+        harness = "crates/evpn-linux/tests/docker/run-netns-tests.sh"
+        cases = (
+            (workflow, "name: netns-selector-receipt", "name: incomplete-receipt"),
+            (workflow, 'cat "$RUNNER_TEMP/netns-selector-summary.md" >> "$GITHUB_STEP_SUMMARY"', "true"),
+            (workflow, "--vrf-available \"${VRF_AVAILABLE:-false}\"", "--vrf-available true"),
+            (harness, "printf '%s\\n' \"$SELECTOR\" >> \"$NETNS_SELECTOR_RECEIPT\"", "true"),
+        )
+        for relative, old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
 
     def test_destructive_workflow_seams(self):
         cases = (

--- a/scripts/test_check_netns_selector_receipt.py
+++ b/scripts/test_check_netns_selector_receipt.py
@@ -35,7 +35,8 @@ class ReceiptTest(unittest.TestCase):
         self.assertIn(f"missing selector: {BASE[0]}", errors)
         self.assertIn(f"duplicate selector: {BASE[1]}", errors)
         self.assertIn("unexpected selector: surprise", errors)
-        self.assertEqual(payload["errors"], sorted(errors))
+        self.assertEqual(errors, sorted(errors))
+        self.assertEqual(payload["errors"], errors)
         self.assertIn("FAIL", summary)
 
 

--- a/scripts/test_check_netns_selector_receipt.py
+++ b/scripts/test_check_netns_selector_receipt.py
@@ -1,0 +1,43 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_netns_selector_receipt import BASE, VRF, finalize
+
+
+class ReceiptTest(unittest.TestCase):
+    def run_case(self, selectors, vrf):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            receipt, output, summary = root / "seen", root / "out.json", root / "summary"
+            receipt.write_text("".join(f"{item}\n" for item in selectors))
+            errors = finalize(receipt, output, summary, vrf)
+            return errors, json.loads(output.read_text()), summary.read_text()
+
+    def test_vrf_available_requires_all_21(self):
+        errors, payload, summary = self.run_case(BASE + VRF, True)
+        self.assertEqual(errors, [])
+        self.assertEqual(payload["executed_selectors"], list(BASE + VRF))
+        self.assertEqual(payload["omitted_selectors"], [])
+        self.assertIn("PASS", summary)
+
+    def test_vrf_unavailable_requires_16_and_publishes_five_omissions(self):
+        errors, payload, _ = self.run_case(BASE, False)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            payload["omitted_selectors"],
+            [{"selector": item, "reason": "vrf_unavailable"} for item in VRF],
+        )
+
+    def test_rejects_missing_duplicate_and_unexpected(self):
+        errors, payload, summary = self.run_case(BASE[1:] + (BASE[1], "surprise"), False)
+        self.assertIn(f"missing selector: {BASE[0]}", errors)
+        self.assertIn(f"duplicate selector: {BASE[1]}", errors)
+        self.assertIn("unexpected selector: surprise", errors)
+        self.assertEqual(payload["errors"], sorted(errors))
+        self.assertIn("FAIL", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- record each privileged netns selector only after its harness invocation succeeds
- fail closed on missing, duplicate, or unexpected selectors while preserving explicit VRF optionality
- always publish a stable JSON receipt artifact and concise job summary
- protect the workflow and harness seams with truth-table and mutation tests

When VRF is available, the receipt requires all 21 selectors. Without VRF, it requires the 16 unconditional selectors and records the exact five omissions as vrf_unavailable.

## Validation

- Bash syntax check for the netns harness
- 38 receipt and CI-primer contract tests
- live CI-primer contract check
- diff and documentation checks
- hosted Kernel Dataplane selector execution and artifact inspection are merge gates

Linear: LAN-1216