### PR TITLE
docs(bmp): list every manager event input

### DIFF
--- a/crates/bmp/README.md
+++ b/crates/bmp/README.md
@@ -28,8 +28,10 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 ## Architecture
 
-The transport layer captures raw BGP PDUs and emits `BmpEvent` variants
-(PeerUp, PeerDown, RouteMonitoring) through an `mpsc` channel.
+`BmpManager` receives every `BmpEvent` variant through an `mpsc` channel:
+`PeerUp`, `PeerDown`, `RouteMonitoring`, `StatsReport`,
+`LocRibRouteMonitoring`, and `LocRibStats`.
+
 `BmpManager` encodes events and distributes to per-collector `BmpClient`
 tasks. Zero overhead when no collectors are configured.
 

--- a/crates/bmp/tests/readme_contract.rs
+++ b/crates/bmp/tests/readme_contract.rs
@@ -20,6 +20,24 @@ fn section_between_exact_headings(markdown: &str, start: &str, end: &str) -> Str
     lines[starts[0] + 1..ends[0]].join("\n")
 }
 
+fn expected_manager_roster(names: &[&str]) -> String {
+    let (last, leading) = names.split_last().expect("event roster must not be empty");
+    let roster = match leading {
+        [] => format!("`{last}`"),
+        [only] => format!("`{only}` and `{last}`"),
+        _ => format!(
+            "{}, and `{last}`",
+            leading
+                .iter()
+                .map(|name| format!("`{name}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    };
+
+    format!("`BmpManager` receives every `BmpEvent` variant through an `mpsc` channel: {roster}.")
+}
+
 macro_rules! assert_bmp_event_roster {
     ($($variant:ident),+ $(,)?) => {{
         let assert_exhaustive = |event: &BmpEvent| match event {
@@ -27,11 +45,7 @@ macro_rules! assert_bmp_event_roster {
         };
         let _ = assert_exhaustive;
 
-        let names = [$(stringify!($variant)),+];
-        format!(
-            "`BmpManager` receives every `BmpEvent` variant through an `mpsc` channel: `{}`, `{}`, `{}`, `{}`, `{}`, and `{}`.",
-            names[0], names[1], names[2], names[3], names[4], names[5]
-        )
+        expected_manager_roster(&[$(stringify!($variant)),+])
     }};
 }
 

--- a/crates/bmp/tests/readme_contract.rs
+++ b/crates/bmp/tests/readme_contract.rs
@@ -1,0 +1,74 @@
+use rustbgpd_bmp::BmpEvent;
+
+fn section_between_exact_headings(markdown: &str, start: &str, end: &str) -> String {
+    let lines: Vec<_> = markdown.lines().collect();
+    let starts: Vec<_> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| (*line == start).then_some(index))
+        .collect();
+    let ends: Vec<_> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| (*line == end).then_some(index))
+        .collect();
+
+    assert_eq!(starts.len(), 1, "expected exactly one {start} heading");
+    assert_eq!(ends.len(), 1, "expected exactly one {end} heading");
+    assert!(starts[0] < ends[0], "{start} must precede {end}");
+
+    lines[starts[0] + 1..ends[0]].join("\n")
+}
+
+macro_rules! assert_bmp_event_roster {
+    ($($variant:ident),+ $(,)?) => {{
+        let assert_exhaustive = |event: &BmpEvent| match event {
+            $(BmpEvent::$variant { .. } => (),)+
+        };
+        let _ = assert_exhaustive;
+
+        let names = [$(stringify!($variant)),+];
+        format!(
+            "`BmpManager` receives every `BmpEvent` variant through an `mpsc` channel: `{}`, `{}`, `{}`, `{}`, `{}`, and `{}`.",
+            names[0], names[1], names[2], names[3], names[4], names[5]
+        )
+    }};
+}
+
+#[test]
+fn architecture_lists_every_manager_event_input() {
+    let readme = include_str!("../README.md").replace("\r\n", "\n");
+    let architecture = section_between_exact_headings(&readme, "## Architecture", "## License");
+    let paragraphs: Vec<_> = architecture
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|paragraph| !paragraph.is_empty())
+        .collect();
+    let manager_rosters: Vec<_> = paragraphs
+        .iter()
+        .filter(|paragraph| {
+            paragraph.starts_with("`BmpManager` receives every `BmpEvent` variant ")
+        })
+        .collect();
+
+    assert_eq!(
+        manager_rosters.len(),
+        1,
+        "Architecture must contain exactly one BmpEvent roster paragraph"
+    );
+
+    let expected = assert_bmp_event_roster!(
+        PeerUp,
+        PeerDown,
+        RouteMonitoring,
+        StatsReport,
+        LocRibRouteMonitoring,
+        LocRibStats,
+    );
+    let actual = manager_rosters[0]
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
## Summary

- correct the BMP Architecture roster to name all six manager event inputs
- derive both an exhaustive wildcard-free match over the real public enum and the exact expected prose from one authoritative identifier list
- fail closed when the enum grows while preserving the existing Features section and production behavior

## Validation

- focused README contract integration test
- full BMP package test suite
- strict all-target BMP Clippy
- BMP rustdoc
- formatting, diff, commit, and push hooks

Linear: LAN-1252