### PR TITLE
refactor(config): centralize hold timer validation

### DIFF
--- a/src/config/tests/neighbor_validation.rs
+++ b/src/config/tests/neighbor_validation.rs
@@ -213,6 +213,32 @@ remote_asn = 65002
 }
 
 #[test]
+fn hold_timer_validation_matches_neighbor_and_peer_group() {
+    let debug_error = |source: &str| {
+        let error = parse(source).unwrap_err();
+        format!("{error:?}")
+    };
+    let direct_base = valid_toml().replace("hold_time = 90", "");
+    for (fields, expected) in [
+        ("hold_time = 1", "InvalidHoldTime { value: 1 }"),
+        ("min_hold_time = 2", "InvalidMinHoldTime { value: 2 }"),
+        (
+            "hold_time = 30\nmin_hold_time = 31",
+            "InvalidMinHoldTimeForHoldTime { minimum: 31, hold_time: 30 }",
+        ),
+        (
+            "send_hold_time = 90",
+            "InvalidSendHoldTime { value: 90, hold_time: 90 }",
+        ),
+    ] {
+        let direct = format!("{direct_base}\n{fields}");
+        let group = format!("{}\n[peer_groups.validation]\n{fields}", valid_toml());
+        assert_eq!(debug_error(&direct), expected);
+        assert_eq!(debug_error(&group), expected);
+    }
+}
+
+#[test]
 #[expect(
     clippy::too_many_lines,
     reason = "one end-to-end inheritance and negotiation matrix keeps the floor contract coherent"

--- a/src/config/tests/neighbor_validation.rs
+++ b/src/config/tests/neighbor_validation.rs
@@ -214,27 +214,34 @@ remote_asn = 65002
 
 #[test]
 fn hold_timer_validation_matches_neighbor_and_peer_group() {
-    let debug_error = |source: &str| {
-        let error = parse(source).unwrap_err();
-        format!("{error:?}")
-    };
+    fn signature(error: ConfigError) -> (&'static str, u32, u16) {
+        match error {
+            ConfigError::InvalidHoldTime { value } => ("hold", u32::from(value), 0),
+            ConfigError::InvalidMinHoldTime { value } => ("minimum", u32::from(value), 0),
+            ConfigError::InvalidMinHoldTimeForHoldTime { minimum, hold_time } => {
+                ("minimum_for_hold", u32::from(minimum), hold_time)
+            }
+            ConfigError::InvalidSendHoldTime { value, hold_time } => ("send", value, hold_time),
+            other => panic!("expected a hold-timer error, got {other}"),
+        }
+    }
     let direct_base = valid_toml().replace("hold_time = 90", "");
     for (fields, expected) in [
-        ("hold_time = 1", "InvalidHoldTime { value: 1 }"),
-        ("min_hold_time = 2", "InvalidMinHoldTime { value: 2 }"),
+        ("hold_time = 1", ("hold", 1, 0)),
+        ("min_hold_time = 2", ("minimum", 2, 0)),
         (
             "hold_time = 30\nmin_hold_time = 31",
-            "InvalidMinHoldTimeForHoldTime { minimum: 31, hold_time: 30 }",
+            ("minimum_for_hold", 31, 30),
         ),
-        (
-            "send_hold_time = 90",
-            "InvalidSendHoldTime { value: 90, hold_time: 90 }",
-        ),
+        ("send_hold_time = 90", ("send", 90, 90)),
     ] {
         let direct = format!("{direct_base}\n{fields}");
         let group = format!("{}\n[peer_groups.validation]\n{fields}", valid_toml());
-        assert_eq!(debug_error(&direct), expected);
-        assert_eq!(debug_error(&group), expected);
+        let direct_error = signature(parse(&direct).unwrap_err());
+        let group_error = signature(parse(&group).unwrap_err());
+        assert_eq!(direct_error, expected);
+        assert_eq!(group_error, expected);
+        assert_eq!(direct_error, group_error);
     }
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -171,6 +171,54 @@ impl EffectivePeerModes {
     }
 }
 
