### PR TITLE
docs(cookbook): add concise deployment leads (LAN-1239)

### DIFF
--- a/docs/cookbook/evpn-fabric-rr.md
+++ b/docs/cookbook/evpn-fabric-rr.md
@@ -1,5 +1,7 @@
 # EVPN fabric route reflector (control-plane only)
 
+This recipe builds a control-plane-only VXLAN-EVPN fabric route reflector.
+
 **When this is you:** a VXLAN-EVPN leaf/spine fabric where the VTEPs
 (FRR, SR Linux, GoBGP, or rustbgpd leaves) do the dataplane and you
 want a lean, API-first reflector distributing the RFC 7432 routes

--- a/docs/cookbook/l3vpn-route-reflector.md
+++ b/docs/cookbook/l3vpn-route-reflector.md
@@ -1,5 +1,7 @@
 # L3VPN route reflector (VPNv4/VPNv6 + RT-Constrain)
 
+This recipe builds a control-plane-only VPNv4/VPNv6 route reflector.
+
 **When this is you:** you have a PE fleet exchanging VPNv4/VPNv6
 routes (SAFI 128) and want the reflector out of the vendor-appliance
 business — reflect with RD, MPLS label stack, next-hop, and Route

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -1,5 +1,7 @@
 # IXP route server
 
+This recipe builds an IXP route server for transparent member route exchange.
+
 **When this is you:** you run (or are about to run) an Internet-exchange
 route server — one BGP speaker that redistributes routes among member
 networks so they don't need a full mesh of bilateral sessions. You want


### PR DESCRIPTION
## Summary\n\n- add a concise first sentence to the L3VPN route-reflector cookbook\n- add a concise first sentence to the VXLAN-EVPN fabric route-reflector cookbook\n- add a concise first sentence to the IXP route-server cookbook\n- preserve every existing technical detail, heading, command, configuration block, and evidence claim\n\nEach lead is 68–77 characters and names the deployment shape before the detailed “When this is you” guidance.\n\n## Validation\n\n- exact first-sentence length scan\n- public tracker ID checker and 15 tests\n- IXP Manager docs checker and 14 tests\n- release-checklist path checker and 9 tests\n- full pre-push: fmt, Clippy, tests, rustdoc\n- \n\nLinear: LAN-1239