### PR TITLE
docs(event-history): clarify bounded retention targets (LAN-1191)

### DIFF
--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -142,13 +142,17 @@ pub struct EventHistoryConfig {
     pub batch_interval: Duration,
     /// Per-subscriber broadcast capacity.
     pub broadcast_capacity: usize,
-    /// Count-cap retention.
+    /// Count retention target. Each scheduled pass evicts at most 5,000
+    /// oldest events above the target before evaluating the byte target.
+    /// This is not a hard retained-event cap.
     pub max_events: u64,
-    /// Byte-cap retention (combined events.db + WAL).
+    /// Byte retention target (combined events.db + WAL).
     ///
-    /// This is a retention trigger/target, not a strict filesystem cap:
-    /// SQLite DELETE frees pages for reuse but does not guarantee the
-    /// main DB file shrinks without vacuum/compaction.
+    /// After the count phase, each pass removes up to ten 5,000-event batches
+    /// while oversized. Sustained production above that bounded eviction
+    /// throughput can keep the store growing. SQLite DELETE frees pages for
+    /// reuse but does not guarantee the main DB file shrinks without
+    /// vacuum/compaction.
     pub max_bytes: u64,
     /// SQLite synchronous mode.
     pub synchronous: SynchronousMode,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4003,11 +4003,16 @@ double the peak CPU at 2p/100k); a routing daemon should be lean by
 default. While disabled, `SubscribeFromEvent` and gNMI `Subscribe
 ON_CHANGE` return `FAILED_PRECONDITION`; the live `WatchEvents` /
 `List*Events` surfaces are unaffected. When enabled, the
-outbox is bounded by a hard `max_events` count cap plus a `max_bytes`
-retention trigger. SQLite reuses freed pages after DELETE and does not
-guarantee that the main database file immediately shrinks without a
-future compaction pass, so `max_bytes` is an operational target rather
-than a strict filesystem ceiling in v1.
+outbox applies scheduled, bounded retention passes against a `max_events`
+count target and a `max_bytes` size target. Each pass first removes at most
+5,000 oldest events above the count target, then removes up to ten additional
+5,000-event batches while the database remains above the size target. A busy
+or heavily oversized store can therefore remain above either target between
+passes or after one pass. Sustained event production above the maximum
+per-pass eviction throughput can make the store continue growing without a
+hard ceiling. SQLite reuses freed pages after DELETE and does not guarantee
+that the main database file immediately shrinks without a future compaction
+pass.
 
 All fields are restart-required; see
 [reload-matrix.md](reload-matrix.md#event_history-adr-0072) for
@@ -4018,7 +4023,7 @@ the per-field classification.
 enabled = false                 # default (v0.32.0); set true for durable event replay
 required = false                # if true, daemon fails to start when DB unrecoverable
 path = ""                       # relative to runtime_state_dir; "" = events.db
-max_events = 100_000            # hard count cap
+max_events = 100_000            # count retention target; bounded work per pass
 max_bytes = 256_000_000         # byte retention target (events.db + WAL)
 synchronous = "full"            # full = fsync per commit; normal trades crash window for throughput
 overflow = "drop"               # v1 only supports "drop"; "block" reserved for a future ADR

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1202,7 +1202,7 @@ any `WatchEvents` subscriber is alive.
 | `bgp_event_outbox_committed_total{category}` | Events durably committed to the local outbox, per category. Increments inside EHM after the SQLite transaction commits — not on producer enqueue. |
 | `bgp_event_outbox_dropped_total{category, reason}` | Events lost before durable storage, or committed events skipped during durable cursor delivery. `reason` is `queue_full`, `closed`, `db_error`, `shutdown_timeout`, `decode_failure`, `opaque_codec`, or `source_lagged`. `shutdown_timeout` means the actor observed an accepted event still queued when the coordinated shutdown deadline expired. `source_lagged` fires when an upstream broadcast receiver (FIB or BFD bridge) reports `Lagged(missed)` — those missed events never reached the bridge body and therefore never reached EHM; the counter increments by `missed`. `queue_full`, `db_error`, `shutdown_timeout`, decode/codec failures, and `source_lagged` flip `bgp_event_outbox_degraded` to `1`; shutdown-time `closed` drops do not. |
 | `bgp_event_outbox_queue_depth{category}` | Pending events in the EHM producer queue by category. Climbs before drops start — early-warning signal. |
-| `bgp_event_outbox_db_size_bytes` | Combined size of `events.db` + WAL on disk, refreshed after commits and retention passes. `[event_history].max_bytes` is the soft retention trigger. |
+| `bgp_event_outbox_db_size_bytes` | Combined size of `events.db` + WAL on disk, refreshed after commits and retention passes. `[event_history].max_bytes` is the scheduled size-retention target; a bounded pass can finish while the store remains above it. |
 | `bgp_event_outbox_retention_evicted_total{reason}` | Events evicted by the retention pass. `reason` is `count_cap` or `byte_cap`. |
 | `bgp_event_outbox_latest_event_id` | The latest committed `event_id`. Forward progress indicator. |
 | `bgp_event_outbox_open_failures_total` | DB-open failures across the process lifetime. Typically 0 or 1; non-zero means EHM went into recovery or pass-through at startup. |
@@ -1226,16 +1226,21 @@ any `WatchEvents` subscriber is alive.
    `.stale-<ts>` quarantine file with no sidecar fallback). Same
    recovery: check log, fix the underlying I/O issue, restart.
 
