### PR TITLE
refactor: remove dead RIB query variants

### DIFF
--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2097,9 +2097,6 @@ impl RibManager {
                 self.handle_withdraw_injected(prefix, path_id, reply);
                 self.retire_exact_export_rejections([ExactExportKey::Unicast(prefix, path_id)]);
             }
-            RibUpdate::QueryReceivedRoutes { peer, reply } => {
-                self.handle_query_received_routes(peer, reply);
-            }
             RibUpdate::QueryRoutesPage {
                 scope,
                 filter,
@@ -2127,9 +2124,6 @@ impl RibManager {
                 self.handle_query_fib_install_candidates(max_paths, relax, weighted, reply);
             }
             RibUpdate::QueryPeerGroups { reply } => self.handle_query_peer_groups(reply),
-            RibUpdate::QueryAdvertisedRoutes { peer, reply } => {
-                self.handle_query_advertised_routes(peer, reply);
-            }
             RibUpdate::ExplainBestPath {
                 prefix,
                 peer,

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -477,28 +477,6 @@ impl RibManager {
             (Afi::Ipv6 as u16, Safi::MplsVpn as u8, vpnv6),
         ]);
     }
-    pub(super) fn handle_query_received_routes(
-        &mut self,
-        peer: Option<IpAddr>,
-        reply: tokio::sync::oneshot::Sender<Vec<crate::route::Route>>,
-    ) {
-        let routes: Vec<_> = match peer {
-            Some(peer_addr) => self
-                .ribs
-                .get(&peer_addr)
-                .map(|rib| rib.iter().cloned().collect())
-                .unwrap_or_default(),
-            None => self
-                .ribs
-                .values()
-                .flat_map(|rib| rib.iter().cloned())
-                .collect(),
-        };
-
-        if reply.send(routes).is_err() {
-            warn!("query caller dropped before receiving response");
-        }
-    }
     /// One bounded page of a resumable route listing. The reply channel
     /// doubles as the cancellation token: an abandoned caller (dropped
     /// receiver — e.g. a canceled gRPC request whose page query was
