### PR TITLE
refactor(config): reuse required-family resolution

### DIFF
--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -590,7 +590,7 @@ impl Config {
         Ok(f)
     }
 
-    fn resolved_required_families(
+    pub(super) fn resolved_required_families(
         neighbor: &Neighbor,
         group: Option<&PeerGroupConfig>,
     ) -> Result<Vec<(Afi, Safi)>, ConfigError> {

--- a/src/config/tests/families.rs
+++ b/src/config/tests/families.rs
@@ -646,8 +646,8 @@ disable_ipv4_unicast = true
 #[test]
 fn required_families_inherit_and_neighbor_nonempty_override_is_validated() {
     // Load-bearing: changing resolution to union/group-first makes the first
-    // peer inherit IPv6 despite its non-empty IPv4 override; removing subset
-    // validation lets the second, impossible peer load.
+    // peer inherit IPv6 despite its non-empty IPv4 override; skipping inherited
+    // resolution misses the second peer's IPv6 requirement.
     let valid = r#"
 [global]
 asn = 65001
@@ -664,14 +664,20 @@ address = "10.0.0.2"
 remote_asn = 65002
 peer_group = "fabric"
 required_families = ["ipv4_unicast"]
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65003
+peer_group = "fabric"
 "#;
     let config = parse(valid).unwrap();
+    let peers = config.to_peer_configs().unwrap();
     assert_eq!(
-        config.to_peer_configs().unwrap()[0]
-            .0
-            .peer
-            .required_families,
+        peers[0].0.peer.required_families,
         vec![(Afi::Ipv4, Safi::Unicast)]
+    );
+    assert_eq!(
+        peers[1].0.peer.required_families,
+        vec![(Afi::Ipv6, Safi::Unicast)]
     );
 
     let invalid = valid.replace(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -835,13 +835,7 @@ impl Config {
                 }
             }
 
-            let required_families = if !neighbor.required_families.is_empty() {
-                parse_families(&neighbor.required_families)?
-            } else if let Some(group) = group.filter(|g| !g.required_families.is_empty()) {
-                parse_families(&group.required_families)?
-            } else {
-                Vec::new()
-            };
+            let required_families = Self::resolved_required_families(neighbor, group)?;
             if !required_families.is_empty() {
                 let peer_addr: IpAddr = neighbor.address.parse().expect("validated above");
                 let mut effective = Self::resolved_families(neighbor, group, peer_addr)?;


### PR DESCRIPTION
## Summary

- reuse the canonical required_families precedence/parser during static-neighbor validation
- preserve neighbor override, peer-group inheritance, diagnostics, validation order, and effective-family checks
- strengthen the family contract with one explicit override peer and one inherited peer

Linear: LAN-1202

## Validation

- focused required_families regression
- full config family tests: 31 passed
- full config tests: 651 passed, 4 ignored
- strict rustbgpd Clippy with all targets and features
- v1 stable-surface inventory
- formatting, diff, commit, push, tests, and docs hooks