### PR TITLE
chore(evpn-linux): tighten lint expectations

### DIFF
--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -113,7 +113,7 @@ impl Plan {
 ///
 /// See module docs for the foreign-entry preservation invariant.
 #[must_use]
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the diff keeps all dataplane object classes in dependency order"
 )]
@@ -420,7 +420,7 @@ fn desired_vlan(instances: &EvpnInstanceTable, vni: EvpnInstanceId) -> Option<u1
 
 /// Pass 1 / IPv6-fallback emission — emit `AddRemoteFdb` /
 /// `UpdateRemoteFdb` for a single-dst entry.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "the pass shares the diff accumulator and its destination context"
 )]
@@ -538,7 +538,7 @@ fn emit_single_dst_pass(
 /// aliasing, or ADR-0083 single-active with a backup — the entry's
 /// `single_active_backup_vtep_ip` rides every Install/Update so the
 /// coordinator can pre-create + pin the backup NH).
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     clippy::too_many_lines,
     reason = "the FDB/NHG pass keeps its ordered object reconciliation together"
@@ -744,7 +744,7 @@ fn emit_fdb_nhg_pass(
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "VLAN conversion needs the shared FDB/NHG reconciliation context"
 )]
@@ -816,7 +816,7 @@ fn emit_fdb_nhg_vlan_conversion(
 ///    the domain layer.
 /// 6. Foreign static / permanent / `self` entry — operator territory;
 ///    skip without logging at warn level.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "kernel-entry handling needs the entry, desired state, and diff context"
 )]

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -364,7 +364,7 @@ impl InMemoryDataplane {
     /// Synchronous half of `apply` — does the fail-injection lookup
     /// and the kernel-state mutation under the same lock so the test
     /// can't observe a partially-applied op.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "one arm per operation shape keeps the in-memory dispatch mirror readable"
     )]

--- a/crates/evpn-linux/src/l3_diff.rs
+++ b/crates/evpn-linux/src/l3_diff.rs
@@ -442,7 +442,7 @@ impl Candidate {
 /// `desired_*` to have been seen during the `want` build. Both
 /// `.expect(...)` sites prove a programmer error, not a runtime
 /// condition.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the L3 diff keeps all dependent kernel object comparisons in order"
 )]

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -745,7 +745,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     }
 
     /// One reconcile pass: probe → dump → diff → apply → emit report.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "one reconciliation pass preserves the plan's ordered safety checks"
     )]
@@ -1918,7 +1918,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     ///    is in the retry schedule and not yet due are skipped; the
     ///    actor's outer `tokio::select!` re-fires on the retry timer
     ///    so a deferred op runs as soon as its backoff elapses.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "per-operation dispatch preserves the plan's ordering and error boundaries"
     )]
@@ -2712,7 +2712,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// the drift gate entirely — mirrors the startup-adoption
     /// permanent-failure semantics. Transient / conflict failures
     /// leave drift enabled; the next reconcile pass retries.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "drift reconciliation keeps detection, repair, and retry ordering together"
     )]
@@ -3434,7 +3434,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// rows that resolve its inner DMAC / tunnel endpoint go away —
     /// the inverse of the install pipeline's resolution-before-route
     /// ordering.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "three reap surfaces share one gate and ordering contract"
     )]
@@ -4156,7 +4156,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// entries. BUM restoration is best-effort because leaving a CE
     /// port suppressed after the daemon exits is more operator-hostile
     /// than a redundant allow-all write.
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "drain coordinates ordered withdrawal across all managed object classes"
     )]
@@ -6741,10 +6741,6 @@ where
     Ok(())
 }
 
-#[allow(
-    clippy::too_many_arguments,
-    reason = "L3 FDB/NHG removal needs the complete reconciliation operation context"
-)]
 async fn apply_remove_l3_fdb_nhg<D>(
     dataplane: &mut D,
     state: &mut ActorState,
@@ -6834,7 +6830,7 @@ async fn rollback_l3_partial_install<D>(
 /// delete → FDB row. ADR-0059 §5 invariants 1 + 3. Reads
 /// top-to-bottom; further breaking this up would obscure the rollback
 /// ordering.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     clippy::too_many_arguments,
     reason = "FDB/NHG installation keeps its ordered kernel operations and shared context together"


### PR DESCRIPTION
## Summary
- convert 13 justified EVPN/Linux lint suppressions into fulfilled expectations
- remove one stale too-many-arguments suppression from a seven-argument helper
- leave function bodies, reasons, and unrelated attributes unchanged

## Validation
- strict all-target EVPN/Linux Clippy
- 455 library tests and focused reconciliation tests
- lint-reason checker and full pre-push suite
