### PR TITLE
docs(evpn): correct leaf diff operand order

### DIFF
--- a/examples/evpn-vtep-leaf/README.md
+++ b/examples/evpn-vtep-leaf/README.md
@@ -39,8 +39,8 @@ see [`../rr-evpn-fabric/`](../rr-evpn-fabric/).
 # uniqueness invariants without starting the daemon.
 rustbgpd --check --strict examples/evpn-vtep-leaf/config.toml
 
-# Preview against another config.
-rustbgpd --diff examples/rr-evpn-fabric/config.toml \
+# Preview what SIGHUP would change if a candidate replaced this leaf config.
+rustbgpd --diff /path/to/candidate.toml \
                 examples/evpn-vtep-leaf/config.toml
 ```
 


### PR DESCRIPTION
## Summary

- make the EVPN leaf example pass the candidate configuration through `--diff PATH`
- keep the current leaf configuration as the positional base loaded by the daemon
- describe the preview in the same candidate-replaces-current terms used by SIGHUP

## Validation

- six CLI invocation tests
- four strict example-configuration tests
- complete public and embedding documentation contract matrix
- 608-document public tracker scan
- workspace formatting, Clippy, rustdoc, diff checks, and all hooks