### PR TITLE
docs(ixp): gate milestone receipt coverage

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -749,11 +749,12 @@ for the architectural record.
 
 ### Later interop scenarios (M30b onward) and where they run
 
-Scenarios beyond the M29-M33 set above live in
-`tests/interop/scripts/`. The Status column names where each one runs:
-hosted `interop.yml` CI, hosted `kernel-dataplane` CI, or local-only —
-the last reserved for scenarios needing privileged kernel capabilities
-or wall time a hosted runner can't sustain:
+Scenarios beyond the M29-M33 set above are catalogued below. Most executable
+drivers live in `tests/interop/scripts/`; compatibility-contract oracles such
+as M98 live under `tests/compat/`. The Status column names where each one runs:
+hosted `interop.yml` or `kernel-dataplane.yml` CI, another named hosted lane,
+or local-only — the last reserved for scenarios needing privileged kernel
+capabilities or wall time a hosted runner can't sustain:
 
 | ID | Scope | Status |
 |----|-------|--------|
@@ -798,6 +799,9 @@ or wall time a hosted runner can't sustain:
 | **M92** | GoBGP 4.7.0 incumbent vs rustbgpd dual-stack route-server differential. Two sources feed five exact routes; independent BIRD views, per-PDU wire EoRs, and two canonical incumbent captures authorize one semantic diff. Baseline/restore match four routes; one target-policy mutant adds exactly one rustbgpd-only IPv6 row. A separate GR-disabled negative retains routes but withholds both GoBGP EoRs and refuses comparison. | Hosted CI (GitHub-hosted) in `.github/workflows/interop.yml`, baseline plus the `M92_COMPLETENESS_NEGATIVE` proof. Script: `test-m92-gobgp-v47-rs-differential.sh`; the load-bearing proof is recorded in the lab README. |
 | **M93** | Required-family OPEN enforcement against BIRD 2: exact missing-IPv6 OPEN 2/7 bytes, explicit dual-stack restart success, then cleared-requirement IPv4-only compatibility. | Hosted CI beside M85 (`m93-required-families-bird.clab.yml`, `test-m93-required-families-bird.sh`). |
 | **M94** | RFC 6793 legacy-AS migration. A digest-pinned real ExaBGP 5.0.9 OLD source sends type 2 `[65010, 23456]`, type 17 `[65010, 4200000194]`, type 7 `23456:10.94.0.2`, and type 18 `4200000294:10.94.0.2` through an independently decoding byte-transparent relay; both rustbgpd sessions negotiate without ASN4. The 13/13 receipt proves canonical ingress reconstruction, a second route's high local ASN triggers loop rejection after reconstruction, the exact accepted-route pairs reach an independent Python OLD-speaker sink, source withdrawal removes the received route, and both sessions remain Established. ExaBGP is not used as a receiver because 5.0.9 rejects its own valid legacy AS4 output. | Hosted CI (`m94-as4-migration-exabgp.clab.yml`, `test-m94-as4-migration-exabgp.sh`). |
+| **M96** | IXP Manager v7.4 local activation. Feeds the pinned Foil capture through the real renderer and strict checker, then proves atomic initial, no-op, hot-reload, and pre-effect spawn-failure restoration with exact prior bytes, unchanged daemon PID, and route/session continuity. | Local containerlab with MD5-authenticated FRR. Script: `test-m96-ixp-manager-activation-frr.sh`. |
+| **M97** | IXP Manager v7.4 authenticated lifecycle. Proves two same-host IPv4/IPv6 handles with distinct processes, state and UDS endpoints, and TCP/179 listeners, plus a shared durable host fence, competing-423 behavior, sequential callbacks, and cross-handle failure containment. | Local containerlab with IXP Manager v7.4.0, MySQL 8.4, and MD5-authenticated FRR. Script: `test-m97-ixp-manager-authenticated-lifecycle.sh`. |
+| **M98** | IXP Manager v7.4 Nagios monitoring. Proves both pinned Nagios generators include the rustbgpd route server and its client-session services, then requires the pinned Bird's Eye daemon plugin to report `OK` with `Last Reconfigure` against the live adapter. | Hosted CI in `.github/workflows/ixp-compat.yml`; entry point: `tests/compat/ixp-manager-birdseye/run.sh`. |
 
 ---
 

