### PR TITLE
test(interop): make M95 BIRD poll read through

### DIFF
--- a/tests/interop/scripts/test-m95-rfc8212-presence.sh
+++ b/tests/interop/scripts/test-m95-rfc8212-presence.sh
@@ -239,7 +239,7 @@ log "Waiting for the BIRD session to reach Established..."
 bird_up=0
 for i in $(seq 1 45); do
     if docker exec "$BIRD" birdc show protocols edge 2>/dev/null \
-        | grep -q Established; then
+        | grep Established >/dev/null; then
         ok "rustbgpd <-> BIRD session established (attempt $i)"
         bird_up=1
         break


### PR DESCRIPTION
## Summary

- make the M95 BIRD establishment poll read the complete protocol output
- preserve the exact birdc producer, BRE match, positive polarity, 45-by-two-second timing, messages, summary, and diagnostic dump
- prevent early consumer exit from turning long valid output into a false session timeout under `pipefail`

## Validation

- shell syntax and warning-level ShellCheck
- source-faithful present, absent, long-output, and producer-failure proof matrices
- focused Primer and conservative path-classifier contracts
- strict workspace formatting, Clippy, library tests, and rustdoc
- repository pre-commit and pre-push hooks