### PR TITLE
chore(evpn-load): finish lint expectation cleanup

### DIFF
--- a/bench/evpn-load/src/bin/monitor.rs
+++ b/bench/evpn-load/src/bin/monitor.rs
@@ -9,7 +9,7 @@
 
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(
+#![expect(
     clippy::too_many_lines,
     reason = "the monitor binary keeps its command wiring and reporting flow in one entrypoint"
 )]

--- a/bench/evpn-load/src/bin/tester.rs
+++ b/bench/evpn-load/src/bin/tester.rs
@@ -10,11 +10,6 @@
 
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(
-    clippy::too_many_lines,
-    reason = "the test driver keeps scenario construction and reporting in one entrypoint"
-)]
-
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
## Summary

- convert the active EVPN monitor too-many-lines suppression to a self-checking expectation
- remove the EVPN tester suppression after strict Clippy proved it stale
- leave zero too-many allow attributes in workspace-member src trees

## Validation

- strict rustbgpd-evpn-load Clippy with all targets and features
- 17 rustbgpd-evpn-load tests
- Clippy-reason checker and mutation tests
- authoritative workspace-member src-tree roster scan
- full pre-push formatting, workspace Clippy, library tests, and rustdoc

Linear: LAN-1268