### PR TITLE
docs(security): inventory Birdwatcher disclosures

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -228,8 +228,10 @@ Mitigations, in preference order:
   the network isolation and separate credentials, not for tier filtering.
 - Disable retention daemon-side with `[policy.reject_retention]
   enabled = false`: the reject store is never populated, so the filtered view
-  and reserved rejection-pair view are served empty as a configuration fact.
-  This does not disable the adapter's other route or identity disclosures.
+  and the `{daemon ASN}:1101` rejection-pair behavior of
+  `/routes/lc-zwild/protocol/{id}/{x}/{y}` are served empty as a configuration
+  fact. This does not disable the adapter's other route, ordinary
+  large-community wildcard, or identity disclosures.
 
 ## TCP MD5 and GTSM
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -176,9 +176,9 @@ surface over the daemon's gRPC API. Its 14 registered HTTP routes disclose:
 - Daemon identity and health through `GET /status`.
 - Peer and table identities: `GET /protocols/bgp`, `GET /protocol/{id}`, and
   `GET /symbols`.
-- Received, advertised, and Loc-RIB-selected route views through
-  `GET /routes/protocol/{id}`, `GET /routes/export/{id}`, and
-  `GET /routes/table/{table}`.
+- Received and advertised route views through `GET /routes/protocol/{id}` and
+  `GET /routes/export/{id}`, plus the global received-candidate table with
+  Loc-RIB winner attribution through `GET /routes/table/{table}`.
 - Exact-prefix or most-specific-covering route candidates through
   `GET /route/{prefix}/protocol/{id}`, `GET /route/{prefix}/export/{id}`, and
   `GET /route/{prefix}/table/{table}`.
@@ -195,18 +195,21 @@ retained rejection's prefix, next hop, AS path, communities, RPKI/ASPA
 validation state, and the policy rejection reason (canonical reason token,
 human-readable detail string, and a synthesized reject-reason large
 community). `/protocols/bgp` carries real per-neighbor filtered counts.
