### PR TITLE
docs: correct the suppression census and record the cfg(test) visibility constraint

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2073,27 +2073,64 @@ branch is between features.
   lock with SIGHUP through config-persistence acknowledgement. Persistence
   rejection rolls the accepted runtime mutation back, completing the same
   lock/ack/rollback invariant used by FIB-table and dynamic-neighbor CRUD.
-- [ ] **`#[expect(clippy::too_many_lines)]` reduction.** ~326 occurrences
-  workspace-wide (2026-07-30 re-measure; ~117 outside test files and
-  top-level test modules — the non-test count is roughly flat, so recent
-  growth is concentrated in test code) — the earlier "~30" figure was stale
-  and the direction is *up*, tracking the
-  RIB-manager / policy-language / EVPN expansion of the last sprints.
+- [x] **`clippy::too_many_lines` suppressions are `expect`, not `allow`.**
+  Across the production source trees the clippy-reason ratchet covers, every
+  suppression of this lint is now `#[expect(...)]` and none is
+  `#[allow(...)]`. That is the half that matters for rot: an `expect` fails
+  the build the moment the lint stops firing, so a suppression that outlives
+  the function it was written for reports itself, while an `allow` goes
+  stale in silence. Three `#[allow(clippy::too_many_lines)]` remain outside
+  that fence by design — `bench/scale/reloadstall` and
+  `bench/scale/rrharness` (standalone harness crates, not workspace members)
+  and `tests/config_persistence_lifecycle.rs` (an integration-test target,
+  which the production-source contract deliberately excludes).
+- [ ] **Long-function reduction (`clippy::too_many_lines`).** Readings are
+  point-in-time, not targets. 2026-08-23: 356 `expect` / 0 `allow` across
+  the production source roots; 357 / 3 across the whole tree. Compare only
+  like scopes across time — the earlier "~326" (2026-07-30) counted both
+  forms tree-wide and split 279 `expect` / 47 `allow`, so most of the jump
+  in the `expect`-only series is that conversion, not new suppressions. Real
+  growth over those weeks is the tree-wide 326 → 360, and the direction is
+  still *up*, tracking the RIB-manager / policy-language / EVPN expansion
+  and test-module growth. Re-derive instead of hand-counting; this borrows
+  the ratchet's own scope and attribute parser, so it follows workspace
+  packages as they are added:
+
+  ```sh
+  python3 - <<'PY'
+  import importlib.util, pathlib, re, collections
+  s = importlib.util.spec_from_file_location("c", "scripts/check-clippy-reasons.py")
+  c = importlib.util.module_from_spec(s); s.loader.exec_module(c)
+  head, n = re.compile(r"#!?\[\s*(allow|expect)\s*\("), collections.Counter()
+  for f in c.rust_files(c.workspace_source_roots(pathlib.Path.cwd())):
+      t, off = f.read_text(), 0
+      while (m := head.search(t, off)) and (end := c.find_attribute_end(t, m.start())):
+          if "clippy::too_many_lines" in t[m.start() : end + 1]:
+              n[m.group(1)] += 1
+          off = end + 1
+  print(n)
+  PY
+  ```
+
   Concentrated in long dispatchers (FSM action loop, EVPN reconcilers,
   `manager/{mod,distribution/*}`, `rpol/{typeck,lower}`, encode/decode match
-  arms). Some are honest match-heavy dispatch; this tracks the trend, not a
-  per-PR gate. A 2026-07-29 recount of
+  arms) and in test modules. Some are honest match-heavy dispatch; this
+  tracks the trend, not a per-PR gate. A 2026-07-29 recount of
   `crates/telemetry/src/metrics.rs::BgpMetrics::with_registry` found 159 metric
   fields, 159 constructor definitions, and 159 matching explicit registry
   registrations (plus the feature-gated jemalloc collector), with no live
   registration defect. A tiny local helper would reduce boilerplate but would
   not couple those three inventories enough to prevent drift, so that refactor
   is not justified.
