### PR TITLE
docs: shorten cookbook audience clauses

### DIFF
--- a/docs/cookbook/evpn-fabric-rr.md
+++ b/docs/cookbook/evpn-fabric-rr.md
@@ -2,14 +2,14 @@
 
 This recipe builds a control-plane-only VXLAN-EVPN fabric route reflector.
 
-**When this is you:** a VXLAN-EVPN leaf/spine fabric where the VTEPs
-(FRR, SR Linux, GoBGP, or rustbgpd leaves) do the dataplane and you
-want a lean, API-first reflector distributing the RFC 7432 routes
-between them. Scope, stated up front: **this recipe is the RR role.**
-The RR holds no EVI state, learns no MACs, and forwards no packets —
-it reflects all five EVPN route types verbatim between clients.
-rustbgpd also has a bidirectional VTEP mode (alpha, Linux/VXLAN-only,
-with IRB and multi-homing — see
+**When this is you:** You operate a VXLAN-EVPN leaf/spine fabric. Its
+VTEPs (FRR, SR Linux, GoBGP, or rustbgpd leaves) do the dataplane, and
+you want a lean, API-first reflector distributing the RFC 7432 routes
+between them. Scope, stated up front: **this recipe is the RR role.** The
+RR holds no EVI state, learns no MACs, and forwards no packets — it
+reflects all five EVPN route types verbatim between clients. rustbgpd
+also has a bidirectional VTEP mode (alpha, Linux/VXLAN-only, with IRB
+and multi-homing — see
 [`evpn-enablement.md`](../evpn-enablement.md)); that is a different
 deployment and not this document.
 

--- a/docs/cookbook/l3vpn-route-reflector.md
+++ b/docs/cookbook/l3vpn-route-reflector.md
@@ -2,12 +2,12 @@
 
 This recipe builds a control-plane-only VPNv4/VPNv6 route reflector.
 
-**When this is you:** you have a PE fleet exchanging VPNv4/VPNv6
-routes (SAFI 128) and want the reflector out of the vendor-appliance
-business — reflect with RD, MPLS label stack, next-hop, and Route
-Targets preserved verbatim, and only send each PE the routes whose RTs
-it actually imports (RFC 4684 RT-Constrain). Scope honesty up front:
-this is the **route-reflector / controller-feed slice only**
+**When this is you:** Your PE fleet exchanges VPNv4/VPNv6 routes.
+These use SAFI 128, and you want the reflector out of the
+vendor-appliance business — reflect with RD, MPLS label stack, next-hop,
+and Route Targets preserved verbatim, and only send each PE the routes
+whose RTs it actually imports (RFC 4684 RT-Constrain). Scope honesty up
+front: this is the **route-reflector / controller-feed slice only**
 ([ADR-0077](../adr/0077-mpls-vpn-bgpls-address-family-boundary.md)).
 rustbgpd does no VRF import, no MPLS label forwarding, no CE-facing
 attachment circuits — the PEs keep their dataplane; the RR moves

--- a/docs/cookbook/manrs-ixp-action1.md
+++ b/docs/cookbook/manrs-ixp-action1.md
@@ -2,10 +2,10 @@
 
 Map rustbgpd controls to MANRS IXP Programme Action 1.
 
-**When this is you:** your exchange participates in (or is applying to)
-the MANRS IXP Programme and you need to show, control by control, how a
-rustbgpd route server implements Action 1 — and how members can verify
-each control from the outside.
+**When this is you:** Your exchange participates in or is applying to the
+MANRS IXP Programme. You need to show, control by control, how a rustbgpd
+route server implements Action 1 — and how members can verify each control
+from the outside.
 
 The normative source is
 [MANRS-004.01, "MANRS Actions for IXP Program"](https://manrs.org/specifications/MANRS-004/01/).

--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -2,13 +2,14 @@
 
 Export routing state to your monitoring stack.
 
-**When this is you:** a controller, analytics pipeline, or NOC stack
-needs to see what this daemon sees — pre-policy, post-policy, and
-Loc-RIB route streams into BMP collectors, a durable event feed your
-bridge can replay after a restart, periodic MRT table archives, and a
-Grafana dashboard on top. rustbgpd exports the full BMP monitoring
-trio on one exporter (RFC 7854 Adj-RIB-In, RFC 8671 Adj-RIB-Out as
-byte-exact wire PDUs, RFC 9069 Loc-RIB), selectable per collector.
+**When this is you:** Your controller, analytics pipeline, or NOC needs
+routing state. It needs to see what this daemon sees — pre-policy,
+post-policy, and Loc-RIB route streams into BMP collectors, a durable
+event feed your bridge can replay after a restart, periodic MRT table
+archives, and a Grafana dashboard on top. rustbgpd exports the full BMP
+monitoring trio on one exporter (RFC 7854 Adj-RIB-In, RFC 8671
+Adj-RIB-Out as byte-exact wire PDUs, RFC 9069 Loc-RIB), selectable per
+collector.
 
 **Proven by:** [M24](../RECEIPTS.md#interop-labs--pr-gated-interopyml)
 (BMP Initiation / PeerUp / RouteMonitoring ordering vs a BMP receiver)

--- a/docs/cookbook/paired-route-servers.md
+++ b/docs/cookbook/paired-route-servers.md
@@ -2,11 +2,11 @@
 
 Operate a resilient pair of IXP route servers.
 
-**When this is you:** your exchange runs (or should run) two route
-servers, every member peers with both, and you want the operational
-discipline that makes the pair actually redundant: independent
-instances, staggered config rollout, a mechanical inter-RS consistency
-check, and a drain flow for maintenance.
+**When this is you:** Your exchange runs or should run two route servers.
+Every member peers with both, and you want the operational discipline
+that makes the pair actually redundant: independent instances,
+staggered config rollout, a mechanical inter-RS consistency check, and a
+drain flow for maintenance.
 
 ## Why two, and why members peer with both
 

--- a/docs/cookbook/peer-flap-triage.md
+++ b/docs/cookbook/peer-flap-triage.md
@@ -2,9 +2,9 @@
 
 Diagnose a BGP session that keeps flapping.
 
-**When this is you:** a session keeps cycling in and out of Established
-— the `BgpSessionFlapping` alert fired, or a client noticed churn.
-Work top to bottom; each step narrows the cause.
+**When this is you:** A session keeps cycling in and out of Established.
+The `BgpSessionFlapping` alert fired, or a client noticed churn. Work top
+to bottom; each step narrows the cause.
 
 ## 1. Confirm and size the flap
 

--- a/docs/cookbook/policy-quickstart.md
+++ b/docs/cookbook/policy-quickstart.md
@@ -2,12 +2,12 @@
 
 Build and validate your first rustbgpd routing policy.
 
-**When this is you:** you're about to write your first real routing
-policy on rustbgpd and want the workflow that keeps it honest — a
-typed, compiled policy file with its unit tests *in the file*, checked
-before it ever touches the daemon, dry-run against the live RIB before
-it's attached, hot-swapped under traffic with SIGHUP, and explainable
-per term afterwards. Full language reference:
+**When this is you:** You're about to write your first real rustbgpd
+routing policy. You want the workflow that keeps it honest — a typed,
+compiled policy file with its unit tests *in the file*, checked before
+it ever touches the daemon, dry-run against the live RIB before it's
+attached, hot-swapped under traffic with SIGHUP, and explainable per
+term afterwards. Full language reference:
 [`rpol-language.md`](../rpol-language.md)
 ([ADR-0096](../adr/0096-policy-language.md)).
 

--- a/docs/cookbook/route-reflector.md
+++ b/docs/cookbook/route-reflector.md
@@ -2,13 +2,13 @@
 
 Replace an iBGP full mesh with a dedicated route reflector.
 
-**When this is you:** you run (or are about to run) an iBGP full mesh
-that no longer scales, and you want a dedicated route reflector —
-tens to a thousand clients, fast convergence without per-peer tuning,
-stale-route protection across client restarts, and per-client optimal
-paths if your clients sit in different corners of the IGP. rustbgpd's
-RR path needs no fanout configuration: peers whose staged output is
-provably identical share one update group automatically.
+**When this is you:** Your current or planned iBGP full mesh no longer
+scales. You want a dedicated route reflector — tens to a thousand
+clients, fast convergence without per-peer tuning, stale-route
+protection across client restarts, and per-client optimal paths if your
+clients sit in different corners of the IGP. rustbgpd's RR path needs no
+fanout configuration: peers whose staged output is provably identical
+share one update group automatically.
 
 **Proven by:** [M14](../RECEIPTS.md#interop-labs--pr-gated-interopyml)
 (RFC 4456 reflection vs FRR), M76 (RFC 9107 Optimal Route Reflection),

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -2,14 +2,14 @@
 
 This recipe builds an IXP route server for transparent member route exchange.
 
-**When this is you:** you run (or are about to run) an Internet-exchange
-route server — one BGP speaker that redistributes routes among member
-networks so they don't need a full mesh of bilateral sessions. You want
-transparent redistribution (the members' own NEXT_HOP and AS_PATH, not
-yours), RPKI origin validation and import hygiene at the door, RFC 9234
-roles so a member can't leak transit back through the fabric, and a path
-that doesn't hide a prefix from a member just because that member's own
-policy rejected the single best path.
+**When this is you:** You run or plan an Internet-exchange route server.
+It is one BGP speaker that redistributes routes among member networks so
+they don't need a full mesh of bilateral sessions. You want transparent
+redistribution (the members' own NEXT_HOP and AS_PATH, not yours), RPKI
+origin validation and import hygiene at the door, RFC 9234 roles so a
+member can't leak transit back through the fabric, and a path that
+doesn't hide a prefix from a member just because that member's own policy
+rejected the single best path.
 
 **Proven by:**
 [M83](../RECEIPTS.md#interop-labs--pr-gated-interopyml) (RFC 7947

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -2,7 +2,7 @@
 
 This recipe builds an IXP route server for transparent member route exchange.
 
-**When this is you:** You run or plan an Internet-exchange route server.
+**When this is you:** You run or plan to run an Internet-exchange route server.
 It is one BGP speaker that redistributes routes among member networks so
 they don't need a full mesh of bilateral sessions. You want transparent
 redistribution (the members' own NEXT_HOP and AS_PATH, not yours), RPKI

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -2,10 +2,11 @@
 
 Operate a production route-reflector pair safely.
 
-**When this is you:** a redundant route-reflector pair (per
-[route-reflector.md](route-reflector.md)) is in production and you need
-to make routine changes without dropping the fleet. Rule of thumb for
-every task below: change one RR, verify, then the other.
+**When this is you:** Your redundant route-reflector pair is in
+production. It follows the
+[route-reflector recipe](route-reflector.md), and you need to make
+routine changes without dropping the fleet. Rule of thumb for every task
+below: change one RR, verify, then the other.
 
 ## GR settings sanity
 


### PR DESCRIPTION
## Summary

- split the ten remaining long cookbook audience clauses into short standalone first sentences
- preserve each recipe's detailed audience, scope, links, technical claims, and proof references
- complete the literal `When this is you` boundary from the rbgp.rs ingestion audit without changing site code

## Canonical ingest audit

- 26/26 generated page descriptions remain 27–80 characters
- all 229 ingested H2 headings remain at most 45 characters
- all ten literal cookbook audience clauses now terminate within 43–72 visible characters
- removing each edited audience paragraph leaves the rest of its source file byte-identical to the base

## Validation

- `PYTHONPATH=. python3 scripts/test_check_metric_consumers.py` (27 tests) and live checker
- `PYTHONPATH=. python3 scripts/test_check_public_tracker_ids.py` (18 tests) and live checker
- `PYTHONPATH=. python3 scripts/test_check_ixp_manager_docs.py` (16 tests) and live checker
- `PYTHONPATH=. python3 scripts/test_check_release_checklist_paths.py` (9 tests) and live checker
- canonical `lance0/rbgp.rs` 26-file ingestion audit
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-commit and pre-push hooks
