### PR TITLE
docs: finish route diagnostic heading cleanup

### DIFF
--- a/docs/explain.md
+++ b/docs/explain.md
@@ -35,7 +35,8 @@ For operators coming from FRR/BIRD, the
 [familiar command map](../crates/cli/README.md#familiar-command-map)
 translates the usual show-commands into these.
 
-## Best-path explain — decisive-comparison attribution
+<a id="best-path-explain--decisive-comparison-attribution"></a>
+## Best-path explain
 
 Why did this path win? Every losing candidate is annotated with the
 decisive comparison step (`only_path`, `higher_local_pref`,
@@ -78,7 +79,8 @@ an unresolved vantage, or an explanation without `--explain-peer` retains
 the ordinary global Loc-RIB ladder.
 Details: [OPERATIONS.md](OPERATIONS.md#explain-a-best-path-decision).
 
-## Export explain — the full gate ladder, from the real export body
+<a id="export-explain--the-full-gate-ladder-from-the-real-export-body"></a>
+## Export explain
 
 Why did (or didn't) this exact prefix reach this exact peer? The
 answer is produced by a read-only dry run of the *same staging body*
@@ -126,7 +128,8 @@ policy-permitted rank. It stays 0 before ranking or beyond `send_max`; an OTC
 or exact-wire denial after ranking retains the attempted rank. Omit the flags
 for the legacy winner-oriented explanation.
 
-### ORR: why two clients received different winners
+<a id="orr-why-two-clients-received-different-winners"></a>
+### ORR client differences
 
 For an ORR client, the advertised-route explanation ranks the same
 split-horizon/RR-eligible candidates as live distribution, using that target's
@@ -149,7 +152,8 @@ resolves to its own address; different clients can therefore select different
 winners for the same prefix. Run the advertised explanation once per client,
 then use `--explain-peer <client>` for the candidate-by-candidate comparison.
 
-## Import explain — the per-session decision cache
+<a id="import-explain--the-per-session-decision-cache"></a>
+## Import explain
 
 What did import policy decide when this prefix arrived from this
 peer — including paths that were denied and are therefore *not in the
@@ -196,7 +200,8 @@ Details:
 and
 [OPERATIONS.md](OPERATIONS.md#explain-an-import-decision-adr-0073).
 
-## The filtered-route view — rejected routes, retained with reasons
+<a id="the-filtered-route-view--rejected-routes-retained-with-reasons"></a>
+## Filtered routes
 
 The route-server member-support question — "you're eating my
 routes, which ones and why?" — without knowing a prefix in advance.

--- a/docs/ribdiff.md
+++ b/docs/ribdiff.md
@@ -246,7 +246,8 @@ on stdout, 2 refused. Per-incumbent capture prerequisites, view
 limitations, and worked examples live in the
 [route-server migration cookbook](cookbook/route-server-migration.md#capturing-the-incumbents-advertised-view).
 
-### `rbgp diff snapshot from-mrt` and the `--view` contract
+<a id="rbgp-diff-snapshot-from-mrt-and-the---view-contract"></a>
+### MRT snapshot view contract
 
 RFC 6396 `TABLE_DUMP_V2` is, by default, a **collector RIB view** — best
 paths as seen by a collector, not what any client was sent after export
@@ -271,7 +272,10 @@ RFC 8050 Add-Path entries carry their path identifier through as
 `path_id`. Extended and large communities are emitted from the raw
 attribute bytes.
 
-### `rbgp diff snapshot from-bmp` — RFC 8671 post-policy BMP captures
+<a id="rbgp-diff-snapshot-from-bmp--rfc-8671-post-policy-bmp-captures"></a>
+### BMP post-policy snapshots
+
+`rbgp diff snapshot from-bmp` consumes RFC 8671 post-policy BMP captures.
 
 If the incumbent exports BMP with the RFC 8671 post-policy Adj-RIB-Out
 view enabled, its own BMP feed is a wire-true source of what it sent

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -1252,7 +1252,10 @@ import: there is no filesystem to resolve against, and the diagnostic
 says so. Check import-using files with `rbgp policy check`; the daemon
 resolves them at config load / SIGHUP.
 
-### Migration example — extracting a shared library
+<a id="migration-example--extracting-a-shared-library"></a>
+### Migration example
+
+This example extracts a repeated bogon set into a shared library.
 
 ```rpol
 # Before: every edge policy file carries its own bogon list.


### PR DESCRIPTION
## Summary

- shorten eight remaining long headings across the rpol, route-explain, and RIB-diff ingested pages
- retain each descriptive tail in the surrounding prose instead of the right-rail heading
- preserve every prior deep-link target with an explicit invisible anchor alias

## Validation

- exact heading/alias contract: 8 long headings reduced from 47-65 to 14-26 characters
- old headings absent and legacy aliases present exactly once
- Markdown parser recognizes the new H2/H3 structure outside code fences
- python3 scripts/test_check_public_tracker_ids.py
- python3 scripts/check_public_tracker_ids.py docs
- git diff --check
- workspace commit and push hooks