### PR TITLE
docs(cookbook): add concise ingestion leads

### DIFF
--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -1,5 +1,7 @@
 # Controller / monitoring feed (BMP trio, events, MRT)
 
+Export routing state to your monitoring stack.
+
 **When this is you:** a controller, analytics pipeline, or NOC stack
 needs to see what this daemon sees — pre-policy, post-policy, and
 Loc-RIB route streams into BMP collectors, a durable event feed your

--- a/docs/cookbook/paired-route-servers.md
+++ b/docs/cookbook/paired-route-servers.md
@@ -1,5 +1,7 @@
 # Paired route servers — staggered updates and maintenance windows
 
+Operate a resilient pair of IXP route servers.
+
 **When this is you:** your exchange runs (or should run) two route
 servers, every member peers with both, and you want the operational
 discipline that makes the pair actually redundant: independent

--- a/docs/cookbook/policy-quickstart.md
+++ b/docs/cookbook/policy-quickstart.md
@@ -1,5 +1,7 @@
 # Policy quickstart (`.rpol`)
 
+Build and validate your first rustbgpd routing policy.
+
 **When this is you:** you're about to write your first real routing
 policy on rustbgpd and want the workflow that keeps it honest — a
 typed, compiled policy file with its unit tests *in the file*, checked

--- a/docs/cookbook/route-reflector.md
+++ b/docs/cookbook/route-reflector.md
@@ -1,5 +1,7 @@
 # iBGP route reflector at scale
 
+Replace an iBGP full mesh with a dedicated route reflector.
+
 **When this is you:** you run (or are about to run) an iBGP full mesh
 that no longer scales, and you want a dedicated route reflector —
 tens to a thousand clients, fast convergence without per-peer tuning,


### PR DESCRIPTION
## Summary

- add short complete-sentence leads to four high-value cookbook guides
- preserve the existing operator scenarios, headings, and anchors verbatim
- reduce generated descriptions from 295–362 characters to 46–59 characters

## Validation

- exact output through the real rbgp.rs ingestion function
- four remove-lead mutations restoring each original long description
- curated documentation commands parsed with the real CLI
- 18 public-document tracker tests and the live 608-document checker
- formatting, lint, documentation, and whitespace checks