### PR TITLE
docs(evpn): mark later-shipped Gate non-goals

### DIFF
--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -935,7 +935,9 @@ did not take on:
 - VTEP mode (landed across Gates 7a/7b/7b+1/7b+2/7c)
 - DF election execution (landed in Gate 8; enforcement alpha in Gate 8b)
 - Symmetric Interface-less IRB semantics (Gate 9, v0.18.0 — end-to-end shipped)
-- Auto-derivation of Route Targets
+- Auto-derivation of Route Targets (landed later as
+  `auto_derive_route_target` for both `[[evpn_instances]]` and
+  `[[evpn_ip_vrfs]]`; see [CONFIGURATION.md](CONFIGURATION.md))
 - PBB-EVPN (RFC 7623)
 - Multicast EVPN / MVPN (including RFC 9251 IGMP/MLD proxy routes)
 - MPLS encapsulation
@@ -943,7 +945,9 @@ did not take on:
   [CONFIGURATION.md — Match conditions](CONFIGURATION.md#match-conditions))
 - `match_vni` / `match_mac` policy clauses (Phase 1.5 nicety, not
   blocking)
-- EVPN MRT dump
+- EVPN MRT dump (landed later; snapshots encode L2VPN/EVPN routes as
+  `RIB_GENERIC` subtype 6; see
+  [`crates/mrt/README.md`](../crates/mrt/README.md))
 - EVPN BMP export (wire records already pass through, but no typed
   extraction in BMP message generation)
 


### PR DESCRIPTION
## Summary

- annotate the original Gate 1–6 non-goals that later shipped
- point Route Target auto-derivation to both current configuration surfaces
- describe EVPN MRT snapshots with the shipped L2VPN/EVPN `RIB_GENERIC` subtype and authoritative crate documentation

## Validation

- nine Route Target auto-derivation behavior and reload tests
- full `rustbgpd-mrt` suite, including Type 2 and Type 5 `RIB_GENERIC` encoding
- embedding-version, crate-map, metric-consumer, public-tracker, IXP-doc, and release-path contracts
- 608-document public scan
- workspace formatting, diff checks, pre-commit hooks, and pre-push rustdoc