### PR TITLE
chore(api): make lint expectations self-checking (LAN-1268)

### DIFF
--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -296,7 +296,7 @@ impl EvpnService {
 
     /// Construct a service exposing the full EVPN surface plus the
     /// optional duplicate-MAC manual-clear control hook.
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "constructor wires independent EVPN status/control hooks explicitly"
     )]
@@ -329,7 +329,7 @@ impl EvpnService {
     /// Construct a service exposing the full EVPN surface with an
     /// explicit ADR-0063 runtime model provider and optional apply
     /// hook.
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "constructor wires the full EVPN runtime surface without hiding optional hooks"
     )]

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -701,7 +701,7 @@ impl GnmiService {
     /// Broadcast lag or producer-side loss closes with `DataLoss` so the
     /// collector reconnects without `updates_only` and resyncs from a full
     /// initial snapshot.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "presence-aware live events and heartbeat reconciliation share one select loop"
     )]

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -65,7 +65,7 @@ fn input_statement_to_proto(statement: &PolicyStatementDefinition) -> proto::Pol
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "peer-group conversion mirrors the complete protobuf definition"
 )]


### PR DESCRIPTION
## Summary

- convert four reasoned API lint allowances to self-checking expectations
- cover the gNMI live-event loop, peer-group protobuf conversion, and two EVPN full-surface constructors
- preserve every function body and existing rationale while making stale suppressions fail strict Clippy

This is a mechanical defensive-quality tranche for LAN-1268 with no runtime behavior change.

## Validation

- strict `cargo clippy -p rustbgpd-api --all-targets --all-features -- -D warnings`
- `cargo test -p rustbgpd-api` (668 unit tests, 1 process-exit integration test, doc tests)
- lint-reason checker and its five tests
- full pre-push: fmt, Clippy, tests, rustdoc
- independent exact-roster and overlap review: no findings

Linear: LAN-1268
