### PR TITLE
refactor(api): gate test-only service constructors

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -72,9 +72,9 @@ pub struct EventService {
 }
 
 impl EventService {
-    #[allow(dead_code)]
+    #[cfg(test)]
     #[must_use]
-    pub fn new(
+    pub(crate) fn new(
         rib_tx: tokio::sync::mpsc::Sender<RibUpdate>,
         peer_mgr_tx: tokio::sync::mpsc::Sender<PeerManagerCommand>,
     ) -> Self {
@@ -86,6 +86,7 @@ impl EventService {
         )
     }
 
+    #[cfg(test)]
     #[must_use]
     pub fn with_dataplane_snapshots(
         rib_tx: tokio::sync::mpsc::Sender<RibUpdate>,
@@ -102,6 +103,7 @@ impl EventService {
         )
     }
 
+    #[cfg(test)]
     #[must_use]
     pub(crate) fn with_dataplane_snapshots_and_broadcaster(
         rib_tx: tokio::sync::mpsc::Sender<RibUpdate>,

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -150,7 +150,7 @@ pub struct RibService {
 
 impl RibService {
     /// Create a new RIB service backed by the given RIB channel.
-    #[allow(dead_code)]
+    #[cfg(any(test, feature = "bench-internals"))]
     pub fn new(rib_tx: mpsc::Sender<RibUpdate>) -> Self {
         Self {
             rib_tx,

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -923,7 +923,8 @@ mod tests {
             config_history_dir: None,
         });
         let (rib_tx, _rib_rx) = mpsc::channel(1);
-        RibService::new(rib_tx).with_fib_table_control(AccessMode::ReadWrite, Some(control))
+        RibService::with_status_snapshots(rib_tx, Arc::new(Vec::new), Arc::new(Vec::new))
+            .with_fib_table_control(AccessMode::ReadWrite, Some(control))
     }
 
     #[tokio::test]
@@ -1010,11 +1011,12 @@ mod tests {
             })
         });
         let (rib_tx, _rib_rx) = mpsc::channel(1);
-        let status = RibService::new(rib_tx)
-            .with_fib_table_control(AccessMode::ReadWrite, Some(control))
-            .list_fib_tables(Request::new(proto::ListFibTablesRequest {}))
-            .await
-            .unwrap_err();
+        let status =
+            RibService::with_status_snapshots(rib_tx, Arc::new(Vec::new), Arc::new(Vec::new))
+                .with_fib_table_control(AccessMode::ReadWrite, Some(control))
+                .list_fib_tables(Request::new(proto::ListFibTablesRequest {}))
+                .await
+                .unwrap_err();
         assert_eq!(status.code(), Code::Internal);
         assert_eq!(status.message(), "sentinel hook failure");
     }


### PR DESCRIPTION
## Summary

- keep RibService::new available only to API unit tests and bench-internals benchmarks
- narrow EventService convenience constructors to API unit tests
- migrate root FIB-control tests to the production snapshot constructor without changing behavior

## Validation

- 670 rustbgpd-api library tests
- 18 focused root FIB-table-control tests
- API benchmark build with bench-internals
- strict API all-target Clippy with benchmark and VPN query features
- independent feature-off, all-feature, docs, caller-roster, and cfg-boundary review
- full pre-push formatting, workspace Clippy, library tests, and rustdoc

Linear: LAN-1272