### PR TITLE
test(observability): require metric consumers

### DIFF
--- a/.github/workflows/public-docs-contract.yml
+++ b/.github/workflows/public-docs-contract.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Check emitted metrics have a shipped consumer
+        run: |
+          python3 -m unittest -v scripts/test_check_metric_consumers.py
+          python3 scripts/check-metric-consumers.py
       - name: Check public documentation cites no private tracker IDs
         run: |
           python3 -m unittest -v scripts/test_check_public_tracker_ids.py

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -335,6 +335,13 @@ broader platform-diversity validation beyond the protected hosted matrix.
 
 ---
 
+The M61 adoption receipt also pins the component-level ownership counters:
+`evpn_l3_neighbor_adopted_total` and `evpn_l3_neighbor_reaped_total` cover the
+shared L3 neighbor, while `evpn_l3vxlan_fdb_adopted_total` and
+`evpn_l3vxlan_fdb_reaped_total` cover its L3VXLAN FDB resolution row. These raw
+counters distinguish restart adoption from deferred cleanup; current route and
+IP-VRF state remain the primary operational view.
+
 ## Running Interop Tests
 
 ### Prerequisites

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1416,6 +1416,12 @@ create avoidable load and disconnected streams fail like any other RPC. After a
 lag warning, treat the stream as a live tail after a gap and refresh state with
 a snapshot or bounded history query.
 
+### RFC 7999 BLACKHOLE discards
+
+`bgp_blackhole_discard_rejected_total{reason}` counts discard candidates
+withheld before kernel installation. The bounded reason is `broad_prefix` or
+`not_ebgp`; use `rbgp rib blackholes` for current per-prefix decision details.
+
 ### General Unicast FIB
 
 These metrics are present when the daemon is built with the ADR-0061 general
@@ -1570,7 +1576,16 @@ daemon log for the peer-specific reason.
 | `evpn_duplicate_mac_first_move_timestamp_seconds{vni,mac}` | Unix timestamp of the first observed duplicate-MAC / mobility contention event for that key |
 | `evpn_duplicate_mac_threshold_exceeded_total{vni,mac,action}` | RFC 7432 §15.1 M/N threshold crossings. `action` is `detect` or `suppress_local` from the per-instance config |
 | `evpn_duplicate_mac_quarantine_active{vni,mac}` | `1` while `action = "suppress_local"` is actively suppressing local Type 2 originations for that key; returns to `0` after timed recovery |
+| `evpn_ip_vrf_observed_routes{vrf}` | Kernel routes currently eligible for Type 5 origination from each configured IP-VRF |
+| `evpn_ip_vrf_observed_routes_filtered_total{vrf,reason}` | Kernel routes rejected by the bounded IP-VRF observation classifier |
+| `evpn_ip_vrf_origination_suppressed_total{vrf,reason}` | Type 5 candidates withheld because the IP-VRF is not ready or the address family does not match |
+| `evpn_ip_vrf_originated_routes{vrf}` | Locally originated Type 5 routes currently advertised from each IP-VRF |
+| `evpn_ip_vrf_installed_routes{vrf}` | Remote Type 5 routes currently owned in each IP-VRF kernel table |
 | `evpn_ip_vrf_remote_prefix_drops{vrf,reason}` | Current remote Type 5 projection drops by bounded IP-VRF/reason labels. Overlay-index reasons include `overlay_index_no_linked_l2vni`, `unresolved_overlay_index_gateway`, and `ambiguous_overlay_index_gateway`; `vrf="_unscoped"` means the drop happened before a configured IP-VRF could be selected. |
+| `evpn_foreign_replaces_blocked_total` | Installs or replaces withheld because an exact-key foreign kernel row already exists |
+| `evpn_foreign_deletes_skipped_total` | Deletes skipped after the live kernel row ceased to be rustbgpd-owned |
+| `evpn_foreign_owned_relinquished_total` | Owned keys released after another writer replaced the live kernel row |
+| `evpn_single_active_backup_active` | Single-active groups currently retargeted to a backup PE during the post-failover window |
 
 During M37 or a synthetic MAC-churn soak, the inject and withdraw counters
 should follow the `bridge fdb add` / `bridge fdb del` cadence. Any non-zero

--- a/docs/soaks/soak-gate8b-mac-churn-1h.md
+++ b/docs/soaks/soak-gate8b-mac-churn-1h.md
@@ -141,8 +141,8 @@ on both sides within the first sample after re-establishment.
 |---|---|---|
 | `evpn_fdb_nhg_drift_members_repaired_total` | 0 | 0 (samples while running) |
 | `evpn_fdb_nhg_drift_groups_replaced_total` | 0 | 0 |
-| `evpn_fdb_nhg_drift_orphans_cleaned_total` | 0 | 0 |
-| `evpn_fdb_nhg_drift_disabled` (gauge) | 0 | 0 |
+| `evpn_fdb_nhg_orphans_cleaned_total` | 0 | 0 |
+| `evpn_fdb_nhg_drift_disabled_total` (counter) | 0 | 0 |
 
 Zero drift events across the full hour, across 5 flip events and
 ~10 600 FDB ops (adds + dels + moves). The drift recovery path is

--- a/docs/soaks/soak-gate8b-mac-churn-24h.md
+++ b/docs/soaks/soak-gate8b-mac-churn-24h.md
@@ -124,8 +124,8 @@ exercised in every cycle.
 |---|---|
 | `evpn_fdb_nhg_drift_members_repaired_total` | 0 |
 | `evpn_fdb_nhg_drift_groups_replaced_total` | 0 |
