### PR TITLE
test(interop): fail closed on M41 kernel snapshots

### DIFF
--- a/tests/interop/scripts/test-m41-blackhole-frr.sh
+++ b/tests/interop/scripts/test-m41-blackhole-frr.sh
@@ -152,12 +152,18 @@ wait_blackhole_status() {
     return 1
 }
 
+kernel_route_exact() {
+    local prefix=$1
+    docker exec "$RUSTBGPD" ip route show exact "$prefix"
+}
+
 wait_kernel_blackhole_route() {
     local prefix=$1
+    local route
     log "Waiting for kernel blackhole route $prefix..."
     for i in $(seq 1 30); do
-        if docker exec "$RUSTBGPD" ip route show exact "$prefix" \
-            | grep -Eq "^blackhole ${prefix%/*}"; then
+        if route=$(kernel_route_exact "$prefix") \
+            && printf '%s\n' "$route" | grep -E "^blackhole ${prefix%/*}" >/dev/null; then
             ok "$prefix installed as kernel blackhole route after ${i}s"
             return 0
         fi
@@ -170,7 +176,13 @@ wait_kernel_blackhole_route() {
 
 assert_no_kernel_route() {
     local prefix=$1
-    if docker exec "$RUSTBGPD" ip route show exact "$prefix" | grep -q .; then
+    local route
+    if ! route=$(kernel_route_exact "$prefix"); then
+        fail "could not observe $prefix in rustbgpd kernel FIB"
+        dump_state_on_failure
+        return 1
+    fi
+    if [ -n "$route" ]; then
         fail "$prefix unexpectedly present in rustbgpd kernel FIB"
         dump_state_on_failure
         return 1
@@ -180,11 +192,14 @@ assert_no_kernel_route() {
 
 wait_no_kernel_route() {
     local prefix=$1
+    local route
     log "Waiting for kernel route $prefix to be removed..."
     for i in $(seq 1 30); do
-        if ! docker exec "$RUSTBGPD" ip route show exact "$prefix" | grep -q .; then
-            ok "$prefix removed from rustbgpd kernel FIB after ${i}s"
-            return 0
+        if route=$(kernel_route_exact "$prefix"); then
+            if [ -z "$route" ]; then
+                ok "$prefix removed from rustbgpd kernel FIB after ${i}s"
+                return 0
+            fi
         fi
         sleep 1
     done


### PR DESCRIPTION
## Summary

- classify M41 kernel presence or absence only from successful captured snapshots
- make query failures fail or retry instead of passing absence checks
- keep diagnostic dumps best-effort and preserve the exact Docker/IP query, timing, call sites, and existing verdict messages

Linear: LAN-1282

## Validation

- baseline status-42 query failure reproduced false-success in both absence paths
- patched assertion truth table: absent 0, present 1, query failure 1
- patched poller truth table: absent 0, present/repeated failure 1, failure-then-absence 0
- long captured presence proof for read-through matching
- bash syntax and warning-level ShellCheck
- three focused contracts, diff checks, formatting, Clippy, rustdoc, and full rebase push hooks
- stable patch ID and byte-identical changed file after rebase onto current main