### PR TITLE
docs(transport): explain rejected-route completeness

### DIFF
--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -44,8 +44,14 @@ before forwarding to the RIB — the FSM sees only payloadless events.
 - **Rejected-route retention** — a bounded per-session store of
   import-rejected routes with canonical reject reasons, backing
   `PolicyService.ListRejectedRoutes` / `rbgp rib received <peer>
-  --rejected` (`[policy.reject_retention]`); diagnostic state only,
-  resets on session reset
+  --rejected` (`[policy.reject_retention]`). **On by default:**
+  `TransportConfig::reject_retention_enabled` defaults to `true`, unlike the
+  opt-in import-explain cache above. The `ListRejectedRoutes` reply reports
+  `enabled`, `capacity`, and `evictions_since_reset`; `enabled = false` makes
+  an empty result a configuration fact, zero evictions proves no retained
+  rejection was displaced by capacity since the session reset, and a nonzero
+  count means the bounded listing may be incomplete. Entries and the eviction
+  count are diagnostic state and reset with the session.
 - **Private AS removal** — strip/replace private ASNs before eBGP export
 - **Route server transparency** — preserve original NEXT_HOP and skip
   local ASN prepend for route-server clients

--- a/crates/transport/src/session/tests/reject_retention.rs
+++ b/crates/transport/src/session/tests/reject_retention.rs
@@ -533,6 +533,38 @@ async fn session_down_flushes_reject_retention_and_gauge() {
     assert_eq!(session.rejected_routes.evictions_since_reset(), 0);
 }
 
+/// The crate README must expose the current completeness contract in
+/// the one bounded feature bullet operators and embedders will read.
+#[test]
+fn transport_readme_pins_rejected_route_retention_completeness() {
+    const README: &str = include_str!("../../../README.md");
+    const START: &str = "- **Rejected-route retention**";
+    const END: &str = "- **Private AS removal**";
+
+    assert_eq!(README.matches(START).count(), 1, "unique section start");
+    assert_eq!(README.matches(END).count(), 1, "unique section end");
+    let start = README.find(START).expect("rejected-route retention bullet");
+    let relative_end = README[start..]
+        .find(END)
+        .expect("private-AS bullet follows rejected-route retention");
+    let section = README[start..start + relative_end]
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    for clause in [
+        "**On by default:** `TransportConfig::reject_retention_enabled` defaults to `true`",
+        "unlike the opt-in import-explain cache above",
+        "The `ListRejectedRoutes` reply reports `enabled`, `capacity`, and `evictions_since_reset`",
+        "`enabled = false` makes an empty result a configuration fact",
+        "zero evictions proves no retained rejection was displaced by capacity since the session reset",
+        "a nonzero count means the bounded listing may be incomplete",
+        "Entries and the eviction count are diagnostic state and reset with the session",
+    ] {
+        assert!(section.contains(clause), "missing README clause: {clause}");
+    }
+}
+
 /// LAN-472 pin: the `ListRejectedRoutes` session command returns the
 /// retained entries (sorted by key) with the enabled flag and the
 /// configured capacity, and is a read — it must not move the
@@ -553,14 +585,19 @@ async fn list_rejected_routes_command_returns_sorted_snapshot() {
         .handle_command(PeerCommand::ListRejectedRoutes { reply: reply_tx })
         .await;
     assert_eq!(flow, ControlFlow::Continue(()));
-    let reply = reply_rx.await.expect("session replied");
-    assert!(reply.enabled);
+    let super::rejected_routes::RejectedRoutesReply {
+        enabled,
+        capacity,
+        evictions_since_reset,
+        entries,
+    } = reply_rx.await.expect("session replied");
+    assert!(enabled);
     assert_eq!(
-        reply.capacity,
+        capacity,
         super::rejected_routes::DEFAULT_REJECT_RETENTION_CAPACITY
     );
-    assert_eq!(reply.evictions_since_reset, 0);
-    let keys: Vec<RetentionKey> = reply.entries.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(evictions_since_reset, 0);
+    let keys: Vec<RetentionKey> = entries.iter().map(|(k, _)| k.clone()).collect();
     assert_eq!(
         keys,
         vec![retention_key(b), retention_key(a)],


### PR DESCRIPTION
## Summary

- document that rejected-route retention is default-on while import-explain remains opt-in
- define the exact reply completeness signals and session-reset boundary
- pin the bounded README contract and exhaustively destructure the live reply fields

## Validation

- focused README contract and live reply tests
- 12 rejected-retention tests
- full transport suite: 526 passed, 3 kernel-dependent ignored
- strict transport Clippy and rustdoc
- public tracker: 18 tests and 608-document scan
- full pre-commit and pre-push hooks

Linear: LAN-1252