### PR TITLE
test(interop): repair M96 v2 binding proof

### DIFF
--- a/tests/compat/ixp-manager-birdseye/config-consumer.php
+++ b/tests/compat/ixp-manager-birdseye/config-consumer.php
@@ -211,3 +211,32 @@ if ($skinned['unsupported']['route_server_skin_files'] !== [
 ]) {
     $fail('active BIRD skin file was not surfaced');
 }
+
+// Restore the exact single-session PCH state consumed by M96. This capture is
+// generated from the pinned v7.4 database on every run; the harness compares
+// it semantically with the checked-in v1 fixture after the schema-v2 additions.
+DB::beginTransaction();
+try {
+    DB::table('route_server_filters_prod')->update(['enabled' => 0]);
+    DB::table('vlaninterface')->update(['rsclient' => 0]);
+    DB::table('vlaninterface')->where('id', 3)->update([
+        'rsclient' => 1, 'ipv4enabled' => 1, 'ipv6enabled' => 0,
+    ]);
+    DB::table('irrdb_asn')->where('customer_id', 3)->where('protocol', 4)
+        ->where('asn', '<>', 42)->delete();
+    DB::table('irrdb_prefix')->where('customer_id', 3)->where('protocol', 4)
+        ->where('prefix', '<>', '31.135.128.0/19')->delete();
+    $pch = json_decode($render('config-pch-v2.json'), true, 512, JSON_THROW_ON_ERROR);
+} finally {
+    DB::rollBack();
+}
+if ($pch['schema'] !== 'rustbgpd.ixp-manager.router-config/v2'
+    || array_column($pch['clients'], 'vlan_interface_id') !== [3]
+    || $pch['clients'][0]['customer_id'] !== 3
+    || $pch['clients'][0]['asn'] !== 42
+    || $pch['clients'][0]['origins'] !== [42]
+    || $pch['clients'][0]['prefixes'] !== ['31.135.128.0/19']
+    || $pch['ui_filters'] !== []
+    || $pch['complete']['ui_filter_count'] !== 0) {
+    $fail('single-session PCH schema-v2 export drifted');
+}

--- a/tests/compat/ixp-manager-birdseye/run-in-container.sh
+++ b/tests/compat/ixp-manager-birdseye/run-in-container.sh
@@ -85,7 +85,8 @@ exporter="$ixp_manager/resources/skins/${VIEW_SKIN}/api/v4/router/server/rustbgp
 mkdir -p "$exporter"
 cp /exporter/json.foil.php "$exporter/json.foil.php"
 IXP_MANAGER_ROOT="$ixp_manager" php "$root/config-consumer.php"
-for config_capture in config-implicit.json config-ui-filter.json config-skin.json ixp-manager-v7.4-rustbgpd.json; do
+for config_capture in config-implicit.json config-ui-filter.json config-skin.json \
+  config-pch-v2.json ixp-manager-v7.4-rustbgpd.json; do
   [ -s "${CAPTURE_OUTPUT}/$config_capture" ] || { echo "IXP Manager config capture failed: $config_capture" >&2; exit 1; }
 done
 python3 "$root/verify_capture.py" "$capture" "$CAPTURE_OUTPUT"

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -94,8 +94,15 @@ jq -S '
   | .complete.ui_filter_count = 0
 ' "$legacy_fixture" >"$expected_pch_v2"
 jq -S . "$pch_v2" >"$actual_pch_v2"
-if ! cmp -s "$expected_pch_v2" "$actual_pch_v2"; then
-  diff -u "$expected_pch_v2" "$actual_pch_v2" >&2 || true
+if [ "${CAPTURE_FIXTURES:-0}" != 1 ] \
+    && ! cmp -s "$expected_pch_v2" "$actual_pch_v2"; then
+  jq -nr --slurpfile actual "$actual_pch_v2" \
+    --slurpfile expected "$expected_pch_v2" '
+      [($actual[0] | paths(scalars)), ($expected[0] | paths(scalars))]
+      | unique[] as $path
+      | select(($actual[0] | getpath($path)) != ($expected[0] | getpath($path)))
+      | $path | map(tostring) | join(".")
+    ' >&2 || true
   echo "fresh PCH schema-v2 capture drifted from the pinned v1 fixture" >&2
   exit 1
 fi

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -76,13 +76,30 @@ docker run --rm --user "$(id -u):$(id -g)" \
   "$image" /harness/run-in-container.sh
 
 supported="$capture_output/ixp-manager-v7.4-rustbgpd.json"
+pch_v2="$capture_output/config-pch-v2.json"
 for capture in config-default.json config-default-excluded.json \
   config-default-all-excluded.json config-explicit-empty.json \
   config-explicit-nonempty.json config-implicit.json config-ui-filter.json \
-  config-skin.json "$supported"; do
+  config-skin.json "$pch_v2" "$supported"; do
   [ -f "$capture_output/$(basename "$capture")" ] || { echo "missing real IXP Manager capture: $capture" >&2; exit 1; }
   chmod 600 "$capture_output/$(basename "$capture")"
 done
