### PR TITLE
chore(rib): tighten benchmark lint expectation

### DIFF
--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -420,7 +420,7 @@ impl RibManager {
         rx
     }
 
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "the bench seam keeps each production PeerUp grouping dimension explicit"
     )]


### PR DESCRIPTION
## Summary

- convert the reasoned `too_many_arguments` suppression on the RIB benchmark PeerUp seam from `allow` to `expect`
- preserve the explicit grouping dimensions, rationale, and benchmark behavior unchanged
- make future seam simplification surface the now-unfulfilled exception

## Validation

- compile the real `route_paging` benchmark with `bench-internals`
- strict `rustbgpd-rib` Clippy with all targets and features
- lint-reason checker and checker tests
- formatting, workspace tests, and documentation via the full pre-push gate