### PR TITLE
docs(fsm): add crate-scoped changelog

### DIFF
--- a/crates/fsm/CHANGELOG.md
+++ b/crates/fsm/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+This changelog covers the independently published `rustbgpd-fsm` crate. Daemon
+and workspace changes remain in the repository-level `CHANGELOG.md`.
+
+## Unreleased
+
+- **Additive FSM API:** Added `Event::BfdDown`. A BFD-triggered teardown in
+  `OpenSent`, `OpenConfirm`, or `Established` emits the typed Cease notification
+  and authoritative session-down cleanup; earlier connection states return to
+  `Idle` without a notification.
+- **Adoption example:** Added a socket-free walkthrough that uses only public
+  APIs to drive `Idle` through `Established`, print returned `Action` values,
+  and verify the negotiated peer identity, hold time, and address family.
+
+## 0.4.1 - 2026-08-19
+
+- **Additive FSM API:** Added `Session::negotiated_shared`, which returns shared
+  ownership of the negotiated session parameters. The existing borrowed
+  `Session::negotiated` accessor is unchanged.
+- Updated the dependency boundary to `rustbgpd-wire` 0.17.1 without removing or
+  changing an existing direct FSM API.
+
+## 0.4.0 - 2026-08-08
+
+- **Dependency-only breaking change:** Updated the public wire-type boundary
+  from `rustbgpd-wire` 0.16 to 0.17. The wire crate's fallible EVPN NLRI encoder
+  changed those exposed type identities; the FSM itself made no direct API
+  change in this release.
+
+## 0.3.1 - 2026-07-27
+
+- **Additive FSM API:** Added `PeerConfig::min_hold_time` and
+  `PeerConfig::required_families` behind the existing `#[non_exhaustive]`
+  construction boundary.
+- Negotiation now honors the last duplicate Graceful Restart capability and
+  rejects invalid OPEN identities, including AS 0 and a local router ID reused
+  by an iBGP peer.
+- Updated the dependency boundary to `rustbgpd-wire` 0.16 without removing or
+  changing an existing direct FSM API.
+
+## 0.3.0 - 2026-07-18
+
+- **Direct FSM match-boundary change:** Marked `TimerType` and `FsmError`
+  `#[non_exhaustive]`; downstream matches must include a wildcard arm.
+- Added experimental family-local Paths-Limit negotiation state and the
+  `graceful_restart_preserves_family` helper.
+- **Dependency breaking change:** Updated the exposed wire-type boundary to the
+  incompatible `rustbgpd-wire` 0.15 line.
+
+## 0.2.0 - 2026-07-06
+
+- **Direct breaking FSM API:** Added a `hold_time` argument to
+  `default_send_hold_time`; `PeerConfig` gained `send_hold_time`.
+- **Dependency breaking change:** Updated the exposed wire-type boundary from
+  `rustbgpd-wire` 0.13 to 0.14.
+
+## 0.1.0 - 2026-06-30
+
+- Initial independent crate release of the six-state RFC 4271 FSM, with timers
+  modeled as input `Event` values and output `Action` values and with OPEN
+  validation and capability negotiation.
+- Established the forward-compatible construction and matching boundary:
+  `PeerConfig`, `Event`, `Action`, and `NegotiatedSession` are
+  `#[non_exhaustive]`; `PeerConfig::new` and `Default` construct configurations;
+  the fixed six-state `SessionState` remains exhaustively matchable.

--- a/crates/fsm/CHANGELOG.md
+++ b/crates/fsm/CHANGELOG.md
@@ -24,9 +24,12 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 ## 0.4.0 - 2026-08-08
 
 - **Dependency-only breaking change:** Updated the public wire-type boundary
-  from `rustbgpd-wire` 0.16 to 0.17. The wire crate's fallible EVPN NLRI encoder
-  changed those exposed type identities; the FSM itself made no direct API
-  change in this release.
+  from `rustbgpd-wire` 0.16 to 0.17. The incompatible 0.x dependency update
+  changes the identity of the wire types exposed through the FSM API; the FSM
+  itself made no direct API change in this release.
+- The paired `rustbgpd-wire` 0.17 release separately made
+  `encode_evpn_nlri` fallible. Direct wire callers must handle its `Result`;
+  that encoder change is not what changes the FSM's exposed type identities.
 
 ## 0.3.1 - 2026-07-27
 

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -8,6 +8,8 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 Requires Rust 1.95 or newer.
 
