### PR TITLE
docs: add Unreleased upgrade action index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Use `Route.local_pref_attr` when attribute presence matters;
   `Route.local_pref` is the effective value and defaults to 100 when the
   attribute is absent.
-- Migrate removed `RibService.WatchRoutes` and `WatchRouteEvents` consumers to
-  `EventService.WatchEvents` for live deltas or `SubscribeFromEvent` for
-  durable replay. Update route-stream metric selectors to
+- Migrate removed `RibService.WatchRoutes` and `RibService.WatchRouteEvents`
+  consumers to `EventService.WatchEvents` for live deltas or
+  `EventService.SubscribeFromEvent` for durable replay. Update route-stream
+  metric selectors to
   `{service="watch_events",source="route"}`.
 - Recognize `chain_default_permit` as the stable policy-attribution value for
   a nonempty chain that completes without rejection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- Use `Route.local_pref_attr` when attribute presence matters;
+  `Route.local_pref` is the effective value and defaults to 100 when the
+  attribute is absent.
+- Migrate removed `RibService.WatchRoutes` and `WatchRouteEvents` consumers to
+  `EventService.WatchEvents` for live deltas or `SubscribeFromEvent` for
+  durable replay. Update route-stream metric selectors to
+  `{service="watch_events",source="route"}`.
+- Recognize `chain_default_permit` as the stable policy-attribution value for
+  a nonempty chain that completes without rejection.
+- Revalidate custom Bird's Eye consumers against the verified IXP Manager 7.4
+  compatibility contract: route shapes and longest-match lookup behavior now
+  converge on the pinned oracle.
+
 ### Added
 
 - `rustbgpd-wire` gains an optional, default-off `tokio-codec` feature with a

--- a/scripts/fixtures/release-notes/changelog-section.expected.md
+++ b/scripts/fixtures/release-notes/changelog-section.expected.md
@@ -1,4 +1,11 @@
 
+### Upgrade notes
+
+- Use `Route.local_pref_attr` when attribute presence matters; `Route.local_pref` is the effective value and defaults to 100 when the attribute is absent.
+- Migrate removed `RibService.WatchRoutes` and `WatchRouteEvents` consumers to `EventService.WatchEvents` for live deltas or `SubscribeFromEvent` for durable replay. Update route-stream metric selectors to `{service="watch_events",source="route"}`.
+- Recognize `chain_default_permit` as the stable policy-attribution value for a nonempty chain that completes without rejection.
+- Revalidate custom Bird's Eye consumers against the verified IXP Manager 7.4 compatibility contract: route shapes and longest-match lookup behavior now converge on the pinned oracle.
+
 ### Added
 
 - **ADR-0089 EVPN VNI-per-broadcast-domain VLAN-aware bridge support.** The VLAN-aware bridge follow-up now has a precise v1 scope: Linux `vlan_filtering=1` support targets the existing one-VNI-per-broadcast domain EVPN model, keeps Type 2 / Type 3 / EAD-per-EVI Ethernet Tag ID at `0`, adds a local `bridge_vlan` binding for kernel attribution, and defers true RFC VLAN-aware bundle / non-zero-Ethernet-Tag service models plus SVD / managed-netdev support to separate gates. The ADR is the design gate for the implementation slices below.

--- a/scripts/fixtures/release-notes/changelog-section.expected.md
+++ b/scripts/fixtures/release-notes/changelog-section.expected.md
@@ -2,7 +2,7 @@
 ### Upgrade notes
 
 - Use `Route.local_pref_attr` when attribute presence matters; `Route.local_pref` is the effective value and defaults to 100 when the attribute is absent.
