### PR TITLE
docs(evpn): remove stale L3 proof counts

### DIFF
--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -383,11 +383,11 @@ landing, tracked here for visibility)
     diffing only against `L3OwnedState`, never the kernel dump.
     Shutdown drain (`reconcile::drain`) computes
     `compute_l3_diff` against empty intent so the L3 ownership
-    state unwinds before exit. 12 unit tests in `l3_diff.rs`
-    cover cold start, refcount, shape change, value drift,
-    Router MAC conflict, partial-success cleanup, failed-remove
-    retry, NotReady drain, idempotent record, and route-event
-    wakeup behavior. Three privileged netns integration tests at
+    state unwinds before exit. Unit tests in `l3_diff.rs` cover
+    cold start, refcount, shape change, value drift, Router MAC
+    conflict, partial-success cleanup, failed-remove retry,
+    NotReady drain, idempotent record, and route-event wakeup
+    behavior. Privileged netns integration tests at
     `crates/evpn-linux/tests/netns_l3_install.rs` (gated on
     `EVPN_LINUX_NETNS=1`) re-exec the process inside an `ip
     netns` and assert kernel `ip route show table`, `ip neigh

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -707,8 +707,8 @@ for the architectural record.
   forwarding-safe across transitions; Router MAC conflicts drop
   conflicting prefixes with `L3Drop::RouterMacConflict`;
   foreign state preservation is enforced by diffing only
-  against `L3OwnedState`. Validated by 12 unit tests in
-  `crates/evpn-linux/src/l3_diff.rs` and three privileged netns
+  against `L3OwnedState`. Validated by unit tests in
+  `crates/evpn-linux/src/l3_diff.rs` and privileged netns
   integration tests at `crates/evpn-linux/tests/netns_l3_install.rs`
   (gated on `EVPN_LINUX_NETNS=1`) against Linux 6.17, including
   foreign-route preservation and route-event wakeup. **M39 containerlab smoke**
@@ -1097,8 +1097,8 @@ to the plain capability they delivered.
   apply ordering (route-remove → resolution-add → route-add → resolution-remove)
   keeps the kernel forwarding-safe across transitions; Router MAC conflicts drop
   conflicting prefixes with `L3Drop::RouterMacConflict`; foreign state is
-  preserved by diffing only against `L3OwnedState`. 11 unit tests in
-  `l3_diff.rs` and two privileged netns integration tests validate kernel
+  preserved by diffing only against `L3OwnedState`. Unit tests in `l3_diff.rs`
+  and privileged netns integration tests validate kernel
   programming against Linux 6.17. M39 hosted kernel-dataplane smoke validates the
   bidirectional symmetric IRB datapath against FRR 10.3.1.
 - **EVPN aliasing dataplane ECMP via FDB nexthop groups** (v0.19.0–v0.20.0,


### PR DESCRIPTION
## Summary

- remove historical numeric test counts from three Gate 9 L3 proof narratives
- preserve the concrete proof paths, covered behaviors, kernel boundary, and delivery history
- avoid recurring documentation drift as the shipped test suites continue growing

## Validation

- live inventory: 17 `l3_diff` unit tests and six privileged L3 netns tests
- focused stale-count absence check
- public tracker, metric-consumer, IXP docs, release-checklist, embedding-version, and crate-map contract suites
- 608-document public scan
- workspace formatting, diff checks, pre-commit hooks, and pre-push rustdoc