### PR TITLE
ci: add optional local gate recipes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,45 @@ Markdown. Published docs name the thing directly, link the ADR, or cite the
 GitHub PR number — never a private issue-tracker ID an external reader
 cannot resolve.
 
+### Optional local task runner
+
+The repository includes an optional [`just`](https://just.systems/) task
+runner for a curated local baseline. It does not add a build dependency, and
+the recipes are not a full CI or pre-merge replica. Install it outside the
+repository if you want the shortcuts:
+
+```bash
+cargo install --locked just
+just --list
+```
+
+The recipes intentionally expose their direct commands:
+
+- `just gate` runs formatting, lightweight repository contracts, strict
+  workspace Clippy, the full workspace tests, and library docs. This is the
+  broad local baseline and can take several minutes on a cold target directory.
+- `just gate-rib` compiles the feature-gated RIB, transport, and API benchmark
+  surfaces that the default workspace build cannot see.
+- `just gate-deps` tests the four standalone scale-harness manifests. These
+  builds have separate lockfiles and can add substantial cold-build time.
+- `just gate-contract` executes every Criterion benchmark body once without
+  collecting timings. The harness is Linux/GNU-Bash oriented and requires the
+  same local toolchain and system libraries as those benches.
+- `just fix` applies safe Clippy suggestions before formatting. Cargo's normal
+  refusal to modify dirty or staged worktrees remains in force.
+
+Hosted checks remain authoritative and cover more than these recipes: the
+declared MSRV, platform and workflow contracts, receipt classifiers, and
+privileged interoperability lanes. In particular, the exact v0.64 migration
+test only runs when `RUSTBGPD_V064_VALIDATOR` points to the verified v0.64
+binary that CI prepares. Privileged network-namespace tests require Linux,
+`EVPN_LINUX_NETNS=1`, and `CAP_NET_ADMIN` plus `CAP_SYS_ADMIN`; use
+`crates/evpn-linux/tests/docker/run-netns-tests.sh` as documented in that
+harness's README. Neither prerequisite is installed or enabled by `just gate`.
+
+Treat the `justfile` as a convenient reviewed snapshot, not a single source of
+truth. Check the applicable workflows when changing CI or preparing a merge.
+
 ### Comparison documentation
 
 Describe every project by capability and scope, pin the compared release, and
@@ -130,9 +169,9 @@ maintaining a second crate list.
 We ship a `.pre-commit-config.yaml` that runs `cargo fmt` and
 `cargo clippy --workspace --all-targets -- -D warnings` on every
 commit and `cargo test --workspace --lib` on every push. The
-clippy invocation matches CI exactly so a clean commit is a clean
-PR. `cargo test` is gated to pre-push (not pre-commit) so commits
-stay fast.
+hooks are a fast local subset, not an exact CI mirror or a guarantee that a
+pull request is ready. `cargo test` is gated to pre-push (not pre-commit) so
+commits stay fast.
 
 Set it up once:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,14 +58,15 @@ The recipes intentionally expose their direct commands:
   workspace Clippy, the full workspace tests, and library docs. This is the
   broad local baseline and can take several minutes on a cold target directory.
 - `just gate-rib` compiles the feature-gated RIB, transport, and API benchmark
-  surfaces that the default workspace build cannot see, including both API
-  feature combinations.
+  surfaces that the default workspace build cannot see, including the root
+  FIB projection and both API feature combinations.
 - `just gate-deps` tests the four standalone scale-harness manifests. These
   manifests share `bench/scale/Cargo.lock`, which is separate from the
   workspace lockfile, and can add substantial cold-build time.
 - `just gate-contract` executes every Criterion benchmark body once without
-  collecting timings. The harness is Linux/GNU-Bash oriented and requires the
-  same local toolchain and system libraries as those benches.
+  collecting timings, with locked dependency resolution and fail-fast local
+  behavior. The harness is Linux/GNU-Bash oriented and requires the same local
+  toolchain and system libraries as those benches.
 - `just fix` applies safe Clippy suggestions before formatting. Cargo's normal
   refusal to modify dirty or staged worktrees remains in force.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,9 @@ cannot resolve.
 
 The repository includes an optional [`just`](https://just.systems/) task
 runner for a curated local baseline. It does not add a build dependency, and
-the recipes are not a full CI or pre-merge replica. Install it outside the
-repository if you want the shortcuts:
+the recipes are not a full CI or pre-merge replica. The contract checks require
+Python 3.11 or newer. Install `just` outside the repository if you want the
+shortcuts:
 
 ```bash
 cargo install --locked just
@@ -57,9 +58,11 @@ The recipes intentionally expose their direct commands:
   workspace Clippy, the full workspace tests, and library docs. This is the
   broad local baseline and can take several minutes on a cold target directory.
 - `just gate-rib` compiles the feature-gated RIB, transport, and API benchmark
-  surfaces that the default workspace build cannot see.
+  surfaces that the default workspace build cannot see, including both API
+  feature combinations.
 - `just gate-deps` tests the four standalone scale-harness manifests. These
-  builds have separate lockfiles and can add substantial cold-build time.
+  manifests share `bench/scale/Cargo.lock`, which is separate from the
+  workspace lockfile, and can add substantial cold-build time.
 - `just gate-contract` executes every Criterion benchmark body once without
   collecting timings. The harness is Linux/GNU-Bash oriented and requires the
   same local toolchain and system libraries as those benches.

--- a/bench/smoke-benches.sh
+++ b/bench/smoke-benches.sh
@@ -21,6 +21,24 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+locked_args=()
+fail_fast=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --locked)
+      locked_args=(--locked)
+      ;;
+    --fail-fast)
+      fail_fast=1
+      ;;
+    *)
+      echo "usage: $0 [--locked] [--fail-fast]" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
 # Excluded — standalone measurement harnesses with their own CLIs rather than
 # criterion, so they reject criterion's `--test` flag:
 #
@@ -34,7 +52,7 @@ cd "$(dirname "$0")/.."
 EXCLUDED=(snapshot_allocation route_paging vpn_query_timing vpn_query_allocation)
 
 mapfile -t targets < <(
-  cargo metadata --no-deps --format-version 1 | python3 -c '
+  cargo metadata "${locked_args[@]}" --no-deps --format-version 1 | python3 -c '
 import json, sys
 
 for package in json.load(sys.stdin)["packages"]:
@@ -72,8 +90,11 @@ for target in "${targets[@]}"; do
   fi
 
   echo "smoke $package/$name ${features:+[$features]}"
-  if ! cargo test -p "$package" --bench "$name" "${feature_args[@]}"; then
+  if ! cargo test "${locked_args[@]}" -p "$package" --bench "$name" "${feature_args[@]}"; then
     echo "::error::bench target $package/$name failed to execute" >&2
+    if [ "$fail_fast" -eq 1 ]; then
+      exit 1
+    fi
     status=1
   fi
 done

--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ gate:
 
 # Compile the feature-gated RIB, transport, and API bench surfaces.
 gate-rib:
+    cargo check --locked -p rustbgpd --features bench-internals --benches
     cargo check --locked -p rustbgpd-rib --features bench-internals --benches
     cargo check --locked -p rustbgpd-transport --features bench-internals --benches
     cargo check --locked -p rustbgpd-api --features bench-internals --benches
@@ -39,7 +40,7 @@ gate-deps:
 
 # Execute every Criterion benchmark body once without collecting timings.
 gate-contract:
-    bash bench/smoke-benches.sh
+    bash bench/smoke-benches.sh --locked --fail-fast
 
 # Apply safe Clippy suggestions, then format the workspace.
 fix:

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ gate-rib:
     cargo check --locked -p rustbgpd-rib --features bench-internals --benches
     cargo check --locked -p rustbgpd-transport --features bench-internals --benches
     cargo check --locked -p rustbgpd-api --features bench-internals --benches
+    cargo check --locked -p rustbgpd-api --features bench-internals,vpn-query-allocation --bench vpn_query_allocation
 
 # Test the four standalone scale-harness manifests used by CI.
 gate-deps:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,46 @@
+# Optional, curated local checks. Hosted CI remains the source of truth.
+
+# Show the available local checks.
+default:
+    just --list
+
+# Run the broad local correctness baseline in diagnostic order.
+gate:
+    cargo fmt --all -- --check
+    python3 -m unittest -v scripts/test_check_clippy_reasons.py
+    python3 scripts/check-clippy-reasons.py
+    python3 scripts/check-v1-stable-surface.py
+    python3 scripts/reflow-release-notes.py --selftest
+    python3 -m unittest -v scripts/test_check_public_tracker_ids.py
+    python3 scripts/check_public_tracker_ids.py
+    python3 -m unittest -v scripts/test_check_ixp_manager_docs.py
+    python3 scripts/check_ixp_manager_docs.py
+    python3 -m unittest -v scripts/test_check_release_checklist_paths.py
+    python3 scripts/check_release_checklist_paths.py
+    python3 -m unittest -v scripts/test_check_metric_consumers.py
+    python3 scripts/check-metric-consumers.py
+    cargo clippy --locked --workspace --all-targets -- -D warnings
+    cargo test --locked --workspace
+    cargo doc --locked --workspace --lib --no-deps
+
+# Compile the feature-gated RIB, transport, and API bench surfaces.
+gate-rib:
+    cargo check --locked -p rustbgpd-rib --features bench-internals --benches
+    cargo check --locked -p rustbgpd-transport --features bench-internals --benches
+    cargo check --locked -p rustbgpd-api --features bench-internals --benches
+
+# Test the four standalone scale-harness manifests used by CI.
+gate-deps:
+    cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked
+    cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked
+    cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked
+    cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked
+
+# Execute every Criterion benchmark body once without collecting timings.
+gate-contract:
+    bash bench/smoke-benches.sh
+
+# Apply safe Clippy suggestions, then format the workspace.
+fix:
+    cargo clippy --fix --locked --workspace --all-targets -- -D warnings
+    cargo fmt --all


### PR DESCRIPTION
## Summary

- add an optional `just` task runner with a curated local correctness baseline
- add focused recipes for all feature-gated root, RIB, transport, and API benchmark surfaces, the shared-lockfile scale harnesses, and benchmark-body smoke contracts
- add backward-compatible `--locked` and `--fail-fast` smoke-harness modes for the local contract gate; hosted CI retains its existing aggregate behavior
- keep the baseline and compile recipes direct and fail-fast, with no output filtering or error masking
- document Python 3.11+, cost, platform boundaries, privileged netns and v0.64 validator prerequisites, and the fact that hosted checks remain authoritative
- correct the existing claim that local pre-commit hooks exactly mirror CI

## Validation

- `just --fmt --check`
- `just --list` and dry-runs for every recipe
- exact command/order and failure-propagation checks
- full `just gate`
- full expanded `just gate-rib`, including root FIB projection and both API feature combinations
- full `just gate-deps`
- full locked, fail-fast `just gate-contract`
- Bash syntax, ShellCheck, and unknown-option refusal for the smoke harness
- commit hooks, public tracker checker, and `git diff --check`

Linear: LAN-1270