### PR TITLE
fix: report completed recover steps on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   re-advertised; unknown optional transitive attributes remain preserved with
   the Partial bit. (LAN-1265)
 
+- `rs-config-render recover` now reports the restore steps that completed
+  before a later step failed while preserving the non-zero exit status and
+  error output; steps that were not reached are not claimed as restored.
+  (LAN-1251)
+
 - Genuine BFD Down transitions now tear established BGP sessions down with
   RFC 9384 Cease/BFD Down; peers that negotiated Notification GR receive an
   RFC 8538 Hard Reset carrying the original BFD Down reason. (LAN-1261)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   re-advertised; unknown optional transitive attributes remain preserved with
   the Partial bit. (LAN-1265)
 
-- `rs-config-render recover` now reports the restore steps that completed
+- `rs-config-render recover` now reports the recovery steps that completed
   before a later step failed while preserving the non-zero exit status and
-  error output; steps that were not reached are not claimed as restored.
+  error output; steps that were not reached are not reported.
   (LAN-1251)
 
 - Genuine BFD Down transitions now tear established BGP sessions down with

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -440,14 +440,16 @@ fn recover_exit(
             }))
         }
         Err(failure) => {
-            let written = write_stdout(|writer| {
-                for step in &failure.completed.steps {
-                    writeln!(writer, "recover {name}: {step}")?;
+            if !failure.completed.steps.is_empty() {
+                let written = write_stdout(|writer| {
+                    for step in &failure.completed.steps {
+                        writeln!(writer, "recover {name}: {step}")?;
+                    }
+                    Ok(())
+                });
+                if let Err(error) = written {
+                    return stdout_exit(Err(error));
                 }
-                Ok(())
-            });
-            if let Err(error) = written {
-                return stdout_exit(Err(error));
             }
             eprintln!("rs-config-render: recover {name}: {}", failure.error);
             failure.error.exit_code().into()

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -439,9 +439,15 @@ fn recover_exit(
                 writeln!(writer, "{summary}")
             }))
         }
-        Err(error) => {
-            eprintln!("rs-config-render: recover {name}: {error}");
-            error.exit_code().into()
+        Err(failure) => {
+            let _ = write_stdout(|writer| {
+                for step in &failure.completed.steps {
+                    writeln!(writer, "recover {name}: {step}")?;
+                }
+                Ok(())
+            });
+            eprintln!("rs-config-render: recover {name}: {}", failure.error);
+            failure.error.exit_code().into()
         }
     }
 }

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -368,19 +368,47 @@ fn stdout_exit_with(
 ) -> ExitCode {
     match result {
         Ok(()) => Exit::Success.into(),
-        Err(StdoutWriteError::BrokenPipe) => Exit::InvalidInput.into(),
-        Err(StdoutWriteError::Other(error)) => {
-            let _ = writeln!(
-                diagnostic,
-                "rs-config-render: failed to write stdout: {error}"
-            );
+        Err(error) => {
+            report_stdout_error_with(error, diagnostic);
             Exit::InvalidInput.into()
         }
+    }
+}
+fn report_stdout_error_with(error: StdoutWriteError, diagnostic: &mut dyn std::io::Write) {
+    if let StdoutWriteError::Other(error) = error {
+        let _ = writeln!(
+            diagnostic,
+            "rs-config-render: failed to write stdout: {error}"
+        );
     }
 }
 fn stdout_exit(result: Result<(), StdoutWriteError>) -> ExitCode {
     let stderr = std::io::stderr();
     stdout_exit_with(result, &mut stderr.lock())
+}
+
+fn recover_failure_exit_with(
+    name: &str,
+    failure: &rs_config_render::recover::Failure,
+    output: &mut dyn std::io::Write,
+    diagnostic: &mut dyn std::io::Write,
+) -> ExitCode {
+    if !failure.completed.steps.is_empty()
+        && let Err(error) = write_stdout_with(output, |writer| {
+            for step in &failure.completed.steps {
+                writeln!(writer, "recover {name}: {step}")?;
+            }
+            Ok(())
+        })
+    {
+        report_stdout_error_with(error, diagnostic);
+    }
+    let _ = writeln!(
+        diagnostic,
+        "rs-config-render: recover {name}: {}",
+        failure.error
+    );
+    failure.error.exit_code().into()
 }
 
 fn parse_activation() -> Option<ActivateArgs> {
@@ -440,19 +468,9 @@ fn recover_exit(
             }))
         }
         Err(failure) => {
-            if !failure.completed.steps.is_empty() {
-                let written = write_stdout(|writer| {
-                    for step in &failure.completed.steps {
-                        writeln!(writer, "recover {name}: {step}")?;
-                    }
-                    Ok(())
-                });
-                if let Err(error) = written {
-                    return stdout_exit(Err(error));
-                }
-            }
-            eprintln!("rs-config-render: recover {name}: {}", failure.error);
-            failure.error.exit_code().into()
+            let stdout = std::io::stdout();
+            let stderr = std::io::stderr();
+            recover_failure_exit_with(name, &failure, &mut stdout.lock(), &mut stderr.lock())
         }
     }
 }