+
+legacy_fixture="$repo/tools/rs-config-render/tests/fixtures/ixp-manager-v1-supported.json"
+expected_pch_v2="$tmp/expected-pch-v2.json"
+actual_pch_v2="$tmp/actual-pch-v2.json"
+jq -S '
+  .schema = "rustbgpd.ixp-manager.router-config/v2"
+  | .ui_filters = []
+  | .complete.ui_filter_count = 0
+' "$legacy_fixture" >"$expected_pch_v2"
+jq -S . "$pch_v2" >"$actual_pch_v2"
+if ! cmp -s "$expected_pch_v2" "$actual_pch_v2"; then
+  diff -u "$expected_pch_v2" "$actual_pch_v2" >&2 || true
+  echo "fresh PCH schema-v2 capture drifted from the pinned v1 fixture" >&2
+  exit 1
+fi
+
 cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" -p rs-config-render --bin rs-config-render
 cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" --bin rustbgpd
 cargo build --quiet --locked --manifest-path "$repo/Cargo.toml" -p rustbgpctl --bin rbgp
@@ -142,7 +159,7 @@ done
 
 legacy="$tmp/candidate-v1"
 legacy_input="$tmp/ixp-manager-v1-supported.json"
-cp "$repo/tools/rs-config-render/tests/fixtures/ixp-manager-v1-supported.json" "$legacy_input"
+cp "$legacy_fixture" "$legacy_input"
 chmod 600 "$legacy_input"
 "$repo/target/debug/rs-config-render" --input-format ixp-manager-v1 \
   --context "$legacy_input" \

--- a/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
+++ b/tests/interop/scripts/test-m96-ixp-manager-activation-frr.sh
@@ -3,7 +3,11 @@
 
 set -euo pipefail
 
-STATE=/var/lib/m96-activation
+HANDLE=b2-rs1-lan1-ipv4
+RUNTIME=/var/lib/rustbgpd/$HANDLE
+STATE=$RUNTIME/activation
+HOST_STATE=/var/lib/rustbgpd/ixp-manager-host
+ADDR=unix://$RUNTIME/grpc.sock
 MARKER='m96 literal;touch /tmp/m96-shell-eval'
 
 # This exact executable is copied into the rustbgpd container. The activation
@@ -13,7 +17,7 @@ if [ "${1:-}" = internal-activate ]; then
     if pid=$(pidof -s rustbgpd 2>/dev/null); then
         kill -HUP "$pid"
     else
-        mkdir -p /var/lib/rustbgpd
+        mkdir -p "$RUNTIME"
         nohup /usr/local/bin/rustbgpd "$STATE/current/config.toml" \
             >/dev/null 2>&1 </dev/null &
     fi
@@ -27,7 +31,6 @@ ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
 TARGET=$ROOT/target/x86_64-unknown-linux-musl/debug/rs-config-render
 BIN=/usr/local/bin/rs-config-render
 ACT=/usr/local/bin/m96-activate
