### PR TITLE
docs(wire): add captured UPDATE decoder example

### DIFF
--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -184,6 +184,10 @@ later registry additions land without a breaking release.
 
 Decode a single BGP message from raw bytes:
 
+For a deterministic interoperability check, run the standalone captured UPDATE
+decoder in `examples/decode_update.rs` with
+`cargo run -p rustbgpd-wire --example decode_update`.
+
 ```rust
 use bytes::Bytes;
 use rustbgpd_wire::{decode_message, Message, MAX_MESSAGE_LEN};

--- a/crates/wire/examples/decode_update.rs
+++ b/crates/wire/examples/decode_update.rs
@@ -1,0 +1,28 @@
+use bytes::Bytes;
+use rustbgpd_wire::{MAX_MESSAGE_LEN, Message, decode_message};
+
+const CAPTURED_UPDATE: [u8; 47] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0x00, 0x2f, 0x02, // marker, length, UPDATE
+    0x00, 0x00, // withdrawn routes length
+    0x00, 0x14, // path attributes length
+    0x40, 0x01, 0x01, 0x00, // ORIGIN: IGP
+    0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xfc, 0x00, // AS_PATH: 64512
+    0x40, 0x03, 0x04, 0xc0, 0x00, 0x02, 0x01, // NEXT_HOP: 192.0.2.1
+    0x18, 0xcb, 0x00, 0x71, // NLRI: 203.0.113.0/24
+];
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut bytes = Bytes::from_static(&CAPTURED_UPDATE);
+    let Message::Update(update) = decode_message(&mut bytes, MAX_MESSAGE_LEN)? else {
+        return Err("capture is not a BGP UPDATE".into());
+    };
+    assert!(bytes.is_empty(), "capture contains trailing bytes");
+    let parsed = update.parse(true, false, &[])?;
+
+    assert_eq!(parsed.announced.len(), 1);
+    let prefix = parsed.announced[0].prefix;
+    assert_eq!(prefix.to_string(), "203.0.113.0/24");
+    println!("announced: {prefix}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a deterministic example that decodes and parses a captured BGP UPDATE
- assert and print the announced 203.0.113.0/24 prefix
- link the runnable example from the wire crate README

## Validation
- strict example Clippy
- 649 wire library tests
- package inclusion and public documentation checks
- full pre-push suite