@@ -863,6 +881,18 @@ mod tests {
     use super::*;
     use std::{fs::File, io::BufWriter};
 
+    struct BrokenPipeWriter;
+
+    impl std::io::Write for BrokenPipeWriter {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::ErrorKind::BrokenPipe.into())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::ErrorKind::BrokenPipe.into())
+        }
+    }
+
     #[test]
     fn stdout_exit_distinguishes_quiet_broken_pipe_from_other_flush_error() {
         let file = tempfile::NamedTempFile::new().unwrap();
@@ -881,5 +911,35 @@ mod tests {
         let broken = stdout_exit_with(Err(StdoutWriteError::BrokenPipe), &mut err);
         assert_eq!(broken, ExitCode::from(Exit::InvalidInput));
         assert!(err.is_empty());
+    }
+
+    #[test]
+    fn recover_failure_keeps_domain_exit_and_diagnostic_when_stdout_fails() {
+        let failure = rs_config_render::recover::Failure {
+            error: rs_config_render::recover::Error::ManualRecovery("retry the recovery"),
+            completed: rs_config_render::recover::Outcome {
+                steps: vec!["remove host fence".to_owned()],
+            },
+        };
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let mut output = BufWriter::new(File::open(file.path()).unwrap());
+        let mut diagnostic = Vec::new();
+        assert_eq!(
+            recover_failure_exit_with("clear", &failure, &mut output, &mut diagnostic),
+            ExitCode::from(Exit::ManualRecovery)
+        );
+        let diagnostic = String::from_utf8(diagnostic).unwrap();
+        assert!(diagnostic.contains("rs-config-render: failed to write stdout: "));
+        assert!(diagnostic.contains("rs-config-render: recover clear: retry the recovery\n"));
+
+        let mut diagnostic = Vec::new();
+        assert_eq!(
+            recover_failure_exit_with("clear", &failure, &mut BrokenPipeWriter, &mut diagnostic),
+            ExitCode::from(Exit::ManualRecovery)
+        );
+        assert_eq!(
+            String::from_utf8(diagnostic).unwrap(),
+            "rs-config-render: recover clear: retry the recovery\n"
+        );
     }
 }

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -440,12 +440,15 @@ fn recover_exit(
             }))
         }
         Err(failure) => {
-            let _ = write_stdout(|writer| {
+            let written = write_stdout(|writer| {
                 for step in &failure.completed.steps {
                     writeln!(writer, "recover {name}: {step}")?;
                 }
                 Ok(())
             });
+            if let Err(error) = written {
+                return stdout_exit(Err(error));
+            }
             eprintln!("rs-config-render: recover {name}: {}", failure.error);
             failure.error.exit_code().into()
         }

--- a/tools/rs-config-render/src/recover.rs
+++ b/tools/rs-config-render/src/recover.rs
@@ -412,6 +412,22 @@ pub struct Outcome {
     pub steps: Vec<String>,
 }
 
+/// A recovery failure plus the exact prefix of steps that completed.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Failure {
+    pub error: Error,
+    pub completed: Outcome,
+}
+
+impl From<Error> for Failure {
+    fn from(error: Error) -> Self {
+        Self {
+            error,
+            completed: Outcome::default(),
+        }
+    }
+}
+
 enum Step {
     Probe(String),
     Receipt {
@@ -542,11 +558,11 @@ fn probe(rbgp: &Path, binding: &Binding, state: &Path, current: &str) -> (bool, 
 /// Plan and, with `apply`, perform one recovery verb. Every verb refuses
 /// (exit 2, nothing changed) unless this binding's fence stands and the
 /// lifecycle journal, if any, is in manual recovery rather than resumable.
-pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error> {
+pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Failure> {
     let binding = options.binding;
     let state = options.state_dir;
     if state != binding.activation_state_dir {
-        return Err(Error::Refused("state directory must match host binding"));
+        return Err(Error::Refused("state directory must match host binding").into());
     }
     let guard = Guard::claim_existing(binding).map_err(host_refusal)?;
     let _activation_lock = activation::state_lock(state).map_err(activation_refusal)?;
@@ -556,12 +572,13 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
     })?;
     if let Some(journal) = &journal {
         if journal.host != *binding {
-            return Err(Error::Refused("lifecycle journal identity does not match"));
+            return Err(Error::Refused("lifecycle journal identity does not match").into());
         }
         if lifecycle::pending(journal).is_some() {
             return Err(Error::Refused(
                 "lifecycle state is resumable, not manual recovery; run ixp-manager-lifecycle resume",
-            ));
+            )
+            .into());
         }
     }
     // A callback needs the connection; validate it (origin, key file) before
@@ -577,14 +594,15 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
             )
             .map_err(lifecycle_refusal)?;
             if journal.origin != client.origin || journal.router_handle != client.handle {
-                return Err(Error::Refused("lifecycle journal identity does not match"));
+                return Err(Error::Refused("lifecycle journal identity does not match").into());
             }
             Some(client)
         }
         (Some(_), None) if !matches!(verb, Verb::Clear) => {
             return Err(Error::Refused(
                 "lifecycle journal owes the upstream lock; pass --ixp-origin and --api-key-file",
-            ));
+            )
+            .into());
         }
         _ => None,
     };
