### PR TITLE
test: audit path attribute registry behavior

### DIFF
--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "BGP message codec — encode/decode OPEN, KEEPALIVE, UPDATE, NOTIFICATION, ROUTE-REFRESH"
 readme = "README.md"
+# Repository governance audit: it reads the workspace-level canonical registry
+# document, which is intentionally outside this published crate package.
+exclude = ["tests/path_attribute_registry.rs"]
 
 [features]
 # Enables allocation counters in the codec diagnostic binary. The ordinary

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -1,0 +1,196 @@
+use rustbgpd_wire::attribute::{decode_path_attributes_revised, encode_path_attributes};
+use rustbgpd_wire::validate::validate_update_attributes;
+use rustbgpd_wire::{ErrorDisposition, PathAttribute};
+
+const DOC: &str = include_str!("../../../docs/path-attribute-registry.md");
+
+fn section(start: &str, end: &str) -> &'static str {
+    DOC.split_once(start)
+        .unwrap_or_else(|| panic!("missing {start}"))
+        .1
+        .split_once(end)
+        .unwrap_or_else(|| panic!("missing {end}"))
+        .0
+}
+
+fn rows(section: &str, columns: usize) -> Vec<Vec<&str>> {
+    section
+        .lines()
+        .filter(|line| line.starts_with('|'))
+        .skip(2)
+        .map(|line| {
+            let cells: Vec<_> = line.trim_matches('|').split('|').map(str::trim).collect();
+            assert_eq!(cells.len(), columns, "bad Markdown row: {line}");
+            assert!(
+                cells.iter().all(|cell| !cell.is_empty()),
+                "blank audited cell: {line}"
+            );
+            cells
+        })
+        .collect()
+}
+
+fn hex(value: &str) -> Vec<u8> {
+    if value == "empty" {
+        return Vec::new();
+    }
+    let (pairs, remainder) = value.as_bytes().as_chunks::<2>();
+    assert!(remainder.is_empty(), "odd hex value {value}");
+    pairs
+        .iter()
+        .map(|pair| {
+            let digits = std::str::from_utf8(pair).unwrap();
+            u8::from_str_radix(digits, 16).unwrap()
+        })
+        .collect()
+}
+
+fn attribute(flags: u8, code: u8, value: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![flags, code, u8::try_from(value.len()).unwrap()];
+    bytes.extend_from_slice(value);
+    bytes
+}
+
+fn disposition(value: &str) -> ErrorDisposition {
+    match value {
+        "attribute-discard" => ErrorDisposition::AttributeDiscard,
+        "treat-as-withdraw" => ErrorDisposition::TreatAsWithdraw,
+        other => panic!("unknown disposition {other}"),
+    }
+}
+
+#[test]
+fn census_covers_every_code_exactly_once() {
+    assert!(DOC.contains("691f147f5c9ef9dbde82febe339f5691a1bfc4d83f63e3ed0d224676ebe68886"));
+    assert!(DOC.contains("https://www.iana.org/assignments/bgp-parameters/bgp-parameters-2.csv"));
+
+    let mut coverage = [0_u8; 256];
+    for row in rows(
+        section(
+            "<!-- registry-census:start -->",
+            "<!-- registry-census:end -->",
+        ),
+        5,
+    ) {
+        let (start, end) = row[0].split_once('-').unwrap_or((row[0], row[0]));
+        let start: u8 = start.parse().unwrap();
+        let end: u8 = end.parse().unwrap();
+        assert!(start <= end, "reversed census range {}", row[0]);
+        for code in start..=end {
+            coverage[usize::from(code)] += 1;
+        }
+    }
+    assert!(
+        coverage.iter().all(|count| *count == 1),
+        "census coverage must be exactly one per code: {coverage:?}"
+    );
+}
+
+#[test]
+fn core_matrix_proves_flags_roundtrip_and_malformed_dispositions() {
+    let matrix = rows(
+        section("<!-- core-behavior:start -->", "<!-- core-behavior:end -->"),
+        6,
+    );
+    assert_eq!(matrix.len(), 10);
+
+    for (index, row) in matrix.iter().enumerate() {
+        let code: u8 = row[0].parse().unwrap();
+        assert_eq!(code, u8::try_from(index + 1).unwrap());
+        let flags = u8::from_str_radix(row[1], 16).unwrap();
+        let valid = attribute(flags, code, &hex(row[2]));
+        let decoded = decode_path_attributes_revised(&valid, true, false, &[]).unwrap();
+        assert!(
+            decoded.malformed.is_empty(),
+            "valid type {code}: {decoded:?}"
+        );
+        let [decoded_attr] = decoded.attributes.as_slice() else {
+            panic!("type {code} did not decode to exactly one attribute");
+        };
+        assert_eq!(decoded_attr.type_code(), code);
+        assert_eq!(decoded_attr.flags(), flags);
+        assert!(!matches!(decoded_attr, PathAttribute::Unknown(_)));
+        let mut reencoded = Vec::new();
+        encode_path_attributes(&decoded.attributes, &mut reencoded, true, false).unwrap();
+        assert_eq!(reencoded, valid, "type {code} round-trip drift");
+
+        let wrong_flags = flags ^ 0x80;
+        let rejected = decode_path_attributes_revised(
+            &attribute(wrong_flags, code, &hex(row[2])),
+            true,
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(rejected.attributes.is_empty());
+        assert_eq!(rejected.malformed.len(), 1);
+        assert_eq!(
+            rejected.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw,
+            "type {code} accepted wrong flags {wrong_flags:#04x}"
+        );
+
+        for (is_ibgp, expected) in [(false, row[4]), (true, row[5])] {
+            let malformed = decode_path_attributes_revised(
+                &attribute(flags, code, &hex(row[3])),
+                true,
+                is_ibgp,
+                &[],
+            )
+            .unwrap();
+            assert!(malformed.attributes.is_empty());
+            assert_eq!(malformed.malformed.len(), 1);
+            assert_eq!(malformed.malformed[0].type_code, code);
+            assert_eq!(
+                malformed.malformed[0].disposition,
+                disposition(expected),
+                "type {code}, is_ibgp={is_ibgp}"
+            );
+        }
+    }
+}
+
+#[test]
+fn assigned_and_unknown_behavior_fences_are_explicit() {
+    let bgpls = attribute(0x80, 29, &[0x04, 0x47, 0, 1, 7]);
+    let decoded = decode_path_attributes_revised(&bgpls, true, false, &[]).unwrap();
+    let [PathAttribute::Unknown(raw)] = decoded.attributes.as_slice() else {
+        panic!("BGP-LS must remain recognized opaque data");
+    };
+    assert_eq!(
+        (raw.flags, raw.type_code, raw.data.as_ref()),
+        (0x80, 29, &[0x04, 0x47, 0, 1, 7][..])
+    );
+    let mut emitted = Vec::new();
+    encode_path_attributes(&decoded.attributes, &mut emitted, true, false).unwrap();
+    assert_eq!(emitted, bgpls);
+    let wrong_bgpls = decode_path_attributes_revised(
+        &attribute(0xc0, 29, &[0x04, 0x47, 0, 1, 7]),
+        true,
+        false,
+        &[],
+    )
+    .unwrap();
+    assert_eq!(
+        wrong_bgpls.malformed[0].disposition,
+        ErrorDisposition::TreatAsWithdraw
+    );
+
+    let aigp = decode_path_attributes_revised(&attribute(0x80, 26, &[1, 0, 11]), true, false, &[])
+        .unwrap();
+    assert!(aigp.attributes.is_empty() && aigp.malformed.is_empty());
+
+    let prefix_sid = attribute(0xc0, 40, &[1, 0, 0]);
+    let decoded = decode_path_attributes_revised(&prefix_sid, true, false, &[]).unwrap();
+    assert!(
+        matches!(&decoded.attributes[..], [PathAttribute::Unknown(raw)] if raw.type_code == 40)
+    );
+    let mut emitted = Vec::new();
+    encode_path_attributes(&decoded.attributes, &mut emitted, true, false).unwrap();
+    assert_eq!(emitted, attribute(0xe0, 40, &[1, 0, 0]));
+
+    let unknown =
+        decode_path_attributes_revised(&attribute(0x40, 200, &[0xaa]), true, false, &[]).unwrap();
+    let error = validate_update_attributes(&unknown.attributes, false, false, true).unwrap_err();
+    assert_eq!(error.disposition, ErrorDisposition::TreatAsWithdraw);
+}

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -171,6 +171,7 @@ fn assigned_and_unknown_behavior_fences_are_explicit() {
         &[],
     )
     .unwrap();
+    assert_eq!(wrong_bgpls.malformed.len(), 1);
     assert_eq!(
         wrong_bgpls.malformed[0].disposition,
         ErrorDisposition::TreatAsWithdraw

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -64,7 +64,7 @@ fn census_covers_every_code_exactly_once() {
     assert!(DOC.contains("691f147f5c9ef9dbde82febe339f5691a1bfc4d83f63e3ed0d224676ebe68886"));
     assert!(DOC.contains("https://www.iana.org/assignments/bgp-parameters/bgp-parameters-2.csv"));
 
-    let mut coverage = [0_u8; 256];
+    let mut coverage = [0_u16; 256];
     for row in rows(
         section(
             "<!-- registry-census:start -->",

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -1,0 +1,110 @@
+# BGP path-attribute registry audit
+
+This is an offline audit baseline, not a claim that every registered attribute is
+implemented. It keeps registry data, protocol requirements, observed behavior,
+and executable evidence distinct so a registry update cannot silently become a
+codec claim.
+
+## Provenance and refresh
+
+- Registry: [IANA BGP Path Attributes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2)
+- CSV: `https://www.iana.org/assignments/bgp-parameters/bgp-parameters-2.csv`
+- Registry snapshot: 2026-08-18 (live-verified 2026-08-23)
+- SHA-256: `691f147f5c9ef9dbde82febe339f5691a1bfc4d83f63e3ed0d224676ebe68886`
+- Normative anchors: [RFC 4271 §§4.3, 5](https://www.rfc-editor.org/rfc/rfc4271), [RFC 7606 §§2, 3, 7.1-7.10](https://www.rfc-editor.org/rfc/rfc7606), [RFC 7311](https://www.rfc-editor.org/rfc/rfc7311), [RFC 9552](https://www.rfc-editor.org/rfc/rfc9552), and [RFC 8669 §3](https://www.rfc-editor.org/rfc/rfc8669).
+
+Manual live comparison (never run by normal CI): download the CSV with
+`curl -fsSL https://www.iana.org/assignments/bgp-parameters/bgp-parameters-2.csv -o /tmp/bgp-parameters-2.csv`, run
+`sha256sum /tmp/bgp-parameters-2.csv`, then compare its `Value` and `Code`
+columns with the census below, expanding every range. A digest change requires
+human review before changing either the census or an observed-behavior claim.
+
+## Complete IANA census
+
+`pending follow-up audit` means this tranche makes no normative or implementation
+claim for that row. The offline test expands the ranges and requires every
+octet from 0 through 255 to appear exactly once with no blank cell.
+
+<!-- registry-census:start -->
+| Code | IANA assignment | Normative requirement | Observed-current behavior | Evidence |
+|---|---|---|---|---|
+| 0 | Reserved | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 1 | ORIGIN | well-known mandatory; flags `0x40`; RFC 4271 §5.1.1; RFC 7606 §7.1 | typed round-trip; malformed is treat-as-withdraw | core matrix below |
+| 2 | AS_PATH | well-known mandatory; flags `0x40`; RFC 4271 §5.1.2; RFC 7606 §7.2 | typed round-trip; malformed is treat-as-withdraw | core matrix below |
+| 3 | NEXT_HOP | well-known mandatory; flags `0x40`; RFC 4271 §5.1.3; RFC 7606 §7.3 | typed round-trip; malformed is treat-as-withdraw | core matrix below |
+| 4 | MULTI_EXIT_DISC | optional non-transitive; flags `0x80`; RFC 4271 §5.1.4; RFC 7606 §7.4 | typed round-trip; malformed is treat-as-withdraw | core matrix below |
+| 5 | LOCAL_PREF | well-known discretionary; flags `0x40`; RFC 4271 §5.1.5; RFC 7606 §7.5 | typed round-trip; malformed is discard on eBGP and treat-as-withdraw on iBGP | core matrix below |
+| 6 | ATOMIC_AGGREGATE | well-known discretionary; flags `0x40`; RFC 4271 §5.1.6; RFC 7606 §7.6 | typed round-trip; bad length is attribute-discard | core matrix below |
+| 7 | AGGREGATOR | optional transitive; flags `0xc0`; RFC 4271 §5.1.7; RFC 7606 §7.7 | typed round-trip; bad length is attribute-discard | core matrix below |
+| 8 | COMMUNITIES | optional transitive; flags `0xc0`; RFC 7606 §7.8 | typed round-trip; malformed is treat-as-withdraw | core matrix below |
+| 9 | ORIGINATOR_ID | optional non-transitive; flags `0x80`; RFC 7606 §7.9 | typed round-trip; malformed is discard on eBGP and treat-as-withdraw on iBGP | core matrix below |
+| 10 | CLUSTER_LIST | optional non-transitive; flags `0x80`; RFC 7606 §7.10 | typed round-trip; malformed is discard on eBGP and treat-as-withdraw on iBGP | core matrix below |
+| 11 | DPA (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 12 | ADVERTISER (historic) (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 13 | RCID_PATH / CLUSTER_ID (Historic) (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 14 | MP_REACH_NLRI | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 15 | MP_UNREACH_NLRI | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 16 | EXTENDED COMMUNITIES | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 17 | AS4_PATH | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 18 | AS4_AGGREGATOR | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 19 | SAFI Specific Attribute (SSA) (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 20 | Connector Attribute (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 21 | AS_PATHLIMIT (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 22 | PMSI_TUNNEL | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 23 | Tunnel Encapsulation | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 24 | Traffic Engineering | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 25 | IPv6 Address Specific Extended Community | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 26 | AIGP | optional non-transitive; flags `0x80`; RFC 7311 §3 | unsupported attribute is ignored, not retained | enriched fence test |
+| 27 | PE Distinguisher Labels | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 28 | BGP Entropy Label Capability Attribute (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 29 | BGP-LS Attribute | optional non-transitive; flags `0x80`; RFC 9552 §5.3 | recognized opaque attribute survives byte-for-byte; `0xc0` is malformed | enriched fence test |
+| 30 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 31 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 32 | LARGE_COMMUNITY | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 33 | BGPsec_Path | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 34 | BGP Community Container Attribute (TEMPORARY - registered 2017-07-28, extension registered 2024-08-22, expires 2025-07-28) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 35 | Only to Customer (OTC) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 36 | BGP Domain Path (D-PATH) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 37 | SFP attribute | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 38 | BFD Discriminator | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 39 | Next Hop Dependent Characteristic (NHC) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 40 | BGP Prefix-SID | optional transitive; flags `0xc0`; RFC 8669 §3 | unsupported attribute is retained and re-emitted with Partial (`0xe0`) | enriched fence test |
+| 41 | BIER | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 42 | Edge Metadata Path Attribute (TEMPORARY - registered 2025-04-23, extension registered 2026-04-03, expires 2027-04-23) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 43-127 | Unassigned | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 128 | ATTR_SET | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 129 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 130-240 | Unassigned | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 241 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 242 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 243 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 244-254 | Unassigned | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 255 | Reserved for development | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+<!-- registry-census:end -->
+
+## Executable RFC 7606 core matrix
+
+Hex values are attribute payloads; the test builds the header. `empty` means a
+zero-length payload. Each valid row must decode to one typed attribute and
+re-encode byte-for-byte. A changed Optional/Transitive flag pair must be
+treat-as-withdraw. The malformed payload must produce the exact neighbor-class
+disposition shown.
+
+<!-- core-behavior:start -->
+| Code | Flags | Valid value | Malformed value | eBGP disposition | iBGP disposition |
+|---|---|---|---|---|---|
+| 1 | 40 | 00 | 03 | treat-as-withdraw | treat-as-withdraw |
+| 2 | 40 | 02010000fde9 | 02020000fde9 | treat-as-withdraw | treat-as-withdraw |
+| 3 | 40 | c0000201 | c00002 | treat-as-withdraw | treat-as-withdraw |
+| 4 | 80 | 00000064 | 000000 | treat-as-withdraw | treat-as-withdraw |
+| 5 | 40 | 00000064 | 000000 | attribute-discard | treat-as-withdraw |
+| 6 | 40 | empty | 00 | attribute-discard | attribute-discard |
+| 7 | c0 | 0000fde9c0000201 | 0000fde9c00002 | attribute-discard | attribute-discard |
+| 8 | c0 | fde80001 | fde800 | treat-as-withdraw | treat-as-withdraw |
+| 9 | 80 | c0000201 | c00002 | attribute-discard | treat-as-withdraw |
+| 10 | 80 | c0000201 | c00002 | attribute-discard | treat-as-withdraw |
+<!-- core-behavior:end -->
+
+The enriched fence test separately proves the three assigned-but-unsupported
+boundaries above and a synthetic unrecognized well-known attribute. Everything
+outside this executable slice remains explicitly `pending follow-up audit`.


### PR DESCRIPTION
## Summary

- pin the complete live IANA path-attribute census as a dated, digest-backed offline audit baseline
- separate normative requirements from observed behavior and leave unaudited rows explicitly pending
- execute RFC 7606 core type 1-10 flags, round trips, and malformed dispositions plus assigned/unknown propagation fences

## Validation

- `cargo test -p rustbgpd-wire --all-features --test path_attribute_registry`
- `cargo test -p rustbgpd-wire --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo fmt --all -- --check`
- live IANA CSV digest and all 52 Value/Code census rows compared

Linear: LAN-1236