### PR TITLE
fix: bound Bird's Eye longest-match scans (LAN-1263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The Bird's Eye adapter now family-scopes and separately bounds protocol and
+  export longest-match fallback scans, refusing incomplete views with HTTP 403
+  instead of evaluating partial results. (LAN-1263)
+
 - Unrecognized optional non-transitive BGP path attributes are now ignored on
   receipt and omitted by defensive encoding instead of being retained and
   re-advertised; unknown optional transitive attributes remain preserved with

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -12,7 +12,7 @@ use tonic::{Request, Response, Status};
 
 use crate::actor_read::rib_manager_read;
 use crate::proto;
-use rustbgpd_rib::update::{OrderedAllRoutesFilter, OrderedRouteFamilyFilter};
+use rustbgpd_rib::update::ordered_route_query_filter;
 use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, EvpnRibRoute, ExplainAdvertisedRoute, ExplainAdvertisedRouteError,
     ExplainBestPath, ExplainDecision, ExportGateVerdict, FlowSpecRoute, LabeledRibRoute,
@@ -967,8 +967,7 @@ fn build_route_query_filter(
     known_total: Option<u64>,
 ) -> Option<RouteQueryFilter> {
     if filters.is_empty() && family_filter_is_noop(afi_safi) {
-        return known_total
-            .map(|total| Box::new(OrderedAllRoutesFilter(total)) as RouteQueryFilter);
+        return known_total.map(|total| ordered_route_query_filter(None, Some(total)));
     }
     if filters.is_empty() {
         let family = if afi_safi == proto::AddressFamily::Ipv4Unicast as i32 {
@@ -976,7 +975,7 @@ fn build_route_query_filter(
         } else {
             Afi::Ipv6
         };
-        return Some(Box::new(OrderedRouteFamilyFilter(family, known_total)));
+        return Some(ordered_route_query_filter(Some(family), known_total));
     }
     Some(Box::new(move |route: &Route| {
         route_matches_family(route, afi_safi) && filters.matches(route)
@@ -4014,9 +4013,14 @@ mod tests {
     #[test]
     fn unspecified_continuation_preserves_signed_known_total_marker() {
         let request = list_routes_request();
+        let first_filters = RouteFilters::from_request(&request).unwrap();
+        assert!(build_route_query_filter(request.afi_safi, first_filters, None).is_none());
         let filters = RouteFilters::from_request(&request).unwrap();
         let filter = build_route_query_filter(request.afi_safi, filters, Some(23)).unwrap();
-        assert_eq!(filter.ordered_family(), Some((None, Some(23))));
+        assert!(filter(&test_route(
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
+            vec![],
+        )));
     }
 
     #[tokio::test]
@@ -5335,10 +5339,15 @@ mod tests {
             }) = rx.recv().await
             {
                 assert_eq!(actual_scope, scope);
-                assert_eq!(
-                    filter.and_then(|filter| filter.ordered_family()),
-                    Some((Some(Afi::Ipv4), Some(1)))
-                );
+                let filter = filter.expect("family continuation carries a filter");
+                assert!(filter(&test_route(
+                    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
+                    vec![],
+                )));
+                assert!(!filter(&test_route(
+                    Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32)),
+                    vec![],
+                )));
                 assert_eq!(after, Some(key));
                 assert_eq!(expected_version, Some(version));
                 let _ = reply.send(Ok(RoutePage {

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -11,6 +11,7 @@ use tonic::{Request, Response, Status};
 
 use crate::actor_read::rib_manager_read;
 use crate::proto;
+use rustbgpd_rib::update::OrderedRouteFamilyFilter;
 use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, EvpnRibRoute, ExplainAdvertisedRoute, ExplainAdvertisedRouteError,
     ExplainBestPath, ExplainDecision, ExportGateVerdict, FlowSpecRoute, LabeledRibRoute,
@@ -714,13 +715,15 @@ const DEFAULT_ROUTE_PAGE_SIZE: usize = 100;
 
 /// Decode the pagination fields of a route-listing request: the resume
 /// cursor (from the opaque `page_token`) and the requested page size.
+type ParsedRouteCursor = (Option<RouteQueryKey>, Option<RoutePageVersion>, Option<u64>);
+
 fn parse_route_page_params(
     req: &proto::ListRoutesRequest,
     scope: RouteQueryScope,
     query_identity: &str,
-) -> Result<(Option<RouteQueryKey>, Option<RoutePageVersion>, usize), Status> {
-    let (after, expected_version) = if req.page_token.is_empty() {
-        (None, None)
+) -> Result<(ParsedRouteCursor, usize), Status> {
+    let (after, expected_version, known_total) = if req.page_token.is_empty() {
+        (None, None, None)
     } else {
         let cursor = decode_route_page_token(&req.page_token)?;
         if cursor.scope != scope {
@@ -733,14 +736,14 @@ fn parse_route_page_params(
                 "page_token belongs to different route filters",
             ));
         }
-        (Some(cursor.after), Some(cursor.version))
+        (Some(cursor.after), Some(cursor.version), Some(cursor.total))
     };
     let page_size = if req.page_size == 0 {
         DEFAULT_ROUTE_PAGE_SIZE
     } else {
         req.page_size as usize
     };
-    Ok((after, expected_version, page_size))
+    Ok(((after, expected_version, known_total), page_size))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -749,6 +752,7 @@ struct RoutePageCursor {
     query_identity: String,
     after: RouteQueryKey,
     version: RoutePageVersion,
+    total: u64,
 }
 
 fn route_page_scope_token(scope: RouteQueryScope) -> String {
@@ -854,11 +858,12 @@ fn encode_route_page_token(
     query_identity: &str,
     key: &RouteQueryKey,
     version: RoutePageVersion,
+    total: u64,
 ) -> String {
     let (prefix, peer, path_id) = key;
     let (addr, len) = prefix_parts(*prefix);
     format!(
-        "rp3|{:016x}|{:016x}|{}|{query_identity}|{addr}/{len}|{peer}|{path_id}",
+        "rp4|{:016x}|{:016x}|{total}|{}|{query_identity}|{addr}/{len}|{peer}|{path_id}",
         version.epoch,
         version.generation,
         route_page_scope_token(scope)
@@ -869,9 +874,10 @@ fn decode_route_page_token(token: &str) -> Result<RoutePageCursor, Status> {
     let invalid = || Status::invalid_argument("invalid page_token");
     let mut parts = token.split('|');
     let (
-        Some("rp3"),
+        Some("rp4"),
         Some(epoch),
         Some(generation),
+        Some(total),
         Some(scope),
         Some(query_identity),
         Some(prefix),
@@ -888,12 +894,14 @@ fn decode_route_page_token(token: &str) -> Result<RoutePageCursor, Status> {
         parts.next(),
         parts.next(),
         parts.next(),
+        parts.next(),
     )
     else {
         return Err(invalid());
     };
     let epoch = u64::from_str_radix(epoch, 16).map_err(|_| invalid())?;
     let generation = u64::from_str_radix(generation, 16).map_err(|_| invalid())?;
+    let total: u64 = total.parse().map_err(|_| invalid())?;
     let scope = parse_route_page_scope_token(scope).ok_or_else(invalid)?;
     if query_identity.len() != 64
         || !query_identity
@@ -912,17 +920,30 @@ fn decode_route_page_token(token: &str) -> Result<RoutePageCursor, Status> {
         query_identity: query_identity.to_string(),
         after: (prefix, peer, path_id),
         version: RoutePageVersion { epoch, generation },
+        total,
     })
 }
 
 /// Build the row filter evaluated inside the RIB task. `None` when
 /// neither the family filter nor the route filters narrow the scope, so
 /// the actor skips per-route predicate calls entirely.
-fn build_route_query_filter(afi_safi: i32, filters: RouteFilters) -> Option<RouteQueryFilter> {
+fn build_route_query_filter(
+    afi_safi: i32,
+    filters: RouteFilters,
+    known_total: Option<u64>,
+) -> Option<RouteQueryFilter> {
     if filters.is_empty() && family_filter_is_noop(afi_safi) {
         return None;
     }
-    Some(Box::new(move |route| {
+    if filters.is_empty() {
+        let family = if afi_safi == proto::AddressFamily::Ipv4Unicast as i32 {
+            Afi::Ipv4
+        } else {
+            Afi::Ipv6
+        };
+        return Some(Box::new(OrderedRouteFamilyFilter(family, known_total)));
+    }
+    Some(Box::new(move |route: &Route| {
         route_matches_family(route, afi_safi) && filters.matches(route)
     }))
 }
@@ -942,6 +963,7 @@ fn route_page_to_response(
                     query_identity,
                     &route_query_key(route),
                     page.version,
+                    page.total,
                 )
             })
             .unwrap_or_default()
@@ -1339,12 +1361,12 @@ impl proto::rib_service_server::RibService for RibService {
         let filters = RouteFilters::from_request(&req)?;
         let query_identity = route_page_query_identity(req.afi_safi, &filters);
         let scope = RouteQueryScope::Received { peer };
-        let (after, expected_version, page_size) =
+        let ((after, expected_version, known_total), page_size) =
             parse_route_page_params(&req, scope, &query_identity)?;
         let page = self
             .query_routes_page(
                 scope,
-                build_route_query_filter(req.afi_safi, filters),
+                build_route_query_filter(req.afi_safi, filters, known_total),
                 after,
                 expected_version,
                 page_size,
@@ -1367,12 +1389,12 @@ impl proto::rib_service_server::RibService for RibService {
         let filters = RouteFilters::from_request(&req)?;
         let query_identity = route_page_query_identity(req.afi_safi, &filters);
         let scope = RouteQueryScope::Best;
-        let (after, expected_version, page_size) =
+        let ((after, expected_version, known_total), page_size) =
             parse_route_page_params(&req, scope, &query_identity)?;
         let page = self
             .query_routes_page(
                 scope,
-                build_route_query_filter(req.afi_safi, filters),
+                build_route_query_filter(req.afi_safi, filters, known_total),
                 after,
                 expected_version,
                 page_size,
@@ -1407,12 +1429,12 @@ impl proto::rib_service_server::RibService for RibService {
         let filters = RouteFilters::from_request(&req)?;
         let query_identity = route_page_query_identity(req.afi_safi, &filters);
         let scope = RouteQueryScope::Advertised { peer };
-        let (after, expected_version, page_size) =
+        let ((after, expected_version, known_total), page_size) =
             parse_route_page_params(&req, scope, &query_identity)?;
         let page = self
             .query_routes_page(
                 scope,
-                build_route_query_filter(req.afi_safi, filters),
+                build_route_query_filter(req.afi_safi, filters, known_total),
                 after,
                 expected_version,
                 page_size,
@@ -4898,14 +4920,15 @@ mod tests {
                     peer: "192.0.2.9".parse().unwrap(),
                 },
             ] {
-                let token = encode_route_page_token(scope, &query_identity, &key, version);
+                let token = encode_route_page_token(scope, &query_identity, &key, version, 37);
                 assert_eq!(
                     decode_route_page_token(&token).unwrap(),
                     RoutePageCursor {
                         scope,
                         query_identity: query_identity.clone(),
                         after: key,
-                        version
+                        version,
+                        total: 37,
                     }
                 );
             }
@@ -5004,7 +5027,7 @@ mod tests {
         };
         let base_identity = route_page_identity(&base);
         assert_eq!(base_identity.len(), 64);
-        let token = encode_route_page_token(scope, &base_identity, &key, version);
+        let token = encode_route_page_token(scope, &base_identity, &key, version, 19);
 
         // Host bits, OR-filter ordering/duplicates, invalid large-community
         // spellings, and page size do not change the query's semantics.
@@ -5024,7 +5047,7 @@ mod tests {
         assert_eq!(equivalent_identity, base_identity);
         assert_eq!(
             parse_route_page_params(&equivalent, scope, &equivalent_identity).unwrap(),
-            (Some(key), Some(version), 999)
+            ((Some(key), Some(version), Some(19)), 999)
         );
 
         let mut changed_requests = Vec::new();
@@ -5109,6 +5132,7 @@ mod tests {
                 epoch: 1,
                 generation: 2,
             },
+            0,
         );
         let error = parse_route_page_params(
             &request,
@@ -5207,7 +5231,8 @@ mod tests {
                 RoutePageVersion {
                     epoch: 7,
                     generation: 9
-                }
+                },
+                2,
             )
         );
     }
@@ -5225,10 +5250,13 @@ mod tests {
             epoch: 11,
             generation: 13,
         };
-        let query_identity = route_page_identity(&list_routes_request());
+        let mut request = list_routes_request();
+        request.afi_safi = proto::AddressFamily::Ipv4Unicast as i32;
+        let query_identity = route_page_identity(&request);
         tokio::spawn(async move {
             if let Some(RibUpdate::QueryRoutesPage {
                 scope: actual_scope,
+                filter,
                 after,
                 expected_version,
                 reply,
@@ -5236,6 +5264,10 @@ mod tests {
             }) = rx.recv().await
             {
                 assert_eq!(actual_scope, scope);
+                assert_eq!(
+                    filter.and_then(|filter| filter.ordered_family()),
+                    Some((Afi::Ipv4, Some(1)))
+                );
                 assert_eq!(after, Some(key));
                 assert_eq!(expected_version, Some(version));
                 let _ = reply.send(Ok(RoutePage {
@@ -5251,8 +5283,8 @@ mod tests {
         let response = service
             .list_received_routes(Request::new(proto::ListRoutesRequest {
                 page_size: 1,
-                page_token: encode_route_page_token(scope, &query_identity, &key, version),
-                ..list_routes_request()
+                page_token: encode_route_page_token(scope, &query_identity, &key, version, 1),
+                ..request
             }))
             .await
             .unwrap()

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -2,6 +2,7 @@
 
 use std::net::IpAddr;
 use std::pin::Pin;
+use std::sync::OnceLock;
 #[cfg(feature = "bench-internals")]
 use std::time::Instant;
 
@@ -850,9 +851,27 @@ fn route_page_query_identity(afi_safi: i32, filters: &RouteFilters) -> String {
     encoded
 }
 
-/// Encode a self-contained opaque cursor. Scope binding rejects cross-RPC or
-/// cross-peer reuse; the process-local version makes mutation a visible
-/// restart instead of a silently skipped or duplicated row.
+static ROUTE_PAGE_TOKEN_SECRET: OnceLock<[u8; 16]> = OnceLock::new();
+
+fn route_page_token_signature(payload: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let secret = ROUTE_PAGE_TOKEN_SECRET.get_or_init(|| *uuid::Uuid::new_v4().as_bytes());
+    let mut hasher = Sha256::new();
+    hasher.update(b"rustbgpd-route-page-token-v1");
+    hasher.update(secret);
+    hasher.update(payload.as_bytes());
+    hasher.update(secret);
+    let digest = hasher.finalize();
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+/// Encode an opaque cursor whose process-local integrity tag binds every field.
+/// Tokens intentionally expire across process restarts.
 fn encode_route_page_token(
     scope: RouteQueryScope,
     query_identity: &str,
@@ -862,19 +881,34 @@ fn encode_route_page_token(
 ) -> String {
     let (prefix, peer, path_id) = key;
     let (addr, len) = prefix_parts(*prefix);
-    format!(
-        "rp4|{:016x}|{:016x}|{total}|{}|{query_identity}|{addr}/{len}|{peer}|{path_id}",
+    let payload = format!(
+        "rp5|{:016x}|{:016x}|{total}|{}|{query_identity}|{addr}/{len}|{peer}|{path_id}",
         version.epoch,
         version.generation,
         route_page_scope_token(scope)
-    )
+    );
+    let signature = route_page_token_signature(&payload);
+    format!("{payload}|{signature}")
 }
 
 fn decode_route_page_token(token: &str) -> Result<RoutePageCursor, Status> {
     let invalid = || Status::invalid_argument("invalid page_token");
-    let mut parts = token.split('|');
+    let (payload, signature) = token.rsplit_once('|').ok_or_else(invalid)?;
+    let expected_signature = route_page_token_signature(payload);
+    if signature.len() != expected_signature.len()
+        || signature
+            .bytes()
+            .zip(expected_signature.bytes())
+            .fold(0u8, |difference, (actual, expected)| {
+                difference | (actual ^ expected)
+            })
+            != 0
+    {
+        return Err(invalid());
+    }
+    let mut parts = payload.split('|');
     let (
-        Some("rp4"),
+        Some("rp5"),
         Some(epoch),
         Some(generation),
         Some(total),
@@ -4935,6 +4969,23 @@ mod tests {
         }
     }
 
+    fn encode_test_route_page_token(query_identity: &str, total: u64) -> String {
+        encode_route_page_token(
+            RouteQueryScope::Best,
+            query_identity,
+            &(
+                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
+                "192.0.2.1".parse().unwrap(),
+                0,
+            ),
+            RoutePageVersion {
+                epoch: 1,
+                generation: 2,
+            },
+            total,
+        )
+    }
+
     /// Load-bearing response proof: removing `page_version` from
     /// `route_page_to_response` makes this empty terminal-page assertion red.
     #[test]
@@ -4981,20 +5032,31 @@ mod tests {
 
     #[test]
     fn route_page_token_rejects_garbage() {
-        let short_identity = format!("rp3|1|2|best|{}|10.0.0.0/24|192.0.2.1|0", "a".repeat(63));
-        let uppercase_identity = format!("rp3|1|2|best|{}|10.0.0.0/24|192.0.2.1|0", "A".repeat(64));
-        for token in [
-            "",
-            "5",
-            "not-a-token",
-            "10.0.0.0/24|192.0.2.1",
-            "a|b|c|d",
-            &short_identity,
-            &uppercase_identity,
-        ] {
-            let err = decode_route_page_token(token).unwrap_err();
+        let mut tokens = vec![
+            String::new(),
+            "5".to_string(),
+            "not-a-token".to_string(),
+            "10.0.0.0/24|192.0.2.1".to_string(),
+            "a|b|c|d".to_string(),
+        ];
+        for identity in ["a".repeat(63), "A".repeat(64)] {
+            tokens.push(encode_test_route_page_token(&identity, 3));
+        }
+        for token in tokens {
+            let err = decode_route_page_token(&token).unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
+    }
+
+    #[test]
+    fn route_page_token_rejects_altered_total() {
+        let identity = route_page_identity(&list_routes_request());
+        let token = encode_test_route_page_token(&identity, 37);
+        let mut fields: Vec<_> = token.split('|').collect();
+        assert_eq!(fields[3], "37");
+        fields[3] = "38";
+        let error = decode_route_page_token(&fields.join("|")).unwrap_err();
+        assert_eq!(error.code(), tonic::Code::InvalidArgument);
     }
 
     #[test]

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -12,7 +12,7 @@ use tonic::{Request, Response, Status};
 
 use crate::actor_read::rib_manager_read;
 use crate::proto;
-use rustbgpd_rib::update::OrderedRouteFamilyFilter;
+use rustbgpd_rib::update::{OrderedAllRoutesFilter, OrderedRouteFamilyFilter};
 use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, EvpnRibRoute, ExplainAdvertisedRoute, ExplainAdvertisedRouteError,
     ExplainBestPath, ExplainDecision, ExportGateVerdict, FlowSpecRoute, LabeledRibRoute,
@@ -967,7 +967,8 @@ fn build_route_query_filter(
     known_total: Option<u64>,
 ) -> Option<RouteQueryFilter> {
     if filters.is_empty() && family_filter_is_noop(afi_safi) {
-        return None;
+        return known_total
+            .map(|total| Box::new(OrderedAllRoutesFilter(total)) as RouteQueryFilter);
     }
     if filters.is_empty() {
         let family = if afi_safi == proto::AddressFamily::Ipv4Unicast as i32 {
@@ -4010,6 +4011,14 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn unspecified_continuation_preserves_signed_known_total_marker() {
+        let request = list_routes_request();
+        let filters = RouteFilters::from_request(&request).unwrap();
+        let filter = build_route_query_filter(request.afi_safi, filters, Some(23)).unwrap();
+        assert_eq!(filter.ordered_family(), Some((None, Some(23))));
+    }
+
     #[tokio::test]
     async fn list_received_routes_rejects_unsupported_afi() {
         let svc = make_service();
@@ -5328,7 +5337,7 @@ mod tests {
                 assert_eq!(actual_scope, scope);
                 assert_eq!(
                     filter.and_then(|filter| filter.ordered_family()),
-                    Some((Afi::Ipv4, Some(1)))
+                    Some((Some(Afi::Ipv4), Some(1)))
                 );
                 assert_eq!(after, Some(key));
                 assert_eq!(expected_version, Some(version));

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -269,6 +269,8 @@ pub struct RibManager {
     /// group table; for private peers it suppresses repeated diagnostics and
     /// withdrawals for routes that were never advertised.
     peer_unexportable: HashMap<IpAddr, HashSet<ExactExportKey>>,
+    #[cfg(test)]
+    grouped_advertised_count_calls: std::sync::atomic::AtomicUsize,
     export_policy: Option<PolicyChain>,
     peer_export_policies: HashMap<IpAddr, Option<PolicyChain>>,
     /// Families the transport can actually serialize per peer.
@@ -1121,6 +1123,8 @@ impl RibManager {
             pending_peer_gr_context: HashMap::new(),
             peer_export_encoders: HashMap::new(),
             peer_unexportable: HashMap::new(),
+            #[cfg(test)]
+            grouped_advertised_count_calls: std::sync::atomic::AtomicUsize::new(0),
             export_policy,
             peer_export_policies: HashMap::new(),
             peer_sendable_families: HashMap::new(),

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -264,17 +264,22 @@ fn matches_ordered_family(route: &crate::route::Route, family: Option<Afi>) -> b
     family.is_none_or(|family| prefix_family(&route.prefix).0 == family)
 }
 
+fn ordered_family_routes<'a>(
+    routes: impl Iterator<Item = &'a crate::route::Route>,
+    family: Option<Afi>,
+) -> impl Iterator<Item = &'a crate::route::Route> {
+    routes
+        .skip_while(move |route| !matches_ordered_family(route, family))
+        .take_while(move |route| matches_ordered_family(route, family))
+}
+
 fn page_ordered_family<'a>(
     routes: impl Iterator<Item = &'a crate::route::Route>,
     family: Option<Afi>,
     total: u64,
     page_size: usize,
 ) -> RoutePage {
-    page_ordered_routes(
-        routes.take_while(move |route| matches_ordered_family(route, family)),
-        total,
-        page_size,
-    )
+    page_ordered_routes(ordered_family_routes(routes, family), total, page_size)
 }
 
 /// Merge multiple individually ordered Adj-RIB-In iterators into one route
@@ -591,19 +596,14 @@ impl RibManager {
                     let iterators = self
                         .ribs
                         .values()
-                        .map(|rib| {
-                            rib.iter_ordered_from(after)
-                                .take_while(move |route| matches_ordered_family(route, family))
-                        })
+                        .map(|rib| ordered_family_routes(rib.iter_ordered_from(after), family))
                         .collect();
                     page_merged_ordered_routes(iterators, route_total, page_size)
                 }
                 RouteQueryScope::Best => {
                     let route_total = total(self.loc_rib.len());
                     page_ordered_routes(
-                        self.loc_rib
-                            .iter_ordered_from(after)
-                            .take_while(move |route| matches_ordered_family(route, family)),
+                        ordered_family_routes(self.loc_rib.iter_ordered_from(after), family),
                         route_total,
                         page_size,
                     )
@@ -625,8 +625,7 @@ impl RibManager {
                                 |(_, total)| total,
                             );
                             page_ordered_routes(
-                                routes
-                                    .take_while(move |route| matches_ordered_family(route, family)),
+                                ordered_family_routes(routes, family),
                                 route_total,
                                 page_size,
                             )
@@ -2303,6 +2302,64 @@ mod cancellation_tests {
             2,
         );
         assert_eq!((scanned.get(), page.routes.len(), page.total), (3, 2, 6));
+    }
+
+    #[test]
+    fn ipv6_family_first_page_and_continuation_are_lazy_and_complete() {
+        let peer = Ipv4Addr::new(192, 0, 2, 1);
+        let mut rib = AdjRibIn::new(peer.into());
+        for octet in 0..4 {
+            rib.insert(crate::test_support::make_route(
+                rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::new(10, 0, octet, 0), 24),
+                peer,
+            ));
+        }
+        let next_hop = "2001:db8::1".parse().unwrap();
+        let mut expected = Vec::new();
+        for segment in 0..5 {
+            let route = crate::test_support::make_v6_route(
+                rustbgpd_wire::Ipv6Prefix::new(
+                    std::net::Ipv6Addr::new(0x2001, 0xdb8, segment, 0, 0, 0, 0, 0),
+                    48,
+                ),
+                next_hop,
+            );
+            expected.push(route_query_key(&route));
+            rib.insert(route);
+        }
+        expected.sort_unstable();
+
+        let scanned = std::cell::Cell::new(0);
+        let first = page_ordered_family(
+            rib.iter_ordered_from(None)
+                .inspect(|_| scanned.set(scanned.get() + 1)),
+            Some(Afi::Ipv6),
+            5,
+            2,
+        );
+        assert_eq!(
+            first.routes.iter().map(route_query_key).collect::<Vec<_>>(),
+            expected[..2]
+        );
+        assert_eq!((scanned.get(), first.has_more, first.total), (7, true, 5));
+
+        scanned.set(0);
+        let second = page_ordered_family(
+            rib.iter_ordered_from(first.routes.last().map(route_query_key))
+                .inspect(|_| scanned.set(scanned.get() + 1)),
+            Some(Afi::Ipv6),
+            5,
+            2,
+        );
+        assert_eq!(
+            second
+                .routes
+                .iter()
+                .map(route_query_key)
+                .collect::<Vec<_>>(),
+            expected[2..4]
+        );
+        assert_eq!((scanned.get(), second.has_more, second.total), (3, true, 5));
     }
 
     #[test]

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -245,7 +245,7 @@ pub(super) fn page_routes<'a>(
 /// before yielding those rows.
 fn page_ordered_routes<'a>(
     routes: impl Iterator<Item = &'a crate::route::Route>,
-    total: usize,
+    total: u64,
     page_size: usize,
 ) -> RoutePage {
     let n = page_size.clamp(1, ROUTE_QUERY_MAX_PAGE_SIZE);
@@ -254,18 +254,36 @@ fn page_ordered_routes<'a>(
     routes.truncate(n);
     RoutePage {
         routes,
-        total: u64::try_from(total).unwrap_or(u64::MAX),
+        total,
         has_more,
         version: RoutePageVersion::default(),
     }
 }
+
+fn matches_ordered_family(route: &crate::route::Route, family: Option<Afi>) -> bool {
+    family.is_none_or(|family| prefix_family(&route.prefix).0 == family)
+}
+
+fn page_ordered_family<'a>(
+    routes: impl Iterator<Item = &'a crate::route::Route>,
+    family: Option<Afi>,
+    total: u64,
+    page_size: usize,
+) -> RoutePage {
+    page_ordered_routes(
+        routes.take_while(move |route| matches_ordered_family(route, family)),
+        total,
+        page_size,
+    )
+}
+
 /// Merge multiple individually ordered Adj-RIB-In iterators into one route
 /// page. The heap retains one key per peer and the output retains at most one
 /// page, so a Received(all) request is bounded by O(peers + page) rather than
 /// the route-table size.
 fn page_merged_ordered_routes<'a, I>(
     mut iterators: Vec<I>,
-    total: usize,
+    total: u64,
     page_size: usize,
 ) -> RoutePage
 where
@@ -304,7 +322,7 @@ where
     routes.truncate(n);
     RoutePage {
         routes,
-        total: u64::try_from(total).unwrap_or(u64::MAX),
+        total,
         has_more,
         version: RoutePageVersion::default(),
     }
@@ -482,6 +500,7 @@ impl RibManager {
     /// receiver — e.g. a canceled gRPC request whose page query was
     /// already enqueued) skips the scan entirely, so abandoned
     /// pagination stops costing the RIB task anything.
+    #[expect(clippy::too_many_lines, reason = "paired paging branches")]
     pub(super) fn handle_query_routes_page_versioned(
         &mut self,
         scope: RouteQueryScope,
@@ -515,7 +534,10 @@ impl RibManager {
         // through persistent ordered indices and clone only one page plus a
         // lookahead row. A grouped advertised view may inspect extra index rows
         // while applying member-local split horizon and exact-rejection filters.
-        let page = if filter.is_some() {
+        let ordered_family = filter
+            .and_then(|filter| filter.ordered_family())
+            .and_then(|(family, total)| total.map(|total| (family, total)));
+        let page = if filter.is_some() && ordered_family.is_none() {
             match scope {
                 RouteQueryScope::Received { peer: Some(peer) } => page_routes(
                     self.ribs.get(&peer).into_iter().flat_map(AdjRibIn::iter),
@@ -546,24 +568,45 @@ impl RibManager {
                 }
             }
         } else {
+            let family = ordered_family.map(|(family, _)| family);
+            let total = |unfiltered: usize| {
+                ordered_family.map_or_else(
+                    || u64::try_from(unfiltered).unwrap_or(u64::MAX),
+                    |(_, total)| total,
+                )
+            };
             match scope {
                 RouteQueryScope::Received { peer: Some(peer) } => {
                     self.ribs.get(&peer).map_or_else(RoutePage::default, |rib| {
-                        page_ordered_routes(rib.iter_ordered_from(after), rib.len(), page_size)
+                        page_ordered_family(
+                            rib.iter_ordered_from(after),
+                            family,
+                            total(rib.len()),
+                            page_size,
+                        )
                     })
                 }
                 RouteQueryScope::Received { peer: None } => {
-                    let total = self.ribs.values().map(AdjRibIn::len).sum();
+                    let route_total = total(self.ribs.values().map(AdjRibIn::len).sum());
                     let iterators = self
                         .ribs
                         .values()
-                        .map(|rib| rib.iter_ordered_from(after))
+                        .map(|rib| {
+                            rib.iter_ordered_from(after)
+                                .take_while(move |route| matches_ordered_family(route, family))
+                        })
                         .collect();
-                    page_merged_ordered_routes(iterators, total, page_size)
+                    page_merged_ordered_routes(iterators, route_total, page_size)
                 }
                 RouteQueryScope::Best => {
-                    let total = self.loc_rib.len();
-                    page_ordered_routes(self.loc_rib.iter_ordered_from(after), total, page_size)
+                    let route_total = total(self.loc_rib.len());
+                    page_ordered_routes(
+                        self.loc_rib
+                            .iter_ordered_from(after)
+                            .take_while(move |route| matches_ordered_family(route, family)),
+                        route_total,
+                        page_size,
+                    )
                 }
                 RouteQueryScope::Advertised { peer } => {
                     // A grouped member holds no per-peer unicast Adj-RIB-Out;
@@ -573,17 +616,18 @@ impl RibManager {
                     let grouped_total = self.grouped_advertised_count(peer);
                     match self.grouped_advertised_routes_ordered_iter(peer, after) {
                         Some(routes) => page_ordered_routes(
-                            routes,
-                            grouped_total.unwrap_or_default(),
+                            routes.take_while(move |route| matches_ordered_family(route, family)),
+                            total(grouped_total.unwrap_or_default()),
                             page_size,
                         ),
                         None => {
                             self.adj_ribs_out
                                 .get(&peer)
                                 .map_or_else(RoutePage::default, |rib| {
-                                    page_ordered_routes(
+                                    page_ordered_family(
                                         rib.iter_ordered_from(after),
-                                        rib.len(),
+                                        family,
+                                        total(rib.len()),
                                         page_size,
                                     )
                                 })
@@ -2227,6 +2271,28 @@ impl RibManager {
 #[cfg(test)]
 mod cancellation_tests {
     use super::*;
+
+    #[test]
+    fn family_continuation_starts_at_cursor_and_reads_one_lookahead() {
+        let peer = Ipv4Addr::new(192, 0, 2, 1);
+        let mut rib = AdjRibIn::new(peer.into());
+        for octet in 0..6 {
+            rib.insert(crate::test_support::make_route(
+                rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::new(10, 0, octet, 0), 24),
+                peer,
+            ));
+        }
+        let cursor = rib.iter_ordered_from(None).nth(1).map(route_query_key);
+        let scanned = std::cell::Cell::new(0);
+        let page = page_ordered_family(
+            rib.iter_ordered_from(cursor)
+                .inspect(|_| scanned.set(scanned.get() + 1)),
+            Some(Afi::Ipv4),
+            6,
+            2,
+        );
+        assert_eq!((scanned.get(), page.routes.len(), page.total), (3, 2, 6));
+    }
 
     #[test]
     fn canceled_materialized_rows_does_not_invoke_builder() {

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -22,7 +22,7 @@ use crate::update::{
     ExplainBestPath, MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, NeighborRibSnapshot,
     NeighborRibSnapshotResponse, RibRowFilter, RoutePage, RoutePageError, RoutePageVersion,
     RouteQueryFilter, RouteQueryKey, RouteQueryScope, UpdateGroupPeerComparison,
-    WarmMrtSnapshotBudget, WarmMrtSnapshotView, route_query_key,
+    WarmMrtSnapshotBudget, WarmMrtSnapshotView, ordered_route_query, route_query_key,
 };
 
 /// Copy the rows of one non-unicast Loc-RIB table that match the caller's
@@ -540,7 +540,7 @@ impl RibManager {
         // lookahead row. A grouped advertised view may inspect extra index rows
         // while applying member-local split horizon and exact-rejection filters.
         let ordered_family = filter
-            .and_then(|filter| filter.ordered_family())
+            .and_then(ordered_route_query)
             .and_then(|(family, total)| total.map(|total| (family, total)));
         let page = if filter.is_some() && ordered_family.is_none() {
             match scope {

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -573,7 +573,7 @@ impl RibManager {
                 }
             }
         } else {
-            let family = ordered_family.map(|(family, _)| family);
+            let family = ordered_family.and_then(|(family, _)| family);
             let total = |unfiltered: usize| {
                 ordered_family.map_or_else(
                     || u64::try_from(unfiltered).unwrap_or(u64::MAX),

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -613,13 +613,24 @@ impl RibManager {
                     // its view is group table − own-sourced − exact-export
                     // rejections. Both branches resume through their table's
                     // compact prefix index without materializing the scope.
-                    let grouped_total = self.grouped_advertised_count(peer);
                     match self.grouped_advertised_routes_ordered_iter(peer, after) {
-                        Some(routes) => page_ordered_routes(
-                            routes.take_while(move |route| matches_ordered_family(route, family)),
-                            total(grouped_total.unwrap_or_default()),
-                            page_size,
-                        ),
+                        Some(routes) => {
+                            let route_total = ordered_family.map_or_else(
+                                || {
+                                    u64::try_from(
+                                        self.grouped_advertised_count(peer).unwrap_or_default(),
+                                    )
+                                    .unwrap_or(u64::MAX)
+                                },
+                                |(_, total)| total,
+                            );
+                            page_ordered_routes(
+                                routes
+                                    .take_while(move |route| matches_ordered_family(route, family)),
+                                route_total,
+                                page_size,
+                            )
+                        }
                         None => {
                             self.adj_ribs_out
                                 .get(&peer)

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -7,7 +7,27 @@ use std::net::Ipv6Addr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::*;
-use crate::update::{RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope, route_query_key};
+use crate::update::{
+    RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryPredicate, RouteQueryScope,
+    route_query_key,
+};
+
+struct OrderedFamilyProbe {
+    full_scan: Box<dyn Fn(&Route) -> bool + Send + Sync>,
+    ordered_calls: Arc<AtomicUsize>,
+    total: u64,
+}
+
+impl RouteQueryPredicate for OrderedFamilyProbe {
+    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
+        &*self.full_scan
+    }
+
+    fn ordered_family(&self) -> Option<(Afi, Option<u64>)> {
+        self.ordered_calls.fetch_add(1, Ordering::Relaxed);
+        Some((Afi::Ipv4, Some(self.total)))
+    }
+}
 
 async fn query_page(
     tx: &mpsc::Sender<RibUpdate>,
@@ -878,6 +898,58 @@ async fn canceled_paged_query_skips_the_scan() {
         0,
         "canceled query must not scan any route"
     );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn ordered_family_dispatch_resumes_without_full_scan() {
+    let (tx, _target, _out_rx, handle) = seeded_manager().await;
+    let scope = RouteQueryScope::Received { peer: None };
+    tx.send(RibUpdate::RoutesReceived {
+        peer: "2001:db8::1".parse().unwrap(),
+        session_id: 0,
+        announced: vec![make_v6_route(
+            Ipv6Prefix::new("2001:db8:1::".parse().unwrap(), 48),
+            "2001:db8::1".parse().unwrap(),
+        )],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let all = query_page(&tx, scope, None, None, 100).await;
+
+    let (full_scan_calls, ordered_calls) =
+        (Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0)));
+    let full_scan_probe = Arc::clone(&full_scan_calls);
+    let page = query_page_at(
+        &tx,
+        scope,
+        Some(Box::new(OrderedFamilyProbe {
+            full_scan: Box::new(move |_| {
+                full_scan_probe.fetch_add(1, Ordering::Relaxed);
+                true
+            }),
+            ordered_calls: Arc::clone(&ordered_calls),
+            total: 12,
+        })),
+        Some(route_query_key(&all.routes[3])),
+        Some(all.version),
+        2,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(keys(&page.routes), keys(&all.routes[4..6]));
+    assert!(page.has_more, "ordered page clones one lookahead row");
+    assert_eq!(page.total, 12);
+    assert_eq!(ordered_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(full_scan_calls.load(Ordering::Relaxed), 0);
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::*;
 use crate::update::{
-    RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryPredicate, RouteQueryScope,
-    route_query_key,
+    OrderedRouteFamilyFilter, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryPredicate,
+    RouteQueryScope, route_query_key,
 };
 
 struct OrderedFamilyProbe {
@@ -1036,6 +1036,69 @@ fn grouped_pages_match_snapshot_with_split_horizon_and_exact_rejection() {
         }
         assert_eq!(actual, expected, "grouped page size {page_size}");
     }
+}
+
+#[test]
+fn grouped_family_continuation_reuses_total_without_count_walk() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let sibling = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let source = Ipv4Addr::new(192, 0, 2, 1);
+    let _target_rx = peer_up_direct(&mut manager, target);
+    let _sibling_rx = peer_up_direct(&mut manager, sibling);
+    let routes: Vec<_> = (1..=4)
+        .map(|octet| {
+            make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, octet), 32),
+                source,
+            )
+        })
+        .collect();
+    receive_direct(&mut manager, source.into(), routes.clone(), vec![]);
+    manager
+        .peer_unexportable
+        .entry(target)
+        .or_default()
+        .insert(ExactExportKey::Unicast(routes[1].prefix, routes[1].path_id));
+
+    let scope = RouteQueryScope::Advertised { peer: target };
+    manager
+        .grouped_advertised_count_calls
+        .store(0, Ordering::Relaxed);
+    let first = direct_page(&mut manager, scope, None, 1);
+    assert_eq!((first.total, first.has_more), (3, true));
+    assert_eq!(
+        manager
+            .grouped_advertised_count_calls
+            .load(Ordering::Relaxed),
+        1
+    );
+    manager
+        .grouped_advertised_count_calls
+        .store(0, Ordering::Relaxed);
+
+    let filter: RouteQueryFilter = Box::new(OrderedRouteFamilyFilter(Afi::Ipv4, Some(first.total)));
+    let (reply, mut response) = oneshot::channel();
+    manager.handle_query_routes_page_versioned(
+        scope,
+        Some(&filter),
+        first.routes.last().map(route_query_key),
+        Some(first.version),
+        1,
+        reply,
+    );
+    let page = response
+        .try_recv()
+        .expect("route page handler replies synchronously")
+        .unwrap();
+    assert_eq!(page.total, first.total);
+    assert_eq!(
+        manager
+            .grouped_advertised_count_calls
+            .load(Ordering::Relaxed),
+        0
+    );
 }
 
 #[test]

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -8,19 +8,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::*;
 use crate::update::{
-    OrderedAllRoutesFilter, OrderedRouteFamilyFilter, RoutePage, RouteQueryFilter, RouteQueryKey,
-    RouteQueryPredicate, RouteQueryScope, route_query_key,
+    RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope, ordered_route_query_filter,
+    route_query_key,
 };
-
-struct CustomPredicateProbe {
-    full_scan: Box<dyn Fn(&Route) -> bool + Send + Sync>,
-}
-
-impl RouteQueryPredicate for CustomPredicateProbe {
-    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
-        &*self.full_scan
-    }
-}
 
 async fn query_page(
     tx: &mpsc::Sender<RibUpdate>,
@@ -54,6 +44,20 @@ async fn query_page_at(
     .await
     .unwrap();
     reply_rx.await.unwrap()
+}
+
+#[test]
+fn public_route_query_filter_and_command_remain_closure_compatible() {
+    let f: RouteQueryFilter = Box::new(|_: &Route| true);
+    let (reply, _receiver) = oneshot::channel();
+    let _query = RibUpdate::QueryRoutesPage {
+        scope: RouteQueryScope::Best,
+        filter: Some(f),
+        after: None,
+        expected_version: None,
+        page_size: 1,
+        reply,
+    };
 }
 
 /// Drive the resumable loop: follow `has_more` + last-key cursors until
@@ -930,11 +934,9 @@ async fn custom_predicate_continuation_preserves_filter_semantics() {
     let page = query_page_at(
         &tx,
         scope,
-        Some(Box::new(CustomPredicateProbe {
-            full_scan: Box::new(move |route| {
-                full_scan_probe.fetch_add(1, Ordering::Relaxed);
-                route.peer == wanted_peer
-            }),
+        Some(Box::new(move |route: &Route| {
+            full_scan_probe.fetch_add(1, Ordering::Relaxed);
+            route.peer == wanted_peer
         })),
         Some(cursor),
         Some(all.version),
@@ -1078,7 +1080,7 @@ fn grouped_family_and_unfiltered_continuations_reuse_total_without_count_walk() 
         .grouped_advertised_count_calls
         .store(0, Ordering::Relaxed);
 
-    let filter: RouteQueryFilter = Box::new(OrderedRouteFamilyFilter(Afi::Ipv4, Some(first.total)));
+    let filter = ordered_route_query_filter(Some(Afi::Ipv4), Some(first.total));
     let (reply, mut response) = oneshot::channel();
     manager.handle_query_routes_page_versioned(
         scope,
@@ -1100,7 +1102,7 @@ fn grouped_family_and_unfiltered_continuations_reuse_total_without_count_walk() 
         0
     );
 
-    let filter: RouteQueryFilter = Box::new(OrderedAllRoutesFilter(first.total));
+    let filter = ordered_route_query_filter(None, Some(first.total));
     let (reply, mut response) = oneshot::channel();
     manager.handle_query_routes_page_versioned(
         scope,

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -8,24 +8,17 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::*;
 use crate::update::{
-    OrderedRouteFamilyFilter, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryPredicate,
-    RouteQueryScope, route_query_key,
+    OrderedAllRoutesFilter, OrderedRouteFamilyFilter, RoutePage, RouteQueryFilter, RouteQueryKey,
+    RouteQueryPredicate, RouteQueryScope, route_query_key,
 };
 
-struct OrderedFamilyProbe {
+struct CustomPredicateProbe {
     full_scan: Box<dyn Fn(&Route) -> bool + Send + Sync>,
-    ordered_calls: Arc<AtomicUsize>,
-    total: u64,
 }
 
-impl RouteQueryPredicate for OrderedFamilyProbe {
+impl RouteQueryPredicate for CustomPredicateProbe {
     fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
         &*self.full_scan
-    }
-
-    fn ordered_family(&self) -> Option<(Afi, Option<u64>)> {
-        self.ordered_calls.fetch_add(1, Ordering::Relaxed);
-        Some((Afi::Ipv4, Some(self.total)))
     }
 }
 
@@ -904,7 +897,7 @@ async fn canceled_paged_query_skips_the_scan() {
 }
 
 #[tokio::test]
-async fn ordered_family_dispatch_resumes_without_full_scan() {
+async fn custom_predicate_continuation_preserves_filter_semantics() {
     let (tx, _target, _out_rx, handle) = seeded_manager().await;
     let scope = RouteQueryScope::Received { peer: None };
     tx.send(RibUpdate::RoutesReceived {
@@ -924,32 +917,39 @@ async fn ordered_family_dispatch_resumes_without_full_scan() {
     .unwrap();
     let all = query_page(&tx, scope, None, None, 100).await;
 
-    let (full_scan_calls, ordered_calls) =
-        (Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0)));
+    let wanted_peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let expected: Vec<_> = all
+        .routes
+        .iter()
+        .filter(|route| route.peer == wanted_peer)
+        .cloned()
+        .collect();
+    let cursor = route_query_key(&expected[0]);
+    let full_scan_calls = Arc::new(AtomicUsize::new(0));
     let full_scan_probe = Arc::clone(&full_scan_calls);
     let page = query_page_at(
         &tx,
         scope,
-        Some(Box::new(OrderedFamilyProbe {
-            full_scan: Box::new(move |_| {
+        Some(Box::new(CustomPredicateProbe {
+            full_scan: Box::new(move |route| {
                 full_scan_probe.fetch_add(1, Ordering::Relaxed);
-                true
+                route.peer == wanted_peer
             }),
-            ordered_calls: Arc::clone(&ordered_calls),
-            total: 12,
         })),
-        Some(route_query_key(&all.routes[3])),
+        Some(cursor),
         Some(all.version),
         2,
     )
     .await
     .unwrap();
 
-    assert_eq!(keys(&page.routes), keys(&all.routes[4..6]));
-    assert!(page.has_more, "ordered page clones one lookahead row");
-    assert_eq!(page.total, 12);
-    assert_eq!(ordered_calls.load(Ordering::Relaxed), 1);
-    assert_eq!(full_scan_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(keys(&page.routes), keys(&expected[1..3]));
+    assert!(page.has_more);
+    assert_eq!(page.total, 4);
+    assert_eq!(
+        full_scan_calls.load(Ordering::Relaxed),
+        usize::try_from(all.total).unwrap()
+    );
 
     drop(tx);
     handle.await.unwrap();
@@ -1039,7 +1039,7 @@ fn grouped_pages_match_snapshot_with_split_horizon_and_exact_rejection() {
 }
 
 #[test]
-fn grouped_family_continuation_reuses_total_without_count_walk() {
+fn grouped_family_and_unfiltered_continuations_reuse_total_without_count_walk() {
     let (_tx, rx) = mpsc::channel(1);
     let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
@@ -1079,6 +1079,28 @@ fn grouped_family_continuation_reuses_total_without_count_walk() {
         .store(0, Ordering::Relaxed);
 
     let filter: RouteQueryFilter = Box::new(OrderedRouteFamilyFilter(Afi::Ipv4, Some(first.total)));
+    let (reply, mut response) = oneshot::channel();
+    manager.handle_query_routes_page_versioned(
+        scope,
+        Some(&filter),
+        first.routes.last().map(route_query_key),
+        Some(first.version),
+        1,
+        reply,
+    );
+    let page = response
+        .try_recv()
+        .expect("route page handler replies synchronously")
+        .unwrap();
+    assert_eq!(page.total, first.total);
+    assert_eq!(
+        manager
+            .grouped_advertised_count_calls
+            .load(Ordering::Relaxed),
+        0
+    );
+
+    let filter: RouteQueryFilter = Box::new(OrderedAllRoutesFilter(first.total));
     let (reply, mut response) = oneshot::channel();
     manager.handle_query_routes_page_versioned(
         scope,

--- a/crates/rib/src/manager/update_groups/views.rs
+++ b/crates/rib/src/manager/update_groups/views.rs
@@ -400,6 +400,9 @@ impl RibManager {
     /// Synthesized advertised-route count for a grouped peer; `None`
     /// for ungrouped peers.
     pub(in crate::manager) fn grouped_advertised_count(&self, peer: IpAddr) -> Option<usize> {
+        #[cfg(test)]
+        self.grouped_advertised_count_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let group = self.group_ribs.get(&self.grouped_member_of(peer)?)?;
         if self.outbound_prefix_limits.contains_key(&peer) {
             // A limited member advertises its admitted projection, and that

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1260,12 +1260,14 @@ pub struct OrderedRouteFamilyFilter(pub Afi, pub Option<u64>);
 
 static IPV4_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V4(_));
 static IPV6_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V6(_));
+static NO_ROUTE_FILTER: fn(&Route) -> bool = |_| false;
 
 impl RouteQueryPredicate for OrderedRouteFamilyFilter {
     fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
         match self.0 {
             Afi::Ipv4 => &IPV4_ROUTE_FILTER,
-            _ => &IPV6_ROUTE_FILTER,
+            Afi::Ipv6 => &IPV6_ROUTE_FILTER,
+            _ => &NO_ROUTE_FILTER,
         }
     }
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1239,7 +1239,50 @@ pub fn route_query_key(route: &Route) -> RouteQueryKey {
 }
 
 /// Row filter evaluated inside the RIB task during a paged route query.
-pub type RouteQueryFilter = Box<dyn Fn(&Route) -> bool + Send + Sync>;
+pub trait RouteQueryPredicate: Send + Sync {
+    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static);
+
+    fn ordered_family(&self) -> Option<(Afi, Option<u64>)> {
+        None
+    }
+}
+
+impl<F> RouteQueryPredicate for F
+where
+    F: for<'a> Fn(&'a Route) -> bool + Send + Sync + 'static,
+{
+    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
+        self
+    }
+}
+
+pub struct OrderedRouteFamilyFilter(pub Afi, pub Option<u64>);
+
+static IPV4_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V4(_));
+static IPV6_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V6(_));
+
+impl RouteQueryPredicate for OrderedRouteFamilyFilter {
+    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
+        match self.0 {
+            Afi::Ipv4 => &IPV4_ROUTE_FILTER,
+            _ => &IPV6_ROUTE_FILTER,
+        }
+    }
+
+    fn ordered_family(&self) -> Option<(Afi, Option<u64>)> {
+        Some((self.0, self.1))
+    }
+}
+
+impl std::ops::Deref for dyn RouteQueryPredicate {
+    type Target = dyn Fn(&Route) -> bool + Send + Sync + 'static;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_filter()
+    }
+}
+
+pub type RouteQueryFilter = Box<dyn RouteQueryPredicate>;
 
 /// Row filter evaluated inside the RIB task while copying one non-unicast
 /// Loc-RIB table (EVPN, BGP-LS, VPN, labeled-unicast, RT-Constrain,

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1239,12 +1239,8 @@ pub fn route_query_key(route: &Route) -> RouteQueryKey {
 }
 
 /// Row filter evaluated inside the RIB task during a paged route query.
-pub trait RouteQueryPredicate: Send + Sync {
+pub trait RouteQueryPredicate: Send + Sync + Any {
     fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static);
-
-    fn ordered_family(&self) -> Option<(Afi, Option<u64>)> {
-        None
-    }
 }
 
 impl<F> RouteQueryPredicate for F
@@ -1258,9 +1254,13 @@ where
 
 pub struct OrderedRouteFamilyFilter(pub Afi, pub Option<u64>);
 
+/// Trusted marker for an unfiltered continuation carrying its signed total.
+pub struct OrderedAllRoutesFilter(pub u64);
+
 static IPV4_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V4(_));
 static IPV6_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V6(_));
 static NO_ROUTE_FILTER: fn(&Route) -> bool = |_| false;
+static ALL_ROUTE_FILTER: fn(&Route) -> bool = |_| true;
 
 impl RouteQueryPredicate for OrderedRouteFamilyFilter {
     fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
@@ -1270,9 +1270,25 @@ impl RouteQueryPredicate for OrderedRouteFamilyFilter {
             _ => &NO_ROUTE_FILTER,
         }
     }
+}
 
-    fn ordered_family(&self) -> Option<(Afi, Option<u64>)> {
-        Some((self.0, self.1))
+impl RouteQueryPredicate for OrderedAllRoutesFilter {
+    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
+        &ALL_ROUTE_FILTER
+    }
+}
+
+impl dyn RouteQueryPredicate {
+    /// Ordered-query capability sealed to the two built-in marker types.
+    #[must_use]
+    pub fn ordered_family(&self) -> Option<(Option<Afi>, Option<u64>)> {
+        let predicate = self as &dyn Any;
+        if let Some(filter) = predicate.downcast_ref::<OrderedRouteFamilyFilter>() {
+            return Some((Some(filter.0), filter.1));
+        }
+        predicate
+            .downcast_ref::<OrderedAllRoutesFilter>()
+            .map(|filter| (None, Some(filter.0)))
     }
 }
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2,8 +2,8 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::num::NonZeroU32;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 use rustbgpd_policy::PolicyChain;
@@ -1239,68 +1239,118 @@ pub fn route_query_key(route: &Route) -> RouteQueryKey {
 }
 
 /// Row filter evaluated inside the RIB task during a paged route query.
-pub trait RouteQueryPredicate: Send + Sync + Any {
-    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static);
+pub type RouteQueryFilter = Box<dyn Fn(&Route) -> bool + Send + Sync>;
+
+type OrderedRouteQuery = (Option<Afi>, Option<u64>);
+
+static ORDERED_ROUTE_QUERIES: OnceLock<Mutex<HashMap<usize, OrderedRouteQuery>>> = OnceLock::new();
+
+struct OrderedRouteQueryRegistration {
+    filter_identity: AtomicUsize,
 }
 
-impl<F> RouteQueryPredicate for F
-where
-    F: for<'a> Fn(&'a Route) -> bool + Send + Sync + 'static,
-{
-    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
-        self
-    }
-}
-
-pub struct OrderedRouteFamilyFilter(pub Afi, pub Option<u64>);
-
-/// Trusted marker for an unfiltered continuation carrying its signed total.
-pub struct OrderedAllRoutesFilter(pub u64);
-
-static IPV4_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V4(_));
-static IPV6_ROUTE_FILTER: fn(&Route) -> bool = |route| matches!(route.prefix, Prefix::V6(_));
-static NO_ROUTE_FILTER: fn(&Route) -> bool = |_| false;
-static ALL_ROUTE_FILTER: fn(&Route) -> bool = |_| true;
-
-impl RouteQueryPredicate for OrderedRouteFamilyFilter {
-    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
-        match self.0 {
-            Afi::Ipv4 => &IPV4_ROUTE_FILTER,
-            Afi::Ipv6 => &IPV6_ROUTE_FILTER,
-            _ => &NO_ROUTE_FILTER,
+impl Drop for OrderedRouteQueryRegistration {
+    fn drop(&mut self) {
+        let identity = self.filter_identity.load(Ordering::Relaxed);
+        if let Some(registry) = ORDERED_ROUTE_QUERIES.get() {
+            registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&identity);
         }
     }
 }
 
-impl RouteQueryPredicate for OrderedAllRoutesFilter {
-    fn as_filter(&self) -> &(dyn Fn(&Route) -> bool + Send + Sync + 'static) {
-        &ALL_ROUTE_FILTER
-    }
+fn route_query_filter_identity(filter: &RouteQueryFilter) -> usize {
+    let pointer: *const (dyn Fn(&Route) -> bool + Send + Sync) = &**filter;
+    pointer.cast::<()>() as usize
 }
 
-impl dyn RouteQueryPredicate {
-    /// Ordered-query capability sealed to the two built-in marker types.
-    #[must_use]
-    pub fn ordered_family(&self) -> Option<(Option<Afi>, Option<u64>)> {
-        let predicate = self as &dyn Any;
-        if let Some(filter) = predicate.downcast_ref::<OrderedRouteFamilyFilter>() {
-            return Some((Some(filter.0), filter.1));
-        }
-        predicate
-            .downcast_ref::<OrderedAllRoutesFilter>()
-            .map(|filter| (None, Some(filter.0)))
-    }
+/// Build the trusted family-only closure used by the API's ordered continuations.
+#[doc(hidden)]
+#[must_use]
+pub fn ordered_route_query_filter(
+    family: Option<Afi>,
+    known_total: Option<u64>,
+) -> RouteQueryFilter {
+    let registration = Arc::new(OrderedRouteQueryRegistration {
+        filter_identity: AtomicUsize::new(0),
+    });
+    let keep_registered = Arc::clone(&registration);
+    let filter: RouteQueryFilter = Box::new(move |route| {
+        let _ = &keep_registered;
+        family.is_none_or(|family| match family {
+            Afi::Ipv4 => matches!(route.prefix, Prefix::V4(_)),
+            Afi::Ipv6 => matches!(route.prefix, Prefix::V6(_)),
+            _ => false,
+        })
+    });
+    let identity = route_query_filter_identity(&filter);
+    registration
+        .filter_identity
+        .store(identity, Ordering::Relaxed);
+    let replaced = ORDERED_ROUTE_QUERIES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(identity, (family, known_total));
+    debug_assert!(
+        replaced.is_none(),
+        "live route-query filter identity reused"
+    );
+    filter
 }
 
-impl std::ops::Deref for dyn RouteQueryPredicate {
-    type Target = dyn Fn(&Route) -> bool + Send + Sync + 'static;
-
-    fn deref(&self) -> &Self::Target {
-        self.as_filter()
-    }
+pub(crate) fn ordered_route_query(filter: &RouteQueryFilter) -> Option<OrderedRouteQuery> {
+    ORDERED_ROUTE_QUERIES
+        .get()?
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&route_query_filter_identity(filter))
+        .copied()
 }
 
-pub type RouteQueryFilter = Box<dyn RouteQueryPredicate>;
+#[cfg(test)]
+mod ordered_route_query_filter_tests {
+    use super::*;
+
+    #[test]
+    fn metadata_is_factory_only_and_scoped_to_each_live_closure() {
+        let filter = ordered_route_query_filter(Some(Afi::Ipv4), Some(7));
+        let all_routes = ordered_route_query_filter(None, Some(11));
+        assert_eq!(
+            ordered_route_query(&filter),
+            Some((Some(Afi::Ipv4), Some(7)))
+        );
+        assert_eq!(ordered_route_query(&all_routes), Some((None, Some(11))));
+        drop(filter);
+        assert_eq!(ordered_route_query(&all_routes), Some((None, Some(11))));
+
+        let ordinary: RouteQueryFilter = Box::new(|_: &Route| true);
+        assert_eq!(ordered_route_query(&ordinary), None);
+    }
+
+    #[test]
+    fn registration_drop_removes_its_registry_entry() {
+        let identity = usize::MAX;
+        let registry = ORDERED_ROUTE_QUERIES.get_or_init(|| Mutex::new(HashMap::new()));
+        let replaced = registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(identity, (None, Some(1)));
+        assert_eq!(replaced, None);
+
+        drop(OrderedRouteQueryRegistration {
+            filter_identity: AtomicUsize::new(identity),
+        });
+        assert!(
+            !registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .contains_key(&identity)
+        );
+    }
+}
 
 /// Row filter evaluated inside the RIB task while copying one non-unicast
 /// Loc-RIB table (EVPN, BGP-LS, VPN, labeled-unicast, RT-Constrain,

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -45,6 +45,7 @@ Flags (also settable via env):
 | `--protocol-alias-file PATH` | `BIRDWATCHER_ADAPTER_PROTOCOL_ALIAS_FILE` | (unset) | File-backed aliases; mutually exclusive with `--protocol-alias` |
 | `--arouteserver-reject-communities-file PATH` | `BIRDWATCHER_ADAPTER_AROUTESERVER_REJECT_COMMUNITIES_FILE` | (unset) | Startup-only artifact emitted by `rs-config-render` for effective `tag_and_reject` peers |
 | `--max-routes` | `BIRDWATCHER_ADAPTER_MAX_ROUTES` | `1000` | Maximum RIB-derived route-array response size; must be non-zero |
+| `--max-lpm-scan-routes` | `BIRDWATCHER_ADAPTER_MAX_LPM_SCAN_ROUTES` | `10000` | Maximum route rows scanned by a protocol/export longest-match fallback; must be non-zero |
 
 The command-line token path takes precedence over the environment variable.
 The adapter reads it once at startup, trims trailing whitespace, and rejects
@@ -172,9 +173,13 @@ use `/route/<prefix>%2F<mask>/protocol/{id}`,
 The protocol and export views are longest-match, like Bird's Eye's
 `show route for`: they request an exact prefix on every gRPC page, retain
 every Add-Path candidate in daemon order, and when the queried prefix has no
-entry they answer with the view's most-specific covering prefix (a linear
-scan over that member's paged view — there is no covering-prefix RPC filter);
-`--max-routes` applies only to the routes of the one matched prefix.
+entry they answer with the view's most-specific covering prefix. Exact and
+fallback pages are scoped to the queried IPv4 or IPv6 unicast family. The
+fallback is a linear scan because there is no covering-prefix RPC filter;
+`--max-lpm-scan-routes` bounds that work separately, while `--max-routes`
+applies only to the routes returned for the one matched prefix. If the scan
+budget is exhausted before the peer view is complete, the request returns a
+sanitized HTTP 403 and never evaluates the partial view.
 The table view instead performs one bounded longest-prefix lookup and atomically
 returns the installed winner first followed by every same-prefix alternative;
 it applies `--max-routes` before rendering. Syntactically valid input with

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -110,6 +110,15 @@ struct Args {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     max_routes: u64,
+
+    /// Maximum route rows scanned by a longest-match fallback.
+    #[arg(
+        long,
+        env = "BIRDWATCHER_ADAPTER_MAX_LPM_SCAN_ROUTES",
+        default_value_t = 10_000,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    max_lpm_scan_routes: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -548,6 +557,7 @@ struct AppState {
     identities: Arc<IdentityResolver>,
     identity_store: Arc<ResolverStore>,
     max_routes: u64,
+    max_lpm_scan_routes: u64,
     arouteserver_reject_communities: Option<Arc<ArsRejectCommunities>>,
 }
 
@@ -558,6 +568,7 @@ impl Clone for AppState {
             identities: self.identity_store.snapshot(),
             identity_store: Arc::clone(&self.identity_store),
             max_routes: self.max_routes,
+            max_lpm_scan_routes: self.max_lpm_scan_routes,
             arouteserver_reject_communities: self.arouteserver_reject_communities.clone(),
         }
     }
@@ -597,6 +608,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         identities: identity_store.snapshot(),
         identity_store,
         max_routes: args.max_routes,
+        max_lpm_scan_routes: args.max_lpm_scan_routes,
         arouteserver_reject_communities: args
             .arouteserver_reject_communities_file
             .as_deref()
@@ -1287,6 +1299,13 @@ impl ExactPrefix {
         (length <= width && network_aligned(address, length)).then_some(Self { address, length })
     }
 
+    fn family(self) -> i32 {
+        match self.address {
+            IpAddr::V4(_) => proto::AddressFamily::Ipv4Unicast as i32,
+            IpAddr::V6(_) => proto::AddressFamily::Ipv6Unicast as i32,
+        }
+    }
+
     fn covers(self, query: Self) -> bool {
         if self.length > query.length {
             return false;
@@ -1360,7 +1379,7 @@ fn exact_route_request(
     };
     proto::ListRoutesRequest {
         neighbor_address: peer.to_string(),
-        afi_safi: proto::AddressFamily::Unspecified as i32,
+        afi_safi: prefix.family(),
         page_size: 1000,
         page_token,
         prefix_filter,
@@ -1368,6 +1387,48 @@ fn exact_route_request(
         longer_prefixes: false,
         ..Default::default()
     }
+}
+
+fn view_route_request(
+    peer: IpAddr,
+    prefix: ExactPrefix,
+    page_token: String,
+    remaining: u64,
+) -> proto::ListRoutesRequest {
+    proto::ListRoutesRequest {
+        neighbor_address: peer.to_string(),
+        afi_safi: prefix.family(),
+        page_size: remaining.min(1000) as u32,
+        page_token,
+        ..Default::default()
+    }
+}
+
+fn lpm_scan_limit(max_scan_routes: u64) -> HttpError {
+    json_error(
+        StatusCode::FORBIDDEN,
+        format!(
+            "Longest-match scan limit reached before the peer view was exhausted ({max_scan_routes}/{max_scan_routes} routes)"
+        ),
+    )
+}
+
+fn append_view_page(
+    view: &mut Vec<proto::Route>,
+    page: Vec<proto::Route>,
+    next_page_token: &str,
+    max_scan_routes: u64,
+) -> Result<(), HttpError> {
+    let remaining = max_scan_routes.saturating_sub(view.len() as u64);
+    if page.len() as u64 > remaining {
+        return Err(lpm_scan_limit(max_scan_routes));
+    }
+    let accumulated = view.len() as u64 + page.len() as u64;
+    if accumulated == max_scan_routes && !next_page_token.is_empty() {
+        return Err(lpm_scan_limit(max_scan_routes));
+    }
+    view.extend(page);
+    Ok(())
 }
 
 fn append_exact_routes(
@@ -1399,18 +1460,15 @@ async fn route_export(
 async fn view_routes(
     client: &mut proto::rib_service_client::RibServiceClient<Upstream>,
     peer: IpAddr,
+    prefix: ExactPrefix,
     source: ExactRouteSource,
+    max_scan_routes: u64,
 ) -> Result<Vec<proto::Route>, HttpError> {
     let mut view = Vec::new();
     let mut page_token = String::new();
     loop {
-        let request = proto::ListRoutesRequest {
-            neighbor_address: peer.to_string(),
-            afi_safi: proto::AddressFamily::Unspecified as i32,
-            page_size: 1000,
-            page_token,
-            ..Default::default()
-        };
+        let remaining = max_scan_routes.saturating_sub(view.len() as u64);
+        let request = view_route_request(peer, prefix, page_token, remaining);
         let response = match source {
             ExactRouteSource::Received => client
                 .list_received_routes(request)
@@ -1422,11 +1480,17 @@ async fn view_routes(
                 .map_err(|error| bad_gateway("ListAdvertisedRoutes", &error))?,
         }
         .into_inner();
-        view.extend(response.routes);
-        if response.next_page_token.is_empty() {
+        let next_page_token = response.next_page_token;
+        append_view_page(
+            &mut view,
+            response.routes,
+            &next_page_token,
+            max_scan_routes,
+        )?;
+        if next_page_token.is_empty() {
             break;
         }
-        page_token = response.next_page_token;
+        page_token = next_page_token;
     }
     Ok(view)
 }
@@ -1471,7 +1535,8 @@ async fn serve_exact_route(
     // matched prefix's candidates, not to the scanned view.
     let mut matched = prefix;
     if routes.is_empty() {
-        let view = view_routes(&mut client, peer, source).await?;
+        let view =
+            view_routes(&mut client, peer, prefix, source, state.max_lpm_scan_routes).await?;
         if let Some(covering) = longest_match(&view, prefix) {
             routes = view
                 .into_iter()
@@ -2578,6 +2643,7 @@ mod tests {
             identities: store.snapshot(),
             identity_store: store,
             max_routes: 1,
+            max_lpm_scan_routes: 10_000,
             arouteserver_reject_communities: None,
         };
         let mut neighbor = proto::NeighborState {
@@ -3437,6 +3503,7 @@ mod tests {
             identities: store.snapshot(),
             identity_store: Arc::clone(&store),
             max_routes: 1,
+            max_lpm_scan_routes: 10_000,
             arouteserver_reject_communities: None,
         };
         let request_a = state.clone();
@@ -3479,16 +3546,26 @@ mod tests {
         assert_eq!(api["Version"], api["version"]);
         assert!(api["version"].as_str().unwrap().starts_with("rustbgpd "));
 
-        assert!(
-            Args::try_parse_from([
-                "birdwatcher-adapter",
-                "--grpc-addr",
-                "http://127.0.0.1:50051",
-                "--max-routes",
-                "0",
-            ])
-            .is_err()
-        );
+        let defaults = Args::try_parse_from([
+            "birdwatcher-adapter",
+            "--grpc-addr",
+            "http://127.0.0.1:50051",
+        ])
+        .unwrap();
+        assert_eq!(defaults.max_lpm_scan_routes, 10_000);
+
+        for flag in ["--max-routes", "--max-lpm-scan-routes"] {
+            assert!(
+                Args::try_parse_from([
+                    "birdwatcher-adapter",
+                    "--grpc-addr",
+                    "http://127.0.0.1:50051",
+                    flag,
+                    "0",
+                ])
+                .is_err()
+            );
+        }
     }
 
     #[test]
@@ -3575,6 +3652,7 @@ mod tests {
             identities: store.snapshot(),
             identity_store: store,
             max_routes: 7,
+            max_lpm_scan_routes: 10_000,
             arouteserver_reject_communities: None,
         };
         for source in [ExactRouteSource::Received, ExactRouteSource::Advertised] {
@@ -3609,19 +3687,33 @@ mod tests {
     #[test]
     fn exact_route_requests_pin_every_filter_on_every_page_and_unknown_id_is_404() {
         let peer: IpAddr = "192.0.2.1".parse().unwrap();
-        let prefix = ExactPrefix::parse("2001:db8::/32").unwrap().unwrap();
-        for source in [ExactRouteSource::Received, ExactRouteSource::Advertised] {
-            for token in ["", "opaque-page-2"] {
+        for (value, address, length, family) in [
+            (
+                "192.0.2.0/24",
+                "192.0.2.0",
+                24,
+                proto::AddressFamily::Ipv4Unicast,
+            ),
+            (
+                "2001:db8::/32",
+                "2001:db8::",
+                32,
+                proto::AddressFamily::Ipv6Unicast,
+            ),
+        ] {
+            let prefix = ExactPrefix::parse(value).unwrap().unwrap();
+            for (source, token) in [
+                (ExactRouteSource::Received, ""),
+                (ExactRouteSource::Received, "opaque-page-2"),
+                (ExactRouteSource::Advertised, ""),
+                (ExactRouteSource::Advertised, "opaque-page-2"),
+            ] {
                 let request = exact_route_request(peer, prefix, token.to_string(), source);
                 assert_eq!(request.neighbor_address, peer.to_string(), "{source:?}");
-                assert_eq!(request.prefix_filter, "2001:db8::", "{source:?}");
-                assert_eq!(request.prefix_filter_length, 32, "{source:?}");
+                assert_eq!(request.prefix_filter, address, "{source:?}");
+                assert_eq!(request.prefix_filter_length, length, "{source:?}");
                 assert!(!request.longer_prefixes, "{source:?}");
-                assert_eq!(
-                    request.afi_safi,
-                    proto::AddressFamily::Unspecified as i32,
-                    "{source:?}"
-                );
+                assert_eq!(request.afi_safi, family as i32, "{source:?}");
                 assert_eq!(request.page_token, token, "{source:?}");
             }
         }
@@ -3629,6 +3721,59 @@ mod tests {
         let (status, Json(body)) = resolver.resolve("missing-alias").unwrap_err();
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(body, serde_json::json!({"message":"Protocol not found"}));
+    }
+
+    #[test]
+    fn fallback_pages_pin_family_token_shrinking_budget_and_complete_view() {
+        let peer: IpAddr = "192.0.2.1".parse().unwrap();
+        for (value, family) in [
+            ("192.0.2.1/32", proto::AddressFamily::Ipv4Unicast),
+            ("2001:db8::1/128", proto::AddressFamily::Ipv6Unicast),
+        ] {
+            let prefix = ExactPrefix::parse(value).unwrap().unwrap();
+            for (token, remaining, page_size) in [("", 10_000, 1000), ("opaque-page-2", 999, 999)] {
+                let request = view_route_request(peer, prefix, token.to_string(), remaining);
+                assert_eq!(request.neighbor_address, peer.to_string());
+                assert_eq!(request.afi_safi, family as i32);
+                assert_eq!(request.page_token, token);
+                assert_eq!(request.page_size, page_size);
+            }
+        }
+
+        let route = || proto::Route::default();
+        let mut below = Vec::new();
+        append_view_page(&mut below, vec![route()], "next", 3).unwrap();
+        append_view_page(&mut below, vec![route()], "", 3).unwrap();
+        assert_eq!(below.len(), 2);
+
+        let mut exact = vec![route(), route()];
+        append_view_page(&mut exact, vec![route()], "", 3).unwrap();
+        assert_eq!(exact.len(), 3);
+
+        for (mut view, page, token) in [
+            (vec![route(), route()], vec![route()], "next"),
+            (vec![route(), route()], vec![route(), route()], ""),
+        ] {
+            let before = view.len();
+            let (status, Json(body)) = append_view_page(&mut view, page, token, 3).unwrap_err();
+            assert_eq!(status, StatusCode::FORBIDDEN);
+            assert_eq!(
+                body,
+                serde_json::json!({
+                    "message": "Longest-match scan limit reached before the peer view was exhausted (3/3 routes)"
+                })
+            );
+            assert_eq!(view.len(), before, "a refused page must not be evaluated");
+        }
+
+        let (status, Json(body)) = lpm_scan_limit(10_000);
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "message": "Longest-match scan limit reached before the peer view was exhausted (10000/10000 routes)"
+            })
+        );
     }
 
     #[test]

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -829,6 +829,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .arg("--arouteserver-reject-communities-file")
             .arg(&ars_artifact)
             .args(["--max-routes", "2"])
+            .args(["--max-lpm-scan-routes", "3"])
             .stdout(Stdio::null())
             .stderr(Stdio::from(
                 std::fs::File::create(&adapter_stderr).expect("adapter stderr log"),


### PR DESCRIPTION
## Summary

- add a separate positive 10,000-row default budget for protocol and export longest-match fallback scans
- scope exact and fallback pages to the queried IPv4 or IPv6 family and shrink requests to the remaining budget
- return a sanitized HTTP 403 without evaluating a partial view when continuation remains at the exact limit
- make family-only continuations resume from persistent ordered cursors instead of repeating a full RIB scan
- preserve the public closure filter boundary while binding trusted ordered metadata only to private factory-created closure lifetimes; custom predicates retain identical full-evaluation filtering on continuation pages
- integrity-bind every opaque continuation field, including the exact family total, with a process-local tag
- reuse signed totals for family-scoped and unfiltered grouped advertised continuations without repeating the exact-export rejection count walk
- make empty-cursor IPv6 ordered pages lazily pass the preceding IPv4 partition before taking the bounded IPv6 page

Tokens intentionally expire across daemon restarts. The first family page still performs the required exact-total scan; ordered pages clone only the requested family rows plus one lookahead. Empty-cursor IPv6 pages may inspect the preceding IPv4 partition but do not clone or materialize it.

## Validation

- full RIB and API library suites, plus exact custom-predicate, unfiltered-total-reuse, and signed-marker regressions
- mixed-family IPv6 first-page/continuation and grouped-export no-recount regressions
- all adapter tests and both Birdwatcher smoke tests
- strict all-target/all-feature RIB, API, and adapter Clippy
- public documentation and lint-reason checker suites
- exact-current-main full pre-push formatting, workspace Clippy, tests, and rustdoc
- independent semantic review with every current-head finding addressed

Linear: LAN-1263

