### PR TITLE
fix(wire): enforce MP attribute error contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- MP_REACH_NLRI / MP_UNREACH_NLRI framing overruns now reset the session with
+  exact Optional Attribute Error data, illegal Partial flags reset with an
+  Attribute Flags Error, and empty MP_UNREACH marks End-of-RIB only for a
+  negotiated non-IPv4-unicast family; IPv4 keeps its empty UPDATE marker.
+  (LAN-1236)
 - Recognized optional-transitive Communities, Extended Communities, PMSI
   Tunnel, and Large Communities attributes now preserve a received Partial
   bit as typed state through policy and the RIB to egress; existing read

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1519,6 +1519,8 @@ impl PeerSession {
             // MP EoR: UPDATE with only an empty MP_UNREACH_NLRI (IPv6 unicast, FlowSpec, etc.)
             if parsed.attributes.len() == 1
                 && let Some(PathAttribute::MpUnreachNlri(mp)) = parsed.attributes.first()
+                && self.negotiated_families().contains(&(mp.afi, mp.safi))
+                && (mp.afi, mp.safi) != (Afi::Ipv4, Safi::Unicast)
                 && mp.withdrawn.is_empty()
                 && mp.flowspec_withdrawn.is_empty()
                 && mp.evpn_withdrawn.is_empty()

--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -353,7 +353,7 @@ async fn bgpls_attribute_discard_keeps_nlri_and_session() {
 #[tokio::test]
 async fn rfc7606_malformed_mp_reach_still_resets_session() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
-    let (client, _server) = connected_stream_pair().await;
+    let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
     rfc7606_drain(&mut rib_rx);
@@ -378,6 +378,134 @@ async fn rfc7606_malformed_mp_reach_still_resets_session() {
         );
     }
     assert_single_malformed_disposition(&session, "session_reset");
+    let notification = read_until_notification(&mut server).await;
+    assert_eq!(
+        notification.code,
+        rustbgpd_wire::notification::NotificationCode::UpdateMessage
+    );
+    assert_eq!(
+        notification.subcode,
+        rustbgpd_wire::notification::update_subcode::ATTRIBUTE_LENGTH_ERROR
+    );
+    assert_eq!(
+        notification.data.as_ref(),
+        &[0x80, 14, 2, 0, 1],
+        "complete undersized MP value must be returned exactly"
+    );
+}
+
+/// RFC 7606 §§3(j), 4, 5.3: a visible MP attribute whose declared value
+/// overruns Total Path Attribute Length cannot expose reliably parsed MP NLRI.
+/// Body NLRI is deliberately present so the independent §5.2 no-reachable-NLRI
+/// escalation cannot make this test pass.
+#[tokio::test]
+async fn rfc7606_mp_attribute_value_overrun_sends_optional_attribute_error() {
+    for type_code in [14, 15] {
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let (client, mut server) = connected_stream_pair().await;
+        session.test_install_stream(client);
+        establish_test_session(&mut session, 65002).await;
+        rfc7606_drain(&mut rib_rx);
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+        let malformed_mp = [0x80, type_code, 8, 0, 2, 1];
+
+        session
+            .process_update(rfc7606_update(rfc7606_attr_bytes(&malformed_mp), &[prefix]))
+            .await;
+
+        assert_ne!(
+            session.fsm.state(),
+            SessionState::Established,
+            "type {type_code}: MP framing overrun must reset even with body NLRI present"
+        );
+        while let Ok(message) = rib_rx.try_recv() {
+            assert!(
+                !matches!(message, RibUpdate::RoutesReceived { .. }),
+                "type {type_code}: no route may reach the RIB"
+            );
+        }
+        assert_single_malformed_disposition(&session, "session_reset");
+
+        let notification = read_until_notification(&mut server).await;
+        assert_eq!(
+            notification.code,
+            rustbgpd_wire::notification::NotificationCode::UpdateMessage,
+            "type {type_code}"
+        );
+        assert_eq!(
+            notification.subcode,
+            rustbgpd_wire::notification::update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+            "type {type_code}"
+        );
+        assert_eq!(
+            notification.data.as_ref(),
+            malformed_mp,
+            "type {type_code}: NOTIFICATION data must be the exact received attribute bytes"
+        );
+    }
+}
+
+/// RFC 4760 §§3-4 and RFC 7606 §5.3: MP attributes are optional
+/// non-transitive and therefore cannot carry Partial. Compact and Extended
+/// Length examples exercise the same live session-reset and exact 3/4
+/// NOTIFICATION contract; body NLRI prevents a §5.2-only pass.
+#[tokio::test]
+async fn rfc7606_mp_partial_flag_resets_with_exact_attribute_flags_error() {
+    let cases = [
+        (14, false, &[0, 1, Safi::FlowSpec as u8, 0, 0][..]),
+        (14, true, &[0, 1, Safi::FlowSpec as u8, 0, 0][..]),
+        (15, false, &[0, 2, Safi::Unicast as u8][..]),
+        (15, true, &[0, 2, Safi::Unicast as u8][..]),
+    ];
+    for (type_code, extended, value) in cases {
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let (client, mut server) = connected_stream_pair().await;
+        session.test_install_stream(client);
+        establish_test_session(&mut session, 65002).await;
+        rfc7606_drain(&mut rib_rx);
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+        let mut malformed_mp = vec![0x80 | 0x20 | if extended { 0x10 } else { 0 }, type_code];
+        if extended {
+            malformed_mp.extend_from_slice(&u16::try_from(value.len()).unwrap().to_be_bytes());
+        } else {
+            malformed_mp.push(u8::try_from(value.len()).unwrap());
+        }
+        malformed_mp.extend_from_slice(value);
+
+        session
+            .process_update(rfc7606_update(rfc7606_attr_bytes(&malformed_mp), &[prefix]))
+            .await;
+
+        assert_ne!(
+            session.fsm.state(),
+            SessionState::Established,
+            "type {type_code}, extended={extended}: Partial must reset the session"
+        );
+        while let Ok(message) = rib_rx.try_recv() {
+            assert!(
+                !matches!(message, RibUpdate::RoutesReceived { .. }),
+                "type {type_code}, extended={extended}: no route may reach the RIB"
+            );
+        }
+        assert_single_malformed_disposition(&session, "session_reset");
+
+        let notification = read_until_notification(&mut server).await;
+        assert_eq!(
+            notification.code,
+            rustbgpd_wire::notification::NotificationCode::UpdateMessage,
+            "type {type_code}, extended={extended}"
+        );
+        assert_eq!(
+            notification.subcode,
+            rustbgpd_wire::notification::update_subcode::ATTRIBUTE_FLAGS_ERROR,
+            "type {type_code}, extended={extended}"
+        );
+        assert_eq!(
+            notification.data.as_ref(),
+            malformed_mp,
+            "type {type_code}, extended={extended}: exact received attribute bytes"
+        );
+    }
 }
 
 /// RFC 7606 §5.2: an UPDATE carrying path attributes but no reachable NLRI
