### PR TITLE
chore(config): tighten lifecycle lint expectations

### DIFF
--- a/src/config/tests/examples.rs
+++ b/src/config/tests/examples.rs
@@ -210,7 +210,7 @@ fn shared_test_only_operator_auth_is_tier_valid_and_wired() {
 }
 
 #[test]
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "one frozen inventory keeps config, topology, and driver wiring atomic"
 )]

--- a/src/config_history/v2.rs
+++ b/src/config_history/v2.rs
@@ -51,7 +51,7 @@ pub(crate) fn record_v2(dir: &Path, normalized_toml: &str, manifest: Manifest) -
     record_v2_with(dir, normalized_toml, manifest, |_| Ok(()))
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the writer keeps one ordered crash-consistency transaction visible"
 )]

--- a/src/config_migration.rs
+++ b/src/config_migration.rs
@@ -638,10 +638,6 @@ fn fingerprint(metadata: &fs::Metadata, digest: [u8; 32]) -> Fingerprint {
     }
 }
 
-#[allow(
-    clippy::too_many_arguments,
-    reason = "the fence compares every pinned source, symlink, and stage identity together"
-)]
 fn verify_fence(
     spelled: &Path,
     resolved: &Path,
@@ -679,10 +675,6 @@ fn verify_source(
     Ok(())
 }
 
-#[allow(
-    clippy::too_many_arguments,
-    reason = "the I/O adapter preserves the complete atomic-fence input tuple"
-)]
 fn verify_fence_io(
     spelled: &Path,
     resolved: &Path,


### PR DESCRIPTION
## Summary

- convert two active configuration-lifecycle too-many-lines allowances into self-checking expectations
- remove two stale too-many-arguments suppressions from helpers with exactly seven parameters
- preserve every function body, test body, lint reason, and unrelated attribute

## Validation

- four focused tests covering every changed site
- strict root all-target/all-feature Clippy
- lint-reason checker and all checker tests
- exact attribute-roster and word-diff review
- full pre-push formatting, workspace Clippy, tests, and rustdoc
- independent review with no findings

Linear: LAN-1268