### PR TITLE
docs: shorten remaining ingested H2 headings

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1307,14 +1307,15 @@ What to do when it fires:
    wedged socket, and outbound-buffer saturation tears the session
    down with `Cease/Out of Resources`.
 
-## gRPC authorization audit and resource guardrails
+<a id="grpc-authorization-audit-and-resource-guardrails"></a>
+## gRPC audit and resource guardrails
 
 ADR-0064 v1 uses the daemon's structured JSON log path plus Prometheus metrics
-as the operational audit surface. rustbgpd does not run a separate in-daemon
-audit file writer or remote audit sink in this release. That keeps audit
-emission on the existing non-blocking logging path instead of adding a second
-I/O path that could wedge routing-control tasks if a disk, syslog daemon, or
-collector stalls.
+as the operational gRPC authorization audit and resource-guardrail surface.
+rustbgpd does not run a separate in-daemon audit file writer or remote audit
+sink in this release. That keeps audit emission on the existing non-blocking
+logging path instead of adding a second I/O path that could wedge
+routing-control tasks if a disk, syslog daemon, or collector stalls.
 
 For production, collect stdout/stderr with journald, syslog, or your log agent
 of choice and apply retention outside the daemon:
@@ -1683,7 +1684,8 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 
 ---
 
-## Support bundles and triage checks (`rbgp doctor`)
+<a id="support-bundles-and-triage-checks-rbgp-doctor"></a>
+## Support bundles with `rbgp doctor`
 
 `rbgp doctor` runs red/green triage checks live (daemon reachable and
 healthy, peers stuck outside Established with time-in-state, flap loops,

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -227,11 +227,13 @@ covers this view, its retention knobs, and the follow-up explain
 workflow; the full explain surface catalog is in
 [explain.md](../explain.md).
 
-## 6. Looking glass: Alice-LG via the birdwatcher adapter
+<a id="6-looking-glass-alice-lg-via-the-birdwatcher-adapter"></a>
+## 6. Alice-LG via the birdwatcher adapter
 
-The external
+Alice-LG uses the external
 [`examples/birdwatcher-adapter`](../../examples/birdwatcher-adapter/README.md)
-serves a Birdwatcher-shaped REST subset from the daemon's gRPC API —
+sidecar, which serves a Birdwatcher-shaped REST subset from the daemon's gRPC
+API —
 status, peers, a member's accepted routes, the filtered-route view
 above, and a noexport view (routes withheld from a member, each named
 by the export gate that stopped it, tagged `64496:65521:<id>`). For the

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -10,7 +10,8 @@ supported structural subset and refuses to guess at anything else. There is
 untranslated policy and run the shadow trial before carrying production
 traffic.
 
-## The mechanical first step (BIRD, FRR, and GoBGP)
+<a id="the-mechanical-first-step-bird-frr-and-gobgp"></a>
+## Mechanical import: BIRD, FRR, and GoBGP
 
 ```bash
 # 1. Translate the structure; the report lists every warning and stanza that

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -175,16 +175,16 @@ role = "route_server"
 max_prefixes = 50000
 ```
 
-## Member-set control communities (RFC 7947 §2.3.2 / RFC 8195)
+<a id="member-set-control-communities-rfc-7947-232--rfc-8195"></a>
+## Member-set control communities
 
-A member with a selective peering policy steers what the route server
-redistributes on its behalf by tagging its announcements with control
-communities keyed on the *target* member's ASN — the same convention
-the major IXPs document. `RS` below is the route server's ASN, `PEER`
-the target member's ASN. The standard (16-bit) forms exist only when
-both ASNs fit 16 bits; the large-community forms (RFC 8195) work for
-4-byte ASNs. Extended-community control forms are deliberately not
-implemented (draft-ietf-grow-ixp-ext-comms).
+RFC 7947 §2.3.2 member-set control communities let a member with a selective
+peering policy steer what the route server redistributes on its behalf by
+tagging announcements for the *target* member's ASN — the same convention the
+major IXPs document. `RS` below is the route server's ASN, `PEER` the target
+member's ASN. The standard (16-bit) forms exist only when both ASNs fit 16 bits;
+the RFC 8195 large-community forms work for 4-byte ASNs. Extended-community
+control forms are deliberately not implemented (draft-ietf-grow-ixp-ext-comms).
 
 | Member intent | Standard | Large |
 |---|---|---|

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -318,10 +318,12 @@ chains all add/change/remove cleanly via reload.
 |---|---|---|
 | `[gnmi_dialout]` (whole section) | reload-applied | SIGHUP reconciles the dial-out target set in place: removed targets stop (their `gnmi_dialout_connected{target}` series is reaped), added targets start, changed targets tear down and redial, unchanged targets keep their live collector connection. The new section is validated during reload preflight; a rejected config leaves the running targets untouched. TLS key/cert *file contents* rotate without any reload — the files are re-read on every (re)connection attempt. |
 
-## `[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, `[[ethernet_segments]]`
+<a id="evpn_instances-evpn_ip_vrfs-ethernet_segments"></a>
+## EVPN coordinator sections
 
-SIGHUP reuses the ADR-0063 EVPN runtime coordinator for the same supported
-live shapes as `EvpnService.ApplyEvpnRuntime`: single L2VNI/IP-VRF/ES
+`[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, and `[[ethernet_segments]]` reuse
+the ADR-0063 EVPN runtime coordinator on SIGHUP for the same supported live
+shapes as `EvpnService.ApplyEvpnRuntime`: single L2VNI/IP-VRF/ES
 add/delete/redefine within the documented identity bounds, atomic tenant
 teardown, `ip_vrf` relink, additive build-up, and standalone L2VNI swaps that
 only combine L2VNI adds with standalone L2VNI deletes, plus L2VNI-only batch


### PR DESCRIPTION
## Summary

- shorten the six remaining overlong H2 headings in the curated rbgp.rs operator-doc set
- preserve each former GitHub deep-link target with an explicit legacy anchor
- retain removed RFC, subsystem, and tool precision in the adjacent prose
- leave H1s, H3s, and opening ingestion leads unchanged

## Validation

- canonical rbgp.rs scan: six curated H2s over 45 characters reduced to zero
- canonical ingest and rewritten-link verification
- all six former aliases verified exactly once with `github-slugger`
- six focused mutations independently restore the expected over-45 finding
- `python3 -m unittest -v scripts/test_check_public_tracker_ids.py`
- `python3 scripts/check_public_tracker_ids.py`
- repository commit and pre-push hooks
- `git diff --check`