-**Sizing retention** — `max_events` and `max_bytes` are *both* hard
-caps; whichever fires first wins. Default `100_000` events /
+**Sizing retention** — `max_events` and `max_bytes` are retention targets
+evaluated during each scheduled pass. The count target is evaluated first and
+removes at most 5,000 oldest events above the target; the byte target then
+removes up to ten 5,000-event batches while the database remains oversized.
+Default `100_000` events /
 `256_000_000` bytes covers a few minutes of even a busy daemon's
 event stream. Operators with longer collector-reconnect tolerance
 should raise both proportionally; collectors should alert on
 `bgp_event_outbox_cursor_gap_total > 0` to know when retention is
-too small for their SLA. Note that `bgp_event_outbox_db_size_bytes`
-can briefly exceed `max_bytes` between retention passes — `max_bytes`
-is the trigger, not a strict cap. SQLite may also hold onto freed
-pages rather than immediately shrink the main DB.
+too small for their SLA. A busy or heavily oversized store can remain
+above either target between passes or after one bounded pass. If sustained
+event production exceeds the maximum per-pass eviction throughput, the store
+can continue growing without a hard ceiling; alert on
+`bgp_event_outbox_db_size_bytes`. SQLite may also hold onto freed pages rather
+than immediately shrink the main DB.
 
 **External-bus integration** — see `examples/event-bridge/` for the
 reference skeleton. The pattern is:

--- a/docs/adr/0072-durable-event-history.md
+++ b/docs/adr/0072-durable-event-history.md
@@ -476,25 +476,32 @@ The RPC baselines EHM's loss generation before delivery; later loss wins replay
 or blocked-delivery races and terminates with `DATA_LOSS`. Unlike a retention
 gap, pre-commit loss requires authoritative reconciliation before resuming.
 
-### Retention — small, hard-capped, two dimensions
+### Retention — small, bounded-pass, two dimensions
 
 Defaults are **deliberately small** so that when an operator enables
 the outbox it keeps local retention pressure bounded (the outbox is
 opt-in / default-off as of v0.32.0 — see *Status*):
 
