### PR TITLE
chore(evpn): tighten daemon lint expectations

### DIFF
--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -350,7 +350,7 @@ impl EvpnDataplaneHandle {
 ///
 /// Quarantined `(VNI, MAC)` keys are excluded from remote-FDB intent while
 /// preserving RIB and route-reflector visibility.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "the spawn API keeps each explicit actor dependency visible"
 )]
@@ -448,7 +448,7 @@ where
 
 /// Test/production helper that injects a dataplane implementation and an
 /// external duplicate-MAC quarantine feed.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "the generic dataplane spawn API keeps each explicit actor dependency visible"
 )]
@@ -709,7 +709,7 @@ impl SupervisorIntentState {
     }
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "intent publication needs the actor handles and shared generation state"
 )]
@@ -849,7 +849,7 @@ fn publish_cached_dataplane_intent(
 /// tables. A future coordinator commit can publish a complete effective
 /// L2VNI/IP-VRF snapshot, and the supervisor will re-project
 /// immediately without waiting for the next poll interval.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     clippy::too_many_lines,
     reason = "the supervisor keeps actor dependencies and its ordered lifecycle handling explicit"

--- a/src/evpn_es_drain.rs
+++ b/src/evpn_es_drain.rs
@@ -298,7 +298,7 @@ pub(crate) enum EsDrainError {
 /// mutation that only recomposed the reason set (e.g. a link failure
 /// on an already operator-drained ES) commits coordinator-side with
 /// no actor traffic — the routes are already withdrawn.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "the drain hook keeps the ADR-0084 dependency spine explicit"
 )]

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -503,7 +503,7 @@ struct AdditiveBuildUpActors<'a> {
 }
 
 impl EvpnRuntimeActorConverger {
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "one optional control per EVPN actor plus shared drain state is explicit wiring"
     )]

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -229,7 +229,7 @@ pub fn spawn(
 /// — no dataplane / no binding feed — in which case no bias snapshot
 /// is published / no segment counts as bound.
 #[must_use = "drop the handle to shut down the EVPN segment orchestrator"]
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "the segment actor keeps the dataplane supervisor's dependency spine explicit"
 )]
@@ -325,7 +325,7 @@ struct SegmentState {
     esi_label: MplsLabel,
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "setup and the select loop form one ordered segment lifecycle"
 )]


### PR DESCRIPTION
## Summary
- convert eight justified EVPN segment, drain, dataplane, and runtime-converger suppressions into fulfilled expectations
- cover nine active too-many lint memberships
- leave bodies, reasons, unrelated attributes, tests, and runtime behavior unchanged

## Validation
- strict all-target root-package Clippy
- four separately filtered EVPN behavior tests
- lint-reason checker and full pre-push suite
- exact word-diff review
