### PR TITLE
feat(gnmi): count established-session resyncs (LAN-1190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The shipped Grafana overview now pairs the RFC 9107 ORR SPF computation
   rate with current topology node and usable-link counts. (LAN-1205)
 
+- gNMI dial-out now exposes `gnmi_dialout_resync_total{target}` so repeated
+  established-session loss and fresh-snapshot resyncs are visible even while
+  the binary connection gauge otherwise looks healthy. (LAN-1190)
+
 - BMP divergence repair is now operator-visible through the lifecycle-correct
   `bmp_stream_diverged{peer}` gauge, a sustained-divergence alert, a control
   event-drop alert, and a focused Grafana panel. The gauge clears after repair

--- a/crates/api/src/gnmi_dialout.rs
+++ b/crates/api/src/gnmi_dialout.rs
@@ -18,7 +18,7 @@
 //! Each target runs an independent reconnect loop with capped exponential
 //! backoff, logs at `warn` only on state transitions (first failure after
 //! a success, disconnect) and at `debug` for repeated retries, and surfaces
-//! its state as the `gnmi_dialout_connected{target}` gauge.
+//! connection state and established-session loss as per-target metrics.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -44,7 +44,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// connection across SIGHUP; any field edit tears down and redials.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DialoutTarget {
-    /// Unique name — the `gnmi_dialout_connected{target}` label and log key.
+    /// Unique name — the dial-out metric label and log key.
     pub name: String,
     /// Full endpoint URI (`http://host:port` or `https://host:port`).
     pub endpoint: String,
@@ -257,7 +257,7 @@ impl DialoutManager {
     }
 
     /// Reconcile the running dial-out tasks with `targets`: stop removed
-    /// targets (reaping their `gnmi_dialout_connected` series), restart
+    /// targets (reaping their connection and resync series), restart
     /// changed ones, start added ones, and leave unchanged targets — and
     /// their live collector connections — untouched.
     pub fn apply(&mut self, targets: &[DialoutTarget]) {
@@ -290,8 +290,8 @@ impl DialoutManager {
 /// One target's connect / stream / reconnect loop. Never returns under
 /// normal operation; the manager aborts it on removal or shutdown.
 async fn run_target(service: GnmiService, metrics: BgpMetrics, target: DialoutTarget) {
-    // Materialize the series at 0 immediately so a collector that is down
-    // at daemon startup is visible on /metrics before the first success.
+    // Materialize both target series at 0 immediately so a collector that is
+    // down at daemon startup is visible on /metrics before the first success.
     metrics.set_gnmi_dialout_connected(&target.name, false);
     let mut backoff = target.backoff_initial.max(Duration::from_millis(1));
     let mut failure_announced = false;
@@ -299,6 +299,7 @@ async fn run_target(service: GnmiService, metrics: BgpMetrics, target: DialoutTa
         match publish_session(&service, &metrics, &target).await {
             Ok(()) => {
                 // Connected and then cleanly/abruptly disconnected.
+                metrics.record_gnmi_dialout_resync(&target.name);
                 metrics.set_gnmi_dialout_connected(&target.name, false);
                 warn!(
                     target = %target.name,
@@ -756,6 +757,23 @@ mod tests {
             .map(|metric| metric.get_gauge().value() as i64)
     }
 
+    fn counter_value(metrics: &BgpMetrics, target: &str) -> Option<f64> {
+        metrics
+            .registry()
+            .gather()
+            .iter()
+            .find(|family| family.name() == "gnmi_dialout_resync_total")?
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "target" && label.value() == target)
+            })
+            .map(|metric| metric.get_counter().value())
+    }
+
     async fn wait_for_gauge(metrics: &BgpMetrics, target: &str, expected: i64) {
         tokio::time::timeout(Duration::from_secs(10), async {
             loop {
@@ -937,6 +955,7 @@ mod tests {
         expect_update_with_as(&mut received).await;
         expect_sync(&mut received).await;
         wait_for_gauge(&metrics, "collector-silent", 1).await;
+        assert_eq!(counter_value(&metrics, "collector-silent"), Some(0.0));
 
         // Fail the next sample tick. The subscription errors and the
         // outbound stream ends; since the collector stays silent forever,
@@ -947,13 +966,14 @@ mod tests {
         expect_update_with_as(&mut received).await;
         expect_sync(&mut received).await;
         wait_for_gauge(&metrics, "collector-silent", 1).await;
+        assert_eq!(counter_value(&metrics, "collector-silent"), Some(1.0));
 
         server.abort();
         manager.apply(&[]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn manager_reaps_gauge_series_on_target_removal() {
+    async fn manager_reaps_target_series_on_target_removal() {
         let metrics = BgpMetrics::new();
         let (reservation, addr) = reserve_port(None);
         let (server, mut received) = spawn_stub_collector(reservation);
@@ -961,11 +981,13 @@ mod tests {
         manager.apply(&[test_target("collector-reap", addr)]);
         expect_update_with_as(&mut received).await;
         wait_for_gauge(&metrics, "collector-reap", 1).await;
+        assert_eq!(counter_value(&metrics, "collector-reap"), Some(0.0));
 
-        // Removing the target from config reaps the series entirely —
-        // not just sets it to 0 — so /metrics stops exporting it.
+        // Removing the target from config reaps both series entirely rather
+        // than retaining stale per-target labels in /metrics.
         manager.apply(&[]);
         assert_eq!(gauge_value(&metrics, "collector-reap"), None);
+        assert_eq!(counter_value(&metrics, "collector-reap"), None);
         server.abort();
     }
 
@@ -984,6 +1006,7 @@ mod tests {
         wait_for_gauge(&metrics, "collector-late", 0).await;
         tokio::time::sleep(Duration::from_millis(300)).await;
         assert_eq!(gauge_value(&metrics, "collector-late"), Some(0));
+        assert_eq!(counter_value(&metrics, "collector-late"), Some(0.0));
 
         // The collector comes up later; the retry loop finds it.
         let (server, mut received) = spawn_stub_collector(reservation);

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -200,6 +200,7 @@ struct BgpMetricsInner {
 
     // ── gNMI dial-out (LAN-471) ────────────────────────────────────
     gnmi_dialout_connected: IntGaugeVec,
+    gnmi_dialout_resync_total: IntCounterVec,
 
     // ── Notifications ──────────────────────────────────────────────
     notifications_sent: IntCounterVec,
@@ -529,6 +530,15 @@ impl BgpMetrics {
                 "gnmi_dialout_connected",
                 "gNMI dial-out collector connection state per configured target \
                  (1 = Publish stream established, 0 = disconnected/retrying)",
+            ),
+            &["target"],
+        )
+        .expect("valid metric definition");
+
+        let gnmi_dialout_resync_total = IntCounterVec::new(
+            Opts::new(
+                "gnmi_dialout_resync_total",
+                "Established gNMI dial-out sessions that ended and will trigger a fresh snapshot resync, per configured target",
             ),
             &["target"],
         )
@@ -2043,6 +2053,9 @@ impl BgpMetrics {
             .register(Box::new(gnmi_dialout_connected.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(gnmi_dialout_resync_total.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(stale_timer_events.clone()))
             .expect("metric not already registered");
         registry
@@ -2565,6 +2578,7 @@ impl BgpMetrics {
             bfd_session_up,
             bfd_session_flaps_total,
             gnmi_dialout_connected,
+            gnmi_dialout_resync_total,
             notifications_sent,
             notifications_received,
             messages_sent,
@@ -2955,18 +2969,37 @@ impl BgpMetrics {
 
     /// Set the gNMI dial-out connection gauge for a configured target.
     /// Refreshed on BOTH transitions (connect and disconnect) so the series
-    /// always reflects the live Publish-stream state.
+    /// always reflects the live Publish-stream state. The first call for a
+    /// target also materializes its resync counter at zero without incrementing
+    /// it, making failed-dial targets visible on `/metrics`.
     pub fn set_gnmi_dialout_connected(&self, target: &str, connected: bool) {
+        let _resync_counter = self
+            .0
+            .gnmi_dialout_resync_total
+            .with_label_values(&[target]);
         self.0
             .gnmi_dialout_connected
             .with_label_values(&[target])
             .set(i64::from(connected));
     }
 
-    /// Reap the dial-out connection series for a target removed from the
-    /// config (SIGHUP reload), so `/metrics` stops exporting stale targets.
+    /// Count an established dial-out session ending before its fresh-snapshot
+    /// reconnect. Connection attempts that never establish do not call this.
+    pub fn record_gnmi_dialout_resync(&self, target: &str) {
+        self.0
+            .gnmi_dialout_resync_total
+            .with_label_values(&[target])
+            .inc();
+    }
+
+    /// Reap the dial-out metric series for a target removed from the config
+    /// (SIGHUP reload), so `/metrics` stops exporting stale targets.
     pub fn remove_gnmi_dialout_target(&self, target: &str) {
         let _ = self.0.gnmi_dialout_connected.remove_label_values(&[target]);
+        let _ = self
+            .0
+            .gnmi_dialout_resync_total
+            .remove_label_values(&[target]);
     }
 
     /// Record a BFD session state change: set the per-peer up gauge and count a

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -752,7 +752,9 @@ affects BGP operation; telemetry for that target is simply not delivered
 while disconnected. The daemon logs one `warn` when a target becomes
 unreachable and one `info` when it (re)connects; repeated retries log at
 `debug` only. Watch `gnmi_dialout_connected{target}` (0/1) for the live
-connection state. Every (re)connection restarts the subscription, so the
+connection state and `gnmi_dialout_resync_total{target}` for established
+sessions that ended and entered the fresh-snapshot reconnect path; failed dials
+do not increment it. Every (re)connection restarts the subscription, so the
 collector resyncs from a fresh initial snapshot + `sync_response` — the
 disconnect window is not replayed (same contract as a dial-in Subscribe
 reconnect; use the durable event cursor for gap-free history).
@@ -1117,6 +1119,7 @@ query with a new live watch.
 | Metric | What it tells you |
 |--------|-------------------|
 | `gnmi_dialout_connected{target}` | 1 while the dial-out Publish stream to this `[gnmi_dialout]` target is established, 0 while disconnected/retrying. Refreshed on both transitions; the series exists (at 0) from startup even when the collector is down, and is reaped when the target is removed from config (SIGHUP) |
+| `gnmi_dialout_resync_total{target}` | Established Publish sessions that ended and entered the reconnect path, where the next connection starts a fresh initial snapshot. Failed dials do not increment it; the series exists at 0 from startup and is reaped with the target |
 
 ### BMP
 


### PR DESCRIPTION
## Summary

- add `gnmi_dialout_resync_total{target}` for established Publish sessions that end and enter the fresh-snapshot reconnect path
- materialize the series at zero, exclude failed dials, and reap its target label with the existing connection gauge
- document how to distinguish a healthy connection from repeated resynchronization

This is the first bounded observability tranche for LAN-1190. Lag/queue-depth and time-since-publish signals remain separate, and protocol flow control stays deferred until remote-collector evidence justifies it.

## Validation

- 10 focused gNMI dial-out tests, including silent-collector reconnect, failed-dial zero, and label reaping
- strict `cargo clippy -p rustbgpd-api -p rustbgpd-telemetry --all-targets -- -D warnings`
- public tracker and Clippy-reason checkers
- full pre-push: fmt, Clippy, tests, rustdoc
- independent semantic and exact-diff review: no findings

Linear: LAN-1190
