### PR TITLE
refactor(api): keep unbounded settlement wait test-only

### DIFF
--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -1304,9 +1304,9 @@ impl RuntimeConfigSettlementWatchdog {
         }
     }
 
-    /// Block the calling OS thread until every clean registration settles.
-    /// Ambiguous ownership deliberately never unregisters; its fail-stop wins.
-    pub fn wait_until_idle(&self) {
+    /// Unbounded test-only wait for focused condition-variable settlement proofs.
+    #[cfg(test)]
+    fn wait_until_idle(&self) {
         let mut idle = self
             .registry
             .idle_lock


### PR DESCRIPTION
## Summary

- compile the retired unbounded settlement wait only in unit tests
- make the helper private and document its focused condition-variable proof role
- leave the bounded fail-stop production method, sole production caller, metrics, schemas, and tests unchanged

## Validation

- both focused settlement proofs, process-exit integration, and production coordinator inventory
- release rustbgpd-api check
- full API suite: 676 unit tests plus exit integration
- full workspace tests and doctests
- strict workspace Clippy, warning-free rustdoc, and v1 stable-surface inventory
- formatting, diff checks, and full hooks
- exact-current-main rebase retained stable patch ID and byte-identical blob

Linear: LAN-1279