### PR TITLE
feat(wire): add optional Tokio codec adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
       - run: python3 scripts/check-v1-stable-surface.py
       - run: python3 scripts/reflow-release-notes.py --selftest
       - run: cargo clippy --locked --workspace --all-targets -- -D warnings
+      # `tokio-codec` is intentionally off by default, so the workspace lint
+      # above does not compile its public adapter, tests, or example.
+      - run: cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings
       # `bench-internals` is off by default and its bench target carries
       # `required-features`, so nothing above compiles the feature-gated
       # bench_support surface; it has silently broken before when a
@@ -326,7 +329,11 @@ jobs:
       - run: cargo test --locked --workspace
         env:
           RUSTBGPD_V064_VALIDATOR: ${{ runner.temp }}/rustbgpd-v064/rustbgpd-v0.64.0
+      - run: cargo test --locked -p rustbgpd-wire --features tokio-codec
       - run: cargo doc --locked --workspace --lib --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - run: cargo doc --locked -p rustbgpd-wire --lib --no-deps --features tokio-codec
         env:
           RUSTDOCFLAGS: "-D warnings"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rustbgpd-wire` gains an optional, default-off `tokio-codec` feature with a
+  typed `tokio_util::codec::Decoder` / `Encoder` adapter. Inbound and outbound
+  message ceilings remain independently configurable so asymmetric RFC 8654
+  Extended Message negotiation is represented without widening the default
+  runtime-neutral dependency surface. (LAN-1212)
+
 - The shipped Grafana overview now pairs the RFC 9107 ORR SPF computation
   rate with current topology node and usable-link counts. (LAN-1205)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,6 +3294,7 @@ dependencies = [
  "criterion",
  "proptest",
  "thiserror 2.0.20",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ rustbgpd-event-history = { path = "crates/event-history", version = "0.66.0" }
 bytes = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tonic = { version = "0.14", features = ["tls-ring"] }
@@ -175,7 +176,7 @@ uuid.workspace = true
 owo-colors.workspace = true
 axum.workspace = true
 socket2.workspace = true
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { workspace = true, features = ["rt"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.23"

--- a/crates/evpn-linux/Cargo.toml
+++ b/crates/evpn-linux/Cargo.toml
@@ -14,7 +14,7 @@ description = "Linux netlink dataplane reconciler for EVPN VTEP — observes bri
 rustbgpd-evpn.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "time", "macros", "rt"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 
 # Linux-only real netlink; cfg-gating preserves portable trait/test surfaces

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -18,10 +18,14 @@ exclude = ["tests/path_attribute_registry.rs"]
 # Enables allocation counters in the codec diagnostic binary. The ordinary
 # Criterion benchmark compiles without this feature and has no probe atomics.
 codec-allocation-diagnostics = []
+# Provides a `tokio_util::codec` adapter without making Tokio integration part
+# of the default, runtime-neutral wire crate dependency surface.
+tokio-codec = ["dep:tokio-util"]
 
 [dependencies]
 bytes.workspace = true
 thiserror.workspace = true
+tokio-util = { workspace = true, features = ["codec"], optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
@@ -30,3 +34,7 @@ criterion.workspace = true
 [[bench]]
 name = "codec"
 harness = false
+
+[[example]]
+name = "tokio_codec"
+required-features = ["tokio-codec"]

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -240,9 +240,46 @@ let open = OpenMessage {
 let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
 ```
 
