### PR TITLE
ci: centralize shared heavy-lane preparation

### DIFF
--- a/.github/actions/prepare-gobgp-artifact/action.yml
+++ b/.github/actions/prepare-gobgp-artifact/action.yml
@@ -1,0 +1,26 @@
+name: "Prepare exact GoBGP artifact"
+description: "Restore, verify, and upload the pinned GoBGP archive for heavy CI lanes."
+runs:
+  using: "composite"
+  steps:
+    - name: Restore exact gobgp archive cache
+      uses: actions/cache@v6
+      with:
+        path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
+        key: gobgp-v3.37.0-linux-amd64-e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522
+
+    - name: Prepare exact gobgp archive
+      shell: bash
+      run: |
+        .github/scripts/install-gobgp.sh \
+          --prepare-archive \
+          "$RUNNER_TEMP/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz"
+
+    - name: Upload verified gobgp archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: gobgp-v3.37.0-linux-amd64
+        path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
+        if-no-files-found: error
+        retention-days: 1
+        compression-level: 0

--- a/.github/actions/prime-rustbgpd-dev-cache/action.yml
+++ b/.github/actions/prime-rustbgpd-dev-cache/action.yml
@@ -1,0 +1,17 @@
+name: "Prime rustbgpd:dev build cache"
+description: "Warm the fixed heavy-lane image cache without loading a local image."
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Prime rustbgpd:dev build cache
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        load: false
+        tags: rustbgpd:dev
+        target: dev
+        cache-from: type=gha,scope=rustbgpd-dev
+        cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -218,24 +218,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
-      - name: Restore exact gobgp archive cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
-          key: gobgp-v3.37.0-linux-amd64-e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522
-      - name: Prepare exact gobgp archive
-        run: |
-          .github/scripts/install-gobgp.sh \
-            --prepare-archive \
-            "$RUNNER_TEMP/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz"
-      - name: Upload verified gobgp archive
-        uses: actions/upload-artifact@v7
-        with:
-          name: gobgp-v3.37.0-linux-amd64
-          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
+      - name: Restore, prepare, and upload exact gobgp archive
+        uses: ./.github/actions/prepare-gobgp-artifact
 
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
@@ -252,17 +236,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
       - name: Prime rustbgpd:dev build cache
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          load: false
-          tags: rustbgpd:dev
-          target: dev
-          cache-from: type=gha,scope=rustbgpd-dev
-          cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true
+        uses: ./.github/actions/prime-rustbgpd-dev-cache
 
   m1:
     needs: [grpcurl_archive, prime_dev_image]

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -74,24 +74,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
-      - name: Restore exact gobgp archive cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
-          key: gobgp-v3.37.0-linux-amd64-e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522
-      - name: Prepare exact gobgp archive
-        run: |
-          .github/scripts/install-gobgp.sh \
-            --prepare-archive \
-            "$RUNNER_TEMP/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz"
-      - name: Upload verified gobgp archive
-        uses: actions/upload-artifact@v7
-        with:
-          name: gobgp-v3.37.0-linux-amd64
-          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
+      - name: Restore, prepare, and upload exact gobgp archive
+        uses: ./.github/actions/prepare-gobgp-artifact
 
   # This archive feeds exactly one scenario, m43. Its host is a third party:
   # when it refuses to serve the pinned tarball (nic.cz returned 403 on all
@@ -165,17 +149,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
       - name: Prime rustbgpd:dev build cache
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          load: false
-          tags: rustbgpd:dev
-          target: dev
-          cache-from: type=gha,scope=rustbgpd-dev
-          cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true
+        uses: ./.github/actions/prime-rustbgpd-dev-cache
 
   m36:
     needs: [grpcurl_archive, prime_dev_image]

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -158,9 +158,104 @@ PINS = collections.Counter(
     }
 )
 
+GOBGP_PRODUCER_JOB_ENVELOPE = (
+    "    needs: classify_changes",
+    "    if: needs.classify_changes.outputs.run_labs == 'true'",
+    "    name: Prepare exact gobgp archive",
+    "    runs-on: ubuntu-latest",
+    "    timeout-minutes: 10",
+    "    steps:",
+)
+PRIME_DEV_IMAGE_JOB_ENVELOPE = (
+    "    needs: classify_changes",
+    "    if: needs.classify_changes.outputs.run_labs == 'true'",
+    "    name: Prime rustbgpd:dev build cache",
+    "    runs-on: ubuntu-latest",
+    "    timeout-minutes: 30",
+    "    concurrency:",
+    "      group: rustbgpd-dev-image-${{ github.sha }}",
+    "      cancel-in-progress: false",
+    "    steps:",
+)
+PREPARE_GOBGP_ACTION_CONTRACT = (
+    'name: "Prepare exact GoBGP artifact"',
+    (
+        'description: "Restore, verify, and upload the pinned GoBGP archive '
+        'for heavy CI lanes."'
+    ),
+    "runs:",
+    '  using: "composite"',
+    "  steps:",
+    "    - name: Restore exact gobgp archive cache",
+    "      uses: actions/cache@v6",
+    "      with:",
+    f"        path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}",
+    f"        key: {GOBGP_CACHE_KEY}",
+    "    - name: Prepare exact gobgp archive",
+    "      shell: bash",
+    "      run: |",
+    "        .github/scripts/install-gobgp.sh \\",
+    "          --prepare-archive \\",
+    f'          "$RUNNER_TEMP/gobgp-cache/{GOBGP_ARCHIVE}"',
+    "    - name: Upload verified gobgp archive",
+    "      uses: actions/upload-artifact@v7",
+    "      with:",
+    f"        name: {GOBGP_ARTIFACT}",
+    f"        path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}",
+    "        if-no-files-found: error",
+    "        retention-days: 1",
+    "        compression-level: 0",
+)
+PRIME_DEV_IMAGE_ACTION_CONTRACT = (
+    'name: "Prime rustbgpd:dev build cache"',
+    (
+        'description: "Warm the fixed heavy-lane image cache without loading '
+        'a local image."'
+    ),
+    "runs:",
+    '  using: "composite"',
+    "  steps:",
+    "    - name: Set up Docker Buildx",
+    "      uses: docker/setup-buildx-action@v4",
+    "    - name: Prime rustbgpd:dev build cache",
+    "      uses: docker/build-push-action@v7",
+    "      with:",
+    "        context: .",
+    "        load: false",
+    "        tags: rustbgpd:dev",
+    "        target: dev",
+    "        cache-from: type=gha,scope=rustbgpd-dev",
+    "        cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true",
+)
+
 
 def _hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _canonical_yaml_contract(text: str) -> tuple[str, ...]:
