### PR TITLE
docs(wire): pin downstream usage contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,6 +3293,7 @@ dependencies = [
  "bytes",
  "criterion",
  "proptest",
+ "syn 2.0.117",
  "thiserror 2.0.20",
  "tokio-util",
 ]

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -30,6 +30,7 @@ tokio-util = { workspace = true, features = ["codec"], optional = true }
 [dev-dependencies]
 proptest.workspace = true
 criterion.workspace = true
+syn = { version = "2", features = ["full"] }
 
 [[bench]]
 name = "codec"

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -184,6 +184,18 @@ later registry additions land without a breaking release.
 
 ## Usage
 
+Add the codec and its buffer type as direct dependencies:
+
+```toml
+[dependencies]
+rustbgpd-wire = "0.17.2"
+bytes = "1"
+```
+
+`decode_message` accepts `&mut bytes::Bytes`. The `bytes` crate is a public
+dependency of `rustbgpd-wire`, but it is not re-exported, so downstream
+projects must declare their own direct `bytes` dependency.
+
 Decode a single BGP message from raw bytes:
 
 For a deterministic interoperability check, run the standalone captured UPDATE
@@ -360,8 +372,12 @@ The enums that track IANA/RFC registries — `Capability`, `PathAttribute`,
 `Afi`/`Safi`, `Message`/`MessageType`, `NotificationCode`,
 `RouteRefreshSubtype`, the EVPN route/key enums, `BgpLsNlriType`, the
 FlowSpec component/action enums, the ORF type/entries enums, the PMSI
-tunnel enums, `BgpRole`, `AspaValidation`, and the decode/encode error
-enums — are `#[non_exhaustive]`. Match them with a wildcard arm:
+tunnel enums, `BgpRole`, and `AspaValidation` are `#[non_exhaustive]`.
+The five public error enums are also non-exhaustive: `DecodeError`,
+`EncodeError`, `RouteDistinguisherParseError`,
+`ShutdownCommunicationError`, and `BgpCodecError` (available with the
+`tokio-codec` feature). Downstream matches on any of these enums must include
+a wildcard arm:
 
 ```rust
 use rustbgpd_wire::Capability;

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -193,8 +193,9 @@ bytes = "1"
 ```
 
 `decode_message` accepts `&mut bytes::Bytes`. The `bytes` crate is a public
-dependency of `rustbgpd-wire`, but it is not re-exported, so downstream
-projects must declare their own direct `bytes` dependency.
+dependency of `rustbgpd-wire`, but the crate root does not expose a stable
+`Bytes` re-export, so downstream projects should declare a direct `bytes`
+dependency.
 
 Decode a single BGP message from raw bytes:
 

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use syn::{Attribute, Item, ItemExternCrate, ItemUse, UseTree, Visibility};
+
 const README: &str = include_str!("../README.md");
 const LIB_SOURCE: &str = include_str!("../src/lib.rs");
 const MESSAGE_SOURCE: &str = include_str!("../src/message.rs");
@@ -46,65 +48,130 @@ fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
     compact_whitespace(source).contains(&format!("#[non_exhaustive] pub enum {name}"))
 }
 
