### PR TITLE
fix(observability): normalize netlink overrun actor label

### DIFF
--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -112,7 +112,7 @@ pub enum NetlinkSubscriber {
 impl NetlinkSubscriber {
     const ALL: [Self; 3] = [Self::LinkCarrier, Self::GeneralFib, Self::BlackholeDiscard];
 
-    /// Stable Prometheus label for this bounded subscriber.
+    /// Stable Prometheus actor-label value for this bounded subscriber.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -1328,12 +1328,12 @@ impl BgpMetrics {
         let netlink_subscription_overruns = IntCounterVec::new(
             Opts::new(
                 "bgp_netlink_subscription_overruns_total",
-                "NETLINK_ROUTE receive-buffer overrun notifications by bounded subscriber. \
+                "NETLINK_ROUTE receive-buffer overrun notifications by bounded actor. \
                  Each increment proves that one or more multicast notifications may have been \
                  lost; it is not a dropped-message count and does not prove that a later \
                  periodic reconcile repaired the resulting drift.",
             ),
-            &["subscriber"],
+            &["actor"],
         )
         .expect("valid metric definition");
         for subscriber in NetlinkSubscriber::ALL {
@@ -5667,8 +5667,8 @@ mod tests {
             .metric
             .iter()
             .map(|metric| {
-                assert_eq!(metric.get_label().len(), 1, "only subscriber label");
-                assert_eq!(metric.get_label()[0].name(), "subscriber");
+                assert_eq!(metric.get_label().len(), 1, "only actor label");
+                assert_eq!(metric.get_label()[0].name(), "actor");
                 (
                     metric.get_label()[0].value().to_owned(),
                     metric.get_counter().value(),

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1445,7 +1445,7 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_fib_kernel_failures_total{action="remove"}` | Kernel rejected a remove operation |
 | `bgp_kernel_route_notify_dropped_total{actor,reason="channel_full"}` | Kernel route-event wake feed dropped an event before the FIB or BLACKHOLE reconciler could consume it; periodic reconcile remains the repair backstop |
 | `bgp_kernel_route_notify_subscription_failures_total{actor,group}` | The FIB or BLACKHOLE reconciler failed to subscribe to an IPv4/IPv6 route multicast group and is running with periodic-only kernel-drift repair |
-| `bgp_netlink_subscription_overruns_total{subscriber}` | The kernel reported a receive-buffer overrun to the `link_carrier`, `general_fib`, or `blackhole_discard` NETLINK_ROUTE subscriber. Each increment is one overrun notification—not a count of lost events—and proves only that one or more multicast events may have been lost |
+| `bgp_netlink_subscription_overruns_total{actor}` | The kernel reported a receive-buffer overrun to the `link_carrier`, `general_fib`, or `blackhole_discard` NETLINK_ROUTE actor. Each increment is one overrun notification—not a count of lost events—and proves only that one or more multicast events may have been lost |
 
 The three netlink-overrun series are materialized at zero. A non-zero value
 does not identify which multicast group lost events and does not prove that a

--- a/src/kernel_route_notify.rs
+++ b/src/kernel_route_notify.rs
@@ -341,8 +341,8 @@ mod tests {
                 .metric
                 .iter()
                 .map(|metric| {
-                    assert_eq!(metric.get_label().len(), 1, "only subscriber label");
-                    assert_eq!(metric.get_label()[0].name(), "subscriber");
+                    assert_eq!(metric.get_label().len(), 1, "only actor label");
+                    assert_eq!(metric.get_label()[0].name(), "actor");
                     (
                         metric.get_label()[0].value().to_owned(),
                         metric.get_counter().value(),


### PR DESCRIPTION
## Summary

- align `bgp_netlink_subscription_overruns_total` with the incumbent netlink `actor` label dimension
- preserve the three bounded label values, zero-series materialization, and receive-loop accounting
- keep the internal `NetlinkSubscriber` type while clarifying the exported metric help and Operations guide
- pin the exact exported label key in both telemetry and receive-loop tests

## Validation

- focused telemetry zero-series and receive-loop accounting tests
- 27 metric-consumer contract tests and the live 189 emitted / 183 consumed / 6 justified census
- 18 public-document tracker tests and the live 608-document checker
- strict telemetry and daemon linting
- formatting, full push gates, documentation, and whitespace checks