### PR TITLE
test(rib): tighten fault corpus lint expectation

### DIFF
--- a/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
+++ b/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
@@ -1006,7 +1006,7 @@ fn announced_paths(messages: &[NormMsg], prefix: Ipv4Prefix) -> HashSet<(u32, Ip
         .collect()
 }
 
-#[allow(
+#[expect(
     clippy::too_many_lines,
     reason = "the exhaustive fault-script interpreter keeps every operation's behavior in one auditable match"
 )]


### PR DESCRIPTION
## Summary

- convert the reasoned `too_many_lines` suppression on the exhaustive update-group fault interpreter from `allow` to `expect`
- preserve the existing rationale and operation-match body unchanged
- make future structural shrinkage surface the now-unfulfilled exception

## Validation

- exact deterministic update-group fault-corpus test
- strict `rustbgpd-rib` Clippy with all targets and features
- lint-reason checker and checker tests
- formatting, workspace tests, and documentation via the full pre-push gate