### PR TITLE
refactor(policy): exhaustively view term actions

### DIFF
--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -48,7 +48,7 @@ use super::{
     CommunityMatch, IMPLICIT_LOCAL_PREF, IMPLICIT_MED, NextHopAction, PolicyAction, PolicyChain,
     PolicyStatement, RouteContext, RouteModifications, RouteType,
 };
-use crate::ir::{Cmp, CompiledChain, CompiledPolicy, MatchExpr, Term, TermAction};
+use crate::ir::{Cmp, CompiledChain, CompiledPolicy, MatchExpr, Term, TermAction, TermActionView};
 
 /// One step of a statement-level chain trace: how a single policy in
 /// the chain disposed of the route.
@@ -451,10 +451,11 @@ fn trace_rpol_policy(
     let mut term_traces = Vec::new();
     let mut continued: Option<RouteModifications> = None;
     let mut decided: Option<(usize, &Term)> = None;
-    // LAN-303: a loop permit's resolved modifications — the deciding
-    // term's action is the ForEach node, so the verdict's payload
-    // travels here instead of through the term-action match below.
-    let mut loop_permit: Option<RouteModifications> = None;
+    // A permitting action's modifications travel with the decision so
+    // the result never needs to inspect the original action again.
+    // Loop permits are already resolved by the shared evaluator;
+    // direct permits retain their source expressions for explain.
+    let mut deciding_permit: Option<RouteModifications> = None;
     // LAN-302: the trace walk re-derives `let` bindings term by term
     // (explain may allocate/zero eagerly; the hot path never records)
     // and feeds the frame into the shared guard evaluation.
@@ -505,87 +506,94 @@ fn trace_rpol_policy(
         if !matched {
             continue;
         }
-        // LAN-302: a matched Bind evaluates its initializer eagerly,
-        // exactly like the live walk — an error fails the route
-        // closed; success writes the frame and the walk keeps going.
-        if let TermAction::Bind { slot, expr, .. } = &term.action {
-            match crate::eval::eval_value(expr, ctx, crate::eval::locals_slice(locals.as_ref())) {
-                Ok(value) => {
-                    locals.get_or_insert([0; crate::eval::LOCAL_FRAME_SLOTS])[usize::from(*slot)] =
-                        value;
-                }
-                Err(kind) => {
-                    term_traces.push(format!(
-                        "term {}: evaluation error: {kind} — fail closed => reject",
-                        term.name.as_deref().unwrap_or("<unnamed>"),
-                    ));
-                    eval_failed = true;
-                    decided = Some((index, term));
-                    break;
-                }
-            }
-            continue;
-        }
-        // LAN-303: a matched loop runs through the SAME evaluator as
-        // the live walk (`eval_for_each` — shared fuel, cap, and body
-        // semantics), rendering a bounded summary: iteration count
-        // plus the deciding iteration, never per-iteration output
-        // (ADR-0103 Decision 6).
-        if let TermAction::ForEach(node) = &term.action {
-            match tables.eval_for_each(node, ctx, &mut locals, &mut continued, fuel, pinned) {
-                Ok(outcome) => {
-                    let summary = match (&outcome.flow, outcome.decided_at) {
-                        (crate::eval::LoopFlow::Completed, _) => format!(
-                            "completed after {} iteration(s), no verdict",
-                            outcome.iterations
-                        ),
-                        (crate::eval::LoopFlow::Permit(_), Some(at)) => {
-                            format!("accept at iteration {} of {}", at + 1, outcome.iterations)
-                        }
-                        (crate::eval::LoopFlow::Deny, Some(at)) => {
-                            format!("reject at iteration {} of {}", at + 1, outcome.iterations)
-                        }
-                        _ => format!("{} iteration(s)", outcome.iterations),
-                    };
-                    term_traces.push(format!(
-                        "term {}: loop {summary}",
-                        term.name.as_deref().unwrap_or("<unnamed>"),
-                    ));
-                    match outcome.flow {
-                        crate::eval::LoopFlow::Completed => {}
-                        crate::eval::LoopFlow::Permit(mods) => {
-                            let mut merged = continued.take().unwrap_or_default();
-                            merged.merge_from(mods);
-                            loop_permit = Some(merged);
-                            decided = Some((index, term));
-                            break;
-                        }
-                        crate::eval::LoopFlow::Deny => {
-                            decided = Some((index, term));
-                            break;
-                        }
+        match term.action.view() {
+            // LAN-302: eager binding initialization, identical to the
+            // live walk. An error is terminal on the uniform rail.
+            TermActionView::Bind {
+                slot,
+                name: _name,
+                expr,
+            } => {
+                match crate::eval::eval_value(expr, ctx, crate::eval::locals_slice(locals.as_ref()))
+                {
+                    Ok(value) => {
+                        locals.get_or_insert([0; crate::eval::LOCAL_FRAME_SLOTS])
+                            [usize::from(slot)] = value;
+                    }
+                    Err(kind) => {
+                        term_traces.push(format!(
+                            "term {}: evaluation error: {kind} — fail closed => reject",
+                            term.name.as_deref().unwrap_or("<unnamed>"),
+                        ));
+                        eval_failed = true;
+                        decided = Some((index, term));
+                        break;
                     }
                 }
-                Err((kind, at)) => {
-                    term_traces.push(format!(
-                        "term {}: loop evaluation error at iteration {}: {kind} — fail \
-                         closed => reject",
-                        term.name.as_deref().unwrap_or("<unnamed>"),
-                        at + 1,
-                    ));
-                    eval_failed = true;
-                    decided = Some((index, term));
-                    break;
+            }
+            // LAN-303: run the shared loop evaluator with the same
+            // fuel, snapshot, and body semantics as the live walk.
+            TermActionView::ForEach(node) => {
+                match tables.eval_for_each(node, ctx, &mut locals, &mut continued, fuel, pinned) {
+                    Ok(outcome) => {
+                        let summary = match (&outcome.flow, outcome.decided_at) {
+                            (crate::eval::LoopFlow::Completed, _) => format!(
+                                "completed after {} iteration(s), no verdict",
+                                outcome.iterations
+                            ),
+                            (crate::eval::LoopFlow::Permit(_), Some(at)) => {
+                                format!("accept at iteration {} of {}", at + 1, outcome.iterations)
+                            }
+                            (crate::eval::LoopFlow::Deny, Some(at)) => {
+                                format!("reject at iteration {} of {}", at + 1, outcome.iterations)
+                            }
+                            (
+                                crate::eval::LoopFlow::Permit(_) | crate::eval::LoopFlow::Deny,
+                                None,
+                            ) => {
+                                format!("{} iteration(s)", outcome.iterations)
+                            }
+                        };
+                        term_traces.push(format!(
+                            "term {}: loop {summary}",
+                            term.name.as_deref().unwrap_or("<unnamed>"),
+                        ));
+                        match outcome.flow {
+                            crate::eval::LoopFlow::Completed => {}
+                            crate::eval::LoopFlow::Permit(mods) => {
+                                let mut merged = continued.take().unwrap_or_default();
+                                merged.merge_from(mods);
+                                deciding_permit = Some(merged);
+                                decided = Some((index, term));
+                                break;
+                            }
+                            crate::eval::LoopFlow::Deny => {
+                                decided = Some((index, term));
+                                break;
+                            }
+                        }
+                    }
+                    Err((kind, at)) => {
+                        term_traces.push(format!(
+                            "term {}: loop evaluation error at iteration {}: {kind} — fail \
+                             closed => reject",
+                            term.name.as_deref().unwrap_or("<unnamed>"),
+                            at + 1,
+                        ));
+                        eval_failed = true;
+                        decided = Some((index, term));
+                        break;
+                    }
                 }
             }
-            continue;
-        }
-        // LAN-303: a matched community-variable action stages the
-        // binding's value and the walk keeps going, like the live path.
-        if let TermAction::CommunityVar { add, slot, .. } = &term.action {
-            match crate::eval::exec_community_var(*add, *slot, locals.as_ref(), &mut continued) {
-                Ok(()) => {}
-                Err(kind) => {
+            TermActionView::CommunityVar {
+                add,
+                slot,
+                name: _name,
+            } => {
+                if let Err(kind) =
+                    crate::eval::exec_community_var(add, slot, locals.as_ref(), &mut continued)
+                {
                     term_traces.push(format!(
                         "term {}: evaluation error: {kind} — fail closed => reject",
                         term.name.as_deref().unwrap_or("<unnamed>"),
@@ -595,65 +603,76 @@ fn trace_rpol_policy(
                     break;
                 }
             }
-            continue;
-        }
-        if let TermAction::RemoveLargeCommunityAdmin { global_admin } = &term.action {
-            if !crate::eval::exec_remove_large_community_admin(*global_admin, ctx, &mut continued) {
-                term_traces.push(format!(
-                    "term {}: large-community input exceeds the wildcard-removal bound — fail closed => reject",
-                    term.name.as_deref().unwrap_or("<unnamed>"),
-                ));
-                decided = Some((index, term));
-                break;
+            TermActionView::RemoveLargeCommunityAdmin { global_admin } => {
+                if !crate::eval::exec_remove_large_community_admin(
+                    global_admin,
+                    ctx,
+                    &mut continued,
+                ) {
+                    term_traces.push(format!(
+                        "term {}: large-community input exceeds the wildcard-removal bound — fail closed => reject",
+                        term.name.as_deref().unwrap_or("<unnamed>"),
+                    ));
+                    decided = Some((index, term));
+                    break;
+                }
             }
-            continue;
-        }
-        // Loop control at policy level is a compiler bug: fail closed,
-        // exactly like the live walk's StrayLoopControl rail.
-        if matches!(&term.action, TermAction::Break | TermAction::ContinueLoop) {
-            term_traces.push(format!(
-                "term {}: evaluation error: {} — fail closed => reject",
-                term.name.as_deref().unwrap_or("<unnamed>"),
-                crate::eval::EvalErrorKind::StrayLoopControl,
-            ));
-            eval_failed = true;
-            decided = Some((index, term));
-            break;
-        }
-        // Mirror the live walk's action-execution resolution: an
-        // unresolvable computed operand on the matched term (Permit or
-        // Continue) decides the route as a fail-closed reject here.
-        let action_mods = match &term.action {
-            TermAction::Permit(mods) | TermAction::Continue(mods) => Some(mods),
-            _ => None,
-        };
-        let resolved = match action_mods.map(|mods| {
-            tables.resolve_computed(mods, ctx, crate::eval::locals_slice(locals.as_ref()))
-        }) {
-            Some(Err(kind)) => {
+            // Policy-level loop control is a compiler-bug rail.
+            TermActionView::Break | TermActionView::ContinueLoop => {
                 term_traces.push(format!(
-                    "term {}: evaluation error: {kind} — fail closed => reject",
+                    "term {}: evaluation error: {} — fail closed => reject",
                     term.name.as_deref().unwrap_or("<unnamed>"),
+                    crate::eval::EvalErrorKind::StrayLoopControl,
                 ));
                 eval_failed = true;
                 decided = Some((index, term));
                 break;
             }
-            Some(Ok(resolved)) => resolved,
-            None => None,
-        };
-        if let TermAction::Continue(mods) = &term.action {
-            // Merge the term-time resolution (LAN-302 live parity: a
-            // later sibling scope may reuse the frame slots this
-            // term's computed expressions read, so resolving at trace
-            // end could render a different value than the live walk
-            // applied).
-            continued
-                .get_or_insert_with(RouteModifications::default)
-                .merge_from(resolved.unwrap_or_else(|| mods.clone()));
-        } else {
-            decided = Some((index, term));
-            break;
+            TermActionView::Permit(mods) => {
+                if let Err(kind) =
+                    tables.resolve_computed(mods, ctx, crate::eval::locals_slice(locals.as_ref()))
+                {
+                    term_traces.push(format!(
+                        "term {}: evaluation error: {kind} — fail closed => reject",
+                        term.name.as_deref().unwrap_or("<unnamed>"),
+                    ));
+                    eval_failed = true;
+                    decided = Some((index, term));
+                    break;
+                }
+                let mut merged = continued.take().unwrap_or_default();
+                merged.merge_from(mods.clone());
+                deciding_permit = Some(merged);
+                decided = Some((index, term));
+                break;
+            }
+            TermActionView::Deny => {
+                decided = Some((index, term));
+                break;
+            }
+            TermActionView::Continue(mods) => {
+                let resolved = match tables.resolve_computed(
+                    mods,
+                    ctx,
+                    crate::eval::locals_slice(locals.as_ref()),
+                ) {
+                    Ok(resolved) => resolved,
+                    Err(kind) => {
+                        term_traces.push(format!(
+                            "term {}: evaluation error: {kind} — fail closed => reject",
+                            term.name.as_deref().unwrap_or("<unnamed>"),
+                        ));
+                        eval_failed = true;
+                        decided = Some((index, term));
+                        break;
+                    }
+                };
+                // Resolve at action time: later sibling scopes may
+                // reuse the frame slots this term read.
+                continued
+                    .get_or_insert_with(RouteModifications::default)
+                    .merge_from(resolved.unwrap_or_else(|| mods.clone()));
+            }
         }
     }
     if let Some((index, term)) = decided {
@@ -663,25 +682,13 @@ fn trace_rpol_policy(
         let locals_view = crate::eval::locals_slice(locals.as_ref());
         let (action, modifications) = if eval_failed {
             (PolicyAction::Deny, Vec::new())
-        } else if let Some(merged) = &loop_permit {
-            // LAN-303: a loop body's accept — modifications resolved
-            // (and merged with accumulated Continues) at loop time.
+        } else if let Some(merged) = &deciding_permit {
             (
                 PolicyAction::Permit,
                 render_modifications(merged, ctx, Some(tables), locals_view),
             )
         } else {
-            match &term.action {
-                TermAction::Permit(mods) => {
-                    let mut merged = continued.unwrap_or_default();
-                    merged.merge_from(mods.clone());
-                    (
-                        PolicyAction::Permit,
-                        render_modifications(&merged, ctx, Some(tables), locals_view),
-                    )
-                }
-                _ => (PolicyAction::Deny, Vec::new()),
-            }
+            (PolicyAction::Deny, Vec::new())
         };
         StatementAttribution {
             policy_index,

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -805,3 +805,237 @@ fn rpol_statement_trace_agrees_with_live_evaluation_and_recorded_hits() {
         }
     }
 }
+
+const ACTION_VIEW_RPOL: &str = r"
+policy all-actions {
+    term walk {
+        let next = route.med + 1
+        set local-pref next
+        for c in route.communities {
+            if c == 65000:100 { remove community c }
+        }
+        remove large-community 65501:*:*
+        accept
+    }
+}
+
+policy deny-action { term stop { reject } }
+policy default-action { term miss { if route.med == 999 { reject } } }
+policy permit-error { term fail { set med route.med - 100; accept } }
+policy continue-error {
+    term stage { set med route.med - 100 }
+    term allow { accept }
+}
+";
+
+fn action_view_member(name: &str) -> PolicyChain {
+    let file = crate::rpol::RpolFile::parse(ACTION_VIEW_RPOL).expect("clean action-view rpol");
+    let mut store = crate::sets::SetStore::new();
+    let mut compiled = file
+        .compile_policy(name, &[], &mut store)
+        .unwrap_or_else(|| panic!("policy {name} exists"));
+    if name == "all-actions" {
+        compiled.policies[0]
+            .terms
+            .insert(2, nested_loop_control_term());
+    }
+    PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+        name.to_string(),
+        std::sync::Arc::new(compiled),
+    )])
+}
+
+fn nested_loop_control_term() -> crate::ir::Term {
+    use crate::ir::{ForEachNode, LoopSource, MatchExpr, Term, TermAction};
+
+    let inner = ForEachNode {
+        source: LoopSource::Communities,
+        slot: 251,
+        var: "inner".into(),
+        body: vec![Term {
+            name: Some("next-inner".to_string()),
+            guard: MatchExpr::True,
+            action: TermAction::ContinueLoop,
+        }],
+    };
+    let outer = ForEachNode {
+        source: LoopSource::Communities,
+        slot: 250,
+        var: "outer".into(),
+        body: vec![
+            Term {
+                name: Some("nested".to_string()),
+                guard: MatchExpr::True,
+                action: TermAction::ForEach(Box::new(inner)),
+            },
+            Term {
+                name: Some("stop-outer".to_string()),
+                guard: MatchExpr::True,
+                action: TermAction::Break,
+            },
+        ],
+    };
+    Term {
+        name: Some("walk.nested-control".to_string()),
+        guard: MatchExpr::True,
+        action: TermAction::ForEach(Box::new(outer)),
+    }
+}
+
+fn assert_action_view_attribution(
+    case_name: &str,
+    policy_name: &str,
+    live: &PolicyResult,
+    attribution: &PolicyEvaluation,
+    reject_term: Option<&str>,
+    step: &super::super::explain::StatementAttribution,
+) {
+    if live.action == PolicyAction::Permit {
+        assert_eq!(
+            attribution.matched_policy.as_deref(),
+            Some(CHAIN_DEFAULT_PERMIT_ATTRIBUTION),
+            "completed-chain attribution for {case_name}"
+        );
+    } else {
+        assert_eq!(
+            attribution.matched_policy.as_deref(),
+            Some(policy_name),
+            "denying-member attribution for {case_name}"
+        );
+        let expected_term = if matches!(case_name, "permit-error" | "continue-error") {
+            None
+        } else {
+            step.term_name.as_deref()
+        };
+        assert_eq!(
+            reject_term, expected_term,
+            "reject-term attribution for {case_name}"
+        );
+    }
+}
+
+fn assert_action_view_coverage_positions(
+    case_name: &str,
+    step: &super::super::explain::StatementAttribution,
+    evaluated: &[Vec<u64>],
+    matched: &[Vec<u64>],
+) {
+    let status_lines: Vec<_> = step
+        .term_traces
+        .iter()
+        .filter(|line| line.ends_with("[matched]") || line.ends_with("[not matched]"))
+        .collect();
+    for (index, (eval_count, match_count)) in evaluated[step.policy_index]
+        .iter()
+        .zip(&matched[step.policy_index])
+        .enumerate()
+    {
+        let status = status_lines.get(index);
+        assert_eq!(
+            *eval_count,
+            u64::from(status.is_some()),
+            "evaluated position {index} for {case_name}"
+        );
+        assert_eq!(
+            *match_count,
+            u64::from(status.is_some_and(|line| line.ends_with("[matched]"))),
+            "matched position {index} for {case_name}"
+        );
+    }
+}
+
+/// The action-view agreement pin sweeps every action family through the live,
+/// coverage, and explain walks. It also checks the coverage grid against the
+/// trace's evaluated/matched positions, including action-time error exits.
+#[test]
+fn action_view_walks_agree_across_action_and_error_matrix() {
+    use rustbgpd_wire::LargeCommunity;
+
+    const SCRUB: u32 = (65_000 << 16) | 0x0064;
+    const KEEP: u32 = (65_001 << 16) | 1;
+    let own = LargeCommunity::new(65_501, 1, 2);
+    let foreign = LargeCommunity::new(64_496, 3, 4);
+
+    let mut all_actions = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    all_actions.med = Some(7);
+    all_actions.communities = Box::leak(vec![SCRUB, KEEP].into_boxed_slice());
+    all_actions.large_communities = Box::leak(vec![own, foreign].into_boxed_slice());
+
+    let mut permit_error = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    permit_error.med = Some(5);
+    let mut continue_error = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    continue_error.med = Some(5);
+    let mut oversized = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    oversized.med = Some(7);
+    let wildcard_bound = usize::try_from(crate::eval::MAX_LARGE_COMMUNITIES_PER_ROUTE)
+        .expect("wire-derived bound fits usize");
+    oversized.large_communities = Box::leak(vec![own; wildcard_bound + 1].into_boxed_slice());
+
+    let cases = vec![
+        ("all-actions", all_actions, PolicyAction::Permit),
+        (
+            "deny-action",
+            plain_ctx(v4_prefix([10, 0, 0, 0], 24)),
+            PolicyAction::Deny,
+        ),
+        (
+            "default-action",
+            plain_ctx(v4_prefix([10, 0, 0, 0], 24)),
+            PolicyAction::Permit,
+        ),
+        ("permit-error", permit_error, PolicyAction::Deny),
+        ("continue-error", continue_error, PolicyAction::Deny),
+        ("all-actions-oversized", oversized, PolicyAction::Deny),
+    ];
+
+    for (case_name, ctx, expected) in cases {
+        let policy_name = case_name.strip_suffix("-oversized").unwrap_or(case_name);
+        let chain = action_view_member(policy_name);
+        let (live, attribution, reject_term) =
+            super::super::evaluate_chain_with_reject_term(Some(&chain), &ctx);
+        assert_eq!(live.action, expected, "live action for {case_name}");
+
+        let compiled = chain.compiled();
+        let mut evaluated = compiled.zero_term_hits();
+        let mut matched = compiled.zero_term_hits();
+        let dry = compiled.evaluate_recording_coverage(&ctx, &mut evaluated, &mut matched);
+        assert_eq!(dry, live, "coverage walk for {case_name}");
+
+        let trace = explain_chain_statements(Some(&chain), &ctx);
+        assert_eq!(trace.action, live.action, "explain action for {case_name}");
+        let step = trace.steps.last().expect("one-member chain was evaluated");
+        assert_eq!(step.action, live.action, "step action for {case_name}");
+        assert_action_view_attribution(
+            case_name,
+            policy_name,
+            &live,
+            &attribution,
+            reject_term.as_deref(),
+            step,
+        );
+        assert_action_view_coverage_positions(case_name, step, &evaluated, &matched);
+
+        match case_name {
+            "all-actions" => {
+                assert_eq!(live.modifications.set_local_pref, Some(8));
+                assert_eq!(live.modifications.communities_remove, vec![SCRUB]);
+                assert_eq!(live.modifications.large_communities_remove, vec![own]);
+            }
+            "default-action" => assert_eq!(step.statement_index, None),
+            "permit-error" | "continue-error" => assert!(
+                step.term_traces
+                    .iter()
+                    .any(|line| line.contains("arithmetic underflow")),
+                "missing action-time error for {case_name}"
+            ),
+            "all-actions-oversized" => assert!(
+                step.term_traces
+                    .iter()
+                    .any(|line| line.contains("wildcard-removal bound")),
+                "missing wildcard bound disposition"
+            ),
+            "deny-action" => {}
+            other => panic!("uncovered matrix case {other}"),
+        }
+    }
+}

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -30,7 +30,7 @@ use crate::engine::{
 };
 use crate::ir::{
     ArithOp, Cmp, CompiledChain, CompiledPolicy, DatasetProbe, ForEachNode, LoopSource, MatchExpr,
-    TermAction, ValueCmpOp, ValueExpr, ValueField,
+    TermAction, TermActionView, ValueCmpOp, ValueExpr, ValueField,
 };
 use crate::sets::prefix_entry_matches;
 
@@ -917,8 +917,8 @@ impl CompiledChain {
                 }
                 if matched {
                     *hit += 1;
-                    match &term.action {
-                        TermAction::Permit(mods) => {
+                    match term.action.view() {
+                        TermActionView::Permit(mods) => {
                             match self.resolve_computed(mods, ctx, locals_slice(locals.as_ref())) {
                                 Ok(resolved) => {
                                     permit_mods =
@@ -933,11 +933,13 @@ impl CompiledChain {
                         // Deny denies; stray loop control (confined
                         // to loop bodies by the typechecker) fails
                         // closed like the live walk — same disposition.
-                        TermAction::Deny | TermAction::Break | TermAction::ContinueLoop => {
+                        TermActionView::Deny
+                        | TermActionView::Break
+                        | TermActionView::ContinueLoop => {
                             denied = true;
                             break;
                         }
-                        TermAction::Continue(mods) => {
+                        TermActionView::Continue(mods) => {
                             if let Ok(resolved) =
                                 self.resolve_computed(mods, ctx, locals_slice(locals.as_ref()))
                             {
@@ -951,19 +953,23 @@ impl CompiledChain {
                         }
                         // LAN-302: eager `let`, identical to the live
                         // walk — initializer error fails closed.
-                        TermAction::Bind { slot, expr, .. } => {
+                        TermActionView::Bind {
+                            slot,
+                            name: _name,
+                            expr,
+                        } => {
                             let Ok(value) = eval_value(expr, ctx, locals_slice(locals.as_ref()))
                             else {
                                 denied = true;
                                 break;
                             };
-                            locals.get_or_insert([0; LOCAL_FRAME_SLOTS])[*slot as usize] = value;
+                            locals.get_or_insert([0; LOCAL_FRAME_SLOTS])[usize::from(slot)] = value;
                         }
                         // LAN-303: loops run identically to the live
                         // walk (same eval_for_each), errors fail
                         // closed. Body terms are outside the counter
                         // grid — the loop's own term counted above.
-                        TermAction::ForEach(node) => {
+                        TermActionView::ForEach(node) => {
                             let Ok(outcome) = self.eval_for_each(
                                 node,
                                 ctx,
@@ -987,20 +993,21 @@ impl CompiledChain {
                                 }
                             }
                         }
-                        TermAction::CommunityVar { add, slot, .. } => {
-                            if exec_community_var(*add, *slot, locals.as_ref(), &mut continued)
+                        TermActionView::CommunityVar {
+                            add,
+                            slot,
+                            name: _name,
+                        } => {
+                            if exec_community_var(add, slot, locals.as_ref(), &mut continued)
                                 .is_err()
                             {
                                 denied = true;
                                 break;
                             }
                         }
-                        TermAction::RemoveLargeCommunityAdmin { global_admin } => {
-                            if !exec_remove_large_community_admin(
-                                *global_admin,
-                                ctx,
-                                &mut continued,
-                            ) {
+                        TermActionView::RemoveLargeCommunityAdmin { global_admin } => {
+                            if !exec_remove_large_community_admin(global_admin, ctx, &mut continued)
+                            {
                                 denied = true;
                                 break;
                             }
@@ -1079,8 +1086,8 @@ impl CompiledChain {
                         counter.fetch_add(1, Ordering::Relaxed);
                     }
                 }
-                match &term.action {
-                    TermAction::Permit(mods) => {
+                match term.action.view() {
+                    TermActionView::Permit(mods) => {
                         // LAN-296/LAN-299: fold computed operands
                         // (prepend, set values) into literal fields
                         // before the modifications leave the
@@ -1102,12 +1109,12 @@ impl CompiledChain {
                             (None, None) => PolicyDecision::Permit(Some(mods)),
                         };
                     }
-                    TermAction::Deny => {
+                    TermActionView::Deny => {
                         return PolicyDecision::Deny {
                             term_index: Some(term_index),
                         };
                     }
-                    TermAction::Continue(mods) => {
+                    TermActionView::Continue(mods) => {
                         let resolved =
                             match self.resolve_computed(mods, ctx, locals_slice(locals.as_ref())) {
                                 Ok(resolved) => resolved,
@@ -1122,21 +1129,22 @@ impl CompiledChain {
                     // bindings are readable), write the slot, keep
                     // walking. An initializer error is terminal on the
                     // uniform eval-error rail, used or not.
-                    TermAction::Bind { slot, expr, .. } => {
-                        match eval_value(expr, ctx, locals_slice(locals.as_ref())) {
-                            Ok(value) => {
-                                locals.get_or_insert([0; LOCAL_FRAME_SLOTS])[*slot as usize] =
-                                    value;
-                            }
-                            Err(kind) => return PolicyDecision::Error { kind, term_index },
+                    TermActionView::Bind {
+                        slot,
+                        name: _name,
+                        expr,
+                    } => match eval_value(expr, ctx, locals_slice(locals.as_ref())) {
+                        Ok(value) => {
+                            locals.get_or_insert([0; LOCAL_FRAME_SLOTS])[usize::from(slot)] = value;
                         }
-                    }
+                        Err(kind) => return PolicyDecision::Error { kind, term_index },
+                    },
                     // LAN-303: a bounded loop. A body verdict decides
                     // the policy; otherwise the walk continues after
                     // it. Any error (fuel, iteration cap, body
                     // evaluation) is terminal on the uniform rail,
                     // attributed to the loop's term.
-                    TermAction::ForEach(node) => {
+                    TermActionView::ForEach(node) => {
                         match self.eval_for_each(
                             node,
                             ctx,
@@ -1168,7 +1176,7 @@ impl CompiledChain {
                     // Loop control at policy level is confined to loop
                     // bodies by the typechecker; fail closed on the
                     // compiler-bug rail rather than misinterpret it.
-                    TermAction::Break | TermAction::ContinueLoop => {
+                    TermActionView::Break | TermActionView::ContinueLoop => {
                         return PolicyDecision::Error {
                             kind: EvalErrorKind::StrayLoopControl,
                             term_index,
@@ -1176,15 +1184,19 @@ impl CompiledChain {
                     }
                     // LAN-303: stage the binding's value as a standard
                     // community add/remove; accumulates like Continue.
-                    TermAction::CommunityVar { add, slot, .. } => {
+                    TermActionView::CommunityVar {
+                        add,
+                        slot,
+                        name: _name,
+                    } => {
                         if let Err(kind) =
-                            exec_community_var(*add, *slot, locals.as_ref(), &mut continued)
+                            exec_community_var(add, slot, locals.as_ref(), &mut continued)
                         {
                             return PolicyDecision::Error { kind, term_index };
                         }
                     }
-                    TermAction::RemoveLargeCommunityAdmin { global_admin } => {
-                        if !exec_remove_large_community_admin(*global_admin, ctx, &mut continued) {
+                    TermActionView::RemoveLargeCommunityAdmin { global_admin } => {
+                        if !exec_remove_large_community_admin(global_admin, ctx, &mut continued) {
                             return PolicyDecision::Deny {
                                 term_index: Some(term_index),
                             };

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -802,6 +802,65 @@ pub enum TermAction {
     },
 }
 
+/// Borrowed, one-to-one view of [`TermAction`] used by the three policy
+/// execution walks.
+///
+/// Keeping every variant and payload in this crate-private view makes a new
+/// action a compile-time obligation for live evaluation, coverage evaluation,
+/// and statement tracing without adding allocation or dynamic dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TermActionView<'a> {
+    Permit(&'a RouteModifications),
+    Deny,
+    Continue(&'a RouteModifications),
+    Bind {
+        slot: u8,
+        name: &'a str,
+        expr: &'a ValueExpr,
+    },
+    ForEach(&'a ForEachNode),
+    Break,
+    ContinueLoop,
+    CommunityVar {
+        add: bool,
+        slot: u8,
+        name: &'a str,
+    },
+    RemoveLargeCommunityAdmin {
+        global_admin: u32,
+    },
+}
+
+impl TermAction {
+    /// Borrow this action through the exhaustive execution-walk view.
+    #[must_use]
+    pub(crate) fn view(&self) -> TermActionView<'_> {
+        match self {
+            Self::Permit(mods) => TermActionView::Permit(mods),
+            Self::Deny => TermActionView::Deny,
+            Self::Continue(mods) => TermActionView::Continue(mods),
+            Self::Bind { slot, name, expr } => TermActionView::Bind {
+                slot: *slot,
+                name,
+                expr,
+            },
+            Self::ForEach(node) => TermActionView::ForEach(node),
+            Self::Break => TermActionView::Break,
+            Self::ContinueLoop => TermActionView::ContinueLoop,
+            Self::CommunityVar { add, slot, name } => TermActionView::CommunityVar {
+                add: *add,
+                slot: *slot,
+                name,
+            },
+            Self::RemoveLargeCommunityAdmin { global_admin } => {
+                TermActionView::RemoveLargeCommunityAdmin {
+                    global_admin: *global_admin,
+                }
+            }
+        }
+    }
+}
+
 /// One guarded action inside a [`CompiledPolicy`] — the compiled form
 /// of a TOML `PolicyStatement` or (later) an `.rpol` `term` block.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1102,5 +1161,93 @@ impl CompiledChain {
             TermAction::Permit(mods) | TermAction::Continue(mods) => pred(mods),
             _ => false,
         })
+    }
+}
+
+#[cfg(test)]
+mod action_view_tests {
+    use super::*;
+
+    #[test]
+    fn decision_and_loop_action_views_preserve_payloads() {
+        let permit_mods = RouteModifications {
+            set_local_pref: Some(200),
+            ..RouteModifications::default()
+        };
+        let permit = TermAction::Permit(permit_mods);
+        let TermActionView::Permit(mods) = permit.view() else {
+            panic!("permit view changed variant");
+        };
+        assert_eq!(mods.set_local_pref, Some(200));
+
+        let continue_mods = RouteModifications {
+            set_med: Some(50),
+            ..RouteModifications::default()
+        };
+        let continued = TermAction::Continue(continue_mods);
+        let TermActionView::Continue(mods) = continued.view() else {
+            panic!("continue view changed variant");
+        };
+        assert_eq!(mods.set_med, Some(50));
+
+        assert_eq!(TermAction::Deny.view(), TermActionView::Deny);
+        assert_eq!(TermAction::Break.view(), TermActionView::Break);
+        assert_eq!(
+            TermAction::ContinueLoop.view(),
+            TermActionView::ContinueLoop
+        );
+
+        let loop_action = TermAction::ForEach(Box::new(ForEachNode {
+            source: LoopSource::Communities,
+            slot: 7,
+            var: "community".into(),
+            body: vec![Term {
+                name: Some("stop".to_string()),
+                guard: MatchExpr::True,
+                action: TermAction::Break,
+            }],
+        }));
+        let TermActionView::ForEach(node) = loop_action.view() else {
+            panic!("for-each view changed variant");
+        };
+        assert_eq!(node.source, LoopSource::Communities);
+        assert_eq!(node.slot, 7);
+        assert_eq!(node.var.as_ref(), "community");
+        assert!(matches!(node.body[0].action, TermAction::Break));
+    }
+
+    #[test]
+    fn bound_action_views_preserve_every_field() {
+        let bind = TermAction::Bind {
+            slot: 3,
+            name: "peer".into(),
+            expr: ValueExpr::Const(65_001),
+        };
+        let TermActionView::Bind { slot, name, expr } = bind.view() else {
+            panic!("bind view changed variant");
+        };
+        assert_eq!(slot, 3);
+        assert_eq!(name, "peer");
+        assert_eq!(expr, &ValueExpr::Const(65_001));
+
+        let community = TermAction::CommunityVar {
+            add: false,
+            slot: 5,
+            name: "tag".into(),
+        };
+        let TermActionView::CommunityVar { add, slot, name } = community.view() else {
+            panic!("community-variable view changed variant");
+        };
+        assert!(!add);
+        assert_eq!(slot, 5);
+        assert_eq!(name, "tag");
+
+        let remove = TermAction::RemoveLargeCommunityAdmin {
+            global_admin: 4_200_000_001,
+        };
+        let TermActionView::RemoveLargeCommunityAdmin { global_admin } = remove.view() else {
+            panic!("large-community removal view changed variant");
+        };
+        assert_eq!(global_admin, 4_200_000_001);
     }
 }


### PR DESCRIPTION
## Summary

- introduce a crate-private borrowed `TermActionView` that exhaustively mirrors every compiled policy action
- make live evaluation, dry-run coverage, and statement tracing consume the same exhaustive action view
- preserve action payloads, loop control, modification resolution, attribution, and existing operator output

## Defensive consistency

Adding a new compiled action now creates an explicit compile-time obligation in the shared view and in each consuming walk. The view borrows existing payloads, adds no allocation or dynamic dispatch, and does not change any public type or output format.

The source renderer remains separate because it describes the original policy syntax; the three decision-oriented walks use the exhaustive view.

## Proof

- matrix tests cover every action variant and payload across live evaluation, recording coverage, and explain tracing
- regressions pin modification resolution, decision attribution, coverage positions, loop fuel, and bounded-loop behavior
- the allocation regression remains clean for the hot evaluation path

## Validation

- 409 policy unit tests and 2 integration tests
- focused action-view matrix: 3 tests
- policy allocation regression
- strict all-target/all-feature Clippy
- warnings-denied rustdoc
- formatting, diff checks, and full pre-push hooks

Linear: LAN-1198
