### PR TITLE
chore(evpn): tighten originator lint expectations

### DIFF
--- a/src/evpn_originator/duplicate_mac.rs
+++ b/src/evpn_originator/duplicate_mac.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::evpn_originator::rib_write::apply_actions;
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "duplicate-MAC state construction keeps all explicit ownership inputs visible"
 )]
@@ -192,7 +192,7 @@ pub(super) fn record_duplicate_mac_move(
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "duplicate-MAC observation handling needs the key, timers, and actor state"
 )]
@@ -239,7 +239,7 @@ pub(super) async fn apply_actions_with_duplicate_policy(
     .await;
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "duplicate-MAC transition handling needs the key, timers, and actor state"
 )]
@@ -282,10 +282,6 @@ pub(super) async fn suppress_local_originations_for_mac(
     .await;
 }
 
-#[allow(
-    clippy::too_many_arguments,
-    reason = "duplicate-MAC recovery handling needs the key, timers, and actor state"
-)]
 pub(super) async fn recover_duplicate_macs(
     state: &mut OriginatorState,
     instances: &EvpnInstanceTable,
@@ -328,7 +324,7 @@ pub(super) async fn recover_duplicate_macs(
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "duplicate-MAC expiry handling needs the key, timers, and actor state"
 )]
@@ -384,7 +380,7 @@ pub(super) async fn clear_duplicate_mac_quarantine(
     ClearDuplicateMacQuarantineResult::Cleared
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "duplicate-MAC publication needs the observed state and all actor outputs"
 )]

--- a/src/evpn_originator/rib_polling.rs
+++ b/src/evpn_originator/rib_polling.rs
@@ -79,7 +79,7 @@ pub(super) fn drain_ready_evpn_events(
 /// MAC+IP), diff against the cached state, and fire
 /// `on_remote_changed` / `on_remote_ip_changed` for any tracked
 /// `(MAC)` or `(MAC, IP)` whose view changed.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "MAC-only and MAC-plus-IP diffs remain adjacent to preserve symmetry"
 )]
@@ -276,7 +276,7 @@ pub(super) async fn handle_evpn_event(
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "RIB poll reconciliation needs the snapshot, generation, and actor outputs"
 )]

--- a/src/evpn_originator/rib_write.rs
+++ b/src/evpn_originator/rib_write.rs
@@ -39,10 +39,6 @@ pub(super) async fn drain_to_withdraws(
     }
 }
 
-#[allow(
-    clippy::too_many_arguments,
-    reason = "RIB write construction keeps all route ownership inputs explicit"
-)]
 pub(super) async fn drain_vni_to_withdraws(
     state: &mut OriginatorState,
     instances: &EvpnInstanceTable,
@@ -93,10 +89,6 @@ pub(super) async fn drain_vni_to_withdraws(
 /// the same route identity) before its first attempt, and only the
 /// RIB's acknowledgement clears it. Failed attempts stay pending; the
 /// actor's retry arm re-drives them with bounded backoff.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "RIB write dispatch needs the route, action, and actor outputs"
-)]
 pub(super) async fn apply_actions(
     pending: &mut PendingRibOps,
     actions: Vec<OriginationAction>,
@@ -164,7 +156,7 @@ fn action_key(action: &OriginationAction) -> EvpnRouteKey {
 /// Confirms (and does the success bookkeeping) on ack, defers on any
 /// failure. Shared by the first attempt ([`apply_actions`]) and the
 /// retry path ([`retry_pending_rib_ops`]).
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "the action attempt needs its route, retry, and actor context"
 )]


### PR DESCRIPTION
## Summary
- convert eight justified EVPN originator lint suppressions into fulfilled expectations
- remove three stale too-many-arguments suppressions from seven-argument helpers
- leave function bodies, retained reasons, and unrelated attributes unchanged

## Validation
- strict all-target root-package Clippy
- six focused originator behavior tests
- lint-reason checker and full pre-push suite
