### PR TITLE
feat(gnmi): expose dial-out publish health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The shipped Grafana overview now pairs the RFC 9107 ORR SPF computation
   rate with current topology node and usable-link counts. (LAN-1205)
 
-- gNMI dial-out now exposes `gnmi_dialout_resync_total{target}` so repeated
-  established-session loss and fresh-snapshot resyncs are visible even while
-  the binary connection gauge otherwise looks healthy. (LAN-1190)
+- gNMI dial-out now exposes `gnmi_dialout_resync_total{target}`,
+  `gnmi_dialout_queue_depth{target}`, and
+  `gnmi_dialout_last_publish_timestamp_seconds{target}` so repeated
+  fresh-snapshot resyncs, local response backlog, and publish age are visible
+  even while the binary connection gauge otherwise looks healthy. (LAN-1190)
 
 - BMP divergence repair is now operator-visible through the lifecycle-correct
   `bmp_stream_diverged{peer}` gauge, a sustained-divergence alert, a control

--- a/crates/api/src/gnmi_dialout.rs
+++ b/crates/api/src/gnmi_dialout.rs
@@ -18,7 +18,8 @@
 //! Each target runs an independent reconnect loop with capped exponential
 //! backoff, logs at `warn` only on state transitions (first failure after
 //! a success, disconnect) and at `debug` for repeated retries, and surfaces
-//! connection state and established-session loss as per-target metrics.
+//! connection state, established-session loss, bounded response backlog, and
+//! last transport handoff as per-target metrics.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -38,6 +39,9 @@ use crate::gnmi_service::validate_stream_subscription_list;
 /// How long a single connection attempt may sit in TCP/TLS/HTTP-2
 /// establishment before it counts as failed and enters backoff.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Queue-depth sampling stays independent of transport polling, so a collector
+/// that stops reading cannot leave the gauge at its last healthy value.
+const QUEUE_OBSERVATION_INTERVAL: Duration = Duration::from_millis(250);
 
 /// One configured dial-out collector target, fully resolved from config.
 /// `PartialEq` drives the reload diff: an unchanged target keeps its live
@@ -352,6 +356,22 @@ enum SessionError {
     Fatal(String),
 }
 
+fn subscription_queue_depth(
+    probe: &tokio::sync::mpsc::WeakSender<Result<gnmi::SubscribeResponse, tonic::Status>>,
+) -> usize {
+    probe.upgrade().map_or(0, |sender| {
+        sender.max_capacity().saturating_sub(sender.capacity())
+    })
+}
+
+fn refresh_queue_depth(
+    metrics: &BgpMetrics,
+    target: &str,
+    probe: &tokio::sync::mpsc::WeakSender<Result<gnmi::SubscribeResponse, tonic::Status>>,
+) {
+    metrics.set_gnmi_dialout_queue_depth(target, subscription_queue_depth(probe));
+}
+
 /// Dial the collector, run one Publish session to completion, and report
 /// how it ended. `Ok(())` means the stream was established (the gauge was
 /// raised) and later ended; the caller decides reconnect pacing.
