### PR TITLE
fix(mrt): isolate discard-only attribute recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The MRT `TABLE_DUMP_V2` reader now applies RFC 7606 revised path-attribute
+  decoding with a conservative internal-neighbor default on incomplete session
+  evidence. It continues only when every recovered issue is
+  attribute-discard, retains the first ordinary duplicate, and exposes
+  separate counters for discarded path-attribute instances and BGP-LS NLRIs;
+  treat-as-withdraw and stronger outcomes still fail and fuse iteration. Warm
+  bundles remain lossless and fail closed by rejecting either nonzero count
+  with a typed error. Snapshot writer bytes and the warm-bundle manifest remain
+  unchanged. (LAN-1249)
+
 - Policy decision attribution now distinguishes a nonempty chain that
   completed without rejection from its final member. Import/export metrics,
   cached import explain, grouped export replay, and JSON/protobuf explain use

--- a/crates/mrt/README.md
+++ b/crates/mrt/README.md
@@ -23,7 +23,11 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 - **TABLE_DUMP_V2 reader** — `SnapshotReader` parses `PEER_INDEX_TABLE` +
   `RIB_IPV4_UNICAST` / `RIB_IPV6_UNICAST` records into
   `SnapshotEntry` / `SnapshotNlri`, with gzip auto-detection
-  (`decompress_if_gzip`)
+  (`decompress_if_gzip`). Defensive revised attribute decoding keeps an entry
+  only when every recovered issue is attribute-discard, using the conservative
+  internal-neighbor classification when the snapshot lacks session evidence.
+  Separate path-attribute and BGP-LS NLRI discard counters make that bounded
+  interoperability recovery observable; stronger dispositions remain fatal
 - **Dump health metrics** — `MrtManager` records `mrt_dump_interval_seconds`,
   `mrt_last_dump_success_timestamp_seconds`,
   `mrt_last_dump_duration_milliseconds`, `mrt_dump_bytes_written_total`, and
@@ -53,6 +57,10 @@ Public entry points:
   rename).
 - `load_warm_bundle` — loads only an exact, fresh, byte- and
   semantically-valid bundle against an independently derived expectation.
+
+Warm bundles remain lossless and fail closed: publication and loading reject
+snapshots whose reader reports any discarded path attributes or BGP-LS NLRIs,
+with both counts preserved in the typed validation error.
 
 **Scope boundary:** this module stops at storage and identity validation. It
 never restores a route, mutates the RIB, runs selection, releases RFC 4724

--- a/crates/mrt/src/reader.rs
+++ b/crates/mrt/src/reader.rs
@@ -27,6 +27,7 @@ use bytes::Bytes;
 use rustbgpd_rib::update::MrtPeerEntry;
 use rustbgpd_wire::constants::{attr_flags, attr_type};
 use rustbgpd_wire::error::DecodeError;
+use rustbgpd_wire::notification::update_subcode;
 use rustbgpd_wire::{Afi, ErrorDisposition, Ipv4Prefix, Ipv6Prefix, PathAttribute, Prefix, Safi};
 use std::borrow::Cow;
 use std::collections::VecDeque;
@@ -334,6 +335,21 @@ fn decode_entry_attributes(attrs: &[u8], base: usize) -> Result<EntryAttributes,
         if type_code == attr_type::MP_REACH_NLRI {
             if reduced.is_some() {
                 return Err(malformed(attr_offset, "duplicate MP_REACH_NLRI"));
+            }
+            let flags_mask = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
+            if flags & flags_mask != attr_flags::OPTIONAL {
+                return Err(ReadError::AttributeDecode(
+                    DecodeError::UpdateAttributeError {
+                        subcode: update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                        data: attrs[span_start..cur.rel_pos()].to_vec(),
+                        detail: format!(
+                            "type {} flags {:#04x} (expected {:#04x})",
+                            type_code,
+                            flags & flags_mask,
+                            attr_flags::OPTIONAL
+                        ),
+                    },
+                ));
             }
             reduced = Some(parse_reduced_mp_reach(value, attr_offset)?);
         } else {
@@ -1358,6 +1374,42 @@ mod tests {
                 DecodeError::UpdateAttributeError { .. }
             )))
         ));
