### PR TITLE
test(interop): make M37 grep checks read through

### DIFF
--- a/tests/interop/scripts/test-m37-evpn-local-origination-churn.sh
+++ b/tests/interop/scripts/test-m37-evpn-local-origination-churn.sh
@@ -78,7 +78,7 @@ frr_has_type2() {
     local mac=${1:?}
     frr_macip_table \
         | grep -A1 -iF "$mac" \
-        | grep -qF "$RUSTBGPD_IP"
+        | grep -F "$RUSTBGPD_IP" >/dev/null
 }
 
 frr_type2_absent() {
@@ -87,7 +87,7 @@ frr_type2_absent() {
     local mac=${1:?}
     local out
     out=$(frr_macip_table) || return 1
-    ! printf '%s\n' "$out" | grep -A1 -iF "$mac" | grep -qF "$RUSTBGPD_IP"
+    ! printf '%s\n' "$out" | grep -A1 -iF "$mac" | grep -F "$RUSTBGPD_IP" >/dev/null
 }
 
 rb_fdb_replace() {

--- a/tests/interop/scripts/test-m37-evpn-local-origination.sh
+++ b/tests/interop/scripts/test-m37-evpn-local-origination.sh
@@ -70,13 +70,13 @@ frr_has_type2() {
     # Two-line vtysh layout: MAC on one line, next-hop on the next.
     # `grep -A1 -iF "$mac"` pulls both, then check the next-hop is
     # rustbgpd's loopback.
-    echo "$out" | grep -A1 -iF "$mac" | grep -qF "$RUSTBGPD_IP"
+    echo "$out" | grep -A1 -iF "$mac" | grep -F "$RUSTBGPD_IP" >/dev/null
 }
 
 # Does FRR list a Type 3 IMET route originating from rustbgpd?
 frr_has_type3() {
     frr_vtysh "show bgp l2vpn evpn route type multicast" \
-        | grep -qF "$RUSTBGPD_IP"
+        | grep -F "$RUSTBGPD_IP" >/dev/null
 }
 
 # Absence checks succeed only when the FRR query itself succeeded AND the
@@ -86,13 +86,13 @@ frr_type2_absent() {
     local mac=${1:?}
     local out
     out=$(frr_vtysh_strict "show bgp l2vpn evpn route type macip") || return 1
-    ! echo "$out" | grep -A1 -iF "$mac" | grep -qF "$RUSTBGPD_IP"
+    ! echo "$out" | grep -A1 -iF "$mac" | grep -F "$RUSTBGPD_IP" >/dev/null
 }
 
 frr_type3_absent() {
     local out
     out=$(frr_vtysh_strict "show bgp l2vpn evpn route type multicast") || return 1
-    ! echo "$out" | grep -qF "$RUSTBGPD_IP"
+    ! echo "$out" | grep -F "$RUSTBGPD_IP" >/dev/null
 }
 
 # Inject a static MAC on the rustbgpd container's non-VXLAN bridge


### PR DESCRIPTION
## Summary

- replace six host-side early-exit fixed-string grep consumers across the M37 scenario and churn helper with read-through matches
- prevent pipefail/SIGPIPE from turning a present match into a false absence verdict
- preserve every producer, capture, pattern, context selector, verdict branch, message, retry, query-error guard, and interoperability assertion

## Validation

- exact two-file, six-site source inventory with zero remaining executable verdict consumers
- deterministic direct, context, present, absent, and negated pipefail proofs with a 1,000,001-line producer
- Bash syntax and warning-level ShellCheck on both files; only the existing informational findings remain
- five interop topology command contracts
- formatting, diff, commit, and push hooks

Linear: LAN-1045