### PR TITLE
test(interop): make M30b Type-5 poll read through

### DIFF
--- a/tests/interop/scripts/test-m30b-evpn-type5-frr.sh
+++ b/tests/interop/scripts/test-m30b-evpn-type5-frr.sh
@@ -59,7 +59,7 @@ wait_frr_type5_originated() {
     local attempts=$((timeout / 2))
     for _ in $(seq 1 "$attempts"); do
         if docker exec "$VTEP_A" vtysh -c "show bgp l2vpn evpn route type prefix json" 2>/dev/null \
-            | grep -q "\\[5\\]:\\[0\\]:\\[32\\]:\\[$TENANT_HOST\\]"; then
+            | grep "\\[5\\]:\\[0\\]:\\[32\\]:\\[$TENANT_HOST\\]" >/dev/null; then
             return 0
         fi
         sleep 2


### PR DESCRIPTION
## Summary

- make the M30b FRR Type-5 origination poll read the complete producer output
- preserve the exact vtysh producer, BRE pattern, positive polarity, 30-by-two-second timing, messages, and diagnostics
- prevent early consumer exit from turning long valid output into false retries under `pipefail`

## Validation

- shell syntax and warning-level ShellCheck
- source-faithful present, absent, long-output, and producer-failure proof matrices
- focused Primer and conservative path-classifier contracts
- strict workspace formatting, Clippy, library tests, and rustdoc
- repository pre-commit and pre-push hooks