### PR TITLE
fix(api): bound runtime config settlement wait

### DIFF
--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -1351,10 +1351,11 @@ impl RuntimeConfigSettlementWatchdog {
                 }
                 RuntimeConfigSettlementTerminal::Settled => {
                     // Settlement marks the operation before clearing `current`.
-                    // Recheck that pointer instead of applying a fatal boundary
-                    // to an operation whose outcome is already proven clean.
-                    thread::yield_now();
-                    continue;
+                    // Poll that pointer at a low rate instead of applying a
+                    // fatal boundary to an operation whose outcome is already
+                    // proven clean. The timeout also covers a notification
+                    // delivered between the pointer load and this wait.
+                    now + Duration::from_millis(10)
                 }
             };
             (idle, _) = self

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -1310,6 +1310,54 @@ impl RuntimeConfigSettlementWatchdog {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
         }
     }
+
+    /// Block until every clean registration settles, bounded by the current
+    /// operation's registered deadline and pre-armed fatal boundary.
+    ///
+    /// A wait that reaches the ownership deadline fences the operation. A
+    /// recovery-fenced operation reaches the same process fail-stop used by
+    /// the independent fatal clock. This method returns only after the
+    /// registry proves that no owner remains.
+    pub fn wait_until_idle_or_fail_stop(&self) {
+        let mut idle = self
+            .registry
+            .idle_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        loop {
+            let Some(operation) = self.registry.current.load_full() else {
+                return;
+            };
+            let now = Instant::now();
+            let boundary = match operation.terminal() {
+                RuntimeConfigSettlementTerminal::Owned => {
+                    if now >= operation.deadline {
+                        let _ = transition_to_fenced(
+                            &operation,
+                            RuntimeConfigFenceReason::BudgetExpired,
+                        );
+                        continue;
+                    }
+                    operation.deadline
+                }
+                RuntimeConfigSettlementTerminal::RecoveryFenced
+                | RuntimeConfigSettlementTerminal::Settled => {
+                    let fatal_at = self
+                        .registry
+                        .nanos_instant(operation.fatal_at_nanos.load(Ordering::Acquire));
+                    if now >= fatal_at {
+                        run_terminal_action(&self.registry);
+                    }
+                    fatal_at
+                }
+            };
+            (idle, _) = self
+                .registry
+                .wake
+                .wait_timeout(idle, boundary.saturating_duration_since(now))
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
 }
 
 /// Typed result from an owned body; never inferred from transport status.
@@ -1747,6 +1795,30 @@ mod tests {
             )),
             receiver,
         )
