### PR TITLE
test(interop): make M75 grep checks read through

### DIFF
--- a/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
+++ b/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
@@ -132,7 +132,7 @@ assert_family_negotiated() {
     if gobgp "$container" neighbor "$peer" \
         | grep -A 30 "Neighbor capabilities" \
         | grep -E "(^|[[:space:]])${family}:" \
-        | grep -q "advertised and received"; then
+        | grep "advertised and received" >/dev/null; then
         ok "$label negotiated $family"
     else
         fail "$label did not negotiate $family"
@@ -149,7 +149,7 @@ assert_family_absent() {
     if gobgp "$container" neighbor "$peer" \
         | grep -A 30 "Neighbor capabilities" \
         | grep -E "(^|[[:space:]])${family}:" \
-        | grep -q "advertised and received"; then
+        | grep "advertised and received" >/dev/null; then
         fail "$label unexpectedly negotiated $family"
         gobgp "$container" neighbor "$peer" | grep -A 30 "Neighbor capabilities" || true
     else
@@ -165,7 +165,7 @@ wait_default_rtc_accepted() {
     local container=${1:?} rr=${2:?} label=${3:?}
     log "Waiting for $label to accept the RR's default RTC NLRI into adj-in..."
     for i in $(seq 1 30); do
-        if gobgp "$container" neighbor "$rr" adj-in -a rtc | grep -qi "default"; then
+        if gobgp "$container" neighbor "$rr" adj-in -a rtc | grep -i "default" >/dev/null; then
             ok "$label accepted the RR's default RTC NLRI (attempt $i)"
             return 0
         fi


### PR DESCRIPTION
## Summary

- replace three host-side early-exit grep consumers in M75 with read-through matches
- prevent pipefail/SIGPIPE from turning negotiated capabilities or a present default RTC route into false absence verdicts
- preserve every producer, capability/context filter, pattern, branch, message, call count, and retry

## Validation

- exact one-file, three-site source inventory; the two remaining q-mode checks consume captured input
- deterministic long capability and RTC producers: old present status 141, read-through present 0, absent 1
- Bash syntax and warning-level ShellCheck; only existing lower-severity diagnostics remain
- five interop topology and two tier-authentication route-reflector contracts
- formatting, diff, commit, and push hooks

Linear: LAN-1045