### PR TITLE
ci: centralize grpcurl artifact preparation

### DIFF
--- a/.github/actions/prepare-grpcurl-artifact/action.yml
+++ b/.github/actions/prepare-grpcurl-artifact/action.yml
@@ -1,0 +1,28 @@
+name: "Prepare verified grpcurl artifact"
+description: >-
+  Restore the exact grpcurl archive cache, verify or prepare the pinned archive,
+  and publish it for same-run offline consumers.
+runs:
+  using: "composite"
+  steps:
+    - name: Restore exact grpcurl archive cache
+      uses: actions/cache@v6
+      with:
+        path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
+        key: grpcurl-v1.9.1-linux-x86_64-588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214
+
+    - name: Prepare exact grpcurl archive
+      shell: bash
+      run: |
+        .github/scripts/install-grpcurl.sh \
+          --prepare-archive \
+          "$RUNNER_TEMP/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz"
+
+    - name: Upload verified grpcurl archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: grpcurl-v1.9.1-linux-x86_64
+        path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
+        if-no-files-found: error
+        retention-days: 1
+        compression-level: 0

--- a/.github/scripts/install-grpcurl.sh
+++ b/.github/scripts/install-grpcurl.sh
@@ -204,7 +204,8 @@ check_workflow_consumers() {
 self_test() (
     local repo_root fixture_dir source_dir base_archive valid_archive checksum
     local truncated_size wrong_source wrong_archive wrong_checksum counter
-    local cache_path target_path workflow setup_calls prepare_calls install_calls
+    local cache_path target_path workflow setup_calls producer_calls prepare_calls
+    local prepare_mode_calls install_calls
 
     repo_root=$(git rev-parse --show-toplevel)
     fixture_dir=$(mktemp -d)
@@ -379,11 +380,18 @@ EOF
     [[ "$setup_calls" -eq 1 ]] \
         || fail_self_test "setup-dataplane-host must have one grpcurl consumer"
     for workflow in interop.yml kernel-dataplane.yml; do
-        prepare_calls=$(grep -cF -- '.github/scripts/install-grpcurl.sh' \
+        producer_calls=$(grep -cF \
+            'uses: ./.github/actions/prepare-grpcurl-artifact' \
             "$repo_root/.github/workflows/$workflow")
-        [[ "$prepare_calls" -eq 1 ]] \
+        [[ "$producer_calls" -eq 1 ]] \
             || fail_self_test "$workflow must have exactly one grpcurl producer"
     done
+    prepare_calls=$(grep -cF -- '.github/scripts/install-grpcurl.sh' \
+        "$repo_root/.github/actions/prepare-grpcurl-artifact/action.yml")
+    prepare_mode_calls=$(grep -cF -- '--prepare-archive' \
+        "$repo_root/.github/actions/prepare-grpcurl-artifact/action.yml")
+    [[ "$prepare_calls" -eq 1 && "$prepare_mode_calls" -eq 1 ]] \
+        || fail_self_test "producer action must have one grpcurl prepare call"
     install_calls=$(grep -cF -- '--install-archive' \
         "$repo_root/.github/actions/install-grpcurl-artifact/action.yml")
     [[ "$install_calls" -eq 1 ]] \

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -176,24 +176,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
-      - name: Restore exact grpcurl archive cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
-          key: grpcurl-v1.9.1-linux-x86_64-588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214
-      - name: Prepare exact grpcurl archive
-        run: |
-          .github/scripts/install-grpcurl.sh \
-            --prepare-archive \
-            "$RUNNER_TEMP/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz"
-      - name: Upload verified grpcurl archive
-        uses: actions/upload-artifact@v7
-        with:
-          name: grpcurl-v1.9.1-linux-x86_64
-          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
+      - name: Restore, prepare, and upload exact grpcurl archive
+        uses: ./.github/actions/prepare-grpcurl-artifact
 
   gnmic_archive:
     needs: classify_changes

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -61,24 +61,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
-      - name: Restore exact grpcurl archive cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
-          key: grpcurl-v1.9.1-linux-x86_64-588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214
-      - name: Prepare exact grpcurl archive
-        run: |
-          .github/scripts/install-grpcurl.sh \
-            --prepare-archive \
-            "$RUNNER_TEMP/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz"
-      - name: Upload verified grpcurl archive
-        uses: actions/upload-artifact@v7
-        with:
-          name: grpcurl-v1.9.1-linux-x86_64
-          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
+      - name: Restore, prepare, and upload exact grpcurl archive
+        uses: ./.github/actions/prepare-grpcurl-artifact
 
   gobgp_archive:
     needs: classify_changes

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -77,6 +77,7 @@ GRPCURL_SHA256 = "588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc7702
 GRPCURL_ARCHIVE = "grpcurl_1.9.1_linux_x86_64.tar.gz"
 GRPCURL_ARTIFACT = "grpcurl-v1.9.1-linux-x86_64"
 GRPCURL_CACHE_KEY = f"grpcurl-v1.9.1-linux-x86_64-{GRPCURL_SHA256}"
+PREPARE_GRPCURL_ACTION = "uses: ./.github/actions/prepare-grpcurl-artifact"
 GRPCURL_ACTION = "uses: ./.github/actions/install-grpcurl-artifact"
 GNMIC_SHA256 = "a3ded2f355a615df73900f31b9791f41e796e9c5c63b171e1ce041e8139ee00e"
 GNMIC_ARCHIVE = "gnmic_0.46.0_Linux_x86_64.tar.gz"
@@ -126,8 +127,8 @@ PINS = collections.Counter(
         "dtolnay/rust-toolchain@v1 # 1.95": 2,
         "docker/setup-buildx-action@v4": 45,
         "docker/build-push-action@v7": 46,
-        "actions/cache@v6": 7,
-        "actions/upload-artifact@v7": 9,
+        "actions/cache@v6": 6,
+        "actions/upload-artifact@v7": 8,
         "actions/download-artifact@v8": 6,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
@@ -423,16 +424,8 @@ def check(root: Path) -> list[str]:
             "timeout-minutes: 10",
             CHECKOUT,
             "ref: ${{ github.sha }}",
-            "uses: actions/cache@v6",
-            f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{GRPCURL_ARCHIVE}",
-            f"key: {GRPCURL_CACHE_KEY}",
-            "--prepare-archive",
-            f'"$RUNNER_TEMP/grpcurl-cache/{GRPCURL_ARCHIVE}"',
-            "uses: actions/upload-artifact@v7",
-            f"name: {GRPCURL_ARTIFACT}",
-            "if-no-files-found: error",
-            "retention-days: 1",
-            "compression-level: 0",
+            "name: Restore, prepare, and upload exact grpcurl archive",
+            PREPARE_GRPCURL_ACTION,
         ):
             if seam not in grpcurl_producer:
                 errors.append(f"{name}:grpcurl_archive missing {seam}")
@@ -440,25 +433,28 @@ def check(root: Path) -> list[str]:
             "restore-keys:",
             "continue-on-error:",
             "actions/download-artifact@",
+            "actions/cache@",
+            "actions/upload-artifact@",
+            "--prepare-archive",
             "--install-archive",
         ):
             if forbidden in grpcurl_producer:
                 errors.append(f"{name}:grpcurl_archive permits {forbidden}")
-        if grpcurl_producer.count("uses: actions/cache@v6") != 1:
-            errors.append(f"{name}:grpcurl_archive must restore one exact cache")
-        if grpcurl_producer.count("--prepare-archive") != 1:
-            errors.append(f"{name}:grpcurl_archive must prepare one archive")
-        if grpcurl_producer.count("uses: actions/upload-artifact@v7") != 1:
-            errors.append(f"{name}:grpcurl_archive must upload one artifact")
-        exact_path = (
-            f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{GRPCURL_ARCHIVE}"
+        producer_uses = re.findall(
+            r"(?m)^\s*(?:- )?uses:\s*(.+)$", grpcurl_producer
         )
-        if grpcurl_producer.count(exact_path) != 2:
-            errors.append(f"{name}:grpcurl_archive cache/artifact paths drifted")
-        if grpcurl_producer.count(f"key: {GRPCURL_CACHE_KEY}") != 1:
-            errors.append(f"{name}:grpcurl_archive cache key drifted")
-        if grpcurl_producer.count(f"name: {GRPCURL_ARTIFACT}") != 1:
-            errors.append(f"{name}:grpcurl_archive artifact name drifted")
+        if producer_uses != [
+            "actions/checkout@v7",
+            "./.github/actions/prepare-grpcurl-artifact",
+        ]:
+            errors.append(f"{name}:grpcurl_archive action inventory drifted")
+        if grpcurl_producer.count(PREPARE_GRPCURL_ACTION) != 1:
+            errors.append(
+                f"{name}:grpcurl_archive must call one exact producer action"
+            )
+        producer_call_tail = grpcurl_producer.split(PREPARE_GRPCURL_ACTION, 1)[-1]
+        if "with:" in producer_call_tail:
+            errors.append(f"{name}:grpcurl_archive producer call must have no inputs")
         if not setup:
             gnmic_producer = jobs.get("gnmic_archive", "")
             for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
@@ -743,6 +739,9 @@ def check(root: Path) -> list[str]:
     )
     if interop_classifier != kernel_classifier:
         errors.append("heavy workflows must share an identical classifier job")
+    interop_grpcurl = _jobs(texts["interop.yml"]).get("grpcurl_archive", "")
+    if interop_grpcurl != kernel_jobs.get("grpcurl_archive", ""):
+        errors.append("heavy workflows must share an identical grpcurl producer job")
     netns = kernel_jobs.get("netns", "")
     for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
         if not _has_line(netns, f"    {seam}"):
@@ -807,6 +806,9 @@ def check(root: Path) -> list[str]:
     grpcurl_action = (
         root / ".github" / "actions" / "install-grpcurl-artifact" / "action.yml"
     ).read_text()
+    prepare_grpcurl_action = (
+        root / ".github" / "actions" / "prepare-grpcurl-artifact" / "action.yml"
+    ).read_text()
     gnmic_action = (
         root / ".github" / "actions" / "install-gnmic-artifact" / "action.yml"
     ).read_text()
@@ -816,6 +818,50 @@ def check(root: Path) -> list[str]:
     bird3_action = (
         root / ".github" / "actions" / "stage-bird3-artifact" / "action.yml"
     ).read_text()
+    for seam in (
+        'using: "composite"',
+        "uses: actions/cache@v6",
+        f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{GRPCURL_ARCHIVE}",
+        f"key: {GRPCURL_CACHE_KEY}",
+        "shell: bash",
+        "--prepare-archive",
+        f'"$RUNNER_TEMP/grpcurl-cache/{GRPCURL_ARCHIVE}"',
+        "uses: actions/upload-artifact@v7",
+        f"name: {GRPCURL_ARTIFACT}",
+        "if-no-files-found: error",
+        "retention-days: 1",
+        "compression-level: 0",
+    ):
+        if seam not in prepare_grpcurl_action:
+            errors.append(f"prepare-grpcurl-artifact missing {seam}")
+    if prepare_grpcurl_action.count("uses: actions/cache@v6") != 1:
+        errors.append("prepare-grpcurl-artifact must restore one exact cache")
+    if prepare_grpcurl_action.count("--prepare-archive") != 1:
+        errors.append("prepare-grpcurl-artifact must prepare one archive")
+    if prepare_grpcurl_action.count("uses: actions/upload-artifact@v7") != 1:
+        errors.append("prepare-grpcurl-artifact must upload one artifact")
+    exact_grpcurl_path = (
+        f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{GRPCURL_ARCHIVE}"
+    )
+    if prepare_grpcurl_action.count(exact_grpcurl_path) != 2:
+        errors.append("prepare-grpcurl-artifact cache/artifact paths drifted")
+    if prepare_grpcurl_action.count(f"key: {GRPCURL_CACHE_KEY}") != 1:
+        errors.append("prepare-grpcurl-artifact cache key drifted")
+    if prepare_grpcurl_action.count(f"name: {GRPCURL_ARTIFACT}") != 1:
+        errors.append("prepare-grpcurl-artifact artifact name drifted")
+    for forbidden in (
+        "inputs:",
+        "outputs:",
+        "restore-keys:",
+        "continue-on-error:",
+        "actions/download-artifact@",
+        "--install-archive",
+        "releases/download/",
+    ):
+        if forbidden in prepare_grpcurl_action:
+            errors.append(f"prepare-grpcurl-artifact permits {forbidden}")
+    if re.search(r"(?m)^\s*curl\s", prepare_grpcurl_action):
+        errors.append("prepare-grpcurl-artifact permits curl")
     for seam in (
         "uses: actions/download-artifact@v8",
         f"name: {GRPCURL_ARTIFACT}",
@@ -954,7 +1000,13 @@ def check(root: Path) -> list[str]:
     if texts["kernel-dataplane.yml"].count(GNMIC_ACTION) != 0:
         errors.append("kernel-dataplane.yml: gnmic must remain interop-only")
     grpcurl_surfaces = "\n".join(
-        (texts["interop.yml"], texts["kernel-dataplane.yml"], action, grpcurl_action)
+        (
+            texts["interop.yml"],
+            texts["kernel-dataplane.yml"],
+            action,
+            prepare_grpcurl_action,
+            grpcurl_action,
+        )
     )
     if "bash .github/scripts/install-grpcurl.sh" in grpcurl_surfaces:
         errors.append("legacy grpcurl installer invocation remains")
@@ -988,6 +1040,7 @@ def check(root: Path) -> list[str]:
     for text in [
         *texts.values(),
         action,
+        prepare_grpcurl_action,
         grpcurl_action,
         gnmic_action,
         gobgp_action,

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -93,6 +93,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -136,6 +137,7 @@ class PrimerContractTests(unittest.TestCase):
             ".github/workflows",
             ".github/actions/install-gnmic-artifact",
             ".github/actions/install-grpcurl-artifact",
+            ".github/actions/prepare-grpcurl-artifact",
             ".github/actions/setup-dataplane-host",
             ".github/actions/stage-bird3-artifact",
             ".github/actions/stage-gobgp-artifact",
@@ -231,6 +233,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -258,6 +261,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -405,8 +409,6 @@ class PrimerContractTests(unittest.TestCase):
                     )
 
     def test_grpcurl_producers_are_load_bearing(self):
-        archive = "grpcurl_1.9.1_linux_x86_64.tar.gz"
-        checksum = "588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214"
         for workflow in ("interop.yml", "kernel-dataplane.yml"):
             relative = f".github/workflows/{workflow}"
             cases = (
@@ -417,38 +419,86 @@ class PrimerContractTests(unittest.TestCase):
                     "if: false",
                     0,
                 ),
+                (
+                    "name: Prepare exact grpcurl archive",
+                    "name: Prepare approximate grpcurl archive",
+                    0,
+                ),
+                ("runs-on: ubuntu-latest", "runs-on: ubuntu-24.04", 1),
                 ("timeout-minutes: 10", "timeout-minutes: 9", 0),
                 ("ref: ${{ github.sha }}", "ref: main", 0),
-                ("actions/cache@v6", "actions/cache@main", 0),
-                (f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}", "key: grpcurl", 0),
-                ("--prepare-archive", "--install-archive", 0),
-                ("actions/upload-artifact@v7", "actions/upload-artifact@main", 0),
-                ("name: grpcurl-v1.9.1-linux-x86_64", "name: grpcurl-latest", 0),
-                ("if-no-files-found: error", "if-no-files-found: warn", 0),
-                ("retention-days: 1", "retention-days: 30", 0),
-                ("compression-level: 0", "compression-level: 6", 0),
                 (
-                    f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}",
-                    f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}\n          restore-keys: grpcurl-",
+                    "uses: ./.github/actions/prepare-grpcurl-artifact",
+                    "uses: ./.github/actions/install-grpcurl-artifact",
                     0,
                 ),
                 (
-                    "uses: actions/cache@v6",
-                    "uses: actions/cache@v6\n        continue-on-error: true",
+                    "uses: ./.github/actions/prepare-grpcurl-artifact",
+                    "uses: ./.github/actions/prepare-grpcurl-artifact\n"
+                    "        with:\n"
+                    "          mode: permissive",
+                    0,
+                ),
+                (
+                    "uses: ./.github/actions/prepare-grpcurl-artifact",
+                    "uses: ./.github/actions/prepare-grpcurl-artifact\n"
+                    "      - uses: actions/cache@v6",
                     0,
                 ),
             )
             for old, new, occurrence in cases:
                 with self.subTest(workflow=workflow, seam=old, occurrence=occurrence):
                     self.mutate(relative, old, new, occurrence=occurrence)
