### PR TITLE
test(interop): make M26 grep checks read through

### DIFF
--- a/tests/interop/scripts/test-m26-cease-frr.sh
+++ b/tests/interop/scripts/test-m26-cease-frr.sh
@@ -119,7 +119,7 @@ inject_excess_prefix() {
         -c "address-family ipv4 unicast" \
         -c "network 10.10.0.0/16" >/dev/null 2>&1 || true
     if ! docker exec "$FRR" vtysh -c "show running-config" 2>/dev/null \
-        | grep -q '^  network 10\.10\.0\.0/16$'; then
+        | grep '^  network 10\.10\.0\.0/16$' >/dev/null; then
         fail "FRR did not install the third network statement"
         return 1
     fi
@@ -210,7 +210,7 @@ test_recovery_requires_removal_and_enable() {
         -c "address-family ipv4 unicast" \
         -c "no network 10.10.0.0/16" >/dev/null 2>&1 || true
     if docker exec "$FRR" vtysh -c "show running-config" 2>/dev/null \
-        | grep -q '^  network 10\.10\.0\.0/16$'; then
+        | grep '^  network 10\.10\.0\.0/16$' >/dev/null; then
         fail "FRR retained the third network statement after removal"
         return
     fi


### PR DESCRIPTION
## Summary

- make both live M26 FRR running-config verdict consumers read through their complete input
- preserve the exact producer commands, BRE patterns, branch polarity, messages, and recovery flow
- leave captured-input and non-verdict checks unchanged

Linear: LAN-1045

## Validation

- source-faithful long-writer proof: present status 141 before and 0 after; absent remains 1
- matching producer failure remains status 42
- bash syntax
- warning-level ShellCheck (only existing sourced-library SC2154 findings)
- repository commit and push hooks
- stable patch ID and byte-identical changed file after rebase onto current main