-- `max_events = 100_000` — hard count cap.
-- `max_bytes = 256_000_000` (~256 MB) — byte retention trigger
-  measured against `events.db` + WAL combined. SQLite DELETE frees
-  pages for reuse and does not guarantee the main DB file immediately
-  shrinks without a compaction/vacuum step, so this is a soft
-  filesystem-size target in v1.
+- `max_events = 100_000` — count retention target. Each pass evicts
+  at most 5,000 oldest events above this target.
+- `max_bytes = 256_000_000` (~256 MB) — byte retention target
+  measured against `events.db` + WAL combined. After the count phase,
+  each pass removes up to ten additional 5,000-event batches while the
+  store remains oversized. SQLite DELETE frees pages for reuse and does
+  not guarantee the main DB file immediately shrinks without a
+  compaction/vacuum step.
 
-Both retention triggers run. No time-based retention dimension in v1
-— operators wanting >hours of history push to their bus, not grow the
-local file. Retention runs every 60 s on EHM and
+Both retention targets run in that order during each scheduled pass. A busy
+or heavily oversized store can remain above either target between passes or
+after one bounded pass. If sustained event production exceeds the maximum
+per-pass eviction throughput, the store can continue growing without a hard
+ceiling. No time-based retention dimension in v1 — operators wanting >hours
+of history push to their bus, not grow the local file. Retention runs every
+60 s on EHM and
 **always evicts in `event_id` ascending order** (oldest first).
 SQLite's `DELETE … LIMIT` without an explicit `ORDER BY` is
-implementation-defined, so each pass uses the explicit shape:
+implementation-defined, so each individual eviction batch uses these ordered
+deletes:
 
 ```sql
 DELETE FROM event_peers
@@ -505,13 +512,13 @@ DELETE FROM events
   WHERE event_id IN (
     SELECT event_id FROM events ORDER BY event_id ASC LIMIT 5000
   );
-PRAGMA wal_checkpoint(PASSIVE);
 ```
 
 Both `DELETE`s happen inside one transaction so the join table
 never lags the main table (foreign keys are off; the cleanup is
-explicit by design). Sharded DB files are deferred to a future
-ADR if disk size becomes a real problem.
+explicit by design). After all count- and byte-target batches in the pass,
+EHM issues `PRAGMA wal_checkpoint(PASSIVE);` once. Sharded DB files are
+deferred to a future ADR if disk size becomes a real problem.
 
 ### Config (`src/config/schema.rs`)
 
@@ -520,7 +527,7 @@ ADR if disk size becomes a real problem.
 enabled = false                 # default-off (opt-in since v0.32.0); set true for durable replay
 required = false                # if true, daemon fails to start when DB unavailable
 path = ""                       # relative to runtime_state_dir; "" = events.db
-max_events = 100_000            # count retention bound
+max_events = 100_000            # count retention target; bounded work per pass
 max_bytes = 256_000_000         # byte retention target (~256 MB)
 synchronous = "full"            # full|normal — "full" = fsync per commit
 overflow = "drop"               # "drop" only in v1; "block" reserved for future
@@ -849,8 +856,9 @@ reference bridge at `examples/event-bridge/`:
 - New on-disk file (`events.db` + WAL) under `runtime_state_dir`,
   **only when an operator opts in** (`enabled = true`). As of v0.32.0
   the outbox is default-off, so the common deployment has zero on-disk
-  footprint. v1 has a hard event-count cap and a byte retention target,
-  but SQLite may reuse freed pages rather than shrink the main DB file
+  footprint. v1 has event-count and byte retention targets with bounded work
+  per pass; a busy or heavily oversized store can remain above them after a
+  pass, and SQLite may reuse freed pages rather than shrink the main DB file
   immediately.
 - New crate (`rustbgpd-event-history`) and a small dependency
   footprint addition: `rusqlite` (bundled libsqlite) plus `uuid`.

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -390,8 +390,8 @@ what's deferred.
 | `enabled` | restart-required | Off ⇒ EHM does not open `events.db`; live event broadcast paths remain possible, but no durable outbox/replay state is created. (See ADR-0072 for the pass-through contract on `required = false` recovery failures, which is a runtime degraded state distinct from `enabled = false`.) |
 | `required` | restart-required | If `true`, the daemon fails to start when the events DB cannot be opened or recovered. Default `false`: degrade to pass-through with `bgp_event_outbox_degraded = 1`. |
 | `path` | restart-required | Relative to `runtime_state_dir`. Empty ⇒ `<runtime_state_dir>/events.db`. |
