### PR TITLE
docs(cookbook): finish concise ingestion leads

### DIFF
--- a/docs/cookbook/peer-flap-triage.md
+++ b/docs/cookbook/peer-flap-triage.md
@@ -1,5 +1,7 @@
 # Runbook: a peer is flapping
 
+Diagnose a BGP session that keeps flapping.
+
 **When this is you:** a session keeps cycling in and out of Established
 — the `BgpSessionFlapping` alert fired, or a client noticed churn.
 Work top to bottom; each step narrows the cause.

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -1,5 +1,7 @@
 # Route-server migration notes
 
+Map incumbent route-server concepts to rustbgpd.
+
 This page maps common FRR, BIRD, OpenBGPD, and ARouteServer route-server
 concepts to rustbgpd's config and verification surfaces. Structure is
 mechanical for BIRD 2/3, FRR, and GoBGP: `rbgp config import` translates their


### PR DESCRIPTION
## Summary

- add short complete-sentence leads to the final two curated cookbook pages whose ingested descriptions exceed 80 characters
- preserve the existing operator paragraphs, headings, and anchors verbatim
- bring the projected 14-page curated cookbook census to a 43-77 character range with no page over 80 characters when combined with the adjacent reviewed batches

## Validation

- canonical rbgp.rs ingestion consumer: 43 and 48 character descriptions
- remove-lead mutations restore the original 132 and 129 character descriptions
- projected combined census: 14 pages, 0 over 80 characters
- curated documentation commands parse with the real CLI
- python3 scripts/test_check_public_tracker_ids.py
- python3 scripts/check_public_tracker_ids.py docs
- git diff --check
- commit and push hooks