### PR TITLE
docs: add concise core-page ingestion leads

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,5 +1,7 @@
 # Quickstart
 
+Start and verify a single rustbgpd daemon.
+
 This guide gets a single rustbgpd daemon running on a host with a starter
 config, a local gRPC socket, health probes, and the `rbgp` CLI.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Posture
 
+Protect rustbgpd's privileged management API.
+
 > For the end-to-end install + lifecycle walkthrough (systemd setup,
 > Docker, containerlab quick-start), see [`deployment.md`](deployment.md).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,7 @@
 # Deploying rustbgpd
 
+Install, operate, and upgrade rustbgpd.
+
 This is the end-to-end operator runbook: install, run, validate,
 reload, observe, and upgrade. It's intentionally smaller than the M-
 series interop matrix in [`INTEROP.md`](INTEROP.md) — that document

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -1,5 +1,7 @@
 # Reload Matrix
 
+See when each configuration change takes effect.
+
 Reference for every user-facing config key: what does it take to put a
 change into effect?
 


### PR DESCRIPTION
## Summary

- add short complete-sentence ingestion leads to the four remaining core operator pages over 80 description characters
- preserve the existing detailed introductions, headings, anchors, and operator guidance
- bring the real-consumer core-page census to 12 pages in a 27-80 character range with none over 80

## Validation

- canonical rbgp.rs ingestion consumer: 42, 39, 48, and 45 character descriptions
- remove-lead mutations restore the original 135, 94, 90, and 133 character descriptions
- projected core census: 12 pages, 0 over 80 characters
- python3 scripts/test_check_public_tracker_ids.py
- python3 scripts/check_public_tracker_ids.py docs
- git diff --check
- commit and push hooks