+    }
+
+    fn isolated_test_watchdog(
+        budget: Duration,
+        grace: Duration,
+    ) -> (TestWatchdog, std::sync::mpsc::Receiver<i32>) {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        (
+            TestWatchdog(RuntimeConfigSettlementWatchdog {
+                registry: Arc::new(Registry::new(budget, grace, sender)),
+                threads: Arc::new(Mutex::new(Vec::new())),
+            }),
+            receiver,
+        )
+    }
+
+    fn release_terminal_waiter(
+        watchdog: &RuntimeConfigSettlementWatchdog,
+        waiter: thread::JoinHandle<()>,
+    ) {
+        watchdog.registry.current.store(None);
+        watchdog.registry.wake.notify_all();
+        waiter.thread().unpark();
+        waiter.join().unwrap();
     }
 
     async fn operation(
@@ -2371,7 +2443,8 @@ mod tests {
     #[test]
     fn production_terminal_wrapper_is_an_exact_exit_only_boundary() {
         let source = include_str!("runtime_config_settlement.rs");
-        let body = source
+        let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
+        let body = production
             .split_once("fn terminate_process() -> ! {")
             .unwrap()
             .1
@@ -2391,9 +2464,19 @@ mod tests {
                 "terminal wrapper contains {forbidden}"
             );
         }
-        assert!(source.contains("current: ArcSwapOption<OperationInner>"));
-        let final_decision = source
-            .split_once("if now >= fatal_at {")
+        assert!(production.contains("current: ArcSwapOption<OperationInner>"));
+        assert_eq!(
+            production
+                .matches("run_terminal_action(&self.registry);")
+                .count(),
+            1
+        );
+        assert_eq!(
+            production.matches("run_terminal_action(registry);").count(),
+            1
+        );
+        let final_decision = production
+            .rsplit_once("if now >= fatal_at {")
             .unwrap()
             .1
             .split_once("\n                }")
@@ -2415,6 +2498,83 @@ mod tests {
         assert!(operation.try_settle());
         drop(guard);
         waiter.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn bounded_wait_returns_after_clean_settlement() {
+        let (watchdog, receiver) =
+            isolated_test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let waiter = {
+            let watchdog = watchdog.clone();
+            thread::spawn(move || watchdog.wait_until_idle_or_fail_stop())
+        };
+        thread::sleep(Duration::from_millis(10));
+        assert!(!waiter.is_finished());
+        assert!(operation.try_settle());
+        drop(guard);
+        waiter.join().unwrap();
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn bounded_wait_ignores_spurious_condvar_wake() {
+        let (watchdog, receiver) =
+            isolated_test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let waiter = {
+            let watchdog = watchdog.clone();
+            thread::spawn(move || watchdog.wait_until_idle_or_fail_stop())
+        };
+        thread::sleep(Duration::from_millis(10));
+        watchdog.registry.wake.notify_all();
+        thread::sleep(Duration::from_millis(10));
+        assert!(!waiter.is_finished());
+        assert!(receiver.try_recv().is_err());
+        assert!(operation.try_settle());
+        drop(guard);
+        waiter.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn bounded_wait_uses_existing_fenced_fatal_boundary() {
+        let (watchdog, receiver) =
+            isolated_test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let waiter = {
+            let watchdog = watchdog.clone();
+            thread::spawn(move || watchdog.wait_until_idle_or_fail_stop())
+        };
+        assert!(operation.fence_recovery(RuntimeConfigFenceReason::KnownDivergence));
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(1)).unwrap(), 70);
+        assert_eq!(
+            operation.fence_reason(),
+            Some(RuntimeConfigFenceReason::KnownDivergence)
+        );
+        release_terminal_waiter(&watchdog, waiter);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn bounded_wait_fences_owned_timeout_then_fail_stops() {
+        let (watchdog, receiver) =
+            isolated_test_watchdog(Duration::from_millis(30), Duration::from_millis(20));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let waiter = {
+            let watchdog = watchdog.clone();
+            thread::spawn(move || watchdog.wait_until_idle_or_fail_stop())
+        };
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(1)).unwrap(), 70);
+        assert_eq!(
+            operation.terminal(),
+            RuntimeConfigSettlementTerminal::RecoveryFenced
+        );
+        assert_eq!(
+            operation.fence_reason(),
+            Some(RuntimeConfigFenceReason::BudgetExpired)
+        );
+        release_terminal_waiter(&watchdog, waiter);
+        drop(guard);
     }
 
     #[tokio::test]

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -1340,8 +1340,7 @@ impl RuntimeConfigSettlementWatchdog {
                     }
                     operation.deadline
                 }
-                RuntimeConfigSettlementTerminal::RecoveryFenced
-                | RuntimeConfigSettlementTerminal::Settled => {
+                RuntimeConfigSettlementTerminal::RecoveryFenced => {
                     let fatal_at = self
                         .registry
                         .nanos_instant(operation.fatal_at_nanos.load(Ordering::Acquire));
@@ -1349,6 +1348,13 @@ impl RuntimeConfigSettlementWatchdog {
                         run_terminal_action(&self.registry);
                     }
                     fatal_at
+                }
+                RuntimeConfigSettlementTerminal::Settled => {
+                    // Settlement marks the operation before clearing `current`.
+                    // Recheck that pointer instead of applying a fatal boundary
+                    // to an operation whose outcome is already proven clean.
+                    thread::yield_now();
+                    continue;
                 }
             };
             (idle, _) = self
@@ -2534,6 +2540,28 @@ mod tests {
         assert!(operation.try_settle());
         drop(guard);
         waiter.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn bounded_wait_rechecks_the_settled_unregister_window() {
+        let (watchdog, receiver) =
+            isolated_test_watchdog(Duration::from_millis(20), Duration::from_millis(20));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        operation
+            .inner
+            .state
+            .store(TERMINAL_SETTLED | PHASE_PREFLIGHT, Ordering::Release);
+        let waiter = {
+            let watchdog = watchdog.clone();
+            thread::spawn(move || watchdog.wait_until_idle_or_fail_stop())
+        };
+        thread::sleep(Duration::from_millis(50));
+        assert!(!waiter.is_finished());
+        assert!(receiver.try_recv().is_err());
+        watchdog.registry.current.store(None);
+        waiter.join().unwrap();
+        assert!(receiver.try_recv().is_err());
+        drop(guard);
     }
 
     #[tokio::test]

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -929,6 +929,16 @@ impl Registry {
             fatal.unpark();
         }
     }
+
+    fn unregister_settled_owner(&self) {
+        let idle = self
+            .idle_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.current.store(None);
+        drop(idle);
+        self.wake_threads();
+    }
 }
 
 struct RuntimeConfigSettlementCollector {
@@ -1531,8 +1541,7 @@ impl OwnedRuntimeConfigOperation {
             budget_seconds = self.inner.budget().as_secs(),
             "runtime config settlement settled"
         );
-        self.inner.registry.current.store(None);
-        self.inner.registry.wake_threads();
+        self.inner.registry.unregister_settled_owner();
         let resources = self
             .inner
             .resources
@@ -2561,6 +2570,33 @@ mod tests {
         assert!(receiver.try_recv().is_err());
         watchdog.registry.current.store(None);
         waiter.join().unwrap();
+        assert!(receiver.try_recv().is_err());
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn settled_unregister_synchronizes_with_the_idle_predicate() {
+        let (watchdog, receiver) =
+            isolated_test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let idle = watchdog.registry.idle_lock.lock().unwrap();
+        let settler = {
+            let operation = operation.clone();
+            thread::spawn(move || operation.try_settle())
+        };
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while operation.terminal() != RuntimeConfigSettlementTerminal::Settled {
+            assert!(
+                Instant::now() < deadline,
+                "settlement did not become visible"
+            );
+            thread::yield_now();
+        }
+        assert!(!settler.is_finished());
+        assert!(watchdog.registry.current.load().is_some());
+        drop(idle);
+        assert!(settler.join().unwrap());
+        assert!(watchdog.registry.current.load().is_none());
         assert!(receiver.try_recv().is_err());
         drop(guard);
     }

--- a/docs/settlement-watchdog.md
+++ b/docs/settlement-watchdog.md
@@ -400,7 +400,7 @@ detached), with a few semantics of its own:
   condition-variable waits always recheck the registry and the shutdown
   wait returns only after the registry proves there is no owner. If the
   owner reaches its budget, the waiter fences it as `budget_expired`,
-  preserves the five-second recovery-fence grace, and invokes the same
+  preserves the configured recovery-fence grace, and invokes the same
   exit-70 boundary as the independent fatal clock. It never falls through
   to checkpointing or actor teardown with an active owner. This bounds the
   settlement wait itself; it does **not** establish a finite aggregate time

--- a/docs/settlement-watchdog.md
+++ b/docs/settlement-watchdog.md
@@ -395,10 +395,17 @@ detached), with a few semantics of its own:
   authoritative, now fences and exits 70 instead of logging an error
   and carrying on with a runtime that may not match what any surface
   reports. And coordinated shutdown no longer races an in-flight
