### PR TITLE
docs(bfd): document RFC 5882 coupling

### DIFF
--- a/crates/bfd/README.md
+++ b/crates/bfd/README.md
@@ -35,6 +35,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 |-----|----------|
 | RFC 5880 | Control-packet format (§4.1) and the async session state machine (§6.8), including the slow-while-not-Up transmit floor (§6.8.3), detection time (§6.8.4), reception/FSM (§6.8.6), and AdminDown teardown (§6.8.16). |
 | RFC 5881 | Single-hop encapsulation context (UDP/3784, TTL/Hop-Limit 255). The TTL check and the sockets themselves live in the daemon actor, not this crate. |
+| RFC 5882 | BFD-client/BGP coupling (§3.2, §4.1/§4.2): `Session::remote_admin_down()` distinguishes a peer's administrative disable from a genuine liveness failure. Cause-only flips emit `Action::StateChanged` even when the local state remains `Down`, so callers can permit BGP during remote `AdminDown` without hiding a later remote `Down` or detection timeout. |
 
 ## Design
 

--- a/crates/bfd/src/session.rs
+++ b/crates/bfd/src/session.rs
@@ -702,6 +702,42 @@ mod tests {
         })
     }
 
+    /// The crate README keeps the maintenance-versus-liveness contract in
+    /// its bounded RFC-reference table and names the public cause accessor.
+    #[test]
+    fn bfd_readme_pins_rfc5882_coupling_contract() {
+        const README: &str = include_str!("../README.md");
+        const START: &str = "## RFC references";
+        const END: &str = "## Design";
+
+        let _: fn(&Session) -> bool = Session::remote_admin_down;
+        assert_eq!(README.matches(START).count(), 1, "unique section start");
+        assert_eq!(README.matches(END).count(), 1, "unique section end");
+        let start = README.find(START).expect("RFC-reference section");
+        let relative_end = README[start..]
+            .find(END)
+            .expect("Design section follows RFC references");
+        let section = README[start..start + relative_end]
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert_eq!(
+            section.matches("| RFC 5882 |").count(),
+            1,
+            "exactly one RFC 5882 coverage row"
+        );
+        for clause in [
+            "BFD-client/BGP coupling (§3.2, §4.1/§4.2)",
+            "`Session::remote_admin_down()` distinguishes a peer's administrative disable from a genuine liveness failure",
+            "Cause-only flips emit `Action::StateChanged` even when the local state remains `Down`",
+            "callers can permit BGP during remote `AdminDown`",
+            "without hiding a later remote `Down` or detection timeout",
+        ] {
+            assert!(section.contains(clause), "missing README clause: {clause}");
+        }
+    }
+
     #[test]
     fn remote_admin_down_flip_while_down_is_published() {
         // Local goes Down via detection timeout: a genuine liveness failure.


### PR DESCRIPTION
## Summary

- document the shipped maintenance-versus-liveness coupling contract in the BFD crate RFC table
- distinguish RFC 5882 §3.2 cause semantics from §4.1/§4.2 adjacency permission and reaction
- pin the exact row with a uniquely bounded contract that compile-binds Session::remote_admin_down

## Validation

- verified section mapping against the RFC Editor publication
- focused README contract and existing cause-transition behavior test
- full BFD suite: 28 tests
- strict BFD Clippy and rustdoc
- public tracker: 18 tests and 608-document scan
- formatting, diff checks, and full hooks

Linear: LAN-1252