### PR TITLE
docs: clarify rejected confederation scope

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -245,11 +245,12 @@ byte counts.
   tail demotion rule fires only on EBGP peers. The current EBGP gate
   is a simple `neighbor.remote_asn != self.global.asn` comparison.
   This is correct for traditional EBGP/iBGP topologies (which is all
-  rustbgpd supports today). RFC 5065 support is rejected under the current
-  roadmap. If a future recorded decision revives confederations, support must
-  include an explicit `is_external_neighbor()` helper that understands sub-AS
-  topology as a prerequisite. The conditional requirement remains
-  tracked under "RFC 8326 confederation gating" in `ROADMAP.md`.
+  rustbgpd supports today). RFC 5065 support is rejected under the
+  current roadmap. If a future recorded decision revives confederations,
+  support must include an explicit `is_external_neighbor()` helper that
+  understands sub-AS topology as a prerequisite. The conditional
+  requirement remains tracked under "RFC 8326 confederation gating" in
+  `ROADMAP.md`.
 
 - **RFC 8326 initiator toggle does not persist across daemon restart.**
   `rbgp gshut --peer X` flips a runtime bool on `ManagedPeer`

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -240,19 +240,16 @@ byte counts.
   discards all state and replays Peer Up; a configured Loc-RIB view then gets a
   new EoR-closed dump. Alert on that counter.
 
-- **RFC 8326 receiver gating doesn't yet know about confederations.**
+- **RFC 8326 receiver gating is scoped to non-confederation topologies.**
   When `[global] honor_graceful_shutdown = true`, the implicit chain-
   tail demotion rule fires only on EBGP peers. The current EBGP gate
   is a simple `neighbor.remote_asn != self.global.asn` comparison.
   This is correct for traditional EBGP/iBGP topologies (which is all
-  rustbgpd supports today) but will be wrong once confederation
-  support lands: confederation-EBGP peers have a different sub-AS
-  but are still inside the same routing domain for `LOCAL_PREF`
-  preservation purposes. When confederations land, the gate should
-  key off an explicit `is_external_neighbor()` helper that knows
-  about the sub-AS topology. Tracked under "RFC 8326 confederation
-  gating" in `ROADMAP.md`. No-op for the current release because
-  rustbgpd doesn't support confederations yet.
+  rustbgpd supports today). RFC 5065 support is rejected under the current
+  roadmap. If a future recorded decision revives confederations, support must
+  include an explicit `is_external_neighbor()` helper that understands sub-AS
+  topology as a prerequisite. The conditional requirement remains
+  tracked under "RFC 8326 confederation gating" in `ROADMAP.md`.
 
 - **RFC 8326 initiator toggle does not persist across daemon restart.**
   `rbgp gshut --peer X` flips a runtime bool on `ManagedPeer`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1798,7 +1798,8 @@ an ADR "Deferred" section that points back here. Tightened, not dropped.
   `ASCII` encodings, multicast / VPN AFIs, full OpenConfig coverage; BFD / FIB /
   EVPN OpenConfig-adjacent surfaces; YANG / NETCONF / RESTCONF (deprioritized).
 
-- **RFC 8326 confederation gating.** When confederations land, the EBGP gate
+- **RFC 8326 confederation gating.** If a future recorded decision revives
+  confederations, the EBGP gate
   inside `effective_policy_chains_for_neighbor` (currently
   `remote_asn != self.global.asn`) needs an explicit `is_external_neighbor()`
   helper aware of confederation sub-AS topology. The current gate is correct for