+    """Return behavior-bearing YAML lines with exact order and indentation."""
+    return tuple(
+        line.rstrip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def _job_envelope_contract(block: str) -> tuple[str, ...]:
+    """Return every job-level setting while treating the steps sequence as opaque."""
+    envelope: list[str] = []
+    in_steps = False
+    for line in block.splitlines():
+        if line == "    steps:":
+            envelope.append(line)
+            in_steps = True
+        elif in_steps and re.match(r"^    \S", line):
+            in_steps = False
+            envelope.append(line)
+        elif not in_steps:
+            envelope.append(line)
+    return _canonical_yaml_contract("\n".join(envelope))
 
 
 def _installer_executable(root: Path, installer: Path) -> bool:
@@ -520,13 +615,9 @@ def check(root: Path) -> list[str]:
             if gnmic_producer.count(exact_gnmic_path) != 2:
                 errors.append(f"{name}:gnmic_archive cache/artifact paths drifted")
         gobgp_producer = jobs.get("gobgp_archive", "")
-        for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
-            if not _has_line(gobgp_producer, f"    {seam}"):
-                errors.append(f"{name}:gobgp_archive missing job-level {seam}")
+        if _job_envelope_contract(gobgp_producer) != GOBGP_PRODUCER_JOB_ENVELOPE:
+            errors.append(f"{name}:gobgp_archive exact job envelope drifted")
         for seam in (
-            "name: Prepare exact gobgp archive",
-            "runs-on: ubuntu-latest",
-            "timeout-minutes: 10",
             CHECKOUT,
             "ref: ${{ github.sha }}",
             "name: Restore, prepare, and upload exact gobgp archive",
@@ -604,13 +695,9 @@ def check(root: Path) -> list[str]:
             if bird3_producer.count(exact_bird3_path) != 2:
                 errors.append(f"{name}:bird3_archive cache/artifact paths drifted")
         primer = jobs.get("prime_dev_image", "")
-        for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
-            if not _has_line(primer, f"    {seam}"):
-                errors.append(f"{name}: primer missing job-level {seam}")
+        if _job_envelope_contract(primer) != PRIME_DEV_IMAGE_JOB_ENVELOPE:
+            errors.append(f"{name}: primer exact job envelope drifted")
         for seam in (
-            "timeout-minutes: 30",
-            PRIMER_GROUP,
-            "cancel-in-progress: false",
             CHECKOUT,
             "ref: ${{ github.sha }}",
             "name: Prime rustbgpd:dev build cache",
@@ -903,89 +990,16 @@ def check(root: Path) -> list[str]:
             errors.append(f"prepare-grpcurl-artifact permits {forbidden}")
     if re.search(r"(?m)^\s*curl\s", prepare_grpcurl_action):
         errors.append("prepare-grpcurl-artifact permits curl")
-    for seam in (
-        'using: "composite"',
-        "uses: actions/cache@v6",
-        f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}",
-        f"key: {GOBGP_CACHE_KEY}",
-        "shell: bash",
-        "--prepare-archive",
-        f'"$RUNNER_TEMP/gobgp-cache/{GOBGP_ARCHIVE}"',
-        "uses: actions/upload-artifact@v7",
-        f"name: {GOBGP_ARTIFACT}",
-        "if-no-files-found: error",
-        "retention-days: 1",
-        "compression-level: 0",
+    if (
+        _canonical_yaml_contract(prepare_gobgp_action)
+        != PREPARE_GOBGP_ACTION_CONTRACT
     ):
-        if seam not in prepare_gobgp_action:
-            errors.append(f"prepare-gobgp-artifact missing {seam}")
-    if prepare_gobgp_action.count("uses: actions/cache@v6") != 1:
-        errors.append("prepare-gobgp-artifact must restore one exact cache")
-    if prepare_gobgp_action.count("--prepare-archive") != 1:
-        errors.append("prepare-gobgp-artifact must prepare one archive")
-    if prepare_gobgp_action.count("uses: actions/upload-artifact@v7") != 1:
-        errors.append("prepare-gobgp-artifact must upload one artifact")
-    exact_gobgp_path = (
-        f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}"
-    )
-    if prepare_gobgp_action.count(exact_gobgp_path) != 2:
-        errors.append("prepare-gobgp-artifact cache/artifact paths drifted")
-    if prepare_gobgp_action.count(f"key: {GOBGP_CACHE_KEY}") != 1:
-        errors.append("prepare-gobgp-artifact cache key drifted")
-    if prepare_gobgp_action.count(f"name: {GOBGP_ARTIFACT}") != 1:
-        errors.append("prepare-gobgp-artifact artifact name drifted")
-    for forbidden in (
-        "inputs:",
-        "outputs:",
-        "restore-keys:",
-        "continue-on-error:",
-        "actions/download-artifact@",
-        "--stage-archive",
-        "releases/download/",
+        errors.append("prepare-gobgp-artifact exact action contract drifted")
+    if (
+        _canonical_yaml_contract(prime_dev_image_action)
+        != PRIME_DEV_IMAGE_ACTION_CONTRACT
     ):
-        if forbidden in prepare_gobgp_action:
-            errors.append(f"prepare-gobgp-artifact permits {forbidden}")
-    if re.search(r"(?m)^\s*curl\s", prepare_gobgp_action):
-        errors.append("prepare-gobgp-artifact permits curl")
-
-    primer_action_uses = re.findall(
-        r"(?m)^\s*(?:- )?uses:\s*(.+)$", prime_dev_image_action
-    )
-    if primer_action_uses != [
-        "docker/setup-buildx-action@v4",
-        "docker/build-push-action@v7",
-    ]:
-        errors.append("prime-rustbgpd-dev-cache action inventory drifted")
-    for seam in (
-        'using: "composite"',
-        BUILDX,
-        BUILD_PUSH,
-        "context: .",
-        "load: false",
-        "tags: rustbgpd:dev",
-        "target: dev",
-        IMPORT,
-        EXPORT,
-    ):
-        if seam not in prime_dev_image_action:
-            errors.append(f"prime-rustbgpd-dev-cache missing {seam}")
-    for seam in (BUILDX, BUILD_PUSH, IMPORT, EXPORT):
-        if prime_dev_image_action.count(seam) != 1:
-            errors.append(f"prime-rustbgpd-dev-cache must contain one exact {seam}")
-    for forbidden in (
-        "inputs:",
-        "outputs:",
-        "continue-on-error:",
-        "if:",
-        "load: true",
-        "push: true",
-        "actions/checkout@",
-        "actions/cache@",
-        "actions/upload-artifact@",
-        "actions/download-artifact@",
-    ):
-        if forbidden in prime_dev_image_action:
-            errors.append(f"prime-rustbgpd-dev-cache permits {forbidden}")
+        errors.append("prime-rustbgpd-dev-cache exact action contract drifted")
     for seam in (
         "uses: actions/download-artifact@v8",
         f"name: {GRPCURL_ARTIFACT}",

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -108,6 +108,7 @@ GNMIC_ACTION = "uses: ./.github/actions/install-gnmic-artifact"
 GOBGP_ARCHIVE = f"gobgp_{GOBGP_VERSION}_linux_amd64.tar.gz"
 GOBGP_ARTIFACT = f"gobgp-v{GOBGP_VERSION}-linux-amd64"
 GOBGP_CACHE_KEY = f"{GOBGP_ARTIFACT}-{GOBGP_CHECKSUMS['amd64']}"
+PREPARE_GOBGP_ACTION = "uses: ./.github/actions/prepare-gobgp-artifact"
 GOBGP_ACTION = "uses: ./.github/actions/stage-gobgp-artifact"
 GOBGP_BUILD = (
     "docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop"
@@ -123,6 +124,7 @@ BIRD3_CACHE_SEAMS = (
     "cache-from: type=gha,scope=bird3-tcpao",
     "cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true",
 )
+PRIME_DEV_IMAGE_ACTION = "uses: ./.github/actions/prime-rustbgpd-dev-cache"
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -146,10 +148,10 @@ PINS = collections.Counter(
         "dtolnay/rust-toolchain@v1 # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@v1 # 1.95": 2,
-        "docker/setup-buildx-action@v4": 45,
-        "docker/build-push-action@v7": 46,
-        "actions/cache@v6": 6,
-        "actions/upload-artifact@v7": 8,
+        "docker/setup-buildx-action@v4": 44,
+        "docker/build-push-action@v7": 45,
+        "actions/cache@v6": 5,
+        "actions/upload-artifact@v7": 7,
         "actions/download-artifact@v8": 6,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
@@ -527,16 +529,8 @@ def check(root: Path) -> list[str]:
             "timeout-minutes: 10",
             CHECKOUT,
             "ref: ${{ github.sha }}",
-            "uses: actions/cache@v6",
-            f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}",
-            f"key: {GOBGP_CACHE_KEY}",
-            "--prepare-archive",
-            f'"$RUNNER_TEMP/gobgp-cache/{GOBGP_ARCHIVE}"',
-            "uses: actions/upload-artifact@v7",
-            f"name: {GOBGP_ARTIFACT}",
-            "if-no-files-found: error",
-            "retention-days: 1",
-            "compression-level: 0",
+            "name: Restore, prepare, and upload exact gobgp archive",
+            PREPARE_GOBGP_ACTION,
         ):
             if seam not in gobgp_producer:
                 errors.append(f"{name}:gobgp_archive missing {seam}")
@@ -544,21 +538,28 @@ def check(root: Path) -> list[str]:
             "restore-keys:",
             "continue-on-error:",
             "actions/download-artifact@",
+            "actions/cache@",
+            "actions/upload-artifact@",
+            "--prepare-archive",
             "--stage-archive",
         ):
             if forbidden in gobgp_producer:
                 errors.append(f"{name}:gobgp_archive permits {forbidden}")
-        if gobgp_producer.count("uses: actions/cache@v6") != 1:
-            errors.append(f"{name}:gobgp_archive must restore one exact cache")
-        if gobgp_producer.count("--prepare-archive") != 1:
-            errors.append(f"{name}:gobgp_archive must prepare one archive")
-        if gobgp_producer.count("uses: actions/upload-artifact@v7") != 1:
-            errors.append(f"{name}:gobgp_archive must upload one artifact")
-        exact_gobgp_path = (
-            f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}"
+        producer_uses = re.findall(
+            r"(?m)^\s*(?:- )?uses:\s*(.+)$", gobgp_producer
         )
-        if gobgp_producer.count(exact_gobgp_path) != 2:
-            errors.append(f"{name}:gobgp_archive cache/artifact paths drifted")
+        if producer_uses != [
+            "actions/checkout@v7",
+            "./.github/actions/prepare-gobgp-artifact",
+        ]:
+            errors.append(f"{name}:gobgp_archive action inventory drifted")
+        if gobgp_producer.count(PREPARE_GOBGP_ACTION) != 1:
+            errors.append(
+                f"{name}:gobgp_archive must call one exact producer action"
+            )
+        producer_call_tail = gobgp_producer.split(PREPARE_GOBGP_ACTION, 1)[-1]
+        if "with:" in producer_call_tail:
+            errors.append(f"{name}:gobgp_archive producer call must have no inputs")
         if setup:
             bird3_producer = jobs.get("bird3_archive", "")
             for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
@@ -612,19 +613,32 @@ def check(root: Path) -> list[str]:
             "cancel-in-progress: false",
             CHECKOUT,
             "ref: ${{ github.sha }}",
-            BUILDX,
-            BUILD_PUSH,
-            "context: .",
-            "load: false",
-            "tags: rustbgpd:dev",
-            "target: dev",
-            IMPORT,
-            EXPORT,
+            "name: Prime rustbgpd:dev build cache",
+            PRIME_DEV_IMAGE_ACTION,
         ):
             if seam not in primer:
                 errors.append(f"{name}: primer missing {seam}")
-        if "load: true" in primer:
-            errors.append(f"{name}: primer must export cache, not load an image")
+        primer_uses = re.findall(r"(?m)^\s*(?:- )?uses:\s*(.+)$", primer)
+        if primer_uses != [
+            "actions/checkout@v7",
+            "./.github/actions/prime-rustbgpd-dev-cache",
+        ]:
+            errors.append(f"{name}: primer action inventory drifted")
+        if primer.count(PRIME_DEV_IMAGE_ACTION) != 1:
+            errors.append(f"{name}: primer must call one exact image-primer action")
+        primer_call_tail = primer.split(PRIME_DEV_IMAGE_ACTION, 1)[-1]
+        if "with:" in primer_call_tail:
+            errors.append(f"{name}: image-primer call must have no inputs")
+        for forbidden in (
+            "continue-on-error:",
+            "docker/setup-buildx-action@",
+            "docker/build-push-action@",
+            "cache-from:",
+            "cache-to:",
+            "load:",
+        ):
+            if forbidden in primer:
+                errors.append(f"{name}: primer bypasses shared action with {forbidden}")
         for job_name in roster:
             job = jobs.get(job_name, "")
             if not setup and job_name in ("m54", "m56"):
@@ -830,6 +844,12 @@ def check(root: Path) -> list[str]:
     prepare_grpcurl_action = (
         root / ".github" / "actions" / "prepare-grpcurl-artifact" / "action.yml"
     ).read_text()
+    prepare_gobgp_action = (
+        root / ".github" / "actions" / "prepare-gobgp-artifact" / "action.yml"
+    ).read_text()
+    prime_dev_image_action = (
+        root / ".github" / "actions" / "prime-rustbgpd-dev-cache" / "action.yml"
+    ).read_text()
     gnmic_action = (
         root / ".github" / "actions" / "install-gnmic-artifact" / "action.yml"
     ).read_text()
@@ -883,6 +903,89 @@ def check(root: Path) -> list[str]:
             errors.append(f"prepare-grpcurl-artifact permits {forbidden}")
     if re.search(r"(?m)^\s*curl\s", prepare_grpcurl_action):
         errors.append("prepare-grpcurl-artifact permits curl")
+    for seam in (
+        'using: "composite"',
+        "uses: actions/cache@v6",
+        f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}",
+        f"key: {GOBGP_CACHE_KEY}",
+        "shell: bash",
+        "--prepare-archive",
+        f'"$RUNNER_TEMP/gobgp-cache/{GOBGP_ARCHIVE}"',
+        "uses: actions/upload-artifact@v7",
+        f"name: {GOBGP_ARTIFACT}",
+        "if-no-files-found: error",
+        "retention-days: 1",
+        "compression-level: 0",
+    ):
+        if seam not in prepare_gobgp_action:
+            errors.append(f"prepare-gobgp-artifact missing {seam}")
+    if prepare_gobgp_action.count("uses: actions/cache@v6") != 1:
+        errors.append("prepare-gobgp-artifact must restore one exact cache")
+    if prepare_gobgp_action.count("--prepare-archive") != 1:
+        errors.append("prepare-gobgp-artifact must prepare one archive")
+    if prepare_gobgp_action.count("uses: actions/upload-artifact@v7") != 1:
+        errors.append("prepare-gobgp-artifact must upload one artifact")
+    exact_gobgp_path = (
+        f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}"
+    )
+    if prepare_gobgp_action.count(exact_gobgp_path) != 2:
+        errors.append("prepare-gobgp-artifact cache/artifact paths drifted")
+    if prepare_gobgp_action.count(f"key: {GOBGP_CACHE_KEY}") != 1:
+        errors.append("prepare-gobgp-artifact cache key drifted")
+    if prepare_gobgp_action.count(f"name: {GOBGP_ARTIFACT}") != 1:
+        errors.append("prepare-gobgp-artifact artifact name drifted")
+    for forbidden in (
+        "inputs:",
+        "outputs:",
+        "restore-keys:",
+        "continue-on-error:",
+        "actions/download-artifact@",
+        "--stage-archive",
+        "releases/download/",
+    ):
+        if forbidden in prepare_gobgp_action:
+            errors.append(f"prepare-gobgp-artifact permits {forbidden}")
+    if re.search(r"(?m)^\s*curl\s", prepare_gobgp_action):
+        errors.append("prepare-gobgp-artifact permits curl")
+
+    primer_action_uses = re.findall(
+        r"(?m)^\s*(?:- )?uses:\s*(.+)$", prime_dev_image_action
+    )
+    if primer_action_uses != [
+        "docker/setup-buildx-action@v4",
+        "docker/build-push-action@v7",
+    ]:
+        errors.append("prime-rustbgpd-dev-cache action inventory drifted")
+    for seam in (
+        'using: "composite"',
+        BUILDX,
+        BUILD_PUSH,
+        "context: .",
+        "load: false",
+        "tags: rustbgpd:dev",
+        "target: dev",
+        IMPORT,
+        EXPORT,
+    ):
+        if seam not in prime_dev_image_action:
+            errors.append(f"prime-rustbgpd-dev-cache missing {seam}")
+    for seam in (BUILDX, BUILD_PUSH, IMPORT, EXPORT):
+        if prime_dev_image_action.count(seam) != 1:
+            errors.append(f"prime-rustbgpd-dev-cache must contain one exact {seam}")
+    for forbidden in (
+        "inputs:",
+        "outputs:",
+        "continue-on-error:",
+        "if:",
+        "load: true",
+        "push: true",
+        "actions/checkout@",
+        "actions/cache@",
+        "actions/upload-artifact@",
+        "actions/download-artifact@",
+    ):
+        if forbidden in prime_dev_image_action:
+            errors.append(f"prime-rustbgpd-dev-cache permits {forbidden}")
     for seam in (
         "uses: actions/download-artifact@v8",
         f"name: {GRPCURL_ARTIFACT}",
@@ -1043,7 +1146,12 @@ def check(root: Path) -> list[str]:
     if texts["kernel-dataplane.yml"].count(GOBGP_ACTION) != 3:
         errors.append("kernel-dataplane.yml: gobgp stage consumer inventory drifted")
     gobgp_surfaces = "\n".join(
-        (texts["interop.yml"], texts["kernel-dataplane.yml"], gobgp_action)
+        (
+            texts["interop.yml"],
+            texts["kernel-dataplane.yml"],
+            prepare_gobgp_action,
+            gobgp_action,
+        )
     )
     if "osrg/gobgp/releases" in gobgp_surfaces:
         errors.append("gobgp release URL escaped the installer/Dockerfile")
@@ -1062,6 +1170,8 @@ def check(root: Path) -> list[str]:
         *texts.values(),
         action,
         prepare_grpcurl_action,
+        prepare_gobgp_action,
+        prime_dev_image_action,
         grpcurl_action,
         gnmic_action,
         gobgp_action,

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -108,7 +108,6 @@ GNMIC_ACTION = "uses: ./.github/actions/install-gnmic-artifact"
 GOBGP_ARCHIVE = f"gobgp_{GOBGP_VERSION}_linux_amd64.tar.gz"
 GOBGP_ARTIFACT = f"gobgp-v{GOBGP_VERSION}-linux-amd64"
 GOBGP_CACHE_KEY = f"{GOBGP_ARTIFACT}-{GOBGP_CHECKSUMS['amd64']}"
-PREPARE_GOBGP_ACTION = "uses: ./.github/actions/prepare-gobgp-artifact"
 GOBGP_ACTION = "uses: ./.github/actions/stage-gobgp-artifact"
 GOBGP_BUILD = (
     "docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop"
@@ -124,8 +123,6 @@ BIRD3_CACHE_SEAMS = (
     "cache-from: type=gha,scope=bird3-tcpao",
     "cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true",
 )
-PRIME_DEV_IMAGE_ACTION = "uses: ./.github/actions/prime-rustbgpd-dev-cache"
-
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
     "audit.yml": "1829597143324f5361dfdfece50ddeffd6f7d5934b72198f1837fbdf25339fd3",
@@ -158,15 +155,20 @@ PINS = collections.Counter(
     }
 )
 
-GOBGP_PRODUCER_JOB_ENVELOPE = (
+GOBGP_PRODUCER_JOB_CONTRACT = (
     "    needs: classify_changes",
     "    if: needs.classify_changes.outputs.run_labs == 'true'",
     "    name: Prepare exact gobgp archive",
     "    runs-on: ubuntu-latest",
     "    timeout-minutes: 10",
     "    steps:",
+    "      - uses: actions/checkout@v7",
+    "        with:",
+    "          ref: ${{ github.sha }}",
+    "      - name: Restore, prepare, and upload exact gobgp archive",
+    "        uses: ./.github/actions/prepare-gobgp-artifact",
 )
-PRIME_DEV_IMAGE_JOB_ENVELOPE = (
+PRIME_DEV_IMAGE_JOB_CONTRACT = (
     "    needs: classify_changes",
     "    if: needs.classify_changes.outputs.run_labs == 'true'",
     "    name: Prime rustbgpd:dev build cache",
@@ -176,6 +178,11 @@ PRIME_DEV_IMAGE_JOB_ENVELOPE = (
     "      group: rustbgpd-dev-image-${{ github.sha }}",
     "      cancel-in-progress: false",
     "    steps:",
+    "      - uses: actions/checkout@v7",
+    "        with:",
+    "          ref: ${{ github.sha }}",
+    "      - name: Prime rustbgpd:dev build cache",
+    "        uses: ./.github/actions/prime-rustbgpd-dev-cache",
 )
 PREPARE_GOBGP_ACTION_CONTRACT = (
     'name: "Prepare exact GoBGP artifact"',
@@ -240,22 +247,6 @@ def _canonical_yaml_contract(text: str) -> tuple[str, ...]:
         for line in text.splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     )
-
-
-def _job_envelope_contract(block: str) -> tuple[str, ...]:
-    """Return every job-level setting while treating the steps sequence as opaque."""
-    envelope: list[str] = []
-    in_steps = False
-    for line in block.splitlines():
-        if line == "    steps:":
-            envelope.append(line)
-            in_steps = True
-        elif in_steps and re.match(r"^    \S", line):
-            in_steps = False
-            envelope.append(line)
-        elif not in_steps:
-            envelope.append(line)
-    return _canonical_yaml_contract("\n".join(envelope))
 
 
 def _installer_executable(root: Path, installer: Path) -> bool:
@@ -615,42 +606,11 @@ def check(root: Path) -> list[str]:
             if gnmic_producer.count(exact_gnmic_path) != 2:
                 errors.append(f"{name}:gnmic_archive cache/artifact paths drifted")
         gobgp_producer = jobs.get("gobgp_archive", "")
-        if _job_envelope_contract(gobgp_producer) != GOBGP_PRODUCER_JOB_ENVELOPE:
-            errors.append(f"{name}:gobgp_archive exact job envelope drifted")
-        for seam in (
-            CHECKOUT,
-            "ref: ${{ github.sha }}",
-            "name: Restore, prepare, and upload exact gobgp archive",
-            PREPARE_GOBGP_ACTION,
+        if (
+            _canonical_yaml_contract(gobgp_producer)
+            != GOBGP_PRODUCER_JOB_CONTRACT
         ):
-            if seam not in gobgp_producer:
-                errors.append(f"{name}:gobgp_archive missing {seam}")
-        for forbidden in (
-            "restore-keys:",
-            "continue-on-error:",
-            "actions/download-artifact@",
-            "actions/cache@",
-            "actions/upload-artifact@",
-            "--prepare-archive",
-            "--stage-archive",
-        ):
-            if forbidden in gobgp_producer:
-                errors.append(f"{name}:gobgp_archive permits {forbidden}")
-        producer_uses = re.findall(
-            r"(?m)^\s*(?:- )?uses:\s*(.+)$", gobgp_producer
-        )
-        if producer_uses != [
-            "actions/checkout@v7",
-            "./.github/actions/prepare-gobgp-artifact",
-        ]:
-            errors.append(f"{name}:gobgp_archive action inventory drifted")
-        if gobgp_producer.count(PREPARE_GOBGP_ACTION) != 1:
-            errors.append(
-                f"{name}:gobgp_archive must call one exact producer action"
-            )
-        producer_call_tail = gobgp_producer.split(PREPARE_GOBGP_ACTION, 1)[-1]
-        if "with:" in producer_call_tail:
-            errors.append(f"{name}:gobgp_archive producer call must have no inputs")
+            errors.append(f"{name}:gobgp_archive exact job contract drifted")
         if setup:
             bird3_producer = jobs.get("bird3_archive", "")
             for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
@@ -695,37 +655,11 @@ def check(root: Path) -> list[str]:
             if bird3_producer.count(exact_bird3_path) != 2:
                 errors.append(f"{name}:bird3_archive cache/artifact paths drifted")
         primer = jobs.get("prime_dev_image", "")
-        if _job_envelope_contract(primer) != PRIME_DEV_IMAGE_JOB_ENVELOPE:
-            errors.append(f"{name}: primer exact job envelope drifted")
-        for seam in (
-            CHECKOUT,
-            "ref: ${{ github.sha }}",
-            "name: Prime rustbgpd:dev build cache",
-            PRIME_DEV_IMAGE_ACTION,
+        if (
+            _canonical_yaml_contract(primer)
+            != PRIME_DEV_IMAGE_JOB_CONTRACT
         ):
-            if seam not in primer:
-                errors.append(f"{name}: primer missing {seam}")
-        primer_uses = re.findall(r"(?m)^\s*(?:- )?uses:\s*(.+)$", primer)
-        if primer_uses != [
-            "actions/checkout@v7",
-            "./.github/actions/prime-rustbgpd-dev-cache",
-        ]:
-            errors.append(f"{name}: primer action inventory drifted")
-        if primer.count(PRIME_DEV_IMAGE_ACTION) != 1:
-            errors.append(f"{name}: primer must call one exact image-primer action")
-        primer_call_tail = primer.split(PRIME_DEV_IMAGE_ACTION, 1)[-1]
-        if "with:" in primer_call_tail:
-            errors.append(f"{name}: image-primer call must have no inputs")
-        for forbidden in (
-            "continue-on-error:",
-            "docker/setup-buildx-action@",
-            "docker/build-push-action@",
-            "cache-from:",
-            "cache-to:",
-            "load:",
-        ):
-            if forbidden in primer:
-                errors.append(f"{name}: primer bypasses shared action with {forbidden}")
+            errors.append(f"{name}: primer exact job contract drifted")
         for job_name in roster:
             job = jobs.get(job_name, "")
             if not setup and job_name in ("m54", "m56"):

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -641,6 +641,10 @@ class PrimerContractTests(unittest.TestCase):
                     self.mutate(relative, old, new)
 
         producer = ".github/actions/prepare-gobgp-artifact/action.yml"
+        verified_archive = (
+            '          "$RUNNER_TEMP/gobgp-cache/'
+            'gobgp_3.37.0_linux_amd64.tar.gz"\n'
+        )
         for old, new in (
             ('using: "composite"', 'using: "docker"'),
             ("actions/cache@v6", "actions/cache@main"),
@@ -673,6 +677,16 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/scripts/install-gobgp.sh \\",
                 "curl https://example.invalid/gobgp\n"
                 "        .github/scripts/install-gobgp.sh \\",
+            ),
+            (
+                verified_archive + "\n    - name: Upload verified gobgp archive",
+                verified_archive
+                + "\n    - name: Replace verified archive\n"
+                + "      shell: bash\n"
+                + '      run: cp "$RUNNER_TEMP/unverified.tar.gz" '
+                + '"$RUNNER_TEMP/gobgp-cache/"*.tar.gz\n'
+                + "\n"
+                + "    - name: Upload verified gobgp archive",
             ),
         ):
             with self.subTest(seam=f"gobgp producer action {old}"):
@@ -733,6 +747,41 @@ class PrimerContractTests(unittest.TestCase):
         ):
             with self.subTest(seam=old):
                 self.mutate(installer, old, new)
+
+    def test_shared_job_envelopes_reject_additive_permissions(self):
+        producer = (
+            "  gobgp_archive:\n"
+            "    needs: classify_changes\n"
+            "    if: needs.classify_changes.outputs.run_labs == 'true'\n"
+            "    name: Prepare exact gobgp archive\n"
+            "    runs-on: ubuntu-latest\n"
+            "    timeout-minutes: 10\n"
+            "    steps:\n"
+        )
+        primer = (
+            "  prime_dev_image:\n"
+            "    needs: classify_changes\n"
+            "    if: needs.classify_changes.outputs.run_labs == 'true'\n"
+            "    name: Prime rustbgpd:dev build cache\n"
+            "    runs-on: ubuntu-latest\n"
+            "    timeout-minutes: 30\n"
+            "    concurrency:\n"
+            "      group: rustbgpd-dev-image-${{ github.sha }}\n"
+            "      cancel-in-progress: false\n"
+            "    steps:\n"
+        )
+        for workflow in ("interop.yml", "kernel-dataplane.yml"):
+            relative = f".github/workflows/{workflow}"
+            for job, envelope in (
+                ("gobgp_archive", producer),
+                ("prime_dev_image", primer),
+            ):
+                widened = envelope.replace(
+                    "    steps:\n",
+                    "    permissions: write-all\n    steps:\n",
+                )
+                with self.subTest(workflow=workflow, job=job):
+                    self.mutate(relative, envelope, widened)
 
     def test_bird3_producer_and_stage_consumer_are_load_bearing(self):
         checksum = "d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
@@ -1171,6 +1220,7 @@ class PrimerContractTests(unittest.TestCase):
         for old, new in (
             ('using: "composite"', 'using: "docker"'),
             ("load: false", "load: true"),
+            ("load: false", "load: false\n        no-cache: true"),
             ("context: .", "context: elsewhere"),
             ("tags: rustbgpd:dev", "tags: other:dev"),
             ("target: dev", "target: release"),

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -93,7 +93,9 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-gobgp-artifact",
                 ".github/actions/prepare-grpcurl-artifact",
+                ".github/actions/prime-rustbgpd-dev-cache",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -137,7 +139,9 @@ class PrimerContractTests(unittest.TestCase):
             ".github/workflows",
             ".github/actions/install-gnmic-artifact",
             ".github/actions/install-grpcurl-artifact",
+            ".github/actions/prepare-gobgp-artifact",
             ".github/actions/prepare-grpcurl-artifact",
+            ".github/actions/prime-rustbgpd-dev-cache",
             ".github/actions/setup-dataplane-host",
             ".github/actions/stage-bird3-artifact",
             ".github/actions/stage-gobgp-artifact",
@@ -233,7 +237,9 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-gobgp-artifact",
                 ".github/actions/prepare-grpcurl-artifact",
+                ".github/actions/prime-rustbgpd-dev-cache",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -261,7 +267,9 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-gobgp-artifact",
                 ".github/actions/prepare-grpcurl-artifact",
+                ".github/actions/prime-rustbgpd-dev-cache",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -559,7 +567,7 @@ class PrimerContractTests(unittest.TestCase):
             ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
         ):
             with self.subTest(seam=f"gnmic producer {seam}"):
-                self.mutate(workflow, seam, replacement, occurrence=1)
+                self.mutate(workflow, seam, replacement)
         exact_path = (
             "path: ${{ runner.temp }}/gnmic-cache/"
             "gnmic_0.46.0_Linux_x86_64.tar.gz"
@@ -603,11 +611,23 @@ class PrimerContractTests(unittest.TestCase):
         checksum = "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522"
         for workflow in ("interop.yml", "kernel-dataplane.yml"):
             relative = f".github/workflows/{workflow}"
-            producer_occurrence = 1 if workflow == "interop.yml" else 0
             for old, new in (
                 ("  gobgp_archive:\n", "  removed_gobgp_archive:\n"),
-                (f"key: gobgp-v3.37.0-linux-amd64-{checksum}", "key: gobgp-latest"),
-                ("name: gobgp-v3.37.0-linux-amd64", "name: gobgp-latest"),
+                (
+                    "uses: ./.github/actions/prepare-gobgp-artifact",
+                    "uses: ./.github/actions/stage-gobgp-artifact",
+                ),
+                (
+                    "uses: ./.github/actions/prepare-gobgp-artifact",
+                    "uses: ./.github/actions/prepare-gobgp-artifact\n"
+                    "        with:\n"
+                    "          mode: permissive",
+                ),
+                (
+                    "uses: ./.github/actions/prepare-gobgp-artifact",
+                    "uses: ./.github/actions/prepare-gobgp-artifact\n"
+                    "      - uses: actions/cache@v6",
+                ),
                 (
                     "needs: [grpcurl_archive, gobgp_archive, prime_dev_image]",
                     "needs: [grpcurl_archive, prime_dev_image]",
@@ -619,29 +639,56 @@ class PrimerContractTests(unittest.TestCase):
             ):
                 with self.subTest(workflow=workflow, seam=old):
                     self.mutate(relative, old, new)
-            for seam, replacement in (
-                ("actions/cache@v6", "actions/cache@main"),
-                ("--prepare-archive", "--stage-archive"),
-                ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
-            ):
-                with self.subTest(workflow=workflow, seam=f"gobgp producer {seam}"):
-                    self.mutate(
-                        relative, seam, replacement, occurrence=producer_occurrence
-                    )
-            exact_path = (
-                "path: ${{ runner.temp }}/gobgp-cache/"
-                "gobgp_3.37.0_linux_amd64.tar.gz"
-            )
-            for occurrence in (0, 1):
-                with self.subTest(
-                    workflow=workflow, seam="gobgp exact path", occurrence=occurrence
-                ):
-                    self.mutate(
-                        relative,
-                        exact_path,
-                        "path: ${{ runner.temp }}/gobgp-cache/wrong.tar.gz",
-                        occurrence=occurrence,
-                    )
+
+        producer = ".github/actions/prepare-gobgp-artifact/action.yml"
+        for old, new in (
+            ('using: "composite"', 'using: "docker"'),
+            ("actions/cache@v6", "actions/cache@main"),
+            (f"key: gobgp-v3.37.0-linux-amd64-{checksum}", "key: gobgp-latest"),
+            ("shell: bash", "shell: sh"),
+            ("--prepare-archive", "--stage-archive"),
+            ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
+            ("name: gobgp-v3.37.0-linux-amd64", "name: gobgp-latest"),
+            ("if-no-files-found: error", "if-no-files-found: warn"),
+            ("retention-days: 1", "retention-days: 30"),
+            ("compression-level: 0", "compression-level: 6"),
+            (
+                f"key: gobgp-v3.37.0-linux-amd64-{checksum}",
+                f"key: gobgp-v3.37.0-linux-amd64-{checksum}\n"
+                "        restore-keys: gobgp-",
+            ),
+            (
+                "uses: actions/cache@v6",
+                "uses: actions/cache@v6\n      continue-on-error: true",
+            ),
+            (
+                "runs:\n",
+                "inputs:\n  mode:\n    required: false\nruns:\n",
+            ),
+            (
+                "runs:\n",
+                "outputs:\n  archive:\n    value: latest\nruns:\n",
+            ),
+            (
+                ".github/scripts/install-gobgp.sh \\",
+                "curl https://example.invalid/gobgp\n"
+                "        .github/scripts/install-gobgp.sh \\",
+            ),
+        ):
+            with self.subTest(seam=f"gobgp producer action {old}"):
+                self.mutate(producer, old, new)
+        exact_path = (
+            "path: ${{ runner.temp }}/gobgp-cache/"
+            "gobgp_3.37.0_linux_amd64.tar.gz"
+        )
+        for occurrence in (0, 1):
+            with self.subTest(seam="gobgp exact path", occurrence=occurrence):
+                self.mutate(
+                    producer,
+                    exact_path,
+                    "path: ${{ runner.temp }}/gobgp-cache/wrong.tar.gz",
+                    occurrence=occurrence,
+                )
 
         stage_then_build = (
             "      - name: Stage verified GoBGP archive\n"
@@ -716,7 +763,7 @@ class PrimerContractTests(unittest.TestCase):
             ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
         ):
             with self.subTest(seam=f"bird3 producer {seam}"):
-                self.mutate(relative, seam, replacement, occurrence=1)
+                self.mutate(relative, seam, replacement)
         exact_path = (
             "path: ${{ runner.temp }}/bird3-cache/bird-3.3.1.tar.gz"
         )
@@ -783,7 +830,9 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-gobgp-artifact",
                 ".github/actions/prepare-grpcurl-artifact",
+                ".github/actions/prime-rustbgpd-dev-cache",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -817,7 +866,9 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-gobgp-artifact",
                 ".github/actions/prepare-grpcurl-artifact",
+                ".github/actions/prime-rustbgpd-dev-cache",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -851,7 +902,9 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/workflows",
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
+                ".github/actions/prepare-gobgp-artifact",
                 ".github/actions/prepare-grpcurl-artifact",
+                ".github/actions/prime-rustbgpd-dev-cache",
                 ".github/actions/setup-dataplane-host",
                 ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
@@ -1046,8 +1099,8 @@ class PrimerContractTests(unittest.TestCase):
             ),
             (
                 ".github/workflows/interop.yml",
-                "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true",
-                "cache-to: type=gha",
+                "uses: ./.github/actions/prime-rustbgpd-dev-cache",
+                "uses: docker/build-push-action@v7",
             ),
             (".github/workflows/interop.yml", "load: true", "load: false"),
             (
@@ -1097,30 +1150,58 @@ class PrimerContractTests(unittest.TestCase):
                     "group: rustbgpd-dev-image-main",
                 ),
                 ("cancel-in-progress: false", "cancel-in-progress: true"),
-                ("load: false", "load: true"),
-                ("context: .", "context: elsewhere"),
-                ("tags: rustbgpd:dev", "tags: other:dev"),
-                ("target: dev", "target: release"),
-                ("cache-from: type=gha,scope=rustbgpd-dev", "cache-from: type=gha"),
                 (
-                    "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true",
-                    "cache-to: type=gha",
+                    "uses: ./.github/actions/prime-rustbgpd-dev-cache",
+                    "uses: docker/build-push-action@v7",
+                ),
+                (
+                    "uses: ./.github/actions/prime-rustbgpd-dev-cache",
+                    "uses: ./.github/actions/prime-rustbgpd-dev-cache\n"
+                    "      - uses: docker/build-push-action@v7",
                 ),
                 (
                     "actions/checkout@v7",
                     "actions/checkout@main",
                 ),
-                (
-                    "docker/setup-buildx-action@v4",
-                    "docker/setup-buildx-action@main",
-                ),
-                (
-                    "docker/build-push-action@v7",
-                    "docker/build-push-action@main",
-                ),
             ):
                 with self.subTest(workflow=workflow, seam=old):
                     self.mutate(relative, old, new)
+
+        primer_action = ".github/actions/prime-rustbgpd-dev-cache/action.yml"
+        for old, new in (
+            ('using: "composite"', 'using: "docker"'),
+            ("load: false", "load: true"),
+            ("context: .", "context: elsewhere"),
+            ("tags: rustbgpd:dev", "tags: other:dev"),
+            ("target: dev", "target: release"),
+            ("cache-from: type=gha,scope=rustbgpd-dev", "cache-from: type=gha"),
+            (
+                "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true",
+                "cache-to: type=gha",
+            ),
+            (
+                "docker/setup-buildx-action@v4",
+                "docker/setup-buildx-action@main",
+            ),
+            (
+                "docker/build-push-action@v7",
+                "docker/build-push-action@main",
+            ),
+            (
+                "uses: docker/build-push-action@v7",
+                "uses: docker/build-push-action@v7\n      continue-on-error: true",
+            ),
+            (
+                "runs:\n",
+                "inputs:\n  mode:\n    required: false\nruns:\n",
+            ),
+            (
+                "runs:\n",
+                "outputs:\n  image:\n    value: latest\nruns:\n",
+            ),
+        ):
+            with self.subTest(action=primer_action, seam=old):
+                self.mutate(primer_action, old, new)
 
         for workflow in ("ci.yml", "audit.yml", "interop.yml", "kernel-dataplane.yml"):
             relative = f".github/workflows/{workflow}"
@@ -1141,7 +1222,6 @@ class PrimerContractTests(unittest.TestCase):
                 interop,
                 "cache-from: type=gha,scope=rustbgpd-dev",
                 "cache-from: type=gha",
-                occurrence=1,
             )
         with self.subTest(workflow=interop, seam="consumer export"):
             self.mutate(

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -748,7 +748,7 @@ class PrimerContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(installer, old, new)
 
-    def test_shared_job_envelopes_reject_additive_permissions(self):
+    def test_shared_job_contracts_reject_additive_permissions(self):
         producer = (
             "  gobgp_archive:\n"
             "    needs: classify_changes\n"
@@ -782,6 +782,50 @@ class PrimerContractTests(unittest.TestCase):
                 )
                 with self.subTest(workflow=workflow, job=job):
                     self.mutate(relative, envelope, widened)
+
+    def test_shared_job_steps_reject_additive_behavior(self):
+        gobgp_call = (
+            "      - name: Restore, prepare, and upload exact gobgp archive\n"
+            "        uses: ./.github/actions/prepare-gobgp-artifact"
+        )
+        primer_call = (
+            "      - name: Prime rustbgpd:dev build cache\n"
+            "        uses: ./.github/actions/prime-rustbgpd-dev-cache"
+        )
+        for workflow in ("interop.yml", "kernel-dataplane.yml"):
+            relative = f".github/workflows/{workflow}"
+            cases = (
+                (
+                    "pre-gobgp helper change",
+                    gobgp_call,
+                    "      - name: Alter GoBGP helper\n"
+                    "        run: printf '\\nexit 0\\n' >> "
+                    ".github/scripts/install-gobgp.sh\n\n"
+                    + gobgp_call,
+                ),
+                (
+                    "pre-primer Dockerfile change",
+                    primer_call,
+                    "      - name: Alter Dockerfile before priming\n"
+                    "        run: printf '\\nRUN true\\n' >> Dockerfile\n\n"
+                    + primer_call,
+                ),
+            )
+            for seam, old, new in cases:
+                with self.subTest(workflow=workflow, seam=seam):
+                    self.mutate(relative, old, new)
+
+            for job, call in (
+                ("gobgp_archive", gobgp_call),
+                ("primer", primer_call),
+            ):
+                for field in (
+                    "        if: false",
+                    "        env:\n          CI_PROOF_MODE: altered",
+                    "        with:\n          mode: altered",
+                ):
+                    with self.subTest(workflow=workflow, job=job, field=field):
+                        self.mutate(relative, call, f"{call}\n{field}")
 
     def test_bird3_producer_and_stage_consumer_are_load_bearing(self):
         checksum = "d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"


### PR DESCRIPTION
## Summary

- centralize the identical GoBGP artifact producer used by the interoperability and Kernel Dataplane workflows
- centralize the identical fixed-scope `rustbgpd:dev` cache primer used by both heavy-lane workflows
- retain every workflow trigger, classifier gate, job contract, dependency, capability boundary, and required aggregate

## Contract

Both repository composite actions are intentionally input-free and output-free. The GoBGP action preserves the exact cache key, archive path, pinned installer mode, artifact identity, retention, compression, and missing-file refusal. The image-primer action preserves the pinned Buildx/build actions, fixed context/tag/target, no-load behavior, and exact GitHub Actions cache scope.

The workflow jobs retain checkout at `github.sha`, their names, runners, timeouts, concurrency, conditions, exact ordered steps, and downstream dependency edges. Conservative all-lanes classification on incomplete evidence is unchanged.

## Proof

- complete ordered action contracts reject additive keys, steps, or commands, including changes after archive verification
- complete producer/primer job contracts reject added job-level or step-level behavior, including extra commands, conditions, environment, inputs, and capability expansion
- contract mutations reject action inputs/outputs, inline reintroduction, permissive bypasses, pin drift, cache/artifact drift, and missing shared calls
- exact structural comparison proves untouched jobs and workflow-level envelopes remain unchanged
- the extracted action bodies match the retired workflow copies; GoBGP only gains the shell declaration required by composite actions

## Validation

- 53 image-primer, scale-split, and BIRD3-tolerance contract tests
- live image-primer and scale-split checkers
- YAML parsing for both workflows and both new composite actions
- Python compilation, diff checks, repository formatting, Clippy, and rustdoc hooks

Linear: LAN-1271