-- Migrate removed `RibService.WatchRoutes` and `WatchRouteEvents` consumers to `EventService.WatchEvents` for live deltas or `SubscribeFromEvent` for durable replay. Update route-stream metric selectors to `{service="watch_events",source="route"}`.
+- Migrate removed `RibService.WatchRoutes` and `RibService.WatchRouteEvents` consumers to `EventService.WatchEvents` for live deltas or `EventService.SubscribeFromEvent` for durable replay. Update route-stream metric selectors to `{service="watch_events",source="route"}`.
 - Recognize `chain_default_permit` as the stable policy-attribution value for a nonempty chain that completes without rejection.
 - Revalidate custom Bird's Eye consumers against the verified IXP Manager 7.4 compatibility contract: route shapes and longest-match lookup behavior now converge on the pinned oracle.
 

--- a/scripts/fixtures/release-notes/changelog-section.in.md
+++ b/scripts/fixtures/release-notes/changelog-section.in.md
@@ -4,9 +4,10 @@
 - Use `Route.local_pref_attr` when attribute presence matters;
   `Route.local_pref` is the effective value and defaults to 100 when the
   attribute is absent.
-- Migrate removed `RibService.WatchRoutes` and `WatchRouteEvents` consumers to
-  `EventService.WatchEvents` for live deltas or `SubscribeFromEvent` for
-  durable replay. Update route-stream metric selectors to
+- Migrate removed `RibService.WatchRoutes` and `RibService.WatchRouteEvents`
+  consumers to `EventService.WatchEvents` for live deltas or
+  `EventService.SubscribeFromEvent` for durable replay. Update route-stream
+  metric selectors to
   `{service="watch_events",source="route"}`.
 - Recognize `chain_default_permit` as the stable policy-attribution value for
   a nonempty chain that completes without rejection.

--- a/scripts/fixtures/release-notes/changelog-section.in.md
+++ b/scripts/fixtures/release-notes/changelog-section.in.md
@@ -1,4 +1,19 @@
 
+### Upgrade notes
+
+- Use `Route.local_pref_attr` when attribute presence matters;
+  `Route.local_pref` is the effective value and defaults to 100 when the
+  attribute is absent.
+- Migrate removed `RibService.WatchRoutes` and `WatchRouteEvents` consumers to
+  `EventService.WatchEvents` for live deltas or `SubscribeFromEvent` for
+  durable replay. Update route-stream metric selectors to
+  `{service="watch_events",source="route"}`.
+- Recognize `chain_default_permit` as the stable policy-attribution value for
+  a nonempty chain that completes without rejection.
+- Revalidate custom Bird's Eye consumers against the verified IXP Manager 7.4
+  compatibility contract: route shapes and longest-match lookup behavior now
+  converge on the pinned oracle.
+
 ### Added
 
 - **ADR-0089 EVPN VNI-per-broadcast-domain VLAN-aware bridge support.**


### PR DESCRIPTION
## Summary

- add an action-oriented `Upgrade notes` index under the Unreleased changelog section
- cover the effective `local_pref` contract, event-stream migration, chain-default attribution, and IXP Manager 7.4 consumer compatibility
- pin the complete four-action block through the release-note reflow fixtures

## Consumer actions

- use `Route.local_pref_attr` when wire-level presence matters; `Route.local_pref` is the effective value and defaults to 100 when absent
- migrate removed `RibService.WatchRoutes` / `WatchRouteEvents` consumers to `EventService.WatchEvents` or `SubscribeFromEvent`, and update route-stream metric selectors to `{service="watch_events",source="route"}`
- recognize `chain_default_permit` as the stable attribution for a nonempty policy chain that completes without rejection
- revalidate custom Bird's Eye consumers against the verified IXP Manager 7.4 route-shape and longest-match compatibility contract

The existing detailed Added, Changed, and Removed entries remain intact. This is a curated upgrade index, not a replacement for the release history.

## Validation

- release-note reflow self-tests
- exact complete-block input/expected fixture parity
- real Unreleased extraction and reflow proof
- release-checklist path checker
- public tracker-ID checker
- documentation push hooks and diff integrity checks

Linear: LAN-1264
