### PR TITLE
docs: pin coordinated shutdown ordering

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -280,18 +280,40 @@ description = "ibgp-reflector"
 hold_time = 90
 ```
 
-### Graceful Shutdown
+### Coordinated Shutdown
 
-Shutdown is triggered by SIGINT, SIGTERM, or the `Shutdown` gRPC RPC. Signal
-handlers are registered before the daemon becomes externally reachable, so a
-signal arriving during startup is never dropped:
+Shutdown is triggered by SIGINT, SIGTERM, the `Shutdown` gRPC RPC, or an
+unexpected supervised-component exit. Signal handlers are registered before
+the daemon becomes externally reachable, so a signal arriving during startup
+is never dropped. The common path follows
+[ADR-0020](adr/0020-global-control-services-coordinated-shutdown.md):
 
-1. Stop accepting new gRPC commands.
-2. Send NOTIFICATION/Cease (Administrative Shutdown, subcode 2) to every established peer.
-3. Wait up to 5 seconds for TCP sends to flush. Hard-drop after the timeout — don't hang.
-4. Drop all sessions and close listener sockets.
-5. Flush final telemetry (last metrics scrape, final log entries).
-6. Exit.
+1. Close mutation admission and wait for any owned runtime-config operation to
+   settle or reach its recovery boundary.
+2. Attempt the optional warm checkpoint and restart-marker publication, then
+   fence EVPN runtime applies out of teardown.
+3. Drain the local-MAC, SVI-MAC, L3, and segment originators, then withdraw all
+   locally originated IMET routes. These peer-visible withdrawals deliberately
+   precede Administrative Shutdown and run while BGP sessions are still
+   established. Writer-owned KEEPALIVEs keep those sessions live independently
+   of a session task blocked on RIB delivery
+   ([ADR-0078](adr/0078-inbound-rib-backpressure.md)).
+4. Send the sole PeerManager shutdown command, which initiates
+   Cease/Administrative Shutdown (subcode 2), and await peer teardown.
+5. Drain local-only BLACKHOLE and general-FIB state, BFD sessions, and EVPN
+   Linux dataplane state, followed by the remaining daemon services.
+
+The coordinated path does not replace Administrative Shutdown with an
+Administrative Shutdown Hard Reset. When Notification GR is negotiated, the
+ordinary NOTIFICATION follows the behavior recorded in
+[ADR-0046](adr/0046-notification-gr.md) and
+[RFC 8538 section 4](https://www.rfc-editor.org/rfc/rfc8538.html#section-4).
+
+Configured and default hold timers describe BGP peer-silence handling; they are
+not a time-to-Cease service-level promise or a minimum period for keeping a
+session open. Several explicit stages are individually bounded, but the IMET
+and PeerManager handoffs have no shared deadline, so shipped code has no finite
+aggregate upper bound from shutdown request to first Cease.
 
 Neighbor add/delete mutations made via gRPC are persisted back to the config file (ADR-0043). Full route-state persistence remains deferred — restart replays the config file and re-learns routes from peers.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -292,11 +292,15 @@ is never dropped. The common path follows
    settle or reach its recovery boundary.
 2. Attempt the optional warm checkpoint and restart-marker publication, then
    fence EVPN runtime applies out of teardown.
-3. Drain the local-MAC, SVI-MAC, L3, and segment originators, then withdraw all
-   locally originated IMET routes. These peer-visible withdrawals deliberately
-   precede Administrative Shutdown and run while BGP sessions are still
-   established. Writer-owned KEEPALIVEs keep those sessions live independently
-   of a session task blocked on RIB delivery
+3. Ask the local-MAC, SVI-MAC, L3, and segment originators to drain, waiting up
+   to five seconds for each actor, then fully await withdrawal of all locally
+   originated IMET routes. These peer-visible withdrawal attempts deliberately
+   start before Administrative Shutdown while BGP sessions are still
+   established. An actor that exceeds its five-second wait is detached and can
+   finish after Cease begins, so completion before Cease is best-effort for
+   those four actors; IMET completion is required before the next step.
+   Writer-owned KEEPALIVEs keep sessions live during the bounded attempts
+   independently of a session task blocked on RIB delivery
    ([ADR-0078](adr/0078-inbound-rib-backpressure.md)).
 4. Send the sole PeerManager shutdown command, which initiates
    Cease/Administrative Shutdown (subcode 2), and await peer teardown.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -293,12 +293,13 @@ is never dropped. The common path follows
 2. Attempt the optional warm checkpoint and restart-marker publication, then
    fence EVPN runtime applies out of teardown.
 3. Ask the local-MAC, SVI-MAC, L3, and segment originators to drain, waiting up
-   to five seconds for each actor, then fully await withdrawal of all locally
-   originated IMET routes. These peer-visible withdrawal attempts deliberately
-   start before Administrative Shutdown while BGP sessions are still
+   to five seconds for each actor, then await the complete best-effort sweep of
+   locally originated IMET routes. These peer-visible withdrawal attempts
+   deliberately start before Administrative Shutdown while BGP sessions are still
    established. An actor that exceeds its five-second wait is detached and can
    finish after Cease begins, so completion before Cease is best-effort for
-   those four actors; IMET completion is required before the next step.
+   those four actors. The IMET sweep completes before the next step, but each
+   per-route outcome may still be rejected, unavailable, or reply-unknown.
    Writer-owned KEEPALIVEs keep sessions live during the bounded attempts
    independently of a session task blocked on RIB delivery
    ([ADR-0078](adr/0078-inbound-rib-backpressure.md)).

--- a/docs/settlement-watchdog.md
+++ b/docs/settlement-watchdog.md
@@ -106,14 +106,16 @@ ceilings:
 - restart-marker publication or removal: 5 seconds;
 - acquiring the EVPN runtime-apply fence when the checkpoint did not retain it:
   10 seconds; and
-- local-MAC, SVI-MAC, L3, and segment actor drains: 5 seconds each.
+- local-MAC, SVI-MAC, L3, and segment actor-drain waits: 5 seconds each.
 
-Those caps can account for 65 seconds before IMET withdrawal begins. This is a
-timing decomposition, not a guarantee or a minimum session hold time: stages
-may be skipped or finish early. The subsequent IMET controller mutex, RIB
-channel handoff, sequential per-VNI withdrawal acknowledgements, and
-PeerManager shutdown enqueue and scheduling have no aggregate deadline.
-Therefore the shipped path has no finite aggregate upper bound to first Cease.
+Those caps can account for 65 seconds of main-task waiting before IMET
+withdrawal begins. This is a timing decomposition, not a completion guarantee
+or a minimum session hold time: stages may be skipped or finish early, and an
+actor that exceeds its wait is detached and can finish after Cease begins. The
+subsequent IMET controller mutex, RIB channel handoff, sequential per-VNI
+withdrawal acknowledgements, and PeerManager shutdown enqueue and scheduling
+have no aggregate deadline. Therefore the shipped path has no finite aggregate
+upper bound to first Cease.
 
 While an owner is live, the daemon logs a
 `runtime config settlement budget warning` at 15, 25, and 29 minutes

--- a/docs/settlement-watchdog.md
+++ b/docs/settlement-watchdog.md
@@ -112,10 +112,10 @@ Those caps can account for 65 seconds of main-task waiting before IMET
 withdrawal begins. This is a timing decomposition, not a completion guarantee
 or a minimum session hold time: stages may be skipped or finish early, and an
 actor that exceeds its wait is detached and can finish after Cease begins. The
-subsequent IMET controller mutex, RIB channel handoff, sequential per-VNI
-withdrawal acknowledgements, and PeerManager shutdown enqueue and scheduling
-have no aggregate deadline. Therefore the shipped path has no finite aggregate
-upper bound to first Cease.
+subsequent IMET controller mutex, sequential per-VNI RIB channel handoffs and
+bounded acknowledgement attempts, and PeerManager shutdown enqueue and
+scheduling have no aggregate deadline. Therefore the shipped path has no
+finite aggregate upper bound to first Cease.
 
 While an owner is live, the daemon logs a
 `runtime config settlement budget warning` at 15, 25, and 29 minutes

--- a/docs/settlement-watchdog.md
+++ b/docs/settlement-watchdog.md
@@ -90,6 +90,31 @@ a streamed apply, the candidate upload precedes that wait and is
 separately bounded at 30 minutes by the stream's total timeout, so the
 full RPC-start-to-fail-stop worst case is about 70 minutes 5 seconds.
 
+### What coordinated shutdown bounds
+
+The shutdown waiter bounds only the owned-settlement decision. A live owner
+has 30 minutes to prove settlement. At expiry the watchdog retains ownership,
+uses the configured five-second recovery-fence grace to close admission and
+publish the diagnostic, then exits 70. That path does not advance to BGP Cease.
+A clean settlement instead disarms the fatal boundary and lets coordinated
+teardown continue.
+
+After clean settlement, the explicit pre-Cease stages have these sequential
+ceilings:
+
+- warm-checkpoint capture and publication: 30 seconds;
+- restart-marker publication or removal: 5 seconds;
+- acquiring the EVPN runtime-apply fence when the checkpoint did not retain it:
+  10 seconds; and
+- local-MAC, SVI-MAC, L3, and segment actor drains: 5 seconds each.
+
+Those caps can account for 65 seconds before IMET withdrawal begins. This is a
+timing decomposition, not a guarantee or a minimum session hold time: stages
+may be skipped or finish early. The subsequent IMET controller mutex, RIB
+channel handoff, sequential per-VNI withdrawal acknowledgements, and
+PeerManager shutdown enqueue and scheduling have no aggregate deadline.
+Therefore the shipped path has no finite aggregate upper bound to first Cease.
+
 While an owner is live, the daemon logs a
 `runtime config settlement budget warning` at 15, 25, and 29 minutes
 elapsed (`remaining` = `15_minutes`, `5_minutes`, `1_minute`). The
@@ -402,10 +427,9 @@ detached), with a few semantics of its own:
   owner reaches its budget, the waiter fences it as `budget_expired`,
   preserves the configured recovery-fence grace, and invokes the same
   exit-70 boundary as the independent fatal clock. It never falls through
-  to checkpointing or actor teardown with an active owner. This bounds the
-  settlement wait itself; it does **not** establish a finite aggregate time
-  to the first BGP Cease because a clean owner may use its full budget and
-  later checkpoint and drain stages retain their own bounds.
+  to checkpointing or actor teardown with an active owner. The exact shutdown
+  timing boundary is decomposed in
+  [What coordinated shutdown bounds](#what-coordinated-shutdown-bounds).
 
 ## Related pages
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5872,23 +5872,36 @@ mod tests {
     fn coordinated_shutdown_attempts_peer_visible_withdrawals_before_cease() {
         // Load-bearing shutdown-order proof. Peer-visible EVPN actor drains
         // are initiated and given their bounded wait while BGP sessions remain
-        // available; IMET withdrawal is fully awaited before the one
-        // PeerManager shutdown. Local-only dataplane drains deliberately
+        // available; the complete best-effort IMET sweep is awaited before the
+        // one PeerManager shutdown. Local-only dataplane drains deliberately
         // follow it. Anchor on source constructs rather than incidental
         // log/telemetry order.
         let source = include_str!("main.rs");
         let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
         let find = |needle| {
+            assert_eq!(
+                production.matches(needle).count(),
+                1,
+                "coordinated shutdown anchor must remain unique: `{needle}`"
+            );
             production
                 .find(needle)
                 .unwrap_or_else(|| panic!("coordinated shutdown lost `{needle}`"))
         };
         let ordered_stages = [
             find("_evpn_apply_fence_guard = evpn_apply_fence"),
-            find("if let Some(handle) = evpn_originator_handle"),
-            find("if let Some(handle) = evpn_svi_handle"),
-            find("if let Some(handle) = evpn_l3_originator_handle"),
-            find("if let Some(handle) = evpn_segment_handle"),
+            find(
+                "if let Some(handle) = evpn_originator_handle {\n        info!(\"draining EVPN originator\");\n        handle.shutdown().await;",
+            ),
+            find(
+                "if let Some(handle) = evpn_svi_handle {\n        info!(\"draining EVPN SVI-MAC originator\");\n        handle.shutdown().await;",
+            ),
+            find(
+                "if let Some(handle) = evpn_l3_originator_handle {\n        info!(\"draining EVPN L3 originator\");\n        handle.shutdown().await;",
+            ),
+            find(
+                "if let Some(handle) = evpn_segment_handle {\n        info!(\"draining EVPN segment orchestrator\");\n        handle.shutdown().await;",
+            ),
             find("imet_controller.withdraw_all(&rib_tx).await"),
             find("peer_mgr_tx.send(PeerManagerCommand::Shutdown).await"),
             find("if let Some(handle) = blackhole_handle"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5869,11 +5869,13 @@ mod tests {
     }
 
     #[test]
-    fn coordinated_shutdown_preserves_peer_visible_withdraw_order() {
-        // Load-bearing shutdown-order proof. Peer-visible EVPN withdrawals
-        // must finish while the BGP sessions are still available; local-only
-        // dataplane drains deliberately follow the one PeerManager shutdown.
-        // Anchor on source constructs rather than incidental log/telemetry order.
+    fn coordinated_shutdown_attempts_peer_visible_withdrawals_before_cease() {
+        // Load-bearing shutdown-order proof. Peer-visible EVPN actor drains
+        // are initiated and given their bounded wait while BGP sessions remain
+        // available; IMET withdrawal is fully awaited before the one
+        // PeerManager shutdown. Local-only dataplane drains deliberately
+        // follow it. Anchor on source constructs rather than incidental
+        // log/telemetry order.
         let source = include_str!("main.rs");
         let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
         let find = |needle| {
@@ -5898,7 +5900,7 @@ mod tests {
             ordered_stages
                 .windows(2)
                 .all(|stages| stages[0] < stages[1]),
-            "coordinated shutdown stages must remain in peer-visible withdrawal order"
+            "coordinated shutdown must attempt peer-visible withdrawals before Cease"
         );
         assert_eq!(
             production

--- a/src/main.rs
+++ b/src/main.rs
@@ -5866,16 +5866,47 @@ mod tests {
         assert!(
             production.contains("if initial_peer_boot_failed {\n            break;\n        }")
         );
-        let fence = production
-            .find("// ADR-0080: fence in-flight EVPN")
-            .unwrap();
-        let withdraw = production
-            .find("info!(\"draining EVPN originator\")")
-            .unwrap();
-        let cease = production
-            .find("send(PeerManagerCommand::Shutdown)")
-            .unwrap();
-        assert!(fence < withdraw && withdraw < cease);
+    }
+
+    #[test]
+    fn coordinated_shutdown_preserves_peer_visible_withdraw_order() {
+        // Load-bearing shutdown-order proof. Peer-visible EVPN withdrawals
+        // must finish while the BGP sessions are still available; local-only
+        // dataplane drains deliberately follow the one PeerManager shutdown.
+        // Anchor on source constructs rather than incidental log/telemetry order.
+        let source = include_str!("main.rs");
+        let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
+        let find = |needle| {
+            production
+                .find(needle)
+                .unwrap_or_else(|| panic!("coordinated shutdown lost `{needle}`"))
+        };
+        let ordered_stages = [
+            find("_evpn_apply_fence_guard = evpn_apply_fence"),
+            find("if let Some(handle) = evpn_originator_handle"),
+            find("if let Some(handle) = evpn_svi_handle"),
+            find("if let Some(handle) = evpn_l3_originator_handle"),
+            find("if let Some(handle) = evpn_segment_handle"),
+            find("imet_controller.withdraw_all(&rib_tx).await"),
+            find("peer_mgr_tx.send(PeerManagerCommand::Shutdown).await"),
+            find("if let Some(handle) = blackhole_handle"),
+            find("if let Some(handle) = fib_runtime_handle"),
+            find("if let Some(handle) = bfd_runtime_handle"),
+            find("if let Some(handle) = evpn_dataplane_handle {"),
+        ];
+        assert!(
+            ordered_stages
+                .windows(2)
+                .all(|stages| stages[0] < stages[1]),
+            "coordinated shutdown stages must remain in peer-visible withdrawal order"
+        );
+        assert_eq!(
+            production
+                .matches("send(PeerManagerCommand::Shutdown)")
+                .count(),
+            1,
+            "coordinated shutdown must retain one PeerManager shutdown command"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- pin the peer-visible shutdown attempt order in a dedicated source contract
- document why EVPN withdrawals are attempted before Administrative Shutdown
- record the actual bounded waits, detach behavior, and remaining unbounded handoffs

## Decision

Sending Cease first would remove the established-session opportunity for EVPN withdrawals. The shipped order therefore remains: fence runtime applies, ask the four peer-visible EVPN originators to drain with a five-second wait for each, await the complete best-effort IMET sweep, send the sole PeerManager shutdown command, then drain local-only kernel state.

The four actor helpers detach their tasks when a wait expires, so completion before Cease is explicitly best-effort; the source contract proves initiation and bounded waiting order, not completion order. The full IMET sweep is awaited before PeerManager shutdown, but individual outcomes can still be rejected, unavailable, or reply-unknown.

The settlement owner has a 30-minute decision budget plus a 5-second recovery-fence grace. After clean settlement, explicit pre-IMET waits can total 65 seconds, while the IMET controller and PeerManager handoffs have no aggregate deadline. The documentation therefore makes no finite time-to-first-Cease guarantee and does not treat BGP hold timers as a shutdown SLA.

## Proof

- production `src/main.rs` before the test module is byte-identical to `main`
- unique multiline anchors pin each actor-specific `shutdown().await` call before the one PeerManager shutdown and every local-only drain after it
- the design documents the timed-out-task detach boundary and best-effort IMET outcome boundary
- RFC 8538 and the existing shutdown, Notification GR, and KEEPALIVE ownership ADRs are linked from the operator design

## Validation

- dedicated shutdown-attempt-order unit test
- transport KEEPALIVE ownership tests
- clean-settlement wait test
- public tracker contract tests and live 608-document scan
- workspace formatting, Clippy, library tests, rustdoc, pre-commit, and pre-push hooks

Linear: LAN-1211
