### PR TITLE
test(interop): make M27 status check read through

### DIFF
--- a/tests/interop/scripts/test-m27-aspa-rtr2.sh
+++ b/tests/interop/scripts/test-m27-aspa-rtr2.sh
@@ -51,7 +51,7 @@ start_rtr_server() {
 
     for i in $(seq 1 15); do
         if docker exec "$RTR_SERVER" sh -c 'cat /tmp/rtr-server-status.json 2>/dev/null' \
-            | grep -q '"listening": true'; then
+            | grep '"listening": true' >/dev/null; then
             ok "RTR v2 server is listening (attempt $i)"
             return 0
         fi


### PR DESCRIPTION
## Summary

- make the live M27 RTR-server readiness consumer read through its complete input
- preserve the exact docker/cat producer, BRE pattern, positive-retry polarity, 15x1s timing, and messages
- leave captured log/status checks unchanged

Linear: LAN-1045

## Validation

- source-faithful present, absent, long-output, and producer-failure proof
- bash syntax and warning-level ShellCheck
- focused interop/CI contracts
- repository formatting, Clippy, tests, rustdoc, and push hooks
- clean exact current-main branch with stable patch ID 25f7c122