### PR TITLE
feat(observability): surface blackhole discard activity

### DIFF
--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2945,6 +2945,38 @@
           "refId": "C"
         }
       ]
+    },
+    {
+      "id": 71,
+      "type": "row",
+      "title": "Kernel discard routes",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 191 },
+      "panels": []
+    },
+    {
+      "id": 72,
+      "type": "timeseries",
+      "title": "BLACKHOLE discard activity",
+      "description": "Successful RFC 7999 kernel discard install and removal event rates per instance. These counters reset on restart and do not report the current number of installed discard routes; inspect current kernel state for population.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 192 },
+      "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(bgp_blackhole_discard_installed_total{instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "{{instance}} installed/s",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(bgp_blackhole_discard_withdrawn_total{instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "{{instance}} withdrawn/s",
+          "refId": "B"
+        }
+      ]
     }
   ]
 }

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -267,6 +267,23 @@ groups:
             for 5 minutes; its advertised view is intentionally below group
             intent.
 
+      - alert: BgpBlackholeDiscardInstallActivity
+        # Use a zero-activity baseline so every successful discard install is
+        # correlated with intended policy. This follows the established
+        # reset-safe event-counter convention without inventing a
+        # deployment-specific volume threshold.
+        expr: increase(bgp_blackhole_discard_installed_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BLACKHOLE discard install activity on {{ $labels.instance }}"
+          description: >-
+            rustbgpd successfully installed {{ $value | printf "%.0f" }} RFC
+            7999 kernel discard route(s) on {{ $labels.instance }} in the last
+            10 minutes. Confirm the activity matches expected policy and
+            inspect current kernel discard state.
+
       - alert: RpkiVrpTableEmpty
         # Series only exist once an RTR cache has delivered data, so
         # this cannot fire on deployments without RPKI configured. An

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -632,6 +632,64 @@ tests:
                 (ipv4_unicast) on edge1:9179 has remained 1 for 5 minutes; its
                 advertised view is intentionally below group intent.
 
+  # ── BgpBlackholeDiscardInstallActivity ────────────────────────
+  # Load-bearing: the older increment pins the 10m lookback, the reset then
+  # increment pins reset-safe increase, and the same-evaluation increment pins
+  # for: 0m. Flat install history and withdrawal activity stay quiet; the late
+  # evaluation pins recovery. Each firing increase is 1, pinning the > 0 floor.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_blackhole_discard_installed_total{instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_blackhole_discard_installed_total{instance="edge2:9179"}'
+        values: "10 10 10 10 10 10 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_blackhole_discard_installed_total{instance="edge3:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_blackhole_discard_installed_total{instance="edge4:9179"}'
+        values: "7x22"
+      - series: 'bgp_blackhole_discard_withdrawn_total{instance="edge5:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpBlackholeDiscardInstallActivity
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpBlackholeDiscardInstallActivity
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BLACKHOLE discard install activity on edge1:9179"
+              description: >-
+                rustbgpd successfully installed 1 RFC 7999 kernel discard
+                route(s) on edge1:9179 in the last 10 minutes. Confirm the
+                activity matches expected policy and inspect current kernel
+                discard state.
+          - exp_labels:
+              severity: warning
+              instance: edge2:9179
+            exp_annotations:
+              summary: "BLACKHOLE discard install activity on edge2:9179"
+              description: >-
+                rustbgpd successfully installed 1 RFC 7999 kernel discard
+                route(s) on edge2:9179 in the last 10 minutes. Confirm the
+                activity matches expected policy and inspect current kernel
+                discard state.
+          - exp_labels:
+              severity: warning
+              instance: edge3:9179
+            exp_annotations:
+              summary: "BLACKHOLE discard install activity on edge3:9179"
+              description: >-
+                rustbgpd successfully installed 1 RFC 7999 kernel discard
+                route(s) on edge3:9179 in the last 10 minutes. Confirm the
+                activity matches expected policy and inspect current kernel
+                discard state.
+      - eval_time: 21m
+        alertname: BgpBlackholeDiscardInstallActivity
+        exp_alerts: []
+
   # ── RpkiVrpTableEmpty ─────────────────────────────────────────
   - interval: 1m
     input_series:

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -633,14 +633,15 @@ tests:
                 advertised view is intentionally below group intent.
 
   # ── BgpBlackholeDiscardInstallActivity ────────────────────────
-  # Load-bearing: the older increment pins the 10m lookback, the reset then
+  # Load-bearing: the increment at 2m evaluated at 10m30s pins the exact 10m
+  # lookback, the reset then
   # increment pins reset-safe increase, and the same-evaluation increment pins
   # for: 0m. Flat install history and withdrawal activity stay quiet; the late
   # evaluation pins recovery. Each firing increase is 1, pinning the > 0 floor.
   - interval: 1m
     input_series:
       - series: 'bgp_blackhole_discard_installed_total{instance="edge1:9179"}'
-        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+        values: "0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
       - series: 'bgp_blackhole_discard_installed_total{instance="edge2:9179"}'
         values: "10 10 10 10 10 10 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
       - series: 'bgp_blackhole_discard_installed_total{instance="edge3:9179"}'
@@ -650,10 +651,10 @@ tests:
       - series: 'bgp_blackhole_discard_withdrawn_total{instance="edge5:9179"}'
         values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
     alert_rule_test:
-      - eval_time: 2m
+      - eval_time: 0m
         alertname: BgpBlackholeDiscardInstallActivity
         exp_alerts: []
-      - eval_time: 10m
+      - eval_time: 10m30s
         alertname: BgpBlackholeDiscardInstallActivity
         exp_alerts:
           - exp_labels:

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -596,7 +596,8 @@ def main() -> None:
     blackhole_refs = [target.get("refId") for target in blackhole_panel.get("targets", [])]
     if blackhole_panel.get("type") != "timeseries" or blackhole_refs != ["A", "B"]:
         fail("BLACKHOLE discard activity must be a timeseries with exactly targets A and B")
-    if blackhole_panel.get("gridPos") != {"h": 8, "w": 24, "x": 0, "y": 192}:
+    blackhole_position = blackhole_panel.get("gridPos", {})
+    if blackhole_position.get("w") != 24 or blackhole_position.get("x") != 0:
         fail("BLACKHOLE discard activity must retain its full-width layout")
 
     try:

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -140,6 +140,14 @@ TARGETS = {
     ("ORR SPF activity and topology", "C"): (
         'bgp_orr_topology_links{instance=~"$instance"}'
     ),
+    ("BLACKHOLE discard activity", "A"): (
+        "rate(bgp_blackhole_discard_installed_total"
+        '{instance=~"$instance"}[$__rate_interval])'
+    ),
+    ("BLACKHOLE discard activity", "B"): (
+        "rate(bgp_blackhole_discard_withdrawn_total"
+        '{instance=~"$instance"}[$__rate_interval])'
+    ),
 }
 
 REQUIRED_LEGENDS = {
@@ -172,6 +180,8 @@ REQUIRED_LEGENDS = {
     ("ORR SPF activity and topology", "A"): "{{instance}} SPF runs/s",
     ("ORR SPF activity and topology", "B"): "{{instance}} nodes",
     ("ORR SPF activity and topology", "C"): "{{instance}} usable links",
+    ("BLACKHOLE discard activity", "A"): "{{instance}} installed/s",
+    ("BLACKHOLE discard activity", "B"): "{{instance}} withdrawn/s",
 }
 
 ROUTE_SAFETY_PANELS = {
@@ -572,6 +582,22 @@ def main() -> None:
     orr_refs = [target.get("refId") for target in orr_panel.get("targets", [])]
     if orr_panel.get("type") != "timeseries" or orr_refs != ["A", "B", "C"]:
         fail("ORR activity panel must be a timeseries with exactly targets A through C")
+
+    blackhole_panel = next(
+        (
+            panel
+            for panel in panels
+            if panel.get("title") == "BLACKHOLE discard activity"
+        ),
+        None,
+    )
+    if blackhole_panel is None:
+        fail("BLACKHOLE discard activity panel must exist")
+    blackhole_refs = [target.get("refId") for target in blackhole_panel.get("targets", [])]
+    if blackhole_panel.get("type") != "timeseries" or blackhole_refs != ["A", "B"]:
+        fail("BLACKHOLE discard activity must be a timeseries with exactly targets A and B")
+    if blackhole_panel.get("gridPos") != {"h": 8, "w": 24, "x": 0, "y": 192}:
+        fail("BLACKHOLE discard activity must retain its full-width layout")
 
     try:
         references = dashboard_metric_references(dashboard)

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -595,7 +595,10 @@ def main() -> None:
         fail("BLACKHOLE discard activity panel must exist")
     blackhole_refs = [target.get("refId") for target in blackhole_panel.get("targets", [])]
     if blackhole_panel.get("type") != "timeseries" or blackhole_refs != ["A", "B"]:
-        fail("BLACKHOLE discard activity must be a timeseries with exactly targets A and B")
+        fail(
+            "BLACKHOLE discard activity panel must be a timeseries "
+            "with exactly targets A and B"
+        )
     blackhole_position = blackhole_panel.get("gridPos", {})
     if blackhole_position.get("w") != 24 or blackhole_position.get("x") != 0:
         fail("BLACKHOLE discard activity must retain its full-width layout")

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -15,6 +15,15 @@ SPEC.loader.exec_module(CHECK)
 
 
 class DashboardMetricLinkTests(unittest.TestCase):
+    def remove_panel(self, panels, panel_id):
+        for index, panel in enumerate(panels):
+            if panel.get("id") == panel_id:
+                panels.pop(index)
+                return True
+            if self.remove_panel(panel.get("panels", []), panel_id):
+                return True
+        return False
+
     def rust(self, kind="IntGauge", name="bgp_ready", registered=True):
         registration = (
             "registry.register(Box::new(ready.clone())).unwrap();" if registered else ""
@@ -136,6 +145,18 @@ let families = self.allocated.collect();'''
             else:
                 changes["gridPos"] = {"x": index % 24}
             panel.update(changes)
+        blackhole = next(
+            panel
+            for panel in dashboard["panels"]
+            if panel["title"] == "BLACKHOLE discard activity"
+        )
+        blackhole_row = next(
+            panel
+            for panel in dashboard["panels"]
+            if panel["title"] == "Kernel discard routes"
+        )
+        dashboard["panels"].remove(blackhole)
+        blackhole_row["panels"].append(blackhole)
         with tempfile.TemporaryDirectory() as directory:
             copy = Path(directory) / "dashboard.json"
             copy.write_text(json.dumps(dashboard))
@@ -152,8 +173,11 @@ let families = self.allocated.collect();'''
                     with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
                         CHECK.main()
                     orr["targets"][0][field] = saved
-                blackhole = next(panel for panel in dashboard["panels"]
-                                 if panel["title"] == "BLACKHOLE discard activity")
+                blackhole = next(
+                    panel
+                    for panel in CHECK.all_panels(dashboard["panels"])
+                    if panel["title"] == "BLACKHOLE discard activity"
+                )
                 mutations = ((blackhole["targets"][0], "expr", "broken"),
                              (blackhole["targets"][0], "legendFormat", "broken"),
                              (blackhole, "gridPos", {"x": 0}))
@@ -164,7 +188,7 @@ let families = self.allocated.collect();'''
                     with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
                         CHECK.main()
                     subject[field] = saved
-                dashboard["panels"].remove(blackhole)
+                self.assertTrue(self.remove_panel(dashboard["panels"], blackhole["id"]))
                 copy.write_text(json.dumps(dashboard))
                 stderr = io.StringIO()
                 targets = CHECK.TARGETS

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -128,8 +128,12 @@ let families = self.allocated.collect();'''
     def test_live_dashboard_presentation_mutations_pass_full_check(self):
         dashboard = json.loads(CHECK.DASHBOARD.read_text())
         for index, panel in enumerate(CHECK.all_panels(dashboard["panels"])):
-            panel.update(description="changed", collapsed=not panel.get("collapsed", False),
-                         gridPos={"x": index % 24}, id=panel["id"] + 1000)
+            changes = {"description": "changed",
+                       "collapsed": not panel.get("collapsed", False),
+                       "id": panel["id"] + 1000}
+            if panel["title"] != "BLACKHOLE discard activity":
+                changes["gridPos"] = {"x": index % 24}
+            panel.update(changes)
         with tempfile.TemporaryDirectory() as directory:
             copy = Path(directory) / "dashboard.json"
             copy.write_text(json.dumps(dashboard))
@@ -146,6 +150,42 @@ let families = self.allocated.collect();'''
                     with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
                         CHECK.main()
                     orr["targets"][0][field] = saved
+                blackhole = next(panel for panel in dashboard["panels"]
+                                 if panel["title"] == "BLACKHOLE discard activity")
+                mutations = ((blackhole["targets"][0], "expr", "broken"),
+                             (blackhole["targets"][0], "legendFormat", "broken"),
+                             (blackhole, "gridPos", {"x": 0}))
+                for subject, field, replacement in mutations:
+                    saved = subject[field]
+                    subject[field] = replacement
+                    copy.write_text(json.dumps(dashboard))
+                    with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+                        CHECK.main()
+                    subject[field] = saved
+                dashboard["panels"].remove(blackhole)
+                copy.write_text(json.dumps(dashboard))
+                stderr = io.StringIO()
+                targets = CHECK.TARGETS
+                legends = CHECK.REQUIRED_LEGENDS
+                CHECK.TARGETS = {
+                    key: value
+                    for key, value in targets.items()
+                    if key[0] != "BLACKHOLE discard activity"
+                }
+                CHECK.REQUIRED_LEGENDS = {
+                    key: value
+                    for key, value in legends.items()
+                    if key[0] != "BLACKHOLE discard activity"
+                }
+                try:
+                    with self.assertRaises(SystemExit), redirect_stderr(stderr):
+                        CHECK.main()
+                finally:
+                    CHECK.TARGETS = targets
+                    CHECK.REQUIRED_LEGENDS = legends
+                self.assertIn(
+                    "BLACKHOLE discard activity panel must exist", stderr.getvalue()
+                )
             finally:
                 CHECK.DASHBOARD = original
 

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -131,7 +131,9 @@ let families = self.allocated.collect();'''
             changes = {"description": "changed",
                        "collapsed": not panel.get("collapsed", False),
                        "id": panel["id"] + 1000}
-            if panel["title"] != "BLACKHOLE discard activity":
+            if panel["title"] == "BLACKHOLE discard activity":
+                changes["gridPos"] = {**panel["gridPos"], "h": 9, "y": 17}
+            else:
                 changes["gridPos"] = {"x": index % 24}
             panel.update(changes)
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- add a full-width dashboard panel for successful blackhole discard install and withdrawal event rates
- add a warning alert when any successful discard install occurs within ten minutes
- keep event activity distinct from current installed-route population
- pin reset, lookback, withdrawal isolation, recovery, PromQL, legends, and layout behavior

The alert follows the repository's existing zero-baseline event-counter convention rather than inventing a deployment-specific volume threshold.

## Validation
- pinned Prometheus 3.4.1 rule validation and complete alert fixtures
- dashboard checker and 14 mutation tests
- independent expression, window, reset, metric-selection, delay, and recovery mutations
- public documentation and release-install checks
- full pre-push suite
