### PR TITLE
test(rib): tighten update-group oracle lint expectations

### DIFF
--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -475,7 +475,7 @@ impl Oracle {
 
     // Mirrors the production PeerUp event so schedules can state every
     // grouping input and the session generation at the call site.
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "mirrors every grouping input in the production PeerUp event"
     )]
@@ -502,7 +502,7 @@ impl Oracle {
         .await;
     }
 
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "fault oracle mirrors PeerUp plus negotiated feature changes at a stamped session boundary"
     )]


### PR DESCRIPTION
## Summary

- convert the two reasoned `too_many_arguments` suppressions on update-group oracle helpers from `allow` to `expect`
- preserve both rationales, helper signatures, and test behavior unchanged
- make future argument-count reductions surface stale exceptions automatically

## Validation

- exact deterministic update-group fault-corpus test
- strict `rustbgpd-rib` Clippy with all targets and features
- lint-reason checker and checker tests
- formatting, workspace tests, and documentation via the full pre-push gate