### PR TITLE
refactor(rib): bundle unicast distribution outputs

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -48,6 +48,29 @@ mod vpn;
 
 pub(in crate::manager) use export_memo::ExportMemo;
 
+/// Owned output channels produced by one or more unicast distribution walks.
+///
+/// Keeping the route, withdrawal, next-hop, and policy-filtered channels in
+/// one value makes their association explicit while allowing callers to
+/// retain and reuse the same backing vectors across a complete staging pass.
+pub(in crate::manager) struct UnicastDistributionResult<P = PolicyFilteredRouteKey> {
+    pub(in crate::manager) announce: Vec<crate::route::Route>,
+    pub(in crate::manager) withdraw: Vec<(Prefix, u32)>,
+    pub(in crate::manager) next_hop_override: Vec<Option<rustbgpd_policy::NextHopAction>>,
+    pub(in crate::manager) policy_filtered: Vec<P>,
+}
+
+impl<P> Default for UnicastDistributionResult<P> {
+    fn default() -> Self {
+        Self {
+            announce: Vec::new(),
+            withdraw: Vec::new(),
+            next_hop_override: Vec::new(),
+            policy_filtered: Vec::new(),
+        }
+    }
+}
+
 /// Maximum wire-equivalence cohorts retained for one update group.
 ///
 /// Eight covers the small set of negotiated/profile variants expected inside
@@ -4655,9 +4678,7 @@ impl RibManager {
 
             #[cfg(feature = "bench-internals")]
             let bench_staging_started = bench_per_client_best_resync.then(std::time::Instant::now);
-            let mut announce = Vec::new();
-            let mut withdraw = Vec::new();
-            let mut nh_override_flags: Vec<Option<rustbgpd_policy::NextHopAction>> = Vec::new();
+            let mut unicast = UnicastDistributionResult::default();
             // Set for an in-sync grouped member covered by the group's
             // pre-built shared emission: the announce payload is an Arc
             // clone shared across members, not a per-member Vec build.
@@ -4714,9 +4735,9 @@ impl RibManager {
                             self.pending_extra_withdraws
                                 .get(&peer)
                                 .map(|extras| &extras.unicast),
-                            &mut announce,
-                            &mut withdraw,
-                            &mut nh_override_flags,
+                            &mut unicast.announce,
+                            &mut unicast.withdraw,
+                            &mut unicast.next_hop_override,
                         );
                         // VPN portion of the resync, from the group's VPN
                         // maps under the member's Φ; the per-peer VPN
@@ -4755,15 +4776,15 @@ impl RibManager {
                             // the shared emission — enqueue Arc clones.
                             shared_unicast =
                                 Some((stage.shared_announce.clone(), stage.shared_nh.clone()));
-                            withdraw.extend_from_slice(&stage.shared_withdraw);
+                            unicast.withdraw.extend_from_slice(&stage.shared_withdraw);
                         } else {
                             super::update_groups::emit_group_deltas_for_member(
                                 &stage.deltas,
                                 peer,
                                 rs_control,
-                                &mut announce,
-                                &mut withdraw,
-                                &mut nh_override_flags,
+                                &mut unicast.announce,
+                                &mut unicast.withdraw,
+                                &mut unicast.next_hop_override,
                             );
                             // ADR-0126 Decision 5 lane arm: a
                             // member-scoped emission toward the ONE
@@ -4775,17 +4796,17 @@ impl RibManager {
                                 &stage.lane_deltas,
                                 peer,
                                 rs_control,
-                                &mut announce,
-                                &mut withdraw,
-                                &mut nh_override_flags,
+                                &mut unicast.announce,
+                                &mut unicast.withdraw,
+                                &mut unicast.next_hop_override,
                             );
                             super::update_groups::emit_rs_tag_transitions(
                                 &stage.rs_transitions,
                                 peer,
                                 rs_control,
-                                &mut announce,
-                                &mut withdraw,
-                                &mut nh_override_flags,
+                                &mut unicast.announce,
+                                &mut unicast.withdraw,
+                                &mut unicast.next_hop_override,
                             );
                         }
                     }
