### PR TITLE
chore: remove stale export lint allowance (LAN-1268)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/rust_out
 /bench/scale/target
 **/*.rs.bk
 *.swp

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -1028,10 +1028,6 @@ impl SessionExportProfile {
         result
     }
 
-    #[allow(
-        clippy::too_many_lines,
-        reason = "enumerates every supported export family"
-    )]
     pub(crate) fn probe_announcement(
         &self,
         candidate: ExportCandidate<'_>,


### PR DESCRIPTION
## Summary

- remove the proven-stale too-many-lines allowance from the export probe
- root-ignore the local rust_out build artifact without touching it
- leave the broader allowance-to-expect conversion for a separate tranche

## Validation

- cargo fmt --all -- --check
- cargo clippy -p rustbgpd-transport --all-targets -- -D warnings
- cargo test -p rustbgpd-transport
- python3 scripts/check-clippy-reasons.py
- python3 -m unittest -v scripts/test_check_clippy_reasons.py
- git check-ignore -v rust_out
- full pre-push suite

Linear: LAN-1268