@@ -618,18 +636,19 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
     match verb {
         Verb::KeepCurrent { rbgp, force } => {
             if lock_released {
-                return Err(Error::Refused(
-                    "upstream lock already released; run recover clear",
-                ));
+                return Err(
+                    Error::Refused("upstream lock already released; run recover clear").into(),
+                );
             }
             let Some(current) = current.as_deref() else {
-                return Err(Error::Refused("no current generation to keep"));
+                return Err(Error::Refused("no current generation to keep").into());
             };
             let (equal, detail) = probe(rbgp, binding, state, current);
             if !equal && !*force {
                 return Err(Error::Refused(
                     "daemon is not settled on current; fix the daemon by hand or pass --force",
-                ));
+                )
+                .into());
             }
             plan.push(Step::Probe(if equal {
                 detail
@@ -660,17 +679,18 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
         }
         Verb::Rollback { activation, to } => {
             if lock_released {
-                return Err(Error::Refused(
-                    "upstream lock already released; run recover clear",
-                ));
+                return Err(
+                    Error::Refused("upstream lock already released; run recover clear").into(),
+                );
             }
             if !activated {
                 return Err(Error::Refused(
                     "no candidate was activated (the lock request was ambiguous); run recover release-lock --rolled-back, then recover clear",
-                ));
+                )
+                .into());
             }
             let Some(current) = current.as_deref() else {
-                return Err(Error::Refused("no current generation to roll back from"));
+                return Err(Error::Refused("no current generation to roll back from").into());
             };
             let target = match to {
                 Some(to) => to.to_string(),
@@ -681,16 +701,15 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
             if target == current {
                 return Err(Error::Refused(
                     "rollback target is the current generation; run recover keep-current",
-                ));
+                )
+                .into());
             }
             if !target
                 .strip_prefix("generations/")
                 .is_some_and(activation::valid_digest)
                 || activation::verify_candidate(&state.join(&target), binding).is_err()
             {
-                return Err(Error::Refused(
-                    "rollback target is not a published generation",
-                ));
+                return Err(Error::Refused("rollback target is not a published generation").into());
             }
             session.activation = Some(*activation);
             plan.push(Step::Republish {
@@ -705,9 +724,9 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
         }
         Verb::ReleaseLock(released) => {
             if journal.is_none() {
-                return Err(Error::Refused(
-                    "no lifecycle journal; no upstream lock is owed",
-                ));
+                return Err(
+                    Error::Refused("no lifecycle journal; no upstream lock is owed").into(),
+                );
             }
             plan.push(Step::Callback(match released {
                 Released::Kept => Callback::Updated,
@@ -719,7 +738,8 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
             if journal.is_some() && !lock_released {
                 return Err(Error::Refused(
                     "upstream lock still owed; run recover keep-current, recover rollback, or recover release-lock first",
-                ));
+                )
+                .into());
             }
             if journal.is_some() {
                 plan.push(Step::RemoveJournal);
@@ -730,8 +750,13 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Error>
     let mut outcome = Outcome::default();
     for step in &plan {
         let line = step.describe(&session);
-        if options.apply {
-            session.perform(step)?;
+        if options.apply
+            && let Err(error) = session.perform(step)
+        {
+            return Err(Failure {
+                error,
+                completed: outcome,
+            });
         }
         outcome.steps.push(line);
     }

--- a/tools/rs-config-render/tests/recover.rs
+++ b/tools/rs-config-render/tests/recover.rs
@@ -1047,6 +1047,42 @@ fn dry_runs_change_nothing_and_apply_performs_exactly_the_printed_steps() {
 }
 
 #[test]
+fn keep_current_callback_failure_prints_only_completed_steps() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let server = rig.induce_exit_5("load-then-fail", vec![Response::json(500)]);
+    let candidate = rig.current();
+    let (code, lines, stderr) =
+        rig.recover_cli(&strs(&keep_args(&rig)), true, Some(&server.origin));
+
+    assert_eq!(code, 5);
+    assert_eq!(
+        lines,
+        vec![
+            "probe: daemon healthy, runtime equals current".to_owned(),
+            format!(
+                "write activation receipt: status kept, candidate {}, previous {}",
+                candidate.strip_prefix("generations/").unwrap(),
+                rig.receipt_value()["previous_generation"].as_str().unwrap()
+            ),
+        ],
+        "the failing callback and applied summary must be absent"
+    );
+    assert_eq!(
+        stderr,
+        "rs-config-render: recover keep-current: updated callback was not delivered; upstream lock retained — retry with recover release-lock --kept\n"
+    );
+    assert!(rig.fence().exists() && rig.journal().exists());
+    let journal = rig.journal_value();
+    assert_eq!(journal["callback"], "updated");
+    assert_eq!(journal["callback_attempts"], 1);
+    assert_eq!(journal["lock_released"], false);
+    assert_eq!(journal["phase"], "manual_recovery");
+    assert_eq!(rig.receipt_value()["status"], "kept");
+    assert_eq!(server.finish().len(), 3);
+}
+
+#[test]
 fn keep_current_is_health_gated_unless_forced() {
     let _guard = test_guard();
     let rig = Rig::new();


### PR DESCRIPTION
## Summary

- return recovery failures with the exact prefix of steps that completed before the failing step
- print only that completed prefix on stdout while preserving the original non-zero exit code and stderr error
- keep preflight refusals empty and avoid claiming the failing or unreached steps

## Validation

- focused callback-failure regression with exact stdout, stderr, exit code, receipt, journal, fence, and request assertions
- full rs-config-render recover integration suite
- full rs-config-render package suite
- strict all-target/all-feature package Clippy
- full rebased pre-push workspace tests and rustdoc
- formatting and diff checks

Linear: LAN-1251