### PR TITLE
test(interop): make M30 IMET check read through

### DIFF
--- a/tests/interop/scripts/test-m30-evpn-type2-frr.sh
+++ b/tests/interop/scripts/test-m30-evpn-type2-frr.sh
@@ -126,7 +126,7 @@ log "[test] VTEP-B receives VTEP-A's Type 3 IMET"
 imet_seen=0
 for _ in $(seq 1 15); do
     if docker exec "$VTEP_B" vtysh -c "show bgp l2vpn evpn route type multicast json" 2>/dev/null \
-        | grep -q "$VTEP_A_IP"; then
+        | grep "$VTEP_A_IP" >/dev/null; then
         imet_seen=1
         break
     fi


### PR DESCRIPTION
## Summary

- make the live M30 FRR Type-3 IMET poll consume its complete producer output under pipefail
- preserve the exact producer, BRE, positive polarity, retry timing, messages, and call site
- leave coupled positive/negated MAC helpers and captured checks unchanged

## Validation

- deterministic producer matrix: present 0→0, absent 1→1, long match-first 141→0, matched producer failure 42→42
- exact source loop: old exhausts 15 sleeps; patched succeeds immediately
- bash syntax and warning-level ShellCheck (only unchanged base SC2034)
- three focused primer/classifier contracts
- full formatting, Clippy, workspace tests, rustdoc, and push hooks

Linear: LAN-1045