### PR TITLE
docs(operations): document BLACKHOLE metric lifecycle

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1419,9 +1419,16 @@ a snapshot or bounded history query.
 
 ### RFC 7999 BLACKHOLE discards
 
-`bgp_blackhole_discard_rejected_total{reason}` counts discard candidates
-withheld before kernel installation. The bounded reason is `broad_prefix` or
-`not_ebgp`; use `rbgp rib blackholes` for current per-prefix decision details.
+| Metric | What it tells you |
+|--------|-------------------|
+| `bgp_blackhole_discard_installed_total` | Successful kernel discard-route installation events |
+| `bgp_blackhole_discard_withdrawn_total` | Successful daemon-owned kernel discard-route removal events |
+| `bgp_blackhole_discard_adopted_total` | Startup adoption events for marker-matching kernel discard routes |
+| `bgp_blackhole_discard_reaped_total` | Post-startup cleanup events for adopted-but-unclaimed kernel discard routes |
+| `bgp_blackhole_discard_rejected_total{reason}` | Pre-install rejection events; `reason` is bounded to `broad_prefix` or `not_ebgp` |
+| `bgp_blackhole_discard_kernel_failures_total{action}` | Kernel-operation failure events; `action` is bounded to `setup`, `install`, `remove`, or `dump` |
+
+Use `rbgp rib blackholes` for the current per-prefix decision details.
 
 ### General Unicast FIB
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -58,8 +58,8 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 93)
         self.assertEqual(len(self.rule_refs), 39)
-        self.assertEqual(len(self.public_doc_refs), 176)
-        self.assertEqual(len(self.doc_refs), 176)
+        self.assertEqual(len(self.public_doc_refs), 178)
+        self.assertEqual(len(self.doc_refs), 178)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
         self.assertEqual(len(consumers), 183)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
@@ -73,8 +73,31 @@ class MetricConsumerContractTests(unittest.TestCase):
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
         self.assertIn("189 emitted families", stdout.getvalue())
-        self.assertIn("176 normative-doc families", stdout.getvalue())
+        self.assertIn("178 normative-doc families", stdout.getvalue())
         self.assertIn("183 consumed, 6 justified raw diagnostics", stdout.getvalue())
+
+    def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
+        prefix = "bgp_blackhole_discard_"
+        expected = {
+            "bgp_blackhole_discard_installed_total",
+            "bgp_blackhole_discard_withdrawn_total",
+            "bgp_blackhole_discard_adopted_total",
+            "bgp_blackhole_discard_reaped_total",
+            "bgp_blackhole_discard_rejected_total",
+            "bgp_blackhole_discard_kernel_failures_total",
+        }
+        registered = {name for name in self.inventory if name.startswith(prefix)}
+        self.assertEqual(registered, expected)
+
+        operations = (CHECK.ROOT / "docs/OPERATIONS.md").read_text(encoding="utf-8")
+        start = "### RFC 7999 BLACKHOLE discards"
+        end = "### General Unicast FIB"
+        self.assertEqual(operations.count(start), 1)
+        self.assertEqual(operations.count(end), 1)
+        section = operations.split(start, 1)[1].split(end, 1)[0]
+        for metric in registered:
+            with self.subTest(metric=metric):
+                self.assertEqual(section.count(metric), 1)
 
     def test_comments_literals_and_test_modules_are_not_definitions(self):
         source = r'''

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -95,7 +95,7 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(operations.count(start), 1)
         self.assertEqual(operations.count(end), 1)
         section = operations.split(start, 1)[1].split(end, 1)[0]
-        for metric in registered:
+        for metric in sorted(registered):
             with self.subTest(metric=metric):
                 self.assertEqual(section.count(metric), 1)
 


### PR DESCRIPTION
## Summary

- document all six shipped RFC 7999 BLACKHOLE metric families and their bounded labels
- distinguish successful lifecycle events, pre-install rejections, and kernel-operation failures
- bind the operations table to the exact registered metric inventory

Linear: LAN-1252

## Validation

- 28 metric-consumer contract tests
- metric-consumer audit: 189 emitted, 178 normative, 183 consumed, 6 justified raw
- public documentation tracker: 608 documents
- workspace formatting, Clippy, rustdoc, and diff checks
- stable patch ID and byte-identical changed files after rebase onto current main