### PR TITLE
chore(evpn): tighten originator core lint expectations

### DIFF
--- a/src/evpn_originator/lifecycle.rs
+++ b/src/evpn_originator/lifecycle.rs
@@ -10,7 +10,7 @@ use crate::evpn_originator::duplicate_mac::{
 use crate::evpn_originator::rib_polling::repoll_rib;
 use crate::evpn_originator::rib_write::drain_vni_to_withdraws;
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "classification, drain, and replay are one ordered lifecycle sequence"
 )]

--- a/src/evpn_originator/mod.rs
+++ b/src/evpn_originator/mod.rs
@@ -396,7 +396,7 @@ pub(crate) fn vni_is_drained(
 
 /// Test helper that spawns the originator with an empty duplicate-MAC quarantine.
 /// Returns `None` for RR-only deployments (empty `evpn_instances`).
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "originator spawn keeps each explicit actor dependency visible"
 )]
@@ -427,7 +427,7 @@ pub fn spawn(
     )
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "quarantine-aware spawn keeps each explicit actor dependency visible"
 )]
@@ -615,7 +615,7 @@ impl OriginatorState {
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the actor select keeps shutdown, observations, RIB events, and recovery ordered"
 )]

--- a/src/evpn_originator/observation.rs
+++ b/src/evpn_originator/observation.rs
@@ -70,7 +70,7 @@ fn park_pending_ip_binding(
 ///
 /// See `docs/RFC_NOTES.md` for the RFC 9135 §7.2.3 framing and the
 /// FRR mailing-list bugs that motivated this model.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "the ADR-0084 drain gate shares explicit observation and actor context"
 )]
@@ -298,7 +298,7 @@ fn drop_local_mac_caches(state: &mut OriginatorState, vni: EvpnInstanceId, mac: 
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     clippy::too_many_lines,
     reason = "observation classification keeps its ordered checks and actor context together"
@@ -475,7 +475,7 @@ pub(super) async fn handle_learned(
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "ESI-aware origination needs explicit observation and actor context"
 )]
@@ -525,7 +525,7 @@ pub(super) async fn handle_aged(
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "observation withdrawal needs the complete route and actor context"
 )]
@@ -634,7 +634,7 @@ pub(super) async fn handle_ip_added(
         .insert(ip);
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "observation publication needs the complete route and actor context"
 )]


### PR DESCRIPTION
## Summary
- convert nine justified EVPN originator lifecycle, actor-loop, and observation suppressions into fulfilled expectations
- preserve all function bodies, reasons, attributes, tests, and runtime behavior
- cover ten active too-many lint memberships across the nine attributes

## Validation
- strict all-target root-package Clippy
- six focused originator lifecycle and observation tests
- lint-reason checker and full pre-push suite
- exact word-diff review