--- a/scripts/check_ixp_manager_docs.py
+++ b/scripts/check_ixp_manager_docs.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Fail closed when the IXP Manager documentation drifts from its contract.
 
-Four documents restate facts that `tests/compat/ixp-manager-birdseye/contract.json`
+Five documents restate facts that `tests/compat/ixp-manager-birdseye/contract.json`
 pins executably, and each has drifted silently before:
 
 - the Birdwatcher adapter README's reason-id tables versus
   `reject_reasons.active_ids` / `defined_only_ids` / `fallback_id` / `display`;
 - the same README's capability table versus `runtime_supported` / `unsupported`;
-- `docs/RECEIPTS.md` and `docs/OPERATIONAL_PROOF.md`, which must each carry a
-  row for every M-series receipt that `docs/INTEROP.md` claims in its IXP
-  Manager sections.
+- `docs/INTEROP.md`, which defines the IXP Manager M-series receipt claims;
+- `docs/RECEIPTS.md`, `docs/OPERATIONAL_PROOF.md`, and `docs/milestones.md`,
+  which must each carry a row for every M-series receipt that
+  `docs/INTEROP.md` claims in its IXP Manager sections.
 
 The checks parse the markdown tables positively; an absent table or an empty
 M-number set is itself a failure, because a guard that cannot fail is worse
@@ -29,6 +30,7 @@ README = ROOT / "examples" / "birdwatcher-adapter" / "README.md"
 INTEROP = ROOT / "docs" / "INTEROP.md"
 RECEIPTS = ROOT / "docs" / "RECEIPTS.md"
 PROOF = ROOT / "docs" / "OPERATIONAL_PROOF.md"
+MILESTONES = ROOT / "docs" / "milestones.md"
 
 REASON_HEADER = ("Retained cause", "IXP Manager reason id", "Bird's Eye display")
 DEFINED_ONLY_HEADER = ("Defined-only id", "Bird's Eye display", "Emitted as")
@@ -173,7 +175,7 @@ def receipt_rows(receipts: str, header: str = "Receipt") -> set[str]:
     return found
 
 
-def check_receipts(interop: str, receipts: str, proof: str) -> list[str]:
+def check_receipts(interop: str, receipts: str, proof: str, milestones: str) -> list[str]:
     claimed = interop_ixp_receipts(interop)
     if not claimed:
         return ["INTEROP.md IXP Manager sections name no M-series receipts; the walk is broken"]
@@ -182,6 +184,7 @@ def check_receipts(interop: str, receipts: str, proof: str) -> list[str]:
     for name, rows in (
         ("RECEIPTS.md", receipt_rows(receipts)),
         ("OPERATIONAL_PROOF.md", receipt_rows(proof, "Receipts")),
+        ("milestones.md", receipt_rows(milestones, "ID")),
     ):
         for m in sorted(claimed - rows, key=lambda m: (len(m), m)):
             errors.append(
@@ -190,11 +193,18 @@ def check_receipts(interop: str, receipts: str, proof: str) -> list[str]:
     return errors
 
 
-def check(readme: str, contract: dict, interop: str, receipts: str, proof: str) -> list[str]:
+def check(
+    readme: str,
+    contract: dict,
+    interop: str,
+    receipts: str,
+    proof: str,
+    milestones: str,
+) -> list[str]:
     return (
         check_reason_ids(readme, contract)
         + check_capabilities(readme, contract)
-        + check_receipts(interop, receipts, proof)
+        + check_receipts(interop, receipts, proof, milestones)
     )
 
 
@@ -206,6 +216,7 @@ def main() -> int:
             INTEROP.read_text(encoding="utf-8"),
             RECEIPTS.read_text(encoding="utf-8"),
             PROOF.read_text(encoding="utf-8"),
+            MILESTONES.read_text(encoding="utf-8"),
         )
     except (OSError, KeyError, ValueError) as error:
         errors = [f"cannot load the IXP Manager contract surface: {error!r}"]

