### PR TITLE
fix(wire): preserve Partial on typed transitive attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Recognized optional-transitive Communities, Extended Communities, PMSI
+  Tunnel, and Large Communities attributes now preserve a received Partial
+  bit as typed state through policy and the RIB to egress; existing read
+  projections continue to expose recognized community values. Local synthesis
+  remains canonical, malformed recognized values retain their RFC 7606
+  dispositions, and PMSI tunnel-type/identifier validation now follows the
+  assigned, experimental, and composite registry boundaries. (LAN-1285)
 - Malformed Only-to-Customer (OTC) framing is now handled before BGP Role
   logic: revised decoding omits it and treats reachable NLRI as withdrawn, or
   resets the session per RFC 7606 section 5.2 when none is reachable. Valid

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -394,16 +394,22 @@ impl<'a> RouteFilterAttrs<'a> {
         let mut large_communities = None;
 
         for attr in route.attributes.iter() {
+            if communities.is_none()
+                && let Some(values) = attr.communities()
+            {
+                communities = Some(values);
+                continue;
+            }
+            if large_communities.is_none()
+                && let Some(values) = attr.large_communities()
+            {
+                large_communities = Some(values);
+                continue;
+            }
             match attr {
                 PathAttribute::AsPath(path) if !as_path_seen => {
                     origin_asn = path.origin_asn();
                     as_path_seen = true;
-                }
-                PathAttribute::Communities(values) if communities.is_none() => {
-                    communities = Some(values.as_slice());
-                }
-                PathAttribute::LargeCommunities(values) if large_communities.is_none() => {
-                    large_communities = Some(values.as_slice());
                 }
                 _ => {}
             }
@@ -1261,6 +1267,18 @@ fn route_to_proto(route: &Route, best: bool) -> proto::Route {
     let mut atomic_aggregate = false;
 
     for attr in route.attributes.iter() {
+        if let Some(values) = attr.communities() {
+            communities.extend(values);
+            continue;
+        }
+        if let Some(values) = attr.extended_communities() {
+            extended_communities.extend(values.iter().map(|c| c.as_u64()));
+            continue;
+        }
+        if let Some(values) = attr.large_communities() {
+            large_communities.extend(values.iter().map(ToString::to_string));
+            continue;
+        }
         match attr {
             PathAttribute::Origin(o) => origin = *o as u32,
             PathAttribute::AsPath(path) => {
@@ -1273,13 +1291,6 @@ fn route_to_proto(route: &Route, best: bool) -> proto::Route {
             }
             PathAttribute::LocalPref(lp) => local_pref = *lp,
             PathAttribute::Med(m) => med = *m,
-            PathAttribute::Communities(c) => communities.extend(c),
-            PathAttribute::ExtendedCommunities(ec) => {
-                extended_communities.extend(ec.iter().map(|c| c.as_u64()));
-            }
-            PathAttribute::LargeCommunities(lc) => {
-                large_communities.extend(lc.iter().map(ToString::to_string));
-            }
             PathAttribute::Aggregator(a) => {
                 aggregator = Some(proto::RouteAggregator {
                     asn: a.asn,
@@ -2044,20 +2055,21 @@ fn flowspec_route_to_proto(route: &FlowSpecRoute) -> proto::FlowSpecRouteEntry {
     let mut extended_communities = Vec::new();
 
     for attr in &route.attributes {
-        match attr {
-            PathAttribute::AsPath(path) => {
-                for segment in &path.segments {
-                    let asns = match segment {
-                        AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
-                    };
-                    as_path.extend(asns);
-                }
+        if let Some(values) = attr.communities() {
+            communities.extend(values);
+            continue;
+        }
+        if let Some(values) = attr.extended_communities() {
+            extended_communities.extend(values.iter().map(|c| c.as_u64()));
+            continue;
+        }
+        if let PathAttribute::AsPath(path) = attr {
+            for segment in &path.segments {
+                let asns = match segment {
+                    AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
+                };
+                as_path.extend(asns);
             }
-            PathAttribute::Communities(c) => communities.extend(c),
-            PathAttribute::ExtendedCommunities(ec) => {
-                extended_communities.extend(ec.iter().map(|c| c.as_u64()));
-            }
-            _ => {}
         }
     }
 
@@ -2162,10 +2174,7 @@ fn flowspec_route_to_proto(route: &FlowSpecRoute) -> proto::FlowSpecRouteEntry {
     let actions: Vec<proto::FlowSpecAction> = route
         .attributes
         .iter()
-        .filter_map(|attr| match attr {
-            PathAttribute::ExtendedCommunities(ecs) => Some(ecs),
-            _ => None,
-        })
+        .filter_map(PathAttribute::extended_communities)
         .flatten()
         .filter_map(|ec| {
             use rustbgpd_wire::flowspec::FlowSpecAction as FA;
@@ -2259,6 +2268,14 @@ pub(crate) fn bgpls_route_to_proto(route: &BgpLsRibRoute) -> proto::BgpLsRouteEn
     let mut bgp_ls_attribute = Vec::new();
 
     for attr in route.attributes.iter() {
+        if let Some(values) = attr.communities() {
+            communities.extend(values);
+            continue;
+        }
+        if let Some(values) = attr.extended_communities() {
+            extended_communities.extend(values.iter().map(|ec| ec.as_u64()));
+            continue;
+        }
         match attr {
             PathAttribute::AsPath(path) => {
                 for segment in &path.segments {
@@ -2267,10 +2284,6 @@ pub(crate) fn bgpls_route_to_proto(route: &BgpLsRibRoute) -> proto::BgpLsRouteEn
                     };
                     as_path.extend(asns);
                 }
-            }
-            PathAttribute::Communities(c) => communities.extend(c),
-            PathAttribute::ExtendedCommunities(ecs) => {
-                extended_communities.extend(ecs.iter().map(|ec| ec.as_u64()));
             }
             PathAttribute::Unknown(raw) if raw.type_code == 29 => {
                 bgp_ls_attribute = raw.data.to_vec();
@@ -2315,22 +2328,21 @@ pub(crate) fn vpn_route_to_proto(route: &VpnRibRoute) -> proto::VpnRouteEntry {
     let mut extended_communities = Vec::new();
 
     for attr in route.attributes.iter() {
-        match attr {
-            PathAttribute::AsPath(path) => {
-                for segment in &path.segments {
-                    let asns = match segment {
-                        AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
-                    };
-                    as_path.extend(asns);
-                }
+        if let Some(values) = attr.communities() {
+            communities.extend(values.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
+            continue;
+        }
+        if let Some(values) = attr.extended_communities() {
+            extended_communities.extend(values.iter().map(ToString::to_string));
+            continue;
+        }
+        if let PathAttribute::AsPath(path) = attr {
+            for segment in &path.segments {
+                let asns = match segment {
+                    AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
+                };
+                as_path.extend(asns);
             }
-            PathAttribute::Communities(c) => {
-                communities.extend(c.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
-            }
-            PathAttribute::ExtendedCommunities(ecs) => {
-                extended_communities.extend(ecs.iter().map(ToString::to_string));
-            }
-            _ => {}
         }
     }
 
@@ -2364,22 +2376,21 @@ pub(crate) fn labeled_route_to_proto(route: &LabeledRibRoute) -> proto::LabeledR
     let mut extended_communities = Vec::new();
 
     for attr in route.attributes.iter() {
-        match attr {
-            PathAttribute::AsPath(path) => {
-                for segment in &path.segments {
-                    let asns = match segment {
-                        AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
-                    };
-                    as_path.extend(asns);
-                }
+        if let Some(values) = attr.communities() {
+            communities.extend(values.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
+            continue;
+        }
+        if let Some(values) = attr.extended_communities() {
+            extended_communities.extend(values.iter().map(ToString::to_string));
+            continue;
+        }
+        if let PathAttribute::AsPath(path) = attr {
+            for segment in &path.segments {
+                let asns = match segment {
+                    AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
+                };
+                as_path.extend(asns);
             }
-            PathAttribute::Communities(c) => {
-                communities.extend(c.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
-            }
-            PathAttribute::ExtendedCommunities(ecs) => {
-                extended_communities.extend(ecs.iter().map(ToString::to_string));
-            }
-            _ => {}
         }
     }
 
@@ -2403,19 +2414,17 @@ pub(crate) fn rtc_route_to_proto(route: &RtcRibRoute) -> proto::RtcRouteEntry {
     let mut communities = Vec::new();
 
     for attr in route.attributes.iter() {
-        match attr {
-            PathAttribute::AsPath(path) => {
-                for segment in &path.segments {
-                    let asns = match segment {
-                        AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
-                    };
-                    as_path.extend(asns);
-                }
+        if let Some(values) = attr.communities() {
+            communities.extend(values.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
+            continue;
+        }
+        if let PathAttribute::AsPath(path) = attr {
+            for segment in &path.segments {
+                let asns = match segment {
+                    AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
+                };
+                as_path.extend(asns);
             }
-            PathAttribute::Communities(c) => {
-                communities.extend(c.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
-            }
-            _ => {}
         }
     }
 
@@ -2487,27 +2496,26 @@ pub(crate) fn evpn_route_to_proto(route: &EvpnRibRoute) -> proto::EvpnRouteEntry
     let mut tunnel_type = 0u32;
 
     for attr in route.attributes.iter() {
-        match attr {
-            PathAttribute::AsPath(path) => {
-                for segment in &path.segments {
-                    let asns = match segment {
-                        AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
-                    };
-                    as_path.extend(asns);
+        if let Some(values) = attr.communities() {
+            communities.extend(values);
+            continue;
+        }
+        if let Some(values) = attr.extended_communities() {
+            for ec in values {
+                extended_communities.push(ec.as_u64());
+                if let Some(tt) = ec.as_bgp_encapsulation() {
+                    tunnel_type = u32::from(tt);
                 }
             }
-            PathAttribute::Communities(c) => {
-                communities.extend(c);
+            continue;
+        }
+        if let PathAttribute::AsPath(path) = attr {
+            for segment in &path.segments {
+                let asns = match segment {
+                    AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
+                };
+                as_path.extend(asns);
             }
-            PathAttribute::ExtendedCommunities(ecs) => {
-                for ec in ecs {
-                    extended_communities.push(ec.as_u64());
-                    if let Some(tt) = ec.as_bgp_encapsulation() {
-                        tunnel_type = u32::from(tt);
-                    }
-                }
-            }
-            _ => {}
         }
     }
 
@@ -4765,6 +4773,41 @@ mod tests {
         );
         assert_eq!(without.aggregator, None);
         assert!(!without.atomic_aggregate);
+    }
+
+    #[test]
+    fn route_to_proto_projects_partial_transitive_values_like_canonical() {
+        let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 2, 0), 24));
+        let communities = vec![0x0001_0002];
+        let extended = vec![rustbgpd_wire::ExtendedCommunity::new(0x0002_FDE8_0000_0064)];
+        let large = vec![LargeCommunity::new(65_000, 1, 100)];
+        let canonical = route_to_proto(
+            &test_route(
+                prefix,
+                vec![
+                    PathAttribute::Communities(communities.clone()),
+                    PathAttribute::ExtendedCommunities(extended.clone()),
+                    PathAttribute::LargeCommunities(large.clone()),
+                ],
+            ),
+            false,
+        );
+        let partial = route_to_proto(
+            &test_route(
+                prefix,
+                vec![
+                    PathAttribute::CommunitiesPartial(communities),
+                    PathAttribute::ExtendedCommunitiesPartial(extended),
+                    PathAttribute::LargeCommunitiesPartial(large),
+                ],
+            ),
+            false,
+        );
+
+        assert_eq!(partial, canonical);
+        assert_eq!(partial.communities, [0x0001_0002]);
+        assert_eq!(partial.extended_communities, [0x0002_FDE8_0000_0064]);
+        assert_eq!(partial.large_communities, ["65000:1:100"]);
     }
 
     #[test]

--- a/crates/cli/src/commands/ribsnap_bmp.rs
+++ b/crates/cli/src/commands/ribsnap_bmp.rs
@@ -946,11 +946,16 @@ fn convert_attribute<'a>(
         PathAttribute::NextHop(next_hop) => base.next_hop = Some(IpAddr::V4(*next_hop)),
         PathAttribute::Med(med) => base.med = Some(*med),
         PathAttribute::LocalPref(local_pref) => base.local_pref = Some(*local_pref),
-        PathAttribute::Communities(communities) => base.communities = communities.clone(),
-        PathAttribute::ExtendedCommunities(communities) => {
+        PathAttribute::Communities(communities)
+        | PathAttribute::CommunitiesPartial(communities) => {
+            base.communities = communities.clone();
+        }
+        PathAttribute::ExtendedCommunities(communities)
+        | PathAttribute::ExtendedCommunitiesPartial(communities) => {
             base.extended_communities = communities.iter().map(|c| c.as_u64()).collect();
         }
-        PathAttribute::LargeCommunities(communities) => {
+        PathAttribute::LargeCommunities(communities)
+        | PathAttribute::LargeCommunitiesPartial(communities) => {
             base.large_communities = communities
                 .iter()
                 .map(|c| [c.global_admin, c.local_data1, c.local_data2])
@@ -998,7 +1003,7 @@ fn convert_attribute<'a>(
         }
         PathAttribute::MpReachNlri(mp) => *mp_reach = Some(mp),
         PathAttribute::MpUnreachNlri(mp) => *mp_unreach = Some(mp),
-        PathAttribute::PmsiTunnel(_) => {
+        PathAttribute::PmsiTunnel(_) | PathAttribute::PmsiTunnelPartial(_) => {
             return Err(
                 "PMSI_TUNNEL attribute on a unicast Adj-RIB-Out route is not supported".to_string(),
             );
@@ -1600,6 +1605,58 @@ mod tests {
                 "type_code": attr_type::ONLY_TO_CUSTOMER,
                 "value": "0000ffdc"
             }])
+        );
+    }
+
+    #[test]
+    fn partial_transitive_typed_attributes_expose_canonical_snapshot_values() {
+        let (mut capture, info) = v4_peer_capture();
+        let mut attrs = attr(attr_type::ORIGIN, &[0]);
+        attrs.extend(as_path_attr(&[65500]));
+        attrs.extend(attr(attr_type::NEXT_HOP, &[192, 0, 2, 254]));
+        for (type_code, value) in [
+            (
+                attr_type::COMMUNITIES,
+                0xFDE8_0064u32.to_be_bytes().to_vec(),
+            ),
+            (
+                attr_type::EXTENDED_COMMUNITIES,
+                0x0002_FDE8_0000_0064u64.to_be_bytes().to_vec(),
+            ),
+            (
+                attr_type::LARGE_COMMUNITIES,
+                [65_000u32, 1, 100]
+                    .into_iter()
+                    .flat_map(u32::to_be_bytes)
+                    .collect(),
+            ),
+        ] {
+            let mut partial = attr(type_code, &value);
+            partial[0] |= attr_flags::PARTIAL;
+            attrs.extend(partial);
+        }
+        capture.extend(route_monitoring(
+            &info,
+            &update_pdu(&[], &attrs, &v4_nlri([10, 0, 0, 0], 24, None)),
+        ));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+
+        let (snapshot, _) = run_capture(&capture).unwrap();
+        let route: serde_json::Value = serde_json::from_str(
+            snapshot
+                .lines()
+                .find(|line| line.contains("\"record\":\"route\""))
+                .expect("one route record"),
+        )
+        .unwrap();
+        assert_eq!(route["communities"], serde_json::json!([0xFDE8_0064u32]));
+        assert_eq!(
+            route["extended_communities"],
+            serde_json::json!([0x0002_FDE8_0000_0064u64])
+        );
+        assert_eq!(
+            route["large_communities"],
+            serde_json::json!(["65000:1:100"])
         );
     }
 

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -1645,7 +1645,8 @@ mod tests {
     use super::*;
     use rustbgpd_rib::route::{Route, RouteOrigin};
     use rustbgpd_wire::{
-        Aggregator, AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
+        Aggregator, AsPath, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, LargeCommunity, Origin,
+        PathAttribute, Prefix, RpkiValidation,
     };
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::sync::Arc;
@@ -1667,6 +1668,35 @@ mod tests {
                 RIB_IPV6_UNICAST_ADDPATH,
             ),
         ]
+    }
+
+    #[test]
+    fn mrt_rib_attributes_preserve_partial_transitive_framing() {
+        let pmsi = rustbgpd_wire::PmsiTunnel::for_evpn_ingress_replication(
+            100,
+            "192.0.2.1".parse().unwrap(),
+        );
+        let attrs = [
+            PathAttribute::CommunitiesPartial(vec![0xFDE8_0064]),
+            PathAttribute::ExtendedCommunitiesPartial(vec![ExtendedCommunity::new(
+                0x0002_FDE8_0000_0064,
+            )]),
+            PathAttribute::PmsiTunnelPartial(pmsi),
+            PathAttribute::LargeCommunitiesPartial(vec![LargeCommunity::new(65_000, 1, 100)]),
+        ];
+        let mut bytes = Vec::new();
+        encode_mrt_rib_attributes(&attrs, &mut EncodeBuffer::new(&mut bytes, None)).unwrap();
+
+        let mut expected = vec![0xe0, 8, 4];
+        expected.extend_from_slice(&0xFDE8_0064u32.to_be_bytes());
+        expected.extend_from_slice(&[0xe0, 16, 8]);
+        expected.extend_from_slice(&0x0002_FDE8_0000_0064u64.to_be_bytes());
+        expected.extend_from_slice(&[0xe0, 22, 9, 0, 6, 0, 0, 100, 192, 0, 2, 1]);
+        expected.extend_from_slice(&[0xe0, 32, 12]);
+        for value in [65_000u32, 1, 100] {
+            expected.extend_from_slice(&value.to_be_bytes());
+        }
+        assert_eq!(bytes, expected);
     }
 
     fn subtype_marker(name: &str, subtype: u16) -> String {

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1806,11 +1806,21 @@ pub fn apply_modifications(
         attrs,
         &mods.communities_add,
         &mods.communities_remove,
-        |a| match a {
-            PathAttribute::Communities(c) => Some(c.clone()),
-            _ => None,
+        |a| {
+            a.communities().map(|values| {
+                (
+                    values.to_vec(),
+                    matches!(a, PathAttribute::CommunitiesPartial(_)),
+                )
+            })
         },
-        PathAttribute::Communities,
+        |values, partial| {
+            if partial {
+                PathAttribute::CommunitiesPartial(values)
+            } else {
+                PathAttribute::Communities(values)
+            }
+        },
     );
 
     // 4. Extended communities
@@ -1825,11 +1835,21 @@ pub fn apply_modifications(
         attrs,
         &mods.large_communities_add,
         &mods.large_communities_remove,
-        |a| match a {
-            PathAttribute::LargeCommunities(c) => Some(c.clone()),
-            _ => None,
+        |a| {
+            a.large_communities().map(|values| {
+                (
+                    values.to_vec(),
+                    matches!(a, PathAttribute::LargeCommunitiesPartial(_)),
+                )
+            })
         },
-        PathAttribute::LargeCommunities,
+        |values, partial| {
+            if partial {
+                PathAttribute::LargeCommunitiesPartial(values)
+            } else {
+                PathAttribute::LargeCommunities(values)
+            }
+        },
     );
 
     // 6. AS_PATH prepend
@@ -1888,8 +1908,8 @@ fn apply_community_mods<T: Clone + Eq + Hash>(
     attrs: &mut Vec<PathAttribute>,
     add: &[T],
     remove: &[T],
-    extract: impl Fn(&PathAttribute) -> Option<Vec<T>>,
-    wrap: impl Fn(Vec<T>) -> PathAttribute,
+    extract: impl Fn(&PathAttribute) -> Option<(Vec<T>, bool)>,
+    wrap: impl Fn(Vec<T>, bool) -> PathAttribute,
 ) {
     if add.is_empty() && remove.is_empty() {
         return;
@@ -1897,12 +1917,14 @@ fn apply_community_mods<T: Clone + Eq + Hash>(
 
     let mut items = Vec::new();
     let mut found = false;
+    let mut partial = false;
     let mut index = 0;
     while index < attrs.len() {
-        if let Some(extracted) = extract(&attrs[index]) {
+        if let Some((extracted, extracted_partial)) = extract(&attrs[index]) {
             attrs.remove(index);
             if !found {
                 items = extracted;
+                partial = extracted_partial;
                 found = true;
             }
         } else {
@@ -1912,7 +1934,7 @@ fn apply_community_mods<T: Clone + Eq + Hash>(
 
     apply_exact_community_delta(&mut items, add, remove);
     if !items.is_empty() {
-        attrs.push(wrap(items));
+        attrs.push(wrap(items, partial));
     }
 }
 
@@ -1953,11 +1975,15 @@ fn apply_extended_community_mods(
         return;
     }
 
-    let mut items: Vec<ExtendedCommunity> = attrs
+    let (mut items, partial): (Vec<ExtendedCommunity>, bool) = attrs
         .iter()
-        .find_map(|a| match a {
-            PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
-            _ => None,
+        .find_map(|a| {
+            a.extended_communities().map(|values| {
+                (
+                    values.to_vec(),
+                    matches!(a, PathAttribute::ExtendedCommunitiesPartial(_)),
+                )
+            })
         })
         .unwrap_or_default();
 
@@ -1976,9 +2002,13 @@ fn apply_extended_community_mods(
         }
     }
 
-    attrs.retain(|a| !matches!(a, PathAttribute::ExtendedCommunities(_)));
+    attrs.retain(|a| a.extended_communities().is_none());
     if !items.is_empty() {
-        attrs.push(PathAttribute::ExtendedCommunities(items));
+        attrs.push(if partial {
+            PathAttribute::ExtendedCommunitiesPartial(items)
+        } else {
+            PathAttribute::ExtendedCommunities(items)
+        });
     }
 }
 

--- a/crates/policy/src/engine/tests/modifications.rs
+++ b/crates/policy/src/engine/tests/modifications.rs
@@ -324,6 +324,115 @@ fn apply_large_community_add_remove() {
 }
 
 #[test]
+fn no_op_modifications_preserve_all_partial_variants() {
+    let attrs = vec![
+        PathAttribute::CommunitiesPartial(vec![1]),
+        PathAttribute::ExtendedCommunitiesPartial(vec![make_rt(65_001, 100)]),
+        PathAttribute::LargeCommunitiesPartial(vec![LargeCommunity::new(65_001, 1, 100)]),
+        PathAttribute::PmsiTunnelPartial(rustbgpd_wire::PmsiTunnel::for_evpn_ingress_replication(
+            100,
+            "192.0.2.1".parse().unwrap(),
+        )),
+    ];
+    let mut modified = attrs.clone();
+    apply_modifications(&mut modified, &RouteModifications::default());
+    assert_eq!(modified, attrs);
+}
+
+#[test]
+fn community_modifications_retain_partial_on_existing_attributes() {
+    let c1 = (65_001u32 << 16) | 0x0064;
+    let c2 = (65_001u32 << 16) | 0x00c8;
+    let ec1 = make_rt(65_001, 100);
+    let ec2 = make_rt(65_001, 200);
+    let lc1 = LargeCommunity::new(65_001, 1, 100);
+    let lc2 = LargeCommunity::new(65_001, 1, 200);
+    let mut attrs = vec![
+        PathAttribute::CommunitiesPartial(vec![c1]),
+        PathAttribute::ExtendedCommunitiesPartial(vec![ec1]),
+        PathAttribute::LargeCommunitiesPartial(vec![lc1]),
+    ];
+
+    apply_modifications(
+        &mut attrs,
+        &RouteModifications {
+            communities_add: vec![c2],
+            communities_remove: vec![c1],
+            extended_communities_add: vec![ec2],
+            extended_communities_remove: vec![ec1],
+            large_communities_add: vec![lc2],
+            large_communities_remove: vec![lc1],
+            ..Default::default()
+        },
+    );
+
+    assert!(matches!(
+        attrs.as_slice(),
+        [
+            PathAttribute::CommunitiesPartial(values),
+            PathAttribute::ExtendedCommunitiesPartial(extended),
+            PathAttribute::LargeCommunitiesPartial(large),
+        ] if values == &[c2] && extended == &[ec2] && large == &[lc2]
+    ));
+}
+
+#[test]
+fn removing_all_community_values_removes_partial_attributes() {
+    let community = (65_001u32 << 16) | 0x0064;
+    let extended = make_rt(65_001, 100);
+    let large = LargeCommunity::new(65_001, 1, 100);
+    let mut attrs = vec![
+        PathAttribute::CommunitiesPartial(vec![community]),
+        PathAttribute::ExtendedCommunitiesPartial(vec![extended]),
+        PathAttribute::LargeCommunitiesPartial(vec![large]),
+    ];
+
+    apply_modifications(
+        &mut attrs,
+        &RouteModifications {
+            communities_remove: vec![community],
+            extended_communities_remove: vec![extended],
+            large_communities_remove: vec![large],
+            ..Default::default()
+        },
+    );
+
+    assert!(attrs.is_empty());
+}
+
+#[test]
+fn absent_community_synthesis_is_canonical() {
+    let community = (65_001u32 << 16) | 0x0064;
+    let extended = make_rt(65_001, 100);
+    let large = LargeCommunity::new(65_001, 1, 100);
+    let mut attrs = Vec::new();
+
+    apply_modifications(
+        &mut attrs,
+        &RouteModifications {
+            communities_add: vec![community],
+            extended_communities_add: vec![extended],
+            large_communities_add: vec![large],
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        attrs.iter().any(
+            |attr| matches!(attr, PathAttribute::Communities(values) if values == &[community])
+        )
+    );
+    assert!(attrs.iter().any(
+        |attr| matches!(attr, PathAttribute::ExtendedCommunities(values) if values == &[extended])
+    ));
+    assert!(
+        attrs.iter().any(
+            |attr| matches!(attr, PathAttribute::LargeCommunities(values) if values == &[large])
+        )
+    );
+}
+
+#[test]
 fn apply_as_path_prepend_existing() {
     let mut attrs = vec![PathAttribute::AsPath(AsPath {
         segments: vec![AsPathSegment::AsSequence(vec![65002, 65003])],

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -457,7 +457,7 @@ impl AdjRibIn {
         family: (Afi, Safi),
         attr_intern: &mut crate::attr_intern::AttrInternTable,
     ) -> Vec<Prefix> {
-        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR, PathAttribute};
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
 
         // First pass: remove routes with NO_LLGR community
         let no_llgr_keys: Vec<(Prefix, u32)> = self
@@ -483,17 +483,7 @@ impl AdjRibIn {
                 route.is_llgr_stale = true;
                 // Add LLGR_STALE community
                 let attrs = Arc::make_mut(&mut route.attributes);
-                if let Some(PathAttribute::Communities(comms)) = attrs
-                    .iter_mut()
-                    .find(|a| matches!(a, PathAttribute::Communities(_)))
-                {
-                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
-                        comms.push(COMMUNITY_LLGR_STALE);
-                        self.llgr_stale_local_tags
-                            .insert((route.prefix, route.path_id));
-                    }
-                } else {
-                    attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                if add_llgr_stale_community(attrs) {
                     self.llgr_stale_local_tags
                         .insert((route.prefix, route.path_id));
                 }
@@ -737,7 +727,7 @@ impl AdjRibIn {
         family: (Afi, Safi),
         attr_intern: &mut crate::attr_intern::AttrInternTable,
     ) -> Vec<EvpnRouteKey> {
-        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR};
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
 
         if family != (Afi::L2Vpn, Safi::Evpn) {
             return Vec::new();
@@ -762,16 +752,7 @@ impl AdjRibIn {
                 route.is_stale = false;
                 route.is_llgr_stale = true;
                 let attrs = Arc::make_mut(&mut route.attributes);
-                if let Some(PathAttribute::Communities(comms)) = attrs
-                    .iter_mut()
-                    .find(|a| matches!(a, PathAttribute::Communities(_)))
-                {
-                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
-                        comms.push(COMMUNITY_LLGR_STALE);
-                        self.evpn_llgr_stale_local_tags.insert(route.key());
-                    }
-                } else {
-                    attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                if add_llgr_stale_community(attrs) {
                     self.evpn_llgr_stale_local_tags.insert(route.key());
                 }
                 attr_intern.intern(&mut route.attributes);
@@ -1002,7 +983,7 @@ impl AdjRibIn {
         family: (Afi, Safi),
         attr_intern: &mut crate::attr_intern::AttrInternTable,
     ) -> Vec<BgpLsRouteKey> {
-        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR};
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
 
         let Some(fam) = BgpLsFamily::from_afi_safi(family.0, family.1) else {
             return Vec::new();
@@ -1029,16 +1010,7 @@ impl AdjRibIn {
                 route.is_stale = false;
                 route.is_llgr_stale = true;
                 let attrs = Arc::make_mut(&mut route.attributes);
-                if let Some(PathAttribute::Communities(comms)) = attrs
-                    .iter_mut()
-                    .find(|a| matches!(a, PathAttribute::Communities(_)))
-                {
-                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
-                        comms.push(COMMUNITY_LLGR_STALE);
-                        self.bgpls_llgr_stale_local_tags.insert(route.key());
-                    }
-                } else {
-                    attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                if add_llgr_stale_community(attrs) {
                     self.bgpls_llgr_stale_local_tags.insert(route.key());
                 }
                 attr_intern.intern(&mut route.attributes);
@@ -1316,7 +1288,7 @@ impl AdjRibIn {
         family: (Afi, Safi),
         attr_intern: &mut crate::attr_intern::AttrInternTable,
     ) -> Vec<VpnRibRouteKey> {
-        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR};
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
 
         if family.1 != Safi::MplsVpn {
             return Vec::new();
@@ -1342,16 +1314,7 @@ impl AdjRibIn {
                 route.is_stale = false;
                 route.is_llgr_stale = true;
                 let attrs = Arc::make_mut(&mut route.attributes);
-                if let Some(PathAttribute::Communities(comms)) = attrs
-                    .iter_mut()
-                    .find(|a| matches!(a, PathAttribute::Communities(_)))
-                {
-                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
-                        comms.push(COMMUNITY_LLGR_STALE);
-                        self.vpn_llgr_stale_local_tags.insert(route.key());
-                    }
-                } else {
-                    attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                if add_llgr_stale_community(attrs) {
                     self.vpn_llgr_stale_local_tags.insert(route.key());
                 }
                 attr_intern.intern(&mut route.attributes);
@@ -1619,7 +1582,7 @@ impl AdjRibIn {
         family: (Afi, Safi),
         attr_intern: &mut crate::attr_intern::AttrInternTable,
     ) -> Vec<LabeledRibRouteKey> {
-        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR};
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
 
         if family.1 != Safi::LabeledUnicast {
             return Vec::new();
@@ -1645,16 +1608,7 @@ impl AdjRibIn {
                 route.is_stale = false;
                 route.is_llgr_stale = true;
                 let attrs = Arc::make_mut(&mut route.attributes);
-                if let Some(PathAttribute::Communities(comms)) = attrs
-                    .iter_mut()
-                    .find(|a| matches!(a, PathAttribute::Communities(_)))
-                {
-                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
-                        comms.push(COMMUNITY_LLGR_STALE);
-                        self.labeled_llgr_stale_local_tags.insert(route.key());
-                    }
-                } else {
-                    attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                if add_llgr_stale_community(attrs) {
                     self.labeled_llgr_stale_local_tags.insert(route.key());
                 }
                 attr_intern.intern(&mut route.attributes);
@@ -1884,7 +1838,7 @@ impl AdjRibIn {
         family: (Afi, Safi),
         attr_intern: &mut crate::attr_intern::AttrInternTable,
     ) -> Vec<RtcRibRouteKey> {
-        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR};
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
 
         if family != RtcRibRouteKey::afi_safi() {
             return Vec::new();
@@ -1909,16 +1863,7 @@ impl AdjRibIn {
                 route.is_stale = false;
                 route.is_llgr_stale = true;
                 let attrs = Arc::make_mut(&mut route.attributes);
-                if let Some(PathAttribute::Communities(comms)) = attrs
-                    .iter_mut()
-                    .find(|a| matches!(a, PathAttribute::Communities(_)))
-                {
-                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
-                        comms.push(COMMUNITY_LLGR_STALE);
-                        self.rtc_llgr_stale_local_tags.insert(route.key());
-                    }
-                } else {
-                    attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                if add_llgr_stale_community(attrs) {
                     self.rtc_llgr_stale_local_tags.insert(route.key());
                 }
                 attr_intern.intern(&mut route.attributes);
@@ -2093,7 +2038,7 @@ impl AdjRibIn {
     ///
     /// Returns rules affected (for best-path recalc).
     pub fn promote_to_llgr_stale_flowspec(&mut self, family: (Afi, Safi)) -> Vec<FlowSpecKey> {
-        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR, PathAttribute};
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
 
         if family.1 != Safi::FlowSpec {
             return Vec::new();
@@ -2106,9 +2051,10 @@ impl AdjRibIn {
             .filter(|(_, r)| {
                 r.is_stale
                     && r.afi == family.0
-                    && r.attributes
-                        .iter()
-                        .any(|a| matches!(a, PathAttribute::Communities(c) if c.contains(&COMMUNITY_NO_LLGR)))
+                    && r.attributes.iter().any(|a| {
+                        a.communities()
+                            .is_some_and(|values| values.contains(&COMMUNITY_NO_LLGR))
+                    })
             })
             .map(|(k, _)| k.clone())
             .collect();
@@ -2128,19 +2074,7 @@ impl AdjRibIn {
             if route.is_stale && route.afi == family.0 {
                 route.is_stale = false;
                 route.is_llgr_stale = true;
-                if let Some(PathAttribute::Communities(comms)) = route
-                    .attributes
-                    .iter_mut()
-                    .find(|a| matches!(a, PathAttribute::Communities(_)))
-                {
-                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
-                        comms.push(COMMUNITY_LLGR_STALE);
-                        self.flowspec_llgr_stale_local_tags.insert(route.key());
-                    }
-                } else {
-                    route
-                        .attributes
-                        .push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                if add_llgr_stale_community(&mut route.attributes) {
                     self.flowspec_llgr_stale_local_tags.insert(route.key());
                 }
                 affected.push(route.selection_key());
@@ -2279,6 +2213,23 @@ impl AdjRibIn {
     }
 }
 
+/// Add `LLGR_STALE`, mutating an existing canonical or Partial COMMUNITIES
+/// attribute in place. Returns whether this call added the value.
+fn add_llgr_stale_community(attrs: &mut Vec<PathAttribute>) -> bool {
+    use rustbgpd_wire::COMMUNITY_LLGR_STALE;
+    if let Some(communities) = attrs.iter_mut().find_map(PathAttribute::communities_mut) {
+        if communities.contains(&COMMUNITY_LLGR_STALE) {
+            false
+        } else {
+            communities.push(COMMUNITY_LLGR_STALE);
+            true
+        }
+    } else {
+        attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+        true
+    }
+}
+
 /// Remove the `LLGR_STALE` community from a route's attributes, if present.
 fn remove_llgr_stale_community(route: &mut Route) {
     use std::sync::Arc;
@@ -2287,11 +2238,15 @@ fn remove_llgr_stale_community(route: &mut Route) {
 
 fn remove_llgr_stale_community_attrs(attrs: &mut Vec<PathAttribute>) {
     use rustbgpd_wire::COMMUNITY_LLGR_STALE;
-    for attr in attrs {
-        if let PathAttribute::Communities(comms) = attr {
+    for attr in attrs.iter_mut() {
+        if let Some(comms) = attr.communities_mut() {
             comms.retain(|&c| c != COMMUNITY_LLGR_STALE);
         }
     }
+    attrs.retain(|attr| {
+        attr.communities()
+            .is_none_or(|communities| !communities.is_empty())
+    });
 }
 
 /// Check whether a route's prefix matches an AFI/SAFI family.
@@ -2319,6 +2274,28 @@ mod tests {
 
     use crate::route::BgpLsFamily;
     use crate::test_support::{make_flowspec_route, make_route, make_v6_route};
+
+    #[test]
+    fn llgr_stale_mutation_preserves_partial_and_removes_empty_state() {
+        let other = 0x0001_0002;
+        let mut attrs = vec![PathAttribute::CommunitiesPartial(vec![other])];
+        assert!(add_llgr_stale_community(&mut attrs));
+        assert!(!add_llgr_stale_community(&mut attrs));
+        assert!(matches!(
+            attrs.as_slice(),
+            [PathAttribute::CommunitiesPartial(values)]
+                if values == &[other, COMMUNITY_LLGR_STALE]
+        ));
+
+        remove_llgr_stale_community_attrs(&mut attrs);
+        assert_eq!(attrs, vec![PathAttribute::CommunitiesPartial(vec![other])]);
+
+        let mut only_stale = vec![PathAttribute::CommunitiesPartial(vec![
+            COMMUNITY_LLGR_STALE,
+        ])];
+        remove_llgr_stale_community_attrs(&mut only_stale);
+        assert!(only_stale.is_empty());
+    }
 
     fn bgpls_nlri(payload_suffix: u8) -> rustbgpd_wire::bgpls::BgpLsNlri {
         let bytes = [0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_suffix];

--- a/crates/rib/src/manager/tests/evpn.rs
+++ b/crates/rib/src/manager/tests/evpn.rs
@@ -1902,6 +1902,114 @@ async fn evpn_export_policy_applies_modifications() {
     handle.await.unwrap();
 }
 
+#[tokio::test]
+async fn partial_pmsi_survives_type3_imet_distribution_and_wire_encoding() {
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 100)),
+        BgpMetrics::new(),
+    );
+    let handle = tokio::spawn(manager.run());
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65_000,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: evpn_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let (source_tx, mut source_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: source,
+        peer_asn: 65_000,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 1),
+        outbound_tx: source_tx,
+        export_policy: None,
+        sendable_families: evpn_sendable(),
+        is_ebgp: false,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut source_rx).await;
+
+    let mut imet = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    imet.attributes = Arc::new(vec![PathAttribute::PmsiTunnelPartial(
+        rustbgpd_wire::PmsiTunnel::for_evpn_ingress_replication(100, source),
+    )]);
+    let imet_key = imet.key();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![imet],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_evpn_routes(&tx).await;
+
+    let update = out_rx.try_recv().expect("Type 3 IMET is distributed");
+    let advertised = update
+        .evpn_announce
+        .first()
+        .expect("one Type 3 IMET announced");
+    assert_eq!(advertised.key(), imet_key);
+    assert!(
+        advertised
+            .attributes
+            .iter()
+            .any(|attribute| matches!(attribute, PathAttribute::PmsiTunnelPartial(_)))
+    );
+    let mut wire = Vec::new();
+    rustbgpd_wire::attribute::encode_path_attributes(
+        &advertised.attributes,
+        &mut wire,
+        true,
+        false,
+    )
+    .unwrap();
+    let pmsi_frame = [0xe0, 22, 9, 0, 6, 0, 0, 100, 10, 0, 0, 1];
+    assert!(
+        wire.windows(pmsi_frame.len())
+            .any(|window| window == pmsi_frame)
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Regression: `PendingRoutesReceived::has_more()` previously omitted
 /// the EVPN iterators, so a `RoutesReceived` carrying more than
 /// `ROUTES_RECEIVED_CHUNK_SIZE` EVPN routes had everything past the

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -60,6 +60,11 @@ pub(super) fn with_no_advertise(mut route: Route) -> Route {
     route
 }
 
+fn with_partial_community(mut route: Route, community: u32) -> Route {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::CommunitiesPartial(vec![community]));
+    route
+}
+
 fn with_otc(mut route: Route, asn: u32) -> Route {
     Arc::make_mut(&mut route.attributes).push(PathAttribute::OnlyToCustomer(asn));
     route
@@ -83,6 +88,256 @@ fn drain_unicast_state(
         }
     }
     state
+}
+
+#[tokio::test]
+async fn partial_communities_enforce_no_export_and_no_advertise() {
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let target: IpAddr = "192.0.2.90".parse().unwrap();
+    let source: IpAddr = "198.51.100.90".parse().unwrap();
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        peer: target,
+        session_id: 0,
+        peer_asn: 65_100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        interpret_rfc1997: true,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 119, 0), 24);
+    let plain = make_route(prefix, Ipv4Addr::new(198, 51, 100, 90));
+    for community in [
+        rustbgpd_wire::COMMUNITY_NO_EXPORT,
+        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+    ] {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![plain.clone()],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        let _ = query_best_routes(&tx).await;
+        let announced = out_rx.try_recv().expect("plain route is announced");
+        assert_eq!(announced.announce.len(), 1);
+
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![with_partial_community(plain.clone(), community)],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        let _ = query_best_routes(&tx).await;
+        let withdrawn = out_rx
+            .try_recv()
+            .expect("Partial well-known community withdraws prior route");
+        assert!(withdrawn.announce.is_empty());
+        assert_eq!(withdrawn.withdraw, vec![(Prefix::V4(prefix), 0)]);
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+fn partial_community_export_policy(
+    added_community: u32,
+    added_extended: ExtendedCommunity,
+    added_large: rustbgpd_wire::LargeCommunity,
+) -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications {
+                communities_add: vec![added_community],
+                extended_communities_add: vec![added_extended],
+                large_communities_add: vec![added_large],
+                ..Default::default()
+            },
+        }],
+        default_action: PolicyAction::Deny,
+    }])
+}
+
+fn assert_partial_community_export(
+    advertised: &Route,
+    communities: [u32; 2],
+    extended: [ExtendedCommunity; 2],
+    large: [rustbgpd_wire::LargeCommunity; 2],
+) {
+    assert!(matches!(
+        advertised
+            .attributes
+            .iter()
+            .find(|attr| attr.communities().is_some()),
+        Some(PathAttribute::CommunitiesPartial(values)) if values == &communities
+    ));
+    assert!(matches!(
+        advertised
+            .attributes
+            .iter()
+            .find(|attr| attr.extended_communities().is_some()),
+        Some(PathAttribute::ExtendedCommunitiesPartial(values)) if values == &extended
+    ));
+    assert!(matches!(
+        advertised
+            .attributes
+            .iter()
+            .find(|attr| attr.large_communities().is_some()),
+        Some(PathAttribute::LargeCommunitiesPartial(values)) if values == &large
+    ));
+
+    let mut wire = Vec::new();
+    rustbgpd_wire::attribute::encode_path_attributes(
+        &advertised.attributes,
+        &mut wire,
+        true,
+        false,
+    )
+    .unwrap();
+    let assert_partial_frame = |type_code: u8, value: &[u8]| {
+        let mut expected = vec![0xe0, type_code, u8::try_from(value.len()).unwrap()];
+        expected.extend_from_slice(value);
+        assert!(
+            wire.windows(expected.len())
+                .any(|window| window == expected),
+            "missing Partial type {type_code} frame in {wire:02x?}"
+        );
+    };
+    let communities_value = communities
+        .into_iter()
+        .flat_map(u32::to_be_bytes)
+        .collect::<Vec<_>>();
+    assert_partial_frame(8, &communities_value);
+    let extended_value = extended
+        .into_iter()
+        .flat_map(|value| value.as_u64().to_be_bytes())
+        .collect::<Vec<_>>();
+    assert_partial_frame(16, &extended_value);
+    let large_value = large
+        .into_iter()
+        .flat_map(|value| {
+            [value.global_admin, value.local_data1, value.local_data2]
+                .into_iter()
+                .flat_map(u32::to_be_bytes)
+        })
+        .collect::<Vec<_>>();
+    assert_partial_frame(32, &large_value);
+}
+
+#[tokio::test]
+async fn partial_community_attributes_survive_policy_update_group_and_wire_encoding() {
+    let community = (65_000u32 << 16) | 0x0064;
+    let added_community = (65_000u32 << 16) | 0x00c8;
+    let extended = ExtendedCommunity::new(0x0002_FDE8_0000_0064);
+    let added_extended = ExtendedCommunity::new(0x0002_FDE8_0000_00C8);
+    let large = rustbgpd_wire::LargeCommunity::new(65_000, 1, 100);
+    let added_large = rustbgpd_wire::LargeCommunity::new(65_000, 1, 200);
+    let export_policy =
+        partial_community_export_policy(added_community, added_extended, added_large);
+
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let target: IpAddr = "192.0.2.91".parse().unwrap();
+    let source: IpAddr = "198.51.100.91".parse().unwrap();
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        peer: target,
+        session_id: 0,
+        peer_asn: 65_100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(export_policy),
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        interpret_rfc1997: true,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 120, 0), 24);
+    let mut route = make_route(prefix, Ipv4Addr::new(198, 51, 100, 91));
+    Arc::make_mut(&mut route.attributes).extend([
+        PathAttribute::CommunitiesPartial(vec![community]),
+        PathAttribute::ExtendedCommunitiesPartial(vec![extended]),
+        PathAttribute::LargeCommunitiesPartial(vec![large]),
+    ]);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    let update = out_rx.try_recv().expect("route is exported after policy");
+    let advertised = update.announce.first().expect("one route announced");
+    assert_partial_community_export(
+        advertised,
+        [community, added_community],
+        [extended, added_extended],
+        [large, added_large],
+    );
+
+    drop(tx);
+    handle.await.unwrap();
 }
 
 async fn seed_three_dual_stack_candidates(

--- a/crates/rib/src/manager/update_groups/payload.rs
+++ b/crates/rib/src/manager/update_groups/payload.rs
@@ -169,17 +169,11 @@ pub(in crate::manager) fn source_control_input(
     };
     let communities = attrs
         .iter()
-        .find_map(|attr| match attr {
-            PathAttribute::Communities(values) => Some(values.as_slice()),
-            _ => None,
-        })
+        .find_map(PathAttribute::communities)
         .unwrap_or(&[]);
     let large_communities = attrs
         .iter()
-        .find_map(|attr| match attr {
-            PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
-            _ => None,
-        })
+        .find_map(PathAttribute::large_communities)
         .unwrap_or(&[]);
     (communities, large_communities)
 }

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -261,10 +261,7 @@ impl Route {
     pub fn communities(&self) -> &[u32] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::Communities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::communities)
             .unwrap_or(&[])
     }
 
@@ -273,10 +270,7 @@ impl Route {
     pub fn extended_communities(&self) -> &[ExtendedCommunity] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::ExtendedCommunities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::extended_communities)
             .unwrap_or(&[])
     }
 
@@ -285,10 +279,7 @@ impl Route {
     pub fn large_communities(&self) -> &[LargeCommunity] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::LargeCommunities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::large_communities)
             .unwrap_or(&[])
     }
 
@@ -451,10 +442,7 @@ impl BgpLsRibRoute {
     pub fn communities(&self) -> &[u32] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::Communities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::communities)
             .unwrap_or(&[])
     }
 
@@ -463,10 +451,7 @@ impl BgpLsRibRoute {
     pub fn extended_communities(&self) -> &[ExtendedCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::ExtendedCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::extended_communities)
             .unwrap_or(&[])
     }
 
@@ -475,10 +460,7 @@ impl BgpLsRibRoute {
     pub fn large_communities(&self) -> &[LargeCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::large_communities)
             .unwrap_or(&[])
     }
 }
@@ -626,10 +608,7 @@ impl VpnRibRoute {
     pub fn communities(&self) -> &[u32] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::Communities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::communities)
             .unwrap_or(&[])
     }
 
@@ -641,10 +620,7 @@ impl VpnRibRoute {
     pub fn extended_communities(&self) -> &[ExtendedCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::ExtendedCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::extended_communities)
             .unwrap_or(&[])
     }
 
@@ -653,10 +629,7 @@ impl VpnRibRoute {
     pub fn large_communities(&self) -> &[LargeCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::large_communities)
             .unwrap_or(&[])
     }
 }
@@ -760,10 +733,7 @@ impl LabeledRibRoute {
     pub fn communities(&self) -> &[u32] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::Communities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::communities)
             .unwrap_or(&[])
     }
 
@@ -799,10 +769,7 @@ impl LabeledRibRoute {
     pub fn extended_communities(&self) -> &[ExtendedCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::ExtendedCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::extended_communities)
             .unwrap_or(&[])
     }
 
@@ -811,10 +778,7 @@ impl LabeledRibRoute {
     pub fn large_communities(&self) -> &[LargeCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::large_communities)
             .unwrap_or(&[])
     }
 }
@@ -925,10 +889,7 @@ impl RtcRibRoute {
     pub fn communities(&self) -> &[u32] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::Communities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::communities)
             .unwrap_or(&[])
     }
 
@@ -937,10 +898,7 @@ impl RtcRibRoute {
     pub fn extended_communities(&self) -> &[ExtendedCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::ExtendedCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::extended_communities)
             .unwrap_or(&[])
     }
 
@@ -949,10 +907,7 @@ impl RtcRibRoute {
     pub fn large_communities(&self) -> &[LargeCommunity] {
         self.attributes
             .iter()
-            .find_map(|attr| match attr {
-                PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::large_communities)
             .unwrap_or(&[])
     }
 }
@@ -1046,10 +1001,7 @@ impl FlowSpecRoute {
     pub fn communities(&self) -> &[u32] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::Communities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::communities)
             .unwrap_or(&[])
     }
 
@@ -1058,10 +1010,7 @@ impl FlowSpecRoute {
     pub fn extended_communities(&self) -> &[ExtendedCommunity] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::ExtendedCommunities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::extended_communities)
             .unwrap_or(&[])
     }
 
@@ -1070,10 +1019,7 @@ impl FlowSpecRoute {
     pub fn large_communities(&self) -> &[LargeCommunity] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::LargeCommunities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::large_communities)
             .unwrap_or(&[])
     }
 
@@ -1220,10 +1166,7 @@ impl EvpnRibRoute {
     pub fn communities(&self) -> &[u32] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::Communities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::communities)
             .unwrap_or(&[])
     }
 
@@ -1232,10 +1175,7 @@ impl EvpnRibRoute {
     pub fn extended_communities(&self) -> &[ExtendedCommunity] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::ExtendedCommunities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::extended_communities)
             .unwrap_or(&[])
     }
 
@@ -1244,10 +1184,7 @@ impl EvpnRibRoute {
     pub fn large_communities(&self) -> &[LargeCommunity] {
         self.attributes
             .iter()
-            .find_map(|a| match a {
-                PathAttribute::LargeCommunities(c) => Some(c.as_slice()),
-                _ => None,
-            })
+            .find_map(PathAttribute::large_communities)
             .unwrap_or(&[])
     }
 

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -324,8 +324,8 @@ impl SessionExportProfile {
             return;
         }
         let is_llgr_stale = attrs.iter().any(|attr| {
-            matches!(attr, PathAttribute::Communities(comms)
-                if comms.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE))
+            attr.communities()
+                .is_some_and(|comms| comms.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE))
         });
         if !is_llgr_stale {
             return;
@@ -337,12 +337,13 @@ impl SessionExportProfile {
                     *local_pref = 0;
                     has_local_pref = true;
                 }
-                PathAttribute::Communities(comms)
-                    if !comms.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT) =>
-                {
-                    comms.push(rustbgpd_wire::COMMUNITY_NO_EXPORT);
+                _ => {
+                    if let Some(comms) = attr.communities_mut()
+                        && !comms.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT)
+                    {
+                        comms.push(rustbgpd_wire::COMMUNITY_NO_EXPORT);
+                    }
                 }
-                _ => {}
             }
         }
         if !has_local_pref {
@@ -355,7 +356,7 @@ impl SessionExportProfile {
             return;
         }
         for attr in attrs.iter_mut() {
-            if let PathAttribute::Communities(comms) = attr {
+            if let Some(comms) = attr.communities_mut() {
                 if !comms.contains(&rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN) {
                     comms.push(rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN);
                 }

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -369,16 +369,25 @@ impl<'a> PolicyAttrSummary<'a> {
         // unambiguous — a duplicate *empty* community must not blank out
         // an earlier populated one (an `is_empty()` sentinel would).
         for attr in attrs {
+            if extended_communities.is_none()
+                && let Some(values) = attr.extended_communities()
+            {
+                extended_communities = Some(values);
+                continue;
+            }
+            if communities.is_none()
+                && let Some(values) = attr.communities()
+            {
+                communities = Some(values);
+                continue;
+            }
+            if large_communities.is_none()
+                && let Some(values) = attr.large_communities()
+            {
+                large_communities = Some(values);
+                continue;
+            }
             match attr {
-                PathAttribute::ExtendedCommunities(c) if extended_communities.is_none() => {
-                    extended_communities = Some(c.as_slice());
-                }
-                PathAttribute::Communities(c) if communities.is_none() => {
-                    communities = Some(c.as_slice());
-                }
-                PathAttribute::LargeCommunities(c) if large_communities.is_none() => {
-                    large_communities = Some(c.as_slice());
-                }
                 PathAttribute::AsPath(p) if as_path.is_none() => as_path = Some(p),
                 PathAttribute::LocalPref(v) if local_pref.is_none() => local_pref = Some(*v),
                 PathAttribute::Med(v) if med.is_none() => med = Some(*v),
@@ -670,15 +679,21 @@ impl PeerSession {
         let mut communities: Vec<u32> = Vec::new();
         let mut large_communities: Vec<rustbgpd_wire::LargeCommunity> = Vec::new();
         for attr in &parsed.attributes {
+            if communities.is_empty()
+                && let Some(values) = attr.communities()
+            {
+                communities.extend_from_slice(values);
+                continue;
+            }
+            if large_communities.is_empty()
+                && let Some(values) = attr.large_communities()
+            {
+                large_communities.extend_from_slice(values);
+                continue;
+            }
             match attr {
                 PathAttribute::AsPath(p) if as_path.is_empty() => {
                     as_path = p.to_aspath_string();
-                }
-                PathAttribute::Communities(c) if communities.is_empty() => {
-                    communities.clone_from(c);
-                }
-                PathAttribute::LargeCommunities(c) if large_communities.is_empty() => {
-                    large_communities.clone_from(c);
                 }
                 _ => {}
             }
@@ -3028,6 +3043,19 @@ mod policy_attr_summary_tests {
         assert_eq!(s.origin_asn, Some(65002));
         assert_eq!(s.local_pref, Some(150));
         assert_eq!(s.med, Some(42));
+    }
+
+    #[test]
+    fn partial_community_variants_feed_identical_policy_inputs() {
+        let attrs = vec![
+            PathAttribute::CommunitiesPartial(vec![100, 200]),
+            PathAttribute::ExtendedCommunitiesPartial(vec![ExtendedCommunity::new(1)]),
+            PathAttribute::LargeCommunitiesPartial(vec![LargeCommunity::new(65001, 1, 2)]),
+        ];
+        let s = PolicyAttrSummary::from_route_attrs(&attrs, true);
+        assert_eq!(s.communities, [100u32, 200]);
+        assert_eq!(s.extended_communities, [ExtendedCommunity::new(1)]);
+        assert_eq!(s.large_communities, [LargeCommunity::new(65001, 1, 2)]);
     }
     /// The load-bearing guard for the `find_map` → single-pass change:
     /// first match wins for every attribute type, and a *later empty*

--- a/crates/transport/src/session/tests/outbound_attrs.rs
+++ b/crates/transport/src/session/tests/outbound_attrs.rs
@@ -207,6 +207,97 @@ fn llgr_stale_to_non_llgr_ibgp_peer_carries_no_export_and_lpref_zero() {
     );
 }
 
+#[test]
+fn llgr_rewrite_preserves_partial_communities() {
+    let session = make_test_session(65001, 65001);
+    let route = Route {
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::LocalPref(100),
+            PathAttribute::CommunitiesPartial(vec![rustbgpd_wire::COMMUNITY_LLGR_STALE]),
+        ]),
+        ..make_route(100)
+    };
+
+    let attrs =
+        session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
+    let communities = attrs
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::CommunitiesPartial(values) => Some(values),
+            _ => None,
+        })
+        .expect("LLGR rewrite retains Partial");
+    assert!(communities.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE));
+    assert!(communities.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT));
+    assert!(
+        attrs
+            .iter()
+            .any(|attr| matches!(attr, PathAttribute::LocalPref(0)))
+    );
+}
+
+#[test]
+fn outbound_attribute_preparation_preserves_partial_community_variants() {
+    let session = make_test_session(65001, 65002);
+    let community = 0x0001_0002;
+    let extended = rustbgpd_wire::ExtendedCommunity::new(0x0002_FDE8_0000_0064);
+    let large = rustbgpd_wire::LargeCommunity::new(65_000, 1, 100);
+    let route = Route {
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::CommunitiesPartial(vec![community]),
+            PathAttribute::ExtendedCommunitiesPartial(vec![extended]),
+            PathAttribute::LargeCommunitiesPartial(vec![large]),
+        ]),
+        ..make_route(100)
+    };
+
+    let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
+    assert!(matches!(
+        attrs.iter().find(|attr| attr.communities().is_some()),
+        Some(PathAttribute::CommunitiesPartial(values)) if values == &[community]
+    ));
+    assert!(matches!(
+        attrs
+            .iter()
+            .find(|attr| attr.extended_communities().is_some()),
+        Some(PathAttribute::ExtendedCommunitiesPartial(values)) if values == &[extended]
+    ));
+    assert!(matches!(
+        attrs
+            .iter()
+            .find(|attr| attr.large_communities().is_some()),
+        Some(PathAttribute::LargeCommunitiesPartial(values)) if values == &[large]
+    ));
+
+    let mut wire = Vec::new();
+    rustbgpd_wire::attribute::encode_path_attributes(&attrs, &mut wire, true, false).unwrap();
+    for (type_code, value) in [
+        (8, community.to_be_bytes().to_vec()),
+        (16, extended.as_u64().to_be_bytes().to_vec()),
+        (
+            32,
+            [large.global_admin, large.local_data1, large.local_data2]
+                .into_iter()
+                .flat_map(u32::to_be_bytes)
+                .collect(),
+        ),
+    ] {
+        let mut frame = vec![0xe0, type_code, u8::try_from(value.len()).unwrap()];
+        frame.extend(value);
+        assert!(wire.windows(frame.len()).any(|window| window == frame));
+    }
+}
+
 /// A fresh (non-LLGR-stale) route toward the same non-LLGR iBGP peer is
 /// untouched by the §4.6 rewrite: no `NO_EXPORT`, `LOCAL_PREF` preserved.
 #[test]

--- a/crates/transport/src/session/tests/reject_retention.rs
+++ b/crates/transport/src/session/tests/reject_retention.rs
@@ -224,7 +224,10 @@ async fn reject_retention_clears_when_route_is_later_accepted() {
                 segments: vec![AsPathSegment::AsSequence(vec![65002])],
             }),
             PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
-            PathAttribute::Communities(vec![999]),
+            PathAttribute::CommunitiesPartial(vec![999]),
+            PathAttribute::LargeCommunitiesPartial(vec![rustbgpd_wire::LargeCommunity::new(
+                65_002, 1, 999,
+            )]),
         ],
         true,
         false,
@@ -237,6 +240,11 @@ async fn reject_retention_clears_when_route_is_later_accepted() {
         entries[0].1.communities,
         vec![999],
         "the rejected UPDATE's communities are retained for the surface"
+    );
+    assert_eq!(
+        entries[0].1.large_communities,
+        vec![rustbgpd_wire::LargeCommunity::new(65_002, 1, 999)],
+        "the rejected UPDATE's Partial Large Communities are retained for the surface"
     );
 
     // Re-announce without the community — accepted, entry cleared.

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,14 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- **Additive typed Partial preservation:** Added
+  `PathAttribute::CommunitiesPartial`, `ExtendedCommunitiesPartial`,
+  `PmsiTunnelPartial`, and `LargeCommunitiesPartial` while retaining every
+  canonical tuple variant. Valid Partial-bearing values now remain typed and
+  re-emit with Partial across compact and Extended Length framing; malformed
+  recognized values remain RFC 7606 treat-as-withdraw. PMSI decoding now
+  enforces the assigned, experimental, composite, and identifier-length
+  boundaries from the IANA registry, RFC 6514, and RFC 8317.
 - **Additive typed OTC correction:** Preserved
   `PathAttribute::OnlyToCustomer(u32)` for canonical/local OTC and added
   `PathAttribute::OnlyToCustomerPartial(u32)` for valid received OTC carrying

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -20,12 +20,12 @@ Release-by-release crate changes are recorded in the [changelog](CHANGELOG.md).
 
 | RFC | Feature |
 |-----|---------|
-| 1997 | Standard communities (4-byte), including `NO_EXPORT`, `NO_ADVERTISE`, and `NO_EXPORT_SUBCONFED` well-known constants |
+| 1997 | Standard communities (4-byte), including `NO_EXPORT`, `NO_ADVERTISE`, and `NO_EXPORT_SUBCONFED` well-known constants. Canonical/local values use `PathAttribute::Communities`; received Partial-bearing values use `CommunitiesPartial` and retain Partial through propagation and policy changes |
 | 2545 | IPv6 link-local next-hop in `MP_REACH_NLRI` (32-byte form); second-segment validated as `fe80::/10` on receive (rejects malformed advertisements) |
 | 2918 | Route Refresh capability |
 | 3032 | MPLS label: 3-byte label field as carried in EVPN NLRI |
 | 4271 | BGP-4 core: OPEN, UPDATE, NOTIFICATION, KEEPALIVE |
-| 4360 | Extended communities (route target, route origin, 4-byte AS) |
+| 4360 | Extended communities (route target, route origin, 4-byte AS), represented by `ExtendedCommunities` or the received Partial-preserving `ExtendedCommunitiesPartial` variant |
 | 4364 §4.2 | Route Distinguisher: 8-byte wire form with all three encodings (2-octet AS, IPv4, 4-octet AS) plus `Display` and `FromStr` for the canonical textual forms |
 | 4364 / 4659 | VPNv4/VPNv6 labeled NLRI substrate: label-stack + RD + IPv4/IPv6 prefix encode/decode. No daemon AFI/SAFI negotiation or RIB support by itself |
 | 4456 | Route reflector: ORIGINATOR_ID, CLUSTER_LIST |
@@ -37,19 +37,20 @@ Release-by-release crate changes are recorded in the [changelog](CHANGELOG.md).
 | 5292 | Address-Prefix ORF-Type (64), with the legacy pre-standard type (128) decoded for interoperability |
 | 5492 | BGP capabilities |
 | 5512 | Tunnel Encapsulation extended-community layout (4-byte reserved + 2-byte value) used by the EVPN VXLAN encap sub-type |
-| 6514 §5 | PMSI Tunnel attribute (path attribute type 22): all 8 tunnel types from the IANA registry, with the EVPN-VXLAN ingress-replication form encoding the label field as the raw 24-bit VNI per RFC 8365 §5.1.3 |
+| 6514 §5 | PMSI Tunnel attribute (path attribute type 22): base tunnel-type and identifier semantics, with canonical `PmsiTunnel` and received Partial-preserving `PmsiTunnelPartial` variants. The EVPN-VXLAN ingress-replication form encodes the label field as the raw 24-bit VNI per RFC 8365 §5.1.3 |
 | 6793 | 4-octet AS numbers, including canonical type 2/17 and type 7/18 ingress normalization plus capability-specific egress projection |
 | 6811 | RPKI prefix-origin validation state — the `RpkiValidation` routing-domain enum (no extended-community codec) |
 | 7313 | Enhanced Route Refresh (BoRR / EoRR markers) |
-| 7385 | PMSI Tunnel Type IANA registry — `PmsiTunnelType` preserves unknown values via an `Other(u8)` variant |
+| 7385 | PMSI Tunnel Type IANA registry — assigned unsupported and experimental values round-trip opaquely through `PmsiTunnelType::Other`; unassigned values and invalid composite encodings are rejected |
 | 7432 | EVPN: Types 1–4 (EAD, MAC/IP, IMET, Ethernet Segment) including the MAC Mobility extended community (§7.7) and the flag-only Default Gateway extended community (§7.8, type 0x03 / subtype 0x0D, decode + construct) |
 | 7606 | Revised UPDATE error handling: `UpdateMessage::parse_revised` recovers malformed path attributes without aborting the parse, each carrying its §7 per-attribute disposition (treat-as-withdraw / attribute-discard / session-reset) from `malformed_attr_disposition`; an attribute that decodes but fails validation may be retained in `update.attributes` for observation alongside its disposition; malformed or duplicated `MP_REACH_NLRI` / `MP_UNREACH_NLRI` and unparseable NLRI stay session-reset (§5.3, §7.11) |
 | 7674 | FlowSpec Redirect Extended Community formatting (updates RFC 5575): redirect-to-IPv4 type 0x8108 and redirect-to-4-octet-AS type 0x8208 in `FlowSpecAction` |
 | 7911 | Add-Path: path ID in NLRI encode/decode |
 | 7999 | `BLACKHOLE` well-known community (`0xFFFF_029A`, rendered as `65535:666`) |
-| 8092 | Large communities (3× u32) |
+| 8092 | Large communities (3× u32), represented by `LargeCommunities` or the received Partial-preserving `LargeCommunitiesPartial` variant; duplicate values normalize in first-seen order |
 | 8097 | Origin Validation State Extended Community (type 0x43): `ORIGIN_VALIDATION_{VALID,NOT_FOUND,INVALID}` `ExtendedCommunity` constants with `OV_*` textual rendering. Codec only — RPKI-to-community stamping lives in the daemon |
 | 8277 | IPv4/IPv6 labeled-unicast NLRI codec (SAFI 4): label-stack + prefix encode/decode, Add-Path and withdraw forms. Inert codec substrate |
+| 8317 | PMSI Tunnel composite tunnel-type encoding: valid composites use an assigned base tunnel type other than 0 or 6 and require the 3-octet receiver-label prefix |
 | 8326 | `GRACEFUL_SHUTDOWN` well-known community (`0xFFFF_0000`) |
 | 8365 | EVPN over VXLAN encapsulation |
 | 8538 | Notification GR (N-bit) |
@@ -297,7 +298,7 @@ cargo run -p rustbgpd-wire --features tokio-codec --example tokio_codec
 - **`BgpCodec` / `BgpCodecError`** — optional Tokio `Decoder` / `Encoder`
   adapter and typed I/O/decode/encode errors, gated by `tokio-codec`
 - **`UpdateMessage`** / **`ParsedUpdate`** — raw wire form and parsed routes + attributes
-- **`PathAttribute`** — typed variants plus `Unknown` pass-through, including `AsPath`, `Aggregator`, `AtomicAggregate`, `NextHop`, `Communities`, `MpReachNlri`, `LargeCommunities`, `PmsiTunnel` (RFC 6514), and `OnlyToCustomer` (RFC 9234)
+- **`PathAttribute`** — typed variants plus `Unknown` pass-through, including `AsPath`, `Aggregator`, `AtomicAggregate`, `NextHop`, canonical/Partial pairs `Communities` / `CommunitiesPartial`, `ExtendedCommunities` / `ExtendedCommunitiesPartial`, `LargeCommunities` / `LargeCommunitiesPartial`, and `PmsiTunnel` / `PmsiTunnelPartial`, plus `MpReachNlri` and canonical/Partial `OnlyToCustomer` (RFC 9234)
 - **`Prefix`** — `V4(Ipv4Prefix)` / `V6(Ipv6Prefix)` enum
 - **`RpkiValidation` / `AspaValidation` / `AspaValidationContext`** — shared
   routing-domain validation state and ASPA session context used by rustbgpd's
@@ -326,7 +327,7 @@ cargo run -p rustbgpd-wire --features tokio-codec --example tokio_codec
 - **`rtc` module** — Route Target Constrain NLRI codec (SAFI 132, RFC 4684):
   `RtcNlri` / `RTC_SAFI` / `RTC_MAX_PREFIX_BITS`, `decode_rtc_nlri` /
   `encode_rtc_nlri` with default-route and prefix-bit bounds
-- **`PmsiTunnel`** / **`PmsiTunnelType`** / **`PmsiTunnelIdentifier`** — PMSI Tunnel attribute (RFC 6514 §5) carried on EVPN Type 3 IMET routes for ingress-replication BUM. Constructor `PmsiTunnel::for_evpn_ingress_replication(vni, ip)` emits the RFC 8365 §5.1.3 wire shape (raw 24-bit VNI in the label field, originator IP as the tunnel identifier).
+- **`PmsiTunnel`** / **`PmsiTunnelType`** / **`PmsiTunnelIdentifier`** — PMSI Tunnel attribute (RFC 6514 §5) carried by `PathAttribute::PmsiTunnel` or `PmsiTunnelPartial` on EVPN Type 3 IMET routes for ingress-replication BUM. Constructor `PmsiTunnel::for_evpn_ingress_replication(vni, ip)` emits the RFC 8365 §5.1.3 wire shape (raw 24-bit VNI in the label field, originator IP as the tunnel identifier).
 - **`RouteDistinguisher`** — RFC 4364 §4.2 8-byte RD, used by EVPN and
   VPNv4/v6. Implements `Display` + `FromStr` for the structured `asn:val` /
   `ipv4:val` textual encodings and the exact `0x<16-hex-digits>` display

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -700,11 +700,20 @@ pub enum PathAttribute {
     Med(u32),
     /// RFC 1997 COMMUNITIES — each u32 is high16=ASN, low16=value.
     Communities(Vec<u32>),
+    /// A valid received RFC 1997 COMMUNITIES attribute carrying the RFC 4271
+    /// Partial bit. Values are otherwise identical to [`Self::Communities`].
+    CommunitiesPartial(Vec<u32>),
     /// RFC 4360 EXTENDED COMMUNITIES.
     ExtendedCommunities(Vec<ExtendedCommunity>),
+    /// A valid received RFC 4360 EXTENDED COMMUNITIES attribute carrying the
+    /// RFC 4271 Partial bit.
+    ExtendedCommunitiesPartial(Vec<ExtendedCommunity>),
     /// RFC 8092 LARGE COMMUNITIES. Duplicate values are normalized at
     /// decode and encode boundaries while retaining first-seen order.
     LargeCommunities(Vec<LargeCommunity>),
+    /// A valid received RFC 8092 LARGE COMMUNITIES attribute carrying the
+    /// RFC 4271 Partial bit.
+    LargeCommunitiesPartial(Vec<LargeCommunity>),
     /// RFC 4456 `ORIGINATOR_ID` — original router-id of the route.
     OriginatorId(Ipv4Addr),
     /// RFC 4456 `CLUSTER_LIST` — list of cluster-ids traversed.
@@ -716,6 +725,9 @@ pub enum PathAttribute {
     /// RFC 6514 §5 `PMSI Tunnel` — used by EVPN Type 3 IMET for
     /// ingress-replication BUM forwarding.
     PmsiTunnel(crate::pmsi::PmsiTunnel),
+    /// A valid received RFC 6514 §5 PMSI Tunnel attribute carrying the RFC
+    /// 4271 Partial bit.
+    PmsiTunnelPartial(crate::pmsi::PmsiTunnel),
     /// RFC 9234 §5 `Only-to-Customer` (type 35) — carries the 32-bit ASN
     /// that initially set OTC on the route. Optional + Transitive (`0xC0`).
     OnlyToCustomer(u32),
@@ -737,14 +749,18 @@ impl PathAttribute {
             Self::NextHop(_) => attr_type::NEXT_HOP,
             Self::LocalPref(_) => attr_type::LOCAL_PREF,
             Self::Med(_) => attr_type::MULTI_EXIT_DISC,
-            Self::Communities(_) => attr_type::COMMUNITIES,
+            Self::Communities(_) | Self::CommunitiesPartial(_) => attr_type::COMMUNITIES,
             Self::OriginatorId(_) => attr_type::ORIGINATOR_ID,
             Self::ClusterList(_) => attr_type::CLUSTER_LIST,
-            Self::ExtendedCommunities(_) => attr_type::EXTENDED_COMMUNITIES,
-            Self::LargeCommunities(_) => attr_type::LARGE_COMMUNITIES,
+            Self::ExtendedCommunities(_) | Self::ExtendedCommunitiesPartial(_) => {
+                attr_type::EXTENDED_COMMUNITIES
+            }
+            Self::LargeCommunities(_) | Self::LargeCommunitiesPartial(_) => {
+                attr_type::LARGE_COMMUNITIES
+            }
             Self::MpReachNlri(_) => attr_type::MP_REACH_NLRI,
             Self::MpUnreachNlri(_) => attr_type::MP_UNREACH_NLRI,
-            Self::PmsiTunnel(_) => attr_type::PMSI_TUNNEL,
+            Self::PmsiTunnel(_) | Self::PmsiTunnelPartial(_) => attr_type::PMSI_TUNNEL,
             Self::OnlyToCustomer(_) | Self::OnlyToCustomerPartial(_) => attr_type::ONLY_TO_CUSTOMER,
             Self::Unknown(raw) => raw.type_code,
         }
@@ -777,10 +793,86 @@ impl PathAttribute {
             | Self::LargeCommunities(_)
             | Self::PmsiTunnel(_)
             | Self::OnlyToCustomer(_) => attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
-            Self::OnlyToCustomerPartial(_) => {
+            Self::CommunitiesPartial(_)
+            | Self::ExtendedCommunitiesPartial(_)
+            | Self::LargeCommunitiesPartial(_)
+            | Self::PmsiTunnelPartial(_)
+            | Self::OnlyToCustomerPartial(_) => {
                 attr_flags::OPTIONAL | attr_flags::TRANSITIVE | attr_flags::PARTIAL
             }
             Self::Unknown(raw) => raw.flags,
+        }
+    }
+
+    /// RFC 1997 community values, independent of the received Partial bit.
+    #[inline]
+    #[must_use]
+    pub fn communities(&self) -> Option<&[u32]> {
+        match self {
+            Self::Communities(values) | Self::CommunitiesPartial(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    /// Mutable RFC 1997 community values, preserving the typed variant and
+    /// therefore the received Partial bit.
+    #[inline]
+    pub fn communities_mut(&mut self) -> Option<&mut Vec<u32>> {
+        match self {
+            Self::Communities(values) | Self::CommunitiesPartial(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    /// RFC 4360 extended-community values, independent of Partial.
+    #[inline]
+    #[must_use]
+    pub fn extended_communities(&self) -> Option<&[ExtendedCommunity]> {
+        match self {
+            Self::ExtendedCommunities(values) | Self::ExtendedCommunitiesPartial(values) => {
+                Some(values)
+            }
+            _ => None,
+        }
+    }
+
+    /// Mutable RFC 4360 extended-community values, preserving Partial.
+    #[inline]
+    pub fn extended_communities_mut(&mut self) -> Option<&mut Vec<ExtendedCommunity>> {
+        match self {
+            Self::ExtendedCommunities(values) | Self::ExtendedCommunitiesPartial(values) => {
+                Some(values)
+            }
+            _ => None,
+        }
+    }
+
+    /// RFC 8092 large-community values, independent of Partial.
+    #[inline]
+    #[must_use]
+    pub fn large_communities(&self) -> Option<&[LargeCommunity]> {
+        match self {
+            Self::LargeCommunities(values) | Self::LargeCommunitiesPartial(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    /// Mutable RFC 8092 large-community values, preserving Partial.
+    #[inline]
+    pub fn large_communities_mut(&mut self) -> Option<&mut Vec<LargeCommunity>> {
+        match self {
+            Self::LargeCommunities(values) | Self::LargeCommunitiesPartial(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    /// RFC 6514 PMSI Tunnel value, independent of Partial.
+    #[inline]
+    #[must_use]
+    pub fn pmsi_tunnel(&self) -> Option<&crate::pmsi::PmsiTunnel> {
+        match self {
+            Self::PmsiTunnel(value) | Self::PmsiTunnelPartial(value) => Some(value),
+            _ => None,
         }
     }
 }
@@ -1574,7 +1666,11 @@ fn decode_attribute_value(
                 .iter()
                 .map(|c| u32::from_be_bytes([c[0], c[1], c[2], c[3]]))
                 .collect();
-            Ok(PathAttribute::Communities(communities))
+            if flags & attr_flags::PARTIAL != 0 {
+                Ok(PathAttribute::CommunitiesPartial(communities))
+            } else {
+                Ok(PathAttribute::Communities(communities))
+            }
         }
         attr_type::EXTENDED_COMMUNITIES => {
             // RFC 7606 §7.14: the length must be a NON-ZERO multiple of 8.
@@ -1599,7 +1695,11 @@ fn decode_attribute_value(
                     ]))
                 })
                 .collect();
-            Ok(PathAttribute::ExtendedCommunities(communities))
+            if flags & attr_flags::PARTIAL != 0 {
+                Ok(PathAttribute::ExtendedCommunitiesPartial(communities))
+            } else {
+                Ok(PathAttribute::ExtendedCommunities(communities))
+            }
         }
         attr_type::ORIGINATOR_ID => {
             if value.len() != 4 {
@@ -1652,7 +1752,11 @@ fn decode_attribute_value(
                     seen.insert(community).then_some(community)
                 })
                 .collect();
-            Ok(PathAttribute::LargeCommunities(communities))
+            if flags & attr_flags::PARTIAL != 0 {
+                Ok(PathAttribute::LargeCommunitiesPartial(communities))
+            } else {
+                Ok(PathAttribute::LargeCommunities(communities))
+            }
         }
         attr_type::MP_REACH_NLRI => decode_mp_reach_nlri(value, add_path_families, bgpls_discarded),
         attr_type::MP_UNREACH_NLRI => {
@@ -1660,7 +1764,11 @@ fn decode_attribute_value(
         }
         attr_type::PMSI_TUNNEL => {
             let pmsi = crate::pmsi::PmsiTunnel::decode(value)?;
-            Ok(PathAttribute::PmsiTunnel(pmsi))
+            if flags & attr_flags::PARTIAL != 0 {
+                Ok(PathAttribute::PmsiTunnelPartial(pmsi))
+            } else {
+                Ok(PathAttribute::PmsiTunnel(pmsi))
+            }
         }
         attr_type::BGP_LS => {
             // RFC 9552 §8.2.2: an intact path-attribute boundary containing
@@ -2701,22 +2809,43 @@ fn encode_path_attributes_with_scratch(
                 type_code = attr_type::LOCAL_PREF;
                 value_scratch.extend_from_slice(&lp.to_be_bytes());
             }
-            PathAttribute::Communities(communities) => {
-                flags = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
+            PathAttribute::Communities(communities)
+            | PathAttribute::CommunitiesPartial(communities) => {
+                flags = attr_flags::OPTIONAL
+                    | attr_flags::TRANSITIVE
+                    | if matches!(attr, PathAttribute::CommunitiesPartial(_)) {
+                        attr_flags::PARTIAL
+                    } else {
+                        0
+                    };
                 type_code = attr_type::COMMUNITIES;
                 for &c in communities {
                     value_scratch.extend_from_slice(&c.to_be_bytes());
                 }
             }
-            PathAttribute::ExtendedCommunities(communities) => {
-                flags = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
+            PathAttribute::ExtendedCommunities(communities)
+            | PathAttribute::ExtendedCommunitiesPartial(communities) => {
+                flags = attr_flags::OPTIONAL
+                    | attr_flags::TRANSITIVE
+                    | if matches!(attr, PathAttribute::ExtendedCommunitiesPartial(_)) {
+                        attr_flags::PARTIAL
+                    } else {
+                        0
+                    };
                 type_code = attr_type::EXTENDED_COMMUNITIES;
                 for &c in communities {
                     value_scratch.extend_from_slice(&c.as_u64().to_be_bytes());
                 }
             }
-            PathAttribute::LargeCommunities(communities) => {
-                flags = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
+            PathAttribute::LargeCommunities(communities)
+            | PathAttribute::LargeCommunitiesPartial(communities) => {
+                flags = attr_flags::OPTIONAL
+                    | attr_flags::TRANSITIVE
+                    | if matches!(attr, PathAttribute::LargeCommunitiesPartial(_)) {
+                        attr_flags::PARTIAL
+                    } else {
+                        0
+                    };
                 type_code = attr_type::LARGE_COMMUNITIES;
                 let mut seen = std::collections::HashSet::with_capacity(communities.len());
                 for &c in communities {
@@ -2750,10 +2879,16 @@ fn encode_path_attributes_with_scratch(
                 type_code = attr_type::MP_UNREACH_NLRI;
                 encode_mp_unreach_nlri(mp, value_scratch, add_path_mp)?;
             }
-            PathAttribute::PmsiTunnel(pmsi) => {
+            PathAttribute::PmsiTunnel(pmsi) | PathAttribute::PmsiTunnelPartial(pmsi) => {
                 // RFC 6514 §5: Optional + Transitive.
                 (flags, type_code) = (
-                    attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+                    attr_flags::OPTIONAL
+                        | attr_flags::TRANSITIVE
+                        | if matches!(attr, PathAttribute::PmsiTunnelPartial(_)) {
+                            attr_flags::PARTIAL
+                        } else {
+                            0
+                        },
                     attr_type::PMSI_TUNNEL,
                 );
                 pmsi.encode(value_scratch);
@@ -5825,6 +5960,289 @@ mod tests {
         let err = decode_path_attributes(&buf, true, &[]).unwrap_err();
         assert!(matches!(err, DecodeError::MalformedField { .. }));
     }
+
+    fn framed_test_attribute(flags: u8, type_code: u8, value: &[u8]) -> Vec<u8> {
+        let mut wire = vec![flags, type_code];
+        if flags & attr_flags::EXTENDED_LENGTH != 0 {
+            wire.extend_from_slice(&u16::try_from(value.len()).unwrap().to_be_bytes());
+        } else {
+            wire.push(u8::try_from(value.len()).unwrap());
+        }
+        wire.extend_from_slice(value);
+        wire
+    }
+
+    #[test]
+    fn recognized_optional_transitive_partial_framing_matrix() {
+        let pmsi =
+            crate::pmsi::PmsiTunnel::for_evpn_ingress_replication(100, "10.0.0.1".parse().unwrap());
+        let rows = [
+            (
+                attr_type::COMMUNITIES,
+                65_000_u32.to_be_bytes().to_vec(),
+                PathAttribute::Communities(vec![65_000]),
+                PathAttribute::CommunitiesPartial(vec![65_000]),
+            ),
+            (
+                attr_type::EXTENDED_COMMUNITIES,
+                0x0002_FDE8_0000_0064_u64.to_be_bytes().to_vec(),
+                PathAttribute::ExtendedCommunities(vec![ExtendedCommunity::new(
+                    0x0002_FDE8_0000_0064,
+                )]),
+                PathAttribute::ExtendedCommunitiesPartial(vec![ExtendedCommunity::new(
+                    0x0002_FDE8_0000_0064,
+                )]),
+            ),
+            (
+                attr_type::LARGE_COMMUNITIES,
+                [65_000_u32, 1, 2]
+                    .into_iter()
+                    .flat_map(u32::to_be_bytes)
+                    .collect(),
+                PathAttribute::LargeCommunities(vec![LargeCommunity::new(65_000, 1, 2)]),
+                PathAttribute::LargeCommunitiesPartial(vec![LargeCommunity::new(65_000, 1, 2)]),
+            ),
+            (
+                attr_type::PMSI_TUNNEL,
+                {
+                    let mut value = Vec::new();
+                    pmsi.encode(&mut value);
+                    value
+                },
+                PathAttribute::PmsiTunnel(pmsi.clone()),
+                PathAttribute::PmsiTunnelPartial(pmsi),
+            ),
+        ];
+
+        for (type_code, value, canonical, partial_attr) in rows {
+            for (flags, expected) in [
+                (0xc0, &canonical),
+                (0xd0, &canonical),
+                (0xe0, &partial_attr),
+                (0xf0, &partial_attr),
+                (0xcf, &canonical),
+                (0xdf, &canonical),
+                (0xef, &partial_attr),
+                (0xff, &partial_attr),
+            ] {
+                let wire = framed_test_attribute(flags, type_code, &value);
+                let decoded = decode_path_attributes(&wire, true, &[]).unwrap();
+                assert_eq!(decoded, vec![expected.clone()], "flags {flags:#04x}");
+
+                let mut emitted = Vec::new();
+                encode_path_attributes(&decoded, &mut emitted, true, false).unwrap();
+                assert_eq!(
+                    emitted[0],
+                    if expected.flags() & attr_flags::PARTIAL != 0 {
+                        0xe0
+                    } else {
+                        0xc0
+                    },
+                    "type {type_code}, flags {flags:#04x}"
+                );
+                assert_eq!(emitted[1], type_code);
+                assert_eq!(usize::from(emitted[2]), value.len());
+                assert_eq!(&emitted[3..], value.as_slice());
+            }
+        }
+    }
+
+    #[test]
+    fn recognized_optional_transitive_long_values_use_extended_framing() {
+        let communities: Vec<u32> = (0..64).collect();
+        let extended: Vec<ExtendedCommunity> = (0..32).map(ExtendedCommunity::new).collect();
+        let large: Vec<LargeCommunity> = (0..22)
+            .map(|value| LargeCommunity::new(65_000, value, value + 1))
+            .collect();
+        let pmsi = crate::pmsi::PmsiTunnel {
+            flags: 0,
+            tunnel_type: crate::pmsi::PmsiTunnelType::RsvpTeP2mp,
+            mpls_label: 0,
+            tunnel_identifier: crate::pmsi::PmsiTunnelIdentifier::Raw(vec![0xaa; 251]),
+        };
+        let rows = [
+            (
+                PathAttribute::Communities(communities.clone()),
+                PathAttribute::CommunitiesPartial(communities),
+            ),
+            (
+                PathAttribute::ExtendedCommunities(extended.clone()),
+                PathAttribute::ExtendedCommunitiesPartial(extended),
+            ),
+            (
+                PathAttribute::LargeCommunities(large.clone()),
+                PathAttribute::LargeCommunitiesPartial(large),
+            ),
+            (
+                PathAttribute::PmsiTunnel(pmsi.clone()),
+                PathAttribute::PmsiTunnelPartial(pmsi),
+            ),
+        ];
+
+        for (canonical, partial) in rows {
+            for (attribute, expected_flags) in [(canonical, 0xd0), (partial, 0xf0)] {
+                let mut wire = Vec::new();
+                encode_path_attributes(std::slice::from_ref(&attribute), &mut wire, true, false)
+                    .unwrap();
+                assert_eq!(wire[0], expected_flags, "type {}", attribute.type_code());
+                assert_eq!(wire[1], attribute.type_code());
+                assert!(u16::from_be_bytes([wire[2], wire[3]]) > 255);
+                assert_eq!(
+                    decode_path_attributes(&wire, true, &[]).unwrap(),
+                    vec![attribute]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn recognized_optional_transitive_malformed_matrix_is_treat_as_withdraw() {
+        let malformed_rows = [
+            (attr_type::COMMUNITIES, &[0, 0, 1][..]),
+            (attr_type::EXTENDED_COMMUNITIES, &[0; 7][..]),
+            (attr_type::LARGE_COMMUNITIES, &[0; 11][..]),
+            // Type 6 requires a 4- or 16-octet identifier after its header.
+            (attr_type::PMSI_TUNNEL, &[0, 6, 0, 0, 0][..]),
+        ];
+        for (type_code, value) in malformed_rows {
+            for flags in [0xc0, 0xd0, 0xe0, 0xf0] {
+                let wire = framed_test_attribute(flags, type_code, value);
+                if type_code != attr_type::PMSI_TUNNEL {
+                    let legacy = decode_path_attributes(&wire, true, &[]).unwrap_err();
+                    assert!(matches!(
+                        legacy,
+                        DecodeError::UpdateAttributeError {
+                            subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+                            ref data,
+                            ..
+                        } if data == &wire
+                    ));
+                }
+                let decoded = decode_path_attributes_revised(&wire, true, false, &[]).unwrap();
+                assert!(decoded.attributes.is_empty());
+                let [malformed] = decoded.malformed.as_slice() else {
+                    panic!("type {type_code}, flags {flags:#04x}: expected one malformation");
+                };
+                assert_eq!(malformed.type_code, type_code);
+                assert_eq!(malformed.disposition, ErrorDisposition::TreatAsWithdraw);
+                match type_code {
+                    attr_type::PMSI_TUNNEL => {
+                        assert!(matches!(
+                            malformed.error,
+                            DecodeError::MalformedField { .. }
+                        ));
+                    }
+                    _ => assert!(matches!(
+                        malformed.error,
+                        DecodeError::UpdateAttributeError {
+                            subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+                            ..
+                        }
+                    )),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn composite_pmsi_identifier_prefix_framing_matrix() {
+        const COMPOSITE: u8 = 0x81;
+
+        for identifier_len in 0..=2 {
+            let mut value = vec![0, COMPOSITE, 0, 0, 0];
+            value.extend(std::iter::repeat_n(0xaa, identifier_len));
+            for flags in [0xc0, 0xe0] {
+                let wire = framed_test_attribute(flags, attr_type::PMSI_TUNNEL, &value);
+                let legacy = decode_path_attributes(&wire, true, &[]).unwrap_err();
+                assert!(matches!(
+                    legacy,
+                    DecodeError::MalformedField { ref detail, .. }
+                        if detail.contains("composite PMSI Tunnel")
+                ));
+
+                let revised = decode_path_attributes_revised(&wire, true, false, &[]).unwrap();
+                assert!(revised.attributes.is_empty());
+                let [malformed] = revised.malformed.as_slice() else {
+                    panic!(
+                        "flags {flags:#04x}, identifier len {identifier_len}: expected one malformation"
+                    );
+                };
+                assert_eq!(malformed.type_code, attr_type::PMSI_TUNNEL);
+                assert_eq!(malformed.disposition, ErrorDisposition::TreatAsWithdraw);
+                assert!(matches!(
+                    malformed.error,
+                    DecodeError::MalformedField { .. }
+                ));
+            }
+        }
+
+        for identifier in [&[0x01, 0x02, 0x03][..], &[0x01, 0x02, 0x03, 0xaa, 0xbb][..]] {
+            let mut value = vec![0, COMPOSITE, 0, 0, 0];
+            value.extend_from_slice(identifier);
+            for (flags, partial) in [(0xc0, false), (0xe0, true)] {
+                let wire = framed_test_attribute(flags, attr_type::PMSI_TUNNEL, &value);
+                let decoded = decode_path_attributes(&wire, true, &[]).unwrap();
+                let expected = crate::pmsi::PmsiTunnel {
+                    flags: 0,
+                    tunnel_type: crate::pmsi::PmsiTunnelType::Other(COMPOSITE),
+                    mpls_label: 0,
+                    tunnel_identifier: crate::pmsi::PmsiTunnelIdentifier::Raw(identifier.to_vec()),
+                };
+                assert_eq!(
+                    decoded,
+                    vec![if partial {
+                        PathAttribute::PmsiTunnelPartial(expected)
+                    } else {
+                        PathAttribute::PmsiTunnel(expected)
+                    }]
+                );
+
+                let mut emitted = Vec::new();
+                encode_path_attributes(&decoded, &mut emitted, true, false).unwrap();
+                assert_eq!(emitted, wire);
+            }
+        }
+    }
+
+    #[test]
+    fn partial_large_community_duplicate_normalization_preserves_order_and_framing() {
+        let a = LargeCommunity::new(65_001, 100, 200);
+        let b = LargeCommunity::new(65_002, 300, 400);
+        let mut short = Vec::new();
+        encode_path_attributes(
+            &[PathAttribute::LargeCommunitiesPartial(vec![b, a, a])],
+            &mut short,
+            true,
+            false,
+        )
+        .unwrap();
+        assert_eq!(&short[..3], &[0xe0, attr_type::LARGE_COMMUNITIES, 24]);
+        assert_eq!(
+            decode_path_attributes(&short, true, &[]).unwrap(),
+            vec![PathAttribute::LargeCommunitiesPartial(vec![b, a])]
+        );
+
+        let unique: Vec<_> = (0..22)
+            .map(|value| LargeCommunity::new(65_000, value, value + 1))
+            .collect();
+        let mut with_duplicate = unique.clone();
+        with_duplicate.push(unique[7]);
+        let mut long = Vec::new();
+        encode_path_attributes(
+            &[PathAttribute::LargeCommunitiesPartial(with_duplicate)],
+            &mut long,
+            true,
+            false,
+        )
+        .unwrap();
+        assert_eq!(&long[..2], &[0xf0, attr_type::LARGE_COMMUNITIES]);
+        assert_eq!(u16::from_be_bytes([long[2], long[3]]), 264);
+        assert_eq!(
+            decode_path_attributes(&long, true, &[]).unwrap(),
+            vec![PathAttribute::LargeCommunitiesPartial(unique)]
+        );
+    }
+
     // --- Only-to-Customer (RFC 9234 §5) tests ---
     #[test]
     fn only_to_customer_encode_decode_roundtrip() {

--- a/crates/wire/src/pmsi.rs
+++ b/crates/wire/src/pmsi.rs
@@ -20,9 +20,10 @@
 //!
 //! - **Flags** — RFC 6514 §5 defines bit 0 ("Leaf Information Required")
 //!   only. EVPN ingress replication does not use it.
-//! - **Tunnel Type** — IANA registry, RFC 7385. Values 0–7 are well-
-//!   known; unknown values must round-trip without loss for forward
-//!   compatibility.
+//! - **Tunnel Type** — IANA registry, RFC 7385. Assigned and experimental
+//!   values are accepted, while unassigned values and invalid composite
+//!   encodings are rejected. Assigned values without a dedicated typed
+//!   variant round-trip through `PmsiTunnelType::Other`.
 //! - **MPLS Label** — 3 octets. For pure-MPLS deployments the
 //!   high-order 20 bits carry the MPLS label value (RFC 6514 §5).
 //!   For EVPN-VXLAN deployments **the full 24-bit field is the VNI**,
@@ -35,20 +36,22 @@
 //!   Tunnel Type. For Ingress Replication (type 6) it is the unicast
 //!   tunnel endpoint IP — 4 octets for IPv4, 16 octets for IPv6
 //!   (RFC 6514 §5; ipv6 form per RFC 8365). Other tunnel types carry
-//!   opaque bytes that the codec preserves without interpretation.
+//!   opaque bytes that the codec preserves without interpretation. Type 0
+//!   requires an empty identifier; type 6 requires exactly 4 or 16 octets.
 //!
 //! # Why a typed `PmsiTunnelType`
 //!
 //! Validating the tunnel type at decode time catches the most common
 //! interop bug (operator misconfigures FRR with the wrong tunnel type
-//! and the wire becomes nonsensical) without forcing the daemon to
-//! reject otherwise-legal future tunnel types — `PmsiTunnelType::Other`
-//! preserves any unknown value the IANA registry adds later.
+//! and the wire becomes nonsensical). `PmsiTunnelType::Other` preserves
+//! assigned types without a dedicated variant, experimental values, and
+//! valid composite encodings; unassigned values are rejected until the
+//! registry assigns them.
 //!
 //! # Gate 7b+1 scope
 //!
 //! Only `PmsiTunnelType::IngressReplication` is exercised by rustbgpd
-//! origination today. Decode handles all variants; encode round-trips
+//! origination today. Decode handles all valid variants; encode round-trips
 //! all variants. Phase F (Type 3 IMET) emits Ingress Replication with
 //! the raw 24-bit VNI in the label field (RFC 8365 §5.1.3) and the
 //! local VTEP IP as the tunnel identifier.
@@ -78,7 +81,7 @@ pub enum PmsiTunnelType {
     IngressReplication,
     /// 7 — mLDP MP2MP LSP.
     MldpMp2mp,
-    /// Forward-compat: any value not yet known.
+    /// Assigned unsupported, experimental, or valid composite value.
     Other(u8),
 }
 
@@ -113,6 +116,31 @@ impl PmsiTunnelType {
             7 => Self::MldpMp2mp,
             other => Self::Other(other),
         }
+    }
+}
+
+const fn assigned_tunnel_type(value: u8) -> bool {
+    matches!(value, 0x00..=0x08 | 0x0a..=0x0d | 0xff)
+}
+
+const fn composite_tunnel_type(value: u8) -> bool {
+    if matches!(value, 0x80..=0xfa) {
+        let base = value & 0x7f;
+        base != 0 && base != 6 && assigned_tunnel_type(base)
+    } else {
+        false
+    }
+}
+
+fn validate_tunnel_type(value: u8) -> Result<(), DecodeError> {
+    let experimental = matches!(value, 0x7b..=0x7e | 0xfb..=0xfe);
+    if assigned_tunnel_type(value) || experimental || composite_tunnel_type(value) {
+        Ok(())
+    } else {
+        Err(DecodeError::MalformedField {
+            message_type: "UPDATE",
+            detail: format!("PMSI Tunnel type {value:#04x} is unassigned or invalid"),
+        })
     }
 }
 
@@ -205,14 +233,21 @@ impl PmsiTunnel {
     /// flags, type code, and length.
     ///
     /// Tunnel Identifier interpretation:
-    /// - Tunnel Type 6 (Ingress Replication) with 4-octet rest → IPv4.
-    /// - Tunnel Type 6 with 16-octet rest → IPv6.
-    /// - Anything else (including type 6 with non-4/16 rest) → `Raw`.
+    /// - Tunnel Type 0 requires an empty identifier.
+    /// - Tunnel Type 6 (Ingress Replication) requires 4 octets (IPv4) or 16
+    ///   octets (IPv6).
+    /// - A composite tunnel type requires at least the 3-octet RFC 8317
+    ///   receiver ingress-replication label prefix.
+    /// - Other accepted tunnel types retain a non-empty identifier as `Raw`.
     ///
     /// # Errors
     ///
-    /// Returns [`DecodeError::MalformedField`] when the value is shorter
-    /// than the 5-octet header (flags + type + 3-octet label).
+    /// Returns [`DecodeError::MalformedField`] when the value:
+    /// - is shorter than the 5-octet header;
+    /// - carries an invalid tunnel type;
+    /// - violates the type-0/type-6 identifier length contract; or
+    /// - has a composite identifier shorter than the RFC 8317 receiver-label
+    ///   prefix.
     pub fn decode(value: &[u8]) -> Result<Self, DecodeError> {
         if value.len() < 5 {
             return Err(DecodeError::MalformedField {
@@ -224,12 +259,32 @@ impl PmsiTunnel {
             });
         }
         let flags = value[0];
-        let tunnel_type = PmsiTunnelType::from_u8(value[1]);
+        let tunnel_type_value = value[1];
+        validate_tunnel_type(tunnel_type_value)?;
+        let tunnel_type = PmsiTunnelType::from_u8(tunnel_type_value);
         let label = (u32::from(value[2]) << 16) | (u32::from(value[3]) << 8) | u32::from(value[4]);
         let rest = &value[5..];
 
+        if composite_tunnel_type(tunnel_type_value) && rest.len() < 3 {
+            return Err(DecodeError::MalformedField {
+                message_type: "UPDATE",
+                detail: format!(
+                    "composite PMSI Tunnel type {tunnel_type_value:#04x} identifier length {} (expected at least 3)",
+                    rest.len()
+                ),
+            });
+        }
+
         let tunnel_identifier = match (tunnel_type, rest.len()) {
-            (_, 0) => PmsiTunnelIdentifier::Empty,
+            (PmsiTunnelType::NoTunnelInfo, 0) => PmsiTunnelIdentifier::Empty,
+            (PmsiTunnelType::NoTunnelInfo, len) => {
+                return Err(DecodeError::MalformedField {
+                    message_type: "UPDATE",
+                    detail: format!(
+                        "PMSI Tunnel type 0 requires an empty identifier, got {len} octets"
+                    ),
+                });
+            }
             (PmsiTunnelType::IngressReplication, 4) => {
                 let mut o = [0u8; 4];
                 o.copy_from_slice(rest);
@@ -240,6 +295,15 @@ impl PmsiTunnel {
                 o.copy_from_slice(rest);
                 PmsiTunnelIdentifier::Ipv6(Ipv6Addr::from(o))
             }
+            (PmsiTunnelType::IngressReplication, len) => {
+                return Err(DecodeError::MalformedField {
+                    message_type: "UPDATE",
+                    detail: format!(
+                        "PMSI Tunnel type 6 identifier length {len} (expected 4 or 16)"
+                    ),
+                });
+            }
+            (_, 0) => PmsiTunnelIdentifier::Empty,
             _ => PmsiTunnelIdentifier::Raw(rest.to_vec()),
         };
 
@@ -387,14 +451,54 @@ mod tests {
     }
 
     #[test]
-    fn unknown_tunnel_type_round_trips_without_loss() {
+    fn experimental_tunnel_type_round_trips_without_loss() {
         let t = PmsiTunnel {
             flags: 0x01, // pretend Leaf Information Required is set
-            tunnel_type: PmsiTunnelType::Other(99),
+            tunnel_type: PmsiTunnelType::Other(0x7b),
             mpls_label: 0x00ab_cdef,
             tunnel_identifier: PmsiTunnelIdentifier::Raw(vec![0xde, 0xad, 0xbe, 0xef]),
         };
         roundtrip(&t);
+    }
+
+    #[test]
+    fn assigned_experimental_and_valid_composite_types_are_accepted() {
+        for tunnel_type in [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x07, 0x08, 0x0a, 0x0b, 0x0c, 0x0d, 0x7b, 0x7c,
+            0x7d, 0x7e, 0xfb, 0xfc, 0xfd, 0xfe, 0xff,
+        ] {
+            let decoded = PmsiTunnel::decode(&[0, tunnel_type, 0, 0, 0])
+                .unwrap_or_else(|error| panic!("type {tunnel_type:#04x}: {error}"));
+            assert_eq!(decoded.tunnel_type.as_u8(), tunnel_type);
+        }
+
+        for tunnel_type in [
+            0x81, 0x82, 0x83, 0x84, 0x85, 0x87, 0x88, 0x8a, 0x8b, 0x8c, 0x8d,
+        ] {
+            let decoded = PmsiTunnel::decode(&[0, tunnel_type, 0, 0, 0, 1, 2, 3])
+                .unwrap_or_else(|error| panic!("composite type {tunnel_type:#04x}: {error}"));
+            assert_eq!(decoded.tunnel_type.as_u8(), tunnel_type);
+        }
+
+        for tunnel_type in [0x08, 0x0a, 0x0b, 0x0c, 0x0d, 0xff] {
+            assert!(matches!(
+                PmsiTunnel::decode(&[0, tunnel_type, 0, 0, 0])
+                    .unwrap()
+                    .tunnel_type,
+                PmsiTunnelType::Other(value) if value == tunnel_type
+            ));
+        }
+    }
+
+    #[test]
+    fn unassigned_and_invalid_composite_types_are_rejected() {
+        for tunnel_type in [
+            0x09, 0x0e, 0x20, 0x7a, 0x7f, 0x80, 0x86, 0x89, 0x8e, 0x90, 0xfa,
+        ] {
+            let error = PmsiTunnel::decode(&[0, tunnel_type, 0, 0, 0])
+                .expect_err("unassigned or invalid composite type must fail");
+            assert!(matches!(error, DecodeError::MalformedField { .. }));
+        }
     }
 
     #[test]
@@ -412,16 +516,25 @@ mod tests {
     }
 
     #[test]
-    fn ingress_replication_with_8_byte_id_treated_as_raw() {
-        // Tunnel type 6 but identifier neither 4 nor 16 octets: keep as Raw
-        // for forward-compat (an extension might define a longer form).
+    fn ingress_replication_with_8_byte_id_is_rejected() {
         let buf = [
             0u8, 6u8, // type = Ingress Replication
             0u8, 0u8, 0u8, // label = 0
             1, 2, 3, 4, 5, 6, 7, 8, // 8-byte tunnel identifier
         ];
-        let t = PmsiTunnel::decode(&buf).unwrap();
-        assert!(matches!(t.tunnel_identifier, PmsiTunnelIdentifier::Raw(_)));
+        assert!(matches!(
+            PmsiTunnel::decode(&buf),
+            Err(DecodeError::MalformedField { .. })
+        ));
+    }
+
+    #[test]
+    fn no_tunnel_info_with_non_empty_identifier_is_rejected() {
+        let buf = [0u8, 0u8, 0u8, 0u8, 0u8, 1u8];
+        assert!(matches!(
+            PmsiTunnel::decode(&buf),
+            Err(DecodeError::MalformedField { .. })
+        ));
     }
 
     #[test]

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -170,6 +170,54 @@ fn otc_registry_claim_is_typed_partial_preserving_and_revised_safe() {
 }
 
 #[test]
+fn recognized_optional_transitive_rows_are_typed_partial_preserving() {
+    let census = rows(
+        section(
+            "<!-- registry-census:start -->",
+            "<!-- registry-census:end -->",
+        ),
+        5,
+    );
+    for code in [8_u8, 16, 22, 32] {
+        let row = census
+            .iter()
+            .find(|row| row[0] == code.to_string())
+            .unwrap_or_else(|| panic!("missing registry row {code}"));
+        assert!(row[2].contains("flags `0xc0`"), "row {code}");
+        assert!(row[3].contains("typed canonical + Partial"), "row {code}");
+        assert!(row[3].contains("treat-as-withdraw"), "row {code}");
+    }
+
+    for (code, value) in [
+        (8_u8, 65_000_u32.to_be_bytes().to_vec()),
+        (16, 0x0002_FDE8_0000_0064_u64.to_be_bytes().to_vec()),
+        (22, vec![0, 0, 0, 0, 0]),
+        (
+            32,
+            [65_000_u32, 1, 100]
+                .into_iter()
+                .flat_map(u32::to_be_bytes)
+                .collect(),
+        ),
+    ] {
+        for flags in [0xc0, 0xe0] {
+            let input = attribute(flags, code, &value);
+            let decoded = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+            assert!(decoded.malformed.is_empty(), "row {code}, flags {flags:#x}");
+            let [typed] = decoded.attributes.as_slice() else {
+                panic!("row {code} must decode to one typed attribute");
+            };
+            assert_eq!(typed.type_code(), code);
+            assert_eq!(typed.flags() & 0x20, flags & 0x20);
+            assert!(!matches!(typed, PathAttribute::Unknown(_)));
+            let mut emitted = Vec::new();
+            encode_path_attributes(&decoded.attributes, &mut emitted, true, false).unwrap();
+            assert_eq!(emitted, input);
+        }
+    }
+}
+
+#[test]
 fn core_matrix_proves_flags_roundtrip_and_malformed_dispositions() {
     let matrix = rows(
         section("<!-- core-behavior:start -->", "<!-- core-behavior:end -->"),

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -36,7 +36,7 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 5 | LOCAL_PREF | well-known discretionary; flags `0x40`; RFC 4271 §5.1.5; RFC 7606 §7.5 | typed round-trip; malformed is discard on eBGP and treat-as-withdraw on iBGP | core matrix below |
 | 6 | ATOMIC_AGGREGATE | well-known discretionary; flags `0x40`; RFC 4271 §5.1.6; RFC 7606 §7.6 | typed round-trip; bad length is attribute-discard | core matrix below |
 | 7 | AGGREGATOR | optional transitive; flags `0xc0`; RFC 4271 §5.1.7; RFC 7606 §7.7 | typed round-trip; bad length is attribute-discard | core matrix below |
-| 8 | COMMUNITIES | optional transitive; flags `0xc0`; RFC 7606 §7.8 | typed round-trip; malformed is treat-as-withdraw | core matrix below |
+| 8 | COMMUNITIES | optional transitive; flags `0xc0`; values are four-octet communities; RFC 1997 / RFC 7606 §7.8 | typed canonical + Partial round-trip; Extended Length and reserved low bits canonicalize; malformed length is treat-as-withdraw | core matrix and typed-Partial matrix |
 | 9 | ORIGINATOR_ID | optional non-transitive; flags `0x80`; RFC 7606 §7.9 | typed round-trip; malformed is discard on eBGP and treat-as-withdraw on iBGP | core matrix below |
 | 10 | CLUSTER_LIST | optional non-transitive; flags `0x80`; RFC 7606 §7.10 | typed round-trip; malformed is discard on eBGP and treat-as-withdraw on iBGP | core matrix below |
 | 11 | DPA (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
@@ -44,13 +44,13 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 13 | RCID_PATH / CLUSTER_ID (Historic) (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 14 | MP_REACH_NLRI | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 15 | MP_UNREACH_NLRI | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 16 | EXTENDED COMMUNITIES | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 16 | EXTENDED COMMUNITIES | optional transitive; flags `0xc0`; values are eight-octet communities; RFC 4360 / RFC 7606 §7.14 | typed canonical + Partial round-trip; Extended Length and reserved low bits canonicalize; malformed length is treat-as-withdraw | typed-Partial matrix |
 | 17 | AS4_PATH | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 18 | AS4_AGGREGATOR | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 19 | SAFI Specific Attribute (SSA) (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 20 | Connector Attribute (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 21 | AS_PATHLIMIT (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 22 | PMSI_TUNNEL | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 22 | PMSI_TUNNEL | optional transitive; flags `0xc0`; RFC 6514 §5 / RFC 7385 | typed canonical + Partial round-trip; Extended Length and reserved low bits canonicalize; malformed tunnel type or identifier is treat-as-withdraw | typed-Partial and PMSI tunnel-type matrices |
 | 23 | Tunnel Encapsulation | optional transitive; flags `0xc0`; RFC 9012 | payload semantics unsupported; correct class retained opaque and emitted with Partial; wrong class is treat-as-withdraw | assigned-class matrix below |
 | 24 | Traffic Engineering | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 25 | IPv6 Address Specific Extended Community | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
@@ -60,7 +60,7 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 29 | BGP-LS Attribute | optional non-transitive; flags `0x80`; RFC 9552 §5.3 | recognized opaque attribute survives byte-for-byte; `0xc0` is malformed | enriched fence test |
 | 30 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 31 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 32 | LARGE_COMMUNITY | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 32 | LARGE_COMMUNITY | optional transitive; flags `0xc0`; values are twelve-octet communities; RFC 8092 §6 | typed canonical + Partial round-trip; duplicate values normalize first-seen; malformed length is treat-as-withdraw | typed-Partial matrix |
 | 33 | BGPsec_Path | optional non-transitive; flags `0x80`; RFC 8205 | payload semantics unsupported; correct class ignored; wrong class is treat-as-withdraw | assigned-class matrix below |
 | 34 | BGP Community Container Attribute (TEMPORARY - registered 2017-07-28, extension registered 2024-08-22, expires 2025-07-28) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 35 | Only to Customer (OTC) | optional transitive; flags `0xc0`; exactly one four-octet ASN; RFC 9234 §5 | typed ASN + Partial round-trip; Extended Length and reserved low bits canonicalize; wrong class or length is treat-as-withdraw | OTC codec and transport matrices |
@@ -117,6 +117,25 @@ negotiation. "Wrong O" toggles Optional, "wrong T" toggles Transitive, and
 | 23, 27, 40, 128 | optional transitive (`0xc0`) | opaque retention; Partial set on egress; input Partial and Extended Length preserved | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 | 26 | optional non-transitive (`0x80`) | ignored; no retention or egress | treat-as-withdraw | attribute-discard | attribute-discard | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 | 33 | optional non-transitive (`0x80`) | ignored; no retention or egress | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+
+## PMSI tunnel-type matrix
+
+PMSI Tunnel values use RFC 6514 base type and identifier semantics, the RFC
+7385/IANA registry boundary, and RFC 8317 composite tunnel-type semantics.
+Assigned types without a dedicated enum variant and experimental values remain
+typed through opaque `PmsiTunnelType::Other` state; this is distinct from
+accepting an unassigned value.
+
+| Wire value | Result |
+|---|---|
+| `0x00`-`0x08`, `0x0a`-`0x0d`, `0xff` | accepted assigned type; type 0 requires an empty identifier and type 6 requires exactly 4 or 16 identifier octets |
+| `0x7b`-`0x7e`, `0xfb`-`0xfe` | accepted experimental type with opaque identifier |
+| `0x80`-`0xfa` | accepted only when the low seven bits name an assigned base other than 0 or 6 |
+| `0x09`, `0x0e`-`0x7a`, `0x7f`, invalid composite | malformed field; revised decoding omits the attribute and records treat-as-withdraw |
+
+For a valid RFC 8317 composite, decoding checks only the generic 3-octet
+receiver-label prefix framing; it does not interpret the underlying transmit
+identifier semantics.
 
 The enriched fence tests separately prove all six rows' outcomes, BGP-LS
 opaque behavior, typed PMSI behavior and wrong-class handling, and unchanged

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use rustbgpd_rib::{RibUpdate, Route, RouteOrigin};
 use rustbgpd_telemetry::BgpMetrics;
-use rustbgpd_wire::{PathAttribute, Prefix};
+use rustbgpd_wire::Prefix;
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -1066,11 +1066,8 @@ fn derive_desired(config: BlackholeConfig, routes: &[Route]) -> Vec<Candidate<'_
 
 fn has_blackhole_community(route: &Route) -> bool {
     route.attributes.iter().any(|attr| {
-        matches!(
-            attr,
-            PathAttribute::Communities(values)
-                if values.contains(&rustbgpd_wire::COMMUNITY_BLACKHOLE)
-        )
+        attr.communities()
+            .is_some_and(|values| values.contains(&rustbgpd_wire::COMMUNITY_BLACKHOLE))
     })
 }
 
@@ -1307,7 +1304,7 @@ mod tests {
     use prometheus::Registry;
     use rustbgpd_rib::RouteEvent;
     use rustbgpd_rib::route::RouteOrigin;
-    use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Origin};
+    use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute};
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
@@ -1686,6 +1683,45 @@ mod tests {
             &routes,
         );
         assert!(got.is_empty());
+    }
+
+    #[test]
+    fn derive_desired_treats_partial_blackhole_communities_like_canonical() {
+        let config = BlackholeConfig {
+            enabled: true,
+            allow_broad_prefixes: false,
+        };
+        for (prefix, origin_type, expected_installable, expected_reason) in [
+            (v4(32), RouteOrigin::Ebgp, true, "eligible"),
+            (v4(24), RouteOrigin::Ebgp, false, "broad_prefix"),
+            (v4(32), RouteOrigin::Ibgp, false, "not_ebgp"),
+        ] {
+            let canonical = route(
+                prefix,
+                origin_type,
+                vec![rustbgpd_wire::COMMUNITY_BLACKHOLE],
+            );
+            let mut partial = canonical.clone();
+            partial.attributes = Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::CommunitiesPartial(vec![rustbgpd_wire::COMMUNITY_BLACKHOLE]),
+            ]);
+
+            for candidate in [canonical, partial] {
+                let routes = [candidate];
+                let got = derive_desired(config, &routes);
+                assert_eq!(got.len(), 1);
+                assert_eq!(got[0].installable, expected_installable);
+                assert_eq!(got[0].reason, expected_reason);
+            }
+        }
+
+        let mut untagged = route(v4(32), RouteOrigin::Ebgp, Vec::new());
+        untagged.attributes = Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::CommunitiesPartial(vec![0x0001_0002]),
+        ]);
+        assert!(derive_desired(config, &[untagged]).is_empty());
     }
 
     #[test]

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1494,10 +1494,8 @@ fn project_type5(route: &EvpnRibRoute) -> Option<rustbgpd_evpn::ip_vrf::Projecte
     let ext_comms: Vec<rustbgpd_wire::ExtendedCommunity> = route
         .attributes
         .iter()
-        .find_map(|a| match a {
-            rustbgpd_wire::PathAttribute::ExtendedCommunities(v) => Some(v.clone()),
-            _ => None,
-        })
+        .find_map(rustbgpd_wire::PathAttribute::extended_communities)
+        .map(<[_]>::to_vec)
         .unwrap_or_default();
     let (route_targets, router_mac) =
         rustbgpd_evpn::ip_vrf::ProjectedIpPrefixRoute::extcomms_to_fields(&ext_comms);
@@ -1594,7 +1592,7 @@ fn project_ead_per_es_reachability(
 
 fn ead_per_es_is_single_active(attrs: &[PathAttribute]) -> bool {
     attrs.iter().any(|attr| {
-        let PathAttribute::ExtendedCommunities(ecs) = attr else {
+        let Some(ecs) = attr.extended_communities() else {
             return false;
         };
         ecs.iter().copied().any(|ec| {
@@ -1781,7 +1779,7 @@ fn project_one(
 /// projection's tie-break treats `None` as "older than any sequence").
 fn extract_mac_mobility_sequence(attrs: &[PathAttribute]) -> Option<u32> {
     for attr in attrs {
-        let PathAttribute::ExtendedCommunities(ecs) = attr else {
+        let Some(ecs) = attr.extended_communities() else {
             continue;
         };
         for ec in ecs {
@@ -2002,6 +2000,21 @@ mod tests {
         let projected = project_type5(&route).expect("Type 5 route projects");
 
         assert_eq!(projected.ethernet_tag, EthernetTagId(77));
+    }
+
+    #[test]
+    fn partial_extended_communities_preserve_type5_projection() {
+        let canonical = evpn_ip_prefix_route("10.10.0.0/24", "0.0.0.0", "10.0.0.2", 5000);
+        let mut partial = canonical.clone();
+        let extended_communities = canonical.attributes[0]
+            .extended_communities()
+            .expect("helper carries route target")
+            .to_vec();
+        partial.attributes = Arc::new(vec![PathAttribute::ExtendedCommunitiesPartial(
+            extended_communities,
+        )]);
+
+        assert_eq!(project_type5(&partial), project_type5(&canonical));
     }
 
     fn evpn_ead_per_es_route(
@@ -2630,6 +2643,38 @@ mod tests {
         assert_eq!(
             project_ead_per_es_reachability(&single_active),
             Some(((ipa("10.0.0.3"), esi), true))
+        );
+    }
+
+    #[test]
+    fn partial_extended_communities_preserve_ead_per_es_mode() {
+        let esi = EthernetSegmentIdentifier::new([9; 10]);
+        let canonical = evpn_ead_per_es_route(esi, "10.0.0.3", true);
+        let mut partial = canonical.clone();
+        let extended_communities = canonical.attributes[0]
+            .extended_communities()
+            .expect("helper carries ESI label")
+            .to_vec();
+        partial.attributes = Arc::new(vec![PathAttribute::ExtendedCommunitiesPartial(
+            extended_communities,
+        )]);
+
+        assert_eq!(
+            project_ead_per_es_reachability(&partial),
+            project_ead_per_es_reachability(&canonical)
+        );
+    }
+
+    #[test]
+    fn partial_extended_communities_preserve_mac_mobility_sequence() {
+        let mobility = ExtendedCommunity::mac_mobility(true, 42);
+        let canonical = [PathAttribute::ExtendedCommunities(vec![mobility])];
+        let partial = [PathAttribute::ExtendedCommunitiesPartial(vec![mobility])];
+
+        assert_eq!(extract_mac_mobility_sequence(&canonical), Some(42));
+        assert_eq!(
+            extract_mac_mobility_sequence(&partial),
+            extract_mac_mobility_sequence(&canonical)
         );
     }
 

--- a/src/evpn_originator/rib_polling.rs
+++ b/src/evpn_originator/rib_polling.rs
@@ -474,7 +474,7 @@ pub(super) fn prefer_mac_ip_new(new: &ProjectedEvpnRoute, existing: &ProjectedEv
 /// Extract `(sticky, mobility_seq)` from a route's path attributes.
 pub(super) fn extract_mac_mobility_full(attrs: &[PathAttribute]) -> (bool, Option<u32>) {
     for attr in attrs {
-        let PathAttribute::ExtendedCommunities(ecs) = attr else {
+        let Some(ecs) = attr.extended_communities() else {
             continue;
         };
         for ec in ecs {
@@ -500,4 +500,77 @@ pub(super) async fn query_evpn_routes(
         .await
         .map_err(|_| RibQueryError::SendFailed)?;
     reply_rx.await.map_err(|_| RibQueryError::ReplyDropped)
+}
+
+#[cfg(test)]
+mod partial_extended_community_tests {
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use rustbgpd_evpn::EvpnInstanceTable;
+    use rustbgpd_rib::route::RouteOrigin;
+    use rustbgpd_wire::{
+        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, ExtendedCommunity, MplsLabel,
+        PathAttribute, RouteDistinguisher,
+    };
+
+    use super::*;
+    use crate::test_support::{evpn_instance, ip as ipa, mac, vni};
+
+    fn contender(attribute: PathAttribute) -> EvpnRibRoute {
+        EvpnRibRoute {
+            route: EvpnRoute::MacIp(EvpnMacIp {
+                rd: RouteDistinguisher::ZERO,
+                esi: EthernetSegmentIdentifier::ZERO,
+                ethernet_tag: EthernetTagId(0),
+                mac: mac(0xaa),
+                ip: Some(ipa("192.0.2.10")),
+                label1: MplsLabel::new(100),
+                label2: None,
+            }),
+            next_hop: ipa("10.0.0.2"),
+            link_local_next_hop: None,
+            peer: ipa("10.0.0.99"),
+            attributes: Arc::new(vec![attribute]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ebgp,
+            peer_router_id: "10.0.0.99".parse().unwrap(),
+            is_stale: false,
+            is_llgr_stale: false,
+        }
+    }
+
+    #[test]
+    fn partial_mac_mobility_preserves_sticky_sequence_contender_state() {
+        let mobility = ExtendedCommunity::mac_mobility(true, 7);
+        let canonical = contender(PathAttribute::ExtendedCommunities(vec![mobility]));
+        let partial = contender(PathAttribute::ExtendedCommunitiesPartial(vec![mobility]));
+        let mut instances = EvpnInstanceTable::new();
+        instances
+            .insert(evpn_instance(
+                65_000,
+                100,
+                100,
+                Some("br100".to_string()),
+                false,
+            ))
+            .unwrap();
+
+        let canonical_views = build_remote_views(&instances, &[canonical]);
+        let partial_views = build_remote_views(&instances, &[partial]);
+        assert_eq!(partial_views, canonical_views);
+
+        let mac_view = partial_views
+            .0
+            .get(&(vni(100), mac(0xaa)))
+            .expect("partial contender produces MAC state");
+        assert!(mac_view.sticky);
+        assert_eq!(mac_view.mobility_sequence, Some(7));
+        let mac_ip_view = partial_views
+            .1
+            .get(&(vni(100), mac(0xaa), ipa("192.0.2.10")))
+            .expect("partial contender produces MAC+IP state");
+        assert!(mac_ip_view.sticky);
+        assert_eq!(mac_ip_view.mobility_sequence, Some(7));
+    }
 }

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -1327,7 +1327,7 @@ fn gather_candidates_from_routes(
 fn has_matching_es_import_rt(attrs: &[PathAttribute], esi: EthernetSegmentIdentifier) -> bool {
     let expected = es_import_rt_from_esi(esi);
     attrs.iter().any(|attr| {
-        let PathAttribute::ExtendedCommunities(extcomms) = attr else {
+        let Some(extcomms) = attr.extended_communities() else {
             return false;
         };
         extcomms
@@ -1344,7 +1344,7 @@ fn decode_df_election_extcomm(attrs: &[PathAttribute]) -> Option<(u32, bool, DfA
     // best-effort — unrecognized extcomms fall back to defaults at
     // the call site.
     for attr in attrs {
-        let PathAttribute::ExtendedCommunities(ecs) = attr else {
+        let Some(ecs) = attr.extended_communities() else {
             continue;
         };
         for ec in ecs {
@@ -2143,6 +2143,27 @@ mod tests {
         assert_eq!(pref, 42);
         assert!(dont_preempt);
         assert_eq!(alg, DfAlgorithm::LowestPreference);
+    }
+
+    #[test]
+    fn partial_extended_communities_preserve_es_import_and_df_election() {
+        let id = esi(0x44);
+        let communities = vec![
+            ExtendedCommunity::es_import_rt(es_import_rt_from_esi(id)),
+            ExtendedCommunity::df_election(3, 0x8000, Some(42)),
+        ];
+        let canonical = [PathAttribute::ExtendedCommunities(communities.clone())];
+        let partial = [PathAttribute::ExtendedCommunitiesPartial(communities)];
+
+        assert!(has_matching_es_import_rt(&canonical, id));
+        assert_eq!(
+            has_matching_es_import_rt(&partial, id),
+            has_matching_es_import_rt(&canonical, id)
+        );
+        assert_eq!(
+            decode_df_election_extcomm(&partial),
+            decode_df_election_extcomm(&canonical)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve a received RFC 4271 Partial bit for recognized optional-transitive COMMUNITIES, EXTENDED_COMMUNITIES, PMSI_TUNNEL, and LARGE_COMMUNITIES attributes with additive typed variants; canonical and locally synthesized values remain canonical.
- Centralize value access so policy mutation, RIB controls, LLGR/export handling, rejected-route evidence, API/CLI projections, MRT/BMP paths, RFC 7999 BLACKHOLE classification, and learned EVPN controls treat canonical and Partial values identically without losing egress provenance.
- Validate PMSI tunnel types against the current IANA ranges, including assigned opaque and experimental values, invalid composite bases, RFC 6514 type 0/type 6 identifier lengths, and the RFC 8317 three-octet composite prefix. Malformed values retain the existing RFC 7606 treat-as-withdraw path.

## Proof

- Exact C0/D0/E0/F0 decode and re-encode matrices cover compact and Extended Length framing, reserved-bit canonicalization, duplicate Large Community normalization, and legacy/revised malformed behavior.
- Policy tests prove Partial survives modification, empty results remove the attribute, and absent synthesis stays canonical.
- RIB/export tests prove Partial NO_EXPORT, NO_ADVERTISE, LLGR, route-server control, and exact E0 propagation. The PMSI composition proof uses an EVPN Type 3 IMET through the existing RR-client distribution path.
- API, CLI/BMP, MRT, BLACKHOLE, and learned EVPN tests prove recognized values remain visible and behaviorally equivalent. Existing read projections remain value-only; assigned opaque PMSI preservation is not operational tunnel support.

Primary references: [RFC 4271 section 5](https://www.rfc-editor.org/rfc/rfc4271.html#section-5), [RFC 7606](https://www.rfc-editor.org/rfc/rfc7606.html), [IANA PMSI Tunnel Types](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#pmsi-tunnel-types), and [RFC 8317 section 6.2](https://www.rfc-editor.org/rfc/rfc8317.html#section-6.2). The IANA boundary was live-verified on 2026-08-24.

## Validation

- cargo test --workspace
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- cargo semver-checks check-release --workspace
- both locked MRT snapshot-allocation timing and diagnostic candidate smokes
- actual pre-commit and pre-push hooks
- independent exact-commit semantic and semver review

No manifest, lockfile, protobuf, FSM, config, workflow, embedding-contract, or version boundary changed.

Linear: LAN-1285
