### PR TITLE
docs(changelog): record assigned attribute class fencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   re-advertised; unknown optional transitive attributes remain preserved with
   the Partial bit. (LAN-1265)
 
+- The six IANA-assigned path attribute types whose payloads rustbgpd does not
+  parse (Tunnel Encapsulation, AIGP, PE Distinguisher Labels, BGPsec_Path,
+  BGP Prefix-SID, and ATTR_SET) are now checked against their registered
+  attribute class on receipt. Flags that conflict with the registered class
+  are handled under RFC 7606 instead of being silently ignored or retained
+  opaquely: AIGP carrying Transitive is discarded per RFC 7311 §3.2, and
+  every other class conflict is treat-as-withdraw. Correctly classed
+  attributes keep their existing treatment, ignored when optional
+  non-transitive and retained opaquely with the Partial bit when optional
+  transitive. (LAN-1236)
+
 - `rs-config-render recover` now reports the recovery steps that completed
   before a later step failed while preserving the non-zero exit status and
   error output; steps that were not reached are not reported.

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -38,6 +38,17 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
   attributes are now ignored by both strict and revised decoders and by the
   defensive encoder. Unknown optional transitive attributes remain preserved
   for propagation with the Partial bit.
+- **Additive registry constants and assigned-class fencing:** Added
+  `attr_type::TUNNEL_ENCAPSULATION`, `AIGP`, `PE_DISTINGUISHER_LABELS`,
+  `BGPSEC_PATH`, `PREFIX_SID`, and `ATTR_SET`. Those six assigned types now
+  carry their registered Optional/Transitive class through decode: a class
+  conflict is an UPDATE attribute flags error in the strict decoder and an
+  RFC 7606 outcome in the revised decoder instead of being silently ignored
+  or retained opaquely. AIGP carrying Transitive is attribute-discard per
+  RFC 7311 §3.2; every other class conflict is treat-as-withdraw.
+  Correct-class handling is unchanged, with optional non-transitive types
+  ignored and optional transitive types retained opaque and re-emitted with
+  Partial. Payload semantics remain unsupported for all six.
 - **Adoption example:** Added a standalone captured-UPDATE decoder using the
   crate's public framing and parsed-update APIs.
 


### PR DESCRIPTION
Documents the changes landed in #1987.

`crates/wire/CHANGELOG.md` (Unreleased): records the six additive
`attr_type` constants (`TUNNEL_ENCAPSULATION`, `AIGP`,
`PE_DISTINGUISHER_LABELS`, `BGPSEC_PATH`, `PREFIX_SID`, `ATTR_SET`) and the
decode change that now checks those types against their registered
Optional/Transitive class, including the RFC 7311 §3.2 attribute-discard
carve-out for AIGP carrying Transitive and treat-as-withdraw for every other
class conflict.

`CHANGELOG.md` (Unreleased / Changed): records the same behavior change in
operator-facing terms next to the adjacent unknown-attribute entry
(LAN-1265), scoped to receive-side handling with correct-class treatment
unchanged. No upgrade note: this needs no consumer action.

Documentation only; no Rust source is touched.