### PR TITLE
chore(cli): make argument suppressions self-checking (LAN-1268)

### DIFF
--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -138,7 +138,7 @@ pub async fn list(
     Ok(())
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "CLI arguments map directly to one EVPN route request"
 )]
@@ -178,7 +178,7 @@ pub async fn add_mac_ip(
     output::print_result(json, "add_evpn", "", "EVPN Type 2 route added")
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "CLI arguments map directly to one EVPN route request"
 )]
@@ -215,7 +215,7 @@ pub async fn add_imet(
     output::print_result(json, "add_evpn", "", "EVPN Type 3 route added")
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "CLI arguments map directly to one EVPN route request"
 )]

--- a/crates/cli/src/commands/fib_table.rs
+++ b/crates/cli/src/commands/fib_table.rs
@@ -104,7 +104,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     render(&resp, json)
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "CLI arguments map directly to one FIB-table request"
 )]

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -175,7 +175,7 @@ pub fn check_local(
     )
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "thin CLI plumbing mirroring the flag surface; a struct would only relabel it"
 )]


### PR DESCRIPTION
## Summary

- convert the five remaining CLI `too_many_arguments` allowances to expectations
- preserve each existing reason and every function body unchanged
- make future stale suppressions fail strict Clippy instead of silently lingering

The bounded slice covers the three EVPN route mutations, the FIB-table setter, and local policy checking. Broader workspace conversion remains separate.

## Validation

- strict all-target/all-feature `rustbgpctl` Clippy proves all five expectations currently fire
- 22 library tests, 620 command tests, 38 config-import tests, the stdout-closure test, and doc tests passed
- lint-reason checker and all five checker tests
- full pre-push: fmt, Clippy, tests, rustdoc
- independent no-findings review of the exact five-line conversion roster

Linear: LAN-1268

LAN-1268 remains open for the other workspace packages.