+        assert!(reader.next().is_none());
+        assert_eq!(reader.discarded_path_attributes(), 0);
+        assert_eq!(reader.discarded_bgpls_nlris(), 0);
+    }
+
+    #[test]
+    fn reduced_mp_reach_flag_conflict_fails_and_fuses() {
+        let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
+        let mut data =
+            encode_snapshot(COLLECTOR, std::slice::from_ref(&peer), &[], &[], TS).unwrap();
+        let attr = [
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            attr_type::MP_REACH_NLRI,
+            5,
+            4,
+            192,
+            0,
+            2,
+            1,
+        ];
+        let expected =
+            rustbgpd_wire::attribute::decode_path_attributes_revised(&attr, true, true, &[])
+                .unwrap_err();
+        assert!(matches!(
+            &expected,
+            DecodeError::UpdateAttributeError {
+                subcode: update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                ..
+            }
+        ));
+        append_v4_rib_with_attributes(&mut data, &attr);
+        let mut reader = SnapshotReader::new(&data).unwrap();
+        let Some(Err(ReadError::AttributeDecode(actual))) = reader.next() else {
+            panic!("expected reduced MP_REACH attribute-flags failure");
+        };
+        assert_eq!(actual, expected);
         assert!(reader.next().is_none());
         assert_eq!(reader.discarded_path_attributes(), 0);
         assert_eq!(reader.discarded_bgpls_nlris(), 0);

--- a/crates/mrt/src/reader.rs
+++ b/crates/mrt/src/reader.rs
@@ -27,7 +27,7 @@ use bytes::Bytes;
 use rustbgpd_rib::update::MrtPeerEntry;
 use rustbgpd_wire::constants::{attr_flags, attr_type};
 use rustbgpd_wire::error::DecodeError;
-use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, PathAttribute, Prefix, Safi};
+use rustbgpd_wire::{Afi, ErrorDisposition, Ipv4Prefix, Ipv6Prefix, PathAttribute, Prefix, Safi};
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -305,12 +305,17 @@ struct EntryAttributes {
     attributes: Vec<PathAttribute>,
     next_hop: Option<IpAddr>,
     link_local_next_hop: Option<Ipv6Addr>,
+    discarded_path_attributes: u64,
+    discarded_bgpls_nlris: u64,
 }
 
 /// Split a RIB entry's attribute block: walk the TLV framing with
 /// bounds checks, peel off the MRT-reduced `MP_REACH_NLRI`, and decode
-/// the remaining attributes with the standard wire decoder
-/// (`four_octet_as = true`, matching the writer).
+/// the remaining attributes with the revised wire decoder. Four-octet ASNs
+/// match the writer, while `is_ibgp = true` is the conservative all-lanes
+/// default on incomplete evidence: an MRT peer table does not preserve the
+/// original session relationship. Only attribute-discard recovery is safe for
+/// a snapshot entry; any stronger disposition still fails the decode.
 fn decode_entry_attributes(attrs: &[u8], base: usize) -> Result<EntryAttributes, ReadError> {
     let mut cur = Cur::new(attrs, base);
     let mut other: Vec<u8> = Vec::with_capacity(attrs.len());
@@ -335,7 +340,19 @@ fn decode_entry_attributes(attrs: &[u8], base: usize) -> Result<EntryAttributes,
             other.extend_from_slice(&attrs[span_start..cur.rel_pos()]);
         }
     }
