### PR TITLE
docs(cookbook): add four more ingestion leads

### DIFF
--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,5 +1,7 @@
 # Cookbook — scenario-driven deployment recipes
 
+Choose a complete rustbgpd deployment recipe.
+
 Each recipe here is a complete deployment shape: a working config, the
 verification commands with the output shape to expect, the metrics to
 watch, and the failure modes with the explain commands that debug them.

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -1,5 +1,7 @@
 # IXP filter pipeline: arouteserver → rs-config-render → rustbgpd → Alice-LG
 
+Build an IXP filter pipeline around rustbgpd.
+
 The toolchain an IXP already runs — [arouteserver] for
 IRR/PeeringDB/RPKI member-filter generation, a looking glass for
 member support — end to end on rustbgpd. You keep your existing

--- a/docs/cookbook/manrs-ixp-action1.md
+++ b/docs/cookbook/manrs-ixp-action1.md
@@ -1,5 +1,7 @@
 # MANRS IXP Programme Action 1 on rustbgpd
 
+Map rustbgpd controls to MANRS IXP Programme Action 1.
+
 **When this is you:** your exchange participates in (or is applying to)
 the MANRS IXP Programme and you need to show, control by control, how a
 rustbgpd route server implements Action 1 — and how members can verify

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -1,5 +1,7 @@
 # Runbook: RR pair day-2 operations
 
+Operate a production route-reflector pair safely.
+
 **When this is you:** a redundant route-reflector pair (per
 [route-reflector.md](route-reflector.md)) is in production and you need
 to make routine changes without dropping the fleet. Rule of thumb for


### PR DESCRIPTION
## Summary

- add concise complete-sentence leads to four more cookbook guides
- preserve every existing scenario paragraph, heading, and anchor verbatim
- reduce generated descriptions from 157–241 characters to 45–54 characters

## Validation

- exact output through the real rbgp.rs ingestion function
- four remove-lead mutations restoring each original long description
- curated documentation commands parsed with the real CLI
- 18 public-document tracker tests and the live 608-document checker
- formatting, lint, documentation, and whitespace checks