### PR TITLE
test(interop): make M64 grep checks read through

### DIFF
--- a/tests/interop/scripts/test-m64-ipv6-only.sh
+++ b/tests/interop/scripts/test-m64-ipv6-only.sh
@@ -145,7 +145,7 @@ fi
 # FRR → rustbgpd
 got_v6=0
 for _ in $(seq 1 15); do
-    if grpc_routes_from_peer "$FRR_V6" | grep -q '"prefix": "2001:db8:64::"'; then
+    if grpc_routes_from_peer "$FRR_V6" | grep '"prefix": "2001:db8:64::"' >/dev/null; then
         got_v6=1
         break
     fi
@@ -198,7 +198,7 @@ fi
 # FRR → rustbgpd over the capability-less session
 got_v4=0
 for _ in $(seq 1 15); do
-    if grpc_routes_from_peer "$FRR_V4" | grep -q '"prefix": "10.99.1.0"'; then
+    if grpc_routes_from_peer "$FRR_V4" | grep '"prefix": "10.99.1.0"' >/dev/null; then
         got_v4=1
         break
     fi


### PR DESCRIPTION
## Summary

- make both live M64 gRPC route verdict consumers read through their complete input
- preserve the exact producers, BRE patterns, positive-retry polarity, timing, and messages
- leave captured-input and non-verdict checks unchanged

Linear: LAN-1045

## Validation

- source-faithful present/absent proof for both prefixes
- long matching output: status 141 before and 0 after
- genuine producer failure remains status 42
- bash syntax and warning-level ShellCheck
- three focused interop/CI contract tests
- full repository commit and push hooks
- stable patch ID and byte-identical changed file after rebase onto current main