### PR TITLE
perf(evpn): gate dataplane snapshots by generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The Linux EVPN dataplane supervisor now uses an actor-owned wrapping
+  generation token for its Type 1/2/5 projection input. Stable event and
+  five-second poll passes avoid the EVPN table walk and clone entirely;
+  relevant RIB changes return one atomic filtered snapshot, while local
+  instance, IP-VRF, quarantine, and same-ESI-bias changes force a durable full
+  re-projection. Type 3/4 RR, public API, protobuf, and CLI behavior is
+  unchanged, as are the 200 ms event debounce and BUM cached-republish path.
+  (LAN-1055)
+
 - The MRT `TABLE_DUMP_V2` reader now applies RFC 7606 revised path-attribute
   decoding with a conservative internal-neighbor default on incomplete session
   evidence. It continues only when every recovered issue is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1549,10 +1549,16 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
     change does not necessarily trigger full RIB query + full kernel dump +
     full projection. Design-gated because drift recovery, ECMP siblings,
     peer-group allow-lists, and max-route freeze semantics are non-local.
-  - EVPN dataplane supervisor: move from periodic whole-EVPN-RIB
-    query/project/equality suppression toward generation/dirty-driven
-    projection. Design-gated because EAD mass-withdraw, aliasing, quarantine,
-    and IP-VRF config changes can invalidate more than one route key.
+  - EVPN dataplane supervisor generation query (LAN-1055): **done**. The RIB
+    actor owns a wrapping Type 1/2/5 equality token and exact relevant-row
+    cardinality. Stable event and five-second poll passes now return an O(1)
+    unchanged response without walking/materializing the EVPN table; relevant
+    changes return one actor-atomic Type 1/2/5 snapshot. Local instance,
+    IP-VRF, quarantine, and same-ESI-bias changes durably invalidate the token
+    before querying, while BUM-only changes retain the cached-republish path.
+    Type 3/4 RR/public behavior is unchanged. This deliberately remains a
+    whole relevant-table projection on change rather than a per-key projection:
+    EAD mass-withdraw, aliasing, quarantine, and IP-VRF config are non-local.
   - Add-Path export: avoid sorting all candidate paths when `send_max` is small
     if deterministic ordering and export-policy filtering can be preserved.
   - Session establishment tuning: expose connect-retry timing as per-neighbor /

--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -47,3 +47,8 @@ harness = false
 name = "route_paging"
 harness = false
 required-features = ["bench-internals"]
+
+[[bench]]
+name = "evpn_dataplane_query"
+harness = false
+required-features = ["bench-internals"]

