### PR TITLE
test(interop): make M59 RTR startup poll read through

### DIFF
--- a/tests/interop/scripts/test-m59-aspa-roles.sh
+++ b/tests/interop/scripts/test-m59-aspa-roles.sh
@@ -41,7 +41,7 @@ start_rtr_server() {
     docker exec -d "$RTR_SERVER" python3 /usr/local/bin/rtr-v2-server-m59.py
     for i in $(seq 1 15); do
         if docker exec "$RTR_SERVER" sh -c 'cat /tmp/rtr-server-status.json 2>/dev/null' \
-            | grep -q '"listening": true'; then
+            | grep '"listening": true' >/dev/null; then
             ok "RTR v2 server is listening (attempt $i)"
             return 0
         fi


### PR DESCRIPTION
## Summary

- make the M59 RTR v2 startup poll read the complete status payload
- preserve the exact container producer, BRE match, positive polarity, 15-by-one-second timing, messages, and caller
- prevent early consumer exit from turning long valid status output into a false startup timeout under `pipefail`

## Validation

- shell syntax and warning-level ShellCheck
- source-faithful present, absent, long-output, and producer-failure proof matrices
- focused Primer and conservative path-classifier contracts
- strict workspace formatting, Clippy, library tests, and rustdoc
- repository pre-commit and pre-push hooks