### PR TITLE
test: prove TCP-AO-required accounting for unsigned peers (LAN-1181)

### DIFF
--- a/tests/interop/configs/bird-m43-unsigned.conf
+++ b/tests/interop/configs/bird-m43-unsigned.conf
@@ -1,0 +1,28 @@
+log stderr all;
+router id 10.0.43.2;
+
+protocol device {
+  scan time 10;
+}
+
+protocol direct {
+  ipv4;
+  interface "eth1";
+}
+
+protocol static m43_static {
+  ipv4;
+  route 203.0.113.43/32 blackhole;
+}
+
+protocol bgp rustbgpd {
+  local 10.0.43.2 as 65043;
+  neighbor 10.0.43.1 as 65001;
+  source address 10.0.43.2;
+  hold time 90;
+
+  ipv4 {
+    import all;
+    export all;
+  };
+}

--- a/tests/interop/m43-tcp-ao-bird.clab.yml
+++ b/tests/interop/m43-tcp-ao-bird.clab.yml
@@ -38,6 +38,7 @@ topology:
       binds:
         - ./configs/bird-m43-tcp-ao.conf:/etc/bird/bird.conf:ro
         - ./configs/bird-m43-tcp-ao-bad.conf:/etc/bird/bird-bad.conf:ro
+        - ./configs/bird-m43-unsigned.conf:/etc/bird/bird-unsigned.conf:ro
         - ./configs/bird-m43-tcp-ao-successor.conf:/etc/bird/bird-successor.conf:ro
       exec:
         - ip addr add 10.0.43.2/24 dev eth1

--- a/tests/interop/scripts/test-m43-tcp-ao-bird.sh
+++ b/tests/interop/scripts/test-m43-tcp-ao-bird.sh
@@ -12,7 +12,9 @@
 #      the selected successor, authenticated traffic, session, and the route at
 #      every sample from a 100ms polling oracle.
 #   6. BIRD advertises a route without a session flap throughout every phase.
-#   7. A mismatch in the selected key fails closed and does not re-establish.
+#   7. An unsigned peer cannot establish while its static MKT remains installed,
+#      and the kernel accounts the matching unsigned traffic as TCPAORequired.
+#   8. A mismatch in the selected key fails closed and does not re-establish.
 #
 # Prerequisites:
 #   - BIRD image built:
@@ -36,6 +38,7 @@ source "$SCRIPT_DIR/test-lib.sh"
 BIRD="clab-${TOPO}-bird"
 GOOD_CONF="/etc/bird/bird.conf"
 BAD_CONF="/etc/bird/bird-bad.conf"
+UNSIGNED_CONF="/etc/bird/bird-unsigned.conf"
 TEST_PREFIX="203.0.113.43"
 POST_DELETE_PROBE_PREFIX="203.0.113.44"
 ROUTE_CONTINUITY_PID=""
@@ -141,6 +144,68 @@ wait_route_present() {
     fail "$TEST_PREFIX/32 not received over TCP-AO session"
     dump_diagnostics
     return 1
+}
+
+tcp_ao_required() {
+    docker exec "$RUSTBGPD" awk '
+        $1 == "TcpExt:" {
+            if (column > 0) {
+                print $column
+                found = 1
+                exit
+            }
+            for (i = 2; i <= NF; i++) {
+                if ($i == "TCPAORequired") column = i
+            }
+        }
+        END { if (!found) exit 1 }
+    ' /proc/net/netstat
+}
+
+prove_unsigned_peer_requires_ao() {
+    local before
+    if ! before=$(tcp_ao_required); then
+        fail "Linux did not expose the TCPAORequired accounting oracle"
+        return 1
+    fi
+
+    log "Starting a bounded unsigned BIRD attempt from the MKT-matched address..."
+    start_bird "$UNSIGNED_CONF"
+    local after=$before
+    local state
+    for _ in $(seq 1 10); do
+        if ! state=$(bird_state_strict); then
+            fail "unsigned BIRD protocol state became unavailable"
+            dump_diagnostics
+            return 1
+        fi
+        if ! awk '$1 == "rustbgpd" { found = 1 } END { exit found ? 0 : 1 }' \
+            <<<"$state"; then
+            fail "unsigned BIRD protocol row disappeared"
+            return 1
+        fi
+        if [[ "$state" == *Established* ]]; then
+            fail "unsigned BIRD reached Established against the TCP-AO listener"
+            dump_diagnostics
+            return 1
+        fi
+        if ! after=$(tcp_ao_required); then
+            fail "TCPAORequired accounting disappeared during the unsigned attempt"
+            return 1
+        fi
+        sleep 1
+    done
+    if [ "$after" -le "$before" ]; then
+        fail "unsigned traffic did not increase TCPAORequired ($before -> $after)"
+        dump_diagnostics
+        return 1
+    fi
+    ok "unsigned BIRD stayed non-Established and TCPAORequired increased $before -> $after"
+
+    start_bird "/etc/bird/bird-successor.conf"
+    wait_bird_established
+    wait_route_present
+    ok "authenticated BIRD re-established normally after the unsigned receipt"
 }
 
 start_route_continuity_oracle() {
@@ -903,6 +968,8 @@ main_uninterrupted() {
         dump_diagnostics
         return 1
     fi
+
+    prove_unsigned_peer_requires_ao
 
     log "Restarting BIRD with a mismatched preferred TCP-AO secret"
     start_bird "$BAD_CONF"


### PR DESCRIPTION
## Summary

- add a bounded unsigned BIRD attempt from the existing static MKT-covered peer address
- prove the session remains non-Established while Linux TCPAORequired accounting increases
- restore the authenticated successor and prove session and route recovery

## Validation

- bash syntax and ShellCheck with sourced test helpers
- topology/config reference checks and the 35-test interop primer suite
- nine kernel BIRD tolerance tests
- repository pre-push formatting and strict Clippy gates

The native BIRD/TCP-AO lab requires the hosted M43 job and was not run locally.