### PR TITLE
docs: gate release upgrade notes (LAN-1264)

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -601,6 +601,17 @@ docker run --rm --entrypoint rbgp rustbgpd:dev --help
 
 ### Daemon release
 
+Before rolling any versions:
+
+- [ ] Create a dedicated `### Upgrade notes` group in the new `CHANGELOG.md`
+      release section for consumer- and operator-visible semantic changes.
+- [ ] Review the complete `<prev-tag>..HEAD` range for that group.
+      `**Operator-visible:**` entries are inputs, not an exhaustive index;
+      also capture unmarked changes such as silent semantic reinterpretations
+      and removed metric-label series.
+- [ ] Preview the release workflow's extracted and reflowed GitHub release body
+      and confirm it preserves the `### Upgrade notes` heading and its entries.
+
 1. Update `CHANGELOG.md` with the new version section
 2. **Verify changelog completeness**: run `git log <prev-tag>..HEAD --oneline`
    and confirm every user-visible change (features, fixes, interop suites) is


### PR DESCRIPTION
## Summary

- require a dedicated Upgrade notes group before version rolling
- review the complete tag range instead of relying only on Operator-visible markers
- call out silent semantic reinterpretations and removed metric-label series
- verify the extracted and reflowed GitHub release body preserves the grouping

## Validation

- python3 -m unittest -v scripts/test_check_release_checklist_paths.py
- python3 scripts/check_release_checklist_paths.py
- python3 scripts/check_public_tracker_ids.py
- python3 scripts/reflow-release-notes.py --selftest
- git diff --check
- full pre-push suite

Linear: LAN-1264