### PR TITLE
test(interop): make M45 grep checks read through

### DIFF
--- a/tests/interop/scripts/test-m45-evpn-type5-injection.sh
+++ b/tests/interop/scripts/test-m45-evpn-type5-injection.sh
@@ -97,7 +97,7 @@ wait_frr_type5_present() {
     local prefix=${2:-$PREFIX}
     local attempts=$((timeout / 2))
     for _ in $(seq 1 "$attempts"); do
-        if frr_type5_routes | grep -q "$prefix"; then
+        if frr_type5_routes | grep "$prefix" >/dev/null; then
             return 0
         fi
         sleep 2
@@ -110,7 +110,7 @@ wait_frr_type5_absent() {
     local prefix=${2:-$PREFIX}
     local attempts=$((timeout / 2))
     for _ in $(seq 1 "$attempts"); do
-        if ! frr_type5_routes | grep -q "$prefix"; then
+        if ! frr_type5_routes | grep "$prefix" >/dev/null; then
             return 0
         fi
         sleep 2


### PR DESCRIPTION
## Outcome

Closed unmerged after exact-source review. The M45 FRR producer already ends in || true, which masks producer SIGPIPE, so source-faithful old and new present/absent statuses are identical. The synthetic unmasked-producer 141 proof was not representative of this script.

Review also found a separate boundary: the negated absence helper accepts an actual FRR query failure as withdrawal. That needs an explicit query-status contract in its own scoped change, not a no-op read-through conversion.

Linear: LAN-1045

## Validation performed

- exact source-faithful old/new status comparison
- bash syntax and warning-level ShellCheck
- cargo test --locked --test interop_topology_commands -- --nocapture
- git diff --check
- independent exact-head review