### PR TITLE
refactor(config): centralize GR timer validation

### DIFF
--- a/src/config/tests/families.rs
+++ b/src/config/tests/families.rs
@@ -1,29 +1,16 @@
 use super::*;
 
-#[test]
-fn gr_restart_time_zero_with_gr_enabled_rejected() {
-    let err = parse(&gr_toml("gr_restart_time = 0")).unwrap_err();
-    assert!(matches!(err, ConfigError::InvalidGrConfig { .. }));
-}
-
-#[test]
-fn gr_restart_time_zero_with_gr_disabled_accepted() {
-    let toml = gr_toml("graceful_restart = false\ngr_restart_time = 0");
-    assert!(parse(&toml).is_ok());
-}
-
-#[test]
-fn gr_peer_restart_time_max_outside_wire_range_rejected() {
-    // Load-bearing: deleting either boundary validation makes one case load.
-    for value in [0, 4096] {
-        let err = parse(&gr_toml(&format!("gr_peer_restart_time_max = {value}"))).unwrap_err();
-        assert!(matches!(err, ConfigError::InvalidGrConfig { .. }));
+fn assert_gr_reason(toml: &str, expected: &str) {
+    let err = parse(toml).unwrap_err();
+    match err {
+        ConfigError::InvalidGrConfig { reason } => assert_eq!(reason, expected),
+        other => panic!("expected InvalidGrConfig, got {other:?}"),
     }
 }
 
-#[test]
-fn gr_peer_restart_time_max_peer_group_only_bounds_rejected() {
-    let base = r#"
+fn peer_group_gr_toml(gr_fields: &str) -> String {
+    format!(
+        r#"
 [global]
 asn = 65001
 router_id = "10.0.0.1"
@@ -33,13 +20,214 @@ listen_port = 179
 log_format = "json"
 
 [peer_groups.rr]
-"#;
+{gr_fields}
+"#
+    )
+}
 
-    // Load-bearing: these groups have no members, so removing the dedicated
-    // validate_peer_group bounds branch makes both invalid configs load.
-    for value in [0, 4096] {
-        let err = parse(&format!("{base}gr_peer_restart_time_max = {value}\n")).unwrap_err();
-        assert!(matches!(err, ConfigError::InvalidGrConfig { .. }));
+#[test]
+fn neighbor_gr_timer_failures_preserve_exact_reasons() {
+    let cases = [
+        (
+            "gr_restart_time = 4096",
+            "gr_restart_time 4096 exceeds 4095 (12-bit max)",
+        ),
+        (
+            "gr_restart_time = 0",
+            "gr_restart_time must be > 0 when graceful_restart is enabled",
+        ),
+        (
+            "gr_peer_restart_time_max = 0",
+            "gr_peer_restart_time_max must be > 0",
+        ),
+        (
+            "gr_peer_restart_time_max = 4096",
+            "gr_peer_restart_time_max 4096 exceeds 4095 (12-bit max)",
+        ),
+        (
+            "gr_stale_routes_time = 0",
+            "gr_stale_routes_time must be > 0",
+        ),
+        (
+            "gr_stale_routes_time = 3601",
+            "gr_stale_routes_time 3601 exceeds 3600 (1 hour max)",
+        ),
+        (
+            "llgr_stale_time = 16777216",
+            "llgr_stale_time 16777216 exceeds 16777215 (24-bit max)",
+        ),
+    ];
+
+    for (fields, expected) in cases {
+        assert_gr_reason(&gr_toml(fields), expected);
+    }
+}
+
+#[test]
+fn peer_group_gr_timer_failures_preserve_exact_reasons() {
+    let cases = [
+        (
+            "gr_restart_time = 4096",
+            "gr_restart_time 4096 exceeds 4095 (12-bit max)",
+        ),
+        (
+            "gr_restart_time = 0",
+            "gr_restart_time must be > 0 when graceful_restart is enabled",
+        ),
+        (
+            "gr_peer_restart_time_max = 0",
+            "gr_peer_restart_time_max must be > 0",
+        ),
+        (
+            "gr_peer_restart_time_max = 4096",
+            "gr_peer_restart_time_max 4096 exceeds 4095 (12-bit max)",
+        ),
+        (
+            "gr_stale_routes_time = 0",
+            "gr_stale_routes_time must be > 0",
+        ),
+        (
+            "gr_stale_routes_time = 3601",
+            "gr_stale_routes_time 3601 exceeds 3600 (1 hour max)",
+        ),
+        (
+            "llgr_stale_time = 16777216",
+            "llgr_stale_time 16777216 exceeds 16777215 (24-bit max)",
+        ),
+    ];
+
+    for (fields, expected) in cases {
+        assert_gr_reason(
+            &peer_group_gr_toml(fields),
+            &format!("peer_group \"rr\": {expected}"),
+        );
+    }
+}
+
+#[test]
+fn gr_timer_validation_preserves_observable_error_order() {
+    let cases = [
+        (
+            r"graceful_restart = true
+gr_restart_time = 4096
+gr_peer_restart_time_max = 0
+gr_stale_routes_time = 1
+llgr_stale_time = 0",
+            "gr_restart_time 4096 exceeds 4095 (12-bit max)",
+        ),
+        (
+            r"graceful_restart = true
+gr_restart_time = 0
+gr_peer_restart_time_max = 0
+gr_stale_routes_time = 1
+llgr_stale_time = 0",
+            "gr_restart_time must be > 0 when graceful_restart is enabled",
+        ),
+        (
+            r"graceful_restart = true
+gr_restart_time = 120
+gr_peer_restart_time_max = 0
+gr_stale_routes_time = 0
+llgr_stale_time = 0",
+            "gr_peer_restart_time_max must be > 0",
+        ),
+        (
+            r"graceful_restart = true
+gr_restart_time = 120
+gr_peer_restart_time_max = 4096
+gr_stale_routes_time = 0
+llgr_stale_time = 0",
+            "gr_peer_restart_time_max 4096 exceeds 4095 (12-bit max)",
+        ),
+        (
+            r"graceful_restart = true
+gr_restart_time = 120
+gr_peer_restart_time_max = 4095
+gr_stale_routes_time = 0
+llgr_stale_time = 16777216",
+            "gr_stale_routes_time must be > 0",
+        ),
+        (
+            r"graceful_restart = true
+gr_restart_time = 120
+gr_peer_restart_time_max = 4095
+gr_stale_routes_time = 3601
+llgr_stale_time = 16777216",
+            "gr_stale_routes_time 3601 exceeds 3600 (1 hour max)",
+        ),
+    ];
+
+    for (fields, expected) in cases {
+        assert_gr_reason(&gr_toml(fields), expected);
+    }
+}
+
+#[test]
+fn neighbor_enabled_override_rejects_disabled_group_zero_restart_time() {
+    let toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.rr]
+graceful_restart = false
+gr_restart_time = 0
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "rr"
+graceful_restart = true
+"#;
+    assert_gr_reason(
+        toml,
+        "gr_restart_time must be > 0 when graceful_restart is enabled",
+    );
+}
+
+#[test]
+fn neighbor_disabled_zero_restart_time_overrides_enabled_group() {
+    let toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.rr]
+graceful_restart = true
+gr_restart_time = 120
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "rr"
+graceful_restart = false
+gr_restart_time = 0
+"#;
+    assert!(parse(toml).is_ok());
+}
+
+#[test]
+fn gr_timer_valid_boundaries_are_accepted() {
+    let cases = [
+        "gr_restart_time = 4095",
+        "graceful_restart = false\ngr_restart_time = 0",
+        "gr_peer_restart_time_max = 1",
+        "gr_peer_restart_time_max = 4095",
+        "gr_stale_routes_time = 1",
+        "gr_stale_routes_time = 3600",
+        "llgr_stale_time = 16777215",
+    ];
+
+    for fields in cases {
+        assert!(parse(&gr_toml(fields)).is_ok(), "rejected {fields:?}");
     }
 }
 
@@ -88,17 +276,6 @@ gr_peer_restart_time_max = 300
             .gr_peer_restart_time_max,
         300
     );
-}
-
-#[test]
-fn gr_stale_routes_time_exceeds_max_rejected() {
-    let err = parse(&gr_toml("gr_stale_routes_time = 7200")).unwrap_err();
-    assert!(matches!(err, ConfigError::InvalidGrConfig { .. }));
-}
-
-#[test]
-fn gr_stale_routes_time_at_max_accepted() {
-    assert!(parse(&gr_toml("gr_stale_routes_time = 3600")).is_ok());
 }
 
 #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -219,6 +219,86 @@ impl EffectiveHoldTimers {
     }
 }
 
