### PR TITLE
test(peer-manager): tighten lint expectations

### DIFF
--- a/src/peer_manager/tests/collision.rs
+++ b/src/peer_manager/tests/collision.rs
@@ -130,7 +130,7 @@ fn collision_remote_wins() {
     assert!(local_id < remote_id, "remote should win collision");
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the active-open regression keeps both candidate paths and fencing assertions together"
 )]

--- a/src/peer_manager/tests/export_cohorts.rs
+++ b/src/peer_manager/tests/export_cohorts.rs
@@ -59,7 +59,7 @@ fn import_ack_loss_policy_handle(
 /// whose chains didn't change) — and no RIB `ReplacePeerExportPolicy`.
 /// The peer whose content moved gets exactly the prior behavior:
 /// session installs, RIB replace, and a Route Refresh.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the fanout regression keeps affected and unaffected peer assertions together"
 )]

--- a/src/peer_manager/tests/policy_apply.rs
+++ b/src/peer_manager/tests/policy_apply.rs
@@ -364,7 +364,7 @@ enum NonEstablishedRollbackRibOutcome {
     Internal,
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the rollback helper keeps all peer and RIB outcome assertions together"
 )]
@@ -1091,7 +1091,7 @@ async fn apply_resolved_policy_snapshot_rearms_refresh_on_compound_rollback_fail
     rib_drainer.abort();
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the regression drives both updates through one complete pending-refresh receipt"
 )]

--- a/src/peer_manager/tests/policy_failures.rs
+++ b/src/peer_manager/tests/policy_failures.rs
@@ -53,10 +53,6 @@ async fn gshut_toggle_times_out_when_rib_reply_wedges() {
     );
 }
 
-#[allow(
-    clippy::too_many_lines,
-    reason = "the timeout regression keeps its full transaction and recovery receipt together"
-)]
 #[tokio::test(start_paused = true)]
 async fn export_policy_apply_times_out_when_rib_reply_wedges() {
     use rustbgpd_transport::PeerCommand;
@@ -255,7 +251,7 @@ async fn gshut_not_found_preserves_scoped_peer_label() {
     assert_eq!(err.to_string(), "peer fe80::2%eth1 not found");
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the hot-apply regression keeps all eBGP and iBGP peer assertions together"
 )]
@@ -430,7 +426,7 @@ async fn honor_graceful_shutdown_hot_apply_targets_ebgp_only() {
 /// the production race: the session task can drop a reply
 /// mid-shutdown while the FSM is still reporting Established
 /// for one more poll.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the failure regression keeps the rejected import and no-refresh receipt together"
 )]
@@ -627,7 +623,7 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
 /// `pending_refresh = true`, leave `managed.import_policy` at
 /// the prior value, and (because peer is Idle) NOT fire Route
 /// Refresh.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the idle-peer failure regression keeps pending-refresh state and wire assertions together"
 )]
@@ -802,7 +798,7 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
 /// holds. Failure must propagate, the bookkeeping must not
 /// advance, and `pending_export_apply` must be set so the next
 /// call retries.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the export failure regression keeps bookkeeping and wire assertions together"
 )]
@@ -1018,7 +1014,7 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
 ///
 /// Asserts: first call returns Err with both flags set; second
 /// call returns Ok with `route_refresh_calls > 0`.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the retry regression keeps import, export failure, and refresh receipt together"
 )]
@@ -1260,7 +1256,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
 /// import-side intent independently re-arms `pending_refresh`. A
 /// content-equal retry must therefore revisit the RIB, then refresh
 /// Adj-RIB-In and clear both intents after success.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the RIB failure regression keeps transaction and retry state together"
 )]
@@ -1487,7 +1483,7 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
 /// small (Route Refresh against an empty `AdjRibIn` is a no-op
 /// on the wire) and is the right tradeoff against silent
 /// stale-routes.
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the stale-query regression keeps fencing and retry assertions together"
 )]

--- a/src/peer_manager/tests/transport_config.rs
+++ b/src/peer_manager/tests/transport_config.rs
@@ -194,7 +194,7 @@ fn build_transport_config_preserves_local_role_for_otc() {
 ///    default would pass a weaker test even with the copy missing, so the
 ///    sentinels are chosen to differ from those defaults.
 #[test]
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the inventory test keeps every transport field in one exact assertion"
 )]


### PR DESCRIPTION
## Summary
- convert 12 justified peer-manager test suppressions into fulfilled expectations
- remove one strict-Clippy-proven stale too-many-lines attribute
- leave test bodies, names, timing, assertions, and retained reasons unchanged

## Validation
- strict all-target root-package Clippy
- five focused peer-manager tests, one filter per invocation
- lint-reason checker and full pre-push suite
- exact word-diff review
