### PR TITLE
test(interop): make M86 neighbor check read through

### DIFF
--- a/tests/interop/scripts/test-m86-rr-openbgpd.sh
+++ b/tests/interop/scripts/test-m86-rr-openbgpd.sh
@@ -78,7 +78,7 @@ wait_obgp_established() {
     log "Waiting for $label BGP session to reach Established..."
     for i in $(seq 1 45); do
         if docker exec "$container" bgpctl show neighbor "$rr_addr" 2>/dev/null \
-            | grep -q "BGP state = Established"; then
+            | grep "BGP state = Established" >/dev/null; then
             ok "$label session Established (attempt $i)"
             return 0
         fi


### PR DESCRIPTION
## Summary

- make the live OpenBGPD establishment helper consume complete bgpctl output under pipefail
- preserve the exact producer, BRE, positive polarity, 45×2s timing, messages, and all three call sites
- leave captured capability/neighbor checks and multi-stage pipelines unchanged

## Validation

- producer matrix: present 0→0, absent 1→1, long match-first 141→0, matched producer failure 42→42
- exact source-function matrix covers immediate success, absence, long output, transient genuine failure, and repeated genuine failure
- bash syntax, warning-level ShellCheck (only unchanged base SC2154), and built-in diagnostics
- three focused primer/classifier contracts
- full formatting, Clippy, workspace library tests, rustdoc, diff checks, and hooks

Linear: LAN-1045