--- a/scripts/test_check_ixp_manager_docs.py
+++ b/scripts/test_check_ixp_manager_docs.py
@@ -16,6 +16,7 @@ CONTRACT = json.loads(checker.CONTRACT.read_text(encoding="utf-8"))
 INTEROP = checker.INTEROP.read_text(encoding="utf-8")
 RECEIPTS = checker.RECEIPTS.read_text(encoding="utf-8")
 PROOF = checker.PROOF.read_text(encoding="utf-8")
+MILESTONES = checker.MILESTONES.read_text(encoding="utf-8")
 
 
 def row(document: str, prefix: str) -> str:
@@ -28,12 +29,23 @@ def without(document: str, prefix: str) -> str:
 
 
 class IxpManagerDocsTests(unittest.TestCase):
-    def assert_red(self, needle: str, readme=README, interop=INTEROP, receipts=RECEIPTS, proof=PROOF) -> None:
-        errors = checker.check(readme, CONTRACT, interop, receipts, proof)
+    def assert_red(
+        self,
+        needle: str,
+        readme=README,
+        interop=INTEROP,
+        receipts=RECEIPTS,
+        proof=PROOF,
+        milestones=MILESTONES,
+    ) -> None:
+        errors = checker.check(readme, CONTRACT, interop, receipts, proof, milestones)
         self.assertTrue(any(needle in error for error in errors), errors)
 
     def test_tree_is_green(self) -> None:
-        self.assertEqual(checker.check(README, CONTRACT, INTEROP, RECEIPTS, PROOF), [])
+        self.assertEqual(
+            checker.check(README, CONTRACT, INTEROP, RECEIPTS, PROOF, MILESTONES),
+            [],
+        )
 
     def test_dropped_active_reason_row_is_red(self) -> None:
         self.assert_red("active_ids", readme=without(README, "| `.rpol` term `ixp-manager-hygiene:reject-as-path-too-long` |"))
@@ -63,7 +75,9 @@ class IxpManagerDocsTests(unittest.TestCase):
         self.assert_red("contract unsupported", readme=without(README, "| `full-table-count` |"))
 
     def test_missing_tables_are_red(self) -> None:
-        errors = checker.check("# empty\n", CONTRACT, INTEROP, RECEIPTS, PROOF)
+        errors = checker.check(
+            "# empty\n", CONTRACT, INTEROP, RECEIPTS, PROOF, MILESTONES
+        )
         self.assertTrue(any("reason-id table" in e for e in errors), errors)
         self.assertTrue(any("capability table" in e for e in errors), errors)
 
@@ -72,6 +86,25 @@ class IxpManagerDocsTests(unittest.TestCase):
 
     def test_proof_row_removal_is_red(self) -> None:
         self.assert_red("claims M97 in its IXP Manager sections but OPERATIONAL_PROOF.md", proof=without(PROOF, "| M97 |"))
+
+    def test_milestone_row_removal_fails_closed(self) -> None:
+        self.assert_red(
+            "claims M98 in its IXP Manager sections but milestones.md",
+            milestones=without(MILESTONES, "| **M98** |"),
+        )
+
+    def test_future_claim_without_milestone_row_fails_closed(self) -> None:
+        interop = "# IXP Manager future proof\nM999\n"
+        receipts = "| Receipt | Proves |\n|---|---|\n| M999 | proof |\n"
+        proof = "| Receipts | Coverage |\n|---|---|\n| M999 | proof |\n"
+        milestones = "| ID | Scope | Status |\n|---|---|---|\n"
+        self.assertEqual(
+            checker.check_receipts(interop, receipts, proof, milestones),
+            [
+                "INTEROP.md claims M999 in its IXP Manager sections but "
+                "milestones.md has no row for it"
+            ],
+        )
 
     def test_new_interop_claim_without_receipt_row_is_red(self) -> None:
         unreceipted = next(f"M{n}" for n in range(100, 10000) if f"| {f'M{n}'} " not in RECEIPTS)


### PR DESCRIPTION
## Summary

- catalogue the M96, M97, and M98 IXP Manager proof milestones
- describe the real driver locations and hosted or local execution boundaries
- require every claimed IXP receipt to remain present in the milestones index
- add mutation coverage for removed and future milestone rows

## Validation

- 16 IXP documentation contract tests
- live IXP documentation checker
- 18 public-document tracker tests
- live public-document tracker checker across 608 documents
- Python compilation, formatting, and workspace lint checks