--- a/crates/rib/benches/evpn_dataplane_query.rs
+++ b/crates/rib/benches/evpn_dataplane_query.rs
@@ -1,0 +1,170 @@
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rustbgpd_rib::route::{EvpnRibRoute, RouteOrigin};
+use rustbgpd_rib::{
+    bench_evpn_dataplane_generation_query, bench_evpn_dataplane_generation_snapshot,
+    bench_evpn_dataplane_legacy_snapshot,
+};
+use rustbgpd_wire::{
+    EthernetSegmentIdentifier, EthernetTagId, EvpnEadPerEvi, EvpnEs, EvpnImet, EvpnIpPrefixRoute,
+    EvpnIpPrefixValue, EvpnMacIp, EvpnRoute, Ipv4Prefix, MacAddress, MplsLabel, RouteDistinguisher,
+};
+
+const CURRENT_GENERATION: u64 = 73;
+
+fn rd(index: usize) -> RouteDistinguisher {
+    let bytes = u64::try_from(index).unwrap_or(u64::MAX).to_be_bytes();
+    RouteDistinguisher(bytes)
+}
+
+fn route(index: usize, route_type: u8) -> EvpnRibRoute {
+    let octets = u32::try_from(index).unwrap_or(u32::MAX).to_be_bytes();
+    let tag = EthernetTagId(u32::try_from(index).unwrap_or(u32::MAX));
+    let peer = Ipv4Addr::new(192, 0, 2, 1);
+    let route = match route_type {
+        1 => EvpnRoute::EadPerEvi(EvpnEadPerEvi {
+            rd: rd(index),
+            esi: EthernetSegmentIdentifier::new([0, 1, 2, 3, 4, 5, 6, 7, 8, octets[3]]),
+            ethernet_tag: tag,
+            label: MplsLabel::new(u32::try_from(index % 16_000_000).unwrap()),
+        }),
+        2 => EvpnRoute::MacIp(EvpnMacIp {
+            rd: rd(index),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: tag,
+            mac: MacAddress::new([0x02, octets[0], octets[1], octets[2], octets[3], 1]),
+            ip: Some(IpAddr::V4(Ipv4Addr::new(
+                198, octets[1], octets[2], octets[3],
+            ))),
+            label1: MplsLabel::new(u32::try_from(index % 16_000_000).unwrap()),
+            label2: None,
+        }),
+        3 => EvpnRoute::Imet(EvpnImet {
+            rd: rd(index),
+            ethernet_tag: tag,
+            originator_ip: IpAddr::V4(Ipv4Addr::new(203, octets[1], octets[2], octets[3])),
+        }),
+        4 => EvpnRoute::Es(EvpnEs {
+            rd: rd(index),
+            esi: EthernetSegmentIdentifier::new([0, 9, 8, 7, 6, 5, 4, 3, 2, octets[3]]),
+            originator_ip: IpAddr::V4(Ipv4Addr::new(203, octets[1], octets[2], octets[3])),
+        }),
+        5 => EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
+            rd: rd(index),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: tag,
+            prefix: EvpnIpPrefixValue::V4(Ipv4Prefix::new(
+                Ipv4Addr::new(10, octets[1], octets[2], 0),
+                24,
+            )),
+            gateway: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            label: MplsLabel::new(u32::try_from(index % 16_000_000).unwrap()),
+        }),
+        _ => unreachable!(),
+    };
+    EvpnRibRoute {
+        route,
+        next_hop: IpAddr::V4(peer),
+        link_local_next_hop: None,
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![]),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+    }
+}
+
+fn fixture(rows: usize, mixed: bool) -> Vec<EvpnRibRoute> {
+    const RELEVANT: [u8; 3] = [1, 2, 5];
+    const ALL_TYPES: [u8; 5] = [1, 2, 3, 4, 5];
+    (0..rows)
+        .map(|index| {
+            let route_type = if mixed {
+                ALL_TYPES[index % ALL_TYPES.len()]
+            } else {
+                RELEVANT[index % RELEVANT.len()]
+            };
+            route(index, route_type)
+        })
+        .collect()
+}
+
+fn bench(c: &mut Criterion) {
+    for (dataset, mixed) in [("all-relevant", false), ("mixed-types-1-through-5", true)] {
+        let mut group = c.benchmark_group(format!("evpn_dataplane_query/{dataset}"));
+        group.sample_size(10);
+        group.warm_up_time(Duration::from_secs(1));
+        group.measurement_time(Duration::from_secs(3));
+
+        for rows in [0usize, 1_000, 50_000] {
+            let routes = fixture(rows, mixed);
+            let relevant_rows = routes
+                .iter()
+                .filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+                .count();
+            let changed = bench_evpn_dataplane_generation_snapshot(
+                &routes,
+                Some(CURRENT_GENERATION.wrapping_sub(1)),
+                CURRENT_GENERATION,
+            );
+            assert_eq!(changed.row_visits, rows);
+            assert_eq!(changed.routes.as_ref().map(Vec::len), Some(relevant_rows));
+            let unchanged = bench_evpn_dataplane_generation_snapshot(
+                &routes,
+                Some(CURRENT_GENERATION),
+                CURRENT_GENERATION,
+            );
+            assert_eq!(unchanged.row_visits, 0);
+            assert!(unchanged.routes.is_none());
+            assert_eq!(bench_evpn_dataplane_legacy_snapshot(&routes).len(), rows);
+
+            group.throughput(Throughput::Elements(u64::try_from(rows).unwrap()));
+            group.bench_with_input(
+                BenchmarkId::new("legacy-whole-table", rows),
+                &routes,
+                |b, r| {
+                    b.iter(|| black_box(bench_evpn_dataplane_legacy_snapshot(black_box(r))));
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("generation-changed", rows),
+                &routes,
+                |b, r| {
+                    b.iter(|| {
+                        black_box(bench_evpn_dataplane_generation_query(
+                            black_box(r),
+                            relevant_rows,
+                            Some(CURRENT_GENERATION.wrapping_sub(1)),
+                            CURRENT_GENERATION,
+                        ))
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("generation-unchanged", rows),
+                &routes,
+                |b, r| {
+                    b.iter(|| {
+                        black_box(bench_evpn_dataplane_generation_query(
+                            black_box(r),
+                            relevant_rows,
+                            Some(CURRENT_GENERATION),
+                            CURRENT_GENERATION,
+                        ))
+                    });
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -57,6 +57,11 @@ pub use event::{EvpnRouteEvent, RouteEvent, RouteEventType};
 pub use event_sink::{NoopRibEventSink, RibEventSink};
 pub use loc_rib::LocRib;
 pub use manager::RibManager;
+#[cfg(feature = "bench-internals")]
+pub use manager::{
+    EvpnDataplaneQueryBenchReceipt, bench_evpn_dataplane_generation_query,
+    bench_evpn_dataplane_generation_snapshot, bench_evpn_dataplane_legacy_snapshot,
+};
 pub use manager::{SelectionDeferralConfig, SelectionDeferralWaiterConfig};
 pub use orr::{
     NodeDescriptors, NodeIx, OrrLink, OrrLinkSnapshot, OrrNodeSnapshot, OrrPrefixSnapshot,
@@ -69,21 +74,21 @@ pub use route::{
     VpnRibRouteKey,
 };
 pub use update::{
-    AdjRibOutCounts, BestPathCandidate, EffectiveDistributionMode, ExactExportCandidate,
-    ExactExportEncoder, ExactExportError, ExactExportErrorCode, ExactExportKey, ExactExportResult,
-    ExactExportSnapshot, ExplainAdvertisedRoute, ExplainAdvertisedRouteError, ExplainBestPath,
-    ExplainDecision, ExplainReason, ExportGateStep, ExportGateVerdict, ExportPolicyCohortOutcome,
-    MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, NeighborRibSnapshot,
-    NeighborRibSnapshotResponse, OUTBOUND_PREFIX_LIMIT_REACHED, OrrExplainCandidate,
-    OutboundPrefixLimitConfig, OutboundPrefixLimitFamilyState, OutboundPrefixLimitPair,
-    OutboundPrefixLimitViolation, OutboundRouteUpdate, PeerExportPolicyReplacement,
-    PeerOutboundState, PlannedGroupability, RibCommandError, RibReadinessError, RibReadinessQuery,
-    RibRowFilter, RibUpdate, RoutePage, RoutePageError, RoutePageVersion, RouteQueryFilter,
-    RouteQueryKey, RouteQueryScope, RouteSourceIdentity, SelectionDeferralPeerFamilyState,
-    SharedGroupEncode, UpdateGroupClassification, UpdateGroupClassifierInput,
-    UpdateGroupComparisonDifference, UpdateGroupComparisonMembership, UpdateGroupComparisonVerdict,
-    UpdateGroupFamilyImpact, UpdateGroupFingerprint, UpdateGroupImpactPlan,
-    UpdateGroupImpactRollup, UpdateGroupPeerComparison, UpdateGroupPeerSnapshot,
-    UpdateGroupSnapshot, WarmMrtSnapshotBudget, WarmMrtSnapshotView, classify_update_group,
-    route_query_key,
+    AdjRibOutCounts, BestPathCandidate, EffectiveDistributionMode, EvpnDataplaneRoutesResponse,
+    ExactExportCandidate, ExactExportEncoder, ExactExportError, ExactExportErrorCode,
+    ExactExportKey, ExactExportResult, ExactExportSnapshot, ExplainAdvertisedRoute,
+    ExplainAdvertisedRouteError, ExplainBestPath, ExplainDecision, ExplainReason, ExportGateStep,
+    ExportGateVerdict, ExportPolicyCohortOutcome, MrtPeerEntry, MrtSnapshotData,
+    NeighborPolicyStats, NeighborRibSnapshot, NeighborRibSnapshotResponse,
+    OUTBOUND_PREFIX_LIMIT_REACHED, OrrExplainCandidate, OutboundPrefixLimitConfig,
+    OutboundPrefixLimitFamilyState, OutboundPrefixLimitPair, OutboundPrefixLimitViolation,
+    OutboundRouteUpdate, PeerExportPolicyReplacement, PeerOutboundState, PlannedGroupability,
+    RibCommandError, RibReadinessError, RibReadinessQuery, RibRowFilter, RibUpdate, RoutePage,
+    RoutePageError, RoutePageVersion, RouteQueryFilter, RouteQueryKey, RouteQueryScope,
+    RouteSourceIdentity, SelectionDeferralPeerFamilyState, SharedGroupEncode,
+    UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupComparisonDifference,
+    UpdateGroupComparisonMembership, UpdateGroupComparisonVerdict, UpdateGroupFamilyImpact,
+    UpdateGroupFingerprint, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
+    UpdateGroupPeerComparison, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, WarmMrtSnapshotBudget,
+    WarmMrtSnapshotView, classify_update_group, route_query_key,
 };

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -44,6 +44,65 @@ static PCB_TOTAL_EXACT_NANOS: AtomicU64 = AtomicU64::new(0);
 static PCB_TOTAL_COMMIT_NANOS: AtomicU64 = AtomicU64::new(0);
 static PCB_TOTAL_ENQUEUE_NANOS: AtomicU64 = AtomicU64::new(0);
 
+/// Bench-only receipt for the production EVPN dataplane generation gate.
+#[derive(Debug)]
+pub struct EvpnDataplaneQueryBenchReceipt {
+    pub routes: Option<Vec<crate::route::EvpnRibRoute>>,
+    pub row_visits: usize,
+}
+
+/// The pre-LAN-1055 whole-table clone paid by every supervisor pass.
+#[must_use]
+pub fn bench_evpn_dataplane_legacy_snapshot(
+    rows: &[crate::route::EvpnRibRoute],
+) -> Vec<crate::route::EvpnRibRoute> {
+    rows.to_vec()
+}
+
+/// Time the production collection helper without receipt instrumentation.
+#[must_use]
+pub fn bench_evpn_dataplane_generation_query(
+    rows: &[crate::route::EvpnRibRoute],
+    relevant_rows: usize,
+    known_generation: Option<u64>,
+    current_generation: u64,
+) -> Option<Vec<crate::route::EvpnRibRoute>> {
+    super::collect_evpn_dataplane_routes(
+        rows.iter(),
+        known_generation,
+        current_generation,
+        rows.len(),
+        relevant_rows,
+    )
+}
+
+/// Drive the same generation equality and Type 1/2/5 materialization helper
+/// used by the production actor query, with a deterministic visit receipt.
+#[must_use]
+pub fn bench_evpn_dataplane_generation_snapshot(
+    rows: &[crate::route::EvpnRibRoute],
+    known_generation: Option<u64>,
+    current_generation: u64,
+) -> EvpnDataplaneQueryBenchReceipt {
+    let relevant_rows = rows
+        .iter()
+        .filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+        .count();
+    let visits = Cell::new(0usize);
+    let routes = super::collect_evpn_dataplane_routes(
+        rows.iter()
+            .inspect(|_| visits.set(visits.get().saturating_add(1))),
+        known_generation,
+        current_generation,
+        rows.len(),
+        relevant_rows,
+    );
+    EvpnDataplaneQueryBenchReceipt {
+        routes,
+        row_visits: visits.get(),
+    }
+}
+
 #[derive(Clone, Copy)]
 struct PerClientBestCandidateBenchAggregate {
     capture_active: bool,

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -444,6 +444,23 @@ impl RibManager {
                 };
                 let previous_peer = previous_best.as_ref().map(|r| r.peer);
                 let peer = new_best.as_ref().map(|r| r.peer);
+                if matches!(key.route_type(), 1 | 2 | 5) {
+                    match (previous_best.is_some(), new_best.is_some()) {
+                        (false, true) => {
+                            self.evpn_dataplane_route_count = self
+                                .evpn_dataplane_route_count
+                                .checked_add(1)
+                                .expect("EVPN dataplane route count overflow");
+                        }
+                        (true, false) => {
+                            self.evpn_dataplane_route_count = self
+                                .evpn_dataplane_route_count
+                                .checked_sub(1)
+                                .expect("EVPN dataplane route count underflow");
+                        }
+                        _ => {}
+                    }
+                }
                 self.publish_evpn_route_event(crate::event::EvpnRouteEvent {
                     event_type,
                     key: *key,
@@ -456,6 +473,26 @@ impl RibManager {
                 changed_keys.insert(*key);
             }
         }
+
+        // This token covers exactly the projection input consumed by the
+        // daemon dataplane.  Type 3/4 changes remain visible through the
+        // public EVPN query and event stream, but cannot change that
+        // projection and therefore do not invalidate its snapshot.
+        if changed_keys
+            .iter()
+            .any(|key| matches!(key.route_type(), 1 | 2 | 5))
+        {
+            self.evpn_dataplane_generation = self.evpn_dataplane_generation.wrapping_add(1);
+        }
+
+        debug_assert_eq!(
+            self.evpn_dataplane_route_count,
+            self.loc_rib
+                .iter_evpn()
+                .filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+                .count(),
+            "EVPN dataplane relevant-row cardinality drifted from the Loc-RIB"
+        );
 
         if changed_keys.is_empty() {
             return;

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1,7 +1,11 @@
 #[cfg(feature = "bench-internals")]
 mod bench_support;
 #[cfg(feature = "bench-internals")]
-pub use bench_support::{AdjRibOutFanoutBenchReceipt, PolicyTransitionBenchReceipt};
+pub use bench_support::{
+    AdjRibOutFanoutBenchReceipt, EvpnDataplaneQueryBenchReceipt, PolicyTransitionBenchReceipt,
+    bench_evpn_dataplane_generation_query, bench_evpn_dataplane_generation_snapshot,
+    bench_evpn_dataplane_legacy_snapshot,
+};
 mod distribution;
 mod graceful_restart;
 mod helpers;
@@ -210,6 +214,18 @@ pub struct RibManager {
     /// See [`UnicastPrefixPeers`] for the maintenance contract.
     unicast_prefix_peers: UnicastPrefixPeers,
     loc_rib: LocRib,
+    /// Wrapping equality token for the Type 1/2/5 Loc-RIB projection consumed
+    /// by the daemon's EVPN dataplane supervisor.  Actor ownership makes the
+    /// token and a materialized snapshot one atomic observation.
+    evpn_dataplane_generation: u64,
+    /// Exact cardinality of Type 1/2/5 Loc-RIB rows. Maintained at the same
+    /// recompute seam as the generation token so an all-relevant table can
+    /// retain the pre-existing bulk-clone fast path.
+    evpn_dataplane_route_count: usize,
+    /// Deterministic proof that equality/cancellation branches do not walk
+    /// the Loc-RIB. Counts rows visited only by full internal snapshots.
+    #[cfg(test)]
+    evpn_dataplane_query_row_visits: usize,
     adj_ribs_out: HashMap<IpAddr, AdjRibOut>,
     /// Per-peer outbound unicast prefix admission state (ADR-0113). An entry
     /// exists only for a peer whose resolved `max_prefixes_out_ipv4` /
@@ -637,6 +653,27 @@ const SLOW_POLICY_TRANSITION: std::time::Duration = std::time::Duration::from_se
 /// once ownership is far beyond any legitimate transition receipt.
 pub(in crate::manager) const MAX_HEALTHY_POLICY_TRANSITION_AGE: std::time::Duration =
     std::time::Duration::from_secs(30);
+
+fn collect_evpn_dataplane_routes<'a>(
+    rows: impl Iterator<Item = &'a crate::route::EvpnRibRoute>,
+    known_generation: Option<u64>,
+    current_generation: u64,
+    total_rows: usize,
+    relevant_rows: usize,
+) -> Option<Vec<crate::route::EvpnRibRoute>> {
+    if known_generation == Some(current_generation) {
+        return None;
+    }
+    if relevant_rows == total_rows {
+        return Some(rows.cloned().collect());
+    }
+    let mut routes = Vec::with_capacity(relevant_rows);
+    routes.extend(
+        rows.filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+            .cloned(),
+    );
+    Some(routes)
+}
 
 /// Aggregate pre-commit ownership budget for one clean policy transition:
 /// still short of `CommitMembers` at this age, the transition hands the
@@ -1110,6 +1147,10 @@ impl RibManager {
             attr_intern: crate::attr_intern::AttrInternTable::new(),
             unicast_prefix_peers: UnicastPrefixPeers::default(),
             loc_rib: LocRib::new(),
+            evpn_dataplane_generation: 0,
+            evpn_dataplane_route_count: 0,
+            #[cfg(test)]
+            evpn_dataplane_query_row_visits: 0,
             adj_ribs_out: HashMap::new(),
             outbound_prefix_limits: HashMap::new(),
             outbound_limit_control: outbound_prefix_limits::OutboundLimitControl::default(),
@@ -2420,6 +2461,32 @@ impl RibManager {
             }
             RibUpdate::QueryEvpnRoutes { filter, reply } => {
                 queries::send_filtered_rows(self.loc_rib.iter_evpn(), filter.as_ref(), reply);
+            }
+            RibUpdate::QueryEvpnDataplaneRoutes {
+                known_generation,
+                reply,
+            } => {
+                if reply.is_closed() {
+                    debug!("EVPN dataplane route query canceled before materialization");
+                    return;
+                }
+                #[cfg(test)]
+                if known_generation != Some(self.evpn_dataplane_generation) {
+                    self.evpn_dataplane_query_row_visits = self
+                        .evpn_dataplane_query_row_visits
+                        .saturating_add(self.loc_rib.evpn_len());
+                }
+                let routes = collect_evpn_dataplane_routes(
+                    self.loc_rib.iter_evpn(),
+                    known_generation,
+                    self.evpn_dataplane_generation,
+                    self.loc_rib.evpn_len(),
+                    self.evpn_dataplane_route_count,
+                );
+                let _ = reply.send(crate::update::EvpnDataplaneRoutesResponse {
+                    generation: self.evpn_dataplane_generation,
+                    routes,
+                });
             }
             RibUpdate::QueryBgpLsRoutes { filter, reply } => {
                 queries::send_filtered_rows(self.loc_rib.iter_bgpls(), filter.as_ref(), reply);

--- a/crates/rib/src/manager/tests/evpn_dataplane_query.rs
+++ b/crates/rib/src/manager/tests/evpn_dataplane_query.rs
@@ -1,0 +1,211 @@
+use super::*;
+use crate::adj_rib_in::AdjRibIn;
+use rustbgpd_wire::{
+    EvpnEadPerEs, EvpnEadPerEvi, EvpnEs, EvpnIpPrefixRoute, EvpnIpPrefixValue, EvpnMacIp, EvpnRoute,
+};
+
+const PEER: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 9);
+const RD: RouteDistinguisher = RouteDistinguisher([0, 0, 0xfd, 0xe8, 0, 0, 0, 9]);
+const ESI: EthernetSegmentIdentifier =
+    EthernetSegmentIdentifier::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+fn manager() -> RibManager {
+    let (_tx, rx) = mpsc::channel(8);
+    RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+}
+
+fn rib_route(route: EvpnRoute) -> EvpnRibRoute {
+    EvpnRibRoute {
+        route,
+        next_hop: IpAddr::V4(PEER),
+        link_local_next_hop: None,
+        peer: IpAddr::V4(PEER),
+        attributes: Arc::new(vec![]),
+        received_at: Instant::now(),
+        origin_type: crate::route::RouteOrigin::Ibgp,
+        peer_router_id: PEER,
+        is_stale: false,
+        is_llgr_stale: false,
+    }
+}
+
+fn relevant_routes() -> Vec<EvpnRibRoute> {
+    vec![
+        rib_route(EvpnRoute::EadPerEs(EvpnEadPerEs {
+            rd: RD,
+            esi: ESI,
+            ethernet_tag: EthernetTagId::MAX_ET,
+            label: MplsLabel::new(100),
+        })),
+        rib_route(EvpnRoute::EadPerEvi(EvpnEadPerEvi {
+            rd: RD,
+            esi: ESI,
+            ethernet_tag: EthernetTagId(100),
+            label: MplsLabel::new(100),
+        })),
+        rib_route(EvpnRoute::MacIp(EvpnMacIp {
+            rd: RD,
+            esi: ESI,
+            ethernet_tag: EthernetTagId(100),
+            mac: MacAddress::new([0x02, 0, 0, 0, 0, 1]),
+            ip: Some(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))),
+            label1: MplsLabel::new(100),
+            label2: None,
+        })),
+        rib_route(EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
+            rd: RD,
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(0),
+            prefix: EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+            gateway: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            label: MplsLabel::new(5000),
+        })),
+    ]
+}
+
+fn irrelevant_routes() -> Vec<EvpnRibRoute> {
+    vec![
+        make_evpn_imet(PEER, 100),
+        rib_route(EvpnRoute::Es(EvpnEs {
+            rd: RD,
+            esi: ESI,
+            originator_ip: IpAddr::V4(PEER),
+        })),
+    ]
+}
+
+fn install_and_recompute(manager: &mut RibManager, route: EvpnRibRoute) {
+    let key = route.key();
+    manager
+        .ribs
+        .entry(IpAddr::V4(PEER))
+        .or_insert_with(|| AdjRibIn::new(IpAddr::V4(PEER)))
+        .insert_evpn(route);
+    manager.recompute_and_distribute_evpn(&HashSet::from([key]));
+}
+
+fn withdraw_and_recompute(manager: &mut RibManager, route: &EvpnRibRoute) {
+    let key = route.key();
+    assert!(
+        manager
+            .ribs
+            .get_mut(&IpAddr::V4(PEER))
+            .unwrap()
+            .withdraw_evpn(&key)
+    );
+    manager.recompute_and_distribute_evpn(&HashSet::from([key]));
+}
+
+fn query(
+    manager: &mut RibManager,
+    known_generation: Option<u64>,
+) -> crate::update::EvpnDataplaneRoutesResponse {
+    let (reply, mut response) = oneshot::channel();
+    manager.handle_update(RibUpdate::QueryEvpnDataplaneRoutes {
+        known_generation,
+        reply,
+    });
+    response.try_recv().expect("actor replies synchronously")
+}
+
+#[test]
+fn initial_snapshot_filters_exact_types_and_equal_token_does_zero_work() {
+    let mut manager = manager();
+    for route in relevant_routes().into_iter().chain(irrelevant_routes()) {
+        install_and_recompute(&mut manager, route);
+    }
+
+    let initial = query(&mut manager, None);
+    let routes = initial
+        .routes
+        .expect("startup must receive a full snapshot");
+    let mut types: Vec<u8> = routes.iter().map(EvpnRibRoute::route_type).collect();
+    types.sort_unstable();
+    assert_eq!(types, vec![1, 1, 2, 5]);
+    assert_eq!(initial.generation, 4);
+    let visits = manager.evpn_dataplane_query_row_visits;
+
+    let unchanged = query(&mut manager, Some(initial.generation));
+    assert!(unchanged.routes.is_none());
+    assert_eq!(manager.evpn_dataplane_query_row_visits, visits);
+}
+
+#[test]
+fn type_three_and_four_changes_do_not_advance_projection_generation() {
+    let mut manager = manager();
+    for route in irrelevant_routes() {
+        install_and_recompute(&mut manager, route.clone());
+        assert_eq!(manager.evpn_dataplane_generation, 0);
+        assert_eq!(manager.evpn_dataplane_route_count, 0);
+        withdraw_and_recompute(&mut manager, &route);
+        assert_eq!(manager.evpn_dataplane_generation, 0);
+        assert_eq!(manager.evpn_dataplane_route_count, 0);
+    }
+}
+
+#[test]
+fn every_relevant_shape_add_change_withdraw_advances_exactly_once() {
+    let mut manager = manager();
+    let mut expected = 0;
+    for mut route in relevant_routes() {
+        install_and_recompute(&mut manager, route.clone());
+        expected += 1;
+        assert_eq!(manager.evpn_dataplane_generation, expected);
+        assert_eq!(manager.evpn_dataplane_route_count, 1);
+
+        route.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+        install_and_recompute(&mut manager, route.clone());
+        expected += 1;
+        assert_eq!(manager.evpn_dataplane_generation, expected);
+        assert_eq!(manager.evpn_dataplane_route_count, 1);
+
+        withdraw_and_recompute(&mut manager, &route);
+        expected += 1;
+        assert_eq!(manager.evpn_dataplane_generation, expected);
+        assert_eq!(manager.evpn_dataplane_route_count, 0);
+    }
+
+    let routes: Vec<_> = relevant_routes()
+        .into_iter()
+        .chain(irrelevant_routes())
+        .collect();
+    let keys: HashSet<_> = routes.iter().map(EvpnRibRoute::key).collect();
+    let rib = manager
+        .ribs
+        .entry(IpAddr::V4(PEER))
+        .or_insert_with(|| AdjRibIn::new(IpAddr::V4(PEER)));
+    for route in routes {
+        rib.insert_evpn(route);
+    }
+    manager.recompute_and_distribute_evpn(&keys);
+    assert_eq!(
+        manager.evpn_dataplane_generation,
+        expected + 1,
+        "one completed recompute call advances once even when four relevant keys change"
+    );
+    assert_eq!(manager.evpn_dataplane_route_count, 4);
+    assert_eq!(manager.loc_rib.evpn_len(), 6);
+    let response = query(&mut manager, None);
+    assert_eq!(response.routes.unwrap().len(), 4);
+}
+
+#[test]
+fn canceled_query_skips_work_and_generation_wraps_as_an_equality_token() {
+    let mut manager = manager();
+    manager.evpn_dataplane_generation = u64::MAX;
+    let route = relevant_routes().pop().unwrap();
+    install_and_recompute(&mut manager, route);
+    assert_eq!(manager.evpn_dataplane_generation, 0);
+
+    let visits = manager.evpn_dataplane_query_row_visits;
+    let (reply, response) = oneshot::channel();
+    drop(response);
+    manager.handle_update(RibUpdate::QueryEvpnDataplaneRoutes {
+        known_generation: Some(u64::MAX),
+        reply,
+    });
+    assert_eq!(manager.evpn_dataplane_query_row_visits, visits);
+
+    assert!(query(&mut manager, Some(u64::MAX)).routes.is_some());
+    assert!(query(&mut manager, Some(0)).routes.is_none());
+}

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -1131,6 +1131,7 @@ mod bgpls;
 mod bmp;
 mod events_metrics;
 mod evpn;
+mod evpn_dataplane_query;
 mod exact_export_lifecycle;
 mod explain_mrt;
 mod export_explain;

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2391,6 +2391,18 @@ pub enum RibUpdate {
         /// Response channel.
         reply: oneshot::Sender<Vec<EvpnRibRoute>>,
     },
+    /// Query the dataplane-relevant EVPN Loc-RIB projection input.
+    ///
+    /// This is an internal daemon/RIB seam.  The equality token lets the
+    /// dataplane supervisor avoid walking or materializing the table when no
+    /// Type 1, 2, or 5 best path changed since its last successful snapshot.
+    QueryEvpnDataplaneRoutes {
+        /// Last successfully materialized generation, or `None` to force a
+        /// complete snapshot after startup or local projection invalidation.
+        known_generation: Option<u64>,
+        /// Response channel.
+        reply: oneshot::Sender<EvpnDataplaneRoutesResponse>,
+    },
     /// Query BGP-LS routes from the Loc-RIB (RFC 9552).
     QueryBgpLsRoutes {
         /// Row filter evaluated inside the RIB task; `None` copies every row.
@@ -2481,6 +2493,16 @@ pub enum RibUpdate {
         /// Response channel: `(afi, safi, count)` per family.
         reply: oneshot::Sender<Vec<(u16, u8, u64)>>,
     },
+}
+
+/// Actor-atomic response for the internal EVPN dataplane snapshot query.
+#[derive(Debug)]
+pub struct EvpnDataplaneRoutesResponse {
+    /// Wrapping equality token owned by the RIB actor.
+    pub generation: u64,
+    /// Type 1, 2, and 5 Loc-RIB rows when the caller's token differs; `None`
+    /// when it is already current.
+    pub routes: Option<Vec<EvpnRibRoute>>,
 }
 
 /// Peer metadata for MRT `PEER_INDEX_TABLE`.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -33,7 +33,7 @@ v0.61.0 release-tip real-daemon and single-revision absolute baseline:
 2026-07-26; RIB-ops prefix-fixture audit bounding the above-65,536 rows:
 2026-08; v0.64.0 release-tag bgperf2 spot-check (rustbgpd only, same host):
 2026-08-08; v0.66.0 release-tag bgperf2 spot-check (rustbgpd only, same
-host): 2026-08-23.
+host): 2026-08-23; EVPN dataplane generation-query controlled A/B: 2026-08-24.
 
 | Field | Value |
 |-------|-------|
@@ -171,14 +171,14 @@ measures nothing. `cargo bench --workspace` is not a substitute either: four
 targets are standalone CLIs rather than criterion harnesses and reject
 criterion's flags.
 
-Run each target explicitly with `-p <crate> --bench <name>`. Thirteen exist.
+Run each target explicitly with `-p <crate> --bench <name>`. Fourteen exist.
 Six build with default features (wire/`codec`, rib/`rib_ops`,
 policy/`policy_eval`, policy/`explain_snapshot`, rpki/`validate`,
-mrt/`snapshot_allocation`); seven are `bench-internals`-gated
+mrt/`snapshot_allocation`); eight are `bench-internals`-gated
 (transport/`fanout`, transport/`inbound_attrs`, rustbgpd/`fib_projection`,
-rib/`route_paging`, api/`event_history_producer`, api/`vpn_query_timing`,
-api/`vpn_query_allocation` — the last also requires the api crate's
-`vpn-query-allocation` feature). Four of the thirteen —
+rib/`route_paging`, rib/`evpn_dataplane_query`, api/`event_history_producer`,
+api/`vpn_query_timing`, api/`vpn_query_allocation` — the last also requires
+the api crate's `vpn-query-allocation` feature). Four of the fourteen —
 `snapshot_allocation`, `route_paging`, `vpn_query_timing`, and
 `vpn_query_allocation` — are standalone measurement CLIs with their own
 argument contracts (`snapshot_allocation` hard-errors without a
@@ -194,6 +194,9 @@ cargo bench -p rustbgpd-wire --bench codec
 
 # RIB only
 cargo bench -p rustbgpd-rib --bench rib_ops
+
+# EVPN dataplane generation query (requires bench-internals)
+cargo bench -p rustbgpd-rib --features bench-internals --bench evpn_dataplane_query
 
 # Root-daemon FIB projection internals (requires bench-internals)
 cargo bench --features bench-internals --bench fib_projection
@@ -216,6 +219,55 @@ cargo bench -p rustbgpd-rib --bench rib_ops -- "adj_rib_in_insert"
 ```
 
 HTML reports are generated to `target/criterion/`.
+
+### EVPN dataplane generation query (LAN-1055)
+
+The `evpn_dataplane_query` target isolates the internal query/materialization
+seam. Its legacy path is the exact pre-LAN-1055 whole-EVPN-table clone; the new
+changed path clones only Type 1/2/5 rows. The downstream intent projection is
+outside both timings, which conservatively omits the new path's smaller mixed
+input. Both sides receive the same input cardinality; mixed output cardinality
+differs because filtering in the actor is the shipped optimization. When every
+row is relevant, the actor's exact relevant-row cardinality preserves the
+prior bulk-clone path. The unchanged path compares the caller's token before
+constructing the iterator.
+
+The fixture covers 0, 1,000, and 50,000 rows in two distributions:
+`all-relevant` cycles Types 1/2/5, while `mixed-types-1-through-5` cycles all
+five route types (60% relevant). Before timed iterations, the target asserts
+the changed receipt visited every input row and returned the exact relevant
+cardinality; the unchanged receipt must be `routes=None` with zero row visits.
+Those are control-flow/materialization receipts, not allocator measurements;
+no allocation-count or byte claim is made here.
+
+Measured 2026-08-24 from the LAN-1055 candidate based on
+`5871d4c2fb5583fe1dd1b24c28849f624fa68043`, with rustc 1.98.0, Linux
+6.17.0-35-generic, AMD Ryzen Threadripper 7970X, CPU 8 pinned under the
+`performance` governor, and the shared host lock held:
+
+```bash
+flock -n "$HOME/.local/state/rustbgpd-host.lock" \
+  taskset -c 8 cargo bench -p rustbgpd-rib --features bench-internals \
+  --bench evpn_dataplane_query -- --noplot
+```
+
+Criterion configuration was 1 s warm-up, 3 s measurement, 10 samples. Values
+are point estimates from the same controlled run; delta compares changed with
+legacy at the same input cardinality.
+
+| Distribution | Rows | Legacy clone | Generation changed | Changed delta | Generation unchanged |
+|---|---:|---:|---:|---:|---:|
+| all relevant | 0 | 7.1053 ns | 7.4148 ns | +4.36% | 1.1730 ns |
+| all relevant | 1,000 | 7.0841 us | 7.0540 us | -0.42% | 1.1728 ns |
+| all relevant | 50,000 | 367.27 us | 368.45 us | **+0.32%** | 1.1780 ns |
+| mixed Types 1-5 | 0 | 7.1043 ns | 7.4035 ns | +4.21% | 1.1742 ns |
+| mixed Types 1-5 | 1,000 | 7.1338 us | 5.7271 us | -19.72% | 1.1758 ns |
+| mixed Types 1-5 | 50,000 | 382.54 us | 293.94 us | -23.16% | 1.1746 ns |
+
+The preregistered production switch condition was that the changed 50,000-row
+all-relevant path be no more than 2% slower than legacy. The measured +0.32%
+passes. The 0-row percentage is nanosecond-scale fixed dispatch overhead, not
+a scale result.
 
 ## Comparing Two Refs
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -220,10 +220,10 @@ cargo bench -p rustbgpd-rib --bench rib_ops -- "adj_rib_in_insert"
 
 HTML reports are generated to `target/criterion/`.
 
-### EVPN dataplane generation query (LAN-1055)
+### EVPN dataplane generation query
 
 The `evpn_dataplane_query` target isolates the internal query/materialization
-seam. Its legacy path is the exact pre-LAN-1055 whole-EVPN-table clone; the new
+seam. Its legacy path is the exact pre-change whole-EVPN-table clone; the new
 changed path clones only Type 1/2/5 rows. The downstream intent projection is
 outside both timings, which conservatively omits the new path's smaller mixed
 input. Both sides receive the same input cardinality; mixed output cardinality
@@ -240,7 +240,7 @@ cardinality; the unchanged receipt must be `routes=None` with zero row visits.
 Those are control-flow/materialization receipts, not allocator measurements;
 no allocation-count or byte claim is made here.
 
-Measured 2026-08-24 from the LAN-1055 candidate based on
+Measured 2026-08-24 from the PR #1988 candidate based on
 `5871d4c2fb5583fe1dd1b24c28849f624fa68043`, with rustc 1.98.0, Linux
 6.17.0-35-generic, AMD Ryzen Threadripper 7970X, CPU 8 pinned under the
 `performance` governor, and the shared host lock held:

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -3,10 +3,9 @@
 //!
 //! ADR-0054 §1 forbids `rustbgpd-evpn-linux` from depending on
 //! `rustbgpd-rib` or `rustbgpd-transport`. The daemon binary owns the
-//! coordination between the two: it queries the RIB for current
-//! best-path EVPN Type 2 routes, projects them into a portable
-//! [`RemoteMacTable`] via [`rustbgpd_evpn::project_evpn_routes`],
-//! wraps the result in a [`DataplaneIntent`], and publishes via a
+//! coordination between the two: it generation-queries the RIB for current
+//! best-path EVPN Type 1/2/5 projection inputs, builds the portable L2 and L3
+//! intent tables, wraps them in a [`DataplaneIntent`], and publishes via a
 //! `tokio::sync::watch::Sender<Arc<DataplaneIntent>>` that the
 //! [`ReconcileActor`] consumes.
 //!
@@ -18,9 +17,8 @@
 //! [`EVPN_ROUTE_EVENT_DEBOUNCE`] after the last event of a burst —
 //! the same debounced trigger shape as the blackhole reconciler. Any
 //! EVPN best-path change (Type 1/2/3/4/5 add / withdraw / best-change)
-//! marks the supervisor dirty; the recompute is a full re-projection,
-//! so spurious triggers from route types the projection ignores are
-//! cheap no-ops absorbed by the unchanged-intent early return. This
+//! marks the supervisor dirty. Type 3/4 triggers and stable Type 1/2/5
+//! generations are O(1) equality responses without a RIB walk or clone. This
 //! makes the ADR-0083 single-active failover repair sub-second
 //! instead of poll-cadence-bound.
 //!
@@ -673,6 +671,10 @@ fn publish_remote_prefix_drop_counts(
 #[derive(Debug)]
 struct SupervisorIntentState {
     generation: u64,
+    /// Last Type 1/2/5 RIB equality token successfully materialized. `None`
+    /// forces a full actor snapshot after startup or any local projection
+    /// input change and stays invalid across query failures.
+    evpn_dataplane_generation: Option<u64>,
     last_instances: Arc<EvpnInstanceTable>,
     last_ip_vrfs: Arc<IpVrfTable>,
     managed_netdevs: Arc<ManagedNetdevTable>,
@@ -686,6 +688,7 @@ impl Default for SupervisorIntentState {
     fn default() -> Self {
         Self {
             generation: 0,
+            evpn_dataplane_generation: None,
             last_instances: Arc::new(EvpnInstanceTable::new()),
             last_ip_vrfs: Arc::new(IpVrfTable::new()),
             managed_netdevs: Arc::new(ManagedNetdevTable::new()),
@@ -698,12 +701,17 @@ impl Default for SupervisorIntentState {
 }
 
 impl SupervisorIntentState {
+    fn invalidate_evpn_dataplane_snapshot(&mut self) {
+        self.evpn_dataplane_generation = None;
+    }
+
     fn has_cached_projection_for(
         &self,
         instances: &EvpnInstanceTable,
         ip_vrfs: &IpVrfTable,
     ) -> bool {
         self.generation > 0
+            && self.evpn_dataplane_generation.is_some()
             && instances == self.last_instances.as_ref()
             && ip_vrfs == self.last_ip_vrfs.as_ref()
     }
@@ -729,14 +737,23 @@ async fn publish_dataplane_intent(
     // table itself, so the unchanged-intent early return below covers
     // bias changes through the projected-table comparison — no separate
     // last-bias field is needed.
-    let tables = build_intent_tables(
-        rib_tx,
+    let response = query_evpn_dataplane_routes(rib_tx, state.evpn_dataplane_generation).await?;
+    let Some(routes) = response.routes else {
+        // Equal actor-owned token: the RIB did not iterate or materialize its
+        // EVPN table, and no local projection input was invalidated.
+        return Ok(true);
+    };
+    let tables = project_intent_tables(
+        &routes,
         instances.as_ref(),
         ip_vrfs.as_ref(),
         quarantined_macs,
         same_esi_bias,
-    )
-    .await?;
+    );
+    // A successful full snapshot repairs startup/local invalidation. Set this
+    // before semantic intent deduplication: an unchanged projection is still
+    // a successfully materialized view of the new RIB generation.
+    state.evpn_dataplane_generation = Some(response.generation);
     // ADR-0083 slice 3: refresh the backup-window gauge on every
     // successful projection, BEFORE the unchanged-table early return —
     // the gauge derives from the same RIB snapshot and must converge
@@ -990,6 +1007,7 @@ async fn supervisor_loop(
                 // The bias snapshot is a projection input, so a change
                 // always requires a full re-projection — there is no
                 // cached-republish shortcut like the BUM arm's.
+                state.invalidate_evpn_dataplane_snapshot();
                 let instances = instances_rx.borrow().clone();
                 let ip_vrfs = ip_vrfs_rx.borrow().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
@@ -1020,6 +1038,7 @@ async fn supervisor_loop(
                     duplicate_mac_quarantine_updates_open = false;
                     continue;
                 }
+                state.invalidate_evpn_dataplane_snapshot();
                 let instances = instances_rx.borrow().clone();
                 let ip_vrfs = ip_vrfs_rx.borrow().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
@@ -1049,6 +1068,7 @@ async fn supervisor_loop(
                     debug!("EVPN instance model publisher gone; supervisor exiting");
                     return;
                 }
+                state.invalidate_evpn_dataplane_snapshot();
                 let instances = instances_rx.borrow_and_update().clone();
                 let ip_vrfs = ip_vrfs_rx.borrow().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
@@ -1078,6 +1098,7 @@ async fn supervisor_loop(
                     debug!("EVPN IP-VRF model publisher gone; supervisor exiting");
                     return;
                 }
+                state.invalidate_evpn_dataplane_snapshot();
                 let instances = instances_rx.borrow().clone();
                 let ip_vrfs = ip_vrfs_rx.borrow_and_update().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
@@ -1184,13 +1205,13 @@ async fn recv_evpn_route_event(
 /// for the same ESI. Active duplicate-MAC quarantine keys are also
 /// dropped from the remote-FDB intent so the dataplane stops forwarding
 /// toward a quarantined remote MAC while the RIB/RR surfaces remain
-/// visible. Other route types (Type 3 IMET, Type 4 ES, Type 5
-/// IP-Prefix) are ignored for Gate 7b — they're carried by the RR but
-/// the L2VNI dataplane boundary only programs Type 2 MACs.
-/// Outcome of one RIB query: the L2 (Type 2) remote-MAC table plus
-/// the L3 (Type 5) remote-IP-prefix table, projected from the same
-/// `QueryEvpnRoutes` snapshot. Single function so both tables come
-/// from a consistent best-path view.
+/// visible. Type 5 IP-Prefix routes feed the L3 IP-VRF table. Type 3 IMET and
+/// Type 4 ES routes remain available to the RR/public RIB surfaces but are
+/// excluded from this dataplane projection input.
+/// Outcome of one generation-filtered internal RIB snapshot: the L2 (Type 2,
+/// with Type 1 reachability/alias inputs) remote-MAC table plus the L3 (Type
+/// 5) remote-IP-prefix table. A single actor-atomic snapshot keeps both tables
+/// on one best-path generation.
 struct IntentTables {
     remote_macs: rustbgpd_evpn::RemoteMacTable,
     remote_ip_prefixes: rustbgpd_evpn::ip_vrf::RemoteIpPrefixTable,
@@ -1201,6 +1222,22 @@ struct IntentTables {
     single_active_backup_active: usize,
 }
 
+async fn query_evpn_dataplane_routes(
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    known_generation: Option<u64>,
+) -> Result<rustbgpd_rib::EvpnDataplaneRoutesResponse, RibQueryError> {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    rib_tx
+        .send(RibUpdate::QueryEvpnDataplaneRoutes {
+            known_generation,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| RibQueryError::SendFailed)?;
+    reply_rx.await.map_err(|_| RibQueryError::ReplyDropped)
+}
+
+#[cfg(test)]
 async fn build_intent_tables(
     rib_tx: &mpsc::Sender<RibUpdate>,
     instances: &EvpnInstanceTable,
@@ -1220,6 +1257,22 @@ async fn build_intent_tables(
         .map_err(|_| RibQueryError::SendFailed)?;
     let routes = reply_rx.await.map_err(|_| RibQueryError::ReplyDropped)?;
 
+    Ok(project_intent_tables(
+        &routes,
+        instances,
+        ip_vrfs,
+        quarantined_macs,
+        same_esi_bias,
+    ))
+}
+
+fn project_intent_tables(
+    routes: &[EvpnRibRoute],
+    instances: &EvpnInstanceTable,
+    ip_vrfs: &rustbgpd_evpn::ip_vrf::IpVrfTable,
+    quarantined_macs: &BTreeSet<DuplicateMacKey>,
+    same_esi_bias: &SameEsiBiasTable,
+) -> IntentTables {
     // Build a quick lookup of local VTEP IPs so the EAD-per-EVI
     // self-filter doesn't require a per-route instance-table scan.
     let local_vtep_ips: std::collections::BTreeSet<std::net::IpAddr> =
@@ -1237,12 +1290,12 @@ async fn build_intent_tables(
     // single-active (suppress all-active aliasing ECMP). A last-wins
     // `.collect()` would make this nondeterministic across duplicate or
     // transient (e.g. RD-changing) EAD-per-ES rows for the same key.
-    let ead_per_es_modes = fold_ead_per_es_modes(&routes);
+    let ead_per_es_modes = fold_ead_per_es_modes(routes);
     // Strict unanimous fold for the RFC 9136 §4.3 Type 5 overlay-index
     // import decision only — fail-closed on conflicting redundancy signals.
     // The OR-folded `ead_per_es_modes` above stays the L2 aliasing contract
     // and feeds every L2 consumer below unchanged.
-    let ead_per_es_modes_esi_type5 = fold_ead_per_es_modes_for_esi_type5_import(&routes);
+    let ead_per_es_modes_esi_type5 = fold_ead_per_es_modes_for_esi_type5_import(routes);
     let active_ead_per_es: std::collections::BTreeSet<(
         std::net::IpAddr,
         rustbgpd_wire::EthernetSegmentIdentifier,
@@ -1350,11 +1403,11 @@ async fn build_intent_tables(
         &single_active_index,
     );
 
-    Ok(IntentTables {
+    IntentTables {
         remote_macs,
         remote_ip_prefixes,
         single_active_backup_active,
-    })
+    }
 }
 
 /// ADR-0083 slice 3: returns the `(ESI, EthernetTag)` group key when
@@ -1786,6 +1839,38 @@ mod tests {
         SameEsiBiasTable::new()
     }
 
+    fn reply_dataplane_query(
+        known_generation: Option<u64>,
+        reply: tokio::sync::oneshot::Sender<rustbgpd_rib::EvpnDataplaneRoutesResponse>,
+        generation: u64,
+        routes: Vec<EvpnRibRoute>,
+    ) {
+        let routes = (known_generation != Some(generation)).then_some(routes);
+        let _ = reply.send(rustbgpd_rib::EvpnDataplaneRoutesResponse { generation, routes });
+    }
+
+    async fn publish_empty_models(
+        rib_tx: &mpsc::Sender<RibUpdate>,
+        state: &mut SupervisorIntentState,
+    ) -> Result<bool, RibQueryError> {
+        let (intent_tx, _intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
+        let (drop_counts_tx, _drop_counts_rx) =
+            watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
+        publish_dataplane_intent(
+            rib_tx,
+            &intent_tx,
+            Arc::new(EvpnInstanceTable::new()),
+            Arc::new(IpVrfTable::new()),
+            BumEnforcementTable::new(),
+            &BTreeSet::new(),
+            &no_bias(),
+            &BgpMetrics::new(),
+            state,
+            &drop_counts_tx,
+        )
+        .await
+    }
+
     fn local_instance(v: u32, bridge: Option<&str>) -> EvpnInstance {
         evpn_instance(65001, v, v, bridge.map(String::from), false)
     }
@@ -2095,12 +2180,20 @@ mod tests {
     async fn remote_type5_projection_drop_metrics_track_current_snapshot() {
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(2);
         let _rib_responder = tokio::spawn(async move {
-            if let Some(RibUpdate::QueryEvpnRoutes { reply, .. }) = rib_rx.recv().await {
+            if let Some(RibUpdate::QueryEvpnDataplaneRoutes {
+                known_generation,
+                reply,
+            }) = rib_rx.recv().await
+            {
                 let route = evpn_ip_prefix_route("10.1.0.0/24", "192.0.2.10", "10.0.0.9", 5000);
-                let _ = reply.send(vec![route]);
+                reply_dataplane_query(known_generation, reply, 1, vec![route]);
             }
-            if let Some(RibUpdate::QueryEvpnRoutes { reply, .. }) = rib_rx.recv().await {
-                let _ = reply.send(vec![]);
+            if let Some(RibUpdate::QueryEvpnDataplaneRoutes {
+                known_generation,
+                reply,
+            }) = rib_rx.recv().await
+            {
+                reply_dataplane_query(known_generation, reply, 2, vec![]);
             }
         });
         let metrics = BgpMetrics::new();
@@ -2920,21 +3013,29 @@ mod tests {
         let esi = EthernetSegmentIdentifier::new([7; 10]);
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(2);
         let _responder = tokio::spawn(async move {
-            if let Some(RibUpdate::QueryEvpnRoutes { reply, .. }) = rib_rx.recv().await {
+            if let Some(RibUpdate::QueryEvpnDataplaneRoutes {
+                known_generation,
+                reply,
+            }) = rib_rx.recv().await
+            {
                 let routes = vec![
                     evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
                     evpn_ead_per_es_route(esi, "10.0.0.3", true),
                     evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
                 ];
-                let _ = reply.send(routes);
+                reply_dataplane_query(known_generation, reply, 1, routes);
             }
-            if let Some(RibUpdate::QueryEvpnRoutes { reply, .. }) = rib_rx.recv().await {
+            if let Some(RibUpdate::QueryEvpnDataplaneRoutes {
+                known_generation,
+                reply,
+            }) = rib_rx.recv().await
+            {
                 let routes = vec![
                     evpn_macip_route_with_esi(100, 1, "10.0.0.3", esi),
                     evpn_ead_per_es_route(esi, "10.0.0.3", true),
                     evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
                 ];
-                let _ = reply.send(routes);
+                reply_dataplane_query(known_generation, reply, 2, routes);
             }
         });
         let metrics = BgpMetrics::new();
@@ -3277,16 +3378,20 @@ mod tests {
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
         let shutdown = CancellationToken::new();
 
-        // Stub RIB responder: answer the first QueryEvpnRoutes with a
-        // fake MacIp route, the rest with nothing. The supervisor's
-        // event subscription is ignored (reply dropped → poll-only).
+        // Stub RIB responder: answer the first dataplane query with a fake
+        // MacIp route; later equal-token polls avoid materialization. The
+        // supervisor's event subscription is ignored (reply dropped →
+        // poll-only).
         let _rib_responder = tokio::spawn({
             let route = evpn_macip_route(100, 1, "10.0.0.2", Some(3));
             async move {
-                let mut first = Some(route);
                 while let Some(msg) = rib_rx.recv().await {
-                    if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
-                        let _ = reply.send(first.take().into_iter().collect());
+                    if let RibUpdate::QueryEvpnDataplaneRoutes {
+                        known_generation,
+                        reply,
+                    } = msg
+                    {
+                        reply_dataplane_query(known_generation, reply, 1, vec![route.clone()]);
                     }
                 }
             }
@@ -3332,14 +3437,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalidated_generation_stays_none_across_send_and_reply_failure() {
+        let mut state = SupervisorIntentState {
+            evpn_dataplane_generation: Some(41),
+            ..SupervisorIntentState::default()
+        };
+        state.invalidate_evpn_dataplane_snapshot();
+
+        let (send_failed_tx, send_failed_rx) = mpsc::channel(1);
+        drop(send_failed_rx);
+        assert!(matches!(
+            publish_empty_models(&send_failed_tx, &mut state).await,
+            Err(RibQueryError::SendFailed)
+        ));
+        assert_eq!(state.evpn_dataplane_generation, None);
+
+        let (reply_failed_tx, mut reply_failed_rx) = mpsc::channel(1);
+        let responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnDataplaneRoutes { reply, .. }) =
+                reply_failed_rx.recv().await
+            {
+                drop(reply);
+            }
+        });
+        assert!(matches!(
+            publish_empty_models(&reply_failed_tx, &mut state).await,
+            Err(RibQueryError::ReplyDropped)
+        ));
+        responder.await.unwrap();
+        assert_eq!(state.evpn_dataplane_generation, None);
+
+        let (success_tx, mut success_rx) = mpsc::channel(1);
+        let responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnDataplaneRoutes {
+                known_generation,
+                reply,
+            }) = success_rx.recv().await
+            {
+                assert_eq!(known_generation, None);
+                reply_dataplane_query(known_generation, reply, 42, vec![]);
+            }
+        });
+        assert!(publish_empty_models(&success_tx, &mut state).await.unwrap());
+        responder.await.unwrap();
+        assert_eq!(state.evpn_dataplane_generation, Some(42));
+    }
+
+    #[tokio::test]
     async fn supervisor_republishes_when_bum_enforcement_changes() {
         let instances = Arc::new(local_instance_table(100, Some("br100")));
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
         let shutdown = CancellationToken::new();
         let _rib_responder = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
-                if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
-                    let _ = reply.send(vec![]);
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
+                    reply_dataplane_query(known_generation, reply, 1, vec![]);
                 }
             }
         });
@@ -3425,14 +3581,17 @@ mod tests {
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
         let shutdown = CancellationToken::new();
 
-        // Stub RIB responder: every QueryEvpnRoutes returns the
-        // same single route. The projection result is therefore
-        // identical across polls.
+        // Stub RIB responder: every changed-generation dataplane query returns
+        // the same single route; equal-token polls return no rows.
         let _rib_responder = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
-                if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
                     let route = evpn_macip_route(100, 1, "10.0.0.2", Some(1));
-                    let _ = reply.send(vec![route]);
+                    reply_dataplane_query(known_generation, reply, 1, vec![route]);
                 }
             }
         });
@@ -3496,6 +3655,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn periodic_poll_recovers_a_relevant_generation_without_an_event() {
+        let instances = Arc::new(local_instance_table(100, Some("br100")));
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+        let shutdown = CancellationToken::new();
+        let rib_generation = Arc::new(AtomicUsize::new(1));
+        let responder_generation = rib_generation.clone();
+        let _rib_responder = tokio::spawn(async move {
+            while let Some(msg) = rib_rx.recv().await {
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
+                    let generation = responder_generation.load(Ordering::SeqCst) as u64;
+                    let mut routes = vec![evpn_macip_route(100, 1, "10.0.0.2", Some(1))];
+                    if generation > 1 {
+                        routes.push(evpn_macip_route(100, 2, "10.0.0.3", Some(1)));
+                    }
+                    reply_dataplane_query(known_generation, reply, generation, routes);
+                }
+            }
+        });
+
+        let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
+        let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
+        let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
+        let (drop_counts_tx, _drop_counts_rx) =
+            watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
+        let (_instances_tx, instances_rx) = watch::channel(instances);
+        let (_ip_vrfs_tx, ip_vrfs_rx) = watch::channel(Arc::new(IpVrfTable::new()));
+        let (_managed_tx, managed_netdevs_rx) = watch::channel(Arc::new(ManagedNetdevTable::new()));
+        let join = tokio::spawn(super::supervisor_loop(
+            Duration::from_millis(20),
+            instances_rx,
+            ip_vrfs_rx,
+            managed_netdevs_rx.borrow().clone(),
+            rib_tx,
+            intent_tx,
+            bum_rx,
+            bias_rx,
+            quarantine_rx,
+            drop_counts_tx,
+            BgpMetrics::new(),
+            shutdown.clone(),
+        ));
+
+        tokio::time::timeout(Duration::from_millis(300), intent_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            intent_rx
+                .borrow_and_update()
+                .remote_macs
+                .get(vni(100), mac(1))
+                .is_some()
+        );
+
+        // No event is sent. The periodic equality probe must observe the new
+        // actor generation and materialize the changed snapshot.
+        rib_generation.store(2, Ordering::SeqCst);
+        tokio::time::timeout(Duration::from_millis(300), intent_rx.changed())
+            .await
+            .expect("periodic poll must recover a missed relevant event")
+            .unwrap();
+        assert!(
+            intent_rx
+                .borrow_and_update()
+                .remote_macs
+                .get(vni(100), mac(2))
+                .is_some()
+        );
+
+        shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_millis(200), join).await;
+    }
+
+    #[tokio::test]
     async fn supervisor_reprojects_on_runtime_instance_table_change() {
         let initial_instances = Arc::new(local_instance_table(100, Some("br100")));
         let expanded_instances = Arc::new(local_instance_table_many(&[
@@ -3507,12 +3745,16 @@ mod tests {
 
         let _rib_responder = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
-                if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
                     let routes = vec![
                         evpn_macip_route(100, 1, "10.0.0.2", Some(1)),
                         evpn_macip_route(200, 2, "10.0.0.3", Some(1)),
                     ];
-                    let _ = reply.send(routes);
+                    reply_dataplane_query(known_generation, reply, 1, routes);
                 }
             }
         });
@@ -3578,8 +3820,12 @@ mod tests {
 
         let _rib_responder = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
-                if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
-                    let _ = reply.send(vec![]);
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
+                    reply_dataplane_query(known_generation, reply, 1, vec![]);
                 }
             }
         });
@@ -3645,8 +3891,17 @@ mod tests {
             // update must republish cached route projection instead
             // of depending on another RIB query.
             while let Some(msg) = rib_rx.recv().await {
-                if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
-                    let _ = reply.send(vec![evpn_macip_route(100, 1, "10.0.0.2", Some(1))]);
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
+                    reply_dataplane_query(
+                        known_generation,
+                        reply,
+                        1,
+                        vec![evpn_macip_route(100, 1, "10.0.0.2", Some(1))],
+                    );
                     break;
                 }
             }
@@ -3714,6 +3969,7 @@ mod tests {
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let mut state = SupervisorIntentState {
             generation: 1,
+            evpn_dataplane_generation: Some(7),
             last_instances: cached_instances.clone(),
             last_ip_vrfs: Arc::new(IpVrfTable::new()),
             managed_netdevs: Arc::new(ManagedNetdevTable::new()),
@@ -3753,9 +4009,13 @@ mod tests {
 
         let _rib_responder = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
-                if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
                     let route = evpn_macip_route(100, 1, "10.0.0.2", Some(1));
-                    let _ = reply.send(vec![route]);
+                    reply_dataplane_query(known_generation, reply, 1, vec![route]);
                 }
             }
         });
@@ -3826,12 +4086,16 @@ mod tests {
 
         let _rib_responder = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
-                if let RibUpdate::QueryEvpnRoutes { reply, .. } = msg {
+                if let RibUpdate::QueryEvpnDataplaneRoutes {
+                    known_generation,
+                    reply,
+                } = msg
+                {
                     let routes = vec![
                         evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
                         evpn_ead_per_es_route(esi, "10.0.0.2", false),
                     ];
-                    let _ = reply.send(routes);
+                    reply_dataplane_query(known_generation, reply, 1, routes);
                 }
             }
         });
@@ -3907,7 +4171,7 @@ mod tests {
 
     /// Stub RIB endpoint for the event-trigger tests: answers
     /// `SubscribeEvpnRouteEvents` with a broadcast receiver, answers
-    /// every `QueryEvpnRoutes` with `routes`, and counts the queries.
+    /// every dataplane query with the actor-token response, and counts them.
     fn rib_with_evpn_events(
         routes: Vec<EvpnRibRoute>,
     ) -> (
@@ -3923,9 +4187,12 @@ mod tests {
         tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
                 match msg {
-                    RibUpdate::QueryEvpnRoutes { reply, .. } => {
+                    RibUpdate::QueryEvpnDataplaneRoutes {
+                        known_generation,
+                        reply,
+                    } => {
                         task_count.fetch_add(1, Ordering::SeqCst);
-                        let _ = reply.send(routes.clone());
+                        reply_dataplane_query(known_generation, reply, 1, routes.clone());
                     }
                     RibUpdate::SubscribeEvpnRouteEvents { reply } => {
                         let _ = reply.send(task_events.subscribe());
@@ -3970,13 +4237,16 @@ mod tests {
                     RibUpdate::SubscribeEvpnRouteEvents { reply } => {
                         let _ = reply.send(responder_events.subscribe());
                     }
-                    RibUpdate::QueryEvpnRoutes { reply, .. } => {
+                    RibUpdate::QueryEvpnDataplaneRoutes {
+                        known_generation,
+                        reply,
+                    } => {
                         queries += 1;
                         let mut routes = vec![evpn_macip_route(100, 1, "10.0.0.2", Some(1))];
                         if queries > 1 {
                             routes.push(evpn_macip_route(100, 2, "10.0.0.3", Some(1)));
                         }
-                        let _ = reply.send(routes);
+                        reply_dataplane_query(known_generation, reply, u64::from(queries), routes);
                     }
                     _ => {}
                 }


### PR DESCRIPTION
## Summary

- add an actor-owned wrapping generation token and exact Type 1/2/5 cardinality for the EVPN dataplane projection input
- return an O(1) unchanged response without walking or materializing the EVPN Loc-RIB, while preserving atomic full snapshots after relevant RIB or local projection-input changes
- keep Type 3/4 RR behavior, the public query/API/CLI surfaces, the five-second poll, 200 ms debounce, and BUM cached-republish path unchanged
- add focused generation, cardinality, cancellation, failure-recovery, lost-event, and local-invalidation proofs
- record the controlled 0/1k/50k relevant and mixed Criterion matrix and true up the changelog and roadmap

## Performance receipt

- 50k all-relevant: 367.27 us legacy vs 368.45 us changed, +0.32% and within the preregistered <=2% gate
- 50k mixed Type 1-5: 382.54 us legacy vs 293.94 us changed, -23.16%
- unchanged: about 1.18 ns with `routes=None` and a receipt proving zero row visits/materialization

The A/B isolates the exact old whole-table internal query clone versus the new generation-filtered query at identical input cardinality. Downstream projection is outside both timings.

## Validation

- focused generation query matrix: 4 passed
- exact EVPN dataplane suite: 51 passed
- full RIB suite: 1,189 passed, 2 ignored
- full binary suite: 2,032 passed, 4 ignored
- exact benchmark smoke: all 18 cases
- strict RIB Clippy and rustdoc, binary test Clippy, workspace formatting and diff checks
- repository commit and push hooks, including workspace library tests and workspace rustdoc

Linear: LAN-1055
