### PR TITLE
fix(recover): unify runtime comparison semantics

### DIFF
--- a/docs/cookbook/activation-manual-recovery.md
+++ b/docs/cookbook/activation-manual-recovery.md
@@ -80,17 +80,19 @@ generation tree are the state; the receipt is not.
 
 ## 1. Is the candidate live and healthy, live and broken, or down?
 
-The last two `status` lines are the helper's own settlement test — `rbgp
-health`, then `rbgp config diff` against the `current` generation with its
-policy paths rewritten to the live `current/` prefix (exactly what the helper
-compares). Read them together:
+The last two `status` lines are the helper's own settlement test. It runs
+`rbgp health` first and only when that explicitly reports healthy does it stage
+and run `rbgp config diff` against the `current` generation, with policy paths
+rewritten to the live `current/` prefix (exactly what the helper compares).
+Read them together:
 
 | `daemon` | `runtime_equals_current` | Meaning |
 |---|---|---|
 | `healthy` | `yes` | **Live and equal**: the reload landed; the helper only ran out of settle budget, or the receipt write failed afterwards. |
 | `healthy` | `no` | **Live but still on the previous generation**: the activation command ran and failed without reloading (a sudoers denial, a wrong unit name) or the daemon rejected the reload. The daemon log has no `config reload complete` line for the attempt. |
-| `unreachable` | `unknown` | **Down**: a restart took the old process out and the new one never came up. |
-| `unhealthy`, or `invalid` | any | **Live and broken**: treat it as the down case and prefer the previous generation. |
+| `healthy` | `unknown` | **Comparison inconclusive**: staging failed, or `config diff` could not start, timed out, exited 1, or returned another unexpected status. Do not infer equal or different, or that the diff completed. |
+| `unreachable` | `unknown` | **Down**: a restart took the old process out and the new one never came up. The helper did not run `config diff`. |
+| `unhealthy`, or `invalid` | `unknown` | **Live and broken or an invalid health response**: the helper did not run `config diff`; treat it as the down case and prefer the previous generation. |
 
 To see *what* the daemon is missing in the second row, or to confirm it runs
 the previous generation, run the diff by hand

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -307,8 +307,9 @@ year unpruned, and `--keep 48` bounds it to about 110 MiB.
 fence, the lifecycle journal, and the generation tree with its `current` link —
 plus the advisory activation receipt, and prints one `key: value` line per
 field in a fixed order. It takes the same binding flags as `activate` and
-changes nothing; with `--rbgp` it also runs the settle path's own probe
-(`rbgp health`, then `rbgp config diff` against the `current` generation):
+changes nothing; with `--rbgp` it first runs `rbgp health` and only for a
+healthy daemon stages and runs `rbgp config diff` against the `current`
+generation:
 
 ```console
 sudo -u rustbgpd /usr/bin/rs-config-render status \
@@ -332,7 +333,7 @@ sudo -u rustbgpd /usr/bin/rs-config-render status \
 | `advisory_receipt` | `matches-current` (its `candidate_sha256` is the `current` target), `stale`, `absent`, `unreadable`; the receipt is advisory and may be absent or stale after an exit 5 |
 | `advisory_receipt_status`, `advisory_receipt_previous_generation` | the receipt's values or `none` |
 | `daemon` | `not-probed` (no `--rbgp`), `healthy`, `unhealthy`, `unreachable`, `invalid` |
-| `runtime_equals_current` | `yes`, `no`, `unknown` (not probed, unreachable, or no valid `current`) |
+| `runtime_equals_current` | `yes` only when a healthy daemon's `config diff` exits 0; `no` only when it exits 2; `unknown` when not probed, no valid `current` exists, health is unhealthy/unreachable/invalid, comparison staging fails, or `config diff` cannot start, times out, exits 1, or returns any other status |
 
 Exit 0 whenever the state could be read — manual recovery is a report, not an
 error — and 1 only when the state directory is unreadable. `status` takes no
@@ -354,7 +355,7 @@ connection `resume` takes); a plain `activate` exit 5 needs neither.
 
 | Verb | Does | Refuses when |
 |---|---|---|