--- a/docs/adr/0053-rfc-8326-graceful-shutdown.md
+++ b/docs/adr/0053-rfc-8326-graceful-shutdown.md
@@ -84,7 +84,7 @@ self.global.asn`.
 If a future recorded decision revives confederations, the gate must
 first key off an explicit `is_external_neighbor()` helper that knows
 about confederation sub-AS topology rather than the simple ASN
-comparison. This prerequisite is tracked in ROADMAP under "RFC 8326
+comparison. This prerequisite is tracked in `ROADMAP.md` under "RFC 8326
 confederation gating" and is a documented known limitation in
 `KNOWN_ISSUES.md`.
 

--- a/docs/adr/0053-rfc-8326-graceful-shutdown.md
+++ b/docs/adr/0053-rfc-8326-graceful-shutdown.md
@@ -81,11 +81,12 @@ demotion per iBGP hop would clobber values set legitimately at the
 upstream EBGP edge — that's why the gate is `neighbor.remote_asn !=
 self.global.asn`.
 
-If a future recorded decision revives confederations, the gate must first key
-off an explicit `is_external_neighbor()` helper that knows about confederation
-sub-AS topology rather than the simple ASN comparison. This prerequisite is
-tracked in ROADMAP under "RFC 8326 confederation gating" and is a documented
-known limitation in `KNOWN_ISSUES.md`.
+If a future recorded decision revives confederations, the gate must
+first key off an explicit `is_external_neighbor()` helper that knows
+about confederation sub-AS topology rather than the simple ASN
+comparison. This prerequisite is tracked in ROADMAP under "RFC 8326
+confederation gating" and is a documented known limitation in
+`KNOWN_ISSUES.md`.
 
 **Opt-in by default.** RFC 8326 §4 says receivers SHOULD apply the
 demotion, not MUST. Operators who deliberately don't want the

--- a/docs/adr/0053-rfc-8326-graceful-shutdown.md
+++ b/docs/adr/0053-rfc-8326-graceful-shutdown.md
@@ -81,11 +81,11 @@ demotion per iBGP hop would clobber values set legitimately at the
 upstream EBGP edge — that's why the gate is `neighbor.remote_asn !=
 self.global.asn`.
 
-When confederations land the gate needs to key off an explicit
-`is_external_neighbor()` helper that knows about confederation sub-AS
-topology rather than the simple ASN comparison. This is tracked in
-ROADMAP under "RFC 8326 confederation gating" and is a documented
-known-limitation in `KNOWN_ISSUES.md`.
+If a future recorded decision revives confederations, the gate must first key
+off an explicit `is_external_neighbor()` helper that knows about confederation
+sub-AS topology rather than the simple ASN comparison. This prerequisite is
+tracked in ROADMAP under "RFC 8326 confederation gating" and is a documented
+known limitation in `KNOWN_ISSUES.md`.
 
 **Opt-in by default.** RFC 8326 §4 says receivers SHOULD apply the
 demotion, not MUST. Operators who deliberately don't want the

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -909,7 +909,8 @@ to the plain capability they delivered.
   EBGP gate inside `effective_policy_chains_for_neighbor` remains a follow-up
   (the current `remote_asn != self.global.asn` gate is correct for the
   traditional EBGP/iBGP topology rustbgpd supports today and becomes load-bearing
-  only when confederations land — tracked in `KNOWN_ISSUES.md`).
+  only if a future recorded decision revives confederations — tracked in
+  `KNOWN_ISSUES.md`).
 - **RFC 7999 BLACKHOLE receiver + opt-in FIB discard** (v0.21.0) — natural
   sibling to RFC 8326. Well-known `BLACKHOLE` community (`65535:666`) signals
   "drop traffic to this prefix" for DDoS mitigation; receiver behavior is

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -908,9 +908,9 @@ to the plain capability they delivered.
   route, both toggling GShut without route churn). Confederation gating of the
   EBGP gate inside `effective_policy_chains_for_neighbor` remains a follow-up
   (the current `remote_asn != self.global.asn` gate is correct for the
-  traditional EBGP/iBGP topology rustbgpd supports today and becomes load-bearing
-  only if a future recorded decision revives confederations — tracked in
-  `KNOWN_ISSUES.md`).
+  traditional EBGP/iBGP topology rustbgpd supports today and becomes
+  load-bearing only if a future recorded decision revives confederations —
+  tracked in `KNOWN_ISSUES.md`).
 - **RFC 7999 BLACKHOLE receiver + opt-in FIB discard** (v0.21.0) — natural
   sibling to RFC 8326. Well-known `BLACKHOLE` community (`65535:666`) signals
   "drop traffic to this prefix" for DDoS mitigation; receiver behavior is


### PR DESCRIPTION
## Summary

- state that RFC 5065 confederation support is rejected under the current roadmap
- retain RFC 8326 external-neighbor gating only as a prerequisite for a future recorded revival decision
- remove present-tense wording that implied confederation support was planned

## Validation

- public tracker ID, release checklist path, and IXP docs checker/test pairs
- targeted confederation wording scan
- repository pre-push hooks: formatting, workspace Clippy, library tests, and rustdoc

Linear: LAN-1220