+### Tokio framing (optional)
+
+Enable the default-off `tokio-codec` feature to use `rustbgpd-wire` with
+`tokio_util::codec::Framed`, `FramedRead`, or `FramedWrite`. The feature adds
+Tokio-util's codec support graph, but it does not enable Tokio runtime,
+network, or I/O-util features; the application continues to own its socket
+and runtime.
+
+Extended Messages negotiation is directional. The capability this side
+advertises controls the inbound ceiling, while the peer's capability controls
+the outbound ceiling:
+
+```rust
+use bytes::BytesMut;
+use rustbgpd_wire::{
+    BgpCodec, EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN, Message,
+};
+use tokio_util::codec::{Decoder, Encoder};
+
+let mut codec = BgpCodec::with_max_message_lengths(
+    EXTENDED_MAX_MESSAGE_LEN, // we advertised Extended Messages
+    MAX_MESSAGE_LEN,          // the peer did not
+);
+let mut wire = BytesMut::new();
+codec.encode(Message::Keepalive, &mut wire)?;
+assert_eq!(codec.decode(&mut wire)?, Some(Message::Keepalive));
+# Ok::<(), rustbgpd_wire::BgpCodecError>(())
+```
+
+Run the standalone adapter example with:
+
+```console
+cargo run -p rustbgpd-wire --features tokio-codec --example tokio_codec
+```
+
 ## Key types
 
 - **`Message`** — top-level enum: `Open`, `Update`, `Keepalive`, `Notification`, `RouteRefresh`
+- **`BgpCodec` / `BgpCodecError`** — optional Tokio `Decoder` / `Encoder`
+  adapter and typed I/O/decode/encode errors, gated by `tokio-codec`
 - **`UpdateMessage`** / **`ParsedUpdate`** — raw wire form and parsed routes + attributes
 - **`PathAttribute`** — typed variants plus `Unknown` pass-through, including `AsPath`, `Aggregator`, `AtomicAggregate`, `NextHop`, `Communities`, `MpReachNlri`, `LargeCommunities`, `PmsiTunnel` (RFC 6514), and `OnlyToCustomer` (RFC 9234)
 - **`Prefix`** — `V4(Ipv4Prefix)` / `V6(Ipv6Prefix)` enum

--- a/crates/wire/examples/tokio_codec.rs
+++ b/crates/wire/examples/tokio_codec.rs
@@ -1,0 +1,19 @@
+use bytes::BytesMut;
+use rustbgpd_wire::{BgpCodec, EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN, Message};
+use tokio_util::codec::{Decoder, Encoder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Extended Messages is directional: our advertised capability lets this
+    // side receive extended frames, while a peer that did not advertise it
+    // still limits this side to standard-size outbound frames.
+    let mut codec = BgpCodec::with_max_message_lengths(EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN);
+
+    let mut wire = BytesMut::new();
+    codec.encode(Message::Keepalive, &mut wire)?;
+    let decoded = codec.decode(&mut wire)?.expect("complete KEEPALIVE");
+
+    assert_eq!(decoded, Message::Keepalive);
+    assert!(wire.is_empty());
+    println!("decoded {decoded}");
+    Ok(())
+}

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -16,7 +16,7 @@
 //! - [`encode_message`] — encode a BGP message to bytes
 //! - [`peek_message_length`] — check if a
 //!   complete message is available (for transport framing)
-//! - [`BgpCodec`] — optional `tokio_util::codec` adapter, available with the
+//! - `BgpCodec` — optional `tokio_util::codec` adapter, available with the
 //!   `tokio-codec` feature
 //!
 //! # Invariants

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -16,10 +16,13 @@
 //! - [`encode_message`] — encode a BGP message to bytes
 //! - [`peek_message_length`] — check if a
 //!   complete message is available (for transport framing)
+//! - [`BgpCodec`] — optional `tokio_util::codec` adapter, available with the
+//!   `tokio-codec` feature
 //!
 //! # Invariants
 //!
-//! - Maximum message size: 4096 bytes (RFC 4271 §4.1)
+//! - Message size is 4096 bytes by default (RFC 4271 §4.1), or up to 65535
+//!   bytes for eligible message types after RFC 8654 negotiation
 //! - No panics on malformed input — all paths return `Result`
 //! - No `unsafe` code
 //!
@@ -94,6 +97,9 @@ pub mod pmsi;
 pub mod route_refresh;
 /// RT-Constrain NLRI codec substrate (RFC 4684).
 pub mod rtc;
