### PR TITLE
chore(transport): make lint expectations self-checking (LAN-1268)

### DIFF
--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -369,7 +369,7 @@ impl SessionExportProfile {
 
     /// Prepare the classic unicast attribute set using only this immutable
     /// profile and the post-policy route candidate.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "keeps the ordered outbound attribute transformation in one auditable pass"
     )]
@@ -2666,7 +2666,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "one cache-key matrix keeps scalar equivalence and every memo dimension together"
     )]

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1518,7 +1518,7 @@ impl PeerSession {
     /// default rewrite) is deliberately inert for this family — rewriting it
     /// would break the remote PE's transport-label resolution toward the
     /// originating PE.
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "the MP_REACH chunker receives each wire component explicitly"
     )]
@@ -1624,7 +1624,7 @@ impl PeerSession {
     /// `MP_REACH_NLRI` UPDATEs, splitting so each encoded message fits
     /// `max_len` bytes. Mirrors the VPN sender minus the RD-prefixed
     /// next-hop (RFC 8277 uses the ordinary host next-hop forms).
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "the MP_REACH chunker receives each wire component explicitly"
     )]


### PR DESCRIPTION
## Summary

- convert four reasoned transport lint allowances to self-checking expectations
- cover unicast attribute preparation, its complete cache-key matrix test, and the VPN/labeled-unicast MP_REACH chunkers
- preserve every function body, existing rationale, and neighboring attribute

This is a mechanical defensive-quality tranche for LAN-1268 with no runtime behavior change. Strict Clippy confirms all four expectations currently fire.

## Validation

- strict `cargo clippy -p rustbgpd-transport --all-targets --all-features -- -D warnings`
- four focused one-filter tests for cache-key memoization, VPN reach/unreach, labeled reach/unreach, and eBGP next-hop behavior
- Clippy-reason checker and its five tests
- full pre-push: fmt, Clippy, tests, rustdoc
- independent exact-roster and word-diff review: no findings

Linear: LAN-1268