@@ -474,6 +602,63 @@ async fn rfc7606_nonempty_mp_reach_with_taw_error_stays_established() {
             );
         }
     }
+}
+
+/// RFC 7606 §7.11 reserves reset for MP syntax that prevents reliable NLRI
+/// parsing. A structurally complete `MP_REACH` with an invalid unspecified
+/// IPv6 next hop is instead treat-as-withdraw: the exact accepted replacement
+/// is withdrawn, no announcement survives, and the live session stays up.
+#[tokio::test]
+async fn rfc7606_semantic_mp_next_hop_error_withdraws_without_reset() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    install_dual_stack_session(&mut session, false);
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32);
+    let nlri = [32, 0x20, 0x01, 0x0d, 0xb8];
+
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&rfc7606_mp_reach(&nlri)),
+            &[],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx
+        .try_recv()
+        .expect("valid IPv6 MP route must reach the RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(announced.len(), 1);
+    assert_eq!(announced[0].prefix, Prefix::V6(prefix));
+
+    let mut invalid = rfc7606_mp_reach(&nlri);
+    invalid[7..23].fill(0); // Preserve complete framing; replace NH with ::.
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&invalid), &[]))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("treat-as-withdraw must reach the RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![(Prefix::V6(prefix), 0)]);
+    assert!(rib_rx.try_recv().is_err());
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert!(
+        session.read_half.is_some(),
+        "the live transport must stay up"
+    );
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
 }
 
 /// An UPDATE whose only attributes were discarded as malformed must not be
@@ -590,6 +775,7 @@ async fn mp_eor_empty_mp_unreach_marks_end_of_rib() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
+    install_dual_stack_session(&mut session, false);
     rfc7606_drain(&mut rib_rx);
     // Hand-crafted MP_UNREACH_NLRI: flags 0x80, type 15, len 3,
     // AFI=2 (IPv6), SAFI=1 (unicast), no NLRI.
@@ -613,6 +799,102 @@ async fn mp_eor_empty_mp_unreach_marks_end_of_rib() {
         }
         _ => panic!("expected EndOfRib"),
     }
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+/// RFC 4724 §2 scopes MP End-of-RIB to an AFI/SAFI negotiated on the session.
+/// The same valid empty IPv6 `MP_UNREACH` bytes must be ignored by an IPv4-only
+/// session rather than mutating GR state or notifying the RIB.
+#[tokio::test]
+async fn mp_eor_for_unnegotiated_family_is_ignored() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+
+    session
+        .process_update(UpdateMessage {
+            withdrawn_routes: Bytes::new(),
+            path_attributes: Bytes::from_static(&[0x80, 15, 3, 0, 2, 1]),
+            nlri: Bytes::new(),
+        })
+        .await;
+
+    assert!(
+        !session
+            .received_eor_families
+            .contains(&(Afi::Ipv6, Safi::Unicast)),
+        "an unnegotiated family must not mutate received EoR state"
+    );
+    assert!(
+        rib_rx.try_recv().is_err(),
+        "an unnegotiated family must not emit EndOfRib"
+    );
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+/// IPv4 unicast is negotiated by default, but RFC 8950 Extended Next Hop is
+/// what makes its `MP_REACH` / `MP_UNREACH` wire form eligible. Without that
+/// capability, an empty IPv4 `MP_UNREACH` must not become an MP `EoR`.
+#[tokio::test]
+async fn mp_eor_ipv4_without_extended_next_hop_is_ignored() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+
+    session
+        .process_update(UpdateMessage {
+            withdrawn_routes: Bytes::new(),
+            path_attributes: Bytes::from_static(&[0x80, 15, 3, 0, 1, 1]),
+            nlri: Bytes::new(),
+        })
+        .await;
+
+    assert!(
+        !session
+            .received_eor_families
+            .contains(&(Afi::Ipv4, Safi::Unicast)),
+        "ineligible IPv4 MP form must not mutate received EoR state"
+    );
+    assert!(
+        rib_rx.try_recv().is_err(),
+        "ineligible IPv4 MP form must not emit EndOfRib"
+    );
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+/// RFC 8950 Extended Next Hop makes IPv4-unicast MP route encoding eligible,
+/// but does not amend RFC 4724's classic empty-UPDATE End-of-RIB marker.
+#[tokio::test]
+async fn mp_eor_ipv4_with_extended_next_hop_is_ignored() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    install_test_negotiated_session(&mut session, negotiated_session(65002, true));
+    rfc7606_drain(&mut rib_rx);
+
+    session
+        .process_update(UpdateMessage {
+            withdrawn_routes: Bytes::new(),
+            path_attributes: Bytes::from_static(&[0x80, 15, 3, 0, 1, 1]),
+            nlri: Bytes::new(),
+        })
+        .await;
+
+    assert!(
+        !session
+            .received_eor_families
+            .contains(&(Afi::Ipv4, Safi::Unicast)),
+        "Extended Next Hop must not change IPv4's EoR marker"
+    );
+    assert!(
+        rib_rx.try_recv().is_err(),
+        "IPv4 MP_UNREACH must not emit EndOfRib even with Extended Next Hop"
+    );
     assert_eq!(session.fsm.state(), SessionState::Established);
 }
 

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,13 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- **MP framing and flags:** Visible truncated MP_REACH_NLRI /
+  MP_UNREACH_NLRI attributes now return Optional Attribute Error with the exact
+  received bytes, while incomplete ordinary attributes retain RFC 7606
+  treat-as-withdraw. Partial is now rejected on both optional non-transitive MP
+  attributes, including Extended Length framing. Complete undersized MP values
+  return Attribute Length Error; other intact MP decode failures return
+  Optional Attribute Error with exact attribute data.
 - **Additive typed Partial preservation:** Added
   `PathAttribute::CommunitiesPartial`, `ExtendedCommunitiesPartial`,
   `PmsiTunnelPartial`, and `LargeCommunitiesPartial` while retaining every

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -925,7 +925,7 @@ pub fn decode_path_attributes_counted(
     let mut attrs = Vec::new();
     let mut bgpls_discarded = 0_u32;
     while !buf.is_empty() {
-        let (flags, type_code, value) = split_next_attribute(&mut buf)?;
+        let (flags, type_code, value) = split_next_attribute_mp_aware(&mut buf)?;
         if is_unknown_optional_non_transitive(flags, type_code) {
             continue;
         }
@@ -996,6 +996,32 @@ fn split_next_attribute<'a>(buf: &mut &'a [u8]) -> Result<(u8, u8, &'a [u8]), De
     *buf = &rest[value_len..];
     Ok((flags, type_code, value))
 }
+/// Split one path attribute while preserving the RFC 7606 §5.3 exception for
+/// a visible but incompletely framed MP attribute. The low-level splitter
+/// leaves `buf` unchanged on error, so the NOTIFICATION data is exactly the
+/// received bytes within Total Path Attribute Length.
+fn split_next_attribute_mp_aware<'a>(
+    buf: &mut &'a [u8],
+) -> Result<(u8, u8, &'a [u8]), DecodeError> {
+    let received = *buf;
+    split_next_attribute(buf).map_err(|error| {
+        let type_code = if received.len() >= 2 { received[1] } else { 0 };
+        if matches!(
+            type_code,
+            attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI
+        ) {
+            DecodeError::UpdateAttributeError {
+                subcode: update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+                data: received.to_vec(),
+                detail: format!(
+                    "attribute type {type_code} framing prevents MP NLRI parsing: {error}"
+                ),
+            }
+        } else {
+            error
+        }
+    })
+}
 /// A malformed path attribute recovered during [`decode_path_attributes_revised`].
 ///
 /// Carries enough context for the session layer to log the malformation and