@@ -367,13 +387,22 @@ async fn publish_session(
     // outbound stream (holding the receiver) is dropped, and a reconnecting
     // collector gets a fresh initial snapshot + sync_response — the same
     // resync contract a dial-in reconnect has.
-    let rx = service
+    let subscription = service
         .spawn_stream_subscription(&target.subscriptions)
         .map_err(|status| SessionError::Fatal(status.message().to_string()))?;
+    let queue_probe = subscription.queue_probe;
     let name = target.name.clone();
-    let outbound = ReceiverStream::new(rx).map_while(move |item| match item {
-        Ok(response) => Some(response),
+    let publish_metrics = metrics.clone();
+    let publish_target = target.name.clone();
+    let dequeue_probe = queue_probe.clone();
+    let outbound = ReceiverStream::new(subscription.responses).map_while(move |item| match item {
+        Ok(response) => {
+            refresh_queue_depth(&publish_metrics, &publish_target, &dequeue_probe);
+            publish_metrics.record_gnmi_dialout_publish(&publish_target);
+            Some(response)
+        }
         Err(status) => {
+            refresh_queue_depth(&publish_metrics, &publish_target, &dequeue_probe);
             // e.g. ON_CHANGE broadcast lag → DataLoss. End the stream so the
             // reconnect path resyncs from a fresh snapshot.
             debug!(
@@ -413,6 +442,9 @@ async fn publish_session(
     );
     metrics.set_gnmi_dialout_connected(&target.name, true);
 
+    let mut queue_observation = tokio::time::interval(QUEUE_OBSERVATION_INTERVAL);
+    queue_observation.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     // Drain the collector's response stream. Nothing is expected on it
     // today (PublishResponse is reserved for future flow control); the
     // disconnect signal is its end or error — or the outbound stream
@@ -421,6 +453,9 @@ async fn publish_session(
     // fresh-snapshot resync.
     loop {
         tokio::select! {
+            _ = queue_observation.tick() => {
+                refresh_queue_depth(metrics, &target.name, &queue_probe);
+            }
             _ = &mut ended_rx => {
                 debug!(
                     target = %target.name,
@@ -738,14 +773,14 @@ mod tests {
 
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "the connection gauge only ever holds 0 or 1"
+        reason = "test-only Prometheus gauges under inspection hold bounded integer values"
     )]
-    fn gauge_value(metrics: &BgpMetrics, target: &str) -> Option<i64> {
+    fn labeled_gauge_value(metrics: &BgpMetrics, family_name: &str, target: &str) -> Option<i64> {
         metrics
             .registry()
             .gather()
             .iter()
-            .find(|family| family.name() == "gnmi_dialout_connected")?
+            .find(|family| family.name() == family_name)?
             .get_metric()
             .iter()
             .find(|metric| {
@@ -755,6 +790,22 @@ mod tests {
                     .any(|label| label.name() == "target" && label.value() == target)
             })
             .map(|metric| metric.get_gauge().value() as i64)
+    }
+
+    fn gauge_value(metrics: &BgpMetrics, target: &str) -> Option<i64> {
+        labeled_gauge_value(metrics, "gnmi_dialout_connected", target)
+    }
+
+    fn queue_depth_value(metrics: &BgpMetrics, target: &str) -> Option<i64> {
+        labeled_gauge_value(metrics, "gnmi_dialout_queue_depth", target)
+    }
+
+    fn last_publish_value(metrics: &BgpMetrics, target: &str) -> Option<i64> {
+        labeled_gauge_value(
+            metrics,
+            "gnmi_dialout_last_publish_timestamp_seconds",
+            target,
+        )
     }
 
     fn counter_value(metrics: &BgpMetrics, target: &str) -> Option<f64> {
@@ -789,6 +840,24 @@ mod tests {
                 "gauge gnmi_dialout_connected{{target={target}}} never reached {expected} \
                  (last: {:?})",
                 gauge_value(metrics, target)
+            )
+        });
+    }
+
+    async fn wait_for_first_publish(metrics: &BgpMetrics, target: &str) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if last_publish_value(metrics, target).is_some_and(|value| value > 0) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "gnmi_dialout_last_publish_timestamp_seconds{{target={target}}} remained {:?}",
+                last_publish_value(metrics, target)
             )
         });
     }
@@ -857,6 +926,35 @@ mod tests {
 
     // ── integration: dial out, stream, reconnect ──────────────────────
 
+    #[tokio::test]
+    async fn queue_probe_tracks_bounded_subscription_backlog() {
+        let metrics = BgpMetrics::new();
+        metrics.set_gnmi_dialout_connected("collector-queue", false);
+        let (tx, mut rx) = mpsc::channel(2);
+        let probe = tx.downgrade();
+
+        refresh_queue_depth(&metrics, "collector-queue", &probe);
+        assert_eq!(queue_depth_value(&metrics, "collector-queue"), Some(0));
+
+        tx.send(Ok(gnmi::SubscribeResponse::default()))
+            .await
+            .unwrap();
+        tx.send(Ok(gnmi::SubscribeResponse::default()))
+            .await
+            .unwrap();
+        refresh_queue_depth(&metrics, "collector-queue", &probe);
+        assert_eq!(queue_depth_value(&metrics, "collector-queue"), Some(2));
+
+        let _ = rx.recv().await;
+        refresh_queue_depth(&metrics, "collector-queue", &probe);
+        assert_eq!(queue_depth_value(&metrics, "collector-queue"), Some(1));
+
+        drop(tx);
+        let _ = rx.recv().await;
+        refresh_queue_depth(&metrics, "collector-queue", &probe);
+        assert_eq!(queue_depth_value(&metrics, "collector-queue"), Some(0));
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn dial_out_streams_updates_and_reconnects_after_collector_restart() {
         let metrics = BgpMetrics::new();
@@ -870,7 +968,10 @@ mod tests {
 
         // Initial snapshot arrives and the gauge rises.
         expect_update_with_as(&mut received).await;
+        expect_sync(&mut received).await;
         wait_for_gauge(&metrics, "collector-a", 1).await;
+        wait_for_first_publish(&metrics, "collector-a").await;
+        assert_eq!(queue_depth_value(&metrics, "collector-a"), Some(0));
 
         // Kill the collector (stop accepting, then end the live stream):
         // the gauge must drop (disconnect transition). Await the aborted
@@ -988,6 +1089,8 @@ mod tests {
         manager.apply(&[]);
         assert_eq!(gauge_value(&metrics, "collector-reap"), None);
         assert_eq!(counter_value(&metrics, "collector-reap"), None);
+        assert_eq!(queue_depth_value(&metrics, "collector-reap"), None);
+        assert_eq!(last_publish_value(&metrics, "collector-reap"), None);
         server.abort();
     }
 
@@ -1007,6 +1110,8 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(300)).await;
         assert_eq!(gauge_value(&metrics, "collector-late"), Some(0));
         assert_eq!(counter_value(&metrics, "collector-late"), Some(0.0));
+        assert_eq!(queue_depth_value(&metrics, "collector-late"), Some(0));
+        assert_eq!(last_publish_value(&metrics, "collector-late"), Some(0));
 
         // The collector comes up later; the retry loop finds it.
         let (server, mut received) = spawn_stub_collector(reservation);

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -977,7 +977,8 @@ impl GnmiService {
     }
 
     /// Spawn the STREAM-mode subscription described by `list` and return the
-    /// response channel. This is the dial-out reuse seam: the dial-out client
+    /// response channel plus a non-owning queue-depth probe. This is the
+    /// dial-out reuse seam: the dial-out client
     /// drives the exact `Subscribe` update-generation tasks (`SAMPLE` /
     /// `ON_CHANGE`) a dial-in collector would, then forwards the channel over
     /// its device-initiated connection. The spawned task exits when the
@@ -991,9 +992,10 @@ impl GnmiService {
     pub(crate) fn spawn_stream_subscription(
         &self,
         list: &gnmi::SubscriptionList,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<gnmi::SubscribeResponse, Status>>, Status> {
+    ) -> Result<SpawnedStreamSubscription, Status> {
         let plan = validate_stream_subscription_list(list)?;
         let (tx, rx) = tokio::sync::mpsc::channel(SUBSCRIBE_CHANNEL_DEPTH);
+        let queue_probe = tx.downgrade();
         let service = self.clone();
         tokio::spawn(async move {
             match plan.stream_mode {
@@ -1001,8 +1003,19 @@ impl GnmiService {
                 _ => service.run_stream_sample(plan, tx).await,
             }
         });
-        Ok(rx)
+        Ok(SpawnedStreamSubscription {
+            responses: rx,
+            queue_probe,
+        })
     }
+}
+
+/// One spawned dial-out subscription plus a non-owning probe for its bounded
+/// response queue. The weak sender does not keep the subscription alive; it
+/// only exposes channel capacity while a producer still exists.
+pub(crate) struct SpawnedStreamSubscription {
+    pub(crate) responses: tokio::sync::mpsc::Receiver<Result<gnmi::SubscribeResponse, Status>>,
+    pub(crate) queue_probe: tokio::sync::mpsc::WeakSender<Result<gnmi::SubscribeResponse, Status>>,
 }
 
 /// Validate a dial-out subscription list without spawning anything — shared

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -226,6 +226,8 @@ struct BgpMetricsInner {
     // ── gNMI dial-out (LAN-471) ────────────────────────────────────
     gnmi_dialout_connected: IntGaugeVec,
     gnmi_dialout_resync_total: IntCounterVec,
+    gnmi_dialout_queue_depth: IntGaugeVec,
+    gnmi_dialout_last_publish_timestamp: IntGaugeVec,
 
     // ── Notifications ──────────────────────────────────────────────
     notifications_sent: IntCounterVec,
@@ -565,6 +567,24 @@ impl BgpMetrics {
             Opts::new(
                 "gnmi_dialout_resync_total",
                 "Established gNMI dial-out sessions that ended and will trigger a fresh snapshot resync, per configured target",
+            ),
+            &["target"],
+        )
+        .expect("valid metric definition");
+
+        let gnmi_dialout_queue_depth = IntGaugeVec::new(
+            Opts::new(
+                "gnmi_dialout_queue_depth",
+                "SubscribeResponse items waiting in the bounded gNMI dial-out queue, per configured target",
+            ),
+            &["target"],
+        )
+        .expect("valid metric definition");
+
+        let gnmi_dialout_last_publish_timestamp = IntGaugeVec::new(
+            Opts::new(
+                "gnmi_dialout_last_publish_timestamp_seconds",
+                "Unix time the most recent SubscribeResponse was handed to the gNMI dial-out transport, per configured target; 0 until the first publish",
             ),
             &["target"],
         )
@@ -2098,6 +2118,12 @@ impl BgpMetrics {
             .register(Box::new(gnmi_dialout_resync_total.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(gnmi_dialout_queue_depth.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(gnmi_dialout_last_publish_timestamp.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(stale_timer_events.clone()))
             .expect("metric not already registered");
         registry
@@ -2624,6 +2650,8 @@ impl BgpMetrics {
             bfd_session_flaps_total,
             gnmi_dialout_connected,
             gnmi_dialout_resync_total,
+            gnmi_dialout_queue_depth,
+            gnmi_dialout_last_publish_timestamp,
             notifications_sent,
             notifications_received,
             messages_sent,
@@ -3016,13 +3044,22 @@ impl BgpMetrics {
     /// Set the gNMI dial-out connection gauge for a configured target.
     /// Refreshed on BOTH transitions (connect and disconnect) so the series
     /// always reflects the live Publish-stream state. The first call for a
-    /// target also materializes its resync counter at zero without incrementing
-    /// it, making failed-dial targets visible on `/metrics`.
+    /// target also materializes its resync counter and publish-observability
+    /// gauges at zero without incrementing them, making failed-dial targets
+    /// visible on `/metrics`.
     pub fn set_gnmi_dialout_connected(&self, target: &str, connected: bool) {
         let _resync_counter = self
             .0
             .gnmi_dialout_resync_total
             .with_label_values(&[target]);
+        let queue_depth = self.0.gnmi_dialout_queue_depth.with_label_values(&[target]);
+        let _last_publish = self
+            .0
+            .gnmi_dialout_last_publish_timestamp
+            .with_label_values(&[target]);
+        if !connected {
+            queue_depth.set(0);
+        }
         self.0
             .gnmi_dialout_connected
             .with_label_values(&[target])
@@ -3038,6 +3075,25 @@ impl BgpMetrics {
             .inc();
     }
 
+    /// Publish the current bounded `SubscribeResponse` queue depth for one
+    /// dial-out target.
+    pub fn set_gnmi_dialout_queue_depth(&self, target: &str, depth: usize) {
+        self.0
+            .gnmi_dialout_queue_depth
+            .with_label_values(&[target])
+            .set(i64::try_from(depth).unwrap_or(i64::MAX));
+    }
+
+    /// Record one `SubscribeResponse` being handed to the dial-out transport.
+    /// Without a collector acknowledgement this is the narrowest observable
+    /// successful-publish boundary; it does not claim remote application.
+    pub fn record_gnmi_dialout_publish(&self, target: &str) {
+        self.0
+            .gnmi_dialout_last_publish_timestamp
+            .with_label_values(&[target])
+            .set(unix_now_seconds());
+    }
+
     /// Reap the dial-out metric series for a target removed from the config
     /// (SIGHUP reload), so `/metrics` stops exporting stale targets.
     pub fn remove_gnmi_dialout_target(&self, target: &str) {
@@ -3045,6 +3101,14 @@ impl BgpMetrics {
         let _ = self
             .0
             .gnmi_dialout_resync_total
+            .remove_label_values(&[target]);
+        let _ = self
+            .0
+            .gnmi_dialout_queue_depth
+            .remove_label_values(&[target]);
+        let _ = self
+            .0
+            .gnmi_dialout_last_publish_timestamp
             .remove_label_values(&[target]);
     }
 

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -313,7 +313,8 @@ at the transport layer and remains a possible future alternative.
 Subscriptions are declared in config (paths + `sample`/`on_change` mode
 per target), TLS uses the standard `tls_ca_file`/`tls_cert_file`/
 `tls_key_file` path idiom, reconnects use capped exponential backoff,
-and connection state is exported as `gnmi_dialout_connected{target}`.
+and connection state, bounded response-queue depth, resync count, and the last
+transport-handoff timestamp are exported as `gnmi_dialout_*{target}` metrics.
 Full field reference: `docs/CONFIGURATION.md` `[gnmi_dialout]`;
 operational behavior: `docs/OPERATIONS.md`.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -754,7 +754,12 @@ unreachable and one `info` when it (re)connects; repeated retries log at
 `debug` only. Watch `gnmi_dialout_connected{target}` (0/1) for the live
 connection state and `gnmi_dialout_resync_total{target}` for established
 sessions that ended and entered the fresh-snapshot reconnect path; failed dials
-do not increment it. Every (re)connection restarts the subscription, so the
+do not increment it. A connected target whose `gnmi_dialout_queue_depth`
+stays elevated or whose `time() - gnmi_dialout_last_publish_timestamp_seconds`
+keeps growing is not making healthy publish progress even if its connection
+gauge remains 1. The timestamp records a response handed to the local gRPC
+transport, not a collector acknowledgement; `PublishResponse` remains reserved
+and no remote-apply acknowledgement exists. Every (re)connection restarts the subscription, so the
 collector resyncs from a fresh initial snapshot + `sync_response` — the
 disconnect window is not replayed (same contract as a dial-in Subscribe
 reconnect; use the durable event cursor for gap-free history).
@@ -1120,6 +1125,8 @@ query with a new live watch.
 |--------|-------------------|
 | `gnmi_dialout_connected{target}` | 1 while the dial-out Publish stream to this `[gnmi_dialout]` target is established, 0 while disconnected/retrying. Refreshed on both transitions; the series exists (at 0) from startup even when the collector is down, and is reaped when the target is removed from config (SIGHUP) |
 | `gnmi_dialout_resync_total{target}` | Established Publish sessions that ended and entered the reconnect path, where the next connection starts a fresh initial snapshot. Failed dials do not increment it; the series exists at 0 from startup and is reaped with the target |
+| `gnmi_dialout_queue_depth{target}` | SubscribeResponse items waiting in the bounded local subscription queue. Sustained non-zero depth identifies a target whose transport is not keeping up; it returns to 0 on disconnect and the series is reaped with the target |
+| `gnmi_dialout_last_publish_timestamp_seconds{target}` | Unix time the last SubscribeResponse was handed to the local gRPC transport, or 0 before the first publish. Use `time() - <metric>` for publish age. This is not a collector acknowledgement; the series is reaped with the target |
 
 ### BMP
 

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -499,8 +499,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 189:
-        raise ValueError(f"emitted metric roster changed: expected 189, got {len(inventory)}")
+    if len(inventory) != 191:
+        raise ValueError(f"emitted metric roster changed: expected 191, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,10 +47,10 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 189)
+        self.assertEqual(len(self.inventory), 191)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            178,
+            180,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
@@ -58,10 +58,10 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 93)
         self.assertEqual(len(self.rule_refs), 39)
-        self.assertEqual(len(self.public_doc_refs), 178)
-        self.assertEqual(len(self.doc_refs), 178)
+        self.assertEqual(len(self.public_doc_refs), 180)
+        self.assertEqual(len(self.doc_refs), 180)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 183)
+        self.assertEqual(len(consumers), 185)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("189 emitted families", stdout.getvalue())
-        self.assertIn("178 normative-doc families", stdout.getvalue())
-        self.assertIn("183 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("191 emitted families", stdout.getvalue())
+        self.assertIn("180 normative-doc families", stdout.getvalue())
+        self.assertIn("185 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"


### PR DESCRIPTION
## Summary

- expose the exact bounded `SubscribeResponse` queue depth per gNMI dial-out target
- record the last response handoff to the local gRPC transport as a per-target Unix timestamp
- sample queue depth independently of transport polling and reap both new series on target removal
- document useful publish-age queries and the precise observability boundary
- update the source-derived metric-consumer contract from 189 to 191 emitted families

## Semantics

`gnmi_dialout_last_publish_timestamp_seconds` records local transport handoff, not collector application or acknowledgement. `PublishResponse` remains reserved and this change deliberately does not introduce protocol flow control; the new signals provide the evidence needed before making that larger decision.

## Validation

- gNMI dial-out unit/integration tests: 11/11
- API library tests: 677/677
- telemetry library tests: 104/104
- strict all-target/all-feature API + telemetry Clippy
- metric-consumer contract: 28/28 and 191-family live audit
- public-tracker, embedding-version, and crate-map contracts
- full workspace library tests and rustdoc via push hooks
- formatting and `git diff --check`

Linear: LAN-1190