### PR TITLE
fix: cover release checklist source paths

### DIFF
--- a/scripts/check_release_checklist_paths.py
+++ b/scripts/check_release_checklist_paths.py
@@ -16,7 +16,11 @@ import sys
 from pathlib import Path
 
 
-ROOTS = r"(?:src|crates|tests|docs|scripts|bench|examples|\.github|fuzz)"
+ROOTS = (
+    r"(?:src|crates|tests|docs|scripts|bench|examples|proto|tools|share|"
+    r"\.cargo|\.github|fuzz)"
+)
+GENERATED_PATH_SOURCES = {"share/systemd/": "examples/systemd/"}
 BACKTICKED = re.compile(r"`([^`\s]+)`")
 BARE = re.compile(rf"(?<![\w/`.-])({ROOTS}/[\w./-]*[\w/])")
 IS_PATH = re.compile(rf"^{ROOTS}/")
@@ -25,7 +29,7 @@ DOCUMENT = Path("docs") / "RELEASE_CHECKLIST.md"
 
 
 def named_paths(document: str) -> dict[str, list[int]]:
-    """Map each path-shaped token in `document` to the lines naming it."""
+    """Map each recognized repository-source path to its document lines."""
     found: dict[str, list[int]] = {}
     in_fence = False
     for number, line in enumerate(document.splitlines(), start=1):
@@ -37,7 +41,8 @@ def named_paths(document: str) -> dict[str, list[int]]:
             tokens += [match.group(1) for match in BARE.finditer(line)]
         for token in tokens:
             if IS_PATH.match(token):
-                found.setdefault(token, []).append(number)
+                source = GENERATED_PATH_SOURCES.get(token, token)
+                found.setdefault(source, []).append(number)
     return found
 
 
@@ -55,7 +60,7 @@ def check(root: Path) -> tuple[int, list[str]]:
         if not (root / token.rstrip("/")).exists():
             where = ",".join(str(number) for number in lines)
             errors.append(
-                f"{DOCUMENT.as_posix()}:{where} names `{token}`, which does "
+                f"{DOCUMENT.as_posix()}:{where} resolves to `{token}`, which does "
                 "not exist in the tree; the gate it triggers can never fire"
             )
     return len(found), errors
@@ -71,8 +76,8 @@ def main() -> int:
         print("\n".join(errors), file=sys.stderr)
         return 1
     print(
-        f"release checklist path check passed: all {checked} named "
-        "trigger paths exist"
+        f"release checklist path check passed: validated {checked} recognized "
+        "repository-source path tokens"
     )
     return 0
 

--- a/scripts/check_release_checklist_paths.py
+++ b/scripts/check_release_checklist_paths.py
@@ -20,7 +20,7 @@ ROOTS = (
     r"(?:src|crates|tests|docs|scripts|bench|examples|proto|tools|share|"
     r"\.cargo|\.github|fuzz)"
 )
-GENERATED_PATH_SOURCES = {"share/systemd/": "examples/systemd/"}
+GENERATED_PATH_PREFIX_SOURCES = {"share/systemd/": "examples/systemd/"}
 BACKTICKED = re.compile(r"`([^`\s]+)`")
 BARE = re.compile(rf"(?<![\w/`.-])({ROOTS}/[\w./-]*[\w/])")
 IS_PATH = re.compile(rf"^{ROOTS}/")
@@ -41,7 +41,14 @@ def named_paths(document: str) -> dict[str, list[int]]:
             tokens += [match.group(1) for match in BARE.finditer(line)]
         for token in tokens:
             if IS_PATH.match(token):
-                source = GENERATED_PATH_SOURCES.get(token, token)
+                source = token
+                for (
+                    generated,
+                    repository_source,
+                ) in GENERATED_PATH_PREFIX_SOURCES.items():
+                    if token.startswith(generated):
+                        source = repository_source + token.removeprefix(generated)
+                        break
                 found.setdefault(source, []).append(number)
     return found
 

