### PR TITLE
feat(grafana): surface ORR activity and topology (LAN-1205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The shipped Grafana overview now pairs the RFC 9107 ORR SPF computation
+  rate with current topology node and usable-link counts. (LAN-1205)
+
 - BMP divergence repair is now operator-visible through the lifecycle-correct
   `bmp_stream_diverged{peer}` gauge, a sustained-divergence alert, a control
   event-drop alert, and a focused Grafana panel. The gauge clears after repair

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2907,6 +2907,44 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 69,
+      "type": "row",
+      "title": "ORR",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 182 },
+      "panels": []
+    },
+    {
+      "id": 70,
+      "type": "timeseries",
+      "title": "ORR SPF activity and topology",
+      "description": "Per-instance RFC 9107 ORR SPF computation rate with the current cached topology node and usable directed-link counts for context. All three series remain zero while ORR has no configured vantage.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 183 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (instance) (rate(bgp_orr_spf_runs_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} SPF runs/s",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_orr_topology_nodes{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}} nodes",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_orr_topology_links{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}} usable links",
+          "refId": "C"
+        }
+      ]
     }
   ]
 }

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -130,6 +130,16 @@ TARGETS = {
         "rate(bgp_dynamic_neighbor_limit_rejections_total"
         '{instance=~"$instance"}[$__rate_interval]) > 0'
     ),
+    ("ORR SPF activity and topology", "A"): (
+        "sum by (instance) (rate(bgp_orr_spf_runs_total"
+        '{instance=~"$instance"}[$__rate_interval]))'
+    ),
+    ("ORR SPF activity and topology", "B"): (
+        'bgp_orr_topology_nodes{instance=~"$instance"}'
+    ),
+    ("ORR SPF activity and topology", "C"): (
+        'bgp_orr_topology_links{instance=~"$instance"}'
+    ),
 }
 
 REQUIRED_LEGENDS = {
@@ -159,6 +169,9 @@ REQUIRED_LEGENDS = {
     ("Dynamic-neighbor admission rejections", "A"): "{{instance}} rejected",
     ("RIB ingest pressure", "B"): "inbound safely parked {{peer}}",
     ("RIB ingest pressure", "C"): "outbound work lost {{peer}}",
+    ("ORR SPF activity and topology", "A"): "{{instance}} SPF runs/s",
+    ("ORR SPF activity and topology", "B"): "{{instance}} nodes",
+    ("ORR SPF activity and topology", "C"): "{{instance}} usable links",
 }
 
 ROUTE_SAFETY_PANELS = {
@@ -552,6 +565,13 @@ def main() -> None:
     )
     if dynamic_rejection_defaults != {"unit": "ops", "min": 0}:
         fail("dynamic-neighbor rejection rate must render as nonnegative operations")
+
+    orr_panel = next(
+        panel for panel in panels if panel.get("title") == "ORR SPF activity and topology"
+    )
+    orr_refs = [target.get("refId") for target in orr_panel.get("targets", [])]
+    if orr_panel.get("type") != "timeseries" or orr_refs != ["A", "B", "C"]:
+        fail("ORR activity panel must be a timeseries with exactly targets A through C")
 
     try:
         references = dashboard_metric_references(dashboard)

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -4,7 +4,7 @@ import io
 import json
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 
@@ -137,6 +137,15 @@ let families = self.allocated.collect();'''
             try:
                 with redirect_stdout(io.StringIO()):
                     CHECK.main()
+                orr = next(panel for panel in dashboard["panels"]
+                           if panel["title"] == "ORR SPF activity and topology")
+                for field in ("expr", "legendFormat"):
+                    saved = orr["targets"][0][field]
+                    orr["targets"][0][field] = "broken"
+                    copy.write_text(json.dumps(dashboard))
+                    with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+                        CHECK.main()
+                    orr["targets"][0][field] = saved
             finally:
                 CHECK.DASHBOARD = original
 


### PR DESCRIPTION
## Summary

- add a shipped Grafana ORR row pairing SPF runs per second with current topology node and usable-link counts
- pin all three PromQL targets, legends, panel type, and target order in the dashboard contract checker
- add mutation proofs that ORR query or legend drift fails closed

This makes the existing RFC 9107 topology signals directly operator-visible. LAN-1205 remains open for the separate blackhole counters and the broader emitted-metric consumer inventory.

## Validation

- Grafana dashboard contract: 70 unique panels, 35 operator targets, 92 linked metrics
- 14 dashboard-checker mutation tests
- exact JSON and PromQL review
- full pre-push: fmt, Clippy, tests, rustdoc
- independent scope and layout review: no findings

Linear: LAN-1205
