### PR TITLE
docs(route diagnostics): add ingest-ready summaries

### DIFF
--- a/docs/explain.md
+++ b/docs/explain.md
@@ -1,5 +1,7 @@
 # Explain route decisions
 
+Find the `rbgp` command that explains each stage of a route decision.
+
 Every stage of a route's life through the daemon can explain itself,
 from the live RIB, in one command — no debug rebuild, no external
 looking-glass daemon, no packet capture. This page is the catalog:

--- a/docs/ribdiff.md
+++ b/docs/ribdiff.md
@@ -1,5 +1,7 @@
 # Compare advertised routes
 
+Compare rustbgpd's advertised routes with an incumbent route server.
+
 Compares what rustbgpd is advertising to each peer (the live Adj-RIB-Out,
 read over gRPC) against a snapshot of what an incumbent route server
 advertises to the same peers, and reports semantic divergence. Built for


### PR DESCRIPTION
## Summary

- add concise lead sentences to the route-explanation and advertisement-comparison guides
- preserve the detailed operator guidance and existing anchors
- keep generated search summaries within the ingestion length boundary

## Validation

- curated documentation command parsing
- public-document tracker contract
- metric-consumer contract
- exact ingestion summary verification
- whitespace and documentation checks