+/// Optional Tokio `Decoder`/`Encoder` adapter for BGP message streams.
+#[cfg(feature = "tokio-codec")]
+pub mod tokio_codec;
 /// UPDATE message struct, codec, and builder.
 pub mod update;
 /// UPDATE attribute semantic validation (RFC 4271 §6.3).
@@ -124,6 +130,8 @@ pub use rtc::{
     RTC_MAX_PREFIX_BITS, RTC_MIN_NON_DEFAULT_PREFIX_BITS, RTC_SAFI, RtcNlri, decode_rtc_nlri,
     encode_rtc_nlri,
 };
+#[cfg(feature = "tokio-codec")]
+pub use tokio_codec::{BgpCodec, BgpCodecError};
 pub use update::{Ipv4UnicastMode, UpdateMessage};
 pub use vpn::{
     LABELED_UNICAST_SAFI, MPLS_VPN_SAFI, MplsLabelEntry, VPNV4_AFI, VPNV6_AFI, VpnAddressFamily,

--- a/crates/wire/src/tokio_codec.rs
+++ b/crates/wire/src/tokio_codec.rs
@@ -1,0 +1,368 @@
+//! Tokio framing adapter for BGP message streams.
+//!
+//! BGP Extended Messages negotiation is directional: the capability we
+//! advertise controls the frames accepted inbound, while the peer's
+//! capability controls the frames sent outbound. [`BgpCodec`] therefore
+//! keeps separate limits for the two directions.
+//!
+//! ```rust
+//! use bytes::BytesMut;
+//! use rustbgpd_wire::{
+//!     BgpCodec, EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN, Message,
+//! };
+//! use tokio_util::codec::{Decoder, Encoder};
+//!
+//! let mut codec = BgpCodec::with_max_message_lengths(
+//!     EXTENDED_MAX_MESSAGE_LEN,
+//!     MAX_MESSAGE_LEN,
+//! );
+//! let mut wire = BytesMut::new();
+//! codec.encode(Message::Keepalive, &mut wire)?;
+//! assert_eq!(codec.decode(&mut wire)?, Some(Message::Keepalive));
+//! # Ok::<(), rustbgpd_wire::BgpCodecError>(())
+//! ```
+
+use std::io;
+
+use bytes::BytesMut;
+use thiserror::Error;
+use tokio_util::codec::{Decoder, Encoder};
+
+use crate::constants::HEADER_LEN;
+use crate::{
+    DecodeError, EncodeError, MAX_MESSAGE_LEN, Message, decode_message, encode_message_with_limit,
+    peek_message_length,
+};
+
+/// Errors produced by [`BgpCodec`].
+///
+/// Tokio requires decoder and encoder errors to accept [`io::Error`]. The
+/// protocol variants remain typed so a caller can, for example, map a
+/// [`DecodeError`] to its BGP NOTIFICATION.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BgpCodecError {
+    /// The framed transport reported an I/O error.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    /// A complete inbound frame failed BGP validation.
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    /// An outbound message could not be encoded within its configured limit.
+    #[error(transparent)]
+    Encode(#[from] EncodeError),
+}
+
+/// A `tokio_util::codec` adapter for complete BGP messages.
+///
+/// The default limits both directions to the RFC 4271 maximum of 4096 bytes.
+/// After OPEN negotiation, update the inbound and outbound limits separately:
+/// our advertised Extended Message capability controls inbound acceptance,
+/// while the peer's advertised capability controls outbound encoding.
+///
+/// The decoded item is [`Message`]. Applications that also require the exact
+/// original PDU bytes should continue to frame with [`peek_message_length`]
+/// and retain the split frame before calling [`decode_message`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BgpCodec {
+    inbound_max_message_len: u16,
+    outbound_max_message_len: u16,
+}
+
+impl BgpCodec {
+    /// Create a codec with the standard 4096-byte limit in both directions.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::with_max_message_lengths(MAX_MESSAGE_LEN, MAX_MESSAGE_LEN)
+    }
+
+    /// Create a codec with explicit inbound and outbound message limits.
+    ///
+    /// RFC 8654 deployments normally use [`MAX_MESSAGE_LEN`] or
+    /// [`crate::EXTENDED_MAX_MESSAGE_LEN`]. Intermediate values are also
+    /// accepted as an application-level defensive ceiling.
+    #[must_use]
+    pub const fn with_max_message_lengths(
+        inbound_max_message_len: u16,
+        outbound_max_message_len: u16,
+    ) -> Self {
+        Self {
+            inbound_max_message_len,
+            outbound_max_message_len,
+        }
+    }
+
+    /// Return the maximum accepted inbound message length.
+    #[must_use]
+    pub const fn inbound_max_message_len(&self) -> u16 {
+        self.inbound_max_message_len
+    }
+
+    /// Set the maximum accepted inbound message length.
+    pub const fn set_inbound_max_message_len(&mut self, max_message_len: u16) {
+        self.inbound_max_message_len = max_message_len;
+    }
+
+    /// Return the maximum encoded outbound message length.
+    #[must_use]
+    pub const fn outbound_max_message_len(&self) -> u16 {
+        self.outbound_max_message_len
+    }
+
+    /// Set the maximum encoded outbound message length.
+    pub const fn set_outbound_max_message_len(&mut self, max_message_len: u16) {
+        self.outbound_max_message_len = max_message_len;
+    }
+}
+
+impl Default for BgpCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Decoder for BgpCodec {
+    type Item = Message;
+    type Error = BgpCodecError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let Some(frame_len) = peek_message_length(src, self.inbound_max_message_len)? else {
+            src.reserve(HEADER_LEN.saturating_sub(src.len()));
+            return Ok(None);
+        };
+        let frame_len = usize::from(frame_len);
+
+        if src.len() < frame_len {
+            src.reserve(frame_len - src.len());
+            return Ok(None);
+        }
+
+        // Split the declared frame before body decoding. A malformed body can
+        // then consume only its own PDU, never bytes from a following frame.
+        let mut frame = src.split_to(frame_len).freeze();
+        let message = decode_message(&mut frame, self.inbound_max_message_len)?;
+        debug_assert!(
+            frame.is_empty(),
+            "complete message decoder left frame bytes"
+        );
+        Ok(Some(message))
+    }
+}
+
+impl Encoder<Message> for BgpCodec {
+    type Error = BgpCodecError;
+
+    fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        // Encode transactionally into a temporary buffer so a validation
+        // error cannot leave a partial frame in Tokio's write buffer.
+        let encoded = encode_message_with_limit(&item, self.outbound_max_message_len)?;
+        dst.reserve(encoded.len());
+        dst.extend_from_slice(&encoded);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use bytes::{BufMut, Bytes};
+    use tokio_util::codec::{Decoder, Encoder};
+
+    use super::*;
+    use crate::constants::{BGP_VERSION, EXTENDED_MAX_MESSAGE_LEN, MARKER, message_type};
+    use crate::{
+        Afi, NotificationCode, NotificationMessage, OpenMessage, RouteRefreshMessage, Safi,
+        UpdateMessage, encode_message, encode_message_with_limit,
+    };
+
+    fn representative_messages() -> Vec<Message> {
+        vec![
+            Message::Open(OpenMessage {
+                version: BGP_VERSION,
+                my_as: 64_512,
+                hold_time: 90,
+                bgp_identifier: Ipv4Addr::new(192, 0, 2, 1),
+                capabilities: vec![],
+            }),
+            Message::Update(UpdateMessage {
+                withdrawn_routes: Bytes::new(),
+                path_attributes: Bytes::new(),
+                nlri: Bytes::new(),
+            }),
+            Message::Notification(NotificationMessage::new(
+                NotificationCode::Cease,
+                0,
+                Bytes::new(),
+            )),
+            Message::Keepalive,
+            Message::RouteRefresh(RouteRefreshMessage::new(Afi::Ipv4, Safi::Unicast)),
+        ]
+    }
+
+    fn extended_notification() -> Message {
+        Message::Notification(NotificationMessage::new(
+            NotificationCode::Cease,
+            0,
+            Bytes::from(vec![0xab; 5000]),
+        ))
+    }
+
+    #[test]
+    fn defaults_to_standard_directional_limits() {
+        let codec = BgpCodec::new();
+        assert_eq!(codec.inbound_max_message_len(), MAX_MESSAGE_LEN);
+        assert_eq!(codec.outbound_max_message_len(), MAX_MESSAGE_LEN);
+        assert_eq!(codec, BgpCodec::default());
+    }
+
+    #[test]
+    fn partial_header_and_body_do_not_advance() {
+        let mut codec = BgpCodec::new();
+        let mut partial_header = BytesMut::from(&MARKER[..10]);
+        let original_header = partial_header.clone();
+        assert!(codec.decode(&mut partial_header).unwrap().is_none());
+        assert_eq!(partial_header, original_header);
+        assert!(partial_header.capacity() >= HEADER_LEN);
+
+        let encoded = encode_message(&Message::Keepalive).unwrap();
+        let mut partial_body = BytesMut::from(&encoded[..encoded.len() - 1]);
+        let original_body = partial_body.clone();
+        assert!(codec.decode(&mut partial_body).unwrap().is_none());
+        assert_eq!(partial_body, original_body);
+        assert!(partial_body.capacity() >= encoded.len());
+    }
+
+    #[test]
+    fn consecutive_frames_advance_exactly_one_at_a_time() {
+        let encoded = encode_message(&Message::Keepalive).unwrap();
+        let mut src = BytesMut::new();
+        src.extend_from_slice(&encoded);
+        src.extend_from_slice(&encoded);
+        let mut codec = BgpCodec::new();
+
+        assert_eq!(codec.decode(&mut src).unwrap(), Some(Message::Keepalive));
+        assert_eq!(src.as_ref(), encoded.as_ref());
+        assert_eq!(codec.decode(&mut src).unwrap(), Some(Message::Keepalive));
+        assert!(src.is_empty());
+    }
+
+    #[test]
+    fn malformed_header_does_not_advance() {
+        let mut src = BytesMut::from(&[0_u8; HEADER_LEN][..]);
+        let original = src.clone();
+        let mut codec = BgpCodec::new();
+
+        assert!(matches!(
+            codec.decode(&mut src),
+            Err(BgpCodecError::Decode(DecodeError::InvalidMarker))
+        ));
+        assert_eq!(src, original);
+    }
+
+    #[test]
+    fn malformed_complete_body_preserves_following_frame() {
+        let mut src = BytesMut::new();
+        src.put_slice(&MARKER);
+        src.put_u16(20);
+        src.put_u8(message_type::NOTIFICATION);
+        src.put_u8(NotificationCode::Cease.as_u8());
+        let keepalive = encode_message(&Message::Keepalive).unwrap();
+        src.extend_from_slice(&keepalive);
+        let mut codec = BgpCodec::new();
+
+        assert!(matches!(
+            codec.decode(&mut src),
+            Err(BgpCodecError::Decode(DecodeError::MalformedField {
+                message_type: "NOTIFICATION",
+                ..
+            }))
+        ));
+        assert_eq!(src.as_ref(), keepalive.as_ref());
+    }
+
+    #[test]
+    fn inbound_and_outbound_extended_limits_are_independent() {
+        let message = extended_notification();
+        let encoded = encode_message_with_limit(&message, EXTENDED_MAX_MESSAGE_LEN).unwrap();
+        let mut src = encoded.clone();
+        let mut codec =
+            BgpCodec::with_max_message_lengths(EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN);
+
+        assert_eq!(codec.decode(&mut src).unwrap(), Some(message.clone()));
+        let mut dst = BytesMut::new();
+        assert!(matches!(
+            codec.encode(message.clone(), &mut dst),
+            Err(BgpCodecError::Encode(EncodeError::MessageTooLong { .. }))
+        ));
+        assert!(dst.is_empty());
+
+        codec.set_outbound_max_message_len(EXTENDED_MAX_MESSAGE_LEN);
+        codec.encode(message, &mut dst).unwrap();
+        assert_eq!(dst, encoded);
+    }
+
+    #[test]
+    fn extended_limit_never_applies_to_open_or_keepalive() {
+        let mut src = BytesMut::new();
+        src.put_slice(&MARKER);
+        src.put_u16(MAX_MESSAGE_LEN + 1);
+        src.put_u8(message_type::OPEN);
+        src.resize(usize::from(MAX_MESSAGE_LEN) + 1, 0);
+        let original = src.clone();
+        let mut codec =
+            BgpCodec::with_max_message_lengths(EXTENDED_MAX_MESSAGE_LEN, EXTENDED_MAX_MESSAGE_LEN);
+
+        assert!(matches!(
+            codec.decode(&mut src),
+            Err(BgpCodecError::Decode(DecodeError::InvalidLength {
+                length
+            })) if length == MAX_MESSAGE_LEN + 1
+        ));
+        assert_eq!(src, original);
+    }
+
+    #[test]
+    fn every_message_variant_round_trips_through_traits() {
+        let mut codec = BgpCodec::new();
+        for message in representative_messages() {
+            let mut wire = BytesMut::new();
+            codec.encode(message.clone(), &mut wire).unwrap();
+            assert_eq!(codec.decode(&mut wire).unwrap(), Some(message));
+            assert!(wire.is_empty());
+        }
+    }
+
+    #[test]
+    fn encode_error_leaves_existing_destination_unchanged() {
+        let mut codec = BgpCodec::new();
+        let mut dst = BytesMut::from(&b"existing"[..]);
+        let original = dst.clone();
+
+        assert!(codec.encode(extended_notification(), &mut dst).is_err());
+        assert_eq!(dst, original);
+    }
+
+    #[test]
+    fn partial_eof_uses_tokio_io_error_contract() {
+        let mut codec = BgpCodec::new();
+        let mut src = BytesMut::from(&MARKER[..10]);
+
+        assert!(matches!(
+            codec.decode_eof(&mut src),
+            Err(BgpCodecError::Io(_))
+        ));
+    }
+
+    #[test]
+    fn setters_update_only_the_selected_direction() {
+        let mut codec = BgpCodec::new();
+        codec.set_inbound_max_message_len(EXTENDED_MAX_MESSAGE_LEN);
+        assert_eq!(codec.inbound_max_message_len(), EXTENDED_MAX_MESSAGE_LEN);
+        assert_eq!(codec.outbound_max_message_len(), MAX_MESSAGE_LEN);
+
+        codec.set_outbound_max_message_len(8192);
+        assert_eq!(codec.inbound_max_message_len(), EXTENDED_MAX_MESSAGE_LEN);
+        assert_eq!(codec.outbound_max_message_len(), 8192);
+    }
+}

