### PR TITLE
docs(crates): true up public API surfaces

### DIFF
--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -21,12 +21,20 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 | **EvpnService** | EVPN runtime read + L2VNI / next-hop / IP-VRF queries, duplicate-MAC quarantine clear, and the mutating `ApplyEvpnRuntime` (no longer read-only) |
 | **gnmi.gNMI** | OpenConfig gNMI: read-only telemetry (Capabilities/Get/Subscribe) plus a transaction-backed Set subset |
 
+The crate also provides the device-initiated
+`gnmi_dialout::DialoutManager`, which publishes configured gNMI subscriptions
+to external collectors and reports per-target connection state through
+`gnmi_dialout_connected{target}`.
+
 See [docs/API.md](../../docs/API.md) for the full RPC reference and examples.
 
 ## Proto
 
-Protocol buffer definitions are in [proto/rustbgpd.proto](../../proto/rustbgpd.proto).
-Code generation runs via `tonic-build` in `build.rs`.
+Protocol buffer definitions live under [proto/](../../proto/):
+`rustbgpd.proto` defines the eleven native services,
+`rustbgpd_dialout.proto` defines the gNMI dial-out publish stream, and the
+vendored OpenConfig `gnmi.proto` / `gnmi_ext.proto` define the gNMI service,
+messages, and extensions. Code generation runs from `build.rs`.
 
 ## License
 

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -20,11 +20,13 @@ one SQLite transaction, and serves cursor-based replay through the
 
 - `lib.rs` — public API. `EventHistoryManager`, `EventHistoryConfig`,
   `EventEnvelope`, `CommittedEvent`, `EventHistorySender`,
-  `Category`, `Severity`, `PayloadCodec`, `EnvelopePeers`, plus the
-  shared `EhmState` and the async actor loop (`run_actor`). It also
+  `EventHistoryHandle`, `SynchronousMode`, `Category`, `Severity`,
+  `PayloadCodec`, `EnvelopePeers`, plus the shared `EhmState` and the
+  crate-private async actor loop (`run_actor`). It also
   re-exports `EventSubscription` / `EventSubscriptionItem` /
   `SubscribeFilter` / `SubscribeRequest` / `SubscribeStats` /
-  `SubscribeStatsSnapshot` from `cursor.rs`.
+  `SubscribeStatsSnapshot` from `cursor.rs`, and `PersistedEvent` /
+  `QueryFilter` / `RetentionOutcome` from `storage.rs`.
 - `storage.rs` — the `spawn_blocking` boundary. Owns the rusqlite
   `Connection` on a dedicated thread; processes batches via an
   internal channel. Sole owner of the live `Connection`:

--- a/crates/rib/README.md
+++ b/crates/rib/README.md
@@ -34,7 +34,7 @@ Single-task ownership — `RibManager` runs as one tokio task with no
 ## Key types
 
 - **`RibManager`** — event loop processing `RibUpdate` messages
-- **`AdjRibIn`** — per-peer inbound route table
+- **`adj_rib_in::AdjRibIn`** — per-peer inbound route table
 - **`Route`** — prefix + attributes + metadata (path_id, validation_state, stale flags)
 - **`best_path_cmp()`** — standalone comparison function (not `Ord` on `Route`)
 

--- a/crates/rib/README.md
+++ b/crates/rib/README.md
@@ -26,6 +26,16 @@ Single-task ownership — `RibManager` runs as one tokio task with no
   held at the cap without withdrawing existing routes or resetting the
   session (ADR-0113)
 - **FlowSpec** — parallel storage for FlowSpec rules (SAFI 133)
+- **VPN, labeled-unicast, and RT-Constrain** — parallel storage and
+  distribution for VPNv4/VPNv6 (SAFI 128), labeled-unicast (SAFI 4), and
+  RT-Constrain membership (SAFI 132)
+- **BGP-LS and EVPN** — typed route storage, best-path selection, and outbound
+  distribution for link-state and EVPN families
+- **Optimal Route Reflection** — RFC 9107 BGP-LS topology, per-vantage SPF,
+  and vantage-scoped next-hop cost comparison
+- **Selection deferral** — RFC 4724 restarting-speaker startup gates that
+  defer per-family selection until the frozen waiter roster completes or the
+  configured timeout expires
 - **Multi-path** — Add-Path multi-candidate distribution with
   rank-based path ID assignment
 - **Graceful Restart** — stale route preservation, per-family EoR


### PR DESCRIPTION
## Summary

- document the API crate’s full proto inventory and shipped gNMI dial-out manager surface
- distinguish public event-history types from its crate-private actor and list the omitted re-exports
- cover the RIB crate’s shipped VPN, labeled-unicast, RT-Constrain, BGP-LS, EVPN, ORR, and selection-deferral surfaces
- name `AdjRibIn` by its actual downstream module path

## Validation

- full API, event-history, and RIB crate test suites
- strict Clippy and rustdoc for all three crates
- embedding-version, crate-map, metric-consumer, public-tracker, IXP, and release-path contract tests
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: LAN-1252