### PR TITLE
test(interop): make M39b Type-5 poll read through

### DIFF
--- a/tests/interop/scripts/test-m39b-evpn-auto-rt-frr.sh
+++ b/tests/interop/scripts/test-m39b-evpn-auto-rt-frr.sh
@@ -74,7 +74,7 @@ wait_frr_sees_type5() {
     local attempts=$((timeout / 2))
     for _ in $(seq 1 "$attempts"); do
         if docker exec "$PE2" vtysh -c "show bgp l2vpn evpn route type prefix json" 2>/dev/null \
-            | grep -q "\\[5\\]:\\[0\\]:\\[$plen\\]:\\[$host\\]"; then
+            | grep "\\[5\\]:\\[0\\]:\\[$plen\\]:\\[$host\\]" >/dev/null; then
             return 0
         fi
         sleep 2


### PR DESCRIPTION
## Summary

- make the live M39b FRR Type-5 poll consume its complete producer output under pipefail
- preserve the exact producer, BRE, positive polarity, 30×2s timing, messages, caller, and diagnostic dump
- leave every other consumer unchanged

## Validation

- producer matrix: present 0→0, absent 1→1, long match-first 141→0, matched producer failure 42→42
- exact source-function matrix covers present, absence, long output, transient failure, and repeated failure with preserved sleep counts
- bash syntax and warning-level ShellCheck with zero findings
- three focused primer/classifier contracts
- full formatting, Clippy, workspace library tests, rustdoc, diff checks, and hooks

Linear: LAN-1045