-    let attributes = rustbgpd_wire::attribute::decode_path_attributes(&other, true, &[])?;
+    let decoded =
+        rustbgpd_wire::attribute::decode_path_attributes_revised(&other, true, true, &[])?;
+    if let Some(malformed) = decoded
+        .malformed
+        .iter()
+        .find(|malformed| malformed.disposition != ErrorDisposition::AttributeDiscard)
+    {
+        return Err(ReadError::AttributeDecode(malformed.error.clone()));
+    }
+    let discarded_path_attributes = u64::try_from(decoded.malformed.len())
+        .map_err(|_| malformed(base, "discarded path-attribute count exceeds u64"))?;
+    let discarded_bgpls_nlris = u64::from(decoded.bgpls_nlri_discarded);
+    let attributes = decoded.attributes;
     let (next_hop, link_local_next_hop) = match reduced {
         Some((nh, ll)) => (Some(nh), ll),
         None => (
@@ -350,7 +367,20 @@ fn decode_entry_attributes(attrs: &[u8], base: usize) -> Result<EntryAttributes,
         attributes,
         next_hop,
         link_local_next_hop,
+        discarded_path_attributes,
+        discarded_bgpls_nlris,
     })
+}
+
+/// Entry plus recovery observations held privately until it is yielded.
+///
+/// Keeping the observations beside the pending entry prevents a later failure
+/// in the same MRT record from incrementing counters for routes the iterator
+/// never exposes.
+struct PendingSnapshotEntry {
+    entry: SnapshotEntry,
+    discarded_path_attributes: u64,
+    discarded_bgpls_nlris: u64,
 }
 
 /// Streaming reader over a `TABLE_DUMP_V2` byte buffer.
@@ -365,8 +395,10 @@ pub struct SnapshotReader<'a> {
     collector_bgp_id: Ipv4Addr,
     view_name: String,
     peers: Vec<MrtPeerEntry>,
-    pending: VecDeque<SnapshotEntry>,
+    pending: VecDeque<PendingSnapshotEntry>,
     skipped_records: u64,
+    discarded_path_attributes: u64,
+    discarded_bgpls_nlris: u64,
     total_entries: u64,
     entry_cap: u64,
     fused: bool,
