### PR TITLE
docs(policy): explain when to choose rpol (LAN-1198)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2297,6 +2297,22 @@ statements. The same named definitions and chain attachments can also be
 managed at runtime through the gRPC `PolicyService`; successful mutations are
 persisted back to TOML.
 
+#### Choosing TOML or `.rpol`
+
+Choose TOML named definitions for an ordered, first-match
+list where each statement is a flat conjunction of its populated match fields
+(with field-local behavior such as OR within `match_community`), followed by a
+`permit` or `deny` decision and optional route modifications. See
+[Policy entries](#policy-entries) for the complete statement surface.
+
+Choose [`.rpol`](rpol-language.md) for arbitrary Boolean expressions (`&&`,
+`||`, `!`), language-declared typed prefix, community, and ASN sets, pure
+functions, external dataset probes, or tests embedded beside the policy. TOML
+and `.rpol` compile to the same typed policy IR, use the same evaluator, share
+one named-policy namespace, and may coexist in a chain. See
+[`.rpol` policy files](#rpol-policy-files-rpol_files-adr-0096) for loading and
+mixed-chain rules.
+
 ```toml
 [policy.definitions.reject-bogons]
 default_action = "deny"


### PR DESCRIPTION
## Summary

- add a chooser beside the named-policy introduction
- explain that TOML named definitions are ordered, first-match statements whose populated match fields form a flat conjunction
- point operators to `.rpol` for arbitrary Boolean expressions, language-declared typed route-data sets, pure functions, dataset probes, and embedded tests
- state the shared typed IR, evaluator, namespace, and mixed-chain behavior without implying separate capability or performance tiers

## Validation

- public tracker ID checker
- mixed TOML/`.rpol` chain compilation test
- full pre-push: fmt, Clippy, tests, rustdoc
- exact one-file, 16-line diff check

Linear: LAN-1198

LAN-1198 remains open for the separate shared-walk and all-permit attribution work.
