### PR TITLE
example(fsm): demonstrate session establishment

### DIFF
--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -8,6 +8,19 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 Requires Rust 1.95 or newer.
 
+## Usage
+
+Run the deterministic session-establishment walkthrough from the repository root:
+
+```sh
+cargo run -p rustbgpd-fsm --example establish
+```
+
+The example uses the public API to drive a session from `Idle` to `Established`
+without opening a socket. An embedding application owns I/O and timers: it turns
+transport and timer outcomes into `Event` values, handles each returned `Action`,
+and feeds the resulting outcomes back into the `Session`.
+
 ## Design
 
 The FSM is intentionally isolated from all I/O concerns. The transport

--- a/crates/fsm/examples/establish.rs
+++ b/crates/fsm/examples/establish.rs
@@ -1,0 +1,63 @@
+use std::net::Ipv4Addr;
+
+use rustbgpd_fsm::{Event, PeerConfig, Session, SessionState};
+use rustbgpd_wire::{Afi, Capability, OpenMessage, Safi};
+
+fn drive(session: &mut Session, event: Event) {
+    let event_name = event.name();
+    let actions = session.handle_event(event);
+
+    println!("{event_name} -> {:?}", session.state());
+    for action in actions {
+        println!("  {action:?}");
+    }
+}
+
+fn main() {
+    let mut config = PeerConfig::new(65_001, 65_002, Ipv4Addr::new(10, 0, 0, 1));
+    config.hold_time = 90;
+    config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+
+    let peer_open = OpenMessage {
+        version: 4,
+        my_as: 65_002,
+        hold_time: 180,
+        bgp_identifier: Ipv4Addr::new(10, 0, 0, 2),
+        capabilities: vec![
+            Capability::MultiProtocol {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+            },
+            Capability::FourOctetAs { asn: 65_002 },
+        ],
+    };
+
+    let mut session = Session::new(config);
+    println!("initial state: {:?}", session.state());
+    assert_eq!(session.state(), SessionState::Idle);
+
+    drive(&mut session, Event::ManualStart);
+    assert_eq!(session.state(), SessionState::Connect);
+
+    drive(&mut session, Event::TcpConnectionConfirmed);
+    assert_eq!(session.state(), SessionState::OpenSent);
+
+    drive(&mut session, Event::OpenReceived(peer_open));
+    assert_eq!(session.state(), SessionState::OpenConfirm);
+
+    drive(&mut session, Event::KeepaliveReceived);
+    assert_eq!(session.state(), SessionState::Established);
+
+    let negotiated = session
+        .negotiated()
+        .expect("an established session has negotiated parameters");
+    assert_eq!(negotiated.peer_asn, 65_002);
+    assert_eq!(negotiated.peer_router_id, Ipv4Addr::new(10, 0, 0, 2));
+    assert_eq!(negotiated.hold_time, 90);
+    assert_eq!(
+        negotiated.negotiated_families,
+        vec![(Afi::Ipv4, Safi::Unicast)]
+    );
+
+    println!("negotiated: {negotiated:?}");
+}


### PR DESCRIPTION
## Summary

- add a public-API walkthrough from `Idle` to `Established`
- print every returned FSM action so embedding responsibilities stay explicit
- assert the negotiated peer ASN, router ID, hold time, and address family
- document how to run the socket-free example

## Validation

- example execution
- strict example linting
- 146 FSM unit tests plus integration, property, and documentation tests
- documentation build with warnings denied
- package-content verification
- formatting and full-workspace lint checks