-| `evpn_fdb_nhg_drift_orphans_cleaned_total` | 0 |
-| `evpn_fdb_nhg_drift_disabled` (gauge) | 0 |
+| `evpn_fdb_nhg_orphans_cleaned_total` | 0 |
+| `evpn_fdb_nhg_drift_disabled_total` (counter) | 0 |
 
 Zero drift events across 24 h, 69 cycles, ~478 K FDB ops
 (194 K adds + 194 K dels + 90 K moves). The drift recovery path

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+"""Require every emitted Prometheus family to have a shipped consumer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from collections import Counter
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TELEMETRY = "crates/telemetry/src/metrics.rs"
+SETTLEMENT = "crates/api/src/runtime_config_settlement.rs"
+DASHBOARD = ROOT / "docs/grafana/rustbgpd-overview.json"
+ALERT_RULES = ROOT / "examples/prometheus/rustbgpd-alerts.yml"
+CARGO_LOCK = ROOT / "Cargo.lock"
+
+EMITTER_FILES = frozenset({TELEMETRY, SETTLEMENT})
+CUSTOM_COLLECTORS = frozenset(
+    {
+        (TELEMETRY, "JemallocCollector"),
+        (SETTLEMENT, "RuntimeConfigSettlementCollector"),
+    }
+)
+CUSTOM_COLLECTOR_PREFIXES = {
+    (TELEMETRY, "JemallocCollector"): "jemalloc_",
+    (SETTLEMENT, "RuntimeConfigSettlementCollector"): "bgp_runtime_config_settlement_",
+}
+SPECIAL_REGISTRATIONS = {
+    TELEMETRY: (
+        "prometheus::process_collector::ProcessCollector::for_self()",
+        "jemalloc_stats::JemallocCollector::new()",
+    ),
+    SETTLEMENT: (
+        "RuntimeConfigSettlementCollector::new(Arc::clone(&self.registry,))",
+    ),
+}
+PROCESS_COLLECTOR_VERSION = "0.14.0"
+PROCESS_FAMILIES = frozenset(
+    {
+        "process_cpu_seconds_total",
+        "process_open_fds",
+        "process_max_fds",
+        "process_virtual_memory_bytes",
+        "process_resident_memory_bytes",
+        "process_start_time_seconds",
+        "process_threads",
+    }
+)
+
+# These generic process families intentionally remain raw diagnostics. The
+# restart signal has a shipped alert, while these six are useful for ad-hoc
+# host/process correlation without prescribing deployment-specific thresholds.
+ALLOWLIST = {
+    "process_cpu_seconds_total": "generic raw process CPU diagnostic",
+    "process_open_fds": "generic raw process file-descriptor diagnostic",
+    "process_max_fds": "generic raw process file-descriptor ceiling",
+    "process_virtual_memory_bytes": "generic raw process virtual-memory diagnostic",
+    "process_resident_memory_bytes": "generic raw process resident-memory diagnostic",
+    "process_threads": "generic raw process thread-count diagnostic",
+}
+
+METRIC_CONSTRUCTOR = re.compile(
+    r"\b(?:Int)?(?:Counter|Gauge)(?:Vec)?::(?:new|with_opts)\s*\("
+    r"|\bHistogram(?:Vec)?::(?:new|with_opts)\s*\("
+)
+RAW_EMITTER_HINT = re.compile(
+    r"(?:Int)?(?:Counter|Gauge)(?:Vec)?::(?:new|with_opts)"
+    r"|Histogram(?:Vec)?::(?:new|with_opts)"
+    r"|impl\s+Collector\s+for|ProcessCollector::for_self"
+    r"|\.register\s*\(\s*Box::new"
+)
+STATIC_DEFINITION = re.compile(
+    r"let\s+(\w+)\s*=\s*"
+    r"((?:Int)?(?:Counter|Gauge)(?:Vec)?|HistogramVec)::new\(\s*"
+    r"(?:(?:Opts|HistogramOpts)::new\(\s*)?__RUST_STRING_(\d+)__",
+    re.DOTALL,
+)
+CUSTOM_COLLECTOR = re.compile(r"\bimpl\s+Collector\s+for\s+(\w+)")
+REGISTER_START = re.compile(r"\.register\s*\(\s*Box::new\s*\(")
+VARIABLE_REGISTRATION = re.compile(r"(\w+)\.clone\(\)")
+METRIC_TOKEN = re.compile(r"(?<![$\w:])([A-Za-z_:][A-Za-z0-9_:]*)(?![\w:])")
+RULE_METRIC_PREFIX = re.compile(
+    r"^(?:bfd|bgp|bmp|evpn|gnmi|jemalloc|mrt|process)_"
+)
+EXTERNAL_RULE_INPUTS = frozenset({"up"})
+BLOCK_SCALARS = frozenset({">", ">-", ">+", "|", "|-", "|+"})
+INLINE_CODE = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
+
+
+def load_helper(filename: str, module_name: str) -> ModuleType:
+    path = ROOT / "scripts" / filename
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"cannot load checker helper {path.relative_to(ROOT)}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DASHBOARD_CHECK = load_helper("check-grafana-dashboard.py", "dashboard_contract")
+PUBLIC_DOCS_CHECK = load_helper("check_public_tracker_ids.py", "public_docs_contract")
+
+
+def production_source(source: str) -> str:
+    """Drop the conventional trailing Rust test module from source discovery."""
+    return re.split(
+        r"\n#\[cfg\(test\)\]\s*\nmod\s+tests\s*\{", source, maxsplit=1
+    )[0]
+
+
+def static_metric_definitions(source: str) -> dict[str, tuple[str, str]]:
+    """Return statically named metric constructors keyed by local variable."""
+    source = production_source(source)
+    syntax, strings = DASHBOARD_CHECK.rust_lex(source)
+    definitions: dict[str, tuple[str, str]] = {}
+    names: set[str] = set()
+    for variable, constructor, string_index in STATIC_DEFINITION.findall(syntax):
+        name = strings[int(string_index)]
+        if variable in definitions:
+            raise ValueError(f"duplicate metric constructor variable {variable}")
+        if name in names:
+            raise ValueError(f"duplicate metric family definition {name}")
+        definitions[variable] = (
+            name,
+            "histogram" if constructor == "HistogramVec" else "ordinary",
+        )
+        names.add(name)
+
+    constructor_count = len(METRIC_CONSTRUCTOR.findall(syntax))
+    if constructor_count != len(definitions):
+        raise ValueError(
+            "metric constructor inventory is not fully static: "
+            f"found {constructor_count} constructor calls but "
+            f"{len(definitions)} literal definitions"
+        )
+    return definitions
+
+
+def braced_body(syntax: str, pattern: str, description: str) -> str:
+    """Return the single balanced brace body following a matched declaration."""
+    matches = list(re.finditer(pattern, syntax))
+    if len(matches) != 1:
+        raise ValueError(f"expected one {description}, found {len(matches)}")
+    opening = syntax.find("{", matches[0].start(), matches[0].end())
+    depth = 1
+    index = opening + 1
+    while index < len(syntax) and depth:
+        if syntax[index] == "{":
+            depth += 1
+        elif syntax[index] == "}":
+            depth -= 1
+        index += 1
+    if depth:
+        raise ValueError(f"unterminated {description}")
+    return syntax[opening + 1 : index - 1]
+
+
+def registry_registration_expressions(source: str) -> list[str]:
+    """Return every Box::new payload registered in production source."""
+    syntax, _ = DASHBOARD_CHECK.rust_lex(production_source(source))
+    expressions: list[str] = []
+    for match in REGISTER_START.finditer(syntax):
+        depth = 1
+        index = match.end()
+        while index < len(syntax) and depth:
+            if syntax[index] == "(":
+                depth += 1
+            elif syntax[index] == ")":
+                depth -= 1
+            index += 1
+        if depth:
+            raise ValueError("unterminated registry Box::new registration")
+        if re.match(r"\s*,?\s*\)", syntax[index:]) is None:
+            raise ValueError("unsupported registry registration after Box::new payload")
+        expression = syntax[match.end() : index - 1].strip()
+        expressions.append(expression.removesuffix(",").rstrip())
+
+    registration_count = len(re.findall(r"\.register\s*\(", syntax))
+    if registration_count != len(expressions):
+        raise ValueError(
+            "registry registration is not a supported Box::new expression: "
+            f"found {registration_count} registrations but parsed {len(expressions)}"
+        )
+    return expressions
+
+
+def custom_collector_metric_inventory(
+    source: str, collector: str, metric_prefix: str
+) -> tuple[dict[str, str], set[str]]:
+    """Map every collected custom-collector field to one literal definition."""
+    source = production_source(source)
+    syntax, _ = DASHBOARD_CHECK.rust_lex(source)
+    definitions = static_metric_definitions(source)
+    inherent = braced_body(
+        syntax,
+        rf"\bimpl\s+{re.escape(collector)}\s*\{{",
+        f"inherent impl for {collector}",
+    )
+    collector_impl = braced_body(
+        syntax,
+        rf"\bimpl\s+Collector\s+for\s+{re.escape(collector)}\s*\{{",
+        f"Collector impl for {collector}",
+    )
+    collect_body = braced_body(
+        collector_impl,
+        r"\bfn\s+collect\s*\(\s*&self\s*\)\s*->\s*Vec\s*<\s*MetricFamily\s*>\s*\{",
+        f"collect method for {collector}",
+    )
+    if "MetricFamily" in collect_body:
+        raise ValueError(
+            f"{collector} collect method constructs MetricFamily values directly"
+        )
+    unexpected_returns = [
+        expression
+        for expression in re.findall(r"\breturn\s+([^;]+);", collect_body)
+        if re.sub(r"\s+", "", expression) != "Vec::new()"
+    ]
+    if unexpected_returns:
+        raise ValueError(
+            f"{collector} returns families outside mapped field collection"
+        )
+    initial_families = re.findall(
+        r"\blet\s+mut\s+families\s*=\s*self\.(\w+)\.collect\(\)\s*;",
+        collect_body,
+    )
+    extended_families = re.findall(
+        r"\bfamilies\.extend\(\s*self\.(\w+)\.collect\(\)\s*\)\s*;",
+        collect_body,
+    )
+    if len(initial_families) != 1:
+        raise ValueError(
+            f"{collector} must initialize families from exactly one mapped field"
+        )
+    collected_field_sequence = [*initial_families, *extended_families]
+    collected_fields = set(collected_field_sequence)
+    if len(collected_fields) != len(collected_field_sequence):
+        raise ValueError(f"{collector} collects a metric field more than once")
+    if len(re.findall(r"\bfamilies\b", collect_body)) != len(collected_fields) + 1:
+        raise ValueError(
+            f"{collector} assembles families outside mapped field collection"
+        )
+    if re.search(r"\bfamilies\s*$", collect_body.strip()) is None:
+        raise ValueError(f"{collector} does not return its mapped families")
+    unexpected_collects = set(
+        re.findall(r"self\.(\w+)\.collect\(\)", collect_body)
+    ) - collected_fields
+    if unexpected_collects:
+        raise ValueError(
+            f"{collector} has unsupported collected fields: {sorted(unexpected_collects)}"
+        )
+    if not collected_fields:
+        raise ValueError(f"{collector} has no collected metric fields")
+
+    field_variables: dict[str, set[str]] = {}
+    for body in re.findall(r"(?<!-> )\bSelf\s*\{([^{}]*)\}", inherent):
+        for entry in body.split(","):
+            parts = [part.strip() for part in entry.split(":", 1)]
+            if not parts or not parts[0]:
+                continue
+            field, variable = parts[0], parts[-1]
+            field_variables.setdefault(field, set()).add(variable)
+
+    emitted: dict[str, str] = {}
+    emitted_variables: set[str] = set()
+    for field in sorted(collected_fields):
+        variables = field_variables.get(field, set())
+        if len(variables) != 1:
+            raise ValueError(
+                f"{collector} collected field {field} has no unique constructor mapping"
+            )
+        variable = next(iter(variables))
+        if variable not in definitions:
+            raise ValueError(
+                f"{collector} collected field {field} does not map to a literal metric definition"
+            )
+        name, kind = definitions[variable]
+        if not name.startswith(metric_prefix):
+            raise ValueError(
+                f"{collector} field {field} emits unexpected metric family {name}"
+            )
+        emitted[name] = kind
+        emitted_variables.add(variable)
+
+    custom_variables = {
+        variable
+        for variable, (name, _) in definitions.items()
+        if name.startswith(metric_prefix)
+    }
+    missing = sorted(custom_variables - emitted_variables)
+    if missing:
+        raise ValueError(
+            f"{collector} literal metric definitions are not collected: {missing}"
+        )
+    return emitted, emitted_variables
+
+
+def registered_metric_variables(
+    relative: str, source: str, definitions: dict[str, tuple[str, str]]
+) -> set[str]:
+    """Require every registry payload to be a literal metric or pinned collector."""
+    variables: list[str] = []
+    specials: list[str] = []
+    for expression in registry_registration_expressions(source):
+        compact = re.sub(r"\s+", "", expression)
+        variable = VARIABLE_REGISTRATION.fullmatch(compact)
+        if variable is not None:
+            name = variable.group(1)
+            if name not in definitions:
+                raise ValueError(
+                    f"registered variable {name} has no parsed literal metric definition"
+                )
+            variables.append(name)
+        else:
+            specials.append(compact)
+
+    expected_specials = Counter(SPECIAL_REGISTRATIONS[relative])
+    actual_specials = Counter(specials)
+    if actual_specials != expected_specials:
+        raise ValueError(
+            f"special collector registrations changed: expected {expected_specials}, "
+            f"got {actual_specials}"
+        )
+    duplicates = sorted(name for name, count in Counter(variables).items() if count != 1)
+    if duplicates:
+        raise ValueError(f"metric variables registered more than once: {duplicates}")
+    return set(variables)
+
+
+def candidate_emitter_sources(root: Path = ROOT) -> dict[str, str]:
+    """Discover tracked production Rust files that can define metric families."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", "*.rs"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"git ls-files exited {result.returncode}"
+        raise ValueError(f"cannot discover Rust metric emitters: {detail}")
+
+    sources: dict[str, str] = {}
+    for relative in (name for name in result.stdout.split("\0") if name):
+        path = root / relative
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            raise ValueError(f"cannot read tracked Rust source {relative}: {error}") from error
+        production = production_source(source)
+        # Avoid feeding unrelated Rust syntax to the deliberately small lexer.
+        # Any supported or unclassified emitter still carries one of these
+        # constructor/collector tokens in code before lexical masking.
+        if RAW_EMITTER_HINT.search(production) is None:
+            continue
+        syntax, _ = DASHBOARD_CHECK.rust_lex(production)
+        if (
+            METRIC_CONSTRUCTOR.search(syntax)
+            or CUSTOM_COLLECTOR.search(syntax)
+            or "ProcessCollector::for_self" in syntax
+            or REGISTER_START.search(syntax)
+        ):
+            sources[relative] = production
+    if not sources:
+        raise ValueError("no production metric emitter sources discovered")
+    return sources
+
+
+def validate_emitter_roster(sources: dict[str, str]) -> None:
+    actual_files = set(sources)
+    if actual_files != EMITTER_FILES:
+        raise ValueError(
+            "metric emitter source roster changed: "
+            f"expected {sorted(EMITTER_FILES)}, got {sorted(actual_files)}"
+        )
+
+    actual_collectors = {
+        (relative, collector)
+        for relative, source in sources.items()
+        for collector in CUSTOM_COLLECTOR.findall(
+            DASHBOARD_CHECK.rust_lex(production_source(source))[0]
+        )
+    }
+    if actual_collectors != CUSTOM_COLLECTORS:
+        raise ValueError(
+            "custom metric collector roster changed: "
+            f"expected {sorted(CUSTOM_COLLECTORS)}, got {sorted(actual_collectors)}"
+        )
+
+
+def settlement_metric_inventory(source: str) -> dict[str, str]:
+    """Inventory scrape-time families wired through the settlement collector."""
+    source = production_source(source)
+    definitions = static_metric_definitions(source)
+    registered = registered_metric_variables(SETTLEMENT, source, definitions)
+    if registered:
+        raise ValueError(
+            f"runtime settlement unexpectedly registers direct metric variables: {registered}"
+        )
+    emitted, _ = custom_collector_metric_inventory(
+        source,
+        "RuntimeConfigSettlementCollector",
+        CUSTOM_COLLECTOR_PREFIXES[(SETTLEMENT, "RuntimeConfigSettlementCollector")],
+    )
+    return emitted
+
+
+def process_dependency_version(lock_text: str) -> str:
+    lock = tomllib.loads(lock_text)
+    versions = sorted(
+        package.get("version", "")
+        for package in lock.get("package", [])
+        if package.get("name") == "prometheus"
+    )
+    if versions != [PROCESS_COLLECTOR_VERSION]:
+        raise ValueError(
+            "Prometheus dependency version changed; revalidate ProcessCollector families: "
+            f"expected {[PROCESS_COLLECTOR_VERSION]}, got {versions}"
+        )
+    return versions[0]
+
+
+def workspace_metric_inventory(
+    sources: dict[str, str] | None = None, lock_text: str | None = None
+) -> dict[str, str]:
+    sources = sources or candidate_emitter_sources()
+    validate_emitter_roster(sources)
+    for relative, source in sources.items():
+        try:
+            static_metric_definitions(source)
+        except ValueError as error:
+            raise ValueError(f"{relative}: {error}") from error
+
+    telemetry_definitions = static_metric_definitions(sources[TELEMETRY])
+    registered = registered_metric_variables(
+        TELEMETRY, sources[TELEMETRY], telemetry_definitions
+    )
+    jemalloc, jemalloc_variables = custom_collector_metric_inventory(
+        sources[TELEMETRY],
+        "JemallocCollector",
+        CUSTOM_COLLECTOR_PREFIXES[(TELEMETRY, "JemallocCollector")],
+    )
+    expected_registered = set(telemetry_definitions) - jemalloc_variables
+    if registered != expected_registered:
+        missing = sorted(
+            telemetry_definitions[variable][0]
+            for variable in expected_registered - registered
+        )
+        extra = sorted(
+            telemetry_definitions[variable][0]
+            for variable in registered - expected_registered
+        )
+        raise ValueError(
+            "telemetry registration does not match its definitions: "
+            f"unregistered={missing}, undefined={extra}"
+        )
+    telemetry = {
+        telemetry_definitions[variable][0]: telemetry_definitions[variable][1]
+        for variable in registered
+    }
+    telemetry.update(jemalloc)
+
+    settlement = settlement_metric_inventory(sources[SETTLEMENT])
+    overlap = sorted(set(telemetry) & set(settlement))
+    if overlap:
+        raise ValueError(f"duplicate workspace metric families: {overlap}")
+
+    process_dependency_version(lock_text or CARGO_LOCK.read_text(encoding="utf-8"))
+
+    inventory = {**telemetry, **settlement}
+    for name in PROCESS_FAMILIES:
+        if name in inventory:
+            raise ValueError(f"process family duplicates workspace family {name}")
+        inventory[name] = "ordinary"
+    if len(inventory) != 188:
+        raise ValueError(f"emitted metric roster changed: expected 188, got {len(inventory)}")
+    return dict(sorted(inventory.items()))
+
+
+def normalize_metric(name: str, inventory: dict[str, str]) -> str | None:
+    if name in inventory:
+        return name
+    for suffix in ("_bucket", "_count", "_sum"):
+        if name.endswith(suffix):
+            base = name.removesuffix(suffix)
+            if inventory.get(base) == "histogram":
+                return base
+    return None
+
+
+def rule_expressions(text: str) -> list[tuple[int, str]]:
+    """Extract only YAML rule expression scalars without needing PyYAML."""
+    lines = text.splitlines()
+    expressions: list[tuple[int, str]] = []
+    index = 0
+    while index < len(lines):
+        match = re.match(r"^(\s*)expr:\s*(.*)$", lines[index])
+        if match is None:
+            index += 1
+            continue
+        line_number = index + 1
+        indentation = len(match.group(1))
+        remainder = match.group(2).strip()
+        index += 1
+        if not remainder:
+            raise ValueError(f"empty YAML expr scalar at line {line_number}")
+        reject_yaml_expr_references(remainder, line_number)
+        if remainder.startswith((">", "|")) and remainder not in BLOCK_SCALARS:
+            raise ValueError(
+                f"unsupported YAML expr block header at line {line_number}: {remainder}"
+            )
+        if remainder not in BLOCK_SCALARS:
+            continuation: list[str] = []
+            while index < len(lines):
+                line = lines[index]
+                current_indent = len(line) - len(line.lstrip())
+                if line.strip() and current_indent <= indentation:
+                    break
+                continuation.append(line.strip())
+                index += 1
+            scalar = "\n".join([remainder, *continuation])
+            decoded = decode_yaml_scalar(scalar, line_number)
+            require_nonempty_yaml_expression(decoded, line_number)
+            expressions.append((line_number, decoded))
+            continue
+        body: list[str] = []
+        while index < len(lines):
+            line = lines[index]
+            current_indent = len(line) - len(line.lstrip())
+            if line.strip() and current_indent <= indentation:
+                break
+            body.append(line)
+            index += 1
+        scalar = "\n".join(body)
+        require_nonempty_yaml_expression(scalar, line_number)
+        expressions.append((line_number, scalar))
+    if not expressions:
+        raise ValueError("no Prometheus rule expressions discovered")
+    return expressions
+
+
+def reject_yaml_expr_references(value: str, line_number: int) -> None:
+    """Reject dependency-free parser ambiguities around YAML anchors and aliases."""
+    syntax = strip_yaml_inline_comment(value)
+    syntax = re.sub(r'"(?:\\.|[^"\\])*"|\'(?:\'\'|[^\'])*\'', '""', syntax)
+    if re.match(r"\s*!", syntax):
+        raise ValueError(f"unsupported YAML expr tag at line {line_number}")
+    if re.match(r"\s*[&*][A-Za-z0-9_-]+(?:\s|$)", syntax):
+        raise ValueError(f"unsupported YAML expr anchor or alias at line {line_number}")
+
+
+def decode_yaml_scalar(value: str, line_number: int) -> str:
+    """Decode the quoted scalar forms accepted by this dependency-free parser."""
+    if not value.startswith(("\"", "'")):
+        return value
+    match = re.fullmatch(
+        r'("(?:\\.|[^"\\])*"|\'(?:\'\'|[^\'])*\')\s*(?:#.*)?', value
+    )
+    if match is None:
+        raise ValueError(f"unsupported quoted YAML expr scalar at line {line_number}")
+    scalar = match.group(1)
+    if scalar.startswith("'"):
+        return scalar[1:-1].replace("''", "'")
+    try:
+        decoded = json.loads(scalar)
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"unsupported double-quoted YAML expr scalar at line {line_number}: {error.msg}"
+        ) from error
+    if not isinstance(decoded, str):
+        raise ValueError(f"non-string YAML expr scalar at line {line_number}")
+    return decoded
+
+
+def strip_yaml_inline_comment(value: str) -> str:
+    """Remove a YAML/PromQL comment marker only when it is outside quotes."""
+    single_quoted = double_quoted = escaped = False
+    for index, character in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\" and double_quoted:
+            escaped = True
+            continue
+        if character == "\"" and not single_quoted:
+            double_quoted = not double_quoted
+            continue
+        if character == "'" and not double_quoted:
+            single_quoted = not single_quoted
+            continue
+        if (
+            character == "#"
+            and not single_quoted
+            and not double_quoted
+            and (index == 0 or value[index - 1].isspace())
+        ):
+            return value[:index].rstrip()
+    return value
+
+
+def require_nonempty_yaml_expression(value: str, line_number: int) -> None:
+    """Reject scalars that are empty after decoding and removing comments."""
+    visible = "\n".join(
+        strip_yaml_inline_comment(line) for line in value.splitlines()
+    ).strip()
+    if not visible:
+        raise ValueError(f"empty YAML expr scalar at line {line_number}")
+
+
+def rule_metric_references(
+    text: str, inventory: dict[str, str]
+) -> dict[str, list[str]]:
+    references: dict[str, list[str]] = {}
+    unresolved: list[str] = []
+    for line_number, expression in rule_expressions(text):
+        expression = "\n".join(
+            strip_yaml_inline_comment(line) for line in expression.splitlines()
+        )
+        syntax = re.sub(r'"(?:\\.|[^"\\])*"', '""', expression)
+        syntax = "\n".join(
+            line for line in syntax.splitlines() if not line.lstrip().startswith("#")
+        )
+        for token in METRIC_TOKEN.findall(syntax):
+            name = normalize_metric(token, inventory)
+            if name is not None:
+                references.setdefault(name, []).append(f"line {line_number}")
+            elif token not in EXTERNAL_RULE_INPUTS and RULE_METRIC_PREFIX.match(token):
+                unresolved.append(f"{token} (line {line_number})")
+    if unresolved:
+        raise ValueError("unregistered Prometheus rule metrics: " + "; ".join(unresolved))
+    if not references:
+        raise ValueError("no emitted metric references discovered in Prometheus rules")
+    return references
+
+
+def public_document_references(
+    documents: dict[str, str], inventory: dict[str, str]
+) -> dict[str, list[str]]:
+    references: dict[str, list[str]] = {}
+    markdown = {
+        relative: text
+        for relative, text in documents.items()
+        if Path(relative).suffix == ".md"
+    }
+    if not markdown:
+        raise ValueError("no public Markdown documents discovered")
+    metric_spellings = {
+        spelling: name
+        for name, kind in inventory.items()
+        for spelling in (
+            (name, f"{name}_bucket", f"{name}_count", f"{name}_sum")
+            if kind == "histogram"
+            else (name,)
+        )
+    }
+    near_misses: list[str] = []
+    for relative, text in markdown.items():
+        for token in set(METRIC_TOKEN.findall(text)):
+            name = normalize_metric(token, inventory)
+            if name is not None:
+                references.setdefault(name, []).append(relative)
+        metric_context = "\n".join(
+            [
+                *INLINE_CODE.findall(text),
+                *(line for line in text.splitlines() if "|" in line),
+                *markdown_fenced_code(text),
+            ]
+        )
+        for token in set(METRIC_TOKEN.findall(metric_context)):
+            if normalize_metric(token, inventory) is not None:
+                continue
+            matches = sorted(
+                spelling
+                for spelling in metric_spellings
+                if one_documentation_edit_apart(token, spelling)
+            )
+            if matches:
+                near_misses.append(f"{token} ({relative}; near {matches[0]})")
+    if near_misses:
+        raise ValueError(
+            "near-miss emitted metric names in public docs: " + "; ".join(near_misses)
+        )
+    return references
+
+
+def markdown_fenced_code(text: str) -> list[str]:
+    """Return fenced Markdown bodies without widening typo checks to prose."""
+    bodies: list[str] = []
+    opening_character = ""
+    opening_length = 0
+    body: list[str] = []
+    for line in text.splitlines():
+        marker = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", line)
+        if not opening_character:
+            if marker is not None:
+                opening_character = marker.group(1)[0]
+                opening_length = len(marker.group(1))
+                body = []
+            continue
+        closing = re.fullmatch(
+            rf" {{0,3}}{re.escape(opening_character)}{{{opening_length},}}\s*", line
+        )
+        if closing is not None:
+            bodies.append("\n".join(body))
+            opening_character = ""
+            opening_length = 0
+            body = []
+        else:
+            body.append(line)
+    if opening_character:
+        bodies.append("\n".join(body))
+    return bodies
+
+
+def one_documentation_edit_apart(left: str, right: str) -> bool:
+    """Return whether one insertion, deletion, substitution, or swap separates tokens."""
+    if left == right or abs(len(left) - len(right)) > 1:
+        return False
+    if len(left) == len(right):
+        mismatches = [
+            index for index, pair in enumerate(zip(left, right)) if pair[0] != pair[1]
+        ]
+        if len(mismatches) == 1:
+            return True
+        return (
+            len(mismatches) == 2
+            and mismatches[1] == mismatches[0] + 1
+            and left[mismatches[0]] == right[mismatches[1]]
+            and left[mismatches[1]] == right[mismatches[0]]
+        )
+    if len(left) > len(right):
+        left, right = right, left
+    left_index = right_index = differences = 0
+    while left_index < len(left) and right_index < len(right):
+        if left[left_index] == right[right_index]:
+            left_index += 1
+            right_index += 1
+        else:
+            differences += 1
+            right_index += 1
+            if differences > 1:
+                return False
+    return True
+
+
+def validate_coverage(
+    inventory: dict[str, str],
+    consumers: set[str],
+    allowlist: dict[str, str] = ALLOWLIST,
+) -> None:
+    empty_reasons = sorted(name for name, reason in allowlist.items() if not reason.strip())
+    unknown = sorted(set(allowlist) - set(inventory))
+    stale = sorted(set(allowlist) & consumers)
+    missing = sorted(set(inventory) - consumers - set(allowlist))
+    failures: list[str] = []
+    if empty_reasons:
+        failures.append(f"allowlist entries without reasons: {empty_reasons}")
+    if unknown:
+        failures.append(f"allowlist entries are not emitted: {unknown}")
+    if stale:
+        failures.append(f"allowlist entries now have shipped consumers: {stale}")
+    if missing:
+        failures.append(f"emitted metric families lack shipped consumers: {missing}")
+    if failures:
+        raise ValueError("; ".join(failures))
+
+
+def main() -> int:
+    try:
+        inventory = workspace_metric_inventory()
+        dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+        dashboard_raw = DASHBOARD_CHECK.dashboard_metric_references(dashboard)
+        DASHBOARD_CHECK.check_metric_linkage(dashboard_raw, inventory)
+        dashboard_refs = {
+            normalized
+            for name in dashboard_raw
+            if (normalized := normalize_metric(name, inventory)) is not None
+        }
+        rule_refs = set(
+            rule_metric_references(
+                ALERT_RULES.read_text(encoding="utf-8"), inventory
+            )
+        )
+        documents = PUBLIC_DOCS_CHECK.discover_documents()
+        doc_refs = set(public_document_references(documents, inventory))
+        consumers = dashboard_refs | rule_refs | doc_refs
+        validate_coverage(inventory, consumers)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"metric consumer check failed: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "metric consumer check passed: "
+        f"{len(inventory)} emitted families; "
+        f"{len(dashboard_refs)} dashboard, {len(rule_refs)} rules, "
+        f"{len(doc_refs)} public docs; {len(consumers)} consumed, "
+        f"{len(ALLOWLIST)} justified raw diagnostics"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+import copy
+import importlib.util
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+PATH = Path(__file__).with_name("check-metric-consumers.py")
+SPEC = importlib.util.spec_from_file_location("metric_consumer_check", PATH)
+CHECK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK)
+
+
+class MetricConsumerContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sources = CHECK.candidate_emitter_sources()
+        cls.lock_text = CHECK.CARGO_LOCK.read_text(encoding="utf-8")
+        cls.inventory = CHECK.workspace_metric_inventory(cls.sources, cls.lock_text)
+        cls.dashboard = json.loads(CHECK.DASHBOARD.read_text(encoding="utf-8"))
+        dashboard_raw = CHECK.DASHBOARD_CHECK.dashboard_metric_references(cls.dashboard)
+        cls.dashboard_refs = {
+            normalized
+            for name in dashboard_raw
+            if (normalized := CHECK.normalize_metric(name, cls.inventory)) is not None
+        }
+        cls.rule_refs = set(
+            CHECK.rule_metric_references(
+                CHECK.ALERT_RULES.read_text(encoding="utf-8"), cls.inventory
+            )
+        )
+        cls.documents = CHECK.PUBLIC_DOCS_CHECK.discover_documents()
+        cls.doc_refs = set(
+            CHECK.public_document_references(cls.documents, cls.inventory)
+        )
+
+    @staticmethod
+    def before_tests(source, addition):
+        marker = "\n#[cfg(test)]\nmod tests {"
+        if marker not in source:
+            return f"{source}\n{addition}"
+        return source.replace(marker, f"\n{addition}{marker}", 1)
+
+    def test_live_inventory_and_consumer_counts_are_exact(self):
+        self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
+        self.assertEqual(len(self.inventory), 188)
+        self.assertEqual(
+            len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
+            177,
+        )
+        self.assertEqual(
+            len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
+        )
+        self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
+        self.assertEqual(len(self.dashboard_refs), 93)
+        self.assertEqual(len(self.rule_refs), 39)
+        self.assertEqual(len(self.doc_refs), 175)
+        consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
+        self.assertEqual(len(consumers), 182)
+        self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
+        self.assertEqual(
+            set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
+        )
+        CHECK.validate_coverage(self.inventory, consumers)
+
+    def test_live_main_reports_the_exact_roster(self):
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            self.assertEqual(CHECK.main(), 0)
+        self.assertIn("188 emitted families", stdout.getvalue())
+        self.assertIn("182 consumed, 6 justified raw diagnostics", stdout.getvalue())
+
+    def test_comments_literals_and_test_modules_are_not_definitions(self):
+        source = r'''
+let ready = IntGauge::new("bgp_ready", "help").unwrap();
+// let commented = IntGauge::new("bgp_commented", "help").unwrap();
+let note = r#"let quoted = IntGauge::new("bgp_quoted", "help");"#;
+#[cfg(test)]
+mod tests {
+    let test_only = IntGauge::new("bgp_test_only", "help").unwrap();
+}
+'''
+        definitions = CHECK.static_metric_definitions(source)
+        self.assertEqual(definitions, {"ready": ("bgp_ready", "ordinary")})
+
+    def test_dynamic_metric_name_is_rejected(self):
+        sources = dict(self.sources)
+        sources[CHECK.TELEMETRY] = self.before_tests(
+            sources[CHECK.TELEMETRY],
+            '''fn dynamic_metric_name() {
+    let dynamic = IntGauge::new(format!("bgp_dynamic_{}", "name"), "help").unwrap();
+    drop(dynamic);
+}
+''',
+        )
+        with self.assertRaisesRegex(ValueError, "inventory is not fully static"):
+            CHECK.workspace_metric_inventory(sources, self.lock_text)
+
+    def test_unclassified_emitter_file_is_rejected(self):
+        sources = dict(self.sources)
+        sources["src/new_metric_emitter.rs"] = '''
+let surprise = IntGauge::new("bgp_surprise", "help").unwrap();
+registry.register(Box::new(surprise.clone())).unwrap();
+'''
+        with self.assertRaisesRegex(ValueError, "emitter source roster changed"):
+            CHECK.workspace_metric_inventory(sources, self.lock_text)
+
+    def test_unregistered_static_definition_is_rejected(self):
+        sources = dict(self.sources)
+        sources[CHECK.TELEMETRY] = self.before_tests(
+            sources[CHECK.TELEMETRY],
+            '''fn orphan_metric_definition() {
+    let orphan = IntGauge::new("bgp_orphan", "help").unwrap();
+    drop(orphan);
+}
+''',
+        )
+        with self.assertRaisesRegex(ValueError, "unregistered=.*bgp_orphan"):
+            CHECK.workspace_metric_inventory(sources, self.lock_text)
+
+    def test_alias_backed_direct_registration_is_rejected(self):
+        sources = dict(self.sources)
+        sources[CHECK.TELEMETRY] = self.before_tests(
+            sources[CHECK.TELEMETRY],
+            '''type HiddenCounter = IntCounter;
+fn alias_metric(registry: &Registry) {
+    let hidden = HiddenCounter::new("bgp_hidden", "help").unwrap();
+    registry.register(Box::new(hidden.clone())).unwrap();
+}
+''',
+        )
+        with self.assertRaisesRegex(
+            ValueError, "registered variable hidden has no parsed literal"
+        ):
+            CHECK.workspace_metric_inventory(sources, self.lock_text)
+
+    def test_custom_collector_roster_and_wiring_are_pinned(self):
+        sources = dict(self.sources)
+        sources[CHECK.SETTLEMENT] = sources[CHECK.SETTLEMENT].replace(
+            "impl Collector for RuntimeConfigSettlementCollector",
+            "impl Collector for RenamedSettlementCollector",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "custom metric collector roster changed"):
+            CHECK.workspace_metric_inventory(sources, self.lock_text)
+
+        unwired = self.sources[CHECK.SETTLEMENT].replace(
+            "families.extend(self.fail_stops.collect());",
+            "self.fail_stops.reset();",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "not collected.*fail_stops"):
+            CHECK.settlement_metric_inventory(unwired)
+
+    def test_custom_collector_unparsed_fields_are_rejected(self):
+        alias_backed = self.sources[CHECK.SETTLEMENT].replace(
+            "let fail_stops = CounterVec::new(",
+            "let fail_stops = HiddenCounterVec::new(",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "fail_stops.*literal metric definition"):
+            CHECK.settlement_metric_inventory(alias_backed)
+
+        unknown_collected = self.sources[CHECK.SETTLEMENT].replace(
+            "families.extend(self.fail_stops.collect());",
+            "families.extend(self.fail_stops.collect());\n"
+            "        families.extend(self.hidden.collect());",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "hidden.*no unique constructor mapping"):
+            CHECK.settlement_metric_inventory(unknown_collected)
+
+    def test_custom_collector_direct_metric_family_emission_is_rejected(self):
+        direct_proto = self.sources[CHECK.SETTLEMENT].replace(
+            "families.extend(self.fail_stops.collect());\n        families",
+            '''families.extend(self.fail_stops.collect());
+        let mut hidden = MetricFamily::new();
+        hidden.set_name("bgp_runtime_config_settlement_hidden_total".into());
+        families.push(hidden);
+        families''',
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "constructs MetricFamily values directly"):
+            CHECK.settlement_metric_inventory(direct_proto)
+
+    def test_process_dependency_drift_is_rejected(self):
+        drifted = self.lock_text.replace(
+            'name = "prometheus"\nversion = "0.14.0"',
+            'name = "prometheus"\nversion = "0.15.0"',
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "dependency version changed"):
+            CHECK.workspace_metric_inventory(self.sources, drifted)
+
+    def test_rule_parser_handles_scalar_folded_and_ignores_non_expressions(self):
+        inventory = {
+            "bgp_ready": "ordinary",
+            "bgp_latency_seconds": "histogram",
+            "bgp_annotation_only": "ordinary",
+            "bgp_comment_only": "ordinary",
+            "bgp_label_only": "ordinary",
+        }
+        rules = '''
+groups:
+  - name: test
+    rules:
+      - alert: Ready
+        expr: bgp_ready == 1
+        annotations:
+          summary: bgp_annotation_only
+      - alert: Latency
+        expr: >-
+          rate(bgp_latency_seconds_count{state="bgp_label_only"}[5m]) > 0
+          # bgp_comment_only
+'''
+        references = CHECK.rule_metric_references(rules, inventory)
+        self.assertEqual(set(references), {"bgp_ready", "bgp_latency_seconds"})
+
+    def test_unregistered_rule_metric_is_rejected(self):
+        rules = (
+            "groups:\n  - rules:\n      - alert: Typo\n"
+            "        expr: bgp_typo == 1\n"
+        )
+        with self.assertRaisesRegex(ValueError, "unregistered.*bgp_typo"):
+            CHECK.rule_metric_references(rules, {"bgp_ready": "ordinary"})
+
+    def test_quoted_rule_metric_typo_is_decoded_and_rejected(self):
+        rules = '''
+groups:
+  - rules:
+      - alert: Ready
+        expr: bgp_ready == 1
+      - alert: Typo
+        expr: "bgp_typo == 1"
+'''
+        with self.assertRaisesRegex(ValueError, "unregistered.*bgp_typo"):
+            CHECK.rule_metric_references(rules, {"bgp_ready": "ordinary"})
+
+    def test_plain_rule_continuation_is_parsed(self):
+        rules = '''
+groups:
+  - rules:
+      - alert: Continued
+        expr: bgp_ready
+          or bgp_typo
+'''
+        with self.assertRaisesRegex(ValueError, "unregistered.*bgp_typo"):
+            CHECK.rule_metric_references(rules, {"bgp_ready": "ordinary"})
+
+    def test_yaml_rule_references_and_unsupported_block_headers_are_rejected(self):
+        cases = (
+            "        expr: &shared bgp_ready\n",
+            "        expr: *shared\n",
+            "        expr: >2-\n          bgp_ready\n",
+            "        expr: |+2\n          bgp_ready\n",
+        )
+        for expression in cases:
+            rules = "groups:\n  - rules:\n      - alert: Invalid\n" + expression
+            with self.subTest(expression=expression), self.assertRaisesRegex(
+                ValueError, "unsupported YAML expr"
+            ):
+                CHECK.rule_metric_references(rules, {"bgp_ready": "ordinary"})
+
+    def test_yaml_rule_tags_are_rejected_before_quoted_payload_masking(self):
+        cases = (
+            '        expr: !!str "bgp_typo == 1"\n',
+            '        expr: !<tag:yaml.org,2002:str> "bgp_typo == 1"\n',
+        )
+        valid = "groups:\n  - rules:\n      - alert: Ready\n        expr: bgp_ready\n"
+        for expression in cases:
+            rules = valid + "      - alert: Tagged\n" + expression
+            with self.subTest(expression=expression), self.assertRaisesRegex(
+                ValueError, "unsupported YAML expr tag"
+            ):
+                CHECK.rule_metric_references(rules, {"bgp_ready": "ordinary"})
+
+    def test_yaml_rule_actual_empty_scalars_are_rejected(self):
+        cases = (
+            "        expr: # comment\n",
+            '        expr: ""\n',
+            "        expr: ''\n",
+            "        expr: >-\n          # comment only\n",
+        )
+        valid = "groups:\n  - rules:\n      - alert: Ready\n        expr: bgp_ready\n"
+        for expression in cases:
+            rules = valid + "      - alert: Empty\n" + expression
+            with self.subTest(expression=expression), self.assertRaisesRegex(
+                ValueError, "empty YAML expr scalar"
+            ):
+                CHECK.rule_metric_references(rules, {"bgp_ready": "ordinary"})
+
+    def test_inline_rule_comments_outside_quotes_are_ignored(self):
+        inventory = {
+            "bgp_ready": "ordinary",
+            "bgp_comment_only": "ordinary",
+            "bgp_label_value": "ordinary",
+        }
+        rules = '''
+groups:
+  - rules:
+      - alert: Ready
+        expr: bgp_ready{note="# bgp_label_value"} # bgp_comment_only
+'''
+        references = CHECK.rule_metric_references(rules, inventory)
+        self.assertEqual(set(references), {"bgp_ready"})
+
+    def test_document_tokens_are_exact_and_histogram_kind_aware(self):
+        inventory = {
+            "bgp_ready": "ordinary",
+            "bgp_latency_seconds": "histogram",
+            "bgp_non_markdown": "ordinary",
+        }
+        documents = {
+            "docs/metrics.md": (
+                "`bgp_ready`, `bgp_latency_seconds_bucket`, and bgp_ready_suffix"
+            ),
+            "docs/data.json": "bgp_non_markdown",
+        }
+        references = CHECK.public_document_references(documents, inventory)
+        self.assertEqual(set(references), {"bgp_ready", "bgp_latency_seconds"})
+        self.assertIsNone(CHECK.normalize_metric("bgp_ready_count", inventory))
+
+    def test_metric_near_miss_in_document_code_or_table_is_rejected(self):
+        inventory = {"bgp_ready": "ordinary"}
+        CHECK.public_document_references(
+            {"docs/metrics.md": "Plain prose may say bgp_raedy; use `bgp_ready`."},
+            inventory,
+        )
+        for text in (
+            "Use `bgp_raedy`.",
+            "| Metric |\n| --- |\n| bgp_raedy |",
+            "```promql\nbgp_raedy == 1\n```",
+        ):
+            with self.subTest(text=text), self.assertRaisesRegex(
+                ValueError, "near-miss.*bgp_raedy.*bgp_ready"
+            ):
+                CHECK.public_document_references({"docs/metrics.md": text}, inventory)
+
+    def test_dashboard_only_and_docs_only_consumer_removals_fail(self):
+        dashboard = copy.deepcopy(self.dashboard)
+        for panel in CHECK.DASHBOARD_CHECK.all_panels(dashboard["panels"]):
+            for target in panel.get("targets", []):
+                expression = target.get("expr", "")
+                target["expr"] = expression.replace(
+                    "bgp_orr_spf_runs_total", "bgp_orr_topology_nodes"
+                )
+        dashboard_raw = CHECK.DASHBOARD_CHECK.dashboard_metric_references(dashboard)
+        dashboard_refs = {
+            normalized
+            for name in dashboard_raw
+            if (normalized := CHECK.normalize_metric(name, self.inventory)) is not None
+        }
+        with self.assertRaisesRegex(ValueError, "bgp_orr_spf_runs_total"):
+            CHECK.validate_coverage(
+                self.inventory, dashboard_refs | self.rule_refs | self.doc_refs
+            )
+
+        documents = {
+            relative: text.replace(
+                "bgp_event_outbox_cursor_gap_total",
+                "bgp_event_outbox_cursor_gap_removed_total",
+            )
+            for relative, text in self.documents.items()
+        }
+        doc_refs = set(CHECK.public_document_references(documents, self.inventory))
+        with self.assertRaisesRegex(ValueError, "bgp_event_outbox_cursor_gap_total"):
+            CHECK.validate_coverage(
+                self.inventory, self.dashboard_refs | self.rule_refs | doc_refs
+            )
+
+    def test_allowlist_missing_unknown_empty_and_stale_entries_fail(self):
+        inventory = {"bgp_ready": "ordinary", "process_raw": "ordinary"}
+        CHECK.validate_coverage(
+            inventory, {"bgp_ready"}, {"process_raw": "raw diagnostic"}
+        )
+        cases = (
+            ({}, "lack shipped consumers"),
+            ({"unknown": "raw"}, "not emitted"),
+            ({"process_raw": ""}, "without reasons"),
+            ({"bgp_ready": "raw", "process_raw": "raw"}, "now have shipped consumers"),
+        )
+        for allowlist, message in cases:
+            with self.subTest(allowlist=allowlist), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                CHECK.validate_coverage(inventory, {"bgp_ready"}, allowlist)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- inventory every emitted Prometheus family across direct registrations, custom collectors, and the pinned process collector
- require each family to have a shipped dashboard, alert rule, or public-document consumer unless it is one of six justified raw process diagnostics
- fail closed on dynamic or hidden emitters, collector wiring drift, ambiguous YAML expressions, and near-miss metric names in code-oriented documentation
- add the contract to the public-docs workflow and correct stale or missing metric references in operator and soak documentation

## Validation

- 23 metric-consumer contract and mutation tests
- live inventory: 188 emitted, 182 consumed, 6 justified diagnostics
- public tracker, IXP docs, release-path, dashboard, and public-docs contract suites
- 35 Prometheus rules checked and tested with pinned promtool
- independent multi-round fail-closed review
- full pre-push formatting, strict workspace Clippy, library tests, and rustdoc

Linear: LAN-1205