+struct EffectiveHoldTimers(u16, Option<u16>, Option<u32>);
+
+impl EffectiveHoldTimers {
+    fn for_neighbor(neighbor: &Neighbor, group: Option<&PeerGroupConfig>) -> Self {
+        let group_hold = group.and_then(|group| group.hold_time);
+        let group_min = group.and_then(|group| group.min_hold_time);
+        let group_send = group.and_then(|group| group.send_hold_time);
+        Self(
+            neighbor
+                .hold_time
+                .or(group_hold)
+                .unwrap_or(DEFAULT_HOLD_TIME),
+            neighbor.min_hold_time.or(group_min),
+            neighbor.send_hold_time.or(group_send),
+        )
+    }
+
+    fn for_peer_group(group: &PeerGroupConfig) -> Self {
+        let hold_time = group.hold_time.unwrap_or(DEFAULT_HOLD_TIME);
+        Self(hold_time, group.min_hold_time, group.send_hold_time)
+    }
+
+    fn validate(self) -> Result<(), ConfigError> {
+        let Self(hold_time, min_hold_time, send_hold_time) = self;
+        if hold_time != 0 && hold_time < 3 {
+            return Err(ConfigError::InvalidHoldTime { value: hold_time });
+        }
+        if let Some(minimum) = min_hold_time {
+            if minimum < 3 {
+                return Err(ConfigError::InvalidMinHoldTime { value: minimum });
+            }
+            if hold_time == 0 || minimum > hold_time {
+                return Err(ConfigError::InvalidMinHoldTimeForHoldTime { minimum, hold_time });
+            }
+        }
+        // RFC 9687 §4.4: an explicit non-zero SendHoldTime must exceed the
+        // effective hold time. The derived default is not represented here
+        // and always satisfies this constraint.
+        if let Some(value) = send_hold_time
+            && value != 0
+            && value <= u32::from(hold_time)
+        {
+            return Err(ConfigError::InvalidSendHoldTime { value, hold_time });
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 enum PeerModeViolation {
     RouteReflector(String),
@@ -595,37 +643,7 @@ impl Config {
                 validate_tcp_ao_config(&neighbor.address, tcp_ao)?;
             }
 
-            let hold_time = neighbor
-                .hold_time
-                .or_else(|| group.and_then(|g| g.hold_time))
-                .unwrap_or(DEFAULT_HOLD_TIME);
-            if hold_time != 0 && hold_time < 3 {
-                return Err(ConfigError::InvalidHoldTime { value: hold_time });
-            }
-            let min_hold_time = neighbor
-                .min_hold_time
-                .or_else(|| group.and_then(|g| g.min_hold_time));
-            if let Some(minimum) = min_hold_time {
-                if minimum < 3 {
-                    return Err(ConfigError::InvalidMinHoldTime { value: minimum });
-                }
-                if hold_time == 0 || minimum > hold_time {
-                    return Err(ConfigError::InvalidMinHoldTimeForHoldTime { minimum, hold_time });
-                }
-            }
-
-            // RFC 9687 §4.4: a non-zero SendHoldTime MUST be greater
-            // than the hold time. Checked on the effective (inherited)
-            // values; the derived default always satisfies this.
-            let send_hold_time = neighbor
-                .send_hold_time
-                .or_else(|| group.and_then(|g| g.send_hold_time));
-            if let Some(value) = send_hold_time
-                && value != 0
-                && value <= u32::from(hold_time)
-            {
-                return Err(ConfigError::InvalidSendHoldTime { value, hold_time });
-            }
+            EffectiveHoldTimers::for_neighbor(neighbor, group).validate()?;
 
             // Slow-peer backlog threshold is a fraction of the outbound
             // writer buffer: 0 would flag an empty queue and >100 could
@@ -2608,27 +2626,7 @@ fn validate_peer_group(
     peer_groups: &std::collections::HashMap<String, PeerGroupConfig>,
     local_asn: u32,
 ) -> Result<(), ConfigError> {
-    let hold_time = group.hold_time.unwrap_or(DEFAULT_HOLD_TIME);
-    if hold_time != 0 && hold_time < 3 {
-        return Err(ConfigError::InvalidHoldTime { value: hold_time });
-    }
-    if let Some(minimum) = group.min_hold_time {
-        if minimum < 3 {
-            return Err(ConfigError::InvalidMinHoldTime { value: minimum });
-        }
-        if hold_time == 0 || minimum > hold_time {
-            return Err(ConfigError::InvalidMinHoldTimeForHoldTime { minimum, hold_time });
-        }
-    }
-
-    // RFC 9687 §4.4 on the group's own values; neighbor-effective
-    // combinations are re-checked per neighbor.
-    if let Some(value) = group.send_hold_time
-        && value != 0
-        && value <= u32::from(hold_time)
-    {
-        return Err(ConfigError::InvalidSendHoldTime { value, hold_time });
-    }
+    EffectiveHoldTimers::for_peer_group(group).validate()?;
 
     if !group.families.is_empty() {
         parse_families(&group.families)?;


### PR DESCRIPTION
## Summary

- resolve effective hold, minimum-hold, and send-hold values through one private validation value
- run one shared ordered validator for static neighbors and peer groups
- add a direct-neighbor versus unused-peer-group parity matrix for every hold-timer error shape

## Configuration compatibility

Neighbor-over-group inheritance, the default hold time of 90 seconds, independent validation of unused peer groups, and dynamic-neighbor behavior are unchanged. Validation still reports the same error variant and numeric payload in the same order.

Zero continues to disable hold and send-hold behavior. The derived send-hold default remains solely in resolution as `max(480, 2 * hold)` and is neither materialized nor revalidated here. The shared path retains the RFC 9687 constraint for explicit nonzero send-hold values.

This changes no schema, TOML key, default, public type, generated artifact, or resolution behavior.

## Validation

- exact direct-neighbor / peer-group error parity matrix
- inherited minimum-hold and send-hold composition proofs
- 647 config tests with 4 intentional ignores
- v1 stable-surface inventory
- strict all-target/all-feature Clippy
- warnings-denied all-feature workspace rustdoc
- full workspace formatting, tests, Clippy, and rustdoc through push hooks
- diff integrity checks

Linear: LAN-1202