--- a/scripts/test_check_release_checklist_paths.py
+++ b/scripts/test_check_release_checklist_paths.py
@@ -18,8 +18,8 @@ originator (`src/evpn_originator/`), run M-01:
 
 Review the API (`proto/rustbgpd.proto`), renderer
 (`tools/rs-config-render/`), and Rust configuration (`.cargo/config.toml`).
-The release archive stages `share/systemd/`; repository-owned share paths such
-as `share/repository-data/` remain repository paths.
+The release archive stages `share/systemd/`, including
+`share/systemd/rustbgpd.service`.
 
 ```sh
 containerlab deploy -t tests/interop/m01.clab.yml
@@ -42,7 +42,7 @@ FIXTURE_PATHS = (
     "tools/rs-config-render/",
     ".cargo/config.toml",
     "examples/systemd/",
-    "share/repository-data/",
+    "examples/systemd/rustbgpd.service",
 )
 
 
@@ -114,12 +114,18 @@ class ReleaseChecklistPathTests(unittest.TestCase):
                 self.assert_fails(remaining, missing)
 
     def test_generated_share_path_checks_its_repository_source(self) -> None:
-        """The archive-only share token resolves to its checked source tree."""
+        """Archive-only share paths resolve by prefix to checked sources."""
         self.assertNotIn("share/systemd/", FIXTURE_PATHS)
-        remaining = tuple(p for p in FIXTURE_PATHS if p != "share/repository-data/")
-        self.assert_fails(remaining, "share/repository-data/")
-        remaining = tuple(p for p in FIXTURE_PATHS if p != "examples/systemd/")
+        remaining = tuple(
+            p for p in FIXTURE_PATHS if not p.startswith("examples/systemd/")
+        )
         self.assert_fails(remaining, "examples/systemd/")
+
+    def test_other_share_paths_remain_repository_paths(self) -> None:
+        """A non-generated share path is still checked directly."""
+        result = self.run_checker("`share/repository-data/`\n", ())
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("share/repository-data/", result.stderr)
 
     def test_fails_when_no_paths_are_extracted(self) -> None:
         """Fails when the parse yields nothing: an inert gate is broken."""

--- a/scripts/test_check_release_checklist_paths.py
+++ b/scripts/test_check_release_checklist_paths.py
@@ -7,7 +7,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CHECKER = ROOT / "scripts" / "check_release_checklist_paths.py"
 
@@ -17,6 +16,11 @@ CHECKLIST = """\
 If the release touches the parser (`src/parser.rs`) or the
 originator (`src/evpn_originator/`), run M-01:
 
+Review the API (`proto/rustbgpd.proto`), renderer
+(`tools/rs-config-render/`), and Rust configuration (`.cargo/config.toml`).
+The release archive stages `share/systemd/`; repository-owned share paths such
+as `share/repository-data/` remain repository paths.
+
 ```sh
 containerlab deploy -t tests/interop/m01.clab.yml
 bash tests/interop/scripts/test-m01.sh
@@ -24,6 +28,9 @@ bash tests/interop/scripts/test-m01.sh
 
 Unfenced prose such as docs/test improvements is not a path, and a
 prefixed `$PWD/tests/prefixed.rs` token is not a repo path.
