### PR TITLE
refactor(config): reuse canonical peer-group lookup

### DIFF
--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -709,17 +709,7 @@ impl Config {
                 });
             }
 
-            let group = neighbor
-                .peer_group
-                .as_deref()
-                .map(|name| {
-                    self.peer_groups
-                        .get(name)
-                        .ok_or_else(|| ConfigError::UndefinedPeerGroup {
-                            name: name.to_string(),
-                        })
-                })
-                .transpose()?;
+            let group = self.peer_group_for_neighbor(neighbor)?;
 
             if let Some(tcp_ao) = &neighbor.tcp_ao {
                 if neighbor.md5_password.is_some() {


### PR DESCRIPTION
## Summary

- reuse the canonical static-neighbor peer-group lookup during validation
- preserve remote-ASN-before-group error ordering and the exact UndefinedPeerGroup payload
- remove duplicated lookup/error construction without changing public or schema behavior

Linear: LAN-1202

## Validation

- focused undefined-peer-group proof
- 58 neighbor-validation tests
- 651 config tests (4 ignored)
- 9 v1 stable-surface tests
- strict all-target/all-feature package Clippy
- full repository commit and push hooks
- stable patch ID and byte-identical changed file after rebase onto current main