-`/routes/noexport/{id}` additionally serves every Loc-RIB best route
-withheld from that peer with the export gate that stopped it (split
-horizon, reflection rules, family, LLGR, ORF, RT membership, or export
-policy — including the deciding policy term's detail line), sourced from
-`RibService.ListBestRoutes`, `ListAdvertisedRoutes`, and
-`ExplainAdvertisedRoute`. The adapter's HTTP listener is unauthenticated
-and has no TLS; it binds `127.0.0.1:8080` by default and listens elsewhere
-only if you pass `--listen` / `BIRDWATCHER_ADAPTER_LISTEN`. Its optional
-gRPC bearer token authenticates the adapter to rustbgpd, not HTTP clients.
-Anyone who can reach it can enumerate daemon and peer identities, route
-candidates, policy rejects, and export-withholding reasons — treat that as
-looking-glass data you are choosing to publish.
+`/routes/noexport/{id}` additionally serves a prefix-granular view of returned
+Loc-RIB best-route candidates not represented in that peer's Adj-RIB-Out, with
+the export gate that stopped each candidate (split horizon, reflection rules,
+family, LLGR, ORF, RT membership, or export policy — including the deciding
+policy term's detail line). Any advertised path suppresses the whole prefix,
+duplicate candidates collapse per prefix, and cross-snapshot churn can omit a
+candidate if dry-run explanation says it would now advertise. The view is
+sourced from `RibService.ListBestRoutes`, `ListAdvertisedRoutes`, and
+`ExplainAdvertisedRoute`. The adapter's HTTP listener is unauthenticated and
+has no TLS; it binds `127.0.0.1:8080` by default and listens elsewhere only if
+you pass `--listen` / `BIRDWATCHER_ADAPTER_LISTEN`. Its optional gRPC bearer
+token authenticates the adapter to rustbgpd, not HTTP clients. Anyone who can
+reach it can enumerate daemon and peer identities, route candidates, policy
+rejects, and export-withholding reasons — treat that as looking-glass data you
+are choosing to publish.
 
 Mitigations, in preference order:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -171,27 +171,42 @@ to gRPC.
 
 The in-daemon looking glass HTTP server has been removed. The external
 `examples/birdwatcher-adapter` binary serves a Birdwatcher-shaped read-only
-status, peer, accepted-route, filtered-route, and noexport subset over the
-daemon's gRPC API.
+surface over the daemon's gRPC API. Its 14 registered HTTP routes disclose:
+
+- Daemon identity and health through `GET /status`.
+- Peer and table identities: `GET /protocols/bgp`, `GET /protocol/{id}`, and
+  `GET /symbols`.
+- Received, advertised, and Loc-RIB-selected route views through
+  `GET /routes/protocol/{id}`, `GET /routes/export/{id}`, and
+  `GET /routes/table/{table}`.
+- Exact-prefix or most-specific-covering route candidates through
+  `GET /route/{prefix}/protocol/{id}`, `GET /route/{prefix}/export/{id}`, and
+  `GET /route/{prefix}/table/{table}`.
+- The literal-peer received-route view through `GET /routes/peer/{peer}`.
+- Retained rejects, large-community-selected routes, and export-withholding
+  reasons through `GET /routes/filtered/{id}`,
+  `GET /routes/lc-zwild/protocol/{id}/{x}/{y}`, and
+  `GET /routes/noexport/{id}`.
 
 **Disclosure surface.** Beyond neighbor state, received routes, and peer
-addresses, the adapter's `GET /routes/filtered/{id}` endpoint serves
+addresses, the adapter's `/routes/filtered/{id}` endpoint serves
 rejected announcements from `PolicyService.ListRejectedRoutes`: each
 retained rejection's prefix, next hop, AS path, communities, RPKI/ASPA
 validation state, and the policy rejection reason (canonical reason token,
 human-readable detail string, and a synthesized reject-reason large
-community). `GET /protocols/bgp` carries real per-neighbor filtered counts.
-`GET /routes/noexport/{id}` additionally serves every Loc-RIB best route
+community). `/protocols/bgp` carries real per-neighbor filtered counts.
+`/routes/noexport/{id}` additionally serves every Loc-RIB best route
 withheld from that peer with the export gate that stopped it (split
 horizon, reflection rules, family, LLGR, ORF, RT membership, or export
 policy — including the deciding policy term's detail line), sourced from
 `RibService.ListBestRoutes`, `ListAdvertisedRoutes`, and
 `ExplainAdvertisedRoute`. The adapter's HTTP listener is unauthenticated
 and has no TLS; it binds `127.0.0.1:8080` by default and listens elsewhere
-only if you pass `--listen` / `BIRDWATCHER_ADAPTER_LISTEN`. Anyone who can
-reach it can enumerate what your import policy rejects, what your export
-policy withholds from each peer, and why — treat that as looking-glass
-data you are choosing to publish.
+only if you pass `--listen` / `BIRDWATCHER_ADAPTER_LISTEN`. Its optional
+gRPC bearer token authenticates the adapter to rustbgpd, not HTTP clients.
+Anyone who can reach it can enumerate daemon and peer identities, route
+candidates, policy rejects, and export-withholding reasons — treat that as
+looking-glass data you are choosing to publish.
 
 Mitigations, in preference order:
 
@@ -209,8 +224,9 @@ Mitigations, in preference order:
   is `sensitive_read`. A dedicated listener is still worth having, but for
   the network isolation and separate credentials, not for tier filtering.
 - Disable retention daemon-side with `[policy.reject_retention]
-  enabled = false`: the reject store is never populated and the filtered
-  view is served empty as a configuration fact.
+  enabled = false`: the reject store is never populated, so the filtered view
+  and reserved rejection-pair view are served empty as a configuration fact.
+  This does not disable the adapter's other route or identity disclosures.
 
 ## TCP MD5 and GTSM
 

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -726,6 +726,7 @@ fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
         ".nest_service(",
         ".fallback(",
         ".fallback_service(",
+        ".method_not_allowed_fallback(",
         ".merge(",
     ] {
         assert_eq!(

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -714,14 +714,60 @@ fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
         .split_once(".with_state(state);")
         .unwrap()
         .0;
-    let routed_paths: Vec<_> = router
-        .split(".route(")
-        .skip(1)
+    let route_calls: Vec<_> = router.split(".route(").skip(1).collect();
+    assert_eq!(
+        route_calls.len(),
+        14,
+        "adapter must retain 14 direct routes"
+    );
+    for alternate in [
+        ".route_service(",
+        ".nest(",
+        ".nest_service(",
+        ".fallback(",
+        ".fallback_service(",
+        ".merge(",
+    ] {
+        assert_eq!(
+            router.matches(alternate).count(),
+            0,
+            "adapter route inventory must not bypass direct GET registration: {alternate}"
+        );
+    }
+    let routed_paths: Vec<_> = route_calls
+        .iter()
         .map(|call| {
-            call.trim_start()
+            let literal = call
+                .trim_start()
                 .strip_prefix('"')
-                .and_then(|literal| literal.split('"').next())
-                .expect("router paths must remain direct string literals")
+                .expect("router paths must remain direct string literals");
+            let (path, registration) = literal
+                .split_once('"')
+                .expect("router paths must remain terminated string literals");
+            let method = registration
+                .trim_start()
+                .strip_prefix(',')
+                .expect("router path must have a method registration")
+                .trim_start();
+            assert!(
+                method.starts_with("get("),
+                "adapter route must remain GET-only: {path}"
+            );
+            for extra_method in [
+                ".delete(",
+                ".head(",
+                ".options(",
+                ".patch(",
+                ".post(",
+                ".put(",
+                ".trace(",
+            ] {
+                assert!(
+                    !registration.contains(extra_method),
+                    "adapter route gained another HTTP method: {path} {extra_method}"
+                );
+            }
+            path
         })
         .collect();
     let expected_paths: Vec<_> = concat!(

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -711,7 +711,7 @@ fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
         .split_once("let app = Router::new()")
         .unwrap()
         .1
-        .split_once(".with_state(state);")
+        .split_once("axum::serve(listener, app).await?;")
         .unwrap()
         .0;
     let route_calls: Vec<_> = router.split(".route(").skip(1).collect();
@@ -754,13 +754,26 @@ fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
                 "adapter route must remain GET-only: {path}"
             );
             for extra_method in [
+                ".connect(",
+                ".connect_service(",
                 ".delete(",
+                ".delete_service(",
+                ".get(",
+                ".get_service(",
                 ".head(",
+                ".head_service(",
+                ".on(",
+                ".on_service(",
                 ".options(",
+                ".options_service(",
                 ".patch(",
+                ".patch_service(",
                 ".post(",
+                ".post_service(",
                 ".put(",
+                ".put_service(",
                 ".trace(",
+                ".trace_service(",
             ] {
                 assert!(
                     !registration.contains(extra_method),

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -706,6 +706,57 @@ fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
         );
     }
     let adapter = include_str!("../examples/birdwatcher-adapter/src/main.rs");
+    assert_eq!(adapter.matches("let app = Router::new()").count(), 1);
+    let router = adapter
+        .split_once("let app = Router::new()")
+        .unwrap()
+        .1
+        .split_once(".with_state(state);")
+        .unwrap()
+        .0;
+    let routed_paths: Vec<_> = router
+        .split(".route(")
+        .skip(1)
+        .map(|call| {
+            call.trim_start()
+                .strip_prefix('"')
+                .and_then(|literal| literal.split('"').next())
+                .expect("router paths must remain direct string literals")
+        })
+        .collect();
+    let expected_paths: Vec<_> = concat!(
+        "/status /protocols/bgp /protocol/{id} /symbols ",
+        "/routes/protocol/{id} /routes/export/{id} /routes/table/{table} ",
+        "/route/{prefix}/protocol/{id} /route/{prefix}/export/{id} ",
+        "/route/{prefix}/table/{table} /routes/peer/{peer} /routes/filtered/{id} ",
+        "/routes/lc-zwild/protocol/{id}/{x}/{y} /routes/noexport/{id}",
+    )
+    .split_ascii_whitespace()
+    .collect();
+    assert_eq!(
+        routed_paths, expected_paths,
+        "adapter route inventory drifted"
+    );
+
+    let security = include_str!("../docs/SECURITY.md");
+    assert_eq!(security.matches("## Looking glass adapter\n").count(), 1);
+    let disclosure = security
+        .split_once("## Looking glass adapter\n")
+        .unwrap()
+        .1
+        .split_once("\n## ")
+        .expect("looking-glass disclosure must have a following section")
+        .0;
+    let documented_paths: Vec<_> = disclosure
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .filter_map(|code| code.strip_prefix("GET "))
+        .collect();
+    assert_eq!(
+        documented_paths, routed_paths,
+        "security disclosure must exactly track every routed GET path"
+    );
     let causes = adapter
         .split_once("fn arouteserver_reject_cause(")
         .unwrap()


### PR DESCRIPTION
## Summary

- inventory all 14 read-only Birdwatcher adapter endpoints in the security disclosure
- distinguish HTTP-client access from the adapter's upstream gRPC credential
- gate the exact GET-only route roster and alternate Axum registration surfaces

## Defensive disclosure

The adapter's listener is unauthenticated HTTP. Its optional bearer token authenticates the adapter to rustbgpd; it does not authenticate HTTP clients. The disclosure now covers daemon identity and health, peer/table identities, received and advertised routes, the global received-candidate table with Loc-RIB winner attribution, exact and covering-prefix candidates, large-community-selected routes, retained rejects, and export-withholding reasons.

The withholding view is documented at its actual prefix granularity: any advertised path suppresses the prefix, duplicates collapse per prefix, and cross-snapshot churn can omit a candidate that dry-run explanation says would now advertise.

Existing loopback, reverse-proxy, credential-isolation, and reject-retention guidance remains intact. Disabling reject retention empties only the retained-reject views; it does not disable other route or identity disclosures.

## Proof

The integration contract isolates the `Router::new()` construction block, requires the exact 14 literal paths in order, requires every registration to remain GET-only, rejects alternate route-service/nest/fallback/merge builders, isolates the Looking glass adapter security section, and requires a one-to-one list of code-formatted `GET` entries. A future endpoint or method change must therefore update the public disclosure deliberately.

## Validation

- focused and full Birdwatcher adapter smoke suite
- focused strict Clippy for the integration test
- public tracker contract tests and live 608-document scan
- workspace formatting, strict Clippy, typo and diff checks, local hooks

Linear: LAN-1252
