### PR TITLE
test(prefix-limit): tighten lifecycle lint expectation

### DIFF
--- a/tests/outbound_prefix_limits.rs
+++ b/tests/outbound_prefix_limits.rs
@@ -927,7 +927,7 @@ fn log_gates(checks: &mut Checks, log: &str) {
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[allow(clippy::too_many_lines, reason = "one linear behavior arc")]
+#[expect(clippy::too_many_lines, reason = "one linear behavior arc")]
 async fn outbound_prefix_limits_bound_the_wire_and_survive_reload_edits() {
     let rundir = RunDir::new("oplim");
     let bgp_port = free_port();


### PR DESCRIPTION
## Summary

- convert the reasoned `too_many_lines` suppression on the outbound prefix-limit integration arc from `allow` to `expect`
- preserve the existing Tokio worker configuration, rationale, timing, assertions, and test body unchanged
- make future scenario shrinkage surface the now-unfulfilled exception

## Validation

- exact daemon/wire/reload outbound-prefix-limit integration test
- strict workspace Clippy with all targets and features
- lint-reason checker and checker tests
- formatting, workspace tests, and documentation via the full pre-push gate