### PR TITLE
docs: shorten route diagnostic headings

### DIFF
--- a/docs/explain.md
+++ b/docs/explain.md
@@ -1,4 +1,4 @@
-# Explaining routes: "why is this route (not) here?"
+# Explain route decisions
 
 Every stage of a route's life through the daemon can explain itself,
 from the live RIB, in one command — no debug rebuild, no external

--- a/docs/ribdiff.md
+++ b/docs/ribdiff.md
@@ -1,4 +1,4 @@
-# `rbgp diff advertised` — live Adj-RIB-Out vs incumbent snapshot
+# Compare advertised routes
 
 Compares what rustbgpd is advertising to each peer (the live Adj-RIB-Out,
 read over gRPC) against a snapshot of what an incumbent route server


### PR DESCRIPTION
## Summary
- shorten the route-explanation and advertised-route comparison H1s
- preserve the underlying operational guidance and command examples unchanged

## Validation
- public tracker documentation checker
- curated documentation command test
- full pre-push suite