+struct EffectiveGracefulRestartTimers {
+    enabled: bool,
+    restart_time: Option<u16>,
+    peer_restart_time_max: Option<u16>,
+    stale_routes_time: Option<u64>,
+    llgr_stale_time: Option<u32>,
+}
+
+impl EffectiveGracefulRestartTimers {
+    fn for_neighbor(neighbor: &Neighbor, group: Option<&PeerGroupConfig>) -> Self {
+        Self {
+            enabled: neighbor
+                .graceful_restart
+                .or_else(|| group.and_then(|g| g.graceful_restart))
+                .unwrap_or(true),
+            restart_time: neighbor
+                .gr_restart_time
+                .or_else(|| group.and_then(|g| g.gr_restart_time)),
+            peer_restart_time_max: neighbor
+                .gr_peer_restart_time_max
+                .or_else(|| group.and_then(|g| g.gr_peer_restart_time_max)),
+            stale_routes_time: neighbor
+                .gr_stale_routes_time
+                .or_else(|| group.and_then(|g| g.gr_stale_routes_time)),
+            llgr_stale_time: neighbor
+                .llgr_stale_time
+                .or_else(|| group.and_then(|g| g.llgr_stale_time)),
+        }
+    }
+
+    fn for_peer_group(group: &PeerGroupConfig) -> Self {
+        Self {
+            enabled: group.graceful_restart.unwrap_or(true),
+            restart_time: group.gr_restart_time,
+            peer_restart_time_max: group.gr_peer_restart_time_max,
+            stale_routes_time: group.gr_stale_routes_time,
+            llgr_stale_time: group.llgr_stale_time,
+        }
+    }
+
+    fn validate(self) -> Result<(), String> {
+        if let Some(t) = self.restart_time
+            && t > 4095
+        {
+            return Err(format!("gr_restart_time {t} exceeds 4095 (12-bit max)"));
+        }
+        if let Some(0) = self.restart_time
+            && self.enabled
+        {
+            return Err("gr_restart_time must be > 0 when graceful_restart is enabled".to_string());
+        }
+        if let Some(0) = self.peer_restart_time_max {
+            return Err("gr_peer_restart_time_max must be > 0".to_string());
+        }
+        if let Some(t) = self.peer_restart_time_max
+            && t > 4095
+        {
+            return Err(format!(
+                "gr_peer_restart_time_max {t} exceeds 4095 (12-bit max)"
+            ));
+        }
+        if let Some(0) = self.stale_routes_time {
+            return Err("gr_stale_routes_time must be > 0".to_string());
+        }
+        if let Some(t) = self.stale_routes_time
+            && t > 3600
+        {
+            return Err(format!(
+                "gr_stale_routes_time {t} exceeds 3600 (1 hour max)"
+            ));
+        }
+        if let Some(t) = self.llgr_stale_time
+            && t > 16_777_215
+        {
+            return Err(format!("llgr_stale_time {t} exceeds 16777215 (24-bit max)"));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 enum PeerModeViolation {
     RouteReflector(String),
@@ -784,75 +864,9 @@ impl Config {
                     .or_else(|| group.and_then(|g| g.log_level.as_deref())),
             )?;
 
-            // Validate GR config
-            let gr_enabled = neighbor
-                .graceful_restart
-                .or_else(|| group.and_then(|g| g.graceful_restart))
-                .unwrap_or(true);
-            if let Some(t) = neighbor
-                .gr_restart_time
-                .or_else(|| group.and_then(|g| g.gr_restart_time))
-                && t > 4095
-            {
-                return Err(ConfigError::InvalidGrConfig {
-                    reason: format!("gr_restart_time {t} exceeds 4095 (12-bit max)"),
-                });
-            }
-            if let Some(0) = neighbor
-                .gr_restart_time
-                .or_else(|| group.and_then(|g| g.gr_restart_time))
-                && gr_enabled
-            {
-                return Err(ConfigError::InvalidGrConfig {
-                    reason: "gr_restart_time must be > 0 when graceful_restart is enabled"
-                        .to_string(),
-                });
-            }
-            if let Some(t) = neighbor
-                .gr_peer_restart_time_max
-                .or_else(|| group.and_then(|g| g.gr_peer_restart_time_max))
-                && t == 0
-            {
-                return Err(ConfigError::InvalidGrConfig {
-                    reason: "gr_peer_restart_time_max must be > 0".to_string(),
-                });
-            }
-            if let Some(t) = neighbor
-                .gr_peer_restart_time_max
-                .or_else(|| group.and_then(|g| g.gr_peer_restart_time_max))
-                && t > 4095
-            {
-                return Err(ConfigError::InvalidGrConfig {
-                    reason: format!("gr_peer_restart_time_max {t} exceeds 4095 (12-bit max)"),
-                });
-            }
-            if let Some(t) = neighbor
-                .gr_stale_routes_time
-                .or_else(|| group.and_then(|g| g.gr_stale_routes_time))
-                && t == 0
-            {
-                return Err(ConfigError::InvalidGrConfig {
-                    reason: "gr_stale_routes_time must be > 0".to_string(),
-                });
-            }
-            if let Some(t) = neighbor
-                .gr_stale_routes_time
-                .or_else(|| group.and_then(|g| g.gr_stale_routes_time))
-                && t > 3600
-            {
-                return Err(ConfigError::InvalidGrConfig {
-                    reason: format!("gr_stale_routes_time {t} exceeds 3600 (1 hour max)"),
-                });
-            }
-            if let Some(t) = neighbor
-                .llgr_stale_time
-                .or_else(|| group.and_then(|g| g.llgr_stale_time))
-                && t > 16_777_215
-            {
-                return Err(ConfigError::InvalidGrConfig {
-                    reason: format!("llgr_stale_time {t} exceeds 16777215 (24-bit max)"),
-                });
-            }
+            EffectiveGracefulRestartTimers::for_neighbor(neighbor, group)
+                .validate()
+                .map_err(|reason| ConfigError::InvalidGrConfig { reason })?;
 
             // Validate local_ipv6_nexthop if configured
             if let Some(nh) = neighbor
@@ -2679,64 +2693,11 @@ fn validate_peer_group(
 
     validate_log_level(group.log_level.as_deref())?;
 
-    let gr_enabled = group.graceful_restart.unwrap_or(true);
-    if let Some(t) = group.gr_restart_time
-        && t > 4095
-    {
-        return Err(ConfigError::InvalidGrConfig {
-            reason: format!("peer_group {name:?}: gr_restart_time {t} exceeds 4095 (12-bit max)"),
-        });
-    }
-    if let Some(0) = group.gr_restart_time
-        && gr_enabled
-    {
-        return Err(ConfigError::InvalidGrConfig {
-            reason: format!(
-                "peer_group {name:?}: gr_restart_time must be > 0 when graceful_restart is enabled"
-            ),
-        });
-    }
-    if let Some(t) = group.gr_peer_restart_time_max
-        && t == 0
-    {
-        return Err(ConfigError::InvalidGrConfig {
-            reason: format!("peer_group {name:?}: gr_peer_restart_time_max must be > 0"),
-        });
-    }
-    if let Some(t) = group.gr_peer_restart_time_max
-        && t > 4095
-    {
-        return Err(ConfigError::InvalidGrConfig {
-            reason: format!(
-                "peer_group {name:?}: gr_peer_restart_time_max {t} exceeds 4095 (12-bit max)"
-            ),
-        });
-    }
-    if let Some(t) = group.gr_stale_routes_time
-        && t == 0
-    {
-        return Err(ConfigError::InvalidGrConfig {
-            reason: format!("peer_group {name:?}: gr_stale_routes_time must be > 0"),
-        });
-    }
-    if let Some(t) = group.gr_stale_routes_time
-        && t > 3600
-    {
-        return Err(ConfigError::InvalidGrConfig {
-            reason: format!(
-                "peer_group {name:?}: gr_stale_routes_time {t} exceeds 3600 (1 hour max)"
-            ),
-        });
-    }
-    if let Some(t) = group.llgr_stale_time
-        && t > 16_777_215
-    {
-        return Err(ConfigError::InvalidGrConfig {
-            reason: format!(
-                "peer_group {name:?}: llgr_stale_time {t} exceeds 16777215 (24-bit max)"
-            ),
-        });
-    }
+    EffectiveGracefulRestartTimers::for_peer_group(group)
+        .validate()
+        .map_err(|reason| ConfigError::InvalidGrConfig {
+            reason: format!("peer_group {name:?}: {reason}"),
+        })?;
 
     if let Some(nh) = group.local_ipv6_nexthop.as_deref() {
         let addr = nh


### PR DESCRIPTION
## Summary

- centralize graceful-restart timer validation shared by neighbors and standalone peer groups
- preserve neighbor-over-group precedence, defaults, exact diagnostics, and first-error ordering
- add exact reason, boundary, inheritance, and six-edge ordering proofs while reducing production code by 39 lines

## Validation

- `cargo test --locked -p rustbgpd config::tests::families`
- `cargo test --locked -p rustbgpd config::diagnostic::tests`
- `cargo clippy --locked -p rustbgpd --all-targets --all-features -- -D warnings`
- `python3 scripts/check-v1-stable-surface.py`
- full workspace tests and documentation hooks
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: https://linear.app/lance0/issue/LAN-1202/centralize-neighbor-peer-group-inheritance-to-prevent-schema-drift