### PR TITLE
docs: state published crate Rust requirement (LAN-1212)

### DIFF
--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -6,6 +6,8 @@ in-place `SessionState`.
 
 Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
+Requires Rust 1.95 or newer.
+
 ## Design
 
 The FSM is intentionally isolated from all I/O concerns. The transport

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -12,6 +12,8 @@ This crate is the wire-protocol foundation of
 use in any Rust project that needs to parse or build BGP messages — monitors,
 analyzers, test harnesses, MRT readers, etc.
 
+Requires Rust 1.95 or newer.
+
 ## Supported RFCs
 
 | RFC | Feature |


### PR DESCRIPTION
## Summary

- state the workspace-derived Rust 1.95 requirement in the wire crate README
- state the same requirement in the FSM crate README
- keep broader compatibility policy, examples, changelogs, and codec work out of scope

## Validation

- cargo metadata confirms rust_version 1.95 for both packages
- cargo package list for rustbgpd-wire
- cargo package list for rustbgpd-fsm
- python3 scripts/check_public_tracker_ids.py
- git diff --check
- full pre-push suite

Linear: LAN-1212