-| `keep-current --rbgp <PATH> [--force]` | probes the daemon (`rbgp health` + `config diff` against `current`), writes the receipt as `kept`, delivers `updated` (or `release-update-lock` when the journal shows nothing was activated), removes journal and fence | the probe is not healthy and equal (unless `--force`); the lock was already released |
+| `keep-current --rbgp <PATH> [--force]` | probes health and, only when healthy, runs `config diff` against `current`; then writes the receipt as `kept`, delivers `updated` (or `release-update-lock` when the journal shows nothing was activated), and removes journal and fence | the comparison is `Different` or `Unknown` (unless `--force`); the lock was already released |
 | `rollback --rbgp <PATH> --activation-command … [--activation-arg …] [--settle-seconds N] [--to generations/<digest>]` | re-points `current` at the previous generation and runs the activation command through the same publish-activate-settle path as a first activation, writes the receipt as `rolled_back`, delivers `release-update-lock`, removes journal and fence | the previous generation is unknown (receipt absent or stale) and `--to` is not given; the target is `current` or not a published generation; the journal shows nothing was activated; the lock was already released |
 | `release-lock --kept\|--rolled-back` | delivers that one callback and marks the journal `lock_released`; retryable | there is no journal |
 | `clear` | removes journal and fence | a journal exists whose callback no verb delivered |

--- a/tools/rs-config-render/src/activation.rs
+++ b/tools/rs-config-render/src/activation.rs
@@ -599,6 +599,13 @@ mod unix {
         Invalid,
     }
 
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) enum RuntimeDiff {
+        Equal,
+        Different,
+        Unknown,
+    }
+
     pub(crate) fn health_probe(rbgp: &Path, rbgp_addr: &str, deadline: Instant) -> Health {
         let Ok(child) = Command::new(rbgp)
             .args(["--json", "--addr", rbgp_addr, "health"])
@@ -628,12 +635,12 @@ mod unix {
         }
     }
 