-fn error_enums_in_source(source: &str) -> Vec<String> {
-    let compact = compact_whitespace(source);
-    let marker = "#[non_exhaustive] pub enum ";
-    let mut remainder = compact.as_str();
-    let mut names = Vec::new();
-    while let Some(offset) = remainder.find(marker) {
-        let declaration = &remainder[offset + marker.len()..];
-        let end = declaration
-            .find(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
-            .unwrap_or(declaration.len());
-        let name = &declaration[..end];
-        if name.ends_with("Error") {
-            names.push(name.to_string());
-        }
-        remainder = &declaration[end..];
-    }
-    names
+fn is_public(visibility: &Visibility) -> bool {
+    matches!(visibility, Visibility::Public(_))
 }
 
-fn collect_rust_sources(directory: &Path, paths: &mut Vec<PathBuf>) {
-    for entry in std::fs::read_dir(directory)
-        .unwrap_or_else(|error| panic!("cannot read {}: {error}", directory.display()))
-    {
-        let path = entry.expect("source directory entry").path();
-        if path.is_dir() {
-            collect_rust_sources(&path, paths);
-        } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
-            paths.push(path);
-        }
-    }
-}
-
-fn public_non_exhaustive_error_enum_roster() -> Vec<String> {
-    let mut paths = Vec::new();
-    collect_rust_sources(
-        &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
-        &mut paths,
-    );
-    let mut names = paths
+fn has_non_exhaustive_attribute(attributes: &[Attribute]) -> bool {
+    attributes
         .iter()
-        .flat_map(|path| {
-            let source = std::fs::read_to_string(path)
-                .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
-            error_enums_in_source(&source)
-        })
-        .collect::<Vec<_>>();
-    names.sort();
-    names.dedup();
-    names
+        .any(|attribute| attribute.path().is_ident("non_exhaustive"))
 }
 
-fn public_bytes_reexports(source: &str) -> Vec<&str> {
-    source
-        .lines()
-        .map(str::trim)
-        .filter(|line| {
-            line.starts_with("pub use bytes") || line.starts_with("pub extern crate bytes")
-        })
-        .collect()
+fn use_tree_mentions_bytes(tree: &UseTree) -> bool {
+    match tree {
+        UseTree::Path(path) => path.ident == "bytes" || use_tree_mentions_bytes(path.tree.as_ref()),
+        UseTree::Name(name) => name.ident == "bytes",
+        UseTree::Rename(rename) => rename.ident == "bytes",
+        UseTree::Group(group) => group.items.iter().any(use_tree_mentions_bytes),
+        UseTree::Glob(_) => false,
+    }
+}
+
+fn public_item_reexports_bytes(item: &Item) -> bool {
+    match item {
+        Item::Use(ItemUse { vis, tree, .. }) => is_public(vis) && use_tree_mentions_bytes(tree),
+        Item::ExternCrate(ItemExternCrate { vis, ident, .. }) => is_public(vis) && ident == "bytes",
+        _ => false,
+    }
+}
+
+fn external_module_path(module_directory: &Path, name: &str) -> PathBuf {
+    let sibling = module_directory.join(format!("{name}.rs"));
+    if sibling.is_file() {
+        sibling
+    } else {
+        let nested = module_directory.join(name).join("mod.rs");
+        assert!(
+            nested.is_file(),
+            "cannot resolve public module {name:?} below {}",
+            module_directory.display()
+        );
+        nested
+    }
+}
+
+fn inspect_public_items(
+    items: &[Item],
+    module_path: &str,
+    module_directory: &Path,
+    errors: &mut Vec<String>,
+    bytes_reexports: &mut Vec<String>,
+) {
+    for item in items {
+        if public_item_reexports_bytes(item) {
+            bytes_reexports.push(module_path.to_string());
+        }
+
+        match item {
+            Item::Enum(item_enum)
+                if is_public(&item_enum.vis)
+                    && has_non_exhaustive_attribute(&item_enum.attrs)
+                    && item_enum.ident.to_string().ends_with("Error") =>
+            {
+                errors.push(format!("{module_path}::{}", item_enum.ident));
+            }
+            Item::Mod(item_mod) if is_public(&item_mod.vis) => {
+                let name = item_mod.ident.to_string();
+                let child_path = format!("{module_path}::{name}");
+                let child_directory = module_directory.join(&name);
+                if let Some((_, child_items)) = &item_mod.content {
+                    inspect_public_items(
+                        child_items,
+                        &child_path,
+                        &child_directory,
+                        errors,
+                        bytes_reexports,
+                    );
+                } else {
+                    inspect_public_module(
+                        &external_module_path(module_directory, &name),
+                        &child_path,
+                        &child_directory,
+                        errors,
+                        bytes_reexports,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn inspect_public_module(
+    source_path: &Path,
+    module_path: &str,
+    module_directory: &Path,
+    errors: &mut Vec<String>,
+    bytes_reexports: &mut Vec<String>,
+) {
+    let source = std::fs::read_to_string(source_path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", source_path.display()));
+    let syntax = syn::parse_file(&source)
+        .unwrap_or_else(|error| panic!("cannot parse {}: {error}", source_path.display()));
+    inspect_public_items(
+        &syntax.items,
+        module_path,
+        module_directory,
+        errors,
+        bytes_reexports,
+    );
+}
+
+fn public_api_source_inventory() -> (Vec<String>, Vec<String>) {
+    let source_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut errors = Vec::new();
+    let mut bytes_reexports = Vec::new();
+    inspect_public_module(
+        &source_directory.join("lib.rs"),
+        "rustbgpd_wire",
+        &source_directory,
+        &mut errors,
+        &mut bytes_reexports,
+    );
+    errors.sort();
+    bytes_reexports.sort();
+    (errors, bytes_reexports)
 }
 
 #[test]
@@ -132,9 +199,10 @@ fn decode_entry_point_keeps_the_documented_bytes_contract() {
         decode_message_has_bytes_signature(MESSAGE_SOURCE),
         "decode_message no longer has the documented &mut bytes::Bytes signature"
     );
+    let (_, bytes_reexports) = public_api_source_inventory();
     assert!(
-        public_bytes_reexports(LIB_SOURCE).is_empty(),
-        "README says bytes is not re-exported, but lib.rs contains a public bytes re-export"
+        bytes_reexports.is_empty(),
+        "README says bytes is not re-exported, but public modules re-export it: {bytes_reexports:?}"
     );
 }
 
@@ -190,11 +258,19 @@ fn every_documented_public_error_enum_stays_non_exhaustive_in_source() {
 
 #[test]
 fn enum_exhaustiveness_roster_covers_every_public_error_enum() {
-    let mut expected = ERROR_ENUM_NAMES.map(str::to_string).to_vec();
+    let mut expected = [
+        "rustbgpd_wire::error::DecodeError",
+        "rustbgpd_wire::error::EncodeError",
+        "rustbgpd_wire::evpn::RouteDistinguisherParseError",
+        "rustbgpd_wire::notification::ShutdownCommunicationError",
+        "rustbgpd_wire::tokio_codec::BgpCodecError",
+    ]
+    .map(str::to_string)
+    .to_vec();
     expected.sort();
+    let (errors, _) = public_api_source_inventory();
     assert_eq!(
-        public_non_exhaustive_error_enum_roster(),
-        expected,
+        errors, expected,
         "README roster must change whenever the public non-exhaustive error inventory changes"
     );
 }
@@ -211,11 +287,17 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
     let wrong_buffer = MESSAGE_SOURCE.replacen("buf: &mut Bytes", "buf: Bytes", 1);
     assert!(!decode_message_has_bytes_signature(&wrong_buffer));
 
-    let reexported_bytes = format!("{LIB_SOURCE}\npub use bytes::Bytes;");
-    assert_eq!(
-        public_bytes_reexports(&reexported_bytes),
-        ["pub use bytes::Bytes;"]
-    );
+    for reexport in [
+        "pub use bytes::Bytes;",
+        "pub use {bytes::Bytes};",
+        "pub extern crate bytes;",
+    ] {
+        let item = syn::parse_str::<Item>(reexport).expect("valid public re-export mutation");
+        assert!(
+            public_item_reexports_bytes(&item),
+            "inventory must detect {reexport}"
+        );
+    }
 
     let exhaustiveness = section(README, "## Enum exhaustiveness");
     for name in ERROR_ENUM_NAMES {
@@ -245,9 +327,37 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         assert!(!source_enum_is_public_and_non_exhaustive(&exhaustive, name));
     }
 
+    let future_errors =
+        syn::parse_file("#[non_exhaustive]\n#[derive(Debug)]\npub enum FutureError { Example }")
+            .expect("valid future error mutation");
+    let duplicate_name =
+        syn::parse_file("#[non_exhaustive]\npub enum DecodeError { DistinctModuleVariant }")
+            .expect("valid duplicate-name mutation");
+    let private_nested =
+        syn::parse_file("mod private { #[non_exhaustive] pub enum PrivateError { Example } }")
+            .expect("valid private-module control");
+    let mut errors = Vec::new();
+    let mut bytes_reexports = Vec::new();
+    for (syntax, module_path) in [
+        (&future_errors, "rustbgpd_wire::future"),
+        (&duplicate_name, "rustbgpd_wire::distinct"),
+        (&private_nested, "rustbgpd_wire"),
+    ] {
+        inspect_public_items(
+            &syntax.items,
+            module_path,
+            Path::new("unused-for-inline-modules"),
+            &mut errors,
+            &mut bytes_reexports,
+        );
+    }
+    errors.sort();
     assert_eq!(
-        error_enums_in_source("#[non_exhaustive]\npub enum FutureError { Example }"),
-        ["FutureError"],
-        "the inventory helper must detect a newly added public error enum"
+        errors,
+        [
+            "rustbgpd_wire::distinct::DecodeError",
+            "rustbgpd_wire::future::FutureError",
+        ],
+        "inventory must retain qualified duplicates, accept intervening attributes, and ignore private modules"
     );
 }

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -299,7 +299,7 @@ fn usage_matches_the_published_wire_contract() {
     let usage = section(README, "## Usage");
     assert!(usage.contains(&expected_dependency_block(env!("CARGO_PKG_VERSION"))));
     assert!(usage.contains("`decode_message` accepts `&mut bytes::Bytes`"));
-    assert!(usage.contains("it is not re-exported"));
+    assert!(usage.contains("the crate root does not expose a stable\n`Bytes` re-export"));
     assert!(decode_message_has_documented_signature(MESSAGE_SOURCE));
     assert!(message_imports_bytes_type(MESSAGE_SOURCE));
     assert!(lib_has_no_root_bytes_reexport(LIB_SOURCE));

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,6 +1,7 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use syn::{Attribute, Item, ItemExternCrate, ItemUse, Meta, UseTree, Visibility};
+use syn::{Attribute, Expr, Item, Lit, Meta, UseTree, Visibility};
 
 const README: &str = include_str!("../README.md");
 const LIB_SOURCE: &str = include_str!("../src/lib.rs");
@@ -72,7 +73,19 @@ fn message_imports_bytes_type(source: &str) -> bool {
 }
 
 fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
-    compact_whitespace(source).contains(&format!("#[non_exhaustive] pub enum {name}"))
+    syn::parse_file(source)
+        .expect("error source must remain valid Rust")
+        .items
+        .iter()
+        .any(|item| {
+            matches!(
+                item,
+                Item::Enum(item_enum)
+                    if item_enum.ident == name
+                        && is_public(&item_enum.vis)
+                        && has_non_exhaustive_attribute(&item_enum.attrs)
+            )
+        })
 }
 
 fn is_public(visibility: &Visibility) -> bool {
@@ -85,24 +98,6 @@ fn has_non_exhaustive_attribute(attributes: &[Attribute]) -> bool {
         .any(|attribute| attribute.path().is_ident("non_exhaustive"))
 }
 
-fn use_tree_mentions_bytes(tree: &UseTree) -> bool {
-    match tree {
-        UseTree::Path(path) => path.ident == "bytes" || use_tree_mentions_bytes(path.tree.as_ref()),
-        UseTree::Name(name) => name.ident == "bytes",
-        UseTree::Rename(rename) => rename.ident == "bytes",
-        UseTree::Group(group) => group.items.iter().any(use_tree_mentions_bytes),
-        UseTree::Glob(_) => false,
-    }
-}
-
-fn public_item_reexports_bytes(item: &Item) -> bool {
-    match item {
-        Item::Use(ItemUse { vis, tree, .. }) => is_public(vis) && use_tree_mentions_bytes(tree),
-        Item::ExternCrate(ItemExternCrate { vis, ident, .. }) => is_public(vis) && ident == "bytes",
-        _ => false,
-    }
-}
-
 fn has_feature_gate(attributes: &[Attribute], feature: &str) -> bool {
     attributes.iter().any(|attribute| {
         let Meta::List(list) = &attribute.meta else {
@@ -113,24 +108,31 @@ fn has_feature_gate(attributes: &[Attribute], feature: &str) -> bool {
     })
 }
 
-fn lib_reexports_codec_error_behind_feature(source: &str) -> bool {
-    syn::parse_file(source)
-        .expect("lib.rs must remain valid Rust")
-        .items
-        .iter()
-        .any(|item| {
-            matches!(
-                item,
-                Item::Use(item_use)
-                    if is_public(&item_use.vis)
-                        && has_feature_gate(&item_use.attrs, "tokio-codec")
-                        && use_tree_imports_from(
-                            &item_use.tree,
-                            "tokio_codec",
-                            "BgpCodecError",
-                        )
-            )
-        })
+fn lib_exposes_codec_only_behind_feature(source: &str) -> bool {
+    let syntax = syn::parse_file(source).expect("lib.rs must remain valid Rust");
+    let module_is_gated = syntax.items.iter().any(|item| {
+        matches!(
+            item,
+            Item::Mod(item_mod)
+                if item_mod.ident == "tokio_codec"
+                    && is_public(&item_mod.vis)
+                    && has_feature_gate(&item_mod.attrs, "tokio-codec")
+        )
+    });
+    let root_reexport_is_gated = syntax.items.iter().any(|item| {
+        matches!(
+            item,
+            Item::Use(item_use)
+                if is_public(&item_use.vis)
+                    && has_feature_gate(&item_use.attrs, "tokio-codec")
+                    && use_tree_imports_from(
+                        &item_use.tree,
+                        "tokio_codec",
+                        "BgpCodecError",
+                    )
+        )
+    });
+    module_is_gated && root_reexport_is_gated
 }
 
 fn external_module_path(module_directory: &Path, name: &str) -> PathBuf {
@@ -148,87 +150,303 @@ fn external_module_path(module_directory: &Path, name: &str) -> PathBuf {
     }
 }
 
-fn inspect_public_items(
-    items: &[Item],
-    module_path: &str,
-    module_directory: &Path,
-    errors: &mut Vec<String>,
-    bytes_reexports: &mut Vec<String>,
-) {
-    for item in items {
-        if public_item_reexports_bytes(item) {
-            bytes_reexports.push(module_path.to_string());
+fn explicit_module_path(attributes: &[Attribute], module_directory: &Path) -> Option<PathBuf> {
+    attributes.iter().find_map(|attribute| {
+        let Meta::NameValue(name_value) = &attribute.meta else {
+            return None;
+        };
+        if !attribute.path().is_ident("path") {
+            return None;
         }
+        let Expr::Lit(expr_lit) = &name_value.value else {
+            return None;
+        };
+        let Lit::Str(path) = &expr_lit.lit else {
+            return None;
+        };
+        Some(module_directory.join(path.value()))
+    })
+}
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum PublicExport {
+    Error(String),
+    BytesDependency,
+}
+
+#[derive(Clone, Debug)]
+enum PublicUse {
+    Named { source: Vec<String>, local: String },
+    Glob { source: Vec<String> },
+}
+
+#[derive(Default)]
+struct ModuleInventory {
+    direct_exports: BTreeMap<String, PublicExport>,
+    public_uses: Vec<PublicUse>,
+    public_children: Vec<Vec<String>>,
+}
+
+fn flatten_use_tree(tree: &UseTree, prefix: &mut Vec<String>, uses: &mut Vec<PublicUse>) {
+    match tree {
+        UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            flatten_use_tree(path.tree.as_ref(), prefix, uses);
+            prefix.pop();
+        }
+        UseTree::Name(name) => {
+            let mut source = prefix.clone();
+            source.push(name.ident.to_string());
+            uses.push(PublicUse::Named {
+                local: name.ident.to_string(),
+                source,
+            });
+        }
+        UseTree::Rename(rename) => {
+            let mut source = prefix.clone();
+            source.push(rename.ident.to_string());
+            uses.push(PublicUse::Named {
+                local: rename.rename.to_string(),
+                source,
+            });
+        }
+        UseTree::Glob(_) => uses.push(PublicUse::Glob {
+            source: prefix.clone(),
+        }),
+        UseTree::Group(group) => {
+            for item in &group.items {
+                flatten_use_tree(item, prefix, uses);
+            }
+        }
+    }
+}
+
+fn inspect_module_items(
+    items: &[Item],
+    module_path: &[String],
+    module_directory: &Path,
+    modules: &mut BTreeMap<Vec<String>, ModuleInventory>,
+) {
+    let mut inventory = ModuleInventory::default();
+    for item in items {
         match item {
             Item::Enum(item_enum)
                 if is_public(&item_enum.vis)
                     && has_non_exhaustive_attribute(&item_enum.attrs)
                     && item_enum.ident.to_string().ends_with("Error") =>
             {
-                errors.push(format!("{module_path}::{}", item_enum.ident));
+                let name = item_enum.ident.to_string();
+                let mut qualified = vec!["rustbgpd_wire".to_string()];
+                qualified.extend_from_slice(module_path);
+                qualified.push(name.clone());
+                inventory
+                    .direct_exports
+                    .insert(name, PublicExport::Error(qualified.join("::")));
             }
-            Item::Mod(item_mod) if is_public(&item_mod.vis) => {
+            Item::ExternCrate(item_extern)
+                if is_public(&item_extern.vis) && item_extern.ident == "bytes" =>
+            {
+                let local = item_extern
+                    .rename
+                    .as_ref()
+                    .map_or_else(|| "bytes".to_string(), |(_, name)| name.to_string());
+                inventory
+                    .direct_exports
+                    .insert(local, PublicExport::BytesDependency);
+            }
+            Item::Use(item_use) if is_public(&item_use.vis) => {
+                flatten_use_tree(&item_use.tree, &mut Vec::new(), &mut inventory.public_uses);
+            }
+            Item::Mod(item_mod) => {
                 let name = item_mod.ident.to_string();
-                let child_path = format!("{module_path}::{name}");
+                let mut child_path = module_path.to_vec();
+                child_path.push(name.clone());
                 let child_directory = module_directory.join(&name);
+                if is_public(&item_mod.vis) {
+                    inventory.public_children.push(child_path.clone());
+                }
                 if let Some((_, child_items)) = &item_mod.content {
-                    inspect_public_items(
-                        child_items,
-                        &child_path,
-                        &child_directory,
-                        errors,
-                        bytes_reexports,
-                    );
+                    inspect_module_items(child_items, &child_path, &child_directory, modules);
                 } else {
-                    inspect_public_module(
-                        &external_module_path(module_directory, &name),
+                    inspect_module_file(
+                        &explicit_module_path(&item_mod.attrs, module_directory)
+                            .unwrap_or_else(|| external_module_path(module_directory, &name)),
                         &child_path,
                         &child_directory,
-                        errors,
-                        bytes_reexports,
+                        modules,
                     );
                 }
             }
             _ => {}
         }
     }
+    assert!(
+        modules.insert(module_path.to_vec(), inventory).is_none(),
+        "duplicate module path {module_path:?}"
+    );
 }
 
-fn inspect_public_module(
+fn inspect_module_file(
     source_path: &Path,
-    module_path: &str,
+    module_path: &[String],
     module_directory: &Path,
-    errors: &mut Vec<String>,
-    bytes_reexports: &mut Vec<String>,
+    modules: &mut BTreeMap<Vec<String>, ModuleInventory>,
 ) {
     let source = std::fs::read_to_string(source_path)
         .unwrap_or_else(|error| panic!("cannot read {}: {error}", source_path.display()));
     let syntax = syn::parse_file(&source)
         .unwrap_or_else(|error| panic!("cannot parse {}: {error}", source_path.display()));
-    inspect_public_items(
-        &syntax.items,
-        module_path,
-        module_directory,
-        errors,
-        bytes_reexports,
-    );
+    inspect_module_items(&syntax.items, module_path, module_directory, modules);
+}
+
+fn absolute_use_path(current_module: &[String], source: &[String]) -> Vec<String> {
+    let mut source = source;
+    let mut absolute = Vec::new();
+    if source.first().is_some_and(|segment| segment == "crate") {
+        source = &source[1..];
+    } else if source.first().is_some_and(|segment| segment == "self") {
+        absolute.extend_from_slice(current_module);
+        source = &source[1..];
+    } else if source.first().is_some_and(|segment| segment == "super") {
+        absolute.extend_from_slice(current_module);
+        while source.first().is_some_and(|segment| segment == "super") {
+            absolute.pop();
+            source = &source[1..];
+        }
+    }
+    absolute.extend_from_slice(source);
+    absolute
+}
+
+fn resolved_module_exports(
+    modules: &BTreeMap<Vec<String>, ModuleInventory>,
+) -> BTreeMap<Vec<String>, BTreeMap<String, PublicExport>> {
+    let mut exports = modules
+        .iter()
+        .map(|(path, module)| (path.clone(), module.direct_exports.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    loop {
+        let snapshot = exports.clone();
+        let mut changed = false;
+        for (module_path, module) in modules {
+            let module_exports = exports
+                .get_mut(module_path)
+                .expect("every parsed module has an export map");
+            for public_use in &module.public_uses {
+                match public_use {
+                    PublicUse::Named { source, local }
+                        if source.first().is_some_and(|part| part == "bytes") =>
+                    {
+                        changed |= module_exports
+                            .insert(local.clone(), PublicExport::BytesDependency)
+                            .as_ref()
+                            != Some(&PublicExport::BytesDependency);
+                    }
+                    PublicUse::Glob { source }
+                        if source.first().is_some_and(|part| part == "bytes") =>
+                    {
+                        changed |= module_exports
+                            .insert("*bytes".to_string(), PublicExport::BytesDependency)
+                            .as_ref()
+                            != Some(&PublicExport::BytesDependency);
+                    }
+                    PublicUse::Named { source, local } => {
+                        let absolute = absolute_use_path(module_path, source);
+                        let Some((name, target_module)) = absolute.split_last() else {
+                            continue;
+                        };
+                        if let Some(export) = snapshot
+                            .get(target_module)
+                            .and_then(|target| target.get(name))
+                        {
+                            changed |= module_exports
+                                .insert(local.clone(), export.clone())
+                                .as_ref()
+                                != Some(export);
+                        }
+                    }
+                    PublicUse::Glob { source } => {
+                        let absolute = absolute_use_path(module_path, source);
+                        if let Some(target) = snapshot.get(&absolute) {
+                            for (name, export) in target {
+                                changed |=
+                                    module_exports.insert(name.clone(), export.clone()).as_ref()
+                                        != Some(export);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if !changed {
+            return exports;
+        }
+    }
+}
+
+fn inventory_from_modules(
+    modules: &BTreeMap<Vec<String>, ModuleInventory>,
+) -> (Vec<String>, Vec<String>) {
+    let exports = resolved_module_exports(modules);
+    let mut reachable = BTreeSet::from([Vec::<String>::new()]);
+    loop {
+        let mut changed = false;
+        for module_path in reachable.clone() {
+            let module = modules
+                .get(&module_path)
+                .expect("reachable module was parsed");
+            for child in &module.public_children {
+                changed |= reachable.insert(child.clone());
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    let mut errors = BTreeSet::new();
+    let mut bytes_reexports = Vec::new();
+    for module_path in reachable {
+        let module_exports = exports.get(&module_path).expect("reachable export map");
+        if module_exports
+            .values()
+            .any(|export| matches!(export, PublicExport::BytesDependency))
+        {
+            let mut qualified = vec!["rustbgpd_wire".to_string()];
+            qualified.extend(module_path.clone());
+            bytes_reexports.push(qualified.join("::"));
+        }
+        errors.extend(module_exports.values().filter_map(|export| match export {
+            PublicExport::Error(name) => Some(name.clone()),
+            PublicExport::BytesDependency => None,
+        }));
+    }
+    (errors.into_iter().collect(), bytes_reexports)
 }
 
 fn public_api_source_inventory() -> (Vec<String>, Vec<String>) {
     let source_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut errors = Vec::new();
-    let mut bytes_reexports = Vec::new();
-    inspect_public_module(
+    let mut modules = BTreeMap::new();
+    inspect_module_file(
         &source_directory.join("lib.rs"),
-        "rustbgpd_wire",
+        &[],
         &source_directory,
-        &mut errors,
-        &mut bytes_reexports,
+        &mut modules,
     );
-    errors.sort();
-    bytes_reexports.sort();
-    (errors, bytes_reexports)
+    inventory_from_modules(&modules)
+}
+
+fn inline_source_inventory(source: &str) -> (Vec<String>, Vec<String>) {
+    let syntax = syn::parse_file(source).expect("mutation source must be valid Rust");
+    let mut modules = BTreeMap::new();
+    inspect_module_items(
+        &syntax.items,
+        &[],
+        Path::new("unused-for-inline-modules"),
+        &mut modules,
+    );
+    inventory_from_modules(&modules)
 }
 
 #[test]
@@ -309,8 +527,8 @@ fn every_documented_public_error_enum_stays_non_exhaustive_in_source() {
     }
 
     assert!(
-        lib_reexports_codec_error_behind_feature(LIB_SOURCE),
-        "BgpCodecError must remain publicly re-exported behind the tokio-codec feature"
+        lib_exposes_codec_only_behind_feature(LIB_SOURCE),
+        "the tokio_codec module and root BgpCodecError binding must remain feature-gated"
     );
 }
 
@@ -359,24 +577,27 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         "pub use {bytes::Bytes};",
         "pub extern crate bytes;",
     ] {
-        let item = syn::parse_str::<Item>(reexport).expect("valid public re-export mutation");
         assert!(
-            public_item_reexports_bytes(&item),
+            !inline_source_inventory(reexport).1.is_empty(),
             "inventory must detect {reexport}"
         );
     }
 
     let reordered_codec_reexport = r#"
         #[cfg(feature = "tokio-codec")]
+        pub mod tokio_codec { pub struct BgpCodec; pub enum BgpCodecError {} }
+        #[cfg(feature = "tokio-codec")]
         pub use tokio_codec::{BgpCodecError, BgpCodec};
     "#;
-    assert!(lib_reexports_codec_error_behind_feature(
+    assert!(lib_exposes_codec_only_behind_feature(
         reordered_codec_reexport
     ));
-    let ungated_codec_reexport = "pub use tokio_codec::BgpCodecError;";
-    assert!(!lib_reexports_codec_error_behind_feature(
-        ungated_codec_reexport
-    ));
+    let ungated_codec_module = r#"
+        pub mod tokio_codec { pub enum BgpCodecError {} }
+        #[cfg(feature = "tokio-codec")]
+        pub use tokio_codec::BgpCodecError;
+    "#;
+    assert!(!lib_exposes_codec_only_behind_feature(ungated_codec_module));
 
     let exhaustiveness = section(README, "## Enum exhaustiveness");
     for name in ERROR_ENUM_NAMES {
@@ -406,31 +627,22 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         assert!(!source_enum_is_public_and_non_exhaustive(&exhaustive, name));
     }
 
-    let future_errors =
-        syn::parse_file("#[non_exhaustive]\n#[derive(Debug)]\npub enum FutureError { Example }")
-            .expect("valid future error mutation");
-    let duplicate_name =
-        syn::parse_file("#[non_exhaustive]\npub enum DecodeError { DistinctModuleVariant }")
-            .expect("valid duplicate-name mutation");
-    let private_nested =
-        syn::parse_file("mod private { #[non_exhaustive] pub enum PrivateError { Example } }")
-            .expect("valid private-module control");
-    let mut errors = Vec::new();
-    let mut bytes_reexports = Vec::new();
-    for (syntax, module_path) in [
-        (&future_errors, "rustbgpd_wire::future"),
-        (&duplicate_name, "rustbgpd_wire::distinct"),
-        (&private_nested, "rustbgpd_wire"),
-    ] {
-        inspect_public_items(
-            &syntax.items,
-            module_path,
-            Path::new("unused-for-inline-modules"),
-            &mut errors,
-            &mut bytes_reexports,
-        );
-    }
-    errors.sort();
+    let mutations = r#"
+        pub mod future {
+            #[non_exhaustive]
+            #[derive(Debug)]
+            pub enum FutureError { Example }
+        }
+        pub mod distinct {
+            #[non_exhaustive]
+            pub enum DecodeError { DistinctModuleVariant }
+        }
+        mod private {
+            #[non_exhaustive]
+            pub enum PrivateError { Example }
+        }
+    "#;
+    let (errors, bytes_reexports) = inline_source_inventory(mutations);
     assert_eq!(
         errors,
         [
@@ -439,4 +651,17 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         ],
         "inventory must retain qualified duplicates, accept intervening attributes, and ignore private modules"
     );
+    assert!(bytes_reexports.is_empty());
+
+    let private_facade = r#"
+        mod hidden {
+            #[non_exhaustive]
+            pub enum FutureError { Example }
+            pub use bytes::Bytes;
+        }
+        pub use hidden::{Bytes, FutureError};
+    "#;
+    let (facade_errors, facade_bytes) = inline_source_inventory(private_facade);
+    assert_eq!(facade_errors, ["rustbgpd_wire::hidden::FutureError"]);
+    assert_eq!(facade_bytes, ["rustbgpd_wire"]);
 }

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use syn::{Attribute, Item, ItemExternCrate, ItemUse, UseTree, Visibility};
+use syn::{Attribute, Item, ItemExternCrate, ItemUse, Meta, UseTree, Visibility};
 
 const README: &str = include_str!("../README.md");
 const LIB_SOURCE: &str = include_str!("../src/lib.rs");
@@ -44,6 +44,33 @@ fn decode_message_has_bytes_signature(source: &str) -> bool {
     )
 }
 
+fn use_tree_contains_name(tree: &UseTree, name: &str) -> bool {
+    match tree {
+        UseTree::Path(path) => use_tree_contains_name(path.tree.as_ref(), name),
+        UseTree::Name(item) => item.ident == name,
+        UseTree::Rename(item) => item.ident == name,
+        UseTree::Group(group) => group
+            .items
+            .iter()
+            .any(|item| use_tree_contains_name(item, name)),
+        UseTree::Glob(_) => false,
+    }
+}
+
+fn use_tree_imports_from(tree: &UseTree, source: &str, name: &str) -> bool {
+    matches!(tree, UseTree::Path(path) if path.ident == source && use_tree_contains_name(path.tree.as_ref(), name))
+}
+
+fn message_imports_bytes_type(source: &str) -> bool {
+    syn::parse_file(source)
+        .expect("message.rs must remain valid Rust")
+        .items
+        .iter()
+        .any(|item| {
+            matches!(item, Item::Use(item_use) if use_tree_imports_from(&item_use.tree, "bytes", "Bytes"))
+        })
+}
+
 fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
     compact_whitespace(source).contains(&format!("#[non_exhaustive] pub enum {name}"))
 }
@@ -74,6 +101,36 @@ fn public_item_reexports_bytes(item: &Item) -> bool {
         Item::ExternCrate(ItemExternCrate { vis, ident, .. }) => is_public(vis) && ident == "bytes",
         _ => false,
     }
+}
+
+fn has_feature_gate(attributes: &[Attribute], feature: &str) -> bool {
+    attributes.iter().any(|attribute| {
+        let Meta::List(list) = &attribute.meta else {
+            return false;
+        };
+        attribute.path().is_ident("cfg")
+            && compact_whitespace(&list.tokens.to_string()) == format!("feature = \"{feature}\"")
+    })
+}
+
+fn lib_reexports_codec_error_behind_feature(source: &str) -> bool {
+    syn::parse_file(source)
+        .expect("lib.rs must remain valid Rust")
+        .items
+        .iter()
+        .any(|item| {
+            matches!(
+                item,
+                Item::Use(item_use)
+                    if is_public(&item_use.vis)
+                        && has_feature_gate(&item_use.attrs, "tokio-codec")
+                        && use_tree_imports_from(
+                            &item_use.tree,
+                            "tokio_codec",
+                            "BgpCodecError",
+                        )
+            )
+        })
 }
 
 fn external_module_path(module_directory: &Path, name: &str) -> PathBuf {
@@ -199,6 +256,10 @@ fn decode_entry_point_keeps_the_documented_bytes_contract() {
         decode_message_has_bytes_signature(MESSAGE_SOURCE),
         "decode_message no longer has the documented &mut bytes::Bytes signature"
     );
+    assert!(
+        message_imports_bytes_type(MESSAGE_SOURCE),
+        "decode_message's Bytes type must be imported from the bytes crate"
+    );
     let (_, bytes_reexports) = public_api_source_inventory();
     assert!(
         bytes_reexports.is_empty(),
@@ -247,11 +308,8 @@ fn every_documented_public_error_enum_stays_non_exhaustive_in_source() {
         );
     }
 
-    let compact_lib = compact_whitespace(LIB_SOURCE);
     assert!(
-        compact_lib.contains(
-            "#[cfg(feature = \"tokio-codec\")] pub use tokio_codec::{BgpCodec, BgpCodecError};"
-        ),
+        lib_reexports_codec_error_behind_feature(LIB_SOURCE),
         "BgpCodecError must remain publicly re-exported behind the tokio-codec feature"
     );
 }
@@ -286,6 +344,9 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
 
     let wrong_buffer = MESSAGE_SOURCE.replacen("buf: &mut Bytes", "buf: Bytes", 1);
     assert!(!decode_message_has_bytes_signature(&wrong_buffer));
+    let wrong_bytes_source =
+        MESSAGE_SOURCE.replacen("use bytes::{Bytes, BytesMut};", "type Bytes = Vec<u8>;", 1);
+    assert!(!message_imports_bytes_type(&wrong_bytes_source));
 
     for reexport in [
         "pub use bytes::Bytes;",
@@ -298,6 +359,18 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
             "inventory must detect {reexport}"
         );
     }
+
+    let reordered_codec_reexport = r#"
+        #[cfg(feature = "tokio-codec")]
+        pub use tokio_codec::{BgpCodecError, BgpCodec};
+    "#;
+    assert!(lib_reexports_codec_error_behind_feature(
+        reordered_codec_reexport
+    ));
+    let ungated_codec_reexport = "pub use tokio_codec::BgpCodecError;";
+    assert!(!lib_reexports_codec_error_behind_feature(
+        ungated_codec_reexport
+    ));
 
     let exhaustiveness = section(README, "## Enum exhaustiveness");
     for name in ERROR_ENUM_NAMES {

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use syn::{Attribute, Expr, Item, Lit, Meta, Type, UseTree, Visibility};
+use syn::{
+    Attribute, Expr, FnArg, GenericArgument, Item, Lit, Meta, PathArguments, ReturnType, Type,
+    UseTree, Visibility,
+};
 
 const README: &str = include_str!("../README.md");
 const LIB_SOURCE: &str = include_str!("../src/lib.rs");
@@ -40,9 +43,69 @@ fn has_documented_error_roster(exhaustiveness: &str) -> bool {
 }
 
 fn decode_message_has_bytes_signature(source: &str) -> bool {
-    compact_whitespace(source).contains(
-        "pub fn decode_message(buf: &mut Bytes, max_message_len: u16) -> Result<Message, DecodeError>",
+    let syntax = syn::parse_file(source).expect("message.rs must remain valid Rust");
+    let Some(function) = syntax.items.iter().find_map(|item| match item {
+        Item::Fn(function)
+            if function.sig.ident == "decode_message" && is_public(&function.vis) =>
+        {
+            Some(function)
+        }
+        _ => None,
+    }) else {
+        return false;
+    };
+    let mut inputs = function.sig.inputs.iter();
+    let first_is_bytes = inputs.next().is_some_and(|argument| {
+        matches!(argument, FnArg::Typed(argument) if is_mut_reference_to(&argument.ty, "Bytes"))
+    });
+    let second_is_u16 = inputs.next().is_some_and(
+        |argument| matches!(argument, FnArg::Typed(argument) if is_plain_type(&argument.ty, "u16")),
+    );
+    first_is_bytes
+        && second_is_u16
+        && inputs.next().is_none()
+        && return_type_is_result(&function.sig.output, "Message", "DecodeError")
+}
+
+fn is_plain_type(ty: &Type, name: &str) -> bool {
+    matches!(
+        ty,
+        Type::Path(path)
+            if path.qself.is_none()
+                && path.path.leading_colon.is_none()
+                && path.path.segments.len() == 1
+                && path.path.segments[0].ident == name
+                && matches!(path.path.segments[0].arguments, PathArguments::None)
     )
+}
+
+fn is_mut_reference_to(ty: &Type, name: &str) -> bool {
+    matches!(ty, Type::Reference(reference) if reference.mutability.is_some() && is_plain_type(&reference.elem, name))
+}
+
+fn return_type_is_result(output: &ReturnType, ok: &str, error: &str) -> bool {
+    let ReturnType::Type(_, ty) = output else {
+        return false;
+    };
+    let Type::Path(path) = ty.as_ref() else {
+        return false;
+    };
+    if path.qself.is_some() || path.path.segments.len() != 1 {
+        return false;
+    }
+    let result = &path.path.segments[0];
+    let PathArguments::AngleBracketed(arguments) = &result.arguments else {
+        return false;
+    };
+    let mut arguments = arguments.args.iter();
+    result.ident == "Result"
+        && arguments.next().is_some_and(
+            |argument| matches!(argument, GenericArgument::Type(ty) if is_plain_type(ty, ok)),
+        )
+        && arguments.next().is_some_and(
+            |argument| matches!(argument, GenericArgument::Type(ty) if is_plain_type(ty, error)),
+        )
+        && arguments.next().is_none()
 }
 
 fn use_tree_imports_from(
@@ -146,6 +209,11 @@ fn lib_exposes_codec_only_behind_feature(source: &str) -> bool {
             Item::Struct(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
             Item::Type(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
             Item::Union(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Trait(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::TraitAlias(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Fn(item) => item.sig.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Const(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Static(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
             Item::Mod(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
             Item::ExternCrate(item) => {
                 is_public(&item.vis)
@@ -161,6 +229,7 @@ fn lib_exposes_codec_only_behind_feature(source: &str) -> bool {
     codec_modules.len() == 1
         && has_feature_gate(&codec_modules[0].attrs, "tokio-codec")
         && codec_bindings.len() == 1
+        && !root_public_glob_may_bind(source, "BgpCodecError")
         && matches!(
             codec_bindings[0],
             Item::Use(item_use)
@@ -212,6 +281,7 @@ enum PublicExport {
     Error(String),
     BytesDependency,
     Module(Vec<String>),
+    NamedItem,
 }
 
 #[derive(Clone, Debug)]
@@ -225,6 +295,18 @@ struct ModuleInventory {
     direct_exports: BTreeMap<String, PublicExport>,
     public_uses: Vec<PublicUse>,
     public_children: Vec<Vec<String>>,
+}
+
+fn merge_module_inventory(target: &mut ModuleInventory, incoming: ModuleInventory) {
+    // The source graph intentionally sees every cfg branch. Mutually exclusive declarations of
+    // one logical module therefore contribute a conservative all-configuration union here.
+    for (name, export) in incoming.direct_exports {
+        target.direct_exports.entry(name).or_insert(export);
+    }
+    target.public_uses.extend(incoming.public_uses);
+    target.public_children.extend(incoming.public_children);
+    target.public_children.sort();
+    target.public_children.dedup();
 }
 
 fn flatten_use_tree(tree: &UseTree, prefix: &mut Vec<String>, uses: &mut Vec<PublicUse>) {
@@ -270,34 +352,73 @@ fn inspect_module_items(
     let mut inventory = ModuleInventory::default();
     for item in items {
         match item {
-            Item::Enum(item_enum)
-                if is_public(&item_enum.vis)
-                    && has_non_exhaustive_attribute(&item_enum.attrs)
-                    && item_enum.ident.to_string().ends_with("Error") =>
-            {
+            Item::Enum(item_enum) if is_public(&item_enum.vis) => {
                 let name = item_enum.ident.to_string();
-                let mut qualified = vec!["rustbgpd_wire".to_string()];
-                qualified.extend_from_slice(module_path);
-                qualified.push(name.clone());
-                inventory
-                    .direct_exports
-                    .insert(name, PublicExport::Error(qualified.join("::")));
+                let export =
+                    if has_non_exhaustive_attribute(&item_enum.attrs) && name.ends_with("Error") {
+                        let mut qualified = vec!["rustbgpd_wire".to_string()];
+                        qualified.extend_from_slice(module_path);
+                        qualified.push(name.clone());
+                        PublicExport::Error(qualified.join("::"))
+                    } else {
+                        PublicExport::NamedItem
+                    };
+                inventory.direct_exports.insert(name, export);
             }
-            Item::ExternCrate(item_extern)
-                if is_public(&item_extern.vis) && item_extern.ident == "bytes" =>
-            {
-                let local = item_extern
-                    .rename
-                    .as_ref()
-                    .map_or_else(|| "bytes".to_string(), |(_, name)| name.to_string());
+            Item::Struct(item_struct) if is_public(&item_struct.vis) => {
                 inventory
                     .direct_exports
-                    .insert(local, PublicExport::BytesDependency);
+                    .insert(item_struct.ident.to_string(), PublicExport::NamedItem);
+            }
+            Item::Union(item_union) if is_public(&item_union.vis) => {
+                inventory
+                    .direct_exports
+                    .insert(item_union.ident.to_string(), PublicExport::NamedItem);
+            }
+            Item::Trait(item_trait) if is_public(&item_trait.vis) => {
+                inventory
+                    .direct_exports
+                    .insert(item_trait.ident.to_string(), PublicExport::NamedItem);
+            }
+            Item::TraitAlias(item_alias) if is_public(&item_alias.vis) => {
+                inventory
+                    .direct_exports
+                    .insert(item_alias.ident.to_string(), PublicExport::NamedItem);
+            }
+            Item::Fn(item_fn) if is_public(&item_fn.vis) => {
+                inventory
+                    .direct_exports
+                    .insert(item_fn.sig.ident.to_string(), PublicExport::NamedItem);
+            }
+            Item::Const(item_const) if is_public(&item_const.vis) => {
+                inventory
+                    .direct_exports
+                    .insert(item_const.ident.to_string(), PublicExport::NamedItem);
+            }
+            Item::Static(item_static) if is_public(&item_static.vis) => {
+                inventory
+                    .direct_exports
+                    .insert(item_static.ident.to_string(), PublicExport::NamedItem);
+            }
+            Item::ExternCrate(item_extern) if is_public(&item_extern.vis) => {
+                let local = item_extern.rename.as_ref().map_or_else(
+                    || item_extern.ident.to_string(),
+                    |(_, name)| name.to_string(),
+                );
+                let export = if item_extern.ident == "bytes" {
+                    PublicExport::BytesDependency
+                } else {
+                    PublicExport::NamedItem
+                };
+                inventory.direct_exports.insert(local, export);
             }
             Item::Use(item_use) if is_public(&item_use.vis) => {
                 flatten_use_tree(&item_use.tree, &mut Vec::new(), &mut inventory.public_uses);
             }
             Item::Type(item_type) if is_public(&item_type.vis) => {
+                inventory
+                    .direct_exports
+                    .insert(item_type.ident.to_string(), PublicExport::NamedItem);
                 if let Type::Path(type_path) = item_type.ty.as_ref()
                     && type_path.qself.is_none()
                 {
@@ -338,10 +459,11 @@ fn inspect_module_items(
             _ => {}
         }
     }
-    assert!(
-        modules.insert(module_path.to_vec(), inventory).is_none(),
-        "duplicate module path {module_path:?}"
-    );
+    if let Some(existing) = modules.get_mut(module_path) {
+        merge_module_inventory(existing, inventory);
+    } else {
+        modules.insert(module_path.to_vec(), inventory);
+    }
 }
 
 fn inspect_module_file(
@@ -374,6 +496,35 @@ fn absolute_use_path(current_module: &[String], source: &[String]) -> Vec<String
     }
     absolute.extend_from_slice(source);
     absolute
+}
+
+fn resolve_module_path(
+    exports: &BTreeMap<Vec<String>, BTreeMap<String, PublicExport>>,
+    path: &[String],
+) -> Option<Vec<String>> {
+    let mut resolved = Vec::new();
+    for segment in path {
+        let mut physical_child = resolved.clone();
+        physical_child.push(segment.clone());
+        if exports.contains_key(&physical_child) {
+            resolved = physical_child;
+            continue;
+        }
+        let PublicExport::Module(alias_target) = exports.get(&resolved)?.get(segment)? else {
+            return None;
+        };
+        resolved.clone_from(alias_target);
+    }
+    Some(resolved)
+}
+
+fn resolve_export_path(
+    exports: &BTreeMap<Vec<String>, BTreeMap<String, PublicExport>>,
+    path: &[String],
+) -> Option<PublicExport> {
+    let (name, module_path) = path.split_last()?;
+    let resolved_module = resolve_module_path(exports, module_path)?;
+    exports.get(&resolved_module)?.get(name).cloned()
 }
 
 fn resolved_module_exports(
@@ -411,22 +562,18 @@ fn resolved_module_exports(
                     }
                     PublicUse::Named { source, local } => {
                         let absolute = absolute_use_path(module_path, source);
-                        let Some((name, target_module)) = absolute.split_last() else {
-                            continue;
-                        };
-                        if let Some(export) = snapshot
-                            .get(target_module)
-                            .and_then(|target| target.get(name))
-                        {
+                        if let Some(export) = resolve_export_path(&snapshot, &absolute) {
                             changed |= module_exports
                                 .insert(local.clone(), export.clone())
                                 .as_ref()
-                                != Some(export);
+                                != Some(&export);
                         }
                     }
                     PublicUse::Glob { source } => {
                         let absolute = absolute_use_path(module_path, source);
-                        if let Some(target) = snapshot.get(&absolute) {
+                        if let Some(target) = resolve_module_path(&snapshot, &absolute)
+                            .and_then(|target| snapshot.get(&target))
+                        {
                             for (name, export) in target {
                                 changed |=
                                     module_exports.insert(name.clone(), export.clone()).as_ref()
@@ -441,6 +588,32 @@ fn resolved_module_exports(
             return exports;
         }
     }
+}
+
+fn root_public_glob_may_bind(source: &str, name: &str) -> bool {
+    let syntax = syn::parse_file(source).expect("lib.rs must remain valid Rust");
+    let source_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut modules = BTreeMap::new();
+    inspect_module_items(&syntax.items, &[], &source_directory, &mut modules);
+    let exports = resolved_module_exports(&modules);
+    modules
+        .get(&Vec::new())
+        .expect("root module was inspected")
+        .public_uses
+        .iter()
+        .filter_map(|public_use| match public_use {
+            PublicUse::Glob { source } => Some(source),
+            PublicUse::Named { .. } => None,
+        })
+        .any(|source| {
+            let absolute = absolute_use_path(&[], source);
+            let Some(target) = resolve_module_path(&exports, &absolute) else {
+                return true;
+            };
+            exports
+                .get(&target)
+                .is_none_or(|module| module.contains_key(name))
+        })
 }
 
 fn inventory_from_modules(
@@ -486,7 +659,9 @@ fn inventory_from_modules(
         }
         errors.extend(module_exports.values().filter_map(|export| match export {
             PublicExport::Error(name) => Some(name.clone()),
-            PublicExport::BytesDependency | PublicExport::Module(_) => None,
+            PublicExport::BytesDependency | PublicExport::Module(_) | PublicExport::NamedItem => {
+                None
+            }
         }));
     }
     (errors.into_iter().collect(), bytes_reexports)
@@ -629,6 +804,25 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
 
     let wrong_buffer = MESSAGE_SOURCE.replacen("buf: &mut Bytes", "buf: Bytes", 1);
     assert!(!decode_message_has_bytes_signature(&wrong_buffer));
+    let wrong_limit_type =
+        MESSAGE_SOURCE.replacen("max_message_len: u16", "max_message_len: u32", 1);
+    assert!(!decode_message_has_bytes_signature(&wrong_limit_type));
+    let wrong_return = MESSAGE_SOURCE.replacen(
+        "Result<Message, DecodeError>",
+        "Result<Message, EncodeError>",
+        1,
+    );
+    assert!(!decode_message_has_bytes_signature(&wrong_return));
+    let stale_signature_comment = r#"
+        // pub fn decode_message(buf: &mut Bytes, max_message_len: u16) -> Result<Message, DecodeError>
+        pub fn decode_message(
+            _buf: &mut Vec<u8>,
+            _max_message_len: u16,
+        ) -> Result<Message, DecodeError> {
+            unimplemented!()
+        }
+    "#;
+    assert!(!decode_message_has_bytes_signature(stale_signature_comment));
     let wrong_bytes_source =
         MESSAGE_SOURCE.replacen("use bytes::{Bytes, BytesMut};", "type Bytes = Vec<u8>;", 1);
     assert!(!message_imports_bytes_type(&wrong_bytes_source));
@@ -692,6 +886,30 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
     assert!(!lib_exposes_codec_only_behind_feature(
         alternative_ungated_binding
     ));
+    let glob_alternative_binding = r#"
+        #[cfg(feature = "tokio-codec")]
+        pub mod tokio_codec { pub enum BgpCodecError {} }
+        #[cfg(feature = "tokio-codec")]
+        pub use tokio_codec::BgpCodecError;
+        #[cfg(not(feature = "tokio-codec"))]
+        mod fallback {
+            pub struct BgpCodecError;
+        }
+        #[cfg(not(feature = "tokio-codec"))]
+        pub use fallback::*;
+    "#;
+    assert!(!lib_exposes_codec_only_behind_feature(
+        glob_alternative_binding
+    ));
+    let unrelated_glob = r#"
+        #[cfg(feature = "tokio-codec")]
+        pub mod tokio_codec { pub enum BgpCodecError {} }
+        #[cfg(feature = "tokio-codec")]
+        pub use tokio_codec::BgpCodecError;
+        mod additional { pub struct OtherPublicType; }
+        pub use additional::*;
+    "#;
+    assert!(lib_exposes_codec_only_behind_feature(unrelated_glob));
 
     let exhaustiveness = section(README, "## Enum exhaustiveness");
     for name in ERROR_ENUM_NAMES {
@@ -764,4 +982,48 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
     let (module_errors, module_bytes) = inline_source_inventory(private_module_facade);
     assert_eq!(module_errors, ["rustbgpd_wire::hidden::api::FutureError"]);
     assert_eq!(module_bytes, ["rustbgpd_wire::hidden::api"]);
+
+    let chained_module_facade = r#"
+        mod hidden {
+            mod deeper {
+                pub mod api {
+                    #[non_exhaustive]
+                    pub enum FutureError { Example }
+                    pub use bytes::Bytes;
+                }
+            }
+            pub use self::deeper::api as facade;
+            pub use self::facade::{Bytes, FutureError};
+        }
+        pub use hidden::{Bytes, FutureError};
+    "#;
+    let (chained_errors, chained_bytes) = inline_source_inventory(chained_module_facade);
+    assert_eq!(
+        chained_errors,
+        ["rustbgpd_wire::hidden::deeper::api::FutureError"]
+    );
+    assert_eq!(chained_bytes, ["rustbgpd_wire"]);
+
+    let cfg_exclusive_modules = r#"
+        #[cfg(unix)]
+        pub mod platform {
+            #[non_exhaustive]
+            pub enum UnixError { Example }
+        }
+        #[cfg(windows)]
+        pub mod platform {
+            #[non_exhaustive]
+            pub enum WindowsError { Example }
+        }
+    "#;
+    let (cfg_errors, cfg_bytes) = inline_source_inventory(cfg_exclusive_modules);
+    assert_eq!(
+        cfg_errors,
+        [
+            "rustbgpd_wire::platform::UnixError",
+            "rustbgpd_wire::platform::WindowsError",
+        ],
+        "cfg-exclusive declarations of one logical module must form an all-config union"
+    );
+    assert!(cfg_bytes.is_empty());
 }

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,0 +1,183 @@
+const README: &str = include_str!("../README.md");
+const LIB_SOURCE: &str = include_str!("../src/lib.rs");
+const MESSAGE_SOURCE: &str = include_str!("../src/message.rs");
+const ERROR_ENUM_NAMES: [&str; 5] = [
+    "DecodeError",
+    "EncodeError",
+    "RouteDistinguisherParseError",
+    "ShutdownCommunicationError",
+    "BgpCodecError",
+];
+
+fn section<'a>(document: &'a str, heading: &str) -> &'a str {
+    let start = document
+        .find(heading)
+        .unwrap_or_else(|| panic!("missing README section {heading:?}"));
+    let body = &document[start + heading.len()..];
+    let end = body.find("\n## ").unwrap_or(body.len());
+    &body[..end]
+}
+
+fn compact_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn expected_dependency_block(version: &str) -> String {
+    format!("```toml\n[dependencies]\nrustbgpd-wire = \"{version}\"\nbytes = \"1\"\n```")
+}
+
+fn has_documented_error_roster(exhaustiveness: &str) -> bool {
+    compact_whitespace(exhaustiveness).contains(
+        "The five public error enums are also non-exhaustive: `DecodeError`, `EncodeError`, \
+         `RouteDistinguisherParseError`, `ShutdownCommunicationError`, and `BgpCodecError` \
+         (available with the `tokio-codec` feature).",
+    )
+}
+
+fn decode_message_has_bytes_signature(source: &str) -> bool {
+    compact_whitespace(source).contains(
+        "pub fn decode_message(buf: &mut Bytes, max_message_len: u16) -> Result<Message, DecodeError>",
+    )
+}
+
+fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
+    compact_whitespace(source).contains(&format!("#[non_exhaustive] pub enum {name}"))
+}
+
+fn public_bytes_reexports(source: &str) -> Vec<&str> {
+    source
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            line.starts_with("pub use bytes") || line.starts_with("pub extern crate bytes")
+        })
+        .collect()
+}
+
+#[test]
+fn usage_pins_direct_dependencies_to_the_published_wire_version() {
+    let usage = section(README, "## Usage");
+    let dependency_block = expected_dependency_block(env!("CARGO_PKG_VERSION"));
+
+    assert!(
+        usage.contains(&dependency_block),
+        "Usage must pin rustbgpd-wire to the package version and bytes to major version 1"
+    );
+    assert!(
+        usage.contains("`decode_message` accepts `&mut bytes::Bytes`"),
+        "Usage must name the public buffer type accepted by decode_message"
+    );
+    assert!(
+        usage.contains("it is not re-exported"),
+        "Usage must explain why downstream consumers need a direct bytes dependency"
+    );
+}
+
+#[test]
+fn decode_entry_point_keeps_the_documented_bytes_contract() {
+    assert!(
+        decode_message_has_bytes_signature(MESSAGE_SOURCE),
+        "decode_message no longer has the documented &mut bytes::Bytes signature"
+    );
+    assert!(
+        public_bytes_reexports(LIB_SOURCE).is_empty(),
+        "README says bytes is not re-exported, but lib.rs contains a public bytes re-export"
+    );
+}
+
+#[test]
+fn enum_exhaustiveness_names_the_complete_public_error_roster() {
+    let exhaustiveness = section(README, "## Enum exhaustiveness");
+
+    assert!(
+        has_documented_error_roster(exhaustiveness),
+        "Enum exhaustiveness must name the exact five-enum roster and identify BgpCodecError as feature-gated"
+    );
+    assert!(
+        exhaustiveness.contains("must include\na wildcard arm"),
+        "Enum exhaustiveness must preserve downstream wildcard guidance"
+    );
+    assert!(
+        exhaustiveness.contains("_ => {}"),
+        "Enum exhaustiveness must retain its wildcard match example"
+    );
+}
+
+#[test]
+fn every_documented_public_error_enum_stays_non_exhaustive_in_source() {
+    let declarations = [
+        (include_str!("../src/error.rs"), "DecodeError"),
+        (include_str!("../src/error.rs"), "EncodeError"),
+        (
+            include_str!("../src/evpn.rs"),
+            "RouteDistinguisherParseError",
+        ),
+        (
+            include_str!("../src/notification.rs"),
+            "ShutdownCommunicationError",
+        ),
+        (include_str!("../src/tokio_codec.rs"), "BgpCodecError"),
+    ];
+
+    for (source, name) in declarations {
+        assert!(
+            source_enum_is_public_and_non_exhaustive(source, name),
+            "{name} must remain a public #[non_exhaustive] enum"
+        );
+    }
+
+    let compact_lib = compact_whitespace(LIB_SOURCE);
+    assert!(
+        compact_lib.contains(
+            "#[cfg(feature = \"tokio-codec\")] pub use tokio_codec::{BgpCodec, BgpCodecError};"
+        ),
+        "BgpCodecError must remain publicly re-exported behind the tokio-codec feature"
+    );
+}
+
+#[test]
+fn contract_helpers_reject_independent_documentation_and_source_mutations() {
+    let usage = section(README, "## Usage");
+    let wrong_version = usage.replace(
+        &format!("rustbgpd-wire = \"{}\"", env!("CARGO_PKG_VERSION")),
+        "rustbgpd-wire = \"0.0.0\"",
+    );
+    assert!(!wrong_version.contains(&expected_dependency_block(env!("CARGO_PKG_VERSION"))));
+
+    let wrong_buffer = MESSAGE_SOURCE.replacen("buf: &mut Bytes", "buf: Bytes", 1);
+    assert!(!decode_message_has_bytes_signature(&wrong_buffer));
+
+    let reexported_bytes = format!("{LIB_SOURCE}\npub use bytes::Bytes;");
+    assert_eq!(
+        public_bytes_reexports(&reexported_bytes),
+        ["pub use bytes::Bytes;"]
+    );
+
+    let exhaustiveness = section(README, "## Enum exhaustiveness");
+    for name in ERROR_ENUM_NAMES {
+        let missing_name = exhaustiveness.replacen(&format!("`{name}`"), "`RemovedError`", 1);
+        assert!(!has_documented_error_roster(&missing_name));
+    }
+
+    let declarations = [
+        (include_str!("../src/error.rs"), "DecodeError"),
+        (include_str!("../src/error.rs"), "EncodeError"),
+        (
+            include_str!("../src/evpn.rs"),
+            "RouteDistinguisherParseError",
+        ),
+        (
+            include_str!("../src/notification.rs"),
+            "ShutdownCommunicationError",
+        ),
+        (include_str!("../src/tokio_codec.rs"), "BgpCodecError"),
+    ];
+    for (source, name) in declarations {
+        let exhaustive = source.replacen(
+            &format!("#[non_exhaustive]\npub enum {name}"),
+            &format!("pub enum {name}"),
+            1,
+        );
+        assert!(!source_enum_is_public_and_non_exhaustive(&exhaustive, name));
+    }
+}

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use syn::{Attribute, Expr, Item, Lit, Meta, UseTree, Visibility};
+use syn::{Attribute, Expr, Item, Lit, Meta, Type, UseTree, Visibility};
 
 const README: &str = include_str!("../README.md");
 const LIB_SOURCE: &str = include_str!("../src/lib.rs");
@@ -45,21 +45,36 @@ fn decode_message_has_bytes_signature(source: &str) -> bool {
     )
 }
 
-fn use_tree_contains_name(tree: &UseTree, name: &str) -> bool {
+fn use_tree_imports_from(
+    tree: &UseTree,
+    source: &str,
+    source_name: &str,
+    local_name: &str,
+) -> bool {
+    let mut uses = Vec::new();
+    flatten_use_tree(tree, &mut Vec::new(), &mut uses);
+    uses.iter().any(|public_use| {
+        matches!(
+            public_use,
+            PublicUse::Named {
+                source: item_source,
+                local,
+            } if item_source == &[source, source_name] && local == local_name
+        )
+    })
+}
+
+fn use_tree_binds_name(tree: &UseTree, local_name: &str) -> bool {
     match tree {
-        UseTree::Path(path) => use_tree_contains_name(path.tree.as_ref(), name),
-        UseTree::Name(item) => item.ident == name,
-        UseTree::Rename(item) => item.rename == name,
+        UseTree::Path(path) => use_tree_binds_name(path.tree.as_ref(), local_name),
+        UseTree::Name(item) => item.ident == local_name,
+        UseTree::Rename(item) => item.rename == local_name,
         UseTree::Group(group) => group
             .items
             .iter()
-            .any(|item| use_tree_contains_name(item, name)),
+            .any(|item| use_tree_binds_name(item, local_name)),
         UseTree::Glob(_) => false,
     }
-}
-
-fn use_tree_imports_from(tree: &UseTree, source: &str, name: &str) -> bool {
-    matches!(tree, UseTree::Path(path) if path.ident == source && use_tree_contains_name(path.tree.as_ref(), name))
 }
 
 fn message_imports_bytes_type(source: &str) -> bool {
@@ -68,7 +83,7 @@ fn message_imports_bytes_type(source: &str) -> bool {
         .items
         .iter()
         .any(|item| {
-            matches!(item, Item::Use(item_use) if use_tree_imports_from(&item_use.tree, "bytes", "Bytes"))
+            matches!(item, Item::Use(item_use) if use_tree_imports_from(&item_use.tree, "bytes", "Bytes", "Bytes"))
         })
 }
 
@@ -110,29 +125,53 @@ fn has_feature_gate(attributes: &[Attribute], feature: &str) -> bool {
 
 fn lib_exposes_codec_only_behind_feature(source: &str) -> bool {
     let syntax = syn::parse_file(source).expect("lib.rs must remain valid Rust");
-    let module_is_gated = syntax.items.iter().any(|item| {
-        matches!(
-            item,
-            Item::Mod(item_mod)
-                if item_mod.ident == "tokio_codec"
-                    && is_public(&item_mod.vis)
-                    && has_feature_gate(&item_mod.attrs, "tokio-codec")
-        )
-    });
-    let root_reexport_is_gated = syntax.items.iter().any(|item| {
-        matches!(
-            item,
+    let codec_modules = syntax
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Mod(item_mod) if item_mod.ident == "tokio_codec" && is_public(&item_mod.vis) => {
+                Some(item_mod)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let codec_bindings = syntax
+        .items
+        .iter()
+        .filter(|item| match item {
+            Item::Use(item_use) => {
+                is_public(&item_use.vis) && use_tree_binds_name(&item_use.tree, "BgpCodecError")
+            }
+            Item::Enum(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Struct(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Type(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Union(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::Mod(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
+            Item::ExternCrate(item) => {
+                is_public(&item.vis)
+                    && item
+                        .rename
+                        .as_ref()
+                        .is_some_and(|(_, name)| name == "BgpCodecError")
+            }
+            _ => false,
+        })
+        .collect::<Vec<_>>();
+
+    codec_modules.len() == 1
+        && has_feature_gate(&codec_modules[0].attrs, "tokio-codec")
+        && codec_bindings.len() == 1
+        && matches!(
+            codec_bindings[0],
             Item::Use(item_use)
-                if is_public(&item_use.vis)
-                    && has_feature_gate(&item_use.attrs, "tokio-codec")
+                if has_feature_gate(&item_use.attrs, "tokio-codec")
                     && use_tree_imports_from(
                         &item_use.tree,
                         "tokio_codec",
                         "BgpCodecError",
+                        "BgpCodecError",
                     )
         )
-    });
-    module_is_gated && root_reexport_is_gated
 }
 
 fn external_module_path(module_directory: &Path, name: &str) -> PathBuf {
@@ -172,6 +211,7 @@ fn explicit_module_path(attributes: &[Attribute], module_directory: &Path) -> Op
 enum PublicExport {
     Error(String),
     BytesDependency,
+    Module(Vec<String>),
 }
 
 #[derive(Clone, Debug)]
@@ -257,6 +297,21 @@ fn inspect_module_items(
             Item::Use(item_use) if is_public(&item_use.vis) => {
                 flatten_use_tree(&item_use.tree, &mut Vec::new(), &mut inventory.public_uses);
             }
+            Item::Type(item_type) if is_public(&item_type.vis) => {
+                if let Type::Path(type_path) = item_type.ty.as_ref()
+                    && type_path.qself.is_none()
+                {
+                    inventory.public_uses.push(PublicUse::Named {
+                        source: type_path
+                            .path
+                            .segments
+                            .iter()
+                            .map(|segment| segment.ident.to_string())
+                            .collect(),
+                        local: item_type.ident.to_string(),
+                    });
+                }
+            }
             Item::Mod(item_mod) => {
                 let name = item_mod.ident.to_string();
                 let mut child_path = module_path.to_vec();
@@ -264,6 +319,9 @@ fn inspect_module_items(
                 let child_directory = module_directory.join(&name);
                 if is_public(&item_mod.vis) {
                     inventory.public_children.push(child_path.clone());
+                    inventory
+                        .direct_exports
+                        .insert(name.clone(), PublicExport::Module(child_path.clone()));
                 }
                 if let Some((_, child_items)) = &item_mod.content {
                     inspect_module_items(child_items, &child_path, &child_directory, modules);
@@ -399,6 +457,15 @@ fn inventory_from_modules(
             for child in &module.public_children {
                 changed |= reachable.insert(child.clone());
             }
+            for export in exports
+                .get(&module_path)
+                .expect("reachable module has resolved exports")
+                .values()
+            {
+                if let PublicExport::Module(child) = export {
+                    changed |= reachable.insert(child.clone());
+                }
+            }
         }
         if !changed {
             break;
@@ -419,7 +486,7 @@ fn inventory_from_modules(
         }
         errors.extend(module_exports.values().filter_map(|export| match export {
             PublicExport::Error(name) => Some(name.clone()),
-            PublicExport::BytesDependency => None,
+            PublicExport::BytesDependency | PublicExport::Module(_) => None,
         }));
     }
     (errors.into_iter().collect(), bytes_reexports)
@@ -571,11 +638,18 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         1,
     );
     assert!(!message_imports_bytes_type(&aliased_bytes_source));
+    let wrong_source_item = MESSAGE_SOURCE.replacen(
+        "use bytes::{Bytes, BytesMut};",
+        "use bytes::{Bytes as DependencyBytes, BytesMut as Bytes};",
+        1,
+    );
+    assert!(!message_imports_bytes_type(&wrong_source_item));
 
     for reexport in [
         "pub use bytes::Bytes;",
         "pub use {bytes::Bytes};",
         "pub extern crate bytes;",
+        "pub type WireBytes = bytes::Bytes;",
     ] {
         assert!(
             !inline_source_inventory(reexport).1.is_empty(),
@@ -598,6 +672,26 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         pub use tokio_codec::BgpCodecError;
     "#;
     assert!(!lib_exposes_codec_only_behind_feature(ungated_codec_module));
+    let wrong_codec_source_item = r#"
+        #[cfg(feature = "tokio-codec")]
+        pub mod tokio_codec { pub struct BgpCodec; pub enum BgpCodecError {} }
+        #[cfg(feature = "tokio-codec")]
+        pub use tokio_codec::BgpCodec as BgpCodecError;
+    "#;
+    assert!(!lib_exposes_codec_only_behind_feature(
+        wrong_codec_source_item
+    ));
+    let alternative_ungated_binding = r#"
+        #[cfg(feature = "tokio-codec")]
+        pub mod tokio_codec { pub enum BgpCodecError {} }
+        #[cfg(feature = "tokio-codec")]
+        pub use tokio_codec::BgpCodecError;
+        #[cfg(not(feature = "tokio-codec"))]
+        pub use error::DecodeError as BgpCodecError;
+    "#;
+    assert!(!lib_exposes_codec_only_behind_feature(
+        alternative_ungated_binding
+    ));
 
     let exhaustiveness = section(README, "## Enum exhaustiveness");
     for name in ERROR_ENUM_NAMES {
@@ -605,26 +699,18 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         assert!(!has_documented_error_roster(&missing_name));
     }
 
-    let declarations = [
-        (include_str!("../src/error.rs"), "DecodeError"),
-        (include_str!("../src/error.rs"), "EncodeError"),
-        (
-            include_str!("../src/evpn.rs"),
-            "RouteDistinguisherParseError",
-        ),
-        (
-            include_str!("../src/notification.rs"),
-            "ShutdownCommunicationError",
-        ),
-        (include_str!("../src/tokio_codec.rs"), "BgpCodecError"),
-    ];
-    for (source, name) in declarations {
-        let exhaustive = source.replacen(
-            &format!("#[non_exhaustive]\npub enum {name}"),
-            &format!("pub enum {name}"),
-            1,
+    for name in ERROR_ENUM_NAMES {
+        assert!(
+            source_enum_is_public_and_non_exhaustive(
+                &format!("#[derive(Debug)]\n#[non_exhaustive]\npub enum {name} {{ Example }}"),
+                name,
+            ),
+            "structural checker must accept reordered attributes for {name}"
         );
-        assert!(!source_enum_is_public_and_non_exhaustive(&exhaustive, name));
+        assert!(!source_enum_is_public_and_non_exhaustive(
+            &format!("pub enum {name} {{ Example }}"),
+            name
+        ));
     }
 
     let mutations = r#"
@@ -664,4 +750,18 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
     let (facade_errors, facade_bytes) = inline_source_inventory(private_facade);
     assert_eq!(facade_errors, ["rustbgpd_wire::hidden::FutureError"]);
     assert_eq!(facade_bytes, ["rustbgpd_wire"]);
+
+    let private_module_facade = r#"
+        mod hidden {
+            pub mod api {
+                #[non_exhaustive]
+                pub enum FutureError { Example }
+                pub use bytes::Bytes;
+            }
+        }
+        pub use hidden::api;
+    "#;
+    let (module_errors, module_bytes) = inline_source_inventory(private_module_facade);
+    assert_eq!(module_errors, ["rustbgpd_wire::hidden::api::FutureError"]);
+    assert_eq!(module_bytes, ["rustbgpd_wire::hidden::api"]);
 }

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,22 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
-
 use syn::{
-    Attribute, Expr, FnArg, GenericArgument, Item, Lit, Meta, PathArguments, ReturnType, Type,
+    Attribute, FnArg, GenericArgument, GenericParam, Item, Meta, PathArguments, ReturnType, Type,
     UseTree, Visibility,
 };
 
 const README: &str = include_str!("../README.md");
 const LIB_SOURCE: &str = include_str!("../src/lib.rs");
 const MESSAGE_SOURCE: &str = include_str!("../src/message.rs");
-const ERROR_ENUM_NAMES: [&str; 5] = [
-    "DecodeError",
-    "EncodeError",
-    "RouteDistinguisherParseError",
-    "ShutdownCommunicationError",
-    "BgpCodecError",
-];
-
 fn section<'a>(document: &'a str, heading: &str) -> &'a str {
     let start = document
         .find(heading)
@@ -42,29 +31,8 @@ fn has_documented_error_roster(exhaustiveness: &str) -> bool {
     )
 }
 
-fn decode_message_has_bytes_signature(source: &str) -> bool {
-    let syntax = syn::parse_file(source).expect("message.rs must remain valid Rust");
-    let Some(function) = syntax.items.iter().find_map(|item| match item {
-        Item::Fn(function)
-            if function.sig.ident == "decode_message" && is_public(&function.vis) =>
-        {
-            Some(function)
-        }
-        _ => None,
-    }) else {
-        return false;
-    };
-    let mut inputs = function.sig.inputs.iter();
-    let first_is_bytes = inputs.next().is_some_and(|argument| {
-        matches!(argument, FnArg::Typed(argument) if is_mut_reference_to(&argument.ty, "Bytes"))
-    });
-    let second_is_u16 = inputs.next().is_some_and(
-        |argument| matches!(argument, FnArg::Typed(argument) if is_plain_type(&argument.ty, "u16")),
-    );
-    first_is_bytes
-        && second_is_u16
-        && inputs.next().is_none()
-        && return_type_is_result(&function.sig.output, "Message", "DecodeError")
+fn is_public(visibility: &Visibility) -> bool {
+    matches!(visibility, Visibility::Public(_))
 }
 
 fn is_plain_type(ty: &Type, name: &str) -> bool {
@@ -79,10 +47,6 @@ fn is_plain_type(ty: &Type, name: &str) -> bool {
     )
 }
 
-fn is_mut_reference_to(ty: &Type, name: &str) -> bool {
-    matches!(ty, Type::Reference(reference) if reference.mutability.is_some() && is_plain_type(&reference.elem, name))
-}
-
 fn return_type_is_result(output: &ReturnType, ok: &str, error: &str) -> bool {
     let ReturnType::Type(_, ty) = output else {
         return false;
@@ -90,15 +54,17 @@ fn return_type_is_result(output: &ReturnType, ok: &str, error: &str) -> bool {
     let Type::Path(path) = ty.as_ref() else {
         return false;
     };
-    if path.qself.is_some() || path.path.segments.len() != 1 {
+    let Some(result) = path.path.segments.first() else {
         return false;
-    }
-    let result = &path.path.segments[0];
+    };
     let PathArguments::AngleBracketed(arguments) = &result.arguments else {
         return false;
     };
     let mut arguments = arguments.args.iter();
-    result.ident == "Result"
+    path.qself.is_none()
+        && path.path.leading_colon.is_none()
+        && path.path.segments.len() == 1
+        && result.ident == "Result"
         && arguments.next().is_some_and(
             |argument| matches!(argument, GenericArgument::Type(ty) if is_plain_type(ty, ok)),
         )
@@ -108,36 +74,92 @@ fn return_type_is_result(output: &ReturnType, ok: &str, error: &str) -> bool {
         && arguments.next().is_none()
 }
 
-fn use_tree_imports_from(
-    tree: &UseTree,
-    source: &str,
-    source_name: &str,
-    local_name: &str,
-) -> bool {
-    let mut uses = Vec::new();
-    flatten_use_tree(tree, &mut Vec::new(), &mut uses);
-    uses.iter().any(|public_use| {
+fn decode_message_has_documented_signature(source: &str) -> bool {
+    let syntax = syn::parse_file(source).expect("message.rs must remain valid Rust");
+    let mut functions = syntax.items.iter().filter_map(|item| match item {
+        Item::Fn(function)
+            if function.sig.ident == "decode_message" && is_public(&function.vis) =>
+        {
+            Some(function)
+        }
+        _ => None,
+    });
+    let Some(function) = functions.next() else {
+        return false;
+    };
+    let mut inputs = function.sig.inputs.iter();
+    let first_is_bytes = inputs.next().is_some_and(|argument| {
         matches!(
-            public_use,
-            PublicUse::Named {
-                source: item_source,
-                local,
-            } if item_source == &[source, source_name] && local == local_name
+            argument,
+            FnArg::Typed(argument)
+                if matches!(argument.ty.as_ref(), Type::Reference(reference)
+                    if reference.mutability.is_some() && is_plain_type(&reference.elem, "Bytes"))
         )
-    })
+    });
+    let second_is_u16 = inputs.next().is_some_and(
+        |argument| matches!(argument, FnArg::Typed(argument) if is_plain_type(&argument.ty, "u16")),
+    );
+    let shadows_wire_type = function.sig.generics.params.iter().any(|parameter| {
+        matches!(
+            parameter,
+            GenericParam::Type(parameter)
+                if parameter.ident == "Bytes"
+                    || parameter.ident == "Message"
+                    || parameter.ident == "DecodeError"
+        )
+    });
+    functions.next().is_none()
+        && first_is_bytes
+        && second_is_u16
+        && inputs.next().is_none()
+        && !shadows_wire_type
+        && return_type_is_result(&function.sig.output, "Message", "DecodeError")
 }
 
-fn use_tree_binds_name(tree: &UseTree, local_name: &str) -> bool {
+#[derive(Debug)]
+enum UseEntry {
+    Named { source: Vec<String>, local: String },
+    Glob { source: Vec<String> },
+}
+
+fn flatten_use_tree(tree: &UseTree, prefix: &mut Vec<String>, entries: &mut Vec<UseEntry>) {
     match tree {
-        UseTree::Path(path) => use_tree_binds_name(path.tree.as_ref(), local_name),
-        UseTree::Name(item) => item.ident == local_name,
-        UseTree::Rename(item) => item.rename == local_name,
-        UseTree::Group(group) => group
-            .items
-            .iter()
-            .any(|item| use_tree_binds_name(item, local_name)),
-        UseTree::Glob(_) => false,
+        UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            flatten_use_tree(path.tree.as_ref(), prefix, entries);
+            prefix.pop();
+        }
+        UseTree::Name(name) => {
+            let mut source = prefix.clone();
+            source.push(name.ident.to_string());
+            entries.push(UseEntry::Named {
+                source,
+                local: name.ident.to_string(),
+            });
+        }
+        UseTree::Rename(rename) => {
+            let mut source = prefix.clone();
+            source.push(rename.ident.to_string());
+            entries.push(UseEntry::Named {
+                source,
+                local: rename.rename.to_string(),
+            });
+        }
+        UseTree::Glob(_) => entries.push(UseEntry::Glob {
+            source: prefix.clone(),
+        }),
+        UseTree::Group(group) => {
+            for item in &group.items {
+                flatten_use_tree(item, prefix, entries);
+            }
+        }
     }
+}
+
+fn use_entries(tree: &UseTree) -> Vec<UseEntry> {
+    let mut entries = Vec::new();
+    flatten_use_tree(tree, &mut Vec::new(), &mut entries);
+    entries
 }
 
 fn message_imports_bytes_type(source: &str) -> bool {
@@ -146,8 +168,117 @@ fn message_imports_bytes_type(source: &str) -> bool {
         .items
         .iter()
         .any(|item| {
-            matches!(item, Item::Use(item_use) if use_tree_imports_from(&item_use.tree, "bytes", "Bytes", "Bytes"))
+            matches!(item, Item::Use(item_use) if use_entries(&item_use.tree).iter().any(|entry| {
+                matches!(entry, UseEntry::Named { source, local }
+                    if source == &["bytes", "Bytes"] && local == "Bytes")
+            }))
         })
+}
+
+fn lib_has_no_root_bytes_reexport(source: &str) -> bool {
+    syn::parse_file(source)
+        .expect("lib.rs must remain valid Rust")
+        .items
+        .iter()
+        .filter(|item| match item {
+            Item::Use(item) => is_public(&item.vis),
+            Item::ExternCrate(item) => is_public(&item.vis),
+            Item::Type(item) => is_public(&item.vis),
+            _ => false,
+        })
+        .all(|item| match item {
+            Item::Use(item) => use_entries(&item.tree).iter().all(|entry| match entry {
+                UseEntry::Named { source, .. } | UseEntry::Glob { source } => {
+                    !source.first().is_some_and(|segment| segment == "bytes")
+                }
+            }),
+            Item::ExternCrate(item) => item.ident != "bytes",
+            Item::Type(item) => !matches!(item.ty.as_ref(), Type::Path(path)
+                if path.qself.is_none()
+                    && path.path.segments.first().is_some_and(|segment| segment.ident == "bytes")),
+            _ => true,
+        })
+}
+
+fn has_exact_feature_gate(attributes: &[Attribute], feature: &str) -> bool {
+    let mut cfgs = attributes
+        .iter()
+        .filter(|attribute| attribute.path().is_ident("cfg"));
+    let Some(attribute) = cfgs.next() else {
+        return false;
+    };
+    let Meta::List(list) = &attribute.meta else {
+        return false;
+    };
+    cfgs.next().is_none()
+        && !attributes
+            .iter()
+            .any(|attribute| attribute.path().is_ident("cfg_attr"))
+        && compact_whitespace(&list.tokens.to_string()) == format!("feature = \"{feature}\"")
+}
+
+fn item_has_public_name(item: &Item, name: &str) -> bool {
+    match item {
+        Item::Enum(item) => is_public(&item.vis) && item.ident == name,
+        Item::Struct(item) => is_public(&item.vis) && item.ident == name,
+        Item::Type(item) => is_public(&item.vis) && item.ident == name,
+        Item::Union(item) => is_public(&item.vis) && item.ident == name,
+        Item::Trait(item) => is_public(&item.vis) && item.ident == name,
+        Item::TraitAlias(item) => is_public(&item.vis) && item.ident == name,
+        Item::Fn(item) => is_public(&item.vis) && item.sig.ident == name,
+        Item::Const(item) => is_public(&item.vis) && item.ident == name,
+        Item::Static(item) => is_public(&item.vis) && item.ident == name,
+        Item::Mod(item) => is_public(&item.vis) && item.ident == name,
+        Item::ExternCrate(item) => {
+            is_public(&item.vis)
+                && (item.ident == name
+                    || item
+                        .rename
+                        .as_ref()
+                        .is_some_and(|(_, rename)| rename == name))
+        }
+        _ => false,
+    }
+}
+
+fn lib_has_exact_codec_gate(source: &str) -> bool {
+    let syntax = syn::parse_file(source).expect("lib.rs must remain valid Rust");
+    let modules = syntax
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Mod(module) if is_public(&module.vis) && module.ident == "tokio_codec" => {
+                Some(module)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if modules.len() != 1 || !has_exact_feature_gate(&modules[0].attrs, "tokio-codec") {
+        return false;
+    }
+
+    let mut bindings = 0;
+    let mut canonical_binding = false;
+    for item in &syntax.items {
+        if let Item::Use(item_use) = item
+            && is_public(&item_use.vis)
+        {
+            for entry in use_entries(&item_use.tree) {
+                match entry {
+                    UseEntry::Named { source, local } if local == "BgpCodecError" => {
+                        bindings += 1;
+                        canonical_binding |= source == ["tokio_codec", "BgpCodecError"]
+                            && has_exact_feature_gate(&item_use.attrs, "tokio-codec");
+                    }
+                    UseEntry::Glob { .. } => return false,
+                    UseEntry::Named { .. } => {}
+                }
+            }
+        } else if item_has_public_name(item, "BgpCodecError") {
+            bindings += 1;
+        }
+    }
+    bindings == 1 && canonical_binding
 }
 
 fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
@@ -156,598 +287,31 @@ fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
         .items
         .iter()
         .any(|item| {
-            matches!(
-                item,
-                Item::Enum(item_enum)
-                    if item_enum.ident == name
-                        && is_public(&item_enum.vis)
-                        && has_non_exhaustive_attribute(&item_enum.attrs)
-            )
+            matches!(item, Item::Enum(item)
+            if is_public(&item.vis)
+                && item.ident == name
+                && item.attrs.iter().any(|attribute| attribute.path().is_ident("non_exhaustive")))
         })
-}
-
-fn is_public(visibility: &Visibility) -> bool {
-    matches!(visibility, Visibility::Public(_))
-}
-
-fn has_non_exhaustive_attribute(attributes: &[Attribute]) -> bool {
-    attributes
-        .iter()
-        .any(|attribute| attribute.path().is_ident("non_exhaustive"))
-}
-
-fn has_feature_gate(attributes: &[Attribute], feature: &str) -> bool {
-    attributes.iter().any(|attribute| {
-        let Meta::List(list) = &attribute.meta else {
-            return false;
-        };
-        attribute.path().is_ident("cfg")
-            && compact_whitespace(&list.tokens.to_string()) == format!("feature = \"{feature}\"")
-    })
-}
-
-fn lib_exposes_codec_only_behind_feature(source: &str) -> bool {
-    let syntax = syn::parse_file(source).expect("lib.rs must remain valid Rust");
-    let codec_modules = syntax
-        .items
-        .iter()
-        .filter_map(|item| match item {
-            Item::Mod(item_mod) if item_mod.ident == "tokio_codec" && is_public(&item_mod.vis) => {
-                Some(item_mod)
-            }
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-    let codec_bindings = syntax
-        .items
-        .iter()
-        .filter(|item| match item {
-            Item::Use(item_use) => {
-                is_public(&item_use.vis) && use_tree_binds_name(&item_use.tree, "BgpCodecError")
-            }
-            Item::Enum(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Struct(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Type(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Union(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Trait(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::TraitAlias(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Fn(item) => item.sig.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Const(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Static(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::Mod(item) => item.ident == "BgpCodecError" && is_public(&item.vis),
-            Item::ExternCrate(item) => {
-                is_public(&item.vis)
-                    && item
-                        .rename
-                        .as_ref()
-                        .is_some_and(|(_, name)| name == "BgpCodecError")
-            }
-            _ => false,
-        })
-        .collect::<Vec<_>>();
-
-    codec_modules.len() == 1
-        && has_feature_gate(&codec_modules[0].attrs, "tokio-codec")
-        && codec_bindings.len() == 1
-        && !root_public_glob_may_bind(source, "BgpCodecError")
-        && matches!(
-            codec_bindings[0],
-            Item::Use(item_use)
-                if has_feature_gate(&item_use.attrs, "tokio-codec")
-                    && use_tree_imports_from(
-                        &item_use.tree,
-                        "tokio_codec",
-                        "BgpCodecError",
-                        "BgpCodecError",
-                    )
-        )
-}
-
-fn external_module_path(module_directory: &Path, name: &str) -> PathBuf {
-    let sibling = module_directory.join(format!("{name}.rs"));
-    if sibling.is_file() {
-        sibling
-    } else {
-        let nested = module_directory.join(name).join("mod.rs");
-        assert!(
-            nested.is_file(),
-            "cannot resolve public module {name:?} below {}",
-            module_directory.display()
-        );
-        nested
-    }
-}
-
-fn explicit_module_path(attributes: &[Attribute], module_directory: &Path) -> Option<PathBuf> {
-    attributes.iter().find_map(|attribute| {
-        let Meta::NameValue(name_value) = &attribute.meta else {
-            return None;
-        };
-        if !attribute.path().is_ident("path") {
-            return None;
-        }
-        let Expr::Lit(expr_lit) = &name_value.value else {
-            return None;
-        };
-        let Lit::Str(path) = &expr_lit.lit else {
-            return None;
-        };
-        Some(module_directory.join(path.value()))
-    })
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum PublicExport {
-    Error(String),
-    BytesDependency,
-    Module(Vec<String>),
-    NamedItem,
-}
-
-#[derive(Clone, Debug)]
-enum PublicUse {
-    Named { source: Vec<String>, local: String },
-    Glob { source: Vec<String> },
-}
-
-#[derive(Default)]
-struct ModuleInventory {
-    direct_exports: BTreeMap<String, PublicExport>,
-    public_uses: Vec<PublicUse>,
-    public_children: Vec<Vec<String>>,
-}
-
-fn merge_module_inventory(target: &mut ModuleInventory, incoming: ModuleInventory) {
-    // The source graph intentionally sees every cfg branch. Mutually exclusive declarations of
-    // one logical module therefore contribute a conservative all-configuration union here.
-    for (name, export) in incoming.direct_exports {
-        target.direct_exports.entry(name).or_insert(export);
-    }
-    target.public_uses.extend(incoming.public_uses);
-    target.public_children.extend(incoming.public_children);
-    target.public_children.sort();
-    target.public_children.dedup();
-}
-
-fn flatten_use_tree(tree: &UseTree, prefix: &mut Vec<String>, uses: &mut Vec<PublicUse>) {
-    match tree {
-        UseTree::Path(path) => {
-            prefix.push(path.ident.to_string());
-            flatten_use_tree(path.tree.as_ref(), prefix, uses);
-            prefix.pop();
-        }
-        UseTree::Name(name) => {
-            let mut source = prefix.clone();
-            source.push(name.ident.to_string());
-            uses.push(PublicUse::Named {
-                local: name.ident.to_string(),
-                source,
-            });
-        }
-        UseTree::Rename(rename) => {
-            let mut source = prefix.clone();
-            source.push(rename.ident.to_string());
-            uses.push(PublicUse::Named {
-                local: rename.rename.to_string(),
-                source,
-            });
-        }
-        UseTree::Glob(_) => uses.push(PublicUse::Glob {
-            source: prefix.clone(),
-        }),
-        UseTree::Group(group) => {
-            for item in &group.items {
-                flatten_use_tree(item, prefix, uses);
-            }
-        }
-    }
-}
-
-fn inspect_module_items(
-    items: &[Item],
-    module_path: &[String],
-    module_directory: &Path,
-    modules: &mut BTreeMap<Vec<String>, ModuleInventory>,
-) {
-    let mut inventory = ModuleInventory::default();
-    for item in items {
-        match item {
-            Item::Enum(item_enum) if is_public(&item_enum.vis) => {
-                let name = item_enum.ident.to_string();
-                let export =
-                    if has_non_exhaustive_attribute(&item_enum.attrs) && name.ends_with("Error") {
-                        let mut qualified = vec!["rustbgpd_wire".to_string()];
-                        qualified.extend_from_slice(module_path);
-                        qualified.push(name.clone());
-                        PublicExport::Error(qualified.join("::"))
-                    } else {
-                        PublicExport::NamedItem
-                    };
-                inventory.direct_exports.insert(name, export);
-            }
-            Item::Struct(item_struct) if is_public(&item_struct.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_struct.ident.to_string(), PublicExport::NamedItem);
-            }
-            Item::Union(item_union) if is_public(&item_union.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_union.ident.to_string(), PublicExport::NamedItem);
-            }
-            Item::Trait(item_trait) if is_public(&item_trait.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_trait.ident.to_string(), PublicExport::NamedItem);
-            }
-            Item::TraitAlias(item_alias) if is_public(&item_alias.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_alias.ident.to_string(), PublicExport::NamedItem);
-            }
-            Item::Fn(item_fn) if is_public(&item_fn.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_fn.sig.ident.to_string(), PublicExport::NamedItem);
-            }
-            Item::Const(item_const) if is_public(&item_const.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_const.ident.to_string(), PublicExport::NamedItem);
-            }
-            Item::Static(item_static) if is_public(&item_static.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_static.ident.to_string(), PublicExport::NamedItem);
-            }
-            Item::ExternCrate(item_extern) if is_public(&item_extern.vis) => {
-                let local = item_extern.rename.as_ref().map_or_else(
-                    || item_extern.ident.to_string(),
-                    |(_, name)| name.to_string(),
-                );
-                let export = if item_extern.ident == "bytes" {
-                    PublicExport::BytesDependency
-                } else {
-                    PublicExport::NamedItem
-                };
-                inventory.direct_exports.insert(local, export);
-            }
-            Item::Use(item_use) if is_public(&item_use.vis) => {
-                flatten_use_tree(&item_use.tree, &mut Vec::new(), &mut inventory.public_uses);
-            }
-            Item::Type(item_type) if is_public(&item_type.vis) => {
-                inventory
-                    .direct_exports
-                    .insert(item_type.ident.to_string(), PublicExport::NamedItem);
-                if let Type::Path(type_path) = item_type.ty.as_ref()
-                    && type_path.qself.is_none()
-                {
-                    inventory.public_uses.push(PublicUse::Named {
-                        source: type_path
-                            .path
-                            .segments
-                            .iter()
-                            .map(|segment| segment.ident.to_string())
-                            .collect(),
-                        local: item_type.ident.to_string(),
-                    });
-                }
-            }
-            Item::Mod(item_mod) => {
-                let name = item_mod.ident.to_string();
-                let mut child_path = module_path.to_vec();
-                child_path.push(name.clone());
-                let child_directory = module_directory.join(&name);
-                if is_public(&item_mod.vis) {
-                    inventory.public_children.push(child_path.clone());
-                    inventory
-                        .direct_exports
-                        .insert(name.clone(), PublicExport::Module(child_path.clone()));
-                }
-                if let Some((_, child_items)) = &item_mod.content {
-                    inspect_module_items(child_items, &child_path, &child_directory, modules);
-                } else {
-                    inspect_module_file(
-                        &explicit_module_path(&item_mod.attrs, module_directory)
-                            .unwrap_or_else(|| external_module_path(module_directory, &name)),
-                        &child_path,
-                        &child_directory,
-                        modules,
-                    );
-                }
-            }
-            _ => {}
-        }
-    }
-    if let Some(existing) = modules.get_mut(module_path) {
-        merge_module_inventory(existing, inventory);
-    } else {
-        modules.insert(module_path.to_vec(), inventory);
-    }
-}
-
-fn inspect_module_file(
-    source_path: &Path,
-    module_path: &[String],
-    module_directory: &Path,
-    modules: &mut BTreeMap<Vec<String>, ModuleInventory>,
-) {
-    let source = std::fs::read_to_string(source_path)
-        .unwrap_or_else(|error| panic!("cannot read {}: {error}", source_path.display()));
-    let syntax = syn::parse_file(&source)
-        .unwrap_or_else(|error| panic!("cannot parse {}: {error}", source_path.display()));
-    inspect_module_items(&syntax.items, module_path, module_directory, modules);
-}
-
-fn absolute_use_path(current_module: &[String], source: &[String]) -> Vec<String> {
-    let mut source = source;
-    let mut absolute = Vec::new();
-    if source.first().is_some_and(|segment| segment == "crate") {
-        source = &source[1..];
-    } else if source.first().is_some_and(|segment| segment == "self") {
-        absolute.extend_from_slice(current_module);
-        source = &source[1..];
-    } else if source.first().is_some_and(|segment| segment == "super") {
-        absolute.extend_from_slice(current_module);
-        while source.first().is_some_and(|segment| segment == "super") {
-            absolute.pop();
-            source = &source[1..];
-        }
-    }
-    absolute.extend_from_slice(source);
-    absolute
-}
-
-fn resolve_module_path(
-    exports: &BTreeMap<Vec<String>, BTreeMap<String, PublicExport>>,
-    path: &[String],
-) -> Option<Vec<String>> {
-    let mut resolved = Vec::new();
-    for segment in path {
-        let mut physical_child = resolved.clone();
-        physical_child.push(segment.clone());
-        if exports.contains_key(&physical_child) {
-            resolved = physical_child;
-            continue;
-        }
-        let PublicExport::Module(alias_target) = exports.get(&resolved)?.get(segment)? else {
-            return None;
-        };
-        resolved.clone_from(alias_target);
-    }
-    Some(resolved)
-}
-
-fn resolve_export_path(
-    exports: &BTreeMap<Vec<String>, BTreeMap<String, PublicExport>>,
-    path: &[String],
-) -> Option<PublicExport> {
-    let (name, module_path) = path.split_last()?;
-    let resolved_module = resolve_module_path(exports, module_path)?;
-    exports.get(&resolved_module)?.get(name).cloned()
-}
-
-fn resolved_module_exports(
-    modules: &BTreeMap<Vec<String>, ModuleInventory>,
-) -> BTreeMap<Vec<String>, BTreeMap<String, PublicExport>> {
-    let mut exports = modules
-        .iter()
-        .map(|(path, module)| (path.clone(), module.direct_exports.clone()))
-        .collect::<BTreeMap<_, _>>();
-
-    loop {
-        let snapshot = exports.clone();
-        let mut changed = false;
-        for (module_path, module) in modules {
-            let module_exports = exports
-                .get_mut(module_path)
-                .expect("every parsed module has an export map");
-            for public_use in &module.public_uses {
-                match public_use {
-                    PublicUse::Named { source, local }
-                        if source.first().is_some_and(|part| part == "bytes") =>
-                    {
-                        changed |= module_exports
-                            .insert(local.clone(), PublicExport::BytesDependency)
-                            .as_ref()
-                            != Some(&PublicExport::BytesDependency);
-                    }
-                    PublicUse::Glob { source }
-                        if source.first().is_some_and(|part| part == "bytes") =>
-                    {
-                        changed |= module_exports
-                            .insert("*bytes".to_string(), PublicExport::BytesDependency)
-                            .as_ref()
-                            != Some(&PublicExport::BytesDependency);
-                    }
-                    PublicUse::Named { source, local } => {
-                        let absolute = absolute_use_path(module_path, source);
-                        if let Some(export) = resolve_export_path(&snapshot, &absolute) {
-                            changed |= module_exports
-                                .insert(local.clone(), export.clone())
-                                .as_ref()
-                                != Some(&export);
-                        }
-                    }
-                    PublicUse::Glob { source } => {
-                        let absolute = absolute_use_path(module_path, source);
-                        if let Some(target) = resolve_module_path(&snapshot, &absolute)
-                            .and_then(|target| snapshot.get(&target))
-                        {
-                            for (name, export) in target {
-                                changed |=
-                                    module_exports.insert(name.clone(), export.clone()).as_ref()
-                                        != Some(export);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if !changed {
-            return exports;
-        }
-    }
-}
-
-fn root_public_glob_may_bind(source: &str, name: &str) -> bool {
-    let syntax = syn::parse_file(source).expect("lib.rs must remain valid Rust");
-    let source_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut modules = BTreeMap::new();
-    inspect_module_items(&syntax.items, &[], &source_directory, &mut modules);
-    let exports = resolved_module_exports(&modules);
-    modules
-        .get(&Vec::new())
-        .expect("root module was inspected")
-        .public_uses
-        .iter()
-        .filter_map(|public_use| match public_use {
-            PublicUse::Glob { source } => Some(source),
-            PublicUse::Named { .. } => None,
-        })
-        .any(|source| {
-            let absolute = absolute_use_path(&[], source);
-            let Some(target) = resolve_module_path(&exports, &absolute) else {
-                return true;
-            };
-            exports
-                .get(&target)
-                .is_none_or(|module| module.contains_key(name))
-        })
-}
-
-fn inventory_from_modules(
-    modules: &BTreeMap<Vec<String>, ModuleInventory>,
-) -> (Vec<String>, Vec<String>) {
-    let exports = resolved_module_exports(modules);
-    let mut reachable = BTreeSet::from([Vec::<String>::new()]);
-    loop {
-        let mut changed = false;
-        for module_path in reachable.clone() {
-            let module = modules
-                .get(&module_path)
-                .expect("reachable module was parsed");
-            for child in &module.public_children {
-                changed |= reachable.insert(child.clone());
-            }
-            for export in exports
-                .get(&module_path)
-                .expect("reachable module has resolved exports")
-                .values()
-            {
-                if let PublicExport::Module(child) = export {
-                    changed |= reachable.insert(child.clone());
-                }
-            }
-        }
-        if !changed {
-            break;
-        }
-    }
-
-    let mut errors = BTreeSet::new();
-    let mut bytes_reexports = Vec::new();
-    for module_path in reachable {
-        let module_exports = exports.get(&module_path).expect("reachable export map");
-        if module_exports
-            .values()
-            .any(|export| matches!(export, PublicExport::BytesDependency))
-        {
-            let mut qualified = vec!["rustbgpd_wire".to_string()];
-            qualified.extend(module_path.clone());
-            bytes_reexports.push(qualified.join("::"));
-        }
-        errors.extend(module_exports.values().filter_map(|export| match export {
-            PublicExport::Error(name) => Some(name.clone()),
-            PublicExport::BytesDependency | PublicExport::Module(_) | PublicExport::NamedItem => {
-                None
-            }
-        }));
-    }
-    (errors.into_iter().collect(), bytes_reexports)
-}
-
-fn public_api_source_inventory() -> (Vec<String>, Vec<String>) {
-    let source_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut modules = BTreeMap::new();
-    inspect_module_file(
-        &source_directory.join("lib.rs"),
-        &[],
-        &source_directory,
-        &mut modules,
-    );
-    inventory_from_modules(&modules)
-}
-
-fn inline_source_inventory(source: &str) -> (Vec<String>, Vec<String>) {
-    let syntax = syn::parse_file(source).expect("mutation source must be valid Rust");
-    let mut modules = BTreeMap::new();
-    inspect_module_items(
-        &syntax.items,
-        &[],
-        Path::new("unused-for-inline-modules"),
-        &mut modules,
-    );
-    inventory_from_modules(&modules)
 }
 
 #[test]
-fn usage_pins_direct_dependencies_to_the_published_wire_version() {
+fn usage_matches_the_published_wire_contract() {
     let usage = section(README, "## Usage");
-    let dependency_block = expected_dependency_block(env!("CARGO_PKG_VERSION"));
-
-    assert!(
-        usage.contains(&dependency_block),
-        "Usage must pin rustbgpd-wire to the package version and bytes to major version 1"
-    );
-    assert!(
-        usage.contains("`decode_message` accepts `&mut bytes::Bytes`"),
-        "Usage must name the public buffer type accepted by decode_message"
-    );
-    assert!(
-        usage.contains("it is not re-exported"),
-        "Usage must explain why downstream consumers need a direct bytes dependency"
-    );
+    assert!(usage.contains(&expected_dependency_block(env!("CARGO_PKG_VERSION"))));
+    assert!(usage.contains("`decode_message` accepts `&mut bytes::Bytes`"));
+    assert!(usage.contains("it is not re-exported"));
+    assert!(decode_message_has_documented_signature(MESSAGE_SOURCE));
+    assert!(message_imports_bytes_type(MESSAGE_SOURCE));
+    assert!(lib_has_no_root_bytes_reexport(LIB_SOURCE));
 }
 
 #[test]
-fn decode_entry_point_keeps_the_documented_bytes_contract() {
-    assert!(
-        decode_message_has_bytes_signature(MESSAGE_SOURCE),
-        "decode_message no longer has the documented &mut bytes::Bytes signature"
-    );
-    assert!(
-        message_imports_bytes_type(MESSAGE_SOURCE),
-        "decode_message's Bytes type must be imported from the bytes crate"
-    );
-    let (_, bytes_reexports) = public_api_source_inventory();
-    assert!(
-        bytes_reexports.is_empty(),
-        "README says bytes is not re-exported, but public modules re-export it: {bytes_reexports:?}"
-    );
-}
-
-#[test]
-fn enum_exhaustiveness_names_the_complete_public_error_roster() {
+fn enum_guidance_matches_the_five_known_public_errors() {
     let exhaustiveness = section(README, "## Enum exhaustiveness");
-
-    assert!(
-        has_documented_error_roster(exhaustiveness),
-        "Enum exhaustiveness must name the exact five-enum roster and identify BgpCodecError as feature-gated"
-    );
-    assert!(
-        exhaustiveness.contains("must include\na wildcard arm"),
-        "Enum exhaustiveness must preserve downstream wildcard guidance"
-    );
-    assert!(
-        exhaustiveness.contains("_ => {}"),
-        "Enum exhaustiveness must retain its wildcard match example"
-    );
-}
-
-#[test]
-fn every_documented_public_error_enum_stays_non_exhaustive_in_source() {
-    let declarations = [
+    assert!(has_documented_error_roster(exhaustiveness));
+    assert!(exhaustiveness.contains("must include\na wildcard arm"));
+    assert!(exhaustiveness.contains("_ => {}"));
+    for (source, name) in [
         (include_str!("../src/error.rs"), "DecodeError"),
         (include_str!("../src/error.rs"), "EncodeError"),
         (
@@ -759,271 +323,28 @@ fn every_documented_public_error_enum_stays_non_exhaustive_in_source() {
             "ShutdownCommunicationError",
         ),
         (include_str!("../src/tokio_codec.rs"), "BgpCodecError"),
-    ];
-
-    for (source, name) in declarations {
-        assert!(
-            source_enum_is_public_and_non_exhaustive(source, name),
-            "{name} must remain a public #[non_exhaustive] enum"
-        );
-    }
-
-    assert!(
-        lib_exposes_codec_only_behind_feature(LIB_SOURCE),
-        "the tokio_codec module and root BgpCodecError binding must remain feature-gated"
-    );
-}
-
-#[test]
-fn enum_exhaustiveness_roster_covers_every_public_error_enum() {
-    let mut expected = [
-        "rustbgpd_wire::error::DecodeError",
-        "rustbgpd_wire::error::EncodeError",
-        "rustbgpd_wire::evpn::RouteDistinguisherParseError",
-        "rustbgpd_wire::notification::ShutdownCommunicationError",
-        "rustbgpd_wire::tokio_codec::BgpCodecError",
-    ]
-    .map(str::to_string)
-    .to_vec();
-    expected.sort();
-    let (errors, _) = public_api_source_inventory();
-    assert_eq!(
-        errors, expected,
-        "README roster must change whenever the public non-exhaustive error inventory changes"
-    );
-}
-
-#[test]
-fn contract_helpers_reject_independent_documentation_and_source_mutations() {
-    let usage = section(README, "## Usage");
-    let wrong_version = usage.replace(
-        &format!("rustbgpd-wire = \"{}\"", env!("CARGO_PKG_VERSION")),
-        "rustbgpd-wire = \"0.0.0\"",
-    );
-    assert!(!wrong_version.contains(&expected_dependency_block(env!("CARGO_PKG_VERSION"))));
-
-    let wrong_buffer = MESSAGE_SOURCE.replacen("buf: &mut Bytes", "buf: Bytes", 1);
-    assert!(!decode_message_has_bytes_signature(&wrong_buffer));
-    let wrong_limit_type =
-        MESSAGE_SOURCE.replacen("max_message_len: u16", "max_message_len: u32", 1);
-    assert!(!decode_message_has_bytes_signature(&wrong_limit_type));
-    let wrong_return = MESSAGE_SOURCE.replacen(
-        "Result<Message, DecodeError>",
-        "Result<Message, EncodeError>",
-        1,
-    );
-    assert!(!decode_message_has_bytes_signature(&wrong_return));
-    let stale_signature_comment = r#"
-        // pub fn decode_message(buf: &mut Bytes, max_message_len: u16) -> Result<Message, DecodeError>
-        pub fn decode_message(
-            _buf: &mut Vec<u8>,
-            _max_message_len: u16,
-        ) -> Result<Message, DecodeError> {
-            unimplemented!()
-        }
-    "#;
-    assert!(!decode_message_has_bytes_signature(stale_signature_comment));
-    let wrong_bytes_source =
-        MESSAGE_SOURCE.replacen("use bytes::{Bytes, BytesMut};", "type Bytes = Vec<u8>;", 1);
-    assert!(!message_imports_bytes_type(&wrong_bytes_source));
-    let aliased_bytes_source = MESSAGE_SOURCE.replacen(
-        "use bytes::{Bytes, BytesMut};",
-        "use bytes::{Bytes as DependencyBytes, BytesMut};\ntype Bytes = Vec<u8>;",
-        1,
-    );
-    assert!(!message_imports_bytes_type(&aliased_bytes_source));
-    let wrong_source_item = MESSAGE_SOURCE.replacen(
-        "use bytes::{Bytes, BytesMut};",
-        "use bytes::{Bytes as DependencyBytes, BytesMut as Bytes};",
-        1,
-    );
-    assert!(!message_imports_bytes_type(&wrong_source_item));
-
-    for reexport in [
-        "pub use bytes::Bytes;",
-        "pub use {bytes::Bytes};",
-        "pub extern crate bytes;",
-        "pub type WireBytes = bytes::Bytes;",
     ] {
-        assert!(
-            !inline_source_inventory(reexport).1.is_empty(),
-            "inventory must detect {reexport}"
+        assert!(source_enum_is_public_and_non_exhaustive(source, name));
+    }
+    assert!(lib_has_exact_codec_gate(LIB_SOURCE));
+}
+
+#[test]
+fn helpers_reject_contract_mutations() {
+    for shadowed in ["Bytes", "Message", "DecodeError"] {
+        let mutation = MESSAGE_SOURCE.replacen(
+            "pub fn decode_message(",
+            &format!("pub fn decode_message<{shadowed}>("),
+            1,
         );
+        assert!(!decode_message_has_documented_signature(&mutation));
     }
-
-    let reordered_codec_reexport = r#"
+    let extra_codec_cfg = r#"
         #[cfg(feature = "tokio-codec")]
-        pub mod tokio_codec { pub struct BgpCodec; pub enum BgpCodecError {} }
-        #[cfg(feature = "tokio-codec")]
-        pub use tokio_codec::{BgpCodecError, BgpCodec};
-    "#;
-    assert!(lib_exposes_codec_only_behind_feature(
-        reordered_codec_reexport
-    ));
-    let ungated_codec_module = r#"
-        pub mod tokio_codec { pub enum BgpCodecError {} }
-        #[cfg(feature = "tokio-codec")]
-        pub use tokio_codec::BgpCodecError;
-    "#;
-    assert!(!lib_exposes_codec_only_behind_feature(ungated_codec_module));
-    let wrong_codec_source_item = r#"
-        #[cfg(feature = "tokio-codec")]
-        pub mod tokio_codec { pub struct BgpCodec; pub enum BgpCodecError {} }
-        #[cfg(feature = "tokio-codec")]
-        pub use tokio_codec::BgpCodec as BgpCodecError;
-    "#;
-    assert!(!lib_exposes_codec_only_behind_feature(
-        wrong_codec_source_item
-    ));
-    let alternative_ungated_binding = r#"
-        #[cfg(feature = "tokio-codec")]
-        pub mod tokio_codec { pub enum BgpCodecError {} }
-        #[cfg(feature = "tokio-codec")]
-        pub use tokio_codec::BgpCodecError;
-        #[cfg(not(feature = "tokio-codec"))]
-        pub use error::DecodeError as BgpCodecError;
-    "#;
-    assert!(!lib_exposes_codec_only_behind_feature(
-        alternative_ungated_binding
-    ));
-    let glob_alternative_binding = r#"
-        #[cfg(feature = "tokio-codec")]
-        pub mod tokio_codec { pub enum BgpCodecError {} }
-        #[cfg(feature = "tokio-codec")]
-        pub use tokio_codec::BgpCodecError;
-        #[cfg(not(feature = "tokio-codec"))]
-        mod fallback {
-            pub struct BgpCodecError;
-        }
-        #[cfg(not(feature = "tokio-codec"))]
-        pub use fallback::*;
-    "#;
-    assert!(!lib_exposes_codec_only_behind_feature(
-        glob_alternative_binding
-    ));
-    let unrelated_glob = r#"
-        #[cfg(feature = "tokio-codec")]
-        pub mod tokio_codec { pub enum BgpCodecError {} }
-        #[cfg(feature = "tokio-codec")]
-        pub use tokio_codec::BgpCodecError;
-        mod additional { pub struct OtherPublicType; }
-        pub use additional::*;
-    "#;
-    assert!(lib_exposes_codec_only_behind_feature(unrelated_glob));
-
-    let exhaustiveness = section(README, "## Enum exhaustiveness");
-    for name in ERROR_ENUM_NAMES {
-        let missing_name = exhaustiveness.replacen(&format!("`{name}`"), "`RemovedError`", 1);
-        assert!(!has_documented_error_roster(&missing_name));
-    }
-
-    for name in ERROR_ENUM_NAMES {
-        assert!(
-            source_enum_is_public_and_non_exhaustive(
-                &format!("#[derive(Debug)]\n#[non_exhaustive]\npub enum {name} {{ Example }}"),
-                name,
-            ),
-            "structural checker must accept reordered attributes for {name}"
-        );
-        assert!(!source_enum_is_public_and_non_exhaustive(
-            &format!("pub enum {name} {{ Example }}"),
-            name
-        ));
-    }
-
-    let mutations = r#"
-        pub mod future {
-            #[non_exhaustive]
-            #[derive(Debug)]
-            pub enum FutureError { Example }
-        }
-        pub mod distinct {
-            #[non_exhaustive]
-            pub enum DecodeError { DistinctModuleVariant }
-        }
-        mod private {
-            #[non_exhaustive]
-            pub enum PrivateError { Example }
-        }
-    "#;
-    let (errors, bytes_reexports) = inline_source_inventory(mutations);
-    assert_eq!(
-        errors,
-        [
-            "rustbgpd_wire::distinct::DecodeError",
-            "rustbgpd_wire::future::FutureError",
-        ],
-        "inventory must retain qualified duplicates, accept intervening attributes, and ignore private modules"
-    );
-    assert!(bytes_reexports.is_empty());
-
-    let private_facade = r#"
-        mod hidden {
-            #[non_exhaustive]
-            pub enum FutureError { Example }
-            pub use bytes::Bytes;
-        }
-        pub use hidden::{Bytes, FutureError};
-    "#;
-    let (facade_errors, facade_bytes) = inline_source_inventory(private_facade);
-    assert_eq!(facade_errors, ["rustbgpd_wire::hidden::FutureError"]);
-    assert_eq!(facade_bytes, ["rustbgpd_wire"]);
-
-    let private_module_facade = r#"
-        mod hidden {
-            pub mod api {
-                #[non_exhaustive]
-                pub enum FutureError { Example }
-                pub use bytes::Bytes;
-            }
-        }
-        pub use hidden::api;
-    "#;
-    let (module_errors, module_bytes) = inline_source_inventory(private_module_facade);
-    assert_eq!(module_errors, ["rustbgpd_wire::hidden::api::FutureError"]);
-    assert_eq!(module_bytes, ["rustbgpd_wire::hidden::api"]);
-
-    let chained_module_facade = r#"
-        mod hidden {
-            mod deeper {
-                pub mod api {
-                    #[non_exhaustive]
-                    pub enum FutureError { Example }
-                    pub use bytes::Bytes;
-                }
-            }
-            pub use self::deeper::api as facade;
-            pub use self::facade::{Bytes, FutureError};
-        }
-        pub use hidden::{Bytes, FutureError};
-    "#;
-    let (chained_errors, chained_bytes) = inline_source_inventory(chained_module_facade);
-    assert_eq!(
-        chained_errors,
-        ["rustbgpd_wire::hidden::deeper::api::FutureError"]
-    );
-    assert_eq!(chained_bytes, ["rustbgpd_wire"]);
-
-    let cfg_exclusive_modules = r#"
         #[cfg(unix)]
-        pub mod platform {
-            #[non_exhaustive]
-            pub enum UnixError { Example }
-        }
-        #[cfg(windows)]
-        pub mod platform {
-            #[non_exhaustive]
-            pub enum WindowsError { Example }
-        }
+        pub mod tokio_codec {}
+        #[cfg(feature = "tokio-codec")]
+        pub use tokio_codec::BgpCodecError;
     "#;
-    let (cfg_errors, cfg_bytes) = inline_source_inventory(cfg_exclusive_modules);
-    assert_eq!(
-        cfg_errors,
-        [
-            "rustbgpd_wire::platform::UnixError",
-            "rustbgpd_wire::platform::WindowsError",
-        ],
-        "cfg-exclusive declarations of one logical module must form an all-config union"
-    );
-    assert!(cfg_bytes.is_empty());
+    assert!(!lib_has_exact_codec_gate(extra_codec_cfg));
 }

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -48,7 +48,7 @@ fn use_tree_contains_name(tree: &UseTree, name: &str) -> bool {
     match tree {
         UseTree::Path(path) => use_tree_contains_name(path.tree.as_ref(), name),
         UseTree::Name(item) => item.ident == name,
-        UseTree::Rename(item) => item.ident == name,
+        UseTree::Rename(item) => item.rename == name,
         UseTree::Group(group) => group
             .items
             .iter()
@@ -347,6 +347,12 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
     let wrong_bytes_source =
         MESSAGE_SOURCE.replacen("use bytes::{Bytes, BytesMut};", "type Bytes = Vec<u8>;", 1);
     assert!(!message_imports_bytes_type(&wrong_bytes_source));
+    let aliased_bytes_source = MESSAGE_SOURCE.replacen(
+        "use bytes::{Bytes, BytesMut};",
+        "use bytes::{Bytes as DependencyBytes, BytesMut};\ntype Bytes = Vec<u8>;",
+        1,
+    );
+    assert!(!message_imports_bytes_type(&aliased_bytes_source));
 
     for reexport in [
         "pub use bytes::Bytes;",

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 const README: &str = include_str!("../README.md");
 const LIB_SOURCE: &str = include_str!("../src/lib.rs");
 const MESSAGE_SOURCE: &str = include_str!("../src/message.rs");
@@ -42,6 +44,57 @@ fn decode_message_has_bytes_signature(source: &str) -> bool {
 
 fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
     compact_whitespace(source).contains(&format!("#[non_exhaustive] pub enum {name}"))
+}
+
+fn error_enums_in_source(source: &str) -> Vec<String> {
+    let compact = compact_whitespace(source);
+    let marker = "#[non_exhaustive] pub enum ";
+    let mut remainder = compact.as_str();
+    let mut names = Vec::new();
+    while let Some(offset) = remainder.find(marker) {
+        let declaration = &remainder[offset + marker.len()..];
+        let end = declaration
+            .find(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+            .unwrap_or(declaration.len());
+        let name = &declaration[..end];
+        if name.ends_with("Error") {
+            names.push(name.to_string());
+        }
+        remainder = &declaration[end..];
+    }
+    names
+}
+
+fn collect_rust_sources(directory: &Path, paths: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(directory)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", directory.display()))
+    {
+        let path = entry.expect("source directory entry").path();
+        if path.is_dir() {
+            collect_rust_sources(&path, paths);
+        } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+            paths.push(path);
+        }
+    }
+}
+
+fn public_non_exhaustive_error_enum_roster() -> Vec<String> {
+    let mut paths = Vec::new();
+    collect_rust_sources(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+        &mut paths,
+    );
+    let mut names = paths
+        .iter()
+        .flat_map(|path| {
+            let source = std::fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
+            error_enums_in_source(&source)
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
 }
 
 fn public_bytes_reexports(source: &str) -> Vec<&str> {
@@ -136,6 +189,17 @@ fn every_documented_public_error_enum_stays_non_exhaustive_in_source() {
 }
 
 #[test]
+fn enum_exhaustiveness_roster_covers_every_public_error_enum() {
+    let mut expected = ERROR_ENUM_NAMES.map(str::to_string).to_vec();
+    expected.sort();
+    assert_eq!(
+        public_non_exhaustive_error_enum_roster(),
+        expected,
+        "README roster must change whenever the public non-exhaustive error inventory changes"
+    );
+}
+
+#[test]
 fn contract_helpers_reject_independent_documentation_and_source_mutations() {
     let usage = section(README, "## Usage");
     let wrong_version = usage.replace(
@@ -180,4 +244,10 @@ fn contract_helpers_reject_independent_documentation_and_source_mutations() {
         );
         assert!(!source_enum_is_public_and_non_exhaustive(&exhaustive, name));
     }
+
+    assert_eq!(
+        error_enums_in_source("#[non_exhaustive]\npub enum FutureError { Example }"),
+        ["FutureError"],
+        "the inventory helper must detect a newly added public error enum"
+    );
 }


### PR DESCRIPTION
## Summary

- add a copy-ready `rustbgpd-wire` plus `bytes` dependency block to the published wire README
- explain the public `&mut bytes::Bytes` decode boundary without introducing a re-export
- name the current five public non-exhaustive error enums, including feature-gated `BgpCodecError`

## Downstream contract

The Usage section derives its documented `rustbgpd-wire` version from the crate package version and requires `bytes = "1"` directly because `decode_message` accepts `&mut bytes::Bytes` while the wire crate does not re-export `bytes` at its public root.

The Enum exhaustiveness section names `DecodeError`, `EncodeError`, `RouteDistinguisherParseError`, `ShutdownCommunicationError`, and `BgpCodecError`; it preserves the wildcard-match guidance and identifies the `tokio-codec` feature boundary.

No runtime, wire-format, feature, or public-API behavior changes. The only dependency change is a dev-only `syn` parser used by the contract test.

## Proof

- section-scoped checks pin the exact dependency block to the package version and preserve the buffer explanation
- syntax checks verify the public `decode_message` parameter/result structure, reject generic shadowing, and require the exact `bytes::Bytes` import
- the current public root is checked for the documented no-reexport seam
- the `tokio_codec` module and canonical root `BgpCodecError` binding must each carry the exact feature gate
- the five named source declarations must remain public `#[non_exhaustive]` enums, and the README must retain the exact roster plus wildcard guidance

The proof is intentionally scoped to the current published surface; it does not attempt to model arbitrary future Rust name-resolution or transitive-export layouts.

## Validation

- default and `tokio-codec` README contract suites: 3/3 each
- strict all-target/all-feature wire Clippy
- full pre-push tests and rustdoc
- package inventory, formatting, and diff checks

Linear: LAN-1252