@@ -756,24 +734,6 @@ impl RibManager {
     ) {
         if reply.send(self.peer_group.clone()).is_err() {
             warn!("query caller dropped before receiving peer-group map");
-        }
-    }
-    pub(super) fn handle_query_advertised_routes(
-        &mut self,
-        peer: IpAddr,
-        reply: tokio::sync::oneshot::Sender<Vec<crate::route::Route>>,
-    ) {
-        // A grouped member holds no per-peer unicast Adj-RIB-Out; its
-        // advertised set is synthesized: group table − own-sourced.
-        let routes: Vec<_> = self.grouped_advertised_routes(peer).unwrap_or_else(|| {
-            self.adj_ribs_out
-                .get(&peer)
-                .map(|rib| rib.iter().cloned().collect())
-                .unwrap_or_default()
-        });
-
-        if reply.send(routes).is_err() {
-            warn!("query caller dropped before receiving response");
         }
     }
     pub(super) fn handle_explain_advertised_route(

--- a/crates/rib/src/manager/tests/exportability.rs
+++ b/crates/rib/src/manager/tests/exportability.rs
@@ -1013,11 +1013,7 @@ async fn advertised_count(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> usize {
 }
 
 async fn advertised_routes(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Vec<Route> {
-    let (reply, result) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes { peer, reply })
-        .await
-        .unwrap();
-    result.await.unwrap()
+    collect_advertised_routes(tx, peer).await
 }
 
 async fn update_group(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> String {

--- a/crates/rib/src/manager/tests/lifecycle.rs
+++ b/crates/rib/src/manager/tests/lifecycle.rs
@@ -65,14 +65,7 @@ async fn channel_full_marks_dirty_and_resyncs() {
     assert_eq!(update.announce.len(), 1);
 
     // Verify AdjRibOut has the route
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(advertised.len(), 1);
 
     // Send prefix2 — fills the channel (capacity 1)
@@ -114,14 +107,7 @@ async fn channel_full_marks_dirty_and_resyncs() {
     // After channel-full failure, AdjRibOut preserves last successfully
     // sent state: both prefix1 and prefix2 were sent before the failure.
     // The withdrawal of prefix1 was lost because the channel was full.
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(
         advertised.len(),
         2,
@@ -151,14 +137,7 @@ async fn channel_full_marks_dirty_and_resyncs() {
     );
 
     // After successful resync, AdjRibOut should match Loc-RIB
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(
         advertised.len(),
         1,
@@ -361,14 +340,7 @@ async fn initial_dump_failure_leaves_adjribout_empty() {
     .unwrap();
 
     // AdjRibOut should be empty since initial dump send failed
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert!(
         advertised.is_empty(),
         "AdjRibOut should be empty when initial dump send fails"
@@ -437,14 +409,7 @@ async fn initial_dump_failure_resyncs_via_timer() {
     .unwrap();
 
     // Force serialization — initial dump should have failed (channel full)
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert!(
         advertised.is_empty(),
         "AdjRibOut should be empty after failed initial dump"
@@ -468,14 +433,7 @@ async fn initial_dump_failure_resyncs_via_timer() {
     assert_eq!(resync.end_of_rib, ipv4_sendable());
 
     // AdjRibOut should now reflect Loc-RIB
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(
         advertised.len(),
         1,

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -343,6 +343,7 @@ async fn collect_query_routes(tx: &mpsc::Sender<RibUpdate>, scope: RouteQuerySco
             filter: None,
             after,
             expected_version,
+            // Keep migrated callers exercising continuation/version fencing.
             page_size: 2,
             reply,
         })

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -19,7 +19,7 @@ use crate::route::{
     VpnRibRoute,
 };
 use crate::test_support::{make_flowspec_route, make_route, make_route_with_lp, make_v6_route};
-use crate::update::EffectiveDistributionMode;
+use crate::update::{EffectiveDistributionMode, RouteQueryScope, route_query_key};
 
 fn evpn_sendable() -> Vec<(Afi, Safi)> {
     vec![(Afi::L2Vpn, Safi::Evpn)]
@@ -325,14 +325,37 @@ async fn query_fib_install_candidates_opts(
 }
 
 async fn query_received_routes(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Vec<Route> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    reply_rx.await.unwrap()
+    collect_query_routes(tx, RouteQueryScope::Received { peer: Some(peer) }).await
+}
+
+async fn collect_advertised_routes(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Vec<Route> {
+    collect_query_routes(tx, RouteQueryScope::Advertised { peer }).await
+}
+
+async fn collect_query_routes(tx: &mpsc::Sender<RibUpdate>, scope: RouteQueryScope) -> Vec<Route> {
+    let mut routes = Vec::new();
+    let mut after = None;
+    let mut expected_version = None;
+    loop {
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::QueryRoutesPage {
+            scope,
+            filter: None,
+            after,
+            expected_version,
+            page_size: 2,
+            reply,
+        })
+        .await
+        .unwrap();
+        let page = response.await.unwrap().unwrap();
+        expected_version = Some(page.version);
+        after = page.routes.last().map(route_query_key);
+        routes.extend(page.routes);
+        if !page.has_more {
+            return routes;
+        }
+    }
 }
 
 async fn query_evpn_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<EvpnRibRoute> {

--- a/crates/rib/src/manager/tests/multipath_fib.rs
+++ b/crates/rib/src/manager/tests/multipath_fib.rs
@@ -363,14 +363,7 @@ async fn no_advertise_candidate_is_removed_before_add_path_rank_compaction() {
         "one compact delta is sufficient"
     );
 
-    let (reply, response) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply,
-    })
-    .await
-    .unwrap();
-    let advertised = response.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(advertised.len(), 1);
     assert_eq!(advertised[0].peer, IpAddr::V4(source_b));
     assert_eq!(advertised[0].path_id, 1);
@@ -404,14 +397,8 @@ async fn no_advertise_candidate_is_removed_before_add_path_rank_compaction() {
         .expect("policy-added NO_ADVERTISE withdraws the remaining rank");
     assert!(update.announce.is_empty());
     assert_eq!(update.withdraw, vec![(Prefix::V4(prefix), 1)]);
-    let (reply, response) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply,
-    })
-    .await
-    .unwrap();
-    assert!(response.await.unwrap().is_empty());
+    let response = collect_advertised_routes(&tx, target).await;
+    assert!(response.is_empty());
 
     let explain = query_explain_best_path_for_peer(&tx, Prefix::V4(prefix), target)
         .await

--- a/crates/rib/src/manager/tests/no_export.rs
+++ b/crates/rib/src/manager/tests/no_export.rs
@@ -226,11 +226,8 @@ async fn no_export_suppresses_honor_ebgp_only_and_splits_update_groups() {
                 .expect("tagged replacement re-announced to non-suppressed peers");
             assert_eq!(update.announce.len(), 1, "{peer}");
             assert!(update.withdraw.is_empty(), "{peer}");
-            let (reply, response) = oneshot::channel();
-            tx.send(RibUpdate::QueryAdvertisedRoutes { peer, reply })
-                .await
-                .unwrap();
-            assert_eq!(response.await.unwrap().len(), 1, "{peer}");
+            let response = collect_advertised_routes(&tx, peer).await;
+            assert_eq!(response.len(), 1, "{peer}");
         }
 
         // Restore the plain route for the next community round.

--- a/crates/rib/src/manager/tests/orr.rs
+++ b/crates/rib/src/manager/tests/orr.rs
@@ -1140,14 +1140,8 @@ async fn no_advertise_orr_winner_is_withdrawn_without_runner_up_fallback() {
     assert_eq!(update.withdraw, vec![orr_prefix_key()]);
     assert!(out_rx.try_recv().is_err());
 
-    let (reply, response) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: client_b,
-        reply,
-    })
-    .await
-    .unwrap();
-    assert!(response.await.unwrap().is_empty());
+    let response = collect_advertised_routes(&tx, client_b).await;
+    assert!(response.is_empty());
 
     let explain = query_explain_advertised_route(&tx, client_b, Prefix::V4(orr_prefix())).await;
     assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
@@ -1198,14 +1192,8 @@ async fn no_advertise_orr_winner_is_withdrawn_without_runner_up_fallback() {
     assert!(update.announce.is_empty());
     assert_eq!(update.withdraw, vec![orr_prefix_key()]);
 
-    let (reply, response) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: client_b,
-        reply,
-    })
-    .await
-    .unwrap();
-    assert!(response.await.unwrap().is_empty());
+    let response = collect_advertised_routes(&tx, client_b).await;
+    assert!(response.is_empty());
 
     let explain = query_explain_advertised_route(&tx, client_b, Prefix::V4(orr_prefix())).await;
     assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -149,11 +149,25 @@ fn direct_page_at(
 }
 
 fn direct_advertised_snapshot(manager: &mut RibManager, peer: IpAddr) -> Vec<Route> {
-    let (reply, mut response) = oneshot::channel();
-    manager.handle_query_advertised_routes(peer, reply);
-    response
-        .try_recv()
-        .expect("advertised snapshot handler replies synchronously")
+    let mut routes = Vec::new();
+    let mut after = None;
+    let mut version = None;
+    loop {
+        let page = direct_page_at(
+            manager,
+            RouteQueryScope::Advertised { peer },
+            after,
+            version,
+            2,
+        )
+        .unwrap();
+        after = page.routes.last().map(route_query_key);
+        version = Some(page.version);
+        routes.extend(page.routes);
+        if !page.has_more {
+            return routes;
+        }
+    }
 }
 
 fn peer_up_direct(manager: &mut RibManager, peer: IpAddr) -> mpsc::Receiver<OutboundRouteUpdate> {
@@ -289,44 +303,29 @@ async fn seeded_manager() -> (
 async fn paged_union_matches_single_shot_across_page_sizes() {
     let (tx, target, _out_rx, handle) = seeded_manager().await;
 
-    // Single-shot references for every scope.
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: None,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let full_received = reply_rx.await.unwrap();
-    assert_eq!(full_received.len(), 12);
-
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let full_best = reply_rx.await.unwrap();
-    assert_eq!(full_best.len(), 4);
-
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let full_advertised = reply_rx.await.unwrap();
-    assert_eq!(full_advertised.len(), 4);
-
+    // Build the oracle from the fixture, independently of the paging path.
+    let full_received: Vec<_> = (1..=3u8)
+        .flat_map(|peer| {
+            (0..4u8).map(move |prefix| {
+                make_route(
+                    Ipv4Prefix::new(Ipv4Addr::new(192, 168, prefix, 0), 24),
+                    Ipv4Addr::new(10, 0, 0, peer),
+                )
+            })
+        })
+        .collect();
     let one_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(one_peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let full_one_peer = reply_rx.await.unwrap();
-    assert_eq!(full_one_peer.len(), 4);
+    let full_one_peer: Vec<_> = full_received
+        .iter()
+        .filter(|route| route.peer == one_peer)
+        .cloned()
+        .collect();
+    let full_best: Vec<_> = full_received
+        .iter()
+        .filter(|route| route.peer == IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        .cloned()
+        .collect();
+    let full_advertised = full_best.clone();
 
     for page_size in [1, 2, 3, 5, 100] {
         let scopes: [(RouteQueryScope, &[Route]); 4] = [

--- a/crates/rib/src/manager/tests/per_client_best.rs
+++ b/crates/rib/src/manager/tests/per_client_best.rs
@@ -188,26 +188,15 @@ async fn best_denied_single_best_hides_per_client_best_sends_runner_up() {
     drain_eor(&mut mitigated_rx).await;
 
     // Adj-RIB-Out / ListAdvertisedRoutes present the same shape.
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: mitigated,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, mitigated).await;
     assert_eq!(advertised.len(), 1);
     assert_eq!(advertised[0].peer, IpAddr::V4(SOURCE_B));
     assert_eq!(advertised[0].path_id, 0);
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: hidden,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    assert!(reply_rx.await.unwrap().is_empty(), "path hiding pinned");
+    assert!(
+        collect_advertised_routes(&tx, hidden).await.is_empty(),
+        "path hiding pinned"
+    );
 
     drop(tx);
     handle.await.unwrap();
@@ -267,14 +256,7 @@ async fn no_advertise_winner_is_replaced_by_per_client_runner_up_before_policy()
     );
     assert!(out_rx.try_recv().is_err());
 
-    let (reply, response) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply,
-    })
-    .await
-    .unwrap();
-    let advertised = response.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(advertised.len(), 1);
     assert_eq!(advertised[0].peer, IpAddr::V4(SOURCE_B));
     assert_eq!(advertised[0].path_id, 0);
@@ -295,14 +277,8 @@ async fn no_advertise_winner_is_replaced_by_per_client_runner_up_before_policy()
         .expect("policy-added NO_ADVERTISE withdraws the per-client winner");
     assert!(update.announce.is_empty());
     assert_eq!(update.withdraw, vec![(Prefix::V4(prefix()), 0)]);
-    let (reply, response) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply,
-    })
-    .await
-    .unwrap();
-    assert!(response.await.unwrap().is_empty());
+    let response = collect_advertised_routes(&tx, target).await;
+    assert!(response.is_empty());
 
     let explain = query_explain_advertised_route(&tx, target, Prefix::V4(prefix())).await;
     assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);

--- a/crates/rib/src/manager/tests/policy.rs
+++ b/crates/rib/src/manager/tests/policy.rs
@@ -363,15 +363,7 @@ async fn query_advertised_routes() {
     .unwrap();
 
     // Wait for distribution
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-
-    let routes = reply_rx.await.unwrap();
+    let routes = collect_advertised_routes(&tx, target).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].prefix, Prefix::V4(prefix));
 
@@ -817,16 +809,7 @@ async fn explain_advertised_route_reports_policy_deny_without_mutation() {
     assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
     assert_eq!(explain.reasons[0].code, "policy_denied");
 
-    let advertised = {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(RibUpdate::QueryAdvertisedRoutes {
-            peer: target,
-            reply: reply_tx,
-        })
-        .await
-        .unwrap();
-        reply_rx.await.unwrap()
-    };
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert!(advertised.is_empty());
 
     drop(tx);
@@ -924,16 +907,7 @@ async fn export_as_path_regex_still_filters_through_distribution() {
     .await
     .unwrap();
 
-    let advertised = {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(RibUpdate::QueryAdvertisedRoutes {
-            peer: target,
-            reply: reply_tx,
-        })
-        .await
-        .unwrap();
-        reply_rx.await.unwrap()
-    };
+    let advertised = collect_advertised_routes(&tx, target).await;
     let prefixes: Vec<_> = advertised.iter().map(|r| r.prefix).collect();
 
     assert!(
@@ -1190,14 +1164,7 @@ async fn peer_down_cleans_up_export_policy() {
     .unwrap();
 
     // Query to confirm loop processed PeerDown
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let routes = reply_rx.await.unwrap();
+    let routes = collect_advertised_routes(&tx, peer).await;
     assert!(routes.is_empty());
 
     drop(tx);

--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -630,14 +630,7 @@ async fn routes_validated_on_insert_with_vrp_table() {
     .unwrap();
 
     // Query received routes — should have Valid validation state
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].validation_state, RpkiValidation::Valid);
 
@@ -674,14 +667,7 @@ async fn rpki_cache_update_revalidates_existing_routes() {
     .unwrap();
 
     // Verify it's NotFound
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes[0].validation_state, RpkiValidation::NotFound);
 
     // Now send VRP table that covers the route
@@ -696,14 +682,7 @@ async fn rpki_cache_update_revalidates_existing_routes() {
         .unwrap();
 
     // Query again — should be Valid now
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes[0].validation_state, RpkiValidation::Valid);
 
     drop(tx);
@@ -876,14 +855,7 @@ async fn rpki_no_table_all_not_found() {
     .await
     .unwrap();
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes[0].validation_state, RpkiValidation::NotFound);
 
     drop(tx);
@@ -936,16 +908,7 @@ async fn ibgp_aspa_stays_unknown_on_insert_and_cache_revalidation() {
     .await
     .unwrap();
 
-    let query = async |tx: &mpsc::Sender<RibUpdate>| {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(RibUpdate::QueryReceivedRoutes {
-            peer: Some(peer),
-            reply: reply_tx,
-        })
-        .await
-        .unwrap();
-        reply_rx.await.unwrap()
-    };
+    let query = async |tx: &mpsc::Sender<RibUpdate>| query_received_routes(tx, peer).await;
     let inserted = query(&tx).await;
     assert_eq!(
         inserted[0].aspa_state,
@@ -1026,14 +989,7 @@ async fn aspa_cache_update_revalidates_with_stored_downstream_context() {
     .await
     .unwrap();
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes[0].aspa_state, rustbgpd_wire::AspaValidation::Valid);
 
     drop(tx);
@@ -1105,14 +1061,7 @@ async fn rpki_cache_update_no_change_no_redistribution() {
         .unwrap();
 
     // Verify route stays NotFound — no VRP covers 10.0.0.0/24
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes[0].validation_state, RpkiValidation::NotFound);
 
     drop(tx);

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -575,11 +575,8 @@ async fn no_advertise_precedes_policy_for_grouped_and_private_single_best() {
         );
         assert_eq!(update.withdraw, vec![(Prefix::V4(prefix), 0)]);
 
-        let (reply, response) = oneshot::channel();
-        tx.send(RibUpdate::QueryAdvertisedRoutes { peer: *peer, reply })
-            .await
-            .unwrap();
-        assert!(response.await.unwrap().is_empty());
+        let response = collect_advertised_routes(&tx, *peer).await;
+        assert!(response.is_empty());
 
         let explain = query_explain_advertised_route(&tx, *peer, Prefix::V4(prefix)).await;
         assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
@@ -650,11 +647,8 @@ async fn no_advertise_precedes_policy_for_grouped_and_private_single_best() {
         }
         assert!(saw_withdraw, "policy replacement must withdraw from {peer}");
 
-        let (reply, response) = oneshot::channel();
-        tx.send(RibUpdate::QueryAdvertisedRoutes { peer: *peer, reply })
-            .await
-            .unwrap();
-        assert!(response.await.unwrap().is_empty());
+        let response = collect_advertised_routes(&tx, *peer).await;
+        assert!(response.is_empty());
 
         let explain = query_explain_advertised_route(&tx, *peer, Prefix::V4(prefix)).await;
         assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
@@ -1608,15 +1602,7 @@ async fn routes_received_and_queried() {
     .await
     .unwrap();
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].prefix, Prefix::V4(prefix));
 
@@ -1847,15 +1833,7 @@ async fn peer_down_clears_routes() {
     .await
     .unwrap();
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert!(routes.is_empty());
 
     drop(tx);
@@ -1901,15 +1879,7 @@ async fn withdrawal_removes_route() {
     .await
     .unwrap();
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: Some(peer),
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-
-    let routes = reply_rx.await.unwrap();
+    let routes = query_received_routes(&tx, peer).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].prefix, Prefix::V4(prefix2));
 
@@ -1958,15 +1928,7 @@ async fn query_all_peers() {
     .await
     .unwrap();
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryReceivedRoutes {
-        peer: None,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-
-    let routes = reply_rx.await.unwrap();
+    let routes = collect_query_routes(&tx, RouteQueryScope::Received { peer: None }).await;
     assert_eq!(routes.len(), 2);
 
     drop(tx);
@@ -2924,15 +2886,7 @@ async fn peer_down_cleans_up_outbound() {
     .unwrap();
 
     // Query advertised routes — should be empty after PeerDown
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-
-    let routes = reply_rx.await.unwrap();
+    let routes = collect_advertised_routes(&tx, peer).await;
     assert!(routes.is_empty());
 
     drop(tx);
@@ -3176,14 +3130,7 @@ async fn distribute_changes_filters_unsendable_families() {
     assert!(update.withdraw.is_empty());
 
     // Adj-RIB-Out should only contain IPv4
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(advertised.len(), 1);
     assert_eq!(advertised[0].prefix, Prefix::V4(v4_prefix));
 
@@ -3268,14 +3215,7 @@ async fn send_initial_table_filters_unsendable_families() {
     assert!(update.withdraw.is_empty());
 
     // Adj-RIB-Out should only contain IPv4
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryAdvertisedRoutes {
-        peer: target,
-        reply: reply_tx,
-    })
-    .await
-    .unwrap();
-    let advertised = reply_rx.await.unwrap();
+    let advertised = collect_advertised_routes(&tx, target).await;
     assert_eq!(advertised.len(), 1);
     assert_eq!(advertised[0].prefix, Prefix::V4(v4_prefix));
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1721,13 +1721,6 @@ pub enum RibUpdate {
         /// Completion reply.
         reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
-    /// Query: return all received routes, optionally filtered by peer.
-    QueryReceivedRoutes {
-        /// Optional peer filter; `None` returns all peers.
-        peer: Option<IpAddr>,
-        /// Response channel.
-        reply: oneshot::Sender<Vec<Route>>,
-    },
     /// Query: one bounded page of a resumable route listing. Filtering
     /// and pagination run inside the RIB task with per-page bounded
     /// allocation. Continuations are mutation-fenced: a change in the
@@ -1777,13 +1770,6 @@ pub enum RibUpdate {
     QueryPeerGroups {
         /// Response channel.
         reply: oneshot::Sender<HashMap<IpAddr, String>>,
-    },
-    /// Query: return routes advertised to a specific peer.
-    QueryAdvertisedRoutes {
-        /// The target peer.
-        peer: IpAddr,
-        /// Response channel.
-        reply: oneshot::Sender<Vec<Route>>,
     },
     /// Query: explain why a particular route was selected as best for a prefix.
     ExplainBestPath {

--- a/crates/transport/src/session/tests/denied_replacements.rs
+++ b/crates/transport/src/session/tests/denied_replacements.rs
@@ -15,6 +15,7 @@ async fn query_received_routes(
                 filter: None,
                 after,
                 expected_version,
+                // Keep the migrated caller exercising continuation fencing.
                 page_size: 2,
                 reply,
             })
@@ -22,10 +23,7 @@ async fn query_received_routes(
             .unwrap();
         let page = response.await.unwrap().unwrap();
         expected_version = Some(page.version);
-        after = page
-            .routes
-            .last()
-            .map(|route| (route.prefix, route.peer, route.path_id));
+        after = page.routes.last().map(rustbgpd_rib::route_query_key);
         routes.extend(page.routes);
         if !page.has_more {
             return routes;

--- a/crates/transport/src/session/tests/denied_replacements.rs
+++ b/crates/transport/src/session/tests/denied_replacements.rs
@@ -1,5 +1,38 @@
 use super::*;
 
+async fn query_received_routes(
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+) -> Vec<rustbgpd_rib::Route> {
+    let mut routes = Vec::new();
+    let mut after = None;
+    let mut expected_version = None;
+    loop {
+        let (reply, response) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryRoutesPage {
+                scope: rustbgpd_rib::RouteQueryScope::Received { peer: Some(peer) },
+                filter: None,
+                after,
+                expected_version,
+                page_size: 2,
+                reply,
+            })
+            .await
+            .unwrap();
+        let page = response.await.unwrap().unwrap();
+        expected_version = Some(page.version);
+        after = page
+            .routes
+            .last()
+            .map(|route| (route.prefix, route.peer, route.path_id));
+        routes.extend(page.routes);
+        if !page.has_more {
+            return routes;
+        }
+    }
+}
+
 #[tokio::test]
 async fn denied_classic_replacement_withdraws_exact_route_and_remains_explainable() {
     use super::import_decision_cache::{CachedOutcome, ImportDecisionKey, LookupResult};
@@ -554,15 +587,7 @@ async fn denied_replacement_is_removed_before_eorr_and_cannot_survive_gr() {
     );
     session.process_update(accepted.clone()).await;
     assert_eq!(session.known_prefix_count(), 1);
-    let (reply_tx, reply_rx) = oneshot::channel();
-    rib_tx
-        .send(RibUpdate::QueryReceivedRoutes {
-            peer: Some(peer),
-            reply: reply_tx,
-        })
-        .await
-        .unwrap();
-    let initially_received = reply_rx.await.unwrap();
+    let initially_received = query_received_routes(&rib_tx, peer).await;
     assert_eq!(initially_received.len(), 1);
     assert_eq!(initially_received[0].prefix, Prefix::V4(denied_prefix));
 
@@ -606,16 +631,8 @@ async fn denied_replacement_is_removed_before_eorr_and_cannot_survive_gr() {
 
     // The denial itself must remove the old accepted route. Waiting for EoRR
     // would leave a policy-rejected route usable throughout a long refresh.
-    let (reply_tx, reply_rx) = oneshot::channel();
-    rib_tx
-        .send(RibUpdate::QueryReceivedRoutes {
-            peer: Some(peer),
-            reply: reply_tx,
-        })
-        .await
-        .unwrap();
     assert!(
-        reply_rx.await.unwrap().is_empty(),
+        query_received_routes(&rib_tx, peer).await.is_empty(),
         "denied route must be absent before EoRR closes the refresh window"
     );
 
@@ -635,15 +652,7 @@ async fn denied_replacement_is_removed_before_eorr_and_cannot_survive_gr() {
 
     // A subsequent GR teardown cannot mark the already removed route stale.
     session.execute_actions(vec![Action::SessionDown]).await;
-    let (reply_tx, reply_rx) = oneshot::channel();
-    rib_tx
-        .send(RibUpdate::QueryReceivedRoutes {
-            peer: Some(peer),
-            reply: reply_tx,
-        })
-        .await
-        .unwrap();
-    assert!(reply_rx.await.unwrap().is_empty());
+    assert!(query_received_routes(&rib_tx, peer).await.is_empty());
     drop(session);
     drop(rib_tx);
     manager_handle.await.unwrap();


### PR DESCRIPTION
## Summary

- remove the production-dead QueryReceivedRoutes and QueryAdvertisedRoutes variants and their clone handlers
- migrate all 43 test senders to the shared resumable QueryRoutesPage path with continuation keys and first-page versioning preserved
- keep grouped advertised semantics on the existing ordered iterator/count path and use an independent fixture-derived oracle for exact paged sets

## Validation

- zero remaining Rust references to the removed variants and handlers
- RIB all-features library suite: 1,179 passed, 2 ignored
- focused and full transport suites: 520 passed, 3 ignored
- strict workspace all-target/all-feature Clippy
- full workspace all-features clean rerun
- workspace rustdoc with warnings denied
- full rebased pre-push test and rustdoc gates
- formatting, diff, manifest, and lockfile checks

The first broad workspace run recorded one unrelated blue quickstart shutdown non-completion after a successful Shutdown RPC. Its isolated replacement and the complete workspace rerun both passed; the original receipt remains tracked under LAN-1221.

Linear: LAN-1055