### PR TITLE
test(interop): make M66 reload poll read through

### DIFF
--- a/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
+++ b/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
@@ -434,7 +434,7 @@ docker exec "$PE1" sh -c 'kill -HUP "$(cat /var/run/rustbgpd.pid)"' \
 
 reload_applied=0
 for _ in $(seq 1 30); do
-    if pe_ctl "$PE1" evpn instances 2>/dev/null | grep -qE "vni=200( |$)"; then
+    if pe_ctl "$PE1" evpn instances 2>/dev/null | grep -E "vni=200( |$)" >/dev/null; then
         reload_applied=1
         break
     fi


### PR DESCRIPTION
## Summary

- make the M66 EVPN instance reload poll read the complete `grep -E` input
- preserve the original match expression, producer status, retry count, timing, and failure reporting
- prevent an early consumer exit from surfacing as a false poll result under `pipefail`

## Validation

- `bash -n tests/interop/scripts/test-m66-evpn-es-drain-handover.sh`
- focused present, absent, long-output, and producer-failure proof matrices
- focused primer and classifier checks
- strict workspace formatting, Clippy, tests, and rustdoc
- repository pre-commit and pre-push hooks