--- a/crates/wire/src/tokio_codec.rs
+++ b/crates/wire/src/tokio_codec.rs
@@ -156,6 +156,12 @@ impl Encoder<Message> for BgpCodec {
         // Encode transactionally into a temporary buffer so a validation
         // error cannot leave a partial frame in Tokio's write buffer.
         let encoded = encode_message_with_limit(&item, self.outbound_max_message_len)?;
+        if encoded.len() > usize::from(self.outbound_max_message_len) {
+            return Err(EncodeError::MessageTooLong {
+                size: encoded.len(),
+            }
+            .into());
+        }
         dst.reserve(encoded.len());
         dst.extend_from_slice(&encoded);
         Ok(())
@@ -341,6 +347,21 @@ mod tests {
 
         assert!(codec.encode(extended_notification(), &mut dst).is_err());
         assert_eq!(dst, original);
+    }
+
+    #[test]
+    fn custom_outbound_ceiling_also_rejects_open_and_keepalive_atomically() {
+        let mut codec = BgpCodec::with_max_message_lengths(MAX_MESSAGE_LEN, 18);
+        let open = representative_messages().remove(0);
+        for message in [Message::Keepalive, open] {
+            let mut dst = BytesMut::from(&b"existing"[..]);
+            let original = dst.clone();
+            assert!(matches!(
+                codec.encode(message, &mut dst),
+                Err(BgpCodecError::Encode(EncodeError::MessageTooLong { .. }))
+            ));
+            assert_eq!(dst, original);
+        }
     }
 
     #[test]

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -440,7 +440,7 @@ To be the de facto Rust BGP codec, the concrete gaps:
    drives the FSM, and prints every received UPDATE. This is the "it works"
    receipt for consumers #1 and #3. The `event-bridge` example already proves the
    gRPC-client shape; this proves the library-embedding shape.
-2. **Add a `tokio_util::codec::Decoder/Encoder` impl.** Done on main for the
+2. **Add a `tokio_util::codec::Decoder/Encoder` impl.** Implemented for the
    next wire release: the default-off `tokio-codec` feature exports typed
    `BgpCodec` / `BgpCodecError` framing with independent inbound and outbound
    ceilings. It adds Tokio-util's codec support graph without enabling Tokio's

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -60,8 +60,10 @@ publication candidates and the gates that would apply.
 
 The wire crate is a pure codec: encode/decode of BGP messages to/from `bytes`
 buffers. No `unsafe`, no panics on malformed input (all paths return `Result`),
-no async runtime, no sockets. Two external dependencies only: `bytes` and
-`thiserror`.
+no async runtime, no sockets. Its default build has two external dependencies:
+`bytes` and `thiserror`. The optional `tokio-codec` feature adds Tokio-util's
+framing traits and support dependencies, but does not enable Tokio runtime,
+network, or I/O-util features; the embedder still owns the socket and runtime.
 
 Public surface (re-exported at crate root — `crates/wire/src/lib.rs`):
 
@@ -69,6 +71,9 @@ Public surface (re-exported at crate root — `crates/wire/src/lib.rs`):
   `encode_message(&Message) -> Result<BytesMut, EncodeError>`,
   `peek_message_length(&[u8], max_message_len: u16) -> Result<Option<u16>, DecodeError>`
   (transport framing: `Ok(None)` means "header not yet buffered").
+- **Optional Tokio framing:** the default-off `tokio-codec` feature exports
+  `BgpCodec` and `BgpCodecError`, with independent inbound/outbound ceilings
+  for directional Extended Message negotiation.
 - **`Message`** enum: `Open`, `Update`, `Keepalive`, `Notification`, `RouteRefresh`.
 - **`OpenMessage`** — capabilities negotiation; `Capability` enum (MP-BGP,
   4-octet AS, Add-Path, experimental Paths-Limit via `PathsLimitFamily`,
@@ -435,12 +440,12 @@ To be the de facto Rust BGP codec, the concrete gaps:
    drives the FSM, and prints every received UPDATE. This is the "it works"
    receipt for consumers #1 and #3. The `event-bridge` example already proves the
    gRPC-client shape; this proves the library-embedding shape.
-2. **Add a `tokio_util::codec::Decoder/Encoder` impl.** ADR-0002 notes the
-   transport layer integrates via `decode_message`/`encode_message` inside a
-   `tokio_util::codec::Decoder`. Publish that `Decoder`/`Encoder` *in the wire
-   crate* (gated on a `tokio-codec` feature that pulls `bytes` only — no full
-   tokio) so any async consumer gets framed decode for free. This is the
-   "battery-included" ergonomic that bgp-rs/zettabgp lack.
+2. **Add a `tokio_util::codec::Decoder/Encoder` impl.** Done on main for the
+   next wire release: the default-off `tokio-codec` feature exports typed
+   `BgpCodec` / `BgpCodecError` framing with independent inbound and outbound
+   ceilings. It adds Tokio-util's codec support graph without enabling Tokio's
+   runtime, network, or I/O-util features; socket/runtime ownership remains
+   with the embedder.
 3. **Run `cargo-semver-checks` in CI** against the published crates so
    accidental breaking changes are caught before publish. Done: the
    `semver-checks` workflow checks every publishable workspace crate against

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -24,7 +24,7 @@ WORKFLOWS = tuple(
                  "release-install-contract", "release", "update-group-fault")
 )
 EXPECTED_ROOT_COMMANDS = {
-    WORKFLOWS[0]: Counter(build=1, check=6, clippy=1, doc=1, test=5),
+    WORKFLOWS[0]: Counter(build=1, check=6, clippy=2, doc=2, test=6),
     WORKFLOWS[1]: Counter(test=1),
     WORKFLOWS[2]: Counter(test=6),
     WORKFLOWS[3]: Counter(test=1),
@@ -159,8 +159,29 @@ def check(root: Path) -> list[str]:
     ):
         if text.count(command) != 1 or command not in core_tests:
             errors.append(f"{command} must exist exactly once in core_tests")
-    if 'RUSTDOCFLAGS: "-D warnings"' not in core_tests:
+    if core_tests.count('RUSTDOCFLAGS: "-D warnings"') != 2:
         errors.append("core_tests rustdoc warnings contract drifted")
+
+    feature_commands = (
+        (
+            jobs.get("core", ""),
+            "cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings",
+            "core",
+        ),
+        (
+            core_tests,
+            "cargo test --locked -p rustbgpd-wire --features tokio-codec",
+            "core_tests",
+        ),
+        (
+            core_tests,
+            "cargo doc --locked -p rustbgpd-wire --lib --no-deps --features tokio-codec",
+            "core_tests",
+        ),
+    )
+    for job, command, job_name in feature_commands:
+        if text.count(command) != 1 or command not in job:
+            errors.append(f"{command} must exist exactly once in {job_name}")
 
     wire_step_name = "Wire crate README freshness gate"
     wire_step = named_step(jobs.get("core", ""), wire_step_name)

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -124,6 +124,18 @@ class ScaleSplitContractTests(unittest.TestCase):
             ("  evpn_bum_filter_kernel:\n", "  renamed_evpn:\n"),
             ("- run: cargo test --locked --workspace", "- run: true"),
             ("- run: cargo doc --locked --workspace --lib --no-deps", "- run: true"),
+            (
+                "- run: cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings",
+                "- run: true",
+            ),
+            (
+                "- run: cargo test --locked -p rustbgpd-wire --features tokio-codec",
+                "- run: true",
+            ),
+            (
+                "- run: cargo doc --locked -p rustbgpd-wire --lib --no-deps --features tokio-codec",
+                "- run: true",
+            ),
             ('RUSTDOCFLAGS: "-D warnings"', 'RUSTDOCFLAGS: ""'),
             (
                 "- name: Wire crate README freshness gate",


### PR DESCRIPTION
## Summary

- add a default-off `tokio-codec` feature exporting typed `BgpCodec` and `BgpCodecError` APIs
- model RFC 8654 negotiation with independent inbound and outbound ceilings
- preserve incomplete input, isolate malformed complete frames, and encode transactionally without modifying the destination on failure
- cover all five message variants, custom ceilings, EOF behavior, packaging, docs, examples, and explicit feature CI gates

The daemon framing path and raw-PDU API remain unchanged. The wire version bump stays with the separate release boundary.

## Validation

- `cargo test --locked --workspace`
- `cargo test --locked -p rustbgpd-wire --features tokio-codec`
- `cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings`
- default and feature-enabled warnings-denied rustdoc
- `cargo run --locked -p rustbgpd-wire --features tokio-codec --example tokio_codec`
- `cargo check --locked -p rustbgpd-wire --no-default-features`
- package construction and packaged feature/example checks
- `cargo semver-checks`: 196 checks passed
- embedding and CI scale-contract unit/mutation/live checks
- default dependency-tree proof excludes Tokio and Tokio-util
- repository commit and pre-push hooks
- `git diff --check`