+Release-by-release crate changes are recorded in the [changelog](CHANGELOG.md).
+
 ## Usage
 
 Run the deterministic session-establishment walkthrough from the repository root:
@@ -64,8 +66,9 @@ returns `Result` and rejects routes it previously encoded silently altered)
 — see the "0.17.0 compatibility note" in the `rustbgpd-wire` README.
 Upgrade both crates together so the re-exported types unify.
 
-`rustbgpd-fsm 0.4.1` keeps its public API backward-compatible with 0.4.0 — its
-source is unchanged since that publish. Its `^0.17.1` wire requirement admits
+`rustbgpd-fsm 0.4.1` keeps its public API backward-compatible with 0.4.0. It
+adds `Session::negotiated_shared` while preserving the existing
+`Session::negotiated` signature. Its `^0.17.1` wire requirement admits
 `rustbgpd-wire` 0.17.2, whose **decode acceptance changed**: ATOMIC_AGGREGATE
 (type 6) now decodes to `PathAttribute::AtomicAggregate` instead of
 `PathAttribute::Unknown`, so an UPDATE carrying it is no longer

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -73,9 +73,9 @@ adds `Session::negotiated_shared` while preserving the existing
 ATOMIC_AGGREGATE (type 6) now decodes to `PathAttribute::AtomicAggregate`
 instead of `PathAttribute::Unknown`, so an UPDATE carrying that valid form is
 no longer treat-as-withdrawn by unrecognized-well-known validation. A non-zero-
-length type 6 remains an attribute-length error. See the "0.17.2 compatibility
-note" in the `rustbgpd-wire` README, since the FSM surfaces wire decode results
-to its callers.
+length type 6 is an attribute-length error in the current decoder. See the
+"0.17.2 compatibility note" in the `rustbgpd-wire` README, since the FSM
+surfaces wire decode results to its callers.
 
 ## Key types
 

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -69,12 +69,13 @@ Upgrade both crates together so the re-exported types unify.
 `rustbgpd-fsm 0.4.1` keeps its public API backward-compatible with 0.4.0. It
 adds `Session::negotiated_shared` while preserving the existing
 `Session::negotiated` signature. Its `^0.17.1` wire requirement admits
-`rustbgpd-wire` 0.17.2, whose **decode acceptance changed**: ATOMIC_AGGREGATE
-(type 6) now decodes to `PathAttribute::AtomicAggregate` instead of
-`PathAttribute::Unknown`, so an UPDATE carrying it is no longer
-treat-as-withdrawn by unrecognized-well-known validation — see the "0.17.2
-compatibility note" in the `rustbgpd-wire` README, since the FSM surfaces wire
-decode results to its callers.
+`rustbgpd-wire` 0.17.2, whose **decode acceptance changed**: a valid zero-length
+ATOMIC_AGGREGATE (type 6) now decodes to `PathAttribute::AtomicAggregate`
+instead of `PathAttribute::Unknown`, so an UPDATE carrying that valid form is
+no longer treat-as-withdrawn by unrecognized-well-known validation. A non-zero-
+length type 6 remains an attribute-length error. See the "0.17.2 compatibility
+note" in the `rustbgpd-wire` README, since the FSM surfaces wire decode results
+to its callers.
 
 ## Key types
 


### PR DESCRIPTION
## Summary

- add a crate-scoped changelog for all six published FSM releases
- distinguish direct API changes from exposed wire dependency boundaries
- record the current BFD event and establishment example under Unreleased
- link the changelog from the crate README and correct the 0.4.1 source-history wording

## Validation

- package contents include README, changelog, and establishment example
- 146 FSM unit tests plus lifecycle, property, and documentation tests
- warnings-denied FSM documentation
- formatting, full push gates, workspace linting, and whitespace checks

## Baseline package boundary

Pristine tarball verification on unchanged current main already awaits the next wire crate publication: the FSM source uses `cease_subcode::BFD_DOWN`, while published wire 0.17.2 predates that additive constant. The exact baseline result was reproduced with these documentation changes stashed. Release prep already requires publishing wire before the next FSM patch; this PR does not change versions or dependency ordering.