-- [ ] **`#[allow(clippy::too_many_arguments)]` cluster tidy-up.** ~109
-  occurrences workspace-wide (2026-07-30 re-measure) — RIB
-  distribution functions, EVPN originators, BFD socket setup. A
-  `DistributionContext` parameter struct would absorb the metric / policy
-  threading; same trick fits the EVPN originators.
+- [ ] **`clippy::too_many_arguments` cluster tidy-up.** Same derivation with
+  the lint name swapped, and the same caution about comparing scopes.
+  2026-08-23: 113 suppressions across the production source roots, all
+  `expect`, none `allow` — the earlier "~109" (2026-07-30) was a tree-wide
+  count of both forms that split 67 `expect` / 42 `allow`, so the cluster
+  grew by four, not by forty-six. RIB distribution functions, EVPN
+  originators, BFD socket setup. A `DistributionContext` parameter struct
+  would absorb the metric / policy threading; same trick fits the EVPN
+  originators.
 - [x] **`#[allow(clippy::result_large_err)]` audit.** The 2026-07-17 inventory
   found 15 suppressions spread across six files. Fourteen stale API suppressions
   have since been removed: tonic 0.14's `Status` is an 8-byte handle to an

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -72,6 +72,16 @@ pub struct EventService {
 }
 
 impl EventService {
+    /// Minimal service for this crate's own unit tests.
+    ///
+    /// `cfg(test)` holds only inside this crate, so neither the daemon, nor
+    /// other workspace crates, nor this crate's `tests/*.rs` integration
+    /// targets can reach this constructor or the two
+    /// `with_dataplane_snapshots*` ones below it, even under
+    /// `cargo test --workspace`. Callers inside the crate build the service
+    /// through `with_dataplane_snapshots_broadcaster_and_metrics`, as
+    /// `server::serve` does; callers outside it drive the served gRPC
+    /// surface rather than constructing an `EventService`.
     #[cfg(test)]
     #[must_use]
     pub(crate) fn new(

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -150,6 +150,16 @@ pub struct RibService {
 
 impl RibService {
     /// Create a new RIB service backed by the given RIB channel.
+    ///
+    /// Test- and bench-only, and `cfg(test)` holds only inside this crate:
+    /// the daemon, other workspace crates, and this crate's own `tests/*.rs`
+    /// integration targets all link `rustbgpd-api` as an ordinary dependency
+    /// with `cfg(test)` unset, so none of them can call this even under
+    /// `cargo test --workspace`. Build it the way production does instead —
+    /// [`RibService::with_status_snapshots`], plus
+    /// [`RibService::with_fib_table_control`] for the mutating FIB-table
+    /// RPCs. Benchmarks reach this through the `bench-internals` feature
+    /// rather than through `cfg(test)`.
     #[cfg(any(test, feature = "bench-internals"))]
     pub fn new(rib_tx: mpsc::Sender<RibUpdate>) -> Self {
         Self {


### PR DESCRIPTION
Two unrelated accuracy fixes (LAN-1268). Documentation only — no behaviour, no
`cfg` changes.

## 1. `ROADMAP.md`: the suppression census was stale and mis-scoped

### Before

```
- [ ] **`#[expect(clippy::too_many_lines)]` reduction.** ~326 occurrences
  workspace-wide (2026-07-30 re-measure; ~117 outside test files and
  top-level test modules — the non-test count is roughly flat, so recent
  growth is concentrated in test code) — the earlier "~30" figure was stale
  and the direction is *up*, tracking the
  RIB-manager / policy-language / EVPN expansion of the last sprints.
  Concentrated in long dispatchers (...)
...
- [ ] **`#[allow(clippy::too_many_arguments)]` cluster tidy-up.** ~109
  occurrences workspace-wide (2026-07-30 re-measure) — RIB
  distribution functions, EVPN originators, BFD socket setup. (...)
```

### After

The `too_many_lines` entry becomes two items, because it was tracking two
goals under one checkbox:

```
- [x] **`clippy::too_many_lines` suppressions are `expect`, not `allow`.**
  Across the production source trees the clippy-reason ratchet covers, every
  suppression of this lint is now `#[expect(...)]` and none is
  `#[allow(...)]`. That is the half that matters for rot: an `expect` fails
  the build the moment the lint stops firing, so a suppression that outlives
  the function it was written for reports itself, while an `allow` goes
  stale in silence. Three `#[allow(clippy::too_many_lines)]` remain outside
  that fence by design — `bench/scale/reloadstall` and
  `bench/scale/rrharness` (standalone harness crates, not workspace members)
  and `tests/config_persistence_lifecycle.rs` (an integration-test target,
  which the production-source contract deliberately excludes).
- [ ] **Long-function reduction (`clippy::too_many_lines`).** Readings are
  point-in-time, not targets. 2026-08-23: 356 `expect` / 0 `allow` across
  the production source roots; 357 / 3 across the whole tree. Compare only
  like scopes across time — the earlier "~326" (2026-07-30) counted both
  forms tree-wide and split 279 `expect` / 47 `allow`, so most of the jump
  in the `expect`-only series is that conversion, not new suppressions. Real
  growth over those weeks is the tree-wide 326 → 360, and the direction is
  still *up*, tracking the RIB-manager / policy-language / EVPN expansion
  and test-module growth. Re-derive instead of hand-counting; (...)
```

and `too_many_arguments` gets the same treatment:

```
- [ ] **`clippy::too_many_arguments` cluster tidy-up.** Same derivation with
  the lint name swapped, and the same caution about comparing scopes.
  2026-08-23: 113 suppressions across the production source roots, all
  `expect`, none `allow` — the earlier "~109" (2026-07-30) was a tree-wide
  count of both forms that split 67 `expect` / 42 `allow`, so the cluster
  grew by four, not by forty-six. (...)
```

The unchanged tail of each item (long-dispatcher concentration, the
2026-07-29 `BgpMetrics::with_registry` recount and its "no shared helper"
decision, the `DistributionContext` sketch) is kept verbatim.

### Why the raw number rose while the situation improved

Re-derived at this branch's HEAD:

| lint | scope | 2026-07-30 | 2026-08-23 |
| --- | --- | --- | --- |
| `too_many_lines` | production src roots | — | 356 `expect` / 0 `allow` |
| `too_many_lines` | whole tree | 279 `expect` / 47 `allow` (326) | 357 / 3 (360) |
| `too_many_arguments` | production src roots | — | 113 `expect` / 0 `allow` |
| `too_many_arguments` | whole tree | 67 `expect` / 42 `allow` (109) | 113 / 0 |

Two separate things moved, and the old wording conflated them:

- The `allow` → `expect` conversion is count-neutral tree-wide but moves 44
  `too_many_lines` and 42 `too_many_arguments` suppressions into the
  `expect` bucket. Set beside an `expect`-only figure it reads as a spike
  that never happened. It is also the improvement that matters: an `expect`
  fails the build once the lint stops firing, so it cannot go stale unnoticed.
- Underneath that, tree-wide totals did grow — `too_many_lines` 326 → 360,
  `too_many_arguments` 109 → 113 — so the recorded direction (*up*) still
  holds, on a like-for-like basis rather than the mixed one.

A bare number rots by design, so each reading is now dated, scoped, and
labelled point-in-time, and the item carries the command that produced it.
The snippet borrows `scripts/check-clippy-reasons.py`'s own
`workspace_source_roots` and string-aware `find_attribute_end`, so it stays
correct as workspace packages are added and does not need a second copy of
the attribute parser:

```sh
python3 - <<'PY'
import importlib.util, pathlib, re, collections
s = importlib.util.spec_from_file_location("c", "scripts/check-clippy-reasons.py")
c = importlib.util.module_from_spec(s); s.loader.exec_module(c)
head, n = re.compile(r"#!?\[\s*(allow|expect)\s*\("), collections.Counter()
for f in c.rust_files(c.workspace_source_roots(pathlib.Path.cwd())):
    t, off = f.read_text(), 0
    while (m := head.search(t, off)) and (end := c.find_attribute_end(t, m.start())):
        if "clippy::too_many_lines" in t[m.start() : end + 1]:
            n[m.group(1)] += 1
        off = end + 1
print(n)
PY
```

The block was extracted back out of the rendered `ROADMAP.md` and run
verbatim to confirm it is copy-pasteable: `Counter({'expect': 356})`.

A naive `git grep` over the same lint is not a substitute — attributes wrap
across lines and the `allow`/`expect` head is often several lines above the
lint name, so a line-oriented count cannot split the two forms.

## 2. `crates/api`: record the `cfg(test)` visibility constraint

#1892 gated `RibService::new` and `EventService::new` as test-only. The
trap that follows is a Rust-semantics one and is not visible at the call
site: `cfg(test)` is set only while `rustbgpd-api` compiles its own unit
tests. The daemon crate, every other workspace crate, and this crate's own
`tests/*.rs` integration targets all link `rustbgpd-api` as an ordinary
dependency with `cfg(test)` unset, so none of them can call a `#[cfg(test)]`
item even under `cargo test --workspace`. That already forced the
`src/fib_table_control.rs` unit tests onto `with_status_snapshots` in the
same PR.

Each gated constructor now says so and names the entry point production
uses instead — `RibService::with_status_snapshots` (plus
`with_fib_table_control` for the mutating FIB-table RPCs) and
`EventService::with_dataplane_snapshots_broadcaster_and_metrics`, as
`server::serve` builds it. The `RibService` note also records that
benchmarks reach the constructor through the `bench-internals` feature
rather than through `cfg(test)`.

## Gates

All green at `30818c79`:

| gate | rc |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace --no-fail-fast` | 0 (8098 passed, 0 failed) |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `cargo check -p rustbgpd-api --benches` | 0 |
