### PR TITLE
test: drain M85 long-writer match pipelines (LAN-1045)

### DIFF
--- a/tests/interop/scripts/test-m85-rr-bird.sh
+++ b/tests/interop/scripts/test-m85-rr-bird.sh
@@ -77,7 +77,7 @@ wait_bird_established() {
     log "Waiting for $label BGP session to reach Established..."
     for i in $(seq 1 45); do
         if docker exec "$container" birdc show protocols reflector 2>/dev/null \
-            | grep -q "Established"; then
+            | grep "Established" >/dev/null; then
             ok "$label session Established (attempt $i)"
             return 0
         fi
@@ -124,7 +124,7 @@ poll() {
 
 # True if BIRD has a BGP-sourced path for the prefix.
 bird_has_bgp_route() {
-    birdc_route_all "${1:?}" "${2:?}" | grep -q "BGP.as_path"
+    birdc_route_all "${1:?}" "${2:?}" | grep "BGP.as_path" >/dev/null
 }
 
 bird_lacks_bgp_route() { ! bird_has_bgp_route "$1" "$2"; }


### PR DESCRIPTION
## Summary

- replace the two M85 long-writer early-exit match consumers with read-through matches
- preserve the existing pipefail success and failure verdicts without writer-side SIGPIPE retries
- keep captured-value checks and every other interop scenario unchanged

## Validation

- bash syntax and ShellCheck with sourced helpers
- deterministic 200,000-line pipefail proof: both present patterns succeed and an absent pattern returns status 1
- CI image-primer contract and 35 interop unit tests
- full repository pre-push formatting, strict Clippy, library tests, and rustdoc

The hosted M85 job provides the native scenario proof; no local live lab was run.

Linear: LAN-1045