@@ -1039,7 +1065,9 @@ pub struct RevisedAttributeDecode {
 ///   discards the rest; duplicate `MP_REACH_NLRI`/`MP_UNREACH_NLRI` is fatal.
 /// - §4: an attribute whose length overruns the section is treat-as-withdraw
 ///   (the NLRI field was already located from the UPDATE section lengths),
-///   and attribute parsing stops.
+///   and attribute parsing stops. A visible `MP_REACH_NLRI` or
+///   `MP_UNREACH_NLRI` framing failure is instead fatal because its embedded
+///   NLRI cannot be parsed (§5.3).
 /// - §7.6/§7.7: `ATOMIC_AGGREGATE` with a non-zero length and `AGGREGATOR`
 ///   with a length other than 6/8 (by the 4-octet-AS negotiation) are
 ///   attribute-discard. The legacy decoder surfaces both length errors as
@@ -1072,15 +1100,25 @@ pub fn decode_path_attributes_revised(
     let mut malformed = Vec::new();
     let mut seen = [false; 256];
     while !buf.is_empty() {
-        let (flags, type_code, value) = match split_next_attribute(&mut buf) {
+        let (flags, type_code, value) = match split_next_attribute_mp_aware(&mut buf) {
             Ok(split) => split,
             Err(error) => {
+                let type_code = if buf.len() >= 2 { buf[1] } else { 0 };
+                if matches!(
+                    &error,
+                    DecodeError::UpdateAttributeError {
+                        subcode: update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+                        ..
+                    }
+                ) {
+                    return Err(error);
+                }
                 // RFC 7606 §4: framing overrun/underrun inside the attribute
                 // section is treat-as-withdraw — the section boundaries (and
                 // thus the NLRI field) were already fixed by the UPDATE
                 // length fields. Nothing after this point can be parsed.
                 malformed.push(MalformedAttribute {
-                    type_code: if buf.len() >= 2 { buf[1] } else { 0 },
+                    type_code,
                     disposition: ErrorDisposition::TreatAsWithdraw,
                     error,
                 });
@@ -1532,12 +1570,16 @@ fn decode_attribute_value(
 ) -> Result<PathAttribute, DecodeError> {
     // Validate the required flags for known attribute types (RFC 4271 §6.3).
     // RFC 4271 §4.3 requires Partial=0 for optional non-transitive
-    // attributes. Existing typed attributes predate strict Partial checking;
-    // include it for newly recognized Attribute 29 without broadening their
-    // error surface in this change.
+    // attributes. Enforce that bit for MP_REACH_NLRI / MP_UNREACH_NLRI,
+    // whose incorrect flags are fatal under RFC 7606 §5.3, and for the
+    // already-strict BGP-LS Attribute. Do not broaden the legacy flag surface
+    // of unrelated typed attributes here.
     let flags_mask = attr_flags::OPTIONAL
         | attr_flags::TRANSITIVE
-        | if type_code == attr_type::BGP_LS {
+        | if matches!(
+            type_code,
+            attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI | attr_type::BGP_LS
+        ) {
             attr_flags::PARTIAL
         } else {
             0
@@ -1758,9 +1800,37 @@ fn decode_attribute_value(
                 Ok(PathAttribute::LargeCommunities(communities))
             }
         }
-        attr_type::MP_REACH_NLRI => decode_mp_reach_nlri(value, add_path_families, bgpls_discarded),
+        attr_type::MP_REACH_NLRI => {
+            if value.len() < 5 {
+                return Err(DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+                    data: attr_error_data(flags, type_code, value),
+                    detail: format!("MP_REACH_NLRI length {} (minimum 5)", value.len()),
+                });
+            }
+            decode_mp_reach_nlri(value, add_path_families, bgpls_discarded).map_err(|error| {
+                DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+                    data: attr_error_data(flags, type_code, value),
+                    detail: error.to_string(),
+                }
+            })
+        }
         attr_type::MP_UNREACH_NLRI => {
-            decode_mp_unreach_nlri(value, add_path_families, bgpls_discarded)
+            if value.len() < 3 {
+                return Err(DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+                    data: attr_error_data(flags, type_code, value),
+                    detail: format!("MP_UNREACH_NLRI length {} (minimum 3)", value.len()),
+                });
+            }
+            decode_mp_unreach_nlri(value, add_path_families, bgpls_discarded).map_err(|error| {
+                DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+                    data: attr_error_data(flags, type_code, value),
+                    detail: error.to_string(),
+                }
+            })
         }
         attr_type::PMSI_TUNNEL => {
             let pmsi = crate::pmsi::PmsiTunnel::decode(value)?;
@@ -3208,6 +3278,26 @@ fn encode_as_path(as_path: &AsPath, buf: &mut Vec<u8>, four_octet_as: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn assert_mp_optional_attribute_error(
+        error: DecodeError,
+        expected_data: &[u8],
+        detail_fragment: &str,
+    ) {
+        let DecodeError::UpdateAttributeError {
+            subcode,
+            data,
+            detail,
+        } = error
+        else {
+            panic!("expected Optional Attribute Error, got: {error:?}");
+        };
+        assert_eq!(subcode, update_subcode::OPTIONAL_ATTRIBUTE_ERROR);
+        assert_eq!(data, expected_data);
+        assert!(
+            detail.contains(detail_fragment),
+            "expected {detail_fragment:?} in: {detail}"
+        );
+    }
     fn oversized_flowspec_rule() -> crate::flowspec::FlowSpecRule {
         use crate::flowspec::{FlowSpecComponent, FlowSpecRule, NumericMatch};
         let mut ops: Vec<NumericMatch> = (0..2_200)
@@ -3359,15 +3449,7 @@ mod tests {
         attr.extend(std::iter::repeat_n(0u8, 32)); // 32 NH bytes
         attr.push(0); // Reserved
         let err = decode_path_attributes(&attr, true, &[]).unwrap_err();
-        match err {
-            DecodeError::MalformedField { detail, .. } => {
-                assert!(
-                    detail.contains("L2VPN next-hop length 32"),
-                    "expected L2VPN NH-Len rejection, got: {detail}"
-                );
-            }
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &attr, "L2VPN next-hop length 32");
     }
     #[test]
     fn mp_unreach_evpn_attribute_roundtrip() {
@@ -3487,15 +3569,7 @@ mod tests {
         encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
         let err = decode_path_attributes(&buf, true, &[(Afi::BgpLs, Safi::BgpLs)])
             .expect_err("BGP-LS Add-Path must fail closed");
-        match err {
-            DecodeError::MalformedField { detail, .. } => {
-                assert!(
-                    detail.contains("BGP-LS Add-Path is not supported"),
-                    "unexpected detail: {detail}"
-                );
-            }
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &buf, "BGP-LS Add-Path is not supported");
     }
     #[test]
     fn mp_reach_bgpls_vpn_rejects_nonzero_next_hop_rd() {
@@ -3516,15 +3590,7 @@ mod tests {
         attr.extend_from_slice(&value);
         let err = decode_path_attributes(&attr, true, &[])
             .expect_err("BGP-LS VPN next-hop RD must be all zero");
-        match err {
-            DecodeError::MalformedField { detail, .. } => {
-                assert!(
-                    detail.contains("next-hop RD must be all zero"),
-                    "unexpected detail: {detail}"
-                );
-            }
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &attr, "next-hop RD must be all zero");
     }
     #[test]
     fn mp_reach_bgpls_rejects_8_byte_next_hop() {
@@ -3544,13 +3610,7 @@ mod tests {
         attr.extend_from_slice(&value);
         let err = decode_path_attributes(&attr, true, &[])
             .expect_err("BGP-LS next-hop must be 4, 16, or 32 bytes");
-        match err {
-            DecodeError::MalformedField { detail, .. } => assert_eq!(
-                detail,
-                "MP_REACH_NLRI BGP-LS next-hop length 8 (expected 4, 16, or 32)"
-            ),
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &attr, "BGP-LS next-hop length 8");
     }
     fn vpn_rd() -> crate::evpn::RouteDistinguisher {
         crate::evpn::RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 1])
@@ -3796,15 +3856,7 @@ mod tests {
         attr.extend_from_slice(&value);
         let err =
             decode_path_attributes(&attr, true, &[]).expect_err("VPN next-hop RD must be all zero");
-        match err {
-            DecodeError::MalformedField { detail, .. } => {
-                assert!(
-                    detail.contains("next-hop RD must be all zero"),
-                    "unexpected detail: {detail}"
-                );
-            }
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &attr, "next-hop RD must be all zero");
     }
     #[test]
     fn mp_reach_vpn_rejects_16_byte_next_hop() {
@@ -3823,13 +3875,7 @@ mod tests {
         attr.extend_from_slice(&value);
         let err = decode_path_attributes(&attr, true, &[])
             .expect_err("VPN next-hop must be 12, 24, or 48 bytes");
-        match err {
-            DecodeError::MalformedField { detail, .. } => assert_eq!(
-                detail,
-                "MP_REACH_NLRI VPN next-hop length 16 (expected 12, 24, or 48)"
-            ),
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &attr, "VPN next-hop length 16");
     }
     #[test]
     fn mp_reach_vpnv6_48_byte_next_hop_roundtrip() {
@@ -3928,15 +3974,7 @@ mod tests {
         encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
         let err = decode_path_attributes(&buf, true, &[(Afi::Ipv4, Safi::RtConstrain)])
             .expect_err("RTC Add-Path must fail closed");
-        match err {
-            DecodeError::MalformedField { detail, .. } => {
-                assert!(
-                    detail.contains("RTC Add-Path is not supported"),
-                    "unexpected detail: {detail}"
-                );
-            }
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &buf, "RTC Add-Path is not supported");
     }
     #[test]
     fn mp_reach_ipv6_rtc_stays_rejected() {
@@ -3953,7 +3991,7 @@ mod tests {
         attr.extend_from_slice(&value);
         let err =
             decode_path_attributes(&attr, true, &[]).expect_err("(IPv6, RTC) must stay rejected");
-        assert!(matches!(err, DecodeError::MalformedField { .. }));
+        assert_mp_optional_attribute_error(err, &attr, "unsupported AFI/SAFI 2/132");
     }
     // ---- EVPN extended community typed accessors (RFC 7432 / 8365 / 9135) ---
     #[test]
@@ -5048,6 +5086,53 @@ mod tests {
         assert_eq!(attr.flags(), attr_flags::OPTIONAL);
     }
     #[test]
+    fn mp_low_flag_bits_reserved_byte_and_extended_length_canonicalize() {
+        let mut reach_value = vec![0, 2, Safi::Unicast as u8, 16];
+        reach_value.extend_from_slice(&Ipv6Addr::LOCALHOST.octets());
+        reach_value.push(0x7f); // RFC 4760 Reserved field is ignored on receive.
+        let mut reach_wire = vec![
+            attr_flags::OPTIONAL | 0x0f,
+            attr_type::MP_REACH_NLRI,
+            u8::try_from(reach_value.len()).unwrap(),
+        ];
+        reach_wire.extend_from_slice(&reach_value);
+        let reach = decode_path_attributes(&reach_wire, true, &[]).unwrap();
+        let mut canonical_reach = Vec::new();
+        encode_path_attributes(&reach, &mut canonical_reach, true, false).unwrap();
+        reach_value[20] = 0;
+        let mut expected_reach = vec![
+            attr_flags::OPTIONAL,
+            attr_type::MP_REACH_NLRI,
+            u8::try_from(reach_value.len()).unwrap(),
+        ];
+        expected_reach.extend_from_slice(&reach_value);
+        assert_eq!(canonical_reach, expected_reach);
+
+        let unreach_wire = [
+            attr_flags::OPTIONAL | attr_flags::EXTENDED_LENGTH | 0x0f,
+            attr_type::MP_UNREACH_NLRI,
+            0,
+            3,
+            0,
+            2,
+            Safi::Unicast as u8,
+        ];
+        let unreach = decode_path_attributes(&unreach_wire, true, &[]).unwrap();
+        let mut canonical_unreach = Vec::new();
+        encode_path_attributes(&unreach, &mut canonical_unreach, true, false).unwrap();
+        assert_eq!(
+            canonical_unreach,
+            [
+                attr_flags::OPTIONAL,
+                attr_type::MP_UNREACH_NLRI,
+                3,
+                0,
+                2,
+                Safi::Unicast as u8,
+            ]
+        );
+    }
+    #[test]
     fn mp_reach_nlri_empty_nlri() {
         use crate::capability::{Afi, Safi};
         let mp = MpReachNlri {
@@ -5072,7 +5157,7 @@ mod tests {
     #[test]
     fn mp_reach_nlri_bad_flags_rejected() {
         // MP_REACH_NLRI (type 14) with flags 0x40 (Transitive only)
-        // — should be 0xC0 (Optional+Transitive)
+        // — should be 0x80 (Optional, non-transitive).
         // Build minimal valid value: AFI=2, SAFI=1, NH-Len=16, NH=::1, Reserved=0
         let mut value = Vec::new();
         value.extend_from_slice(&2u16.to_be_bytes()); // AFI IPv6
@@ -5316,15 +5401,7 @@ mod tests {
         let mut attr = vec![0x80, 14, u8::try_from(value.len()).unwrap()];
         attr.extend_from_slice(value);
         let err = decode_path_attributes(&attr, true, &[]).unwrap_err();
-        match err {
-            DecodeError::MalformedField { detail, .. } => {
-                assert!(
-                    detail.contains("FlowSpec next-hop length"),
-                    "expected FlowSpec NH-Len rejection, got: {detail}"
-                );
-            }
-            other => panic!("expected MalformedField, got {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &attr, "FlowSpec next-hop length");
     }
     /// RFC 8955 §4.2 makes a `FlowSpec` NLRI carrying an unknown component
     /// type malformed, and §10 defers to RFC 7606. Because the offending
@@ -5345,13 +5422,7 @@ mod tests {
         let mut attr = vec![0x80, 14, u8::try_from(value.len()).unwrap()];
         attr.extend_from_slice(value);
         let err = decode_path_attributes_revised(&attr, true, false, &[]).unwrap_err();
-        match err {
-            DecodeError::MalformedField { detail, .. } => assert!(
-                detail.contains("unknown FlowSpec component type 14"),
-                "expected unknown-component rejection, got: {detail}"
-            ),
-            other => panic!("expected MalformedField, got {other:?}"),
-        }
+        assert_mp_optional_attribute_error(err, &attr, "unknown FlowSpec component type 14");
     }
 
     #[test]
@@ -6983,7 +7054,174 @@ mod tests {
             attr_type::MP_REACH_NLRI,
             &[0, 1],
         ));
-        assert!(decode_path_attributes_revised(&buf, true, false, &[]).is_err());
+        let error = decode_path_attributes_revised(&buf, true, false, &[]).unwrap_err();
+        let DecodeError::UpdateAttributeError { subcode, data, .. } = error else {
+            panic!("expected MP attribute length error");
+        };
+        assert_eq!(subcode, update_subcode::ATTRIBUTE_LENGTH_ERROR);
+        assert_eq!(data, attr_bytes(attr_flags::OPTIONAL, 14, &[0, 1]));
+    }
+    #[test]
+    fn revised_mp_complete_value_errors_use_exact_notification_contract() {
+        let mut bad_reach_nlri = vec![0, 2, Safi::Unicast as u8, 16];
+        bad_reach_nlri.extend_from_slice(&Ipv6Addr::LOCALHOST.octets());
+        bad_reach_nlri.extend([0, 129]);
+        let cases = [
+            (
+                "MP_UNREACH minimum length",
+                attr_type::MP_UNREACH_NLRI,
+                &[0, 2][..],
+                update_subcode::ATTRIBUTE_LENGTH_ERROR,
+            ),
+            (
+                "MP_REACH next-hop mismatch",
+                attr_type::MP_REACH_NLRI,
+                &[0, 2, Safi::Unicast as u8, 4, 192, 0, 2, 1, 0][..],
+                update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+            ),
+            (
+                "MP_REACH embedded NLRI",
+                attr_type::MP_REACH_NLRI,
+                bad_reach_nlri.as_slice(),
+                update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+            ),
+            (
+                "MP_UNREACH embedded NLRI",
+                attr_type::MP_UNREACH_NLRI,
+                &[0, 2, Safi::Unicast as u8, 129][..],
+                update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+            ),
+        ];
+        for (name, type_code, value, expected_subcode) in cases {
+            let wire = attr_bytes(attr_flags::OPTIONAL, type_code, value);
+            let error = decode_path_attributes_revised(&wire, true, false, &[]).unwrap_err();
+            let DecodeError::UpdateAttributeError { subcode, data, .. } = error else {
+                panic!("{name}: expected UPDATE attribute error");
+            };
+            assert_eq!(subcode, expected_subcode, "{name}");
+            assert_eq!(data, wire, "{name}: exact complete attribute bytes");
+        }
+    }
+    #[test]
+    fn revised_mp_flags_matrix_is_session_reset_with_exact_error_data() {
+        let cases = [
+            (
+                attr_type::MP_REACH_NLRI,
+                &[0, 1, Safi::FlowSpec as u8, 0, 0][..],
+            ),
+            (attr_type::MP_UNREACH_NLRI, &[0, 2, Safi::Unicast as u8][..]),
+        ];
+        for (type_code, value) in cases {
+            for bad_flags in [
+                0,
+                attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+                attr_flags::OPTIONAL | attr_flags::PARTIAL,
+            ] {
+                for extended in [false, true] {
+                    let flags = bad_flags
+                        | if extended {
+                            attr_flags::EXTENDED_LENGTH
+                        } else {
+                            0
+                        };
+                    let mut wire = vec![flags, type_code];
+                    if extended {
+                        wire.extend_from_slice(&u16::try_from(value.len()).unwrap().to_be_bytes());
+                    } else {
+                        wire.push(u8::try_from(value.len()).unwrap());
+                    }
+                    wire.extend_from_slice(value);
+
+                    let error =
+                        decode_path_attributes_revised(&wire, true, false, &[]).unwrap_err();
+                    let DecodeError::UpdateAttributeError { subcode, data, .. } = error else {
+                        panic!("type {type_code}, flags {flags:#04x}: expected flags error");
+                    };
+                    assert_eq!(
+                        subcode,
+                        update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                        "type {type_code}, flags {flags:#04x}"
+                    );
+                    assert_eq!(
+                        data, wire,
+                        "type {type_code}, flags {flags:#04x}: exact attribute error data"
+                    );
+                }
+            }
+        }
+    }
+    #[test]
+    fn revised_mp_attribute_framing_failures_are_optional_attribute_errors() {
+        for type_code in [attr_type::MP_REACH_NLRI, attr_type::MP_UNREACH_NLRI] {
+            let cases = [
+                vec![attr_flags::OPTIONAL, type_code],
+                vec![attr_flags::OPTIONAL, type_code, 5, 0, 2, 1],
+                vec![
+                    attr_flags::OPTIONAL | attr_flags::EXTENDED_LENGTH,
+                    type_code,
+                    0,
+                ],
+                vec![
+                    attr_flags::OPTIONAL | attr_flags::EXTENDED_LENGTH,
+                    type_code,
+                    0,
+                    5,
+                    0,
+                    2,
+                    1,
+                ],
+            ];
+            for wire in cases {
+                let error = decode_path_attributes_revised(&wire, true, false, &[]).unwrap_err();
+                let DecodeError::UpdateAttributeError { subcode, data, .. } = error else {
+                    panic!("type {type_code}: expected Optional Attribute Error");
+                };
+                assert_eq!(
+                    subcode,
+                    update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+                    "type {type_code}"
+                );
+                assert_eq!(
+                    data, wire,
+                    "type {type_code}: NOTIFICATION data must contain exactly the received bytes"
+                );
+            }
+        }
+    }
+    #[test]
+    fn strict_mp_attribute_framing_failures_are_optional_attribute_errors() {
+        for type_code in [attr_type::MP_REACH_NLRI, attr_type::MP_UNREACH_NLRI] {
+            let cases = [
+                vec![attr_flags::OPTIONAL, type_code, 5, 0, 2, 1],
+                vec![
+                    attr_flags::OPTIONAL | attr_flags::EXTENDED_LENGTH,
+                    type_code,
+                    0,
+                    5,
+                    0,
+                    2,
+                    1,
+                ],
+            ];
+            for wire in cases {
+                let error = decode_path_attributes(&wire, true, &[]).unwrap_err();
+                let DecodeError::UpdateAttributeError { subcode, data, .. } = error else {
+                    panic!("type {type_code}: expected Optional Attribute Error");
+                };
+                assert_eq!(
+                    subcode,
+                    update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+                    "type {type_code}"
+                );
+                assert_eq!(data, wire, "type {type_code}: exact received bytes");
+            }
+        }
+
+        let ordinary = [attr_flags::OPTIONAL, attr_type::MULTI_EXIT_DISC, 5, 0, 0, 1];
+        assert!(matches!(
+            decode_path_attributes(&ordinary, true, &[]),
+            Err(DecodeError::MalformedField { .. })
+        ));
     }
     #[test]
     fn revised_duplicate_attribute_keeps_first_and_discards_rest() {
@@ -7073,7 +7311,12 @@ mod tests {
         let mp_unreach = attr_bytes(attr_flags::OPTIONAL, attr_type::MP_UNREACH_NLRI, &[0, 2, 1]);
         let mut buf = mp_unreach.clone();
         buf.extend(mp_unreach);
-        assert!(decode_path_attributes_revised(&buf, true, false, &[]).is_err());
+        let error = decode_path_attributes_revised(&buf, true, false, &[]).unwrap_err();
+        let DecodeError::UpdateAttributeError { subcode, data, .. } = error else {
+            panic!("expected Malformed Attribute List");
+        };
+        assert_eq!(subcode, update_subcode::MALFORMED_ATTRIBUTE_LIST);
+        assert!(data.is_empty());
     }
     #[test]
     fn revised_attribute_overrun_is_treat_as_withdraw_and_stops() {
@@ -7093,6 +7336,20 @@ mod tests {
             decoded.malformed[0].disposition,
             ErrorDisposition::TreatAsWithdraw
         );
+    }
+    #[test]
+    fn revised_unidentifiable_attribute_header_is_treat_as_withdraw() {
+        let decoded =
+            decode_path_attributes_revised(&[attr_flags::OPTIONAL], true, false, &[]).unwrap();
+        let [malformed] = decoded.malformed.as_slice() else {
+            panic!("expected one framing malformation");
+        };
+        assert_eq!(malformed.type_code, 0);
+        assert_eq!(malformed.disposition, ErrorDisposition::TreatAsWithdraw);
+        assert!(matches!(
+            malformed.error,
+            DecodeError::MalformedField { .. }
+        ));
     }
     #[test]
     fn revised_clean_update_reports_nothing() {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -388,7 +388,7 @@ Dispositions follow RFC 7606, not RFC 4271's blanket session reset: `wire::valid
 | 4-byte ASN handling (AS_TRANS mapping) | RFC 6793 | Reconstruct valid AS4 compatibility attributes; discard or ignore inconsistent sidecars per RFC 6793 |
 | NEXT_HOP is valid IP, not 0.0.0.0, not multicast | RFC 4271 §5.1.3, RFC 7606 §7.3 | Treat-as-withdraw; subcode (3, 8) |
 | ORIGIN value is valid (IGP, EGP, INCOMPLETE) | RFC 4271 §4.3, RFC 7606 §7.1 | Treat-as-withdraw; subcode (3, 6) |
-| Attribute length does not exceed the attribute section | RFC 7606 §4 | Treat-as-withdraw; subcode (3, 1) |
+| Attribute length does not exceed the attribute section | RFC 7606 §§4, 5.3 | Treat-as-withdraw; a visible MP_REACH_NLRI / MP_UNREACH_NLRI overrun is session-reset because its embedded NLRI cannot be parsed |
 | Total path attributes length consistent with UPDATE length | RFC 7606 §3 (b) | Session-reset — NOTIFICATION (3, 1), the NLRI field boundaries cannot be trusted |
 | Unrecognized well-known attribute | RFC 4271 §5, RFC 7606 §3 (c) | Treat-as-withdraw; subcode (3, 2) |
 | Unrecognized optional non-transitive attribute | RFC 4271 §5 | Not a failure — accepted and ignored |

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -463,7 +463,8 @@ message (§3 (h)).
   Covers ORIGIN, AS_PATH (§7.2 — no longer a session reset), NEXT_HOP,
   MULTI_EXIT_DISC, communities of all sizes, attribute-flag conflicts
   (§3 (c)), missing mandatory attributes (§3 (d)), and attribute-section
-  framing overruns (§4).
+  framing overruns (§4), except visible MP_REACH_NLRI / MP_UNREACH_NLRI
+  framing failures whose embedded NLRI cannot be parsed (§5.3).
 - **Attribute-discard** (§2): ATOMIC_AGGREGATE with a non-zero length and
   AGGREGATOR with a length other than 6/8 (§7.6, §7.7) are dropped and the
   UPDATE proceeds. Malformed LOCAL_PREF / ORIGINATOR_ID / CLUSTER_LIST from
@@ -471,11 +472,22 @@ message (§3 (h)).
   neighbor they are treat-as-withdraw. Duplicate attributes keep the first
   occurrence and discard the rest (§3 (g)).
 - **Session-reset** is retained only where the NLRI cannot be trusted:
-  UPDATE section-length inconsistencies (§3 (b), unchanged), a malformed or
-  duplicated MP_REACH_NLRI / MP_UNREACH_NLRI (§7.11, §3 (g)), syntactically
-  incorrect NLRI or Withdrawn Routes fields (§5.3), and the §5.2 escalation
-  (a treat-as-withdraw-class error in an UPDATE that encodes no reachable
-  NLRI).
+  UPDATE section-length inconsistencies (§3 (b), unchanged), a structurally
+  unparseable or duplicated MP_REACH_NLRI / MP_UNREACH_NLRI (§7.11, §3 (g)),
+  syntactically incorrect NLRI or Withdrawn Routes fields (§5.3), and the
+  §5.2 escalation (a treat-as-withdraw-class error in an UPDATE that encodes
+  no reachable NLRI). A visible MP attribute with incomplete header/value
+  framing uses
+  UPDATE Optional Attribute Error (3/9) with exactly the received attribute
+  bytes, as recommended by RFC 4760 §7; ordinary attribute-section overruns
+  remain treat-as-withdraw. A complete MP attribute shorter than its minimum
+  value uses Attribute Length Error (3/5); other intact structural MP decode
+  failures (including AFI/SAFI decoding, next-hop length/framing, and
+  embedded-NLRI syntax) use 3/9 with the exact complete attribute bytes.
+  A byte-complete next hop that parses but fails semantic address validation
+  (for example, an unspecified IPv6 address) is treat-as-withdraw with Invalid
+  NEXT_HOP (3/8), not session-reset. Duplicate MP attributes remain 3/1 with
+  empty data, and flag conflicts remain 3/4 with exact attribute data.
 
 Interpretation decisions:
 
@@ -580,11 +592,11 @@ Wire layout:
 AFI (2 bytes) | SAFI (1) | NH-Len (1) | Next Hop (variable) | Reserved (1) | NLRI (variable)
 ```
 
-- Flags: Optional + Transitive (0xC0).
-- AFI 2 (IPv6), SAFI 1 (Unicast) is the only supported combination beyond
-  IPv4 unicast.
-- Next-hop length: 16 bytes (global IPv6 address) or 32 bytes (global +
-  link-local). When 32 bytes, rustbgpd takes the first 16 as the primary
+- Flags: Optional + Non-Transitive (`0x80`). The Extended Length bit may be
+  added for framing; Partial is invalid.
+- For IPv6 unicast, next-hop length is 16 bytes (global IPv6 address) or
+  32 bytes (global + link-local). When 32 bytes, rustbgpd takes the first 16
+  as the primary
   next-hop and preserves the trailing 16 in `link_local_next_hop`
   (round-tripped through wire / RIB / MRT since v0.11.0); ADR-0069 resolves a
   link-local next-hop as a scoped next-hop for unnumbered IPv4-over-IPv6 and
@@ -596,7 +608,7 @@ AFI (2 bytes) | SAFI (1) | NH-Len (1) | Next Hop (variable) | Reserved (1) | NLR
   `validate_update_attributes()` relaxes the NEXT_HOP mandatory check when
   `has_mp_nlri` is true.
 
-### §3 — MP_UNREACH_NLRI (Type 15)
+### §4 — MP_UNREACH_NLRI (Type 15)
 
 Wire layout:
 
@@ -606,6 +618,15 @@ AFI (2 bytes) | SAFI (1) | Withdrawn Routes (variable)
 
 - Flags: Optional + Non-Transitive (0x80).
 - Withdrawn routes use the same prefix-length encoding as announced NLRI.
+- An empty NLRI field after AFI/SAFI is End-of-RIB only when that family
+  was negotiated on the session and is not IPv4 unicast (RFC 4724 §2).
+  IPv4 unicast always uses the minimum-length empty UPDATE marker, including
+  sessions that negotiated Extended Next Hop.
+
+The current typed MP decoder supports IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec,
+L2VPN EVPN, BGP-LS/BGP-LS VPN, VPNv4/VPNv6, IPv4/IPv6 labeled-unicast, and
+IPv4 RT-Constrain. This is an implementation boundary, not a claim to support
+every [IANA AFI/SAFI assignment](https://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml).
 
 ### AFI/SAFI Negotiation
 

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -42,8 +42,8 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 11 | DPA (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 12 | ADVERTISER (historic) (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 13 | RCID_PATH / CLUSTER_ID (Historic) (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 14 | MP_REACH_NLRI | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 15 | MP_UNREACH_NLRI | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 14 | MP_REACH_NLRI | optional non-transitive; flags `0x80`; RFC 4760 §3; RFC 7606 §§5.3, 7.11 | typed per-family decode/encode; structural, flag, or embedded-NLRI failure and duplicate attributes are session-reset | wire framing matrix and transport reset proof |
+| 15 | MP_UNREACH_NLRI | optional non-transitive; flags `0x80`; RFC 4760 §4; RFC 7606 §§5.3, 7.11 | typed per-family decode/encode; structural, flag, or embedded-NLRI failure and duplicate attributes are session-reset; empty NLRI is MP End-of-RIB only for a negotiated family other than IPv4 unicast | wire framing matrix and transport reset proof |
 | 16 | EXTENDED COMMUNITIES | optional transitive; flags `0xc0`; values are eight-octet communities; RFC 4360 / RFC 7606 §7.14 | typed canonical + Partial round-trip; Extended Length and reserved low bits canonicalize; malformed length is treat-as-withdraw | typed-Partial matrix |
 | 17 | AS4_PATH | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 18 | AS4_AGGREGATOR | pending follow-up audit | pending follow-up audit | IANA CSV digest above |


### PR DESCRIPTION
## Summary

- make visible MP_REACH_NLRI and MP_UNREACH_NLRI framing failures fatal in both strict and revised decoders, with exact RFC 7606 notification subcodes and data
- reject illegal MP flags and duplicate attributes while preserving the semantic invalid-next-hop treat-as-withdraw boundary
- recognize MP End-of-RIB only for negotiated families other than IPv4 unicast; IPv4 retains the empty UPDATE marker even with Extended Next Hop
- true up the path-attribute registry, RFC notes, design notes, and changelogs for rows 14 and 15

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p rustbgpd-wire -p rustbgpd-transport`
- `cargo check --locked -p rustbgpd-wire -p rustbgpd-transport --all-targets --all-features`
- `cargo clippy --locked -p rustbgpd-wire -p rustbgpd-transport --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --locked -p rustbgpd-wire -p rustbgpd-transport --lib --no-deps --all-features`
- `cargo semver-checks check-release --package rustbgpd-wire`
- `python3 scripts/check-v1-stable-surface.py`
- public tracker contract tests and live 608-document scan
- full repository commit and push hooks, including workspace Clippy, tests, and rustdoc

Linear: LAN-1236