### PR TITLE
test(interop): make M93 grep checks read through

### DIFF
--- a/tests/interop/scripts/test-m93-required-families-bird.sh
+++ b/tests/interop/scripts/test-m93-required-families-bird.sh
@@ -40,7 +40,7 @@ wait_bird_established() {
     local label=${1:?}
     for i in $(seq 1 45); do
         if docker exec "$BIRD" birdc show protocols rustbgpd 2>/dev/null \
-            | grep -q Established; then
+            | grep Established >/dev/null; then
             ok "$label Established (attempt $i)"
             return 0
         fi
@@ -77,7 +77,7 @@ capture_has_exact_rejection() {
         -Y 'ip.src == 10.93.0.1 && bgp.type == 3' \
         -T fields -e tcp.payload 2>/dev/null \
         | tr -d ':\r' \
-        | grep -Fxq "$EXPECTED_NOTIFICATION"
+        | grep -Fx "$EXPECTED_NOTIFICATION" >/dev/null
 }
 
 main() {


### PR DESCRIPTION
## Summary

- make the live BIRD establishment probe and single-shot tshark rejection oracle read through their producers under pipefail
- preserve the BIRD command, tshark display filter, colon/CR normalization, and exact whole-line notification bytes
- leave capture timing, retries, polarity, messages, and common helpers unchanged

Linear: LAN-1045

## Validation

- bash syntax and ShellCheck
- deterministic long-producer proof: old BIRD present 141, new present 0, absence 1
- deterministic tshark/tr proof: old present pipeline 141/141/0, new present 0/0/0, absence 0/0/1
- cargo test --locked --test interop_tier_auth_rr -- --nocapture
- git diff --check
- commit and push hooks