### PR TITLE
docs: add stability contract navigation (LAN-1185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ fabric use.
 
 > **Alpha expectations:** The config format and gRPC API are not yet frozen.
 > Breaking changes are possible between minor versions. The supported daemon
+> exception and separate compatibility boundaries are mapped in
+> [Stability and compatibility](docs/stability.md). The supported daemon
 > targets are Linux x86_64 and aarch64; see the canonical
 > [platform support contract](SUPPORT.md#platform-support) and
 > [Project Status](#project-status) for details.
@@ -512,6 +514,7 @@ evolving API.**
 | [docs/gobgp-parity.md](docs/gobgp-parity.md) | rustbgpd vs GoBGP feature parity by use case |
 | [docs/adr/](docs/adr/) | Architecture decision records — one per protocol and design choice |
 | [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md) | Pre-release smoke matrix and release steps |
+| [docs/stability.md](docs/stability.md) | Stability map: narrow daemon inventory, crate SemVer, authorization tiers, and adapter compatibility |
 | [docs/v1-stable-contract.md](docs/v1-stable-contract.md) | Narrow machine-pinned v1 compatibility contract for proven route-server / route-reflector roles |
 | [ROADMAP.md](ROADMAP.md) | Remaining gaps and planned work |
 | [CHANGELOG.md](CHANGELOG.md) | Release history |

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ control-plane target and expanding toward cloud / AI-scale data-center
 fabric use.
 
 > **Alpha expectations:** The config format and gRPC API are not yet frozen.
-> Breaking changes are possible between minor versions. The supported daemon
+> Breaking changes are possible between minor versions. The narrow daemon
 > exception and separate compatibility boundaries are mapped in
-> [Stability and compatibility](docs/stability.md). The supported daemon
-> targets are Linux x86_64 and aarch64; see the canonical
+> [Stability and compatibility](docs/stability.md). Supported daemon targets
+> are Linux x86_64 and aarch64; see the canonical
 > [platform support contract](SUPPORT.md#platform-support) and
 > [Project Status](#project-status) for details.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Start here if you have never run the daemon.
 | [CONFIGURATION.md](CONFIGURATION.md) | Every TOML config key, with examples |
 | [rustbgpd.schema.json](rustbgpd.schema.json) | JSON Schema for the TOML config (editor integration; regenerated via `--dump-config-schema`) |
 | [reload-matrix.md](reload-matrix.md) | Per-field reload classification: live, reload-applied, restart-required, rejected |
+| [stability.md](stability.md) | Authoritative navigation for the narrow daemon contract, crate SemVer, authorization tiers, and adapter compatibility |
 | [API.md](API.md) | gRPC API reference with examples for every RPC |
 | [grpc-method-inventory.md](grpc-method-inventory.md) | Authorization tier of every gRPC method (machine-readable twin: [grpc-method-inventory.json](grpc-method-inventory.json)) |
 | [rpol-language.md](rpol-language.md) | The `.rpol` typed policy language, ADR-0096 |

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,74 @@
+# Stability and compatibility
+
+rustbgpd remains **public alpha overall**. Features can be shipped, tested, or
+assigned an authorization tier without becoming compatibility promises.
+
+This page is navigation, not another inventory. When wording here and a linked
+contract differ, use the linked contract.
+
+## Narrow stable daemon surface
+
+The only stable daemon boundary is the exact inventory in
+[`v1-stable-surface.json`](v1-stable-surface.json). It applies to the listed
+surfaces for the `route-server-unicast` and `route-reflector-unicast` roles;
+absence from that inventory means absence from the v1 promise.
+
+Read the inventory with the
+[v1 route-server / route-reflector contract](v1-stable-contract.md), which
+defines compatible evolution, migration support, and the evidence required for
+a breaking change. Do not infer stability for a containing config object,
+protobuf service, CLI subtree, JSON object, or feature from one inventoried
+member.
+
+In particular:
+
+- EVPN, including EVPN route-reflector use, remains alpha.
+- Linux dataplane work, including FIB and managed-netdev behavior, remains
+  outside the control-plane contract.
+- Experimental features remain outside the contract.
+- Unlisted RPCs and CLI commands remain alpha. For an inventoried CLI command,
+  only the dimensions named by the inventory are stable; flags and output are
+  not stable by implication.
+
+For operational boundaries and non-goals, see
+[`LIMITATIONS.md`](LIMITATIONS.md).
+
+## Authorization is a different classification
+
+The [gRPC method inventory](grpc-method-inventory.md) assigns every method an
+authorization tier. A tier answers who may call a method and which listener may
+serve it; it does **not** classify compatibility. Check
+[`v1-stable-surface.json`](v1-stable-surface.json) separately before treating
+an RPC signature or behavior as stable.
+
+## Embedding and crate versions
+
+Published Rust crates follow their own SemVer boundary, independently of the
+daemon's narrow v1 contract. Use the versions and upgrade guidance in
+[`EMBEDDING.md`](EMBEDDING.md#published-crate-release-boundary), including the
+per-release compatibility notes and coordinated dependency guidance. A daemon
+release or an inventoried daemon surface does not make an internal workspace
+crate a supported library API.
+
+## Bird's Eye adapter compatibility
+
+`birdwatcher-adapter` has a separate, bounded compatibility contract. The claim
+is verified IXP Manager 7.4 Bird's Eye API compatibility with documented
+BIRD-internal divergences, for the pinned consumer surface and allow-list in
+the [executable contract](../tests/compat/ixp-manager-birdseye/contract.json).
+It is not a claim of unqualified Bird's Eye compatibility and does not enlarge
+the native daemon v1 inventory. The adapter's `api.version` reports rustbgpd
+product identity, not a Bird's Eye version promise.
+
+See the [interop contract description](INTEROP.md#ixp-looking-glass-contract-oracle)
+for the tested boundary, upstream pins, and unsupported behavior.
+
+## Upgrade navigation
+
+- Daemon operators: read the [CHANGELOG](../CHANGELOG.md), the
+  [v1 compatibility rules](v1-stable-contract.md#compatibility-rules), and the
+  [deployment upgrade procedure](deployment.md#upgrade).
+- Rust embedders: follow the
+  [published-crate release boundary](EMBEDDING.md#published-crate-release-boundary).
+- Adapter operators: follow the pinned
+  [Bird's Eye contract oracle](INTEROP.md#ixp-looking-glass-contract-oracle).

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -45,7 +45,7 @@ an RPC signature or behavior as stable.
 
 Published Rust crates follow their own SemVer boundary, independently of the
 daemon's narrow v1 contract. Use the versions and upgrade guidance in
-[`EMBEDDING.md`](EMBEDDING.md#published-crate-release-boundary), including the
+[`EMBEDDING.md`](EMBEDDING.md#7-published-crate-release-boundary), including the
 per-release compatibility notes and coordinated dependency guidance. A daemon
 release or an inventoried daemon surface does not make an internal workspace
 crate a supported library API.
@@ -69,6 +69,6 @@ for the tested boundary, upstream pins, and unsupported behavior.
   [v1 compatibility rules](v1-stable-contract.md#compatibility-rules), and the
   [deployment upgrade procedure](deployment.md#upgrade).
 - Rust embedders: follow the
-  [published-crate release boundary](EMBEDDING.md#published-crate-release-boundary).
+  [published-crate release boundary](EMBEDDING.md#7-published-crate-release-boundary).
 - Adapter operators: follow the pinned
   [Bird's Eye contract oracle](INTEROP.md#ixp-looking-glass-contract-oracle).


### PR DESCRIPTION
## Summary

- add one authoritative navigation page for the project public-alpha default and exact narrow stable daemon exception
- distinguish compatibility from authorization tiers, crate SemVer guidance, and the bounded Bird's Eye adapter contract
- explicitly keep EVPN, Linux dataplane, experimental work, and unlisted RPC or CLI surfaces outside the narrow promise
- link the map from both documentation indexes without duplicating counts, digests, or checker logic

## Validation

- public tracker and release-checklist path checkers
- IXP Manager docs, embedding-version, and v1 stable-surface checks
- 43 related checker mutation tests and targeted path, anchor, and no-count scans
- locked workspace check
- full repository pre-push formatting, strict Clippy, library tests, and rustdoc

Linear: LAN-1185