@@ -409,6 +441,8 @@ impl<'a> SnapshotReader<'a> {
                 peers,
                 pending: VecDeque::new(),
                 skipped_records,
+                discarded_path_attributes: 0,
+                discarded_bgpls_nlris: 0,
                 total_entries: 0,
                 entry_cap: MAX_TOTAL_ENTRIES,
                 fused: false,
@@ -439,6 +473,20 @@ impl<'a> SnapshotReader<'a> {
     #[must_use]
     pub fn skipped_records(&self) -> u64 {
         self.skipped_records
+    }
+
+    /// Number of malformed path-attribute instances omitted from entries
+    /// successfully yielded so far under attribute-discard recovery.
+    #[must_use]
+    pub fn discarded_path_attributes(&self) -> u64 {
+        self.discarded_path_attributes
+    }
+
+    /// Number of malformed BGP-LS NLRIs omitted from path attributes on
+    /// entries successfully yielded so far.
+    #[must_use]
+    pub fn discarded_bgpls_nlris(&self) -> u64 {
+        self.discarded_bgpls_nlris
     }
 
     #[cfg(test)]
@@ -589,16 +637,20 @@ impl<'a> SnapshotReader<'a> {
         let attr_base = cur.offset();
         let attrs = cur.take(usize::from(attr_len), "attribute bytes")?;
         let decoded = decode_entry_attributes(attrs, attr_base)?;
-        self.pending.push_back(SnapshotEntry {
-            nlri: nlri.clone(),
-            peer_index,
-            peer: peer.clone(),
-            originated_time,
-            path_id,
-            add_path,
-            attributes: decoded.attributes,
-            next_hop: decoded.next_hop,
-            link_local_next_hop: decoded.link_local_next_hop,
+        self.pending.push_back(PendingSnapshotEntry {
+            entry: SnapshotEntry {
+                nlri: nlri.clone(),
+                peer_index,
+                peer: peer.clone(),
+                originated_time,
+                path_id,
+                add_path,
+                attributes: decoded.attributes,
+                next_hop: decoded.next_hop,
+                link_local_next_hop: decoded.link_local_next_hop,
+            },
+            discarded_path_attributes: decoded.discarded_path_attributes,
+            discarded_bgpls_nlris: decoded.discarded_bgpls_nlris,
         });
         Ok(())
     }
@@ -612,8 +664,30 @@ impl Iterator for SnapshotReader<'_> {
             return None;
         }
         loop {
-            if let Some(entry) = self.pending.pop_front() {
-                return Some(Ok(entry));
+            if let Some(pending) = self.pending.pop_front() {
+                let Some(discarded_path_attributes) = self
+                    .discarded_path_attributes
+                    .checked_add(pending.discarded_path_attributes)
+                else {
+                    self.fused = true;
+                    return Some(Err(malformed(
+                        self.pos,
+                        "discarded path-attribute counter overflow",
+                    )));
+                };
+                let Some(discarded_bgpls_nlris) = self
+                    .discarded_bgpls_nlris
+                    .checked_add(pending.discarded_bgpls_nlris)
+                else {
+                    self.fused = true;
+                    return Some(Err(malformed(
+                        self.pos,
+                        "discarded BGP-LS NLRI counter overflow",
+                    )));
+                };
+                self.discarded_path_attributes = discarded_path_attributes;
+                self.discarded_bgpls_nlris = discarded_bgpls_nlris;
+                return Some(Ok(pending.entry));
             }
             if self.pos >= self.data.len() {
                 return None;
@@ -844,6 +918,54 @@ mod tests {
         buf
     }
 
+    /// Append one IPv4-unicast RIB record whose single entry carries `attrs`.
+    fn append_v4_rib_with_attributes(data: &mut Vec<u8>, attrs: &[u8]) {
+        append_v4_rib_attribute_entries(data, &[attrs]);
+    }
+
+    fn append_v4_rib_attribute_entries(data: &mut Vec<u8>, attribute_blocks: &[&[u8]]) {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&0u32.to_be_bytes());
+        payload.push(24);
+        payload.extend_from_slice(&[192, 168, 1]);
+        payload.extend_from_slice(&u16::try_from(attribute_blocks.len()).unwrap().to_be_bytes());
+        for attrs in attribute_blocks {
+            payload.extend_from_slice(&0u16.to_be_bytes());
+            payload.extend_from_slice(&TS.to_be_bytes());
+            payload.extend_from_slice(&u16::try_from(attrs.len()).unwrap().to_be_bytes());
+            payload.extend_from_slice(attrs);
+        }
+        data.extend_from_slice(&raw_record(13, 2, &payload));
+    }
+
+    /// `MP_UNREACH_NLRI` carrying one BGP-LS Node NLRI whose descriptor TLVs
+    /// are out of canonical order. RFC 9552 isolates that NLRI and counts it.
+    fn discarded_bgpls_mp_unreach_attribute() -> Vec<u8> {
+        let mut nlri = Vec::new();
+        nlri.extend_from_slice(&1_u16.to_be_bytes()); // Node NLRI.
+        nlri.extend_from_slice(&19_u16.to_be_bytes());
+        nlri.push(3); // OSPFv2 protocol ID.
+        nlri.extend_from_slice(&7_u64.to_be_bytes());
+        nlri.extend_from_slice(&515_u16.to_be_bytes());
+        nlri.extend_from_slice(&1_u16.to_be_bytes());
+        nlri.push(1);
+        nlri.extend_from_slice(&256_u16.to_be_bytes());
+        nlri.extend_from_slice(&1_u16.to_be_bytes());
+        nlri.push(1);
+
+        let mut value = Vec::new();
+        value.extend_from_slice(&(Afi::BgpLs as u16).to_be_bytes());
+        value.push(Safi::BgpLs as u8);
+        value.extend_from_slice(&nlri);
+        let mut attribute = vec![
+            attr_flags::OPTIONAL,
+            attr_type::MP_UNREACH_NLRI,
+            u8::try_from(value.len()).unwrap(),
+        ];
+        attribute.extend_from_slice(&value);
+        attribute
+    }
+
     // ---- round-trip: writer output must read back with full fidelity ----
 
     #[test]
@@ -868,6 +990,8 @@ mod tests {
         assert!(err.is_none(), "unexpected error: {err:?}");
         assert_eq!(entries.len(), 2);
         assert_eq!(reader.skipped_records(), 0);
+        assert_eq!(reader.discarded_path_attributes(), 0);
+        assert_eq!(reader.discarded_bgpls_nlris(), 0);
         // Writer sorts prefixes; 192.168/16 < 198.51.100/24.
         assert_eq!(entries[0].nlri, SnapshotNlri::Unicast(routes[0].prefix));
         assert_eq!(entries[1].nlri, SnapshotNlri::Unicast(routes[1].prefix));
@@ -1199,43 +1323,108 @@ mod tests {
         assert!(matches!(err, Some(ReadError::Truncated { .. })));
     }
 
-    /// The reader decodes entry attributes on the legacy strict path, so a
-    /// non-zero-length `ATOMIC_AGGREGATE` (RFC 4271 §5.1.6 says zero) is an
-    /// attribute-length error that fails the record instead of reading back
-    /// as `PathAttribute::Unknown`.
+    /// RFC 7606 §7.6 permits omitting only the malformed attribute while the
+    /// rest of the snapshot entry remains usable.
     #[test]
-    fn nonzero_length_atomic_aggregate_is_attribute_length_error() {
-        use rustbgpd_wire::notification::update_subcode::ATTRIBUTE_LENGTH_ERROR;
+    fn nonzero_length_atomic_aggregate_is_discarded_and_counted() {
         let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
         let mut data =
             encode_snapshot(COLLECTOR, std::slice::from_ref(&peer), &[], &[], TS).unwrap();
         // ATOMIC_AGGREGATE with flags 0x40, length 1, one value byte.
         let attr = [attr_flags::TRANSITIVE, attr_type::ATOMIC_AGGREGATE, 1, 0];
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&0u32.to_be_bytes());
-        payload.push(24);
-        payload.extend_from_slice(&[192, 168, 1]);
-        payload.extend_from_slice(&1u16.to_be_bytes());
-        payload.extend_from_slice(&0u16.to_be_bytes()); // peer index
-        payload.extend_from_slice(&TS.to_be_bytes()); // originated
-        payload.extend_from_slice(&u16::try_from(attr.len()).unwrap().to_be_bytes());
-        payload.extend_from_slice(&attr);
-        data.extend_from_slice(&raw_record(13, 2, &payload));
+        append_v4_rib_with_attributes(&mut data, &attr);
         let mut reader = SnapshotReader::new(&data).unwrap();
         let (entries, err) = drain(&mut reader);
-        assert!(entries.is_empty());
-        assert!(
-            matches!(
-                err,
-                Some(ReadError::AttributeDecode(
-                    DecodeError::UpdateAttributeError {
-                        subcode: ATTRIBUTE_LENGTH_ERROR,
-                        ..
-                    }
-                ))
-            ),
-            "{err:?}"
-        );
+        assert!(err.is_none(), "unexpected error: {err:?}");
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].attributes.is_empty());
+        assert_eq!(reader.discarded_path_attributes(), 1);
+        assert_eq!(reader.discarded_bgpls_nlris(), 0);
+    }
+
+    #[test]
+    fn treat_as_withdraw_attribute_still_fails_and_fuses() {
+        let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
+        let mut data =
+            encode_snapshot(COLLECTOR, std::slice::from_ref(&peer), &[], &[], TS).unwrap();
+        // LOCAL_PREF must be four bytes. The conservative internal-neighbor
+        // classification makes this treat-as-withdraw rather than discard.
+        let attr = [attr_flags::TRANSITIVE, attr_type::LOCAL_PREF, 3, 0, 0, 100];
+        append_v4_rib_with_attributes(&mut data, &attr);
+        let mut reader = SnapshotReader::new(&data).unwrap();
+        assert!(matches!(
+            reader.next(),
+            Some(Err(ReadError::AttributeDecode(
+                DecodeError::UpdateAttributeError { .. }
+            )))
+        ));
+        assert!(reader.next().is_none());
+        assert_eq!(reader.discarded_path_attributes(), 0);
+        assert_eq!(reader.discarded_bgpls_nlris(), 0);
+    }
+
+    #[test]
+    fn recovery_counters_exclude_entries_not_yielded_before_record_failure() {
+        let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
+        let mut data =
+            encode_snapshot(COLLECTOR, std::slice::from_ref(&peer), &[], &[], TS).unwrap();
+        let discarded = [attr_flags::TRANSITIVE, attr_type::ATOMIC_AGGREGATE, 1, 0];
+        let stronger = [attr_flags::TRANSITIVE, attr_type::LOCAL_PREF, 3, 0, 0, 100];
+        append_v4_rib_attribute_entries(&mut data, &[&discarded, &stronger]);
+        let mut reader = SnapshotReader::new(&data).unwrap();
+        assert!(matches!(
+            reader.next(),
+            Some(Err(ReadError::AttributeDecode(_)))
+        ));
+        assert!(reader.next().is_none());
+        assert_eq!(reader.discarded_path_attributes(), 0);
+        assert_eq!(reader.discarded_bgpls_nlris(), 0);
+    }
+
+    #[test]
+    fn duplicate_ordinary_attribute_keeps_first_and_counts_duplicate() {
+        let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
+        let mut data =
+            encode_snapshot(COLLECTOR, std::slice::from_ref(&peer), &[], &[], TS).unwrap();
+        let attrs = [
+            attr_flags::TRANSITIVE,
+            attr_type::LOCAL_PREF,
+            4,
+            0,
+            0,
+            0,
+            100,
+            attr_flags::TRANSITIVE,
+            attr_type::LOCAL_PREF,
+            4,
+            0,
+            0,
+            0,
+            200,
+        ];
+        append_v4_rib_with_attributes(&mut data, &attrs);
+        let mut reader = SnapshotReader::new(&data).unwrap();
+        let (entries, err) = drain(&mut reader);
+        assert!(err.is_none(), "unexpected error: {err:?}");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].attributes, vec![PathAttribute::LocalPref(100)]);
+        assert_eq!(reader.discarded_path_attributes(), 1);
+        assert_eq!(reader.discarded_bgpls_nlris(), 0);
+    }
+
+    #[test]
+    fn bgpls_nlri_discard_is_counted_separately() {
+        let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
+        let mut data =
+            encode_snapshot(COLLECTOR, std::slice::from_ref(&peer), &[], &[], TS).unwrap();
+        append_v4_rib_with_attributes(&mut data, &discarded_bgpls_mp_unreach_attribute());
+        let mut reader = SnapshotReader::new(&data).unwrap();
+        let (entries, err) = drain(&mut reader);
+        assert!(err.is_none(), "unexpected error: {err:?}");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].attributes.len(), 1);
+        assert_eq!(reader.discarded_path_attributes(), 0);
+        assert_eq!(reader.discarded_bgpls_nlris(), 1);
     }
 
     #[test]

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -546,6 +546,17 @@ pub enum WarmBundleError {
         /// Number skipped by [`SnapshotReader`].
         count: u64,
     },