@@ -4910,7 +4931,6 @@ impl RibManager {
                 };
                 if prefix_send_max > 0 {
                     // Multi-path: collect all candidates, filter, sort, diff
-                    let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
                         &self.unicast_prefix_peers,
@@ -4936,13 +4956,11 @@ impl RibManager {
                         &metrics,
                         policy_stats,
                         &target_peer_label,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         is_force,
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else if per_client_best {
                     // RFC 7947 §2.3.2 per-client best-path: the first
                     // export-policy-permitted candidate from the
@@ -4954,7 +4972,6 @@ impl RibManager {
                     // while per_client_best requires an eBGP
                     // route-server client (validation-enforced).
                     debug_assert!(orr_ctx.is_none(), "ORR vantage on a per-client-best peer");
-                    let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
                         &self.unicast_prefix_peers,
@@ -4980,16 +4997,13 @@ impl RibManager {
                         &metrics,
                         policy_stats,
                         &target_peer_label,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         is_force,
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else if let Some((orr_topology, orr_spf)) = orr_ctx {
                     // ORR peer with a resolved vantage: per-vantage best.
-                    let mut policy_filtered = Vec::new();
                     Self::distribute_orr_best_prefix(
                         &self.ribs,
                         &self.unicast_prefix_peers,
@@ -5013,15 +5027,12 @@ impl RibManager {
                         &metrics,
                         policy_stats,
                         &target_peer_label,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         is_force,
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else {
-                    let mut policy_filtered = Vec::new();
                     let mut target = ExportTarget::Peer {
                         peer,
                         peer_asn: target_peer_asn,
@@ -5046,13 +5057,11 @@ impl RibManager {
                         export_pol.as_ref(),
                         orf,
                         &mut export_memo,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         is_force,
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 }
             }
 
@@ -5242,14 +5251,19 @@ impl RibManager {
                 && member_of.is_none()
                 && let Some(extras) = self.pending_extra_withdraws.get(&peer)
             {
-                let announced: HashSet<(Prefix, u32)> =
-                    announce.iter().map(|r| (r.prefix, r.path_id)).collect();
-                let staged: HashSet<(Prefix, u32)> = withdraw.iter().copied().collect();
-                withdraw.extend(extras.unicast.iter().copied().filter(|key| {
-                    !announced.contains(key)
-                        && !staged.contains(key)
-                        && rib_out.get(&key.0, key.1).is_none()
-                }));
+                let announced: HashSet<(Prefix, u32)> = unicast
+                    .announce
+                    .iter()
+                    .map(|r| (r.prefix, r.path_id))
+                    .collect();
+                let staged: HashSet<(Prefix, u32)> = unicast.withdraw.iter().copied().collect();
+                unicast
+                    .withdraw
+                    .extend(extras.unicast.iter().copied().filter(|key| {
+                        !announced.contains(key)
+                            && !staged.contains(key)
+                            && rib_out.get(&key.0, key.1).is_none()
+                    }));
                 let vpn_announced: HashSet<rustbgpd_wire::VpnRouteKey> =
                     vpn_announce.iter().map(|r| r.nlri.key()).collect();
                 let vpn_staged: HashSet<rustbgpd_wire::VpnRouteKey> =
@@ -5288,17 +5302,18 @@ impl RibManager {
             // member never stages per-peer unicast (grouped + in-sync),
             // so the locals are empty by construction when it is taken.
             debug_assert!(
-                shared_unicast.is_none() || (announce.is_empty() && nh_override_flags.is_empty()),
+                shared_unicast.is_none()
+                    || (unicast.announce.is_empty() && unicast.next_hop_override.is_empty()),
                 "shared group payload must not coexist with per-peer staged unicast"
             );
             let shared_unicast_cache_group = shared_unicast.as_ref().and(member_of);
             let (announce, nh_override_flags): super::update_groups::SharedUnicastPayload =
                 match shared_unicast {
                     Some(shared) => shared,
-                    None => (announce.into(), nh_override_flags.into()),
+                    None => (unicast.announce.into(), unicast.next_hop_override.into()),
                 };
             if !announce.is_empty()
-                || !withdraw.is_empty()
+                || !unicast.withdraw.is_empty()
                 || !fs_announce.is_empty()
                 || !fs_withdraw.is_empty()
                 || !evpn_announce.is_empty()
@@ -5337,7 +5352,7 @@ impl RibManager {
                     vec![]
                 };
                 let announced_count = announce.len();
-                let withdrawn_count = withdraw.len();
+                let withdrawn_count = unicast.withdraw.len();
                 let has_non_unicast_route_payload = !fs_announce.is_empty()
                     || !fs_withdraw.is_empty()
                     || !evpn_announce.is_empty()
@@ -5450,7 +5465,7 @@ impl RibManager {
                     OutboundCommitBatch {
                         next_hop_override: nh_override_flags,
                         announce,
-                        withdraw,
+                        withdraw: unicast.withdraw,
                         end_of_rib: pending_eor.clone(),
                         flowspec_announce: fs_announce,
                         flowspec_withdraw: fs_withdraw,

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -5,10 +5,11 @@ use super::{
     AdjRibIn, AdjRibOut, Afi, Arc, BgpMetrics, ExplainAdvertisedRoute, ExplainDecision,
     ExplainReason, HashMap, HashSet, IpAddr, Ipv4Addr, LOCAL_PEER, LocRib, NeighborPolicyStats,
     PolicyAction, PolicyChain, PolicyFilteredRouteKey, Prefix, RibCommandError, RibManager,
-    RouteContext, Safi, UnicastPrefixPeers, VrpTable, debug, evaluate_chain_with_attribution,
-    family_label, gauge_val, policy_label_with_term, prefix_family, record_export_policy_eval,
-    route_type, route_type_label, route_type_message, routes_equal, rr_suppression_reason,
-    should_suppress_ibgp_inner, unicast_route_family, validate_route_aspa, validate_route_rpki,
+    RouteContext, Safi, UnicastDistributionResult, UnicastPrefixPeers, VrpTable, debug,
+    evaluate_chain_with_attribution, family_label, gauge_val, policy_label_with_term,
+    prefix_family, record_export_policy_eval, route_type, route_type_label, route_type_message,
+    routes_equal, rr_suppression_reason, should_suppress_ibgp_inner, unicast_route_family,
+    validate_route_aspa, validate_route_rpki,
 };
 
 /// Gate code and message for an export-policy deny.
@@ -1448,10 +1449,7 @@ impl RibManager {
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
         target_peer_label: &str,
-        announce: &mut Vec<crate::route::Route>,
-        withdraw: &mut Vec<(Prefix, u32)>,
-        nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
-        policy_filtered: &mut Vec<PolicyFilteredRouteKey>,
+        out: &mut UnicastDistributionResult,
         force: bool,
     ) {
         use crate::best_path::{best_path_cmp, best_path_cmp_orr};
@@ -1464,7 +1462,7 @@ impl RibManager {
         if !sendable.is_some_and(|f| f.contains(&family)) {
             // Withdraw all previously advertised paths for this prefix
             for path_id in rib_out.path_ids_for_prefix(prefix) {
-                withdraw.push((*prefix, path_id));
+                out.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -1473,7 +1471,7 @@ impl RibManager {
         // path-ids — gate the whole prefix once, before collecting candidates.
         if orf_filter.is_some_and(|f| !f.permits(prefix)) {
             for path_id in rib_out.path_ids_for_prefix(prefix) {
-                withdraw.push((*prefix, path_id));
+                out.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -1563,7 +1561,7 @@ impl RibManager {
             let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
             record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
             if result.action != PolicyAction::Permit {
-                policy_filtered.push(PolicyFilteredRouteKey {
+                out.policy_filtered.push(PolicyFilteredRouteKey {
                     target_peer,
                     source_peer: candidate.peer,
                     prefix: *prefix,
@@ -1581,7 +1579,7 @@ impl RibManager {
                 // by policy, so surface it through the same policy-filtered
                 // accounting as the deny arm above (export explain already
                 // covers this seam; live observability must too).
-                policy_filtered.push(PolicyFilteredRouteKey {
+                out.policy_filtered.push(PolicyFilteredRouteKey {
                     target_peer,
                     source_peer: candidate.peer,
                     prefix: *prefix,
@@ -1610,8 +1608,8 @@ impl RibManager {
                     .get(prefix, modified.path_id)
                     .is_none_or(|existing| !routes_equal(existing, &modified));
             if changed {
-                nh_override_flags.push(nh_action);
-                announce.push(modified);
+                out.next_hop_override.push(nh_action);
+                out.announce.push(modified);
             }
 
             next_rank += 1;
@@ -1626,14 +1624,14 @@ impl RibManager {
             let staged_winner = next_rank > 1;
             for path_id in rib_out.path_ids_for_prefix(prefix) {
                 if path_id != 0 || !staged_winner {
-                    withdraw.push((*prefix, path_id));
+                    out.withdraw.push((*prefix, path_id));
                 }
             }
         } else {
             // Withdraw any previously advertised path_ids beyond the new set
             for path_id in rib_out.path_ids_for_prefix(prefix) {
                 if path_id >= next_rank {
-                    withdraw.push((*prefix, path_id));
+                    out.withdraw.push((*prefix, path_id));
                 }
             }
         }
@@ -1701,10 +1699,7 @@ impl RibManager {
         export_pol: Option<&PolicyChain>,
         memo: &mut super::ExportMemo,
         evals: &mut GroupEvalAccumulator,
-        announce: &mut Vec<crate::route::Route>,
-        withdraw: &mut Vec<(Prefix, u32)>,
-        nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
-        policy_filtered: &mut Vec<(PolicyFilteredRouteKey, Option<PolicyLabel>)>,
+        out: &mut UnicastDistributionResult<(PolicyFilteredRouteKey, Option<PolicyLabel>)>,
         otc_blocked: &mut Vec<crate::route::Route>,
     ) -> PerClientBestPrefixStage {
         use crate::best_path::best_path_cmp;
@@ -1716,7 +1711,7 @@ impl RibManager {
         };
         if !sendable.is_some_and(|f| f.contains(&family)) {
             for path_id in rib_out.path_ids_for_prefix(prefix) {
-                withdraw.push((*prefix, path_id));
+                out.withdraw.push((*prefix, path_id));
             }
             return stage;
         }
@@ -1785,7 +1780,7 @@ impl RibManager {
                 path_id: candidate.path_id,
             };
             if result.action != PolicyAction::Permit {
-                policy_filtered.push((filtered_key, label));
+                out.policy_filtered.push((filtered_key, label));
                 continue;
             }
             let (mut modified, nh_action) = memo.apply(candidate, &result.modifications);
@@ -1793,7 +1788,7 @@ impl RibManager {
                 // Policy-added NO_ADVERTISE is a policy suppression —
                 // same accounting as the deny arm, matching the
                 // per-peer multipath body.
-                policy_filtered.push((filtered_key, label));
+                out.policy_filtered.push((filtered_key, label));
                 continue;
             }
             modified.path_id = 0;
@@ -1828,8 +1823,8 @@ impl RibManager {
                 .get(prefix, 0)
                 .is_none_or(|existing| !routes_equal(existing, &modified));
             if changed {
-                nh_override_flags.push(nh_action);
-                announce.push(modified);
+                out.next_hop_override.push(nh_action);
+                out.announce.push(modified);
             }
         }
 
@@ -1840,7 +1835,7 @@ impl RibManager {
         let staged_winner = winner_source.is_some();
         for path_id in rib_out.path_ids_for_prefix(prefix) {
             if path_id != 0 || !staged_winner {
-                withdraw.push((*prefix, path_id));
+                out.withdraw.push((*prefix, path_id));
             }
         }
         stage
@@ -1874,10 +1869,7 @@ impl RibManager {
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
         memo: &mut super::ExportMemo,
-        announce: &mut Vec<crate::route::Route>,
-        withdraw: &mut Vec<(Prefix, u32)>,
-        nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
-        policy_filtered: &mut Vec<PolicyFilteredRouteKey>,
+        result: &mut UnicastDistributionResult,
         force: bool,
     ) {
         use crate::update::ExportGateVerdict::{NotApplicable, Pass, Stop};
@@ -1889,7 +1881,7 @@ impl RibManager {
                 "no best route exists for this prefix".to_string()
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         };
@@ -1917,7 +1909,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -1944,7 +1936,7 @@ impl RibManager {
                 trace.push("rr_reflection", code, Stop, detail.to_string());
             }
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -1959,7 +1951,7 @@ impl RibManager {
                 format!("peer cannot receive {} routes", family_label(family))
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -1982,7 +1974,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2010,7 +2002,7 @@ impl RibManager {
                         .to_string()
                 });
                 for &path_id in &existing_path_ids {
-                    withdraw.push((*prefix, path_id));
+                    result.withdraw.push((*prefix, path_id));
                 }
                 return;
             }
@@ -2033,7 +2025,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2049,7 +2041,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2075,7 +2067,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2110,7 +2102,7 @@ impl RibManager {
             local_pref: best.local_pref_attr(),
             med: best.med_attr(),
         };
-        let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+        let (policy_result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
         target.record_eval(&evaluation, best.peer);
         if let Some(trace) = target.trace() {
             // Enrich the deciding chain member with the rpol term name
@@ -2121,7 +2113,7 @@ impl RibManager {
                 policy_label_with_term(Some(chain), &ctx, evaluation.matched_policy.as_deref())
             });
         }
-        if result.action != PolicyAction::Permit {
+        if policy_result.action != PolicyAction::Permit {
             if let Some(trace) = target.trace() {
                 let label = trace.policy_label.clone().unwrap_or_default();
                 let (code, message) =
@@ -2133,14 +2125,14 @@ impl RibManager {
                     message,
                 );
             }
-            policy_filtered.push(PolicyFilteredRouteKey {
+            result.policy_filtered.push(PolicyFilteredRouteKey {
                 target_peer: target.policy_filtered_target(),
                 source_peer: best.peer,
                 prefix: *prefix,
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2149,7 +2141,7 @@ impl RibManager {
             // denied route carries no modifications (mirrors the
             // per-client-best arm, which sets `explain.modifications`
             // after its own deny early-return).
-            trace.modifications = result.modifications.clone();
+            trace.modifications = policy_result.modifications.clone();
             match trace.policy_label.clone() {
                 Some(label) => trace.push(
                     "export_policy",
@@ -2171,7 +2163,7 @@ impl RibManager {
         // (route, peer) with the same source attribute set and equal
         // modifications; no-modification exports keep sharing the
         // source Arc as before.
-        let (mut modified, nh_action) = memo.apply(best, &result.modifications);
+        let (mut modified, nh_action) = memo.apply(best, &policy_result.modifications);
         modified.path_id = 0;
 
         // Export policy may add NO_ADVERTISE to an otherwise eligible
@@ -2191,14 +2183,14 @@ impl RibManager {
             // Policy-added NO_ADVERTISE is a policy suppression: surface it
             // through the same policy-filtered accounting as the deny arm
             // above, matching the multipath body.
-            policy_filtered.push(PolicyFilteredRouteKey {
+            result.policy_filtered.push(PolicyFilteredRouteKey {
                 target_peer: target.policy_filtered_target(),
                 source_peer: best.peer,
                 prefix: *prefix,
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2231,7 +2223,7 @@ impl RibManager {
             });
             target.record_otc_blocked(modified);
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2295,15 +2287,15 @@ impl RibManager {
             }
         }
         if changed {
-            nh_override_flags.push(nh_action);
-            announce.push(modified);
+            result.next_hop_override.push(nh_action);
+            result.announce.push(modified);
         }
 
         // Clean up any stale multi-path entries if this prefix was previously
         // advertised via Add-Path and is now single-best.
         for &path_id in &existing_path_ids {
             if path_id != 0 {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
         }
     }
@@ -2355,10 +2347,7 @@ impl RibManager {
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
         target_peer_label: &str,
-        announce: &mut Vec<crate::route::Route>,
-        withdraw: &mut Vec<(Prefix, u32)>,
-        nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
-        policy_filtered: &mut Vec<PolicyFilteredRouteKey>,
+        result: &mut UnicastDistributionResult,
         force: bool,
     ) {
         use crate::best_path::best_path_cmp_orr;
@@ -2369,7 +2358,7 @@ impl RibManager {
         let family = prefix_family(prefix);
         if !sendable.is_some_and(|f| f.contains(&family)) {
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2378,7 +2367,7 @@ impl RibManager {
         // policy denial — see `distribute_single_best_prefix`.
         if orf_filter.is_some_and(|f| !f.permits(prefix)) {
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2409,7 +2398,7 @@ impl RibManager {
             )
         }) else {
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         };
@@ -2426,7 +2415,7 @@ impl RibManager {
             llgr,
         ) {
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2436,7 +2425,7 @@ impl RibManager {
         // runner-up merely because the selected best is NO_ADVERTISE.
         if super::no_advertise_export_suppressed(best.communities()) {
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2445,7 +2434,7 @@ impl RibManager {
         if super::no_export_export_suppressed(best.communities(), target_is_ebgp, interpret_rfc1997)
         {
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2477,17 +2466,17 @@ impl RibManager {
             local_pref: best.local_pref_attr(),
             med: best.med_attr(),
         };
-        let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
+        let (policy_result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
         record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
-        if result.action != PolicyAction::Permit {
-            policy_filtered.push(PolicyFilteredRouteKey {
+        if policy_result.action != PolicyAction::Permit {
+            result.policy_filtered.push(PolicyFilteredRouteKey {
                 target_peer,
                 source_peer: best.peer,
                 prefix: *prefix,
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2499,21 +2488,21 @@ impl RibManager {
         // winner memo the doc comment above rejects — the key here is
         // (source attribute identity, modifications value), which is
         // independent of which candidate won.
-        let (mut modified, nh_action) = memo.apply(best, &result.modifications);
+        let (mut modified, nh_action) = memo.apply(best, &policy_result.modifications);
         modified.path_id = 0;
 
         if super::no_advertise_export_suppressed(modified.communities()) {
             // Policy-added NO_ADVERTISE is a policy suppression: record the
             // policy-filtered entry, matching the multipath and single-best
             // bodies.
-            policy_filtered.push(PolicyFilteredRouteKey {
+            result.policy_filtered.push(PolicyFilteredRouteKey {
                 target_peer,
                 source_peer: best.peer,
                 prefix: *prefix,
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
             return;
         }
@@ -2524,15 +2513,15 @@ impl RibManager {
                 .get(prefix, 0)
                 .is_none_or(|existing| !routes_equal(existing, &modified));
         if changed {
-            nh_override_flags.push(nh_action);
-            announce.push(modified);
+            result.next_hop_override.push(nh_action);
+            result.announce.push(modified);
         }
 
         // Clean up any stale multi-path entries if this prefix was
         // previously advertised via Add-Path and is now single-best.
         for &path_id in &existing_path_ids {
             if path_id != 0 {
-                withdraw.push((*prefix, path_id));
+                result.withdraw.push((*prefix, path_id));
             }
         }
     }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1131,9 +1131,7 @@ impl RibManager {
         reason = "initial dump stages every family queue before one Adj-RIB-Out commit"
     )]
     pub(super) fn send_initial_table(&mut self, peer: IpAddr) {
-        let mut announce = Vec::new();
-        let mut withdraw = Vec::new();
-        let mut nh_override_flags: Vec<Option<rustbgpd_policy::NextHopAction>> = Vec::new();
+        let mut unicast = super::distribution::UnicastDistributionResult::default();
         let mut fs_announce = Vec::new();
         let mut fs_withdraw = Vec::new();
         let mut evpn_announce = Vec::new();
@@ -1255,14 +1253,14 @@ impl RibManager {
                 ) {
                     continue;
                 }
-                nh_override_flags.push(entry.nh.cloned());
+                unicast.next_hop_override.push(entry.nh.cloned());
                 let mut route = entry.route.clone();
                 super::distribution::rs_control::rs_control_route_rewrite(
                     &mut route,
                     source_large_communities,
                     rs_control,
                 );
-                announce.push(route);
+                unicast.announce.push(route);
             }
             // VPN join replay: table minus own-sourced, filtered by the
             // joining member's Φ (the RFC 4684 gate the per-peer dump
@@ -1324,7 +1322,6 @@ impl RibManager {
                 0
             };
             if prefix_send_max > 0 {
-                let mut policy_filtered = Vec::new();
                 Self::distribute_multipath_prefix(
                     &self.ribs,
                     &self.unicast_prefix_peers,
@@ -1352,13 +1349,10 @@ impl RibManager {
                     &metrics,
                     policy_stats,
                     &target_peer_label,
-                    &mut announce,
-                    &mut withdraw,
-                    &mut nh_override_flags,
-                    &mut policy_filtered,
+                    &mut unicast,
                     false, // initial dump — equality check is correct
                 );
-                current_policy_filtered_routes.extend(policy_filtered);
+                current_policy_filtered_routes.extend(std::mem::take(&mut unicast.policy_filtered));
             } else if per_client_best {
                 // RFC 7947 §2.3.2 per-client best-path: the first
                 // export-policy-permitted candidate from the per-target
@@ -1370,7 +1364,6 @@ impl RibManager {
                 // requires an eBGP route-server client
                 // (validation-enforced).
                 debug_assert!(orr_ctx.is_none(), "ORR vantage on a per-client-best peer");
-                let mut policy_filtered = Vec::new();
                 Self::distribute_multipath_prefix(
                     &self.ribs,
                     &self.unicast_prefix_peers,
@@ -1398,16 +1391,12 @@ impl RibManager {
                     &metrics,
                     policy_stats,
                     &target_peer_label,
-                    &mut announce,
-                    &mut withdraw,
-                    &mut nh_override_flags,
-                    &mut policy_filtered,
+                    &mut unicast,
                     false, // initial dump — equality check is correct
                 );
-                current_policy_filtered_routes.extend(policy_filtered);
+                current_policy_filtered_routes.extend(std::mem::take(&mut unicast.policy_filtered));
             } else if let Some((orr_topology, orr_spf)) = orr_ctx {
                 // ORR peer with a resolved vantage: per-vantage best.
-                let mut policy_filtered = Vec::new();
                 Self::distribute_orr_best_prefix(
                     &self.ribs,
                     &self.unicast_prefix_peers,
@@ -1433,15 +1422,11 @@ impl RibManager {
                     &metrics,
                     policy_stats,
                     &target_peer_label,
-                    &mut announce,
-                    &mut withdraw,
-                    &mut nh_override_flags,
-                    &mut policy_filtered,
+                    &mut unicast,
                     false, // initial dump — equality check is correct
                 );
-                current_policy_filtered_routes.extend(policy_filtered);
+                current_policy_filtered_routes.extend(std::mem::take(&mut unicast.policy_filtered));
             } else {
-                let mut policy_filtered = Vec::new();
                 let mut target = super::distribution::ExportTarget::Peer {
                     peer,
                     peer_asn: target_peer_asn,
@@ -1468,13 +1453,10 @@ impl RibManager {
                     // has no installed filter during the initial dump.
                     None,
                     &mut export_memo,
-                    &mut announce,
-                    &mut withdraw,
-                    &mut nh_override_flags,
-                    &mut policy_filtered,
+                    &mut unicast,
                     false, // initial dump — equality check is correct
                 );
-                current_policy_filtered_routes.extend(policy_filtered);
+                current_policy_filtered_routes.extend(std::mem::take(&mut unicast.policy_filtered));
             }
         }
 
@@ -1758,8 +1740,8 @@ impl RibManager {
             self.reconcile_peer_otc_blocked(peer, &otc_prefixes, grouped_otc_blocked);
         }
 
-        let has_outbound_diff = !announce.is_empty()
-            || !withdraw.is_empty()
+        let has_outbound_diff = !unicast.announce.is_empty()
+            || !unicast.withdraw.is_empty()
             || !fs_announce.is_empty()
             || !fs_withdraw.is_empty()
             || !evpn_announce.is_empty()
@@ -1777,9 +1759,9 @@ impl RibManager {
             || self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
                 peer,
                 OutboundCommitBatch {
-                    next_hop_override: nh_override_flags.into(),
-                    announce: announce.into(),
-                    withdraw,
+                    next_hop_override: unicast.next_hop_override.into(),
+                    announce: unicast.announce.into(),
+                    withdraw: unicast.withdraw,
                     flowspec_announce: fs_announce,
                     flowspec_withdraw: fs_withdraw,
                     evpn_announce,

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -1048,10 +1048,7 @@ impl RibManager {
             trace: &mut trace,
         };
         let mut memo = distribution::ExportMemo::default();
-        let mut announce = Vec::new();
-        let mut withdraw = Vec::new();
-        let mut nh_override_flags = Vec::new();
-        let mut policy_filtered = Vec::new();
+        let mut result = distribution::UnicastDistributionResult::default();
         Self::distribute_single_best_prefix(
             &self.loc_rib,
             rib_out,
@@ -1068,10 +1065,7 @@ impl RibManager {
             self.export_policy_for(peer),
             orf,
             &mut memo,
-            &mut announce,
-            &mut withdraw,
-            &mut nh_override_flags,
-            &mut policy_filtered,
+            &mut result,
             false,
         );
         let explanation = trace.into_explain(peer, prefix, None, member_of.map(|gid| gid as u64));

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -676,9 +676,7 @@ impl RibManager {
             .get(&peer)
             .and_then(|m| m.get(&family))
             .cloned();
-        let mut announce = Vec::new();
-        let mut withdraw = Vec::new();
-        let mut nh_override_flags: Vec<Option<rustbgpd_policy::NextHopAction>> = Vec::new();
+        let mut unicast = super::distribution::UnicastDistributionResult::default();
         let mut fs_announce = Vec::new();
         let mut fs_withdraw = Vec::new();
         let mut evpn_announce = Vec::new();
@@ -1054,14 +1052,14 @@ impl RibManager {
                     ) {
                         continue;
                     }
-                    nh_override_flags.push(entry.nh.cloned());
+                    unicast.next_hop_override.push(entry.nh.cloned());
                     let mut route = entry.route.clone();
                     super::distribution::rs_control::rs_control_route_rewrite(
                         &mut route,
                         source_large_communities,
                         rs_control,
                     );
-                    announce.push(route);
+                    unicast.announce.push(route);
                 }
                 current_policy_filtered_routes
                     .extend(group.policy_filtered_for_member(peer, &all_prefixes));
@@ -1086,7 +1084,6 @@ impl RibManager {
                     0
                 };
                 if prefix_send_max > 0 {
-                    let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
                         &self.unicast_prefix_peers,
@@ -1112,13 +1109,11 @@ impl RibManager {
                         &metrics,
                         policy_stats,
                         &target_peer_label,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         false, // route refresh re-emits all anyway via empty refresh_view
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else if per_client_best {
                     // RFC 7947 §2.3.2 per-client best-path: the refresh
                     // replay re-derives the same filtered best the live
@@ -1126,7 +1121,6 @@ impl RibManager {
                     // `send_initial_table` arm for the mode-precedence
                     // notes (Add-Path outranks; ORR cannot coexist).
                     debug_assert!(orr_ctx.is_none(), "ORR vantage on a per-client-best peer");
-                    let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
                         &self.unicast_prefix_peers,
@@ -1152,16 +1146,13 @@ impl RibManager {
                         &metrics,
                         policy_stats,
                         &target_peer_label,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         false, // route refresh re-emits all anyway via empty refresh_view
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else if let Some((orr_topology, orr_spf)) = orr_ctx {
                     // ORR peer with a resolved vantage: per-vantage best.
-                    let mut policy_filtered = Vec::new();
                     Self::distribute_orr_best_prefix(
                         &self.ribs,
                         &self.unicast_prefix_peers,
@@ -1185,15 +1176,12 @@ impl RibManager {
                         &metrics,
                         policy_stats,
                         &target_peer_label,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         false,
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else {
-                    let mut policy_filtered = Vec::new();
                     let mut target = super::distribution::ExportTarget::Peer {
                         peer,
                         peer_asn: target_peer_asn,
@@ -1218,13 +1206,11 @@ impl RibManager {
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
                         &mut export_memo,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_override_flags,
-                        &mut policy_filtered,
+                        &mut unicast,
                         false,
                     );
-                    current_policy_filtered_routes.extend(policy_filtered);
+                    current_policy_filtered_routes
+                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 }
             }
             // The refresh view is intentionally empty so permitted routes are
@@ -1239,7 +1225,7 @@ impl RibManager {
                     .iter()
                     .filter(|r| prefix_family(&r.prefix) == family && !filter.permits(&r.prefix))
                 {
-                    withdraw.push((route.prefix, route.path_id));
+                    unicast.withdraw.push((route.prefix, route.path_id));
                 }
             }
         }
@@ -1297,9 +1283,9 @@ impl RibManager {
         if !self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
             peer,
             OutboundCommitBatch {
-                next_hop_override: nh_override_flags.into(),
-                announce: announce.into(),
-                withdraw,
+                next_hop_override: unicast.next_hop_override.into(),
+                announce: unicast.announce.into(),
+                withdraw: unicast.withdraw,
                 end_of_rib,
                 refresh_markers,
                 flowspec_announce: fs_announce,

--- a/crates/rib/src/manager/update_groups/staging.rs
+++ b/crates/rib/src/manager/update_groups/staging.rs
@@ -1,8 +1,8 @@
 use super::{
-    GroupDelta, GroupRibOut, GroupStageOutput, HashMap, HashSet, IpAddr, LaneDelta, NextHopAction,
-    PolicyAction, PolicyChain, PolicyFilteredRouteKey, PolicyLabel, Prefix, RibManager, Route,
-    RunnerUp, VpnDenialRecord, VpnGroupDelta, VpnGroupStageOutput, VpnRibRoute, VpnRibRouteKey,
-    VpnRouteKey, capture_source_attrs, routes_equal, source_control_input,
+    GroupDelta, GroupRibOut, GroupStageOutput, HashMap, HashSet, IpAddr, LaneDelta, PolicyAction,
+    PolicyChain, PolicyFilteredRouteKey, PolicyLabel, Prefix, RibManager, RunnerUp,
+    VpnDenialRecord, VpnGroupDelta, VpnGroupStageOutput, VpnRibRoute, VpnRibRouteKey, VpnRouteKey,
+    capture_source_attrs, routes_equal, source_control_input,
 };
 
 impl RibManager {
@@ -90,18 +90,19 @@ impl RibManager {
         let mut out = GroupStageOutput::default();
         let mut labeled_filtered: Vec<(PolicyFilteredRouteKey, Option<PolicyLabel>)> = Vec::new();
         let mut lane_updates: Vec<(Prefix, Option<RunnerUp>)> = Vec::new();
+        let mut result = crate::manager::distribution::UnicastDistributionResult::default();
+        let mut per_client_best_result =
+            crate::manager::distribution::UnicastDistributionResult::default();
+        let per_client_best;
         {
             let Some(group) = self.group_ribs.get(&gid) else {
                 return out;
             };
+            per_client_best = group.per_client_best;
             // `share()`, not `clone()`: evaluations through the group
             // handle must land in the installed chain's ADR-0096 term
             // hit counters, exactly like the per-peer path's handle.
             let chain = group.export_chain.as_ref().map(PolicyChain::share);
-            let mut announce: Vec<Route> = Vec::new();
-            let mut withdraw: Vec<(Prefix, u32)> = Vec::new();
-            let mut nh_flags: Vec<Option<NextHopAction>> = Vec::new();
-            let mut filtered: Vec<PolicyFilteredRouteKey> = Vec::new();
             for prefix in prefixes {
                 let old_source = group.table.get(prefix, 0).map(|r| r.peer);
                 if group.per_client_best {
@@ -124,17 +125,21 @@ impl RibManager {
                         chain.as_ref(),
                         memo,
                         &mut out.evals,
-                        &mut announce,
-                        &mut withdraw,
-                        &mut nh_flags,
-                        &mut labeled_filtered,
+                        &mut per_client_best_result,
                         &mut out.otc_blocked,
                     );
                     // The winner announce (at most one — the walk
                     // stages a single `path_id 0` winner), captured
                     // for the lane-transition supersession decision.
-                    let winner_announce = announce.first().map(|route| route.peer);
-                    for (route, nh) in announce.drain(..).zip(nh_flags.drain(..)) {
+                    let winner_announce = per_client_best_result
+                        .announce
+                        .first()
+                        .map(|route| route.peer);
+                    for (route, nh) in per_client_best_result
+                        .announce
+                        .drain(..)
+                        .zip(per_client_best_result.next_hop_override.drain(..))
+                    {
                         out.deltas.push(GroupDelta {
                             prefix: *prefix,
                             path_id: route.path_id,
@@ -145,7 +150,7 @@ impl RibManager {
                             lane: stage.runner_up.clone(),
                         });
                     }
-                    for (p, path_id) in withdraw.drain(..) {
+                    for (p, path_id) in per_client_best_result.withdraw.drain(..) {
                         out.deltas.push(GroupDelta {
                             prefix: p,
                             path_id,
@@ -270,17 +275,18 @@ impl RibManager {
                     chain.as_ref(),
                     None, // ORF disqualifies from grouping — never present here
                     memo,
-                    &mut announce,
-                    &mut withdraw,
-                    &mut nh_flags,
-                    &mut filtered,
+                    &mut result,
                     false,
                 );
                 // Single-best stages at most one evaluation per prefix;
                 // its terminal-policy label tags the staged entry (or
                 // the denial residue) for join-time counter replay.
                 let label = out.evals.take_last().and_then(|(label, _, _)| label);
-                for (route, nh) in announce.drain(..).zip(nh_flags.drain(..)) {
+                for (route, nh) in result
+                    .announce
+                    .drain(..)
+                    .zip(result.next_hop_override.drain(..))
+                {
                     out.deltas.push(GroupDelta {
                         prefix: *prefix,
                         path_id: route.path_id,
@@ -291,7 +297,7 @@ impl RibManager {
                         lane: None,
                     });
                 }
-                for (p, path_id) in withdraw.drain(..) {
+                for (p, path_id) in result.withdraw.drain(..) {
                     out.deltas.push(GroupDelta {
                         prefix: p,
                         path_id,
@@ -308,8 +314,16 @@ impl RibManager {
                 {
                     out.rs_transitions.push(transition);
                 }
-                labeled_filtered.extend(filtered.drain(..).map(|key| (key, label.clone())));
+                labeled_filtered.extend(
+                    result
+                        .policy_filtered
+                        .drain(..)
+                        .map(|key| (key, label.clone())),
+                );
             }
+        }
+        if per_client_best {
+            labeled_filtered = per_client_best_result.policy_filtered;
         }
         let group = self.staged_group_mut(gid);
         for delta in &out.deltas {


### PR DESCRIPTION
## Summary

- introduce one private owned result for unicast announce, withdraw, next-hop override, and policy-filtered outputs
- replace the four parallel output-vector parameters across the four distribution helpers and all 15 callers
- preserve buffer reuse, route/output association, policy-label accounting, diagnostics, counters, and send/commit ordering

This is a private mechanical refactor. It changes no public API, wire behavior, clone count, allocation pattern, or operator surface.

## Verification

- update-group oracle: 30/30
- focused update-group tests: 97/97
- deterministic PR fault corpus and full 24-seed ignored fault corpus
- full RIB suite: 1,185 passed, 2 ignored; integration and doctests passed
- exact test inventory: 1,187 tests, 0 benchmarks
- strict all-feature/all-target RIB Clippy
- warnings-denied RIB rustdoc
- workspace Clippy hook, formatting, diff check, commit and push hooks

Linear: LAN-1269
