### PR TITLE
chore(policy): tighten runtime lifecycle lint expectation

### DIFF
--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -2182,7 +2182,7 @@ impl PeerManager {
         result
     }
 
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "runtime policy application keeps ordered import and export transitions together"
     )]


### PR DESCRIPTION
## Summary

- convert the reasoned `too_many_lines` suppression on runtime policy application from `allow` to `expect`
- preserve the existing rationale and ordered import/export lifecycle body unchanged
- make future function shrinkage surface the now-unfulfilled exception

## Validation

- strict workspace Clippy with all targets and features
- focused runtime policy retry and pending-refresh tests
- lint-reason checker and checker tests
- formatting, workspace tests, and documentation via the full pre-push gate