### PR TITLE
refactor(rib): bundle outbound commit payloads

### DIFF
--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -1,7 +1,8 @@
 use super::{
     AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, NeighborPolicyStats,
-    PolicyChain, Prefix, RibManager, RouteContext, Safi, bgpls_route_family, bgpls_routes_equal,
-    gauge_val, record_export_policy_eval, route_type, should_suppress_ibgp_inner, warn,
+    OutboundCommitBatch, PolicyChain, Prefix, RibManager, RouteContext, Safi, bgpls_route_family,
+    bgpls_routes_equal, gauge_val, record_export_policy_eval, route_type,
+    should_suppress_ibgp_inner, warn,
 };
 
 impl RibManager {
@@ -294,23 +295,11 @@ impl RibManager {
             if (!bgpls_announce.is_empty() || !bgpls_withdraw.is_empty())
                 && !self.try_send_and_commit_outbound_update(
                     peer,
-                    vec![].into(),
-                    vec![].into(),
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    bgpls_announce,
-                    bgpls_withdraw,
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
+                    OutboundCommitBatch {
+                        bgpls_announce,
+                        bgpls_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                 )
             {
                 warn!(%peer, "outbound channel full — BGP-LS update deferred");

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -1,8 +1,8 @@
 use super::{
     AdjRibIn, AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LOCAL_PEER, LocRib,
-    NeighborPolicyStats, PolicyChain, Prefix, RibCommandError, RibManager, RouteContext,
-    RouteFamily, Safi, debug, evpn_routes_equal, gauge_val, record_export_policy_eval, route_type,
-    should_suppress_ibgp_inner, warn,
+    NeighborPolicyStats, OutboundCommitBatch, PolicyChain, Prefix, RibCommandError, RibManager,
+    RouteContext, RouteFamily, Safi, debug, evpn_routes_equal, gauge_val,
+    record_export_policy_eval, route_type, should_suppress_ibgp_inner, warn,
 };
 
 impl RibManager {
@@ -520,23 +520,11 @@ impl RibManager {
             if (!evpn_announce.is_empty() || !evpn_withdraw.is_empty())
                 && !self.try_send_and_commit_outbound_update(
                     peer,
-                    vec![].into(),
-                    vec![].into(),
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    evpn_announce,
-                    evpn_withdraw,
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
+                    OutboundCommitBatch {
+                        evpn_announce,
+                        evpn_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                 )
             {
                 warn!(%peer, "outbound channel full — EVPN update deferred");

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -1,8 +1,8 @@
 use super::{
     AdjRibIn, AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LOCAL_PEER, LocRib,
-    NeighborPolicyStats, PolicyChain, Prefix, RibCommandError, RibManager, RouteContext, Safi,
-    debug, flowspec_route_family, gauge_val, record_export_policy_eval, route_type,
-    should_suppress_ibgp_inner, warn,
+    NeighborPolicyStats, OutboundCommitBatch, PolicyChain, Prefix, RibCommandError, RibManager,
+    RouteContext, Safi, debug, flowspec_route_family, gauge_val, record_export_policy_eval,
+    route_type, should_suppress_ibgp_inner, warn,
 };
 use crate::route::{FlowSpecKey, FlowSpecRouteKey};
 
@@ -354,10 +354,6 @@ impl RibManager {
 
     /// Recompute `FlowSpec` Loc-RIB best routes for affected rules and
     /// distribute changes to all outbound peers.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "FlowSpec recompute stages policy-aware changes for every outbound peer"
-    )]
     pub(in crate::manager) fn recompute_and_distribute_flowspec(
         &mut self,
         affected: &HashSet<FlowSpecKey>,
@@ -455,23 +451,11 @@ impl RibManager {
             if (!fs_announce.is_empty() || !fs_withdraw.is_empty())
                 && !self.try_send_and_commit_outbound_update(
                     peer,
-                    vec![].into(),
-                    vec![].into(),
-                    vec![],
-                    vec![],
-                    vec![],
-                    fs_announce,
-                    fs_withdraw,
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
+                    OutboundCommitBatch {
+                        flowspec_announce: fs_announce,
+                        flowspec_withdraw: fs_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                 )
             {
                 warn!(%peer, "outbound channel full — FlowSpec update deferred");

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -1,7 +1,7 @@
 use super::{
-    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, PolicyChain, RibManager,
-    RouteContext, Safi, gauge_val, labeled_route_family, labeled_routes_equal, route_type,
-    should_suppress_ibgp_inner, warn,
+    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, OutboundCommitBatch,
+    PolicyChain, RibManager, RouteContext, Safi, gauge_val, labeled_route_family,
+    labeled_routes_equal, route_type, should_suppress_ibgp_inner, warn,
 };
 use crate::loc_rib::labeled_tiebreak_orr;
 use crate::route::{LabeledRibRoute, LabeledRibRouteKey};
@@ -815,23 +815,11 @@ impl RibManager {
             if (!labeled_announce.is_empty() || !labeled_withdraw.is_empty())
                 && !self.try_send_and_commit_outbound_update(
                     peer,
-                    vec![].into(),
-                    vec![].into(),
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    labeled_announce,
-                    labeled_withdraw,
-                    vec![],
-                    vec![],
+                    OutboundCommitBatch {
+                        labeled_announce,
+                        labeled_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                 )
             {
                 warn!(%peer, "outbound channel full — labeled update deferred");

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -103,9 +103,16 @@ pub(in crate::manager) struct SharedUnicastPrecommit<'a> {
 /// Control state that changes how the payload is committed stays explicit on
 /// the send-ladder methods; this value only keeps the family inventories
 /// together as they move through that ladder.
+///
+/// `announce` and `next_hop_override` are parallel slices: they must have the
+/// same length, and each override applies to the announcement at the same
+/// index. Callers using `..OutboundCommitBatch::default()` must populate both
+/// fields together when adding unicast announcements.
 #[derive(Default)]
 pub(in crate::manager) struct OutboundCommitBatch {
+    /// Next-hop actions indexed exactly like `announce`.
     pub(in crate::manager) next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
+    /// Unicast announcements indexed exactly like `next_hop_override`.
     pub(in crate::manager) announce: Arc<[crate::route::Route]>,
     pub(in crate::manager) withdraw: Vec<(Prefix, u32)>,
     pub(in crate::manager) end_of_rib: Vec<(Afi, Safi)>,

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -98,6 +98,32 @@ pub(in crate::manager) struct SharedUnicastPrecommit<'a> {
     pub(in crate::manager) lazy_group_prior: Option<LazyCleanGroupPrior<'a>>,
 }
 
+/// One owned outbound payload at the RIB-to-session commit boundary.
+///
+/// Control state that changes how the payload is committed stays explicit on
+/// the send-ladder methods; this value only keeps the family inventories
+/// together as they move through that ladder.
+#[derive(Default)]
+pub(in crate::manager) struct OutboundCommitBatch {
+    pub(in crate::manager) next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
+    pub(in crate::manager) announce: Arc<[crate::route::Route]>,
+    pub(in crate::manager) withdraw: Vec<(Prefix, u32)>,
+    pub(in crate::manager) end_of_rib: Vec<(Afi, Safi)>,
+    pub(in crate::manager) refresh_markers: Vec<(Afi, Safi, RouteRefreshSubtype)>,
+    pub(in crate::manager) flowspec_announce: Vec<crate::route::FlowSpecRoute>,
+    pub(in crate::manager) flowspec_withdraw: Vec<crate::route::FlowSpecKey>,
+    pub(in crate::manager) evpn_announce: Vec<crate::route::EvpnRibRoute>,
+    pub(in crate::manager) evpn_withdraw: Vec<rustbgpd_wire::EvpnRouteKey>,
+    pub(in crate::manager) bgpls_announce: Vec<crate::route::BgpLsRibRoute>,
+    pub(in crate::manager) bgpls_withdraw: Vec<crate::route::BgpLsRouteKey>,
+    pub(in crate::manager) vpn_announce: Vec<crate::route::VpnRibRoute>,
+    pub(in crate::manager) vpn_withdraw: Vec<crate::route::VpnRibRouteKey>,
+    pub(in crate::manager) labeled_announce: Vec<crate::route::LabeledRibRoute>,
+    pub(in crate::manager) labeled_withdraw: Vec<crate::route::LabeledRibRouteKey>,
+    pub(in crate::manager) rtc_announce: Vec<crate::route::RtcRibRoute>,
+    pub(in crate::manager) rtc_withdraw: Vec<crate::route::RtcRibRouteKey>,
+}
+
 struct SharedUnicastProbeCacheEntry {
     announce: Arc<[crate::route::Route]>,
     next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
@@ -1907,53 +1933,12 @@ impl RibManager {
         }
     }
 
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "RIB update messages carry every supported family as one transaction"
-    )]
     pub(super) fn try_send_and_commit_outbound_update(
         &mut self,
         peer: IpAddr,
-        next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
-        announce: Arc<[crate::route::Route]>,
-        withdraw: Vec<(Prefix, u32)>,
-        end_of_rib: Vec<(Afi, Safi)>,
-        refresh_markers: Vec<(Afi, Safi, RouteRefreshSubtype)>,
-        flowspec_announce: Vec<crate::route::FlowSpecRoute>,
-        flowspec_withdraw: Vec<crate::route::FlowSpecKey>,
-        evpn_announce: Vec<crate::route::EvpnRibRoute>,
-        evpn_withdraw: Vec<rustbgpd_wire::EvpnRouteKey>,
-        bgpls_announce: Vec<crate::route::BgpLsRibRoute>,
-        bgpls_withdraw: Vec<crate::route::BgpLsRouteKey>,
-        vpn_announce: Vec<crate::route::VpnRibRoute>,
-        vpn_withdraw: Vec<crate::route::VpnRibRouteKey>,
-        labeled_announce: Vec<crate::route::LabeledRibRoute>,
-        labeled_withdraw: Vec<crate::route::LabeledRibRouteKey>,
-        rtc_announce: Vec<crate::route::RtcRibRoute>,
-        rtc_withdraw: Vec<crate::route::RtcRibRouteKey>,
+        batch: OutboundCommitBatch,
     ) -> bool {
-        self.try_send_and_commit_outbound_update_with_group_prior(
-            peer,
-            next_hop_override,
-            announce,
-            withdraw,
-            end_of_rib,
-            refresh_markers,
-            flowspec_announce,
-            flowspec_withdraw,
-            evpn_announce,
-            evpn_withdraw,
-            bgpls_announce,
-            bgpls_withdraw,
-            vpn_announce,
-            vpn_withdraw,
-            labeled_announce,
-            labeled_withdraw,
-            rtc_announce,
-            rtc_withdraw,
-            HashSet::new(),
-            None,
-        )
+        self.try_send_and_commit_outbound_update_with_group_prior(peer, batch, HashSet::new(), None)
     }
 
     /// Reconcile the latest OTC disposition for exactly the prefixes evaluated
@@ -2025,52 +2010,16 @@ impl RibManager {
         }
     }
 
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "outbound commit needs all family queues for one atomic send"
-    )]
     pub(super) fn try_send_and_commit_outbound_update_with_group_prior(
         &mut self,
         peer: IpAddr,
-        next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
-        announce: Arc<[crate::route::Route]>,
-        withdraw: Vec<(Prefix, u32)>,
-        end_of_rib: Vec<(Afi, Safi)>,
-        refresh_markers: Vec<(Afi, Safi, RouteRefreshSubtype)>,
-        flowspec_announce: Vec<crate::route::FlowSpecRoute>,
-        flowspec_withdraw: Vec<crate::route::FlowSpecKey>,
-        evpn_announce: Vec<crate::route::EvpnRibRoute>,
-        evpn_withdraw: Vec<rustbgpd_wire::EvpnRouteKey>,
-        bgpls_announce: Vec<crate::route::BgpLsRibRoute>,
-        bgpls_withdraw: Vec<crate::route::BgpLsRouteKey>,
-        vpn_announce: Vec<crate::route::VpnRibRoute>,
-        vpn_withdraw: Vec<crate::route::VpnRibRouteKey>,
-        labeled_announce: Vec<crate::route::LabeledRibRoute>,
-        labeled_withdraw: Vec<crate::route::LabeledRibRouteKey>,
-        rtc_announce: Vec<crate::route::RtcRibRoute>,
-        rtc_withdraw: Vec<crate::route::RtcRibRouteKey>,
+        batch: OutboundCommitBatch,
         group_prior: HashSet<crate::update::ExactExportKey>,
         shared_unicast_precommit: Option<SharedUnicastPrecommit<'_>>,
     ) -> bool {
         self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
             peer,
-            next_hop_override,
-            announce,
-            withdraw,
-            end_of_rib,
-            refresh_markers,
-            flowspec_announce,
-            flowspec_withdraw,
-            evpn_announce,
-            evpn_withdraw,
-            bgpls_announce,
-            bgpls_withdraw,
-            vpn_announce,
-            vpn_withdraw,
-            labeled_announce,
-            labeled_withdraw,
-            rtc_announce,
-            rtc_withdraw,
+            batch,
             group_prior,
             shared_unicast_precommit,
             None,
@@ -2078,34 +2027,36 @@ impl RibManager {
     }
 
     #[expect(
-        clippy::too_many_arguments,
         clippy::too_many_lines,
-        reason = "outbound commit needs all family queues for one atomic send"
+        reason = "outbound commit validates and commits every family as one atomic send"
     )]
     pub(super) fn try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
         &mut self,
         peer: IpAddr,
-        mut next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
-        mut announce: Arc<[crate::route::Route]>,
-        mut withdraw: Vec<(Prefix, u32)>,
-        end_of_rib: Vec<(Afi, Safi)>,
-        refresh_markers: Vec<(Afi, Safi, RouteRefreshSubtype)>,
-        mut flowspec_announce: Vec<crate::route::FlowSpecRoute>,
-        mut flowspec_withdraw: Vec<crate::route::FlowSpecKey>,
-        mut evpn_announce: Vec<crate::route::EvpnRibRoute>,
-        mut evpn_withdraw: Vec<rustbgpd_wire::EvpnRouteKey>,
-        mut bgpls_announce: Vec<crate::route::BgpLsRibRoute>,
-        mut bgpls_withdraw: Vec<crate::route::BgpLsRouteKey>,
-        mut vpn_announce: Vec<crate::route::VpnRibRoute>,
-        mut vpn_withdraw: Vec<crate::route::VpnRibRouteKey>,
-        mut labeled_announce: Vec<crate::route::LabeledRibRoute>,
-        mut labeled_withdraw: Vec<crate::route::LabeledRibRouteKey>,
-        mut rtc_announce: Vec<crate::route::RtcRibRoute>,
-        mut rtc_withdraw: Vec<crate::route::RtcRibRouteKey>,
+        batch: OutboundCommitBatch,
         group_prior: HashSet<crate::update::ExactExportKey>,
         mut shared_unicast_precommit: Option<SharedUnicastPrecommit<'_>>,
         otc_reconcile_prefixes: Option<&HashSet<Prefix>>,
     ) -> bool {
+        let OutboundCommitBatch {
+            mut next_hop_override,
+            mut announce,
+            mut withdraw,
+            end_of_rib,
+            refresh_markers,
+            mut flowspec_announce,
+            mut flowspec_withdraw,
+            mut evpn_announce,
+            mut evpn_withdraw,
+            mut bgpls_announce,
+            mut bgpls_withdraw,
+            mut vpn_announce,
+            mut vpn_withdraw,
+            mut labeled_announce,
+            mut labeled_withdraw,
+            mut rtc_announce,
+            mut rtc_withdraw,
+        } = batch;
         #[cfg(feature = "bench-internals")]
         let bench_per_client_best_resync = self.peer_per_client_best.contains(&peer)
             && (self.dirty_peers.contains(&peer) || self.force_outbound_peers.contains(&peer));
@@ -5489,23 +5440,25 @@ impl RibManager {
                 };
                 if self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
                     peer,
-                    nh_override_flags,
-                    announce,
-                    withdraw,
-                    pending_eor.clone(),
-                    vec![],
-                    fs_announce,
-                    fs_withdraw,
-                    evpn_announce,
-                    evpn_withdraw,
-                    bgpls_announce,
-                    bgpls_withdraw,
-                    vpn_announce,
-                    vpn_withdraw,
-                    labeled_announce,
-                    labeled_withdraw,
-                    rtc_announce,
-                    rtc_withdraw,
+                    OutboundCommitBatch {
+                        next_hop_override: nh_override_flags,
+                        announce,
+                        withdraw,
+                        end_of_rib: pending_eor.clone(),
+                        flowspec_announce: fs_announce,
+                        flowspec_withdraw: fs_withdraw,
+                        evpn_announce,
+                        evpn_withdraw,
+                        bgpls_announce,
+                        bgpls_withdraw,
+                        vpn_announce,
+                        vpn_withdraw,
+                        labeled_announce,
+                        labeled_withdraw,
+                        rtc_announce,
+                        rtc_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                     group_prior,
                     shared_unicast_cache_group.map(|group_id| SharedUnicastPrecommit {
                         group_id,

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -1,7 +1,8 @@
 use super::{
     AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, NeighborPolicyStats,
-    PolicyChain, Prefix, RibManager, RouteContext, RouteFamily, Safi, gauge_val,
-    record_export_policy_eval, route_type, rtc_routes_equal, should_suppress_ibgp_inner, warn,
+    OutboundCommitBatch, PolicyChain, Prefix, RibManager, RouteContext, RouteFamily, Safi,
+    gauge_val, record_export_policy_eval, route_type, rtc_routes_equal, should_suppress_ibgp_inner,
+    warn,
 };
 
 impl RibManager {
@@ -309,23 +310,11 @@ impl RibManager {
             if (!rtc_announce.is_empty() || !rtc_withdraw.is_empty())
                 && !self.try_send_and_commit_outbound_update(
                     peer,
-                    vec![].into(),
-                    vec![].into(),
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    rtc_announce,
-                    rtc_withdraw,
+                    OutboundCommitBatch {
+                        rtc_announce,
+                        rtc_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                 )
             {
                 warn!(%peer, "outbound channel full — RTC update deferred");

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -1,7 +1,7 @@
 use super::{
-    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, PolicyChain, RibManager,
-    RouteContext, Safi, gauge_val, route_type, should_suppress_ibgp_inner, vpn_route_family,
-    vpn_routes_equal, warn,
+    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, OutboundCommitBatch,
+    PolicyChain, RibManager, RouteContext, Safi, gauge_val, route_type, should_suppress_ibgp_inner,
+    vpn_route_family, vpn_routes_equal, warn,
 };
 use crate::loc_rib::vpn_tiebreak_orr;
 use crate::route::{VpnRibRoute, VpnRibRouteKey};
@@ -886,23 +886,11 @@ impl RibManager {
                     .collect();
                 if !self.try_send_and_commit_outbound_update_with_group_prior(
                     peer,
-                    vec![].into(),
-                    vec![].into(),
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vpn_announce,
-                    vpn_withdraw,
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
+                    OutboundCommitBatch {
+                        vpn_announce,
+                        vpn_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                     group_prior,
                     None,
                 ) {
@@ -1028,23 +1016,11 @@ impl RibManager {
             if (!vpn_announce.is_empty() || !vpn_withdraw.is_empty())
                 && !self.try_send_and_commit_outbound_update(
                     peer,
-                    vec![].into(),
-                    vec![].into(),
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    vpn_announce,
-                    vpn_withdraw,
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
+                    OutboundCommitBatch {
+                        vpn_announce,
+                        vpn_withdraw,
+                        ..OutboundCommitBatch::default()
+                    },
                 )
             {
                 warn!(%peer, "outbound channel full — VPN update deferred");

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -7,6 +7,7 @@ use rustbgpd_wire::{EvpnRouteKey, Prefix, Safi};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
+use super::distribution::OutboundCommitBatch;
 use super::helpers::prefix_family;
 use super::{
     ExactExportKey, LiveSessionRecord, MAX_LIVE_SESSIONS_PER_PEER, PolicyFilteredRouteKey,
@@ -1775,23 +1776,24 @@ impl RibManager {
         let sent = !has_outbound_diff
             || self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
                 peer,
-                nh_override_flags.into(),
-                announce.into(),
-                withdraw,
-                vec![],
-                vec![],
-                fs_announce,
-                fs_withdraw,
-                evpn_announce,
-                evpn_withdraw,
-                bgpls_announce,
-                bgpls_withdraw,
-                vpn_announce,
-                vpn_withdraw,
-                labeled_announce,
-                labeled_withdraw,
-                rtc_announce,
-                rtc_withdraw,
+                OutboundCommitBatch {
+                    next_hop_override: nh_override_flags.into(),
+                    announce: announce.into(),
+                    withdraw,
+                    flowspec_announce: fs_announce,
+                    flowspec_withdraw: fs_withdraw,
+                    evpn_announce,
+                    evpn_withdraw,
+                    bgpls_announce,
+                    bgpls_withdraw,
+                    vpn_announce,
+                    vpn_withdraw,
+                    labeled_announce,
+                    labeled_withdraw,
+                    rtc_announce,
+                    rtc_withdraw,
+                    ..OutboundCommitBatch::default()
+                },
                 HashSet::new(),
                 None,
                 member_of.is_none().then_some(&otc_prefixes),

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use rustbgpd_wire::{Afi, EvpnRouteKey, Prefix, RouteRefreshSubtype, Safi};
 use tracing::{debug, info, warn};
 
+use super::distribution::OutboundCommitBatch;
 use super::helpers::{afi_safi_label, gauge_val, prefix_family};
 use super::{PolicyFilteredRouteKey, RibManager};
 use crate::ERR_REFRESH_TIMEOUT;
@@ -1295,23 +1296,25 @@ impl RibManager {
         };
         if !self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
             peer,
-            nh_override_flags.into(),
-            announce.into(),
-            withdraw,
-            end_of_rib,
-            refresh_markers,
-            fs_announce,
-            fs_withdraw,
-            evpn_announce,
-            evpn_withdraw,
-            bgpls_announce,
-            bgpls_withdraw,
-            vpn_announce,
-            vpn_withdraw,
-            labeled_announce,
-            labeled_withdraw,
-            rtc_announce,
-            rtc_withdraw,
+            OutboundCommitBatch {
+                next_hop_override: nh_override_flags.into(),
+                announce: announce.into(),
+                withdraw,
+                end_of_rib,
+                refresh_markers,
+                flowspec_announce: fs_announce,
+                flowspec_withdraw: fs_withdraw,
+                evpn_announce,
+                evpn_withdraw,
+                bgpls_announce,
+                bgpls_withdraw,
+                vpn_announce,
+                vpn_withdraw,
+                labeled_announce,
+                labeled_withdraw,
+                rtc_announce,
+                rtc_withdraw,
+            },
             group_prior,
             None,
             member_of.is_none().then_some(&all_prefixes),

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::event_sink::RibEventSink;
+use crate::manager::distribution::OutboundCommitBatch;
 
 #[derive(Default)]
 struct SharedRouteCapture(std::sync::Mutex<Option<Arc<crate::event::RouteEvent>>>);
@@ -1097,23 +1098,12 @@ fn commit_family_gauge_fixture(
     let next_hop_override = vec![None; announce.len()].into();
     assert!(manager.try_send_and_commit_outbound_update(
         peer,
-        next_hop_override,
-        announce.into(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        vpn_announce,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
+        OutboundCommitBatch {
+            next_hop_override,
+            announce: announce.into(),
+            vpn_announce,
+            ..OutboundCommitBatch::default()
+        },
     ));
     let gathered = metrics.registry().gather();
     let gauge = gathered

--- a/crates/rib/src/manager/tests/exportability.rs
+++ b/crates/rib/src/manager/tests/exportability.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, RwLock};
 
 use super::*;
+use crate::manager::distribution::OutboundCommitBatch;
 use crate::update::{
     ExactExportCandidate, ExactExportEncoder, ExactExportError, ExactExportErrorCode,
     ExactExportKey, ExactExportResult, ExactExportSnapshot,
@@ -342,23 +343,24 @@ fn commit_batch(manager: &mut RibManager, peer: IpAddr, batch: ExactBatch) -> bo
     let next_hop_override = vec![None; batch.announce.len()].into();
     manager.try_send_and_commit_outbound_update(
         peer,
-        next_hop_override,
-        batch.announce.into(),
-        batch.withdraw,
-        Vec::new(),
-        Vec::new(),
-        batch.flowspec_announce,
-        batch.flowspec_withdraw,
-        batch.evpn_announce,
-        batch.evpn_withdraw,
-        batch.bgpls_announce,
-        batch.bgpls_withdraw,
-        batch.vpn_announce,
-        batch.vpn_withdraw,
-        batch.labeled_announce,
-        batch.labeled_withdraw,
-        batch.rtc_announce,
-        batch.rtc_withdraw,
+        OutboundCommitBatch {
+            next_hop_override,
+            announce: batch.announce.into(),
+            withdraw: batch.withdraw,
+            flowspec_announce: batch.flowspec_announce,
+            flowspec_withdraw: batch.flowspec_withdraw,
+            evpn_announce: batch.evpn_announce,
+            evpn_withdraw: batch.evpn_withdraw,
+            bgpls_announce: batch.bgpls_announce,
+            bgpls_withdraw: batch.bgpls_withdraw,
+            vpn_announce: batch.vpn_announce,
+            vpn_withdraw: batch.vpn_withdraw,
+            labeled_announce: batch.labeled_announce,
+            labeled_withdraw: batch.labeled_withdraw,
+            rtc_announce: batch.rtc_announce,
+            rtc_withdraw: batch.rtc_withdraw,
+            ..OutboundCommitBatch::default()
+        },
     )
 }
 
@@ -392,23 +394,11 @@ fn commit_shared_unicast_with_precommit(
 ) -> bool {
     manager.try_send_and_commit_outbound_update_with_group_prior(
         peer,
-        next_hop_override,
-        announce,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
+        OutboundCommitBatch {
+            next_hop_override,
+            announce,
+            ..OutboundCommitBatch::default()
+        },
         group_prior,
         Some(crate::manager::distribution::SharedUnicastPrecommit {
             group_id: 7,

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -10,6 +10,7 @@ use super::{
     dummy_query_rx, make_bgpls_route, make_evpn_imet, make_flowspec_route, make_labeled_rib_route,
     make_route_with_lp, make_rtc_rib_route, make_vpn_rib_route, query_best_routes,
 };
+use crate::manager::distribution::OutboundCommitBatch;
 use crate::manager::selection_deferral::SelectionDeferralTransition;
 use crate::{
     PeerOutboundState, RibManager, RibUpdate, SelectionDeferralConfig,
@@ -236,23 +237,11 @@ fn commit_control_markers(
 ) -> bool {
     manager.try_send_and_commit_outbound_update(
         peer,
-        Vec::new().into(),
-        Vec::new().into(),
-        Vec::new(),
-        end_of_rib,
-        refresh_markers,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
+        OutboundCommitBatch {
+            end_of_rib,
+            refresh_markers,
+            ..OutboundCommitBatch::default()
+        },
     )
 }
 
@@ -738,23 +727,11 @@ fn deferred_selection_rejects_route_commit_until_release() {
     let commit = |manager: &mut RibManager| {
         manager.try_send_and_commit_outbound_update(
             target,
-            vec![None].into(),
-            vec![make_route_with_lp(prefix, Ipv4Addr::new(10, 0, 0, 2), 100)].into(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
+            OutboundCommitBatch {
+                next_hop_override: vec![None].into(),
+                announce: vec![make_route_with_lp(prefix, Ipv4Addr::new(10, 0, 0, 2), 100)].into(),
+                ..OutboundCommitBatch::default()
+            },
         )
     };
     assert!(

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -43,6 +43,8 @@ use rustbgpd_wire::{
 use rustc_hash::FxHashMap;
 use tracing::{debug, info, warn};
 
+use super::distribution::OutboundCommitBatch;
+
 #[cfg(test)]
 use rustbgpd_wire::ExtendedCommunity;
 
@@ -1565,23 +1567,11 @@ impl RibManager {
         let withdraw_keys: Vec<VpnRouteKey> = vpn_withdraw.iter().map(|key| key.nlri_key).collect();
         if self.try_send_and_commit_outbound_update(
             peer,
-            vec![].into(),
-            vec![].into(),
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vpn_announce,
-            vpn_withdraw,
-            vec![],
-            vec![],
-            vec![],
-            vec![],
+            OutboundCommitBatch {
+                vpn_announce,
+                vpn_withdraw,
+                ..OutboundCommitBatch::default()
+            },
         ) {
             self.bump_export_counters(peer, &permit_rows);
         } else {

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -7,6 +7,7 @@ use rustbgpd_wire::{
 };
 
 use super::*;
+use crate::manager::distribution::OutboundCommitBatch;
 
 #[test]
 fn canceled_update_group_snapshot_does_not_invoke_builder() {
@@ -5337,23 +5338,11 @@ fn single_best_group_otc_at_backstop_trips_debug_assert() {
     let nh: Arc<[Option<NextHopAction>]> = vec![None].into();
     let _ = m.try_send_and_commit_outbound_update(
         MEMBER,
-        nh,
-        announce,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
+        OutboundCommitBatch {
+            next_hop_override: nh,
+            announce,
+            ..OutboundCommitBatch::default()
+        },
     );
 }
 
@@ -5383,23 +5372,11 @@ fn per_client_best_group_otc_at_backstop_strips_with_pending_gated_withdraw() {
     let nh: Arc<[Option<NextHopAction>]> = vec![None].into();
     assert!(m.try_send_and_commit_outbound_update(
         MEMBER,
-        nh,
-        announce,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
+        OutboundCommitBatch {
+            next_hop_override: nh,
+            announce,
+            ..OutboundCommitBatch::default()
+        },
     ));
     let update = outbound_rx.try_recv().unwrap();
     assert!(


### PR DESCRIPTION
## Summary

- replace 17 positional family payload arguments with one manager-private `OutboundCommitBatch`
- migrate the three outbound send-ladder variants and all direct callers mechanically
- keep peer, group-prior, shared precommit, and OTC reconciliation controls explicit
- leave the `distribute_*` quartet and its parallel output vectors for a separate review tranche

## Validation

- update-group oracle: 30 passed
- deterministic fault corpus and full fault suite
- full RIB package suite: 1,185 passed, 2 ignored, plus integration and doc targets
- `cargo clippy --locked -p rustbgpd-rib --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked -p rustbgpd-rib --no-deps`
- identical base/head test declaration inventory
- independent 17-field and 18-caller mapping audit
- repository commit hooks
- `git diff --check`