-            for occurrence in (0, 1):
-                with self.subTest(workflow=workflow, path=occurrence):
-                    self.mutate(
-                        relative,
-                        f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{archive}",
-                        "path: ${{ runner.temp }}/grpcurl-cache/wrong.tar.gz",
-                        occurrence=occurrence,
-                    )
+
+    def test_grpcurl_producer_action_is_load_bearing(self):
+        relative = ".github/actions/prepare-grpcurl-artifact/action.yml"
+        archive = "grpcurl_1.9.1_linux_x86_64.tar.gz"
+        checksum = "588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214"
+        cases = (
+            ('using: "composite"', 'using: "docker"'),
+            ("actions/cache@v6", "actions/cache@main"),
+            (f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}", "key: grpcurl"),
+            ("shell: bash", "shell: sh"),
+            ("--prepare-archive", "--install-archive"),
+            ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
+            ("name: grpcurl-v1.9.1-linux-x86_64", "name: grpcurl-latest"),
+            ("if-no-files-found: error", "if-no-files-found: warn"),
+            ("retention-days: 1", "retention-days: 30"),
+            ("compression-level: 0", "compression-level: 6"),
+            (
+                f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}",
+                f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}\n"
+                "        restore-keys: grpcurl-",
+            ),
+            (
+                "uses: actions/cache@v6",
+                "uses: actions/cache@v6\n      continue-on-error: true",
+            ),
+            (
+                "runs:\n",
+                "inputs:\n  mode:\n    required: false\nruns:\n",
+            ),
+            (
+                "runs:\n",
+                "outputs:\n  archive:\n    value: latest\nruns:\n",
+            ),
+            (
+                ".github/scripts/install-grpcurl.sh \\",
+                "curl https://example.invalid/grpcurl\n"
+                "        .github/scripts/install-grpcurl.sh \\",
+            ),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
+        for occurrence in (0, 1):
+            with self.subTest(path=occurrence):
+                self.mutate(
+                    relative,
+                    f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{archive}",
+                    "path: ${{ runner.temp }}/grpcurl-cache/wrong.tar.gz",
+                    occurrence=occurrence,
+                )
 
     def test_grpcurl_offline_consumer_is_load_bearing(self):
         relative = ".github/actions/install-grpcurl-artifact/action.yml"