+    /// MRT decoding needed loss-tolerant recovery, which is unsuitable for a
+    /// byte- and semantically-exact warm checkpoint.
+    #[error(
+        "warm bundle MRT recovery discarded {discarded_path_attributes} path attributes and {discarded_bgpls_nlris} BGP-LS NLRIs"
+    )]
+    RecoveredMrtData {
+        /// Malformed path-attribute instances omitted by the reader.
+        discarded_path_attributes: u64,
+        /// Malformed BGP-LS NLRIs omitted from otherwise usable attributes.
+        discarded_bgpls_nlris: u64,
+    },
     /// MRT semantic inventory did not exactly match the manifest.
     #[error("warm bundle MRT {field} does not match the manifest")]
     MrtIdentityMismatch {
@@ -1376,6 +1387,14 @@ fn validate_snapshot_semantics(
     if reader.skipped_records() != 0 {
         return Err(WarmBundleError::SkippedMrtRecords {
             count: reader.skipped_records(),
+        });
+    }
+    let discarded_path_attributes = reader.discarded_path_attributes();
+    let discarded_bgpls_nlris = reader.discarded_bgpls_nlris();
+    if discarded_path_attributes != 0 || discarded_bgpls_nlris != 0 {
+        return Err(WarmBundleError::RecoveredMrtData {
+            discarded_path_attributes,
+            discarded_bgpls_nlris,
         });
     }
     Ok(identity
@@ -2490,6 +2509,56 @@ mod tests {
         snapshot
     }
 
+    fn recovered_attributes() -> Vec<u8> {
+        let mut attributes = vec![
+            rustbgpd_wire::constants::attr_flags::TRANSITIVE,
+            rustbgpd_wire::constants::attr_type::ATOMIC_AGGREGATE,
+            1,
+            0,
+        ];
+        let mut nlri = Vec::new();
+        nlri.extend_from_slice(&1_u16.to_be_bytes());
+        nlri.extend_from_slice(&19_u16.to_be_bytes());
+        nlri.push(3);
+        nlri.extend_from_slice(&7_u64.to_be_bytes());
+        nlri.extend_from_slice(&515_u16.to_be_bytes());
+        nlri.extend_from_slice(&1_u16.to_be_bytes());
+        nlri.push(1);
+        nlri.extend_from_slice(&256_u16.to_be_bytes());
+        nlri.extend_from_slice(&1_u16.to_be_bytes());
+        nlri.push(1);
+        let mut value = Vec::new();
+        value.extend_from_slice(&(rustbgpd_wire::Afi::BgpLs as u16).to_be_bytes());
+        value.push(rustbgpd_wire::Safi::BgpLs as u8);
+        value.extend_from_slice(&nlri);
+        attributes.extend_from_slice(&[
+            rustbgpd_wire::constants::attr_flags::OPTIONAL,
+            rustbgpd_wire::constants::attr_type::MP_UNREACH_NLRI,
+            u8::try_from(value.len()).unwrap(),
+        ]);
+        attributes.extend_from_slice(&value);
+        attributes
+    }
+
+    fn with_recovered_attributes(mut snapshot: Vec<u8>) -> Vec<u8> {
+        let record_offset = last_record_offset(&snapshot);
+        let payload_len = u32::from_be_bytes(
+            snapshot[record_offset + 8..record_offset + 12]
+                .try_into()
+                .unwrap(),
+        );
+        let attributes = recovered_attributes();
+        let attr_len_offset = snapshot.len() - 2;
+        assert_eq!(&snapshot[attr_len_offset..], &[0, 0]);
+        snapshot[attr_len_offset..]
+            .copy_from_slice(&u16::try_from(attributes.len()).unwrap().to_be_bytes());
+        snapshot[record_offset + 8..record_offset + 12].copy_from_slice(
+            &(payload_len + u32::try_from(attributes.len()).unwrap()).to_be_bytes(),
+        );
+        snapshot.extend_from_slice(&attributes);
+        snapshot
+    }
+
     fn with_invalid_pit_utf8(identity: &WarmBundleIdentityV1) -> (WarmBundleIdentityV1, Vec<u8>) {
         let mut invalid_identity = identity.clone();
         let suffix = invalid_identity.peer_index_table_view[1..].to_string();
@@ -2573,6 +2642,30 @@ mod tests {
             ),
             "{error:?}"
         );
+    }
+
+    #[test]
+    fn public_write_and_load_reject_recovered_snapshot_with_exact_counts() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let id = identity();
+        let recovered = with_recovered_attributes(valid_snapshot(&id));
+        assert!(matches!(
+            write_warm_bundle(&dir, id.clone(), &recovered),
+            Err(WarmBundleError::RecoveredMrtData {
+                discarded_path_attributes: 1,
+                discarded_bgpls_nlris: 1,
+            })
+        ));
+
+        install_raw_bundle(&temp, id.clone(), &recovered, vec![1, 1]);
+        assert!(matches!(
+            load_warm_bundle(&dir, &expected(&id), freshness()),
+            Err(WarmBundleError::RecoveredMrtData {
+                discarded_path_attributes: 1,
+                discarded_bgpls_nlris: 1,
+            })
+        ));
     }
 
     #[test]

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -84,11 +84,12 @@ changes:
   (subcode 2); it now validates, and the encoder re-emits the attribute with
   the transitive flag and a zero-length value. A non-zero length is an
   attribute-length error — attribute-discard on the revised decode path
-  (RFC 7606 §7.6). On the legacy strict path (`decode_path_attributes`, used
-  by the MRT reader) that error fails the whole decode, so an MRT RIB entry
-  carrying a non-zero-length ATOMIC_AGGREGATE is rejected where it previously
-  read back as `PathAttribute::Unknown`. Code matching on `Unknown` for type
-  code 6 no longer sees it.
+  (RFC 7606 §7.6). The MRT reader now uses that revised path with a conservative
+  internal-neighbor classification when session evidence is incomplete: it
+  omits the malformed attribute, preserves the otherwise usable RIB entry, and
+  counts the discard. Any treat-as-withdraw or stronger result still rejects
+  and fuses the snapshot iteration. Code matching on `Unknown` for type code 6
+  no longer sees it.
 
 The attribute decode path also replaces its `unreachable!` arms (`AS4_PATH`
 segment types, the `COMMUNITIES` / `EXTENDED_COMMUNITIES` / `CLUSTER_LIST` /


### PR DESCRIPTION
## Summary

- use revised path-attribute decoding for `TABLE_DUMP_V2` entries while continuing only when every recovered issue is attribute-discard
- expose separate cumulative counters for discarded path-attribute instances and BGP-LS NLRIs
- keep warm bundles lossless by rejecting snapshots that required either recovery class

## Recovery boundary

The reader uses a conservative internal-neighbor default when the MRT peer table does not preserve enough session evidence to distinguish session relationships. That keeps context-sensitive attribute problems on the stronger path instead of silently discarding them.

Only `AttributeDiscard` outcomes yield an otherwise usable entry. Treat-as-withdraw, decoder failures, reduced `MP_REACH_NLRI` failures, truncation, and other structural errors remain typed failures that fuse iteration. Counters advance only when an entry is actually yielded, and ordinary duplicate attributes retain the first value.

The public `SnapshotEntry` shape, writer bytes, record counts, Add-Path behavior, warm-bundle manifest, schema, and digest are unchanged.

## Warm-bundle exactness

Warm-bundle publication and loading reject either nonzero recovery counter through a typed error carrying both counts. General snapshot inspection gains bounded resilience and observability; warm checkpoints remain exact and fail closed.

## Validation

- 30 reader tests, including discard, duplicate, stronger-disposition, failed-record, and BGP-LS counter boundaries
- 38 warm-bundle tests, including exact write/load rejection counts
- 110 full MRT crate tests
- strict all-target/all-feature MRT Clippy
- wire README contract tests
- full workspace formatting, tests, Clippy, and warnings-denied rustdoc through push hooks
- diff integrity checks

Linear: LAN-1249
