### PR TITLE
test(interop): make M77 RTC poll read through

### DIFF
--- a/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
+++ b/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
@@ -250,7 +250,7 @@ wait_default_rtc_accepted() {
     local container=${1:?} rr=${2:?} label=${3:?}
     log "Waiting for $label to accept the RR's default RTC NLRI..."
     for i in $(seq 1 30); do
-        if gobgp "$container" neighbor "$rr" adj-in -a rtc | grep -qi "default"; then
+        if gobgp "$container" neighbor "$rr" adj-in -a rtc | grep -i "default" >/dev/null; then
             ok "$label accepted the RR's default RTC NLRI (attempt $i)"
             return 0
         fi


### PR DESCRIPTION
## Summary

- make the live M77 GoBGP default-RTC poll consume its complete Adj-RIB-In output under pipefail
- preserve the wrapper/producer, case-insensitive BRE, positive polarity, 30×2s timing, messages, both call sites, and diagnostic dump
- leave every other consumer unchanged

## Validation

- producer matrix: present 0→0, absent 1→1, long match-first 141→0, matched producer failure 42→42
- exact source-function matrix covers present, absence, long output, transient failure, and repeated failure with preserved sleeps/messages
- bash syntax and warning-level ShellCheck (only unchanged base sourced-symbol findings)
- three focused primer/classifier contracts
- full formatting, Clippy, workspace library tests, rustdoc, diff checks, and hooks

Linear: LAN-1045