### PR TITLE
docs: record specialized release gates

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -7,8 +7,11 @@ pushing a version tag.
 
 ## Automated (CI)
 
-These run on every push and PR (`.github/workflows/ci.yml`,
-`.github/workflows/interop.yml`):
+The core `.github/workflows/ci.yml` and `.github/workflows/interop.yml`
+lanes run on qualifying pull requests and main-branch pushes. Both ignore
+Markdown-only changes, and interop also ignores the rest of `docs/`. The
+specialized lanes below have their own event and path filters, so confirm every
+lane applicable to the release diff actually ran before tagging.
 
 - [ ] `cargo fmt --check`
 - [ ] `python3 scripts/check-clippy-reasons.py`
@@ -37,6 +40,25 @@ These run on every push and PR (`.github/workflows/ci.yml`,
       `.github/workflows/interop.yml` (against FRR 10.3.1 via
       containerlab) are green; that workflow is the authoritative job
       set, so check it rather than re-listing M-numbers here.
+- [ ] **Public docs contract** — `.github/workflows/public-docs-contract.yml`
+      is green. It runs unfiltered on every pull request and main-branch push,
+      covering metric consumers, public tracker-ID and artifact-home-path
+      hygiene, pinned IXP Manager docs, and release-checklist source paths.
+- [ ] **Embedding docs contract** — when embedding docs, this checklist,
+      Cargo manifests, or the embedding checker surface changed,
+      `.github/workflows/embedding-doc-contract.yml` ran on the pull request
+      and is green; it is path-scoped on pull requests and main-branch pushes.
+- [ ] **Published-crate semver contract** — when `crates/wire/` or
+      `crates/fsm/` changed, `.github/workflows/semver-checks.yml` is green for
+      the pull request or a manual dispatch at the release commit. It is
+      path-scoped on pull requests to those crate trees and its own workflow;
+      it has no push trigger.
+- [ ] **IXP Manager / Bird's Eye contract** — when the IXP Manager,
+      Bird's Eye, renderer, adapter, or interop-doc surface changed,
+      `.github/workflows/ixp-compat.yml` ran and is green. It is path-scoped on
+      pull requests and main-branch pushes and also supports manual dispatch,
+      so confirm the applicable run instead of assuming a green tag build
+      covered it.
 
 ## Documentation hygiene
 


### PR DESCRIPTION
## Summary

- correct the release checklist's core CI and interoperability trigger wording
- add explicit proof steps for the public-docs, embedding-docs, published-crate semver, and IXP compatibility lanes
- document each lane's actual path and manual-dispatch boundaries

## Validation

- release-checklist path checker: 9 tests and live validation
- public tracker/artifact guard: 15 tests and 608 documents
- embedding version and crate-map checker/test pairs
- exact workflow-trigger cross-check
- `git diff --check`
- commit-hook workspace formatting and Clippy

Linear: LAN-1252 (bounded documentation-audit tranche; remaining audit findings stay in progress)
