### PR TITLE
refactor(config): reuse parsed families and peer groups

### DIFF
--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -379,7 +379,8 @@ impl Config {
         external_pinned: bool,
     ) -> Result<EffectivePolicyChains, ConfigError> {
         let mut store = SetStore::new();
-        self.effective_policy_for_neighbor_with_store(neighbor, external_pinned, &mut store)
+        let group = self.peer_group_for_neighbor(neighbor)?;
+        self.effective_policy_for_neighbor_with_store(neighbor, group, external_pinned, &mut store)
     }
 
     #[expect(
@@ -389,10 +390,10 @@ impl Config {
     fn effective_policy_for_neighbor_with_store(
         &self,
         neighbor: &Neighbor,
+        group: Option<&PeerGroupConfig>,
         external_pinned: bool,
         store: &mut SetStore,
     ) -> Result<EffectivePolicyChains, ConfigError> {
-        let group = self.peer_group_for_neighbor(neighbor)?;
         let global_import = self.import_chain_with_store(store)?;
         let global_export = self.export_chain_with_store(store)?;
         let group_import = if let Some(group) = group {
@@ -897,7 +898,7 @@ impl Config {
         transport.reject_retention_capacity = self.policy.reject_retention.capacity;
 
         let policy =
-            self.effective_policy_for_neighbor_with_store(neighbor, external_pinned, store)?;
+            self.effective_policy_for_neighbor_with_store(neighbor, group, external_pinned, store)?;
 
         Ok(ResolvedNeighbor {
             transport_config: transport,

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -2614,16 +2614,15 @@ fn validate_peer_group(
 ) -> Result<(), ConfigError> {
     EffectiveHoldTimers::for_peer_group(group).validate()?;
 
-    if !group.families.is_empty() {
-        parse_families(&group.families)?;
-    }
+    let configured_families = (!group.families.is_empty())
+        .then(|| parse_families(&group.families))
+        .transpose()?;
     if !group.required_families.is_empty() {
         let required = parse_families(&group.required_families)?;
         // A group with no configured families has no address-dependent
         // default until it is consumed; validate those effective consumers
         // above instead of rejecting an otherwise reusable definition.
-        if !group.families.is_empty() {
-            let mut effective = parse_families(&group.families)?;
+        if let Some(mut effective) = configured_families {
             if group.disable_ipv4_unicast.unwrap_or(false) {
                 effective.retain(|family| {
                     *family != (rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast)


### PR DESCRIPTION
## Summary

- parse non-empty peer-group configured families once and reuse the typed set for required-family validation
- pass the already-resolved peer-group borrow into effective-policy resolution instead of repeating the canonical lookup
- preserve exact validation order, error variants and payloads, inheritance precedence, and effective-policy behavior

## Scope

This is a two-slice deduplication batch across validation and resolution. It changes no schema, TOML, defaults, documentation, public API, or allocation lifetime.

## Validation

- focused family proofs: 2
- focused policy proofs: 2
- typed undefined-group proof: 1
- full locked workspace tests and doctests
- strict workspace all-target/all-feature Clippy
- warning-free all-feature rustdoc
- v1 stable-surface inventory
- formatting, `git diff --check`, and full hooks

Linear: LAN-1202