+These path-shaped tokens are not repository paths: `RibService/SetFibTable`,
+`ghcr.io/lance0/rustbgpd:latest`, `docker/metadata-action`, and
+`releases/latest/download/`.
 """
 
 FIXTURE_PATHS = (
@@ -31,6 +38,11 @@ FIXTURE_PATHS = (
     "src/evpn_originator/",
     "tests/interop/m01.clab.yml",
     "tests/interop/scripts/test-m01.sh",
+    "proto/rustbgpd.proto",
+    "tools/rs-config-render/",
+    ".cargo/config.toml",
+    "examples/systemd/",
+    "share/repository-data/",
 )
 
 
@@ -63,29 +75,54 @@ class ReleaseChecklistPathTests(unittest.TestCase):
         self.assertIn(missing, result.stderr)
 
     def test_passes_when_every_named_path_exists(self) -> None:
-        """Green with all named paths present; prose tokens are not extracted."""
+        """Passes with recognized paths present; prose tokens are not extracted."""
         result = self.run_checker(CHECKLIST, FIXTURE_PATHS)
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_non_repository_path_tokens_stay_excluded(self) -> None:
+        """Path-shaped API, image, action, and download tokens stay out."""
+        result = self.run_checker(
+            "`RibService/SetFibTable` `ghcr.io/lance0/rustbgpd:latest` "
+            "`docker/metadata-action` `releases/latest/download/`\n",
+            (),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no paths were extracted", result.stderr)
+
     def test_fails_on_missing_backticked_trigger_path(self) -> None:
-        """Red when a backticked trigger-list file is gone."""
+        """Fails when a backticked trigger-list file is gone."""
         remaining = tuple(p for p in FIXTURE_PATHS if p != "src/parser.rs")
         self.assert_fails(remaining, "src/parser.rs")
 
     def test_fails_on_missing_trigger_directory(self) -> None:
-        """Red when a trailing-slash trigger directory is gone."""
+        """Fails when a trailing-slash trigger directory is gone."""
         remaining = tuple(p for p in FIXTURE_PATHS if p != "src/evpn_originator/")
         self.assert_fails(remaining, "src/evpn_originator/")
 
     def test_fails_on_missing_fenced_reproduction_path(self) -> None:
-        """Red when a bare path inside a fenced block is gone."""
+        """Fails when a bare path inside a fenced block is gone."""
         remaining = tuple(
             p for p in FIXTURE_PATHS if p != "tests/interop/scripts/test-m01.sh"
         )
         self.assert_fails(remaining, "tests/interop/scripts/test-m01.sh")
 
+    def test_fails_on_missing_proto_or_tool_path(self) -> None:
+        """Fails when newly recognized proto or tool paths disappear."""
+        for missing in ("proto/rustbgpd.proto", "tools/rs-config-render/"):
+            with self.subTest(missing=missing):
+                remaining = tuple(p for p in FIXTURE_PATHS if p != missing)
+                self.assert_fails(remaining, missing)
+
+    def test_generated_share_path_checks_its_repository_source(self) -> None:
+        """The archive-only share token resolves to its checked source tree."""
+        self.assertNotIn("share/systemd/", FIXTURE_PATHS)
+        remaining = tuple(p for p in FIXTURE_PATHS if p != "share/repository-data/")
+        self.assert_fails(remaining, "share/repository-data/")
+        remaining = tuple(p for p in FIXTURE_PATHS if p != "examples/systemd/")
+        self.assert_fails(remaining, "examples/systemd/")
+
     def test_fails_when_no_paths_are_extracted(self) -> None:
-        """Red when the parse yields nothing: a gate that cannot fail is broken."""
+        """Fails when the parse yields nothing: an inert gate is broken."""
         result = self.run_checker("# Empty\n\nNo paths named here.\n", ())
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("no paths were extracted", result.stderr)


### PR DESCRIPTION
## Summary

- recognize proto, tools, .cargo, and share path tokens in the release-checklist gate
- resolve the generated `share/systemd/` archive layout to its repository-owned `examples/systemd/` source
- pin missing-path mutations and retain exclusions for RPC, image, action, and download tokens
- narrow the success message to the path class the checker actually validates

## Validation

- `python3 -m unittest -v scripts/test_check_release_checklist_paths.py`
- `python3 scripts/check_release_checklist_paths.py`
- public tracker ID and IXP docs checker/test pairs
- Python formatting and diff checks
- repository pre-push hooks: workspace Clippy, library tests, and docs

Linear: LAN-1262