-| `max_events` | restart-required | Hard count cap; default 100,000. Retention sweeps every 60s evict oldest `event_id` first. |
-| `max_bytes` | restart-required | Byte retention target on `events.db` + WAL combined; default 256 MB. SQLite may reuse freed pages rather than shrink the main DB immediately, so this is not a strict filesystem cap in v1. |
+| `max_events` | restart-required | Count retention target; default 100,000. Each 60s pass evaluates this first and evicts at most 5,000 oldest events above the target. |
+| `max_bytes` | restart-required | Byte retention target on `events.db` + WAL combined; default 256 MB. After the count phase, a pass removes up to ten additional 5,000-event batches while oversized. A busy or heavily oversized store can remain above either target after a bounded pass, and SQLite may reuse freed pages rather than shrink the main DB immediately. |
 | `synchronous` | restart-required | SQLite `PRAGMA synchronous` mode. `full` (default) fsyncs per commit; `normal` checkpoints periodically and trades a small crash window for throughput. |
 | `overflow` | restart-required | v1 only supports `drop`; `block` is reserved for a future ADR. |
 | `queue_capacity` | restart-required | Per-producer mpsc capacity. |

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -618,14 +618,14 @@
           "default": false
         },
         "max_bytes": {
-          "description": "Byte retention trigger on `events.db` + WAL combined. `SQLite`\nmay reuse freed pages rather than shrink the main DB immediately.",
+          "description": "Byte retention target on `events.db` + WAL combined. After the count\nphase, each pass removes up to ten 5,000-event batches while oversized.\n`SQLite` may reuse freed pages rather than shrink the main DB immediately.",
           "type": "integer",
           "format": "uint64",
           "default": 256000000,
           "minimum": 0
         },
         "max_events": {
-          "description": "Hard count cap on retained events.",
+          "description": "Count retention target. Each scheduled pass evicts at most 5,000\noldest events above the target before evaluating the byte target.",
           "type": "integer",
           "format": "uint64",
           "default": 100000,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -412,11 +412,13 @@ pub struct EventHistoryConfig {
     /// Empty string ⇒ `<runtime_state_dir>/events.db`.
     #[serde(default = "default_event_history_path")]
     pub path: String,
-    /// Hard count cap on retained events.
+    /// Count retention target. Each scheduled pass evicts at most 5,000
+    /// oldest events above the target before evaluating the byte target.
     #[serde(default = "default_event_history_max_events")]
     pub max_events: u64,
-    /// Byte retention trigger on `events.db` + WAL combined. `SQLite`
-    /// may reuse freed pages rather than shrink the main DB immediately.
+    /// Byte retention target on `events.db` + WAL combined. After the count
+    /// phase, each pass removes up to ten 5,000-event batches while oversized.
+    /// `SQLite` may reuse freed pages rather than shrink the main DB immediately.
     #[serde(default = "default_event_history_max_bytes")]
     pub max_bytes: u64,
     /// `SQLite` `PRAGMA synchronous` mode. `full` (default) fsyncs


### PR DESCRIPTION
## Summary

- describe `max_events` and `max_bytes` as scheduled retention targets in public API docs and operator documentation
- document the implementation's count-first order, bounded eviction batches, and sustained-throughput growth boundary
- make the guarantee consistent across Operations, Configuration, the reload matrix, ADR-0072, the source schema, and its generated JSON artifact

This aligns every canonical description with the retention implementation, exported database-size gauge, and measured retention tests.

## Validation

- public tracker ID checker and its 15 mutation tests
- byte-for-byte generated configuration-schema freshness test
- exact contradictory-wording scan
- full pre-push: fmt, Clippy, tests, rustdoc
- seven-file public-API and canonical-consistency diff check

Linear: LAN-1191