-    pub(crate) fn equal_runtime(
+    pub(crate) fn runtime_diff(
         rbgp: &Path,
         rbgp_addr: &str,
         comparison: &Path,
         deadline: Instant,
-    ) -> bool {
+    ) -> RuntimeDiff {
         let Ok(child) = Command::new(rbgp)
             .args(["--addr", rbgp_addr, "config", "diff"])
             .arg(comparison)
@@ -641,9 +648,25 @@ mod unix {
             .stderr(Stdio::null())
             .spawn()
         else {
-            return false;
+            return RuntimeDiff::Unknown;
         };
-        wait_output(child, deadline).is_some_and(|output| output.status.code() == Some(0))
+        let Some(output) = wait_output(child, deadline) else {
+            return RuntimeDiff::Unknown;
+        };
+        match output.status.code() {
+            Some(0) => RuntimeDiff::Equal,
+            Some(2) => RuntimeDiff::Different,
+            _ => RuntimeDiff::Unknown,
+        }
+    }
+
+    pub(crate) fn equal_runtime(
+        rbgp: &Path,
+        rbgp_addr: &str,
+        comparison: &Path,
+        deadline: Instant,
+    ) -> bool {
+        runtime_diff(rbgp, rbgp_addr, comparison, deadline) == RuntimeDiff::Equal
     }
 
     fn settle(rbgp: &Path, rbgp_addr: &str, comparison: &Path, deadline: Instant) -> bool {
@@ -1156,7 +1179,7 @@ mod unix {
 pub use unix::activate;
 #[cfg(unix)]
 pub(crate) use unix::{
-    Activation, Comparison, Health, activate_guarded, comparison_file, current_target,
-    equal_runtime, health_probe, normalized_toml, private, republish, state_lock, unique_name,
+    Activation, Comparison, Health, RuntimeDiff, activate_guarded, comparison_file, current_target,
+    health_probe, normalized_toml, private, republish, runtime_diff, state_lock, unique_name,
     valid_digest, verify_candidate, write_kept_receipt,
 };

--- a/tools/rs-config-render/src/recover.rs
+++ b/tools/rs-config-render/src/recover.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use crate::Exit;
 use crate::ixp_manager_host::{self, Binding, Guard};
 use crate::ixp_manager_lifecycle::{self as lifecycle, Callback, Journal, Phase};
-use crate::{activation, activation::Health};
+use crate::{activation, activation::Health, activation::RuntimeDiff};
 
 const ACTIVATION_RECEIPT: &str = "activation-receipt.json";
 /// rbgp gets this long per probe before `status` reports it as invalid.
@@ -175,6 +175,62 @@ fn comparison(
     activation::comparison_file(&bytes, state, "status")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RuntimeProbe {
+    daemon: &'static str,
+    comparison: RuntimeDiff,
+}
+
+impl RuntimeProbe {
+    const fn report(self) -> &'static str {
+        match self.comparison {
+            RuntimeDiff::Equal => "yes",
+            RuntimeDiff::Different => "no",
+            RuntimeDiff::Unknown => "unknown",
+        }
+    }
+
+    fn detail(self) -> String {
+        match self.comparison {
+            RuntimeDiff::Equal => format!("daemon {}, runtime equals current", self.daemon),
+            RuntimeDiff::Different => {
+                format!("daemon {}, runtime differs from current", self.daemon)
+            }
+            RuntimeDiff::Unknown => {
+                format!("daemon {}, runtime comparison unknown", self.daemon)
+            }
+        }
+    }
+}
+
+fn runtime_probe(
+    rbgp: &Path,
+    binding: &Binding,
+    state: &Path,
+    current: Option<&str>,
+) -> RuntimeProbe {
+    let health = activation::health_probe(rbgp, binding.rbgp_addr(), Instant::now() + PROBE);
+    let daemon = match health {
+        Health::Reachable(true) => "healthy",
+        Health::Reachable(false) => "unhealthy",
+        Health::Unreachable => "unreachable",
+        Health::Invalid => "invalid",
+    };
+    let comparison = match (health, current) {
+        (Health::Reachable(true), Some(current)) => match comparison(state, current, binding) {
+            Ok(file) => activation::runtime_diff(
+                rbgp,
+                binding.rbgp_addr(),
+                file.as_ref(),
+                Instant::now() + PROBE,
+            ),
+            Err(_) => RuntimeDiff::Unknown,
+        },
+        _ => RuntimeDiff::Unknown,
+    };
+    RuntimeProbe { daemon, comparison }
+}
+
 /// Report the activation and lifecycle state of one handle without changing
 /// it. Manual-recovery state is a successful report; only an unreadable
 /// state directory is an error.
@@ -300,38 +356,10 @@ pub fn status(options: &StatusOptions<'_>) -> Result<Report, Error> {
         "advisory_receipt_previous_generation",
         previous.unwrap_or("none"),
     );
-    let (daemon, equal) = match options.rbgp {
-        None => ("not-probed", "unknown"),
-        Some(rbgp) => {
-            let addr = binding.rbgp_addr();
-            let health = activation::health_probe(rbgp, addr, Instant::now() + PROBE);
-            let daemon = match health {
-                Health::Reachable(true) => "healthy",
-                Health::Reachable(false) => "unhealthy",
-                Health::Unreachable => "unreachable",
-                Health::Invalid => "invalid",
-            };
-            let equal = match (health, &current) {
-                (Health::Reachable(_), Some(target)) => match comparison(state, target, binding) {
-                    Ok(file) => {
-                        if activation::equal_runtime(
-                            rbgp,
-                            addr,
-                            file.as_ref(),
-                            Instant::now() + PROBE,
-                        ) {
-                            "yes"
-                        } else {
-                            "no"
-                        }
-                    }
-                    Err(_) => "unknown",
-                },
-                _ => "unknown",
-            };
-            (daemon, equal)
-        }
-    };
+    let (daemon, equal) = options.rbgp.map_or(("not-probed", "unknown"), |rbgp| {
+        let probe = runtime_probe(rbgp, binding, state, current.as_deref());
+        (probe.daemon, probe.report())
+    });
     report.push("daemon", daemon);
     report.push("runtime_equals_current", equal);
     Ok(report)
@@ -529,32 +557,6 @@ fn lifecycle_refusal(error: lifecycle::Error) -> Error {
     }
 }
 
-fn probe(rbgp: &Path, binding: &Binding, state: &Path, current: &str) -> (bool, String) {
-    let health = activation::health_probe(rbgp, binding.rbgp_addr(), Instant::now() + PROBE);
-    let daemon = match health {
-        Health::Reachable(true) => "healthy",
-        Health::Reachable(false) => "unhealthy",
-        Health::Unreachable => "unreachable",
-        Health::Invalid => "invalid",
-    };
-    let equal = health == Health::Reachable(true)
-        && comparison(state, current, binding).is_ok_and(|file| {
-            activation::equal_runtime(
-                rbgp,
-                binding.rbgp_addr(),
-                file.as_ref(),
-                Instant::now() + PROBE,
-            )
-        });
-    (
-        equal,
-        format!(
-            "daemon {daemon}, runtime {} current",
-            if equal { "equals" } else { "differs from" }
-        ),
-    )
-}
-
 /// Plan and, with `apply`, perform one recovery verb. Every verb refuses
 /// (exit 2, nothing changed) unless this binding's fence stands and the
 /// lifecycle journal, if any, is in manual recovery rather than resumable.
@@ -643,7 +645,8 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Failur
             let Some(current) = current.as_deref() else {
                 return Err(Error::Refused("no current generation to keep").into());
             };
-            let (equal, detail) = probe(rbgp, binding, state, current);
+            let probe = runtime_probe(rbgp, binding, state, Some(current));
+            let equal = probe.comparison == RuntimeDiff::Equal;
             if !equal && !*force {
                 return Err(Error::Refused(
                     "daemon is not settled on current; fix the daemon by hand or pass --force",
@@ -651,9 +654,9 @@ pub fn recover(options: &Options<'_>, verb: &Verb<'_>) -> Result<Outcome, Failur
                 .into());
             }
             plan.push(Step::Probe(if equal {
-                detail
+                probe.detail()
             } else {
-                format!("{detail} (overridden by --force)")
+                format!("{} (overridden by --force)", probe.detail())
             }));
             session.checker_version = activation::verify_candidate(&state.join(current), binding)
                 .map_err(activation_refusal)?

--- a/tools/rs-config-render/tests/recover.rs
+++ b/tools/rs-config-render/tests/recover.rs
@@ -186,6 +186,7 @@ impl Rig {
         fs::write(&key, format!("{API_KEY}\n")).unwrap();
         mode(&key, 0o600);
         fs::write(root.join("health-mode"), "ok").unwrap();
+        fs::write(root.join("diff-mode"), "contract").unwrap();
         fs::write(root.join("activation-mode"), "ok").unwrap();
         let checker = root.join("rustbgpd");
         executable(
@@ -194,7 +195,8 @@ impl Rig {
         );
         // The fake daemon "runs" whatever generation the activation command
         // last loaded (`runtime`); `config diff` is equal iff that is what
-        // `current` points at now. `health-mode` is ok | unhealthy | down.
+        // `current` points at now. `health-mode` is ok | unhealthy | down |
+        // invalid.
         let rbgp = root.join("rbgp");
         executable(
             &rbgp,
@@ -209,11 +211,16 @@ case "$*" in
       printf 'Error: cannot reach rustbgpd at test (connection refused)\n' >&2
       exit 1
     fi
+    if [ "$health_mode" = invalid ]; then
+      printf 'not-json\n'
+      exit 0
+    fi
     [ "$health_mode" = unhealthy ] && healthy=false || healthy=true
     printf '{{"healthy":%s}}\n' "$healthy"
     exit 0
     ;;
 esac
+[ "$(cat "$root/diff-mode")" = error ] && exit 1
 [ "$(cat "$root/runtime" 2>/dev/null)" = "$(readlink "$root/{HANDLE}/activation/current")" ] && exit 0
 exit 2
 "#
@@ -293,6 +300,14 @@ esac
 
     fn set(&self, name: &str, value: &str) {
         fs::write(self.root.join(name), value).unwrap();
+    }
+
+    fn rbgp_calls(&self) -> Vec<String> {
+        fs::read_to_string(self.root.join("rbgp.log"))
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_owned)
+            .collect()
     }
 
     fn current(&self) -> String {
@@ -522,8 +537,28 @@ esac
     /// `status` through the binary, asserting it changed nothing: the state,
     /// runtime, and host-state trees are byte-for-byte identical afterwards.
     fn status_cli(&self, probe: bool) -> (i32, BTreeMap<String, String>, String) {
+        self.status_cli_with_limit(probe, false)
+    }
+
+    fn status_cli_unwritable(&self) -> (i32, BTreeMap<String, String>, String) {
+        self.status_cli_with_limit(true, true)
+    }
+
+    fn status_cli_with_limit(
+        &self,
+        probe: bool,
+        unwritable: bool,
+    ) -> (i32, BTreeMap<String, String>, String) {
         let before = snapshot(&self.root);
-        let mut command = Command::new(env!("CARGO_BIN_EXE_rs-config-render"));
+        let mut command = if unwritable {
+            let mut shell = Command::new("/bin/sh");
+            shell
+                .args(["-c", "trap '' XFSZ; ulimit -f 0; exec \"$@\"", "sh"])
+                .arg(env!("CARGO_BIN_EXE_rs-config-render"));
+            shell
+        } else {
+            Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        };
         command.arg("status");
         self.binding_args(&mut command);
         if probe {
@@ -744,7 +779,10 @@ fn status_reports_manual_recovery_with_the_candidate_not_live() {
     let (_, fields, _) = rig.status_cli(true);
     assert_fields(
         &fields,
-        &[("daemon", "unhealthy"), ("runtime_equals_current", "no")],
+        &[
+            ("daemon", "unhealthy"),
+            ("runtime_equals_current", "unknown"),
+        ],
     );
     rig.set("health-mode", "down");
     let (_, fields, _) = rig.status_cli(true);
@@ -755,6 +793,94 @@ fn status_reports_manual_recovery_with_the_candidate_not_live() {
             ("runtime_equals_current", "unknown"),
         ],
     );
+}
+
+#[test]
+fn unknown_runtime_comparisons_are_fail_closed_and_force_still_applies() {
+    let _guard = test_guard();
+    for (health_mode, diff_mode, daemon, runs_diff) in [
+        ("unhealthy", "contract", "unhealthy", false),
+        ("down", "contract", "unreachable", false),
+        ("invalid", "contract", "invalid", false),
+        ("ok", "error", "healthy", true),
+    ] {
+        let rig = Rig::new();
+        let server = rig.induce_exit_5("load-then-fail", vec![Response::json(200)]);
+        rig.set("health-mode", health_mode);
+        rig.set("diff-mode", diff_mode);
+        let before = rig.rbgp_calls().len();
+
+        let (code, fields, stderr) = rig.status_cli(true);
+        assert_eq!(code, 0, "{health_mode}: {stderr}");
+        assert_fields(
+            &fields,
+            &[("daemon", daemon), ("runtime_equals_current", "unknown")],
+        );
+
+        let keep = keep_args(&rig);
+        let (code, lines, stderr) = rig.recover_cli(&strs(&keep), false, Some(&server.origin));
+        assert_eq!(code, 2, "{health_mode}: {stderr}");
+        assert!(lines.is_empty());
+        assert!(stderr.contains("daemon is not settled on current"));
+
+        let mut forced = keep;
+        forced.push("--force".into());
+        let (code, lines, stderr) = rig.recover_cli(&strs(&forced), true, Some(&server.origin));
+        assert_eq!(code, 0, "{health_mode}: {stderr}");
+        assert_eq!(
+            lines[0],
+            format!("probe: daemon {daemon}, runtime comparison unknown (overridden by --force)")
+        );
+        assert_eq!(rig.receipt_value()["phases"]["runtime_equal"], false);
+
+        let calls = rig.rbgp_calls();
+        let new_calls = &calls[before..];
+        assert_eq!(
+            new_calls
+                .iter()
+                .filter(|call| call.ends_with(" health"))
+                .count(),
+            3,
+            "{health_mode}/{diff_mode}: {new_calls:?}"
+        );
+        assert_eq!(
+            new_calls
+                .iter()
+                .filter(|call| call.contains(" config diff "))
+                .count(),
+            if runs_diff { 3 } else { 0 },
+            "{health_mode}/{diff_mode}: {new_calls:?}"
+        );
+        assert_eq!(server.finish().len(), 3);
+    }
+}
+
+#[test]
+fn comparison_staging_failure_is_unknown_on_both_surfaces() {
+    let _guard = test_guard();
+    let rig = Rig::new();
+    let server = rig.induce_exit_5("load-then-fail", vec![]);
+    let before = snapshot(&rig.root);
+
+    // RLIMIT_FSIZE 0 lets the read-only probes and existing locks run but
+    // refuses the fresh private comparison file's first byte.
+    let (status_code, fields, status_stderr) = rig.status_cli_unwritable();
+    let (recover_code, lines, recover_stderr) =
+        rig.recover_cli_unwritable(&strs(&keep_args(&rig)), Some(&server.origin));
+
+    assert_eq!(status_code, 0, "{status_stderr}");
+    assert_fields(
+        &fields,
+        &[("daemon", "healthy"), ("runtime_equals_current", "unknown")],
+    );
+    assert_eq!(recover_code, 2, "{recover_stderr}");
+    assert!(lines.is_empty());
+    assert!(
+        recover_stderr.contains("daemon is not settled on current"),
+        "{recover_stderr}"
+    );
+    assert_eq!(snapshot(&rig.root), before, "failed probes changed state");
+    assert_eq!(server.finish().len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- give runtime comparison one typed `Equal` / `Different` / `Unknown` result shared by status and manual recovery
- run `config diff` only after an explicitly healthy daemon probe
- classify exit 0 as equal, exit 2 as different, and spawn, timeout, exit 1, signal, or other failures as unknown
- keep existing activation-settle boolean callers behavior-compatible while making recovery decisions and status reporting consistent
- document the health-first operator contract in the tool README and manual-recovery runbook

## Validation

- 21 recovery integration tests and 13 activation integration tests
- focused health/comparison matrix and comparison-staging failure coverage
- strict `rs-config-render` Clippy and package docs
- public-document checker and its 15 tests
- formatting, workspace tests, and documentation via the full pre-push gate