### PR TITLE
test(config): tighten abort lifecycle lint expectation

### DIFF
--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -8574,7 +8574,7 @@ remote_asn = 65010
     /// pending (mutation fence closed, second mutations rejected) and a retry
     /// of the abort must be able to resolve it.
     #[tokio::test]
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "the test proves the complete failed-abort, fence, retry, and resolution lifecycle"
     )]


### PR DESCRIPTION
## Summary

- convert the reasoned `too_many_lines` suppression on the failed-abort lifecycle test from `allow` to `expect`
- preserve the existing rationale and complete fence/retry/resolution proof unchanged
- make future test shrinkage surface the now-unfulfilled exception

## Validation

- exact failed-abort lifecycle test
- strict workspace Clippy with all targets and features
- lint-reason checker and checker tests
- formatting, workspace tests, and documentation via the full pre-push gate