@@ -553,7 +603,7 @@ class PrimerContractTests(unittest.TestCase):
         checksum = "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522"
         for workflow in ("interop.yml", "kernel-dataplane.yml"):
             relative = f".github/workflows/{workflow}"
-            producer_occurrence = 2 if workflow == "interop.yml" else 1
+            producer_occurrence = 1 if workflow == "interop.yml" else 0
             for old, new in (
                 ("  gobgp_archive:\n", "  removed_gobgp_archive:\n"),
                 (f"key: gobgp-v3.37.0-linux-amd64-{checksum}", "key: gobgp-latest"),
@@ -666,7 +716,7 @@ class PrimerContractTests(unittest.TestCase):
             ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
         ):
             with self.subTest(seam=f"bird3 producer {seam}"):
-                self.mutate(relative, seam, replacement, occurrence=2)
+                self.mutate(relative, seam, replacement, occurrence=1)
         exact_path = (
             "path: ${{ runner.temp }}/bird3-cache/bird-3.3.1.tar.gz"
         )
@@ -733,6 +783,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -766,6 +817,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -799,6 +851,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",


### PR DESCRIPTION
## Summary

- centralize the identical grpcurl archive cache, preparation, and upload steps in one repository-owned composite action
- preserve both producer job envelopes, workflow-selection gates, exact artifact pins, and every downstream consumer
- extend both CI contracts so producer-action drift fails loudly in either workflow

## Scope

The composite action has no inputs or outputs. Interoperability and kernel workflow triggers, permissions, concurrency, job names, needs, conditions, runners, timeouts, checkout refs, image primers, GoBGP preparation, consumers, and aggregate jobs remain unchanged. The existing installer self-test now verifies one composite producer per workflow and one prepare invocation inside that producer.

## Validation

- `bash .github/scripts/install-grpcurl.sh --self-test`
- `PYTHONPATH=. python3 scripts/test_check_ci_image_primer_contract.py` (36 tests)
- `python3 scripts/check_ci_image_primer_contract.py`
- `PYTHONPATH=. python3 scripts/test_check_ci_scale_split_contract.py` (5 tests)
- `python3 scripts/check_ci_scale_split_contract.py`
- PyYAML parse of both workflows and the composite action
- `actionlint`
- exact producer-payload and workflow-envelope equivalence proof
- pre-commit and pre-push hooks
