### PR TITLE
test(fib): tighten runtime lint expectations

### DIFF
--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -4043,10 +4043,6 @@ mod tests {
         )
     }
 
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "a typed drift event carries all explicit observation and recovery context"
-    )]
     fn drift_event_typed(
         kind: KernelRouteEventKind,
         table_id: u32,
@@ -5284,7 +5280,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "the netns scenario keeps setup, convergence, and cleanup in one receipt"
     )]
@@ -5618,7 +5614,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "the ECMP netns scenario keeps setup, convergence, and cleanup in one receipt"
     )]
@@ -5744,10 +5740,6 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    #[allow(
-        clippy::too_many_lines,
-        reason = "the weighted-ECMP netns scenario keeps setup, convergence, and cleanup in one receipt"
-    )]
     async fn netns_general_unicast_fib_weighted_round_trip() {
         if !netns_gate() {
             eprintln!(


### PR DESCRIPTION
## Summary
- convert two fulfilled FIB-runtime netns suppressions into expectations
- remove two strict-Clippy-proven stale attributes from a drift helper and weighted-ECMP test
- leave implementation and test bodies, reasons, timing, names, and assertions unchanged

## Validation
- strict all-target root-package Clippy
- typed drift-classifier test and three separately filtered netns tests
- lint-reason checker and full pre-push suite
- exact word-diff review
