### PR TITLE
feat(observability): count netlink subscription overruns

### DIFF
--- a/crates/evpn-linux/src/lib.rs
+++ b/crates/evpn-linux/src/lib.rs
@@ -96,7 +96,10 @@ pub mod linux;
 pub use linux::LinuxDataplane;
 
 #[cfg(target_os = "linux")]
-pub use linux::link_carrier::{LinkCarrierHandle, LinkCarrierMap, spawn_link_carrier_monitor};
+pub use linux::link_carrier::{
+    LinkCarrierHandle, LinkCarrierMap, spawn_link_carrier_monitor,
+    spawn_link_carrier_monitor_with_overrun_hook,
+};
 
 #[cfg(target_os = "linux")]
 pub use linux::nexthop_raw::{

--- a/crates/evpn-linux/src/linux/link_carrier.rs
+++ b/crates/evpn-linux/src/linux/link_carrier.rs
@@ -150,6 +150,26 @@ impl LinkCarrierHandle {
 pub async fn spawn_link_carrier_monitor(
     watched: BTreeSet<String>,
 ) -> Result<LinkCarrierHandle, DataplaneError> {
+    spawn_link_carrier_monitor_with_overrun_hook(watched, || {}).await
+}
+
+/// Open the link-carrier monitor with a daemon-owned callback for observed
+/// netlink receive-buffer overruns.
+///
+/// The callback runs once for each overrun notification before the monitor
+/// retains its last projection and waits for the periodic walk to repair any
+/// resulting drift. Keeping this hook generic preserves this crate's
+/// telemetry-independent dataplane boundary.
+///
+/// # Errors
+/// Returns the same errors as [`spawn_link_carrier_monitor`].
+pub async fn spawn_link_carrier_monitor_with_overrun_hook<F>(
+    watched: BTreeSet<String>,
+    on_overrun: F,
+) -> Result<LinkCarrierHandle, DataplaneError>
+where
+    F: Fn() + Send + Sync + 'static,
+{
     let (mut connection, handle, messages) =
         rtnetlink::new_connection().map_err(DataplaneError::Io)?;
 
@@ -190,7 +210,12 @@ pub async fn spawn_link_carrier_monitor(
     // config transactions), never bursty.
     let (cmd_tx, cmd_rx) = mpsc::channel(8);
     tokio::spawn(monitor_loop(
-        handle, messages, carrier_tx, cmd_rx, projection,
+        handle,
+        messages,
+        carrier_tx,
+        cmd_rx,
+        projection,
+        Arc::new(on_overrun),
     ));
 
     Ok(LinkCarrierHandle { carrier_rx, cmd_tx })
@@ -207,6 +232,7 @@ async fn monitor_loop(
     carrier_tx: watch::Sender<LinkCarrierMap>,
     mut cmd_rx: mpsc::Receiver<BTreeSet<String>>,
     mut projection: CarrierProjection,
+    on_overrun: Arc<dyn Fn() + Send + Sync>,
 ) {
     // First tick one full cadence out — spawn already walked.
     let mut tick = tokio::time::interval_at(
@@ -214,6 +240,7 @@ async fn monitor_loop(
         POLL_BACKSTOP_INTERVAL,
     );
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut warned_overrun = false;
 
     loop {
         let changed = tokio::select! {
@@ -222,23 +249,7 @@ async fn monitor_loop(
                     warn!("rtnetlink connection closed; link carrier monitor exiting");
                     return;
                 };
-                let NetlinkPayload::InnerMessage(payload) = msg.payload else {
-                    continue;
-                };
-                match payload {
-                    RouteNetlinkMessage::NewLink(link) => link_name_and_carrier(&link)
-                        .is_some_and(|(name, carrier)| {
-                            projection.apply_event(&name, Some(carrier))
-                        }),
-                    // Link deleted → down (fail-closed). A *rename*
-                    // emits only RTM_NEWLINK under the new name, so
-                    // the old watched name goes stale until the next
-                    // backstop walk marks it down — exactly the gap
-                    // the poll exists to heal.
-                    RouteNetlinkMessage::DelLink(link) => link_name_and_carrier(&link)
-                        .is_some_and(|(name, _)| projection.apply_event(&name, None)),
-                    _ => false,
-                }
+                apply_notification(msg, &mut projection, on_overrun.as_ref(), &mut warned_overrun)
             }
             _ = tick.tick() => {
                 match dump_link_carrier(&handle).await {
@@ -281,6 +292,43 @@ async fn monitor_loop(
             // channel closing exits the loop on the next iteration.
             let _ = carrier_tx.send(projection.snapshot());
         }
+    }
+}
+
+/// Apply one unsolicited link notification. An overrun is evidence that at
+/// least one event may have been lost; retain the last projection and leave
+/// repair to the existing periodic walk rather than claiming recovery here.
+fn apply_notification(
+    msg: NetlinkMessage<RouteNetlinkMessage>,
+    projection: &mut CarrierProjection,
+    on_overrun: &dyn Fn(),
+    warned_overrun: &mut bool,
+) -> bool {
+    let payload = match msg.payload {
+        NetlinkPayload::Overrun(_) => {
+            on_overrun();
+            if !*warned_overrun {
+                *warned_overrun = true;
+                warn!(
+                    "link-carrier netlink subscription overran; one or more events may have \
+                     been lost, retaining the last projection until the periodic poll"
+                );
+            }
+            return false;
+        }
+        NetlinkPayload::InnerMessage(payload) => payload,
+        _ => return false,
+    };
+    match payload {
+        RouteNetlinkMessage::NewLink(link) => link_name_and_carrier(&link)
+            .is_some_and(|(name, carrier)| projection.apply_event(&name, Some(carrier))),
+        // Link deleted → down (fail-closed). A *rename* emits only
+        // RTM_NEWLINK under the new name, so the old watched name
+        // goes stale until the next backstop walk marks it down —
+        // exactly the gap the poll exists to heal.
+        RouteNetlinkMessage::DelLink(link) => link_name_and_carrier(&link)
+            .is_some_and(|(name, _)| projection.apply_event(&name, None)),
+        _ => false,
     }
 }
 
@@ -416,6 +464,44 @@ mod tests {
             msg.attributes.push(LinkAttribute::IfName(name.to_string()));
         }
         msg
+    }
+
+    fn overrun_msg() -> NetlinkMessage<RouteNetlinkMessage> {
+        NetlinkMessage::new(
+            rtnetlink::packet_core::NetlinkHeader::default(),
+            NetlinkPayload::Overrun(Vec::new()),
+        )
+    }
+
+    #[test]
+    fn overrun_counts_without_changing_the_carrier_projection() {
+        use std::cell::Cell;
+
+        let overruns = Cell::new(0_u64);
+        let on_overrun = || overruns.set(overruns.get() + 1);
+        let mut projection = CarrierProjection::new(names(&["es0"]));
+        assert!(projection.apply_event("es0", Some(true)));
+        let before = projection.snapshot();
+        let mut warned = false;
+
+        assert!(!apply_notification(
+            overrun_msg(),
+            &mut projection,
+            &on_overrun,
+            &mut warned
+        ));
+        assert!(warned);
+        assert_eq!(projection.snapshot(), before);
+        assert_eq!(overruns.get(), 1);
+
+        assert!(!apply_notification(
+            overrun_msg(),
+            &mut projection,
+            &on_overrun,
+            &mut warned
+        ));
+        assert_eq!(projection.snapshot(), before);
+        assert_eq!(overruns.get(), 2);
     }
 
     #[test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -98,6 +98,31 @@ const RIB_ACTOR_DURATION_BUCKETS: [f64; 13] = [
 /// Closed operation labels for outbound prefix-limit actor work.
 const OUTBOUND_PREFIX_LIMIT_ACTOR_OPERATIONS: [&str; 2] = ["apply", "recovery"];
 
+/// Closed subscriber vocabulary for `NETLINK_ROUTE` receive-buffer overruns.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NetlinkSubscriber {
+    /// EVPN Ethernet-segment link-carrier watcher.
+    LinkCarrier,
+    /// General FIB kernel-route watcher.
+    GeneralFib,
+    /// BLACKHOLE-discard kernel-route watcher.
+    BlackholeDiscard,
+}
+
+impl NetlinkSubscriber {
+    const ALL: [Self; 3] = [Self::LinkCarrier, Self::GeneralFib, Self::BlackholeDiscard];
+
+    /// Stable Prometheus label for this bounded subscriber.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LinkCarrier => "link_carrier",
+            Self::GeneralFib => "general_fib",
+            Self::BlackholeDiscard => "blackhole_discard",
+        }
+    }
+}
+
 /// Closed label vocabulary for stale session-scoped RIB messages.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StaleSessionMessageKind {
@@ -295,6 +320,7 @@ struct BgpMetricsInner {
     fib_kernel_failures: IntCounterVec,
     kernel_route_notify_dropped: IntCounterVec,
     kernel_route_notify_subscription_failures: IntCounterVec,
+    netlink_subscription_overruns: IntCounterVec,
 
     // ── Loop detection ─────────────────────────────────────────
     as_path_loop_detected: IntCounterVec,
@@ -1299,6 +1325,21 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let netlink_subscription_overruns = IntCounterVec::new(
+            Opts::new(
+                "bgp_netlink_subscription_overruns_total",
+                "NETLINK_ROUTE receive-buffer overrun notifications by bounded subscriber. \
+                 Each increment proves that one or more multicast notifications may have been \
+                 lost; it is not a dropped-message count and does not prove that a later \
+                 periodic reconcile repaired the resulting drift.",
+            ),
+            &["subscriber"],
+        )
+        .expect("valid metric definition");
+        for subscriber in NetlinkSubscriber::ALL {
+            netlink_subscription_overruns.with_label_values(&[subscriber.as_str()]);
+        }
+
         let as_path_loop_detected = IntCounterVec::new(
             Opts::new(
                 "bgp_as_path_loop_detected_total",
@@ -2302,6 +2343,9 @@ impl BgpMetrics {
             .register(Box::new(kernel_route_notify_subscription_failures.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(netlink_subscription_overruns.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(as_path_loop_detected.clone()))
             .expect("metric not already registered");
         registry
@@ -2653,6 +2697,7 @@ impl BgpMetrics {
             fib_kernel_failures,
             kernel_route_notify_dropped,
             kernel_route_notify_subscription_failures,
+            netlink_subscription_overruns,
             as_path_loop_detected,
             rr_loop_detected,
             bgpls_nlri_discarded,
@@ -3843,6 +3888,18 @@ impl BgpMetrics {
         self.0
             .kernel_route_notify_subscription_failures
             .with_label_values(&[actor, group])
+            .inc();
+    }
+
+    /// Record one observed `NETLINK_ROUTE` receive-buffer overrun notification.
+    ///
+    /// The subscriber vocabulary is type-bounded to the three socket owners.
+    /// One notification proves that at least one multicast event may have been
+    /// lost, but does not reveal the drop count.
+    pub fn record_netlink_subscription_overrun(&self, subscriber: NetlinkSubscriber) {
+        self.0
+            .netlink_subscription_overruns
+            .with_label_values(&[subscriber.as_str()])
             .inc();
     }
 
@@ -5593,6 +5650,56 @@ mod tests {
                 .with_label_values(&["blackhole_discard", "ipv6_route"])
                 .get(),
             1
+        );
+    }
+
+    #[test]
+    fn netlink_subscription_overruns_materialize_exact_bounded_zero_series() {
+        let m = BgpMetrics::new();
+
+        let family = m
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_netlink_subscription_overruns_total")
+            .expect("netlink overrun metric registered");
+        let observed: std::collections::BTreeMap<_, _> = family
+            .metric
+            .iter()
+            .map(|metric| {
+                assert_eq!(metric.get_label().len(), 1, "only subscriber label");
+                assert_eq!(metric.get_label()[0].name(), "subscriber");
+                (
+                    metric.get_label()[0].value().to_owned(),
+                    metric.get_counter().value(),
+                )
+            })
+            .collect();
+        assert_eq!(observed.len(), NetlinkSubscriber::ALL.len());
+        for subscriber in NetlinkSubscriber::ALL {
+            assert_eq!(observed.get(subscriber.as_str()), Some(&0.0));
+        }
+
+        m.record_netlink_subscription_overrun(NetlinkSubscriber::GeneralFib);
+        m.record_netlink_subscription_overrun(NetlinkSubscriber::GeneralFib);
+        m.record_netlink_subscription_overrun(NetlinkSubscriber::LinkCarrier);
+        assert_eq!(
+            m.0.netlink_subscription_overruns
+                .with_label_values(&["general_fib"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.0.netlink_subscription_overruns
+                .with_label_values(&["link_carrier"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.0.netlink_subscription_overruns
+                .with_label_values(&["blackhole_discard"])
+                .get(),
+            0
         );
     }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1445,6 +1445,13 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_fib_kernel_failures_total{action="remove"}` | Kernel rejected a remove operation |
 | `bgp_kernel_route_notify_dropped_total{actor,reason="channel_full"}` | Kernel route-event wake feed dropped an event before the FIB or BLACKHOLE reconciler could consume it; periodic reconcile remains the repair backstop |
 | `bgp_kernel_route_notify_subscription_failures_total{actor,group}` | The FIB or BLACKHOLE reconciler failed to subscribe to an IPv4/IPv6 route multicast group and is running with periodic-only kernel-drift repair |
+| `bgp_netlink_subscription_overruns_total{subscriber}` | The kernel reported a receive-buffer overrun to the `link_carrier`, `general_fib`, or `blackhole_discard` NETLINK_ROUTE subscriber. Each increment is one overrun notification—not a count of lost events—and proves only that one or more multicast events may have been lost |
+
+The three netlink-overrun series are materialized at zero. A non-zero value
+does not identify which multicast group lost events and does not prove that a
+later 10 s link-carrier poll or 30 s route reconcile repaired the resulting
+drift. Preserve the counter as incident evidence; `rbgp doctor` includes all
+three series in `system/metrics.prom`.
 
 Use `rbgp rib fib --json` as the per-route companion to these counters.
 The most important states to investigate are `foreign_route_exists` and

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -478,8 +478,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 188:
-        raise ValueError(f"emitted metric roster changed: expected 188, got {len(inventory)}")
+    if len(inventory) != 189:
+        raise ValueError(f"emitted metric roster changed: expected 189, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -46,10 +46,10 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 188)
+        self.assertEqual(len(self.inventory), 189)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            177,
+            178,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
@@ -57,9 +57,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 93)
         self.assertEqual(len(self.rule_refs), 39)
-        self.assertEqual(len(self.doc_refs), 175)
+        self.assertEqual(len(self.doc_refs), 176)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 182)
+        self.assertEqual(len(consumers), 183)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -70,8 +70,8 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("188 emitted families", stdout.getvalue())
-        self.assertIn("182 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("189 emitted families", stdout.getvalue())
+        self.assertIn("183 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_comments_literals_and_test_modules_are_not_definitions(self):
         source = r'''

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -1114,7 +1114,7 @@ struct LinuxBlackholeFib {
 impl LinuxBlackholeFib {
     fn connect(metrics: BgpMetrics) -> Result<Self, String> {
         let (handle, events) = crate::kernel_route_notify::connect_with_route_notifications(
-            "blackhole_discard",
+            rustbgpd_telemetry::metrics::NetlinkSubscriber::BlackholeDiscard,
             metrics,
         )?;
         Ok(Self {

--- a/src/evpn_es_link_drain.rs
+++ b/src/evpn_es_link_drain.rs
@@ -44,6 +44,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
+use rustbgpd_telemetry::BgpMetrics;
+#[cfg(target_os = "linux")]
+use rustbgpd_telemetry::metrics::NetlinkSubscriber;
 use rustbgpd_wire::EthernetSegmentIdentifier;
 use tokio::sync::watch;
 use tokio::time::Instant;
@@ -76,6 +79,7 @@ pub(crate) struct EsLinkDrainDeps {
     pub drain_state: EvpnEsDrainState,
     pub segment: Option<EvpnSegmentRuntimeControl>,
     pub originator: Option<EvpnOriginatorRuntimeControl>,
+    pub metrics: BgpMetrics,
 }
 
 /// Where carrier state comes from.
@@ -116,7 +120,8 @@ async fn run(
     // First probe: evaluate the initial bindings against the feed's
     // initial projection directly — no hold-off (decision 3 startup).
     let initial = bindings_rx.borrow_and_update().clone();
-    feed.sync(watched_links(&initial), &fallback_tx).await;
+    feed.sync(watched_links(&initial), &fallback_tx, &deps.metrics)
+        .await;
     let carrier = feed.carrier_rx.borrow_and_update().clone();
     let actions = planner.replace_bindings(initial, &carrier, Instant::now());
     apply_actions(actions, &deps, &mut planner).await;
@@ -131,7 +136,7 @@ async fn run(
                     return;
                 }
                 let next = bindings_rx.borrow_and_update().clone();
-                feed.sync(watched_links(&next), &fallback_tx).await;
+                feed.sync(watched_links(&next), &fallback_tx, &deps.metrics).await;
                 let carrier = feed.carrier_rx.borrow_and_update().clone();
                 planner.replace_bindings(next, &carrier, Instant::now())
             }
@@ -278,7 +283,14 @@ impl FeedState {
     /// spawn the kernel monitor when the first binding appears,
     /// replace its watched set on change, drop it (drop-to-stop) when
     /// the last binding goes.
-    async fn sync(&mut self, watched: BTreeSet<String>, fallback_tx: &watch::Sender<CarrierMap>) {
+    async fn sync(
+        &mut self,
+        watched: BTreeSet<String>,
+        fallback_tx: &watch::Sender<CarrierMap>,
+        metrics: &BgpMetrics,
+    ) {
+        #[cfg(not(target_os = "linux"))]
+        let _ = metrics;
         if self.injected {
             return;
         }
@@ -304,7 +316,16 @@ impl FeedState {
                 warn!("link carrier monitor exited; respawning");
                 self.handle = None;
             }
-            match rustbgpd_evpn_linux::spawn_link_carrier_monitor(watched.clone()).await {
+            let overrun_metrics = BgpMetrics::clone(metrics);
+            match rustbgpd_evpn_linux::spawn_link_carrier_monitor_with_overrun_hook(
+                watched.clone(),
+                move || {
+                    overrun_metrics
+                        .record_netlink_subscription_overrun(NetlinkSubscriber::LinkCarrier);
+                },
+            )
+            .await
+            {
                 Ok(handle) => {
                     info!(
                         links = %watched.iter().cloned().collect::<Vec<_>>().join(","),
@@ -718,6 +739,7 @@ mod tests {
                 drain_state: drain_state.clone(),
                 segment: Some(probe.control.clone()),
                 originator: None,
+                metrics: BgpMetrics::new(),
             },
             shutdown.clone(),
         );
@@ -878,10 +900,8 @@ mod tests {
     /// and an AC gate row of `Blocked` — with no further stimulus.
     #[tokio::test]
     async fn down_at_boot_converges_segment_bias_and_gate_to_drained() {
-        use rustbgpd_rib::RibUpdate;
-        use rustbgpd_telemetry::BgpMetrics;
-
         use crate::test_support::{evpn_instance, vni};
+        use rustbgpd_rib::RibUpdate;
 
         let id = esi(1);
         let mut table = rustbgpd_evpn::EvpnInstanceTable::new();
@@ -948,6 +968,7 @@ mod tests {
                 drain_state: drain_state.clone(),
                 segment: Some(segment_handle.runtime_control()),
                 originator: None,
+                metrics: BgpMetrics::new(),
             },
             shutdown.clone(),
         );

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -1897,8 +1897,10 @@ struct LinuxUnicastFib {
 #[cfg(target_os = "linux")]
 impl LinuxUnicastFib {
     fn connect(metrics: BgpMetrics) -> Result<Self, String> {
-        let (handle, events) =
-            crate::kernel_route_notify::connect_with_route_notifications("general_fib", metrics)?;
+        let (handle, events) = crate::kernel_route_notify::connect_with_route_notifications(
+            rustbgpd_telemetry::metrics::NetlinkSubscriber::GeneralFib,
+            metrics,
+        )?;
         Ok(Self {
             handle,
             kernel_route_events: Some(events),

--- a/src/kernel_route_notify.rs
+++ b/src/kernel_route_notify.rs
@@ -27,6 +27,8 @@
 //! is exactly the pre-eventing behavior.
 
 use rustbgpd_telemetry::BgpMetrics;
+#[cfg(target_os = "linux")]
+use rustbgpd_telemetry::metrics::NetlinkSubscriber;
 use rustbgpd_wire::Prefix;
 use tokio::sync::mpsc;
 
@@ -124,11 +126,12 @@ pub(crate) async fn recv_kernel_route_event(
 /// falls back to periodic-only kernel-drift repair.
 #[cfg(target_os = "linux")]
 pub(crate) fn connect_with_route_notifications(
-    actor: &'static str,
+    subscriber: NetlinkSubscriber,
     metrics: BgpMetrics,
 ) -> Result<(rtnetlink::Handle, mpsc::Receiver<KernelRouteEvent>), String> {
     use rtnetlink::sys::AsyncSocket;
 
+    let actor = subscriber.as_str();
     let (mut connection, handle, messages) =
         rtnetlink::new_connection().map_err(|e| format!("open NETLINK_ROUTE: {e}"))?;
     for (group, name, label) in [
@@ -149,7 +152,7 @@ pub(crate) fn connect_with_route_notifications(
     tokio::spawn(connection);
     let (event_tx, event_rx) = mpsc::channel(KERNEL_ROUTE_EVENT_BUFFER);
     tokio::spawn(forward_route_notifications(
-        messages, event_tx, actor, metrics,
+        messages, event_tx, subscriber, metrics,
     ));
     Ok((handle, event_rx))
 }
@@ -165,7 +168,7 @@ async fn forward_route_notifications(
         rtnetlink::sys::SocketAddr,
     )>,
     event_tx: mpsc::Sender<KernelRouteEvent>,
-    actor: &'static str,
+    subscriber: NetlinkSubscriber,
     metrics: BgpMetrics,
 ) {
     use futures::StreamExt;
@@ -173,12 +176,28 @@ async fn forward_route_notifications(
     use netlink_packet_route::RouteNetlinkMessage;
     use rtnetlink::packet_core::NetlinkPayload;
 
+    let actor = subscriber.as_str();
+
     // Log the first drop-on-full only, so a sustained storm doesn't
     // spam the log; the periodic backstop repairs whatever was dropped.
     let mut warned_full = false;
+    let mut warned_overrun = false;
     while let Some((message, _addr)) = messages.next().await {
-        let NetlinkPayload::InnerMessage(inner) = message.payload else {
-            continue;
+        let inner = match message.payload {
+            NetlinkPayload::Overrun(_) => {
+                metrics.record_netlink_subscription_overrun(subscriber);
+                if !warned_overrun {
+                    warned_overrun = true;
+                    tracing::warn!(
+                        actor,
+                        "kernel route netlink subscription overran; one or more events may have \
+                         been lost, leaving the periodic reconcile as the repair backstop"
+                    );
+                }
+                continue;
+            }
+            NetlinkPayload::InnerMessage(inner) => inner,
+            _ => continue,
         };
         let event = match inner {
             RouteNetlinkMessage::NewRoute(msg) => {
@@ -280,6 +299,76 @@ mod tests {
     fn route_group_ids_are_rtnetlink_enum_values() {
         assert_eq!(RTNLGRP_IPV4_ROUTE, 7);
         assert_eq!(RTNLGRP_IPV6_ROUTE, 11);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn each_route_subscriber_counts_overruns_without_fabricating_events() {
+        use rtnetlink::packet_core::{NetlinkMessage, NetlinkPayload};
+
+        for subscriber in [
+            NetlinkSubscriber::GeneralFib,
+            NetlinkSubscriber::BlackholeDiscard,
+        ] {
+            let metrics = BgpMetrics::new();
+            let (messages_tx, messages_rx) = futures::channel::mpsc::unbounded();
+            let (event_tx, mut event_rx) = mpsc::channel(1);
+            for _ in 0..2 {
+                let message = NetlinkMessage::new(
+                    rtnetlink::packet_core::NetlinkHeader::default(),
+                    NetlinkPayload::<netlink_packet_route::RouteNetlinkMessage>::Overrun(Vec::new()),
+                );
+                messages_tx
+                    .unbounded_send((message, rtnetlink::sys::SocketAddr::new(0, 0)))
+                    .expect("synthetic overrun queued");
+            }
+            drop(messages_tx);
+
+            forward_route_notifications(messages_rx, event_tx, subscriber, metrics.clone()).await;
+
+            assert!(
+                event_rx.recv().await.is_none(),
+                "overrun is not a route event for {}",
+                subscriber.as_str()
+            );
+            let family = metrics
+                .registry()
+                .gather()
+                .into_iter()
+                .find(|family| family.name() == "bgp_netlink_subscription_overruns_total")
+                .expect("netlink overrun metric registered");
+            let observed: std::collections::BTreeMap<_, _> = family
+                .metric
+                .iter()
+                .map(|metric| {
+                    assert_eq!(metric.get_label().len(), 1, "only subscriber label");
+                    assert_eq!(metric.get_label()[0].name(), "subscriber");
+                    (
+                        metric.get_label()[0].value().to_owned(),
+                        metric.get_counter().value(),
+                    )
+                })
+                .collect();
+            let expected: std::collections::BTreeMap<_, _> = [
+                NetlinkSubscriber::LinkCarrier,
+                NetlinkSubscriber::GeneralFib,
+                NetlinkSubscriber::BlackholeDiscard,
+            ]
+            .into_iter()
+            .map(|candidate| {
+                (
+                    candidate.as_str().to_owned(),
+                    if candidate == subscriber { 2.0 } else { 0.0 },
+                )
+            })
+            .collect();
+            assert_eq!(
+                observed,
+                expected,
+                "{} receive loop must account exactly and continue after the first overrun",
+                subscriber.as_str()
+            );
+        }
     }
 
     #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4656,6 +4656,7 @@ async fn run<T>(
                     drain_state: evpn_es_drain_state.clone(),
                     segment: Some(segment_control.clone()),
                     originator: evpn_originator_runtime_control.clone(),
+                    metrics: metrics.clone(),
                 },
                 evpn_es_link_drain_shutdown.clone(),
             )


### PR DESCRIPTION
## Summary

- expose a typed bounded `bgp_netlink_subscription_overruns_total{subscriber}` counter for link-carrier, general-FIB, and blackhole-discard subscribers
- count each receiver overrun exactly once, warn once per task, continue receiving, and never fabricate route or carrier events
- preserve the existing public link-carrier monitor while adding a telemetry-aware daemon path
- document the signal as a notification event rather than a loss count or automatic-repair claim
- advance the metric-consumer contract to the exact 189 emitted / 183 consumed roster

## Validation

- 23 metric-consumer mutation tests and live 189/183/6 contract
- telemetry and EVPN-Linux focused overrun tests
- route-notify (6), ES-drain (13), FIB-runtime (78), and blackhole (40) suites
- strict workspace Clippy
- public documentation contracts
- full repository pre-push gate and push-hook repeat
