### PR TITLE
test(mrt): gate emitted subtype documentation

### DIFF
--- a/crates/mrt/README.md
+++ b/crates/mrt/README.md
@@ -6,8 +6,14 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 ## Features
 
-- **TABLE_DUMP_V2** (type 13) — PEER_INDEX_TABLE, RIB_IPV4_UNICAST,
-  RIB_IPV6_UNICAST, plus Add-Path subtypes (RFC 8050)
+- **TABLE_DUMP_V2** (type 13) emits these six subtypes:
+  - `PEER_INDEX_TABLE` (subtype 1)
+  - `RIB_IPV4_UNICAST` (subtype 2)
+  - `RIB_IPV6_UNICAST` (subtype 4)
+  - `RIB_GENERIC` (subtype 6) for L2VPN/EVPN (AFI 25 / SAFI 70), following
+    RFC 6396 section 4.3.5
+  - `RIB_IPV4_UNICAST_ADDPATH` (subtype 8), following RFC 8050
+  - `RIB_IPV6_UNICAST_ADDPATH` (subtype 9), following RFC 8050
 - **Periodic + on-demand** — configurable dump interval or gRPC
   `TriggerMrtDump` for immediate snapshots
 - **Optional gzip** compression via flate2

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -1651,6 +1651,104 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
+
+    fn emitted_table_dump_v2_subtypes() -> [(&'static str, u16); 6] {
+        [
+            (stringify!(PEER_INDEX_TABLE), PEER_INDEX_TABLE),
+            (stringify!(RIB_IPV4_UNICAST), RIB_IPV4_UNICAST),
+            (stringify!(RIB_IPV6_UNICAST), RIB_IPV6_UNICAST),
+            (stringify!(RIB_GENERIC), RIB_GENERIC),
+            (
+                stringify!(RIB_IPV4_UNICAST_ADDPATH),
+                RIB_IPV4_UNICAST_ADDPATH,
+            ),
+            (
+                stringify!(RIB_IPV6_UNICAST_ADDPATH),
+                RIB_IPV6_UNICAST_ADDPATH,
+            ),
+        ]
+    }
+
+    fn subtype_marker(name: &str, subtype: u16) -> String {
+        format!("`{name}` (subtype {subtype})")
+    }
+
+    fn emitted_subtype_doc_failures(document_name: &str, contents: &str) -> Vec<String> {
+        emitted_table_dump_v2_subtypes()
+            .into_iter()
+            .filter_map(|(name, subtype)| {
+                let marker = subtype_marker(name, subtype);
+                let count = contents.matches(&marker).count();
+                (count != 1).then(|| {
+                    format!(
+                        "{document_name}: expected exactly one emitted TABLE_DUMP_V2 marker \
+                         {marker:?}, found {count}"
+                    )
+                })
+            })
+            .collect()
+    }
+
+    fn emitted_subtype_documents() -> [(&'static str, String); 2] {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        [
+            (
+                "docs/CONFIGURATION.md",
+                read_subtype_document(&manifest_dir.join("../../docs/CONFIGURATION.md")),
+            ),
+            (
+                "crates/mrt/README.md",
+                read_subtype_document(&manifest_dir.join("README.md")),
+            ),
+        ]
+    }
+
+    fn read_subtype_document(path: &std::path::Path) -> String {
+        std::fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+    }
+
+    #[test]
+    fn emitted_table_dump_v2_subtypes_are_documented() {
+        let failures: Vec<_> = emitted_subtype_documents()
+            .into_iter()
+            .flat_map(|(name, contents)| emitted_subtype_doc_failures(name, &contents))
+            .collect();
+
+        assert!(
+            failures.is_empty(),
+            "emitted TABLE_DUMP_V2 documentation contract failed:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
+    fn emitted_table_dump_v2_doc_contract_rejects_marker_mutations() {
+        for (document_name, contents) in emitted_subtype_documents() {
+            for (name, subtype) in emitted_table_dump_v2_subtypes() {
+                let marker = subtype_marker(name, subtype);
+                let mutations = [
+                    ("removed", contents.replacen(&marker, "", 1)),
+                    (
+                        "renumbered",
+                        contents.replacen(&marker, &subtype_marker(name, subtype + 100), 1),
+                    ),
+                ];
+
+                for (mutation, mutated) in mutations {
+                    let failures = emitted_subtype_doc_failures(document_name, &mutated);
+                    assert!(
+                        failures.iter().any(|failure| {
+                            failure.contains(document_name) && failure.contains(&marker)
+                        }),
+                        "{document_name}: {mutation} mutation of {marker:?} must fail with a \
+                         document-and-marker diagnostic; got {failures:?}"
+                    );
+                }
+            }
+        }
+    }
+
     fn make_peer(addr: IpAddr, asn: u32) -> MrtPeerEntry {
         let bgp_id = match addr {
             IpAddr::V4(v4) => v4,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3167,6 +3167,7 @@ Each dump contains a complete `TABLE_DUMP_V2` snapshot:
 | `PEER_INDEX_TABLE` (subtype 1) | All known peers with ASN and BGP ID |
 | `RIB_IPV4_UNICAST` (subtype 2) | IPv4 routes from Adj-RIB-In per peer |
 | `RIB_IPV6_UNICAST` (subtype 4) | IPv6 routes from Adj-RIB-In per peer |
+| `RIB_GENERIC` (subtype 6) | L2VPN/EVPN routes (AFI 25 / SAFI 70) per RFC 6396 section 4.3.5 |
 | `RIB_IPV4_UNICAST_ADDPATH` (subtype 8) | IPv4 routes with path IDs (RFC 8050) |
 | `RIB_IPV6_UNICAST_ADDPATH` (subtype 9) | IPv6 routes with path IDs (RFC 8050) |
 


### PR DESCRIPTION
## Summary

- document every emitted `TABLE_DUMP_V2` subtype in the operator and MRT crate guides
- include `RIB_GENERIC` subtype 6 for L2VPN/EVPN AFI 25 and SAFI 70
- derive the documentation contract from the six encoder constants
- mutation-test removal and renumbering in both documents

## Validation

- live emitted-subtype documentation contract and 24 mutations
- independent EVPN Type 2, Type 5, and reader round-trip proofs
- 18 public-document tracker tests and the live 608-document checker
- warnings-denied MRT documentation
- strict MRT linting, formatting, full push gates, and whitespace checks