### PR TITLE
refactor(config): reuse canonical BFD group lookup

### DIFF
--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -3222,15 +3222,11 @@ fn validate_bfd(config: &Config) -> Result<(), ConfigError> {
         // Effective BFD = own block, else inherited from the peer group; a
         // disabled (`enabled = false`) block runs no session, so it does not
         // count.
-        let effective_bfd = if neighbor.bfd.is_some() {
-            neighbor.bfd.as_ref()
-        } else {
-            neighbor
-                .peer_group
-                .as_ref()
-                .and_then(|g| config.peer_groups.get(g))
-                .and_then(|pg| pg.bfd.as_ref())
-        };
+        let group = config.peer_group_for_neighbor(neighbor)?;
+        let effective_bfd = neighbor
+            .bfd
+            .as_ref()
+            .or_else(|| group.and_then(|group| group.bfd.as_ref()));
         let has_effective_bfd = effective_bfd.is_some_and(|b| b.enabled);
         if has_effective_bfd && is_ipv6_link_local(&neighbor.address) {
             return Err(ConfigError::InvalidBfd {


### PR DESCRIPTION
## Summary

- reuse the canonical peer-group resolver in effective BFD validation
- preserve inline BFD precedence, including enabled=false suppressing inherited BFD
- keep undefined-group and profile/link-local diagnostic ordering unchanged

## Validation

- four focused BFD precedence and error-order proofs
- locked workspace and rustbgpd package test suites
- strict all-target/all-feature Clippy and warning-free rustdoc
- v1 stable-surface inventory, formatting, diff checks, and full hooks
- exact-current-main rebase retained stable patch ID and byte-identical changed-file blob

Linear: LAN-1202