### PR TITLE
docs(rpki): explain the expire ceiling

### DIFF
--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -13,7 +13,12 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 - **RTR client** (RFC 8210 / draft-ietf-sidrops-8210bis) — prefers RTR
   protocol v2 for ASPA, falls back to v1 on server rejection; persistent TCP
   sessions, Serial Query / Reset Query, Serial Notify handling,
-  expire_interval enforcement
+  `expire_interval` enforcement. `RtrClientConfig::max_expire_interval` adds an
+  optional operator freshness ceiling: it clamps both the configured
+  `expire_interval` and a cache-advertised End of Data expire down, never raises
+  a lower value, and when unset leaves the configured interval unchanged while
+  cache-advertised values retain the protocol ceiling. The crate exports the
+  RFC 8210 two-day ceiling as `RTR_EXPIRE_MAX_SECS` (`172800` seconds).
 - **ASPA path verification** — ASPA table + AS_PATH verification per
   draft-ietf-sidrops-aspa-verification (§6.2), fed over RTR v2
 - **Multi-cache merge** — `VrpManager` combines VRPs from multiple cache

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -3353,6 +3353,43 @@ mod tests {
         let _ = client_handle.await;
     }
 
+    /// The crate README keeps the operator freshness contract in its
+    /// one bounded RTR-client feature bullet, with the numeric ceiling
+    /// derived from the production protocol constant.
+    #[test]
+    fn rpki_readme_pins_operator_expire_ceiling() {
+        const README: &str = include_str!("../README.md");
+        const START: &str = "- **RTR client**";
+        const END: &str = "- **ASPA path verification**";
+
+        assert_eq!(README.matches(START).count(), 1, "unique section start");
+        assert_eq!(README.matches(END).count(), 1, "unique section end");
+        let start = README.find(START).expect("RTR client bullet");
+        let relative_end = README[start..]
+            .find(END)
+            .expect("ASPA path-verification bullet follows RTR client");
+        let section = README[start..start + relative_end]
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        for clause in [
+            "`RtrClientConfig::max_expire_interval` adds an optional operator freshness ceiling",
+            "it clamps both the configured `expire_interval` and a cache-advertised End of Data expire down",
+            "never raises a lower value",
+            "when unset leaves the configured interval unchanged while cache-advertised values retain the protocol ceiling",
+        ] {
+            assert!(section.contains(clause), "missing README clause: {clause}");
+        }
+        let ceiling = format!(
+            "The crate exports the RFC 8210 two-day ceiling as `RTR_EXPIRE_MAX_SECS` (`{EXPIRE_MAX_SECS}` seconds)."
+        );
+        assert!(
+            section.contains(&ceiling),
+            "missing README clause: {ceiling}"
+        );
+    }
+
     /// `max_expire_interval` caps the configured expire at construction
     /// and the cache-advertised expire at End of Data, never raises a
     /// lower one, and — being an expire like any other — drags


### PR DESCRIPTION
## Summary

- document the crate-level max_expire_interval downward-clamp semantics
- distinguish unchanged configured timing from the RFC cap on cache-advertised values when unset
- pin the public RTR_EXPIRE_MAX_SECS value through a production-derived bounded README contract

## Validation

- focused README contract and two existing operator-ceiling runtime tests
- full RPKI suite: 162 tests
- strict RPKI Clippy and rustdoc
- public tracker: 18 tests and 608-document scan
- formatting, diff checks, and full hooks
- root source review corrected the unset-constructor wording before promotion

Linear: LAN-1252