-  reload: it closes new admission, waits for the owned reload to
-  settle, adopts its resulting authority, and only then proceeds to
-  the warm checkpoint and actor teardown. Watchdog expiry during that
-  wait is still a fail-stop, not a successful shutdown.
+  reload: it closes new admission, then waits on the owner's registered
+  deadline and pre-armed, monotonically shortened fatal boundary. Timed
+  condition-variable waits always recheck the registry and the shutdown
+  wait returns only after the registry proves there is no owner. If the
+  owner reaches its budget, the waiter fences it as `budget_expired`,
+  preserves the five-second recovery-fence grace, and invokes the same
+  exit-70 boundary as the independent fatal clock. It never falls through
+  to checkpointing or actor teardown with an active owner. This bounds the
+  settlement wait itself; it does **not** establish a finite aggregate time
+  to the first BGP Cease because a clean owner may use its full budget and
+  later checkpoint and drain stages retain their own bounds.
 
 ## Related pages
 

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4673,7 +4673,8 @@ remote_asn = 65002
             (main, "tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire())", 0),
             (main, "RuntimeConfigSettlementWatchdog::new()", 1),
             (main, ".with_runtime_config_settlement(", 1),
-            (main, "move || settlement_wait.wait_until_idle()", 1),
+            (main, "move || settlement_wait.wait_until_idle()", 0),
+            (main, "move || settlement_wait.wait_until_idle_or_fail_stop()", 1),
             (transaction, "self.deps.lock.acquire()", 2),
             (transaction, ".execute_owned_operation(", 5),
             (settlement, "let coordinator_permit = coordinator.acquire().await?;", 1),
@@ -4953,7 +4954,7 @@ remote_asn = 65002
         assert_eq!(main.matches("runtime_config_lock.close();").count(), 1);
         let shutdown_gate = main.find("daemon_gate.begin_shutdown();").unwrap();
         let watched_idle = main
-            .find("move || settlement_wait.wait_until_idle()")
+            .find("move || settlement_wait.wait_until_idle_or_fail_stop()")
             .unwrap();
         let drained = main
             .find("runtime_config_lock.wait_until_drained().await;")

--- a/src/main.rs
+++ b/src/main.rs
@@ -5405,7 +5405,7 @@ async fn run<T>(
     runtime_config_lock.close();
     info!("initiating coordinated shutdown");
     let settlement_wait = runtime_config_settlement.clone();
-    tokio::task::spawn_blocking(move || settlement_wait.wait_until_idle())
+    tokio::task::spawn_blocking(move || settlement_wait.wait_until_idle_or_fail_stop())
         .await
         .expect("runtime-config settlement wait task must not panic");
     runtime_config_lock.wait_until_drained().await;


### PR DESCRIPTION
## Summary

- bound the coordinated-shutdown settlement wait by the active owner deadline and existing fatal boundary
- convert an owned budget expiry into the existing fenced exit-70 path
- recheck registry ownership after timed or spurious condition-variable wakes
- preserve the existing unbounded compatibility waiter and keep the claim narrow to settlement waiting

## Validation

- focused clean-settlement, spurious-wake, recovery-fence, and budget-expiry tests
- compatibility waiter and fatal-clock/exit-boundary tests
- root ownership-inventory and shutdown-order tests
- `cargo clippy --locked -p rustbgpd-api --all-targets --all-features -- -D warnings`
- `cargo clippy --locked -p rustbgpd --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked -p rustbgpd-api --no-deps`
- public-document tracker unit and live checks
- repository pre-commit and pre-push hooks