-ADDR=unix:///var/lib/rustbgpd/grpc.sock
 SECRET=mcWsqMdzGwTKt67g
 WORK=$(mktemp -d)
 cleanup() {
@@ -46,7 +49,7 @@ done
 
 CAPTURE_OUTPUT="$WORK/capture" \
     "$ROOT/tests/compat/ixp-manager-birdseye/run.sh" >/dev/null
-FIXTURE=$WORK/capture/ixp-manager-v7.4-rustbgpd.json
+FIXTURE=$WORK/capture/config-pch-v2.json
 cargo +1.98.0 build --locked --target x86_64-unknown-linux-musl -p rs-config-render
 docker cp "$TARGET" "$RUST:$BIN"
 docker cp "$0" "$RUST:$ACT"
@@ -57,16 +60,29 @@ for input in initial hot restart; do
     docker cp "$WORK/$input.json" "$RUST:/var/lib/m96-$input.json"
 done
 docker exec "$RUST" sh -c \
-    "chmod 700 '$BIN' '$ACT'; chmod 600 /var/lib/m96-*.json; rm -rf '$STATE'; mkdir -m 700 '$STATE'"
+    "chmod 700 '$BIN' '$ACT'; chmod 600 /var/lib/m96-*.json; \
+     rm -rf '$RUNTIME' '$HOST_STATE'; \
+     mkdir -m 700 -p '$STATE' '$HOST_STATE'; \
+     chmod 700 /var/lib/rustbgpd '$RUNTIME'"
 
 render() {
     local name=$1
     docker exec "$RUST" "$BIN" \
-        --input-format ixp-manager-v1 \
+        --input-format ixp-manager-v2 \
         --context "/var/lib/m96-$name.json" \
         --out-dir "/var/lib/m96-$name-candidate" \
+        --router-handle "$HANDLE" \
+        --runtime-state-dir "$RUNTIME" \
         --max-prefix-restart-seconds 300 \
         --check-with /usr/local/bin/rustbgpd >/dev/null
+    docker exec "$RUST" cat "/var/lib/m96-$name-candidate/render-receipt.json" \
+        | jq -e --arg handle "$HANDLE" --arg runtime "$RUNTIME" '
+            .input.router_handle == $handle
+            and .host == {
+                router_handle: $handle,
+                runtime_state_dir: $runtime
+            }
+        ' >/dev/null || fail "$name render receipt lost the exact handle binding"
 }
 
 activate() {
@@ -79,6 +95,8 @@ activate() {
     set +e
     docker exec "$RUST" "$BIN" activate \
         --candidate "$candidate" --state-dir "$STATE" \
+        --router-handle "$HANDLE" --runtime-state-dir "$RUNTIME" \
+        --host-state-dir "$HOST_STATE" \
         --check-with /usr/local/bin/rustbgpd \
         --rbgp /usr/local/bin/rbgp --rbgp-addr "$ADDR" \
         --settle-seconds 20 "${extra[@]}" \
@@ -132,7 +150,9 @@ runtime_equal() {
 
 private_state() {
     docker exec "$RUST" bash -ec \
-        "test \"\$(stat -c %a '$STATE')\" = 700 &&
+        "test \"\$(stat -c %a '$RUNTIME')\" = 700 &&
+         test \"\$(stat -c %a '$STATE')\" = 700 &&
+         test \"\$(stat -c %a '$HOST_STATE')\" = 700 &&
          test \"\$(stat -c %a '$STATE/activation.lock')\" = 600 &&
          test \"\$(stat -c %a '$STATE/activation-receipt.json')\" = 600 &&
          test -L '$STATE/current' &&
@@ -181,7 +201,16 @@ render initial
 activate /var/lib/m96-initial-candidate 0 initial --initial
 [ "$(cat "$WORK/initial.output")" = 'activation activated' ] || fail "initial output changed"
 receipt >"$WORK/initial-receipt.json"
-jq -e '.status == "activated" and .initial == true and .activation_runs == 1
+jq -e --arg handle "$HANDLE" --arg runtime "$RUNTIME" --arg state "$STATE" \
+    --arg host_state "$HOST_STATE" --arg addr "$ADDR" '
+    .status == "activated" and .initial == true and .activation_runs == 1
+    and .host == {
+        router_handle: $handle,
+        runtime_state_dir: $runtime,
+        activation_state_dir: $state,
+        host_state_dir: $host_state,
+        rbgp_addr: $addr
+    }
     and .phases.candidate_link.durable == true and .phases.runtime_equal == true' \
     "$WORK/initial-receipt.json" >/dev/null || fail "initial receipt is incomplete"
 ! grep -Fq "$SECRET" "$WORK/initial-receipt.json" || fail "initial receipt leaked MD5"
@@ -254,7 +283,16 @@ jq -n --argjson before "$state_before" --argjson after "$state_after" \
      and (($before.flap_count // 0) == ($after.flap_count // 0))
      and (($after.uptime_seconds // 0) >= ($before.uptime_seconds // 0))' \
     >/dev/null || fail "FRR session flapped or its handle was replaced"
-jq -e '.status == "rolled_back" and .activation_runs == 0
+jq -e --arg handle "$HANDLE" --arg runtime "$RUNTIME" --arg state "$STATE" \
+    --arg host_state "$HOST_STATE" --arg addr "$ADDR" '
+    .status == "rolled_back" and .activation_runs == 0
+    and .host == {
+        router_handle: $handle,
+        runtime_state_dir: $runtime,
+        activation_state_dir: $state,
+        host_state_dir: $host_state,
+        rbgp_addr: $addr
+    }
     and .phases.rollback_link.durable == true
     and .phases.candidate_activation_ran == false
     and .phases.rollback_activation_ran == false and .phases.runtime_equal == true' \


### PR DESCRIPTION
## Summary

- emit a fresh pinned-v7.4 PCH v2 capture without adding another checked-in JSON fixture
- semantically pin every field against the existing v1 PCH fixture projected into the v2 envelope
- isolate the temporary PCH database state in a transaction so later pinned consumers retain their two-session dataset
- report only differing scalar paths on projection drift so credential values never enter diagnostics
- let intentional capture mode collect upstream drift for inspection while normal validation remains fail-closed
- update M96 rendering and activation to the exact per-handle runtime, activation, host-state, and rbgp UDS binding
- preserve the existing no-op, hot reload, rollback, private-state, PID, route/session continuity, and secret-redaction assertions

## Validation

- Bash syntax, PHP lint, and ShellCheck
- semantic projection and targeted mutation probes, including credential-safe diagnostics
- full rs-config-render test suite (115 tests)
- public documentation contract workflow
- full repository pre-push gate
- canonical disposable M96 containerlab: pinned IXP Manager, Birds Eye, and Nagios consumers; populated oracle; real render/activation; MD5 FRR session; no-op; hot reload; tamper refusal; and exact rollback all passed