### PR TITLE
fix(wire): validate assigned attribute framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Assigned BGP attributes 36-42 now use their registered propagation classes;
+  D-PATH, SFP, BFD Discriminator, NHC, Prefix-SID, and BIER receive bounded
+  structural framing checks before opaque propagation, while Edge Metadata is
+  never retained or emitted. Strict decoding returns typed errors instead of
+  reaching an impossible branch, and revised decoding applies each row's
+  treat-as-withdraw or attribute-discard action. (LAN-1236, LAN-1286)
+
 - General unicast FIB Add/Replace operations whose unscoped, same-family,
   non-link-local next-hop target receives Linux's family-specific unreachable
   errno are now held as `unresolved` and retried on relevant route notifications

--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -201,6 +201,150 @@ async fn unknown_optional_non_transitive_is_absent_from_delivered_route() {
     assert_eq!(session.fsm.state(), SessionState::Established);
 }
 
+#[tokio::test]
+async fn assigned_opaque_attributes_reach_rib_while_edge_metadata_is_absent() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    assert!(matches!(
+        read_single_bgp_message(&mut server).await,
+        Message::Open(_)
+    ));
+    assert!(matches!(
+        read_single_bgp_message(&mut server).await,
+        Message::Keepalive
+    ));
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 42), 32);
+    let values = [
+        (36_u8, vec![1, 0, 0, 0, 0, 0, 0, 0]),
+        (37, vec![2, 0, 4, 1, 99, 0, 0]),
+        (38, vec![1, 0, 0, 0, 1, 1, 4, 192, 0, 2, 1]),
+        (39, vec![0, 1, 1, 4, 192, 0, 2, 1, 0, 1, 0, 0]),
+        (41, vec![0, 1, 0, 12, 0, 0, 0, 0, 0, 4, 0, 4, 192, 0, 2, 1]),
+    ];
+    let mut extra = Vec::new();
+    for (code, value) in &values {
+        extra.extend([0xc0, *code, u8::try_from(value.len()).unwrap()]);
+        extra.extend(value);
+    }
+    extra.extend([0x80, 42, 1, 0xaa]);
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&extra), &[prefix]))
+        .await;
+
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected assigned opaque announcement");
+    };
+    assert_eq!(announced.len(), 1);
+    for (code, _) in &values {
+        assert!(
+            announced[0]
+                .attributes
+                .iter()
+                .any(|attribute| attribute.type_code() == *code),
+            "assigned type {code} did not reach the RIB"
+        );
+    }
+    assert!(
+        announced[0]
+            .attributes
+            .iter()
+            .all(|attribute| attribute.type_code() != 42)
+    );
+    let delivered = announced[0].clone();
+    session.send_route_update(OutboundRouteUpdate {
+        exact_export_snapshot: Some(session.publish_export_profile()),
+        announce: vec![delivered].into(),
+        next_hop_override: vec![None].into(),
+        ..empty_outbound_update()
+    });
+    let Message::Update(egress) = read_single_bgp_message(&mut server).await else {
+        panic!("expected outbound UPDATE");
+    };
+    let parsed = egress.parse(true, false, &[]).unwrap();
+    for (code, value) in &values {
+        let Some(PathAttribute::Unknown(raw)) = parsed
+            .attributes
+            .iter()
+            .find(|attribute| attribute.type_code() == *code)
+        else {
+            panic!("assigned type {code} missing from outbound UPDATE");
+        };
+        assert_eq!(raw.flags, 0xe0, "assigned type {code} missing Partial");
+        assert_eq!(raw.data.as_ref(), value);
+    }
+    assert!(
+        parsed
+            .attributes
+            .iter()
+            .all(|attribute| attribute.type_code() != 42)
+    );
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+#[tokio::test]
+async fn malformed_domain_path_withdraws_route_and_keeps_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 36), 32);
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&[]), &[prefix]))
+        .await;
+    let _ = rib_rx.try_recv().expect("initial route");
+
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[0xc0, 36, 8, 0, 0, 0, 0, 0, 0, 0, 0]),
+            &[prefix],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx.try_recv().expect("treat-as-withdraw update")
+    else {
+        panic!("expected route withdrawal");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![(Prefix::V4(prefix), 0)]);
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
+}
+
+#[tokio::test]
+async fn malformed_bfd_discriminator_discards_attribute_and_keeps_route() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 38), 32);
+    let malformed = [0xc0, 38, 11, 1, 0, 0, 0, 1, 2, 4, 0, 0, 0, 0];
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&malformed), &[prefix]))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } =
+        rib_rx.try_recv().expect("attribute-discard announcement")
+    else {
+        panic!("expected retained route");
+    };
+    assert_eq!(announced.len(), 1);
+    assert!(
+        announced[0]
+            .attributes
+            .iter()
+            .all(|attribute| attribute.type_code() != 38)
+    );
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "attribute_discard");
+}
+
 /// RFC 6793 / RFC 7606: a malformed `AS4_PATH` is discarded without losing
 /// reachable NLRI or the valid ordinary path on a legacy session.
 ///

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,14 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- **Assigned attribute framing and class fences:** Added registry constants and
+  fail-closed Optional/Transitive class recognition for D-PATH, SFP, BFD
+  Discriminator, NHC, BIER, and Edge Metadata. Attributes 36-41 remain opaque
+  but now receive bounded syntax-only framing checks and their specified RFC
+  7606 dispositions; correct Edge Metadata is ignored as optional
+  non-transitive, including on egress. Partial and other class conflicts are
+  typed strict-decoder flag errors and revised treat-as-withdraw outcomes.
+
 - **MP framing and flags:** Visible truncated MP_REACH_NLRI /
   MP_UNREACH_NLRI attributes now return Optional Attribute Error with the exact
   received bytes, while incomplete ordinary attributes retain RFC 7606

--- a/crates/wire/src/assigned_attributes.rs
+++ b/crates/wire/src/assigned_attributes.rs
@@ -1,0 +1,183 @@
+//! Structural framing checks for assigned attributes retained opaquely.
+
+use crate::constants::attr_type;
+
+pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> {
+    match type_code {
+        attr_type::DOMAIN_PATH => domain_path(value),
+        attr_type::SFP => sfp(value),
+        attr_type::BFD_DISCRIMINATOR => bfd_discriminator(value),
+        attr_type::NHC => nhc(value),
+        attr_type::PREFIX_SID => prefix_sid(value),
+        attr_type::BIER => bier(value),
+        _ => Ok(()),
+    }
+}
+
+fn domain_path(mut value: &[u8]) -> Result<(), &'static str> {
+    if value.len() < 8 {
+        return Err("D-PATH must contain a non-empty domain segment");
+    }
+    while !value.is_empty() {
+        let count = usize::from(value[0]);
+        if count == 0 {
+            return Err("D-PATH domain segment count is zero");
+        }
+        let length = 1_usize
+            .checked_add(7_usize.checked_mul(count).ok_or("D-PATH length overflow")?)
+            .ok_or("D-PATH length overflow")?;
+        if value.len() < length {
+            return Err("D-PATH domain segment overruns attribute");
+        }
+        value = &value[length..];
+    }
+    Ok(())
+}
+
+fn sfp(mut value: &[u8]) -> Result<(), &'static str> {
+    let mut hop = false;
+    while !value.is_empty() {
+        let (kind, body, rest) = tlv_u8_u16(value)?;
+        if kind == 2 {
+            hop = true;
+            if body.len() < 4 {
+                return Err("SFP Hop TLV lacks service index or sub-TLV");
+            }
+            let mut sub = &body[1..];
+            while !sub.is_empty() {
+                let (_, _, rest) = tlv_u8_u16(sub)?;
+                sub = rest;
+            }
+        }
+        value = rest;
+    }
+    if !hop {
+        return Err("SFP attribute lacks a Hop TLV");
+    }
+    Ok(())
+}
+
+fn bfd_discriminator(value: &[u8]) -> Result<(), &'static str> {
+    if value.len() < 11 {
+        return Err("BFD Discriminator attribute is shorter than 11 octets");
+    }
+    let mut source = false;
+    let mut tlvs = &value[5..];
+    while !tlvs.is_empty() {
+        if tlvs.len() < 2 {
+            return Err("BFD Discriminator TLV header is truncated");
+        }
+        let kind = tlvs[0];
+        let length = usize::from(tlvs[1]);
+        if tlvs.len() < 2 + length {
+            return Err("BFD Discriminator TLV overruns attribute");
+        }
+        if kind == 1 {
+            if !matches!(length, 4 | 16) {
+                return Err("BFD Source IP TLV length is not 4 or 16");
+            }
+            source = true;
+        }
+        tlvs = &tlvs[2 + length..];
+    }
+    if !source {
+        return Err("BFD Discriminator lacks Source IP TLV");
+    }
+    Ok(())
+}
+
+fn nhc(value: &[u8]) -> Result<(), &'static str> {
+    if value.len() < 4 {
+        return Err("NHC next-hop header is truncated");
+    }
+    let next_hop_len = usize::from(value[3]);
+    if value.len() < 4 + next_hop_len {
+        return Err("NHC next hop overruns attribute");
+    }
+    let mut characteristics = &value[4 + next_hop_len..];
+    if characteristics.is_empty() {
+        return Err("NHC has no characteristics");
+    }
+    while !characteristics.is_empty() {
+        if characteristics.len() < 4 {
+            return Err("NHC characteristic header is truncated");
+        }
+        let length = usize::from(u16::from_be_bytes([characteristics[2], characteristics[3]]));
+        if characteristics.len() < 4 + length {
+            return Err("NHC characteristic overruns attribute");
+        }
+        characteristics = &characteristics[4 + length..];
+    }
+    Ok(())
+}
+
+fn prefix_sid(mut value: &[u8]) -> Result<(), &'static str> {
+    if value.len() < 3 {
+        return Err("Prefix-SID attribute is shorter than one TLV header");
+    }
+    while !value.is_empty() {
+        let (kind, body, rest) = tlv_u8_u16(value)?;
+        match kind {
+            1 if body.len() != 7 => return Err("Prefix-SID Label-Index TLV length is not 7"),
+            3 if body.len() < 8 || (body.len() - 2) % 6 != 0 => {
+                return Err("Prefix-SID Originator SRGB TLV length is invalid");
+            }
+            _ => {}
+        }
+        value = rest;
+    }
+    Ok(())
+}
+
+fn bier(mut value: &[u8]) -> Result<(), &'static str> {
+    while !value.is_empty() {
+        let (kind, body, rest) = tlv_u16_u16(value)?;
+        if kind == 1 && body.len() >= 4 {
+            validate_bier_subtlvs(&body[4..])?;
+        }
+        value = rest;
+    }
+    Ok(())
+}
+
+fn validate_bier_subtlvs(mut value: &[u8]) -> Result<(), &'static str> {
+    let mut pending = Vec::new();
+    loop {
+        while !value.is_empty() {
+            let (kind, body, rest) = tlv_u16_u16(value)?;
+            match kind {
+                2 | 3 if body.len() >= 4 && !body[4..].is_empty() => {
+                    pending.push(&body[4..]);
+                }
+                _ => {}
+            }
+            value = rest;
+        }
+        let Some(next) = pending.pop() else { break };
+        value = next;
+    }
+    Ok(())
+}
+
+fn tlv_u8_u16(value: &[u8]) -> Result<(u8, &[u8], &[u8]), &'static str> {
+    if value.len() < 3 {
+        return Err("TLV header is truncated");
+    }
+    let length = usize::from(u16::from_be_bytes([value[1], value[2]]));
+    if value.len() < 3 + length {
+        return Err("TLV overruns attribute");
+    }
+    Ok((value[0], &value[3..3 + length], &value[3 + length..]))
+}
+
+fn tlv_u16_u16(value: &[u8]) -> Result<(u16, &[u8], &[u8]), &'static str> {
+    if value.len() < 4 {
+        return Err("TLV header is truncated");
+    }
+    let kind = u16::from_be_bytes([value[0], value[1]]);
+    let length = usize::from(u16::from_be_bytes([value[2], value[3]]));
+    if value.len() < 4 + length {
+        return Err("TLV overruns attribute");
+    }
+    Ok((kind, &value[4..4 + length], &value[4 + length..]))
+}

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1180,8 +1180,8 @@ pub fn decode_path_attributes_revised(
         // must fall through to decode_attribute_value, whose flags error is
         // classified treat-as-withdraw below (§3 (c) — the stronger action
         // wins per §3 (h)).
-        let flags_ok = expected_flags(type_code).is_none_or(|expected| {
-            (flags & (attr_flags::OPTIONAL | attr_flags::TRANSITIVE)) == expected
+        let flags_ok = registered_flags(type_code).is_none_or(|registered| {
+            (flags & (attr_flags::OPTIONAL | attr_flags::TRANSITIVE)) == registered.flags
         });
         let expected_aggregator_len = if four_octet_as { 8 } else { 6 };
         let bad_aggregate_len = flags_ok
@@ -1252,11 +1252,25 @@ pub fn decode_path_attributes_revised(
 /// RFC 4271 section 5 requires unrecognized optional non-transitive
 /// attributes to be quietly ignored rather than stored or propagated.
 fn is_unknown_optional_non_transitive(flags: u8, type_code: u8) -> bool {
-    expected_flags(type_code).is_none()
-        && assigned_unsupported_flags(type_code)
-            .is_none_or(|expected| expected == attr_flags::OPTIONAL)
-        && (flags & attr_flags::OPTIONAL) != 0
-        && (flags & attr_flags::TRANSITIVE) == 0
+    let class = flags & (attr_flags::OPTIONAL | attr_flags::TRANSITIVE | attr_flags::PARTIAL);
+    if is_assigned_unsupported_optional_non_transitive(type_code) {
+        return class == attr_flags::OPTIONAL;
+    }
+    match registered_flags(type_code) {
+        Some(_) => false,
+        None => (flags & attr_flags::OPTIONAL) != 0 && (flags & attr_flags::TRANSITIVE) == 0,
+    }
+}
+
+fn is_assigned_unsupported_optional_non_transitive(type_code: u8) -> bool {
+    matches!(
+        registered_flags(type_code),
+        Some(RegisteredFlags {
+            flags: attr_flags::OPTIONAL,
+            payload_unsupported: true,
+            ..
+        })
+    )
 }
 
 /// Registry-known class for assigned attributes whose payload semantics are
@@ -1264,13 +1278,43 @@ fn is_unknown_optional_non_transitive(flags: u8, type_code: u8) -> bool {
 /// prevents registry recognition from becoming a typed-codec support claim.
 fn assigned_unsupported_flags(type_code: u8) -> Option<u8> {
     match type_code {
-        attr_type::AIGP | attr_type::BGPSEC_PATH => Some(attr_flags::OPTIONAL),
+        attr_type::AIGP | attr_type::BGPSEC_PATH | attr_type::EDGE_METADATA => {
+            Some(attr_flags::OPTIONAL)
+        }
         attr_type::TUNNEL_ENCAPSULATION
         | attr_type::PE_DISTINGUISHER_LABELS
+        | attr_type::DOMAIN_PATH
+        | attr_type::SFP
+        | attr_type::BFD_DISCRIMINATOR
+        | attr_type::NHC
         | attr_type::PREFIX_SID
+        | attr_type::BIER
         | attr_type::ATTR_SET => Some(attr_flags::OPTIONAL | attr_flags::TRANSITIVE),
         _ => None,
     }
+}
+
+#[derive(Clone, Copy)]
+struct RegisteredFlags {
+    flags: u8,
+    payload_unsupported: bool,
+    partial_must_clear: bool,
+}
+
+fn registered_flags(type_code: u8) -> Option<RegisteredFlags> {
+    expected_flags(type_code)
+        .map(|flags| RegisteredFlags {
+            flags,
+            payload_unsupported: false,
+            partial_must_clear: false,
+        })
+        .or_else(|| {
+            assigned_unsupported_flags(type_code).map(|flags| RegisteredFlags {
+                flags,
+                payload_unsupported: true,
+                partial_must_clear: flags == attr_flags::OPTIONAL,
+            })
+        })
 }
 
 /// Consume RFC 6793 compatibility attributes and leave one canonical path and
@@ -1579,14 +1623,15 @@ fn decode_attribute_value(
         | if matches!(
             type_code,
             attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI | attr_type::BGP_LS
-        ) {
+        ) || registered_flags(type_code)
+            .is_some_and(|registered| registered.partial_must_clear)
+        {
             attr_flags::PARTIAL
         } else {
             0
         };
-    if let Some(expected) =
-        expected_flags(type_code).or_else(|| assigned_unsupported_flags(type_code))
-        && (flags & flags_mask) != expected
+    if let Some(registered) = registered_flags(type_code)
+        && (flags & flags_mask) != registered.flags
     {
         return Err(DecodeError::UpdateAttributeError {
             subcode: update_subcode::ATTRIBUTE_FLAGS_ERROR,
@@ -1595,9 +1640,26 @@ fn decode_attribute_value(
                 "type {} flags {:#04x} (expected {:#04x})",
                 type_code,
                 flags & flags_mask,
-                expected
+                registered.flags
             ),
         });
+    }
+    if matches!(
+        type_code,
+        attr_type::DOMAIN_PATH
+            | attr_type::SFP
+            | attr_type::BFD_DISCRIMINATOR
+            | attr_type::NHC
+            | attr_type::PREFIX_SID
+            | attr_type::BIER
+    ) {
+        crate::assigned_attributes::validate(type_code, value).map_err(|detail| {
+            DecodeError::UpdateAttributeError {
+                subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+                data: attr_error_data(flags, type_code, value),
+                detail: format!("attribute type {type_code}: {detail}"),
+            }
+        })?;
     }
     match type_code {
         attr_type::ORIGIN => {
@@ -1892,9 +1954,15 @@ fn decode_attribute_value(
         }
         // Correctly-classed assigned optional non-transitive attributes whose
         // payload semantics are unsupported are ignored, never retained.
-        attr_type::AIGP | attr_type::BGPSEC_PATH => unreachable!(
-            "assigned unsupported optional non-transitive attributes are filtered before decode"
-        ),
+        attr_type::AIGP | attr_type::BGPSEC_PATH | attr_type::EDGE_METADATA => {
+            Err(DecodeError::UpdateAttributeError {
+                subcode: update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+                data: attr_error_data(flags, type_code, value),
+                detail: format!(
+                    "assigned optional non-transitive attribute type {type_code} reached value decoding"
+                ),
+            })
+        }
         // Any unknown type -> RawAttribute. AS4_PATH and AS4_AGGREGATOR are
         // kept raw only until the shared post-decode RFC 6793 normalizer
         // consumes them.
@@ -2796,6 +2864,7 @@ fn encode_path_attributes_with_scratch(
             attr,
             PathAttribute::Unknown(raw)
                 if matches!(raw.type_code, attr_type::AS4_PATH | attr_type::AS4_AGGREGATOR)
+                    || is_assigned_unsupported_optional_non_transitive(raw.type_code)
                     || is_unknown_optional_non_transitive(raw.flags, raw.type_code)
         ) {
             // Compatibility sidecars are derived from canonical attributes,
@@ -6371,7 +6440,7 @@ mod tests {
     #[test]
     fn only_to_customer_bad_flags_returns_attribute_flags_error() {
         // Correct length (4), wrong flags — must be subcode 4
-        // ATTRIBUTE_FLAGS_ERROR (handled by the shared expected_flags()
+        // ATTRIBUTE_FLAGS_ERROR (handled by the shared registered_flags()
         // check before type dispatch).
         for bad_flags in [
             0x00u8,                 // no flags

--- a/crates/wire/src/constants.rs
+++ b/crates/wire/src/constants.rs
@@ -171,8 +171,20 @@ pub mod attr_type {
     pub const BGPSEC_PATH: u8 = 33;
     /// RFC 9234 §5: Only-to-Customer (OTC).
     pub const ONLY_TO_CUSTOMER: u8 = 35;
+    /// D-PATH (draft-ietf-bess-evpn-ipvpn-interworking).
+    pub const DOMAIN_PATH: u8 = 36;
+    /// RFC 9015: Service Function Path attribute.
+    pub const SFP: u8 = 37;
+    /// RFC 9026: BFD Discriminator attribute.
+    pub const BFD_DISCRIMINATOR: u8 = 38;
+    /// Next Hop Dependent Characteristics attribute.
+    pub const NHC: u8 = 39;
     /// RFC 8669: BGP Prefix-SID attribute.
     pub const PREFIX_SID: u8 = 40;
+    /// RFC 9793: BIER attribute.
+    pub const BIER: u8 = 41;
+    /// Edge Metadata Path Attribute.
+    pub const EDGE_METADATA: u8 = 42;
     /// RFC 6368: `ATTR_SET` attribute.
     pub const ATTR_SET: u8 = 128;
 }

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -56,6 +56,7 @@
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 
+mod assigned_attributes;
 /// Path attribute types and codec (`ORIGIN`, `AS_PATH`, `NEXT_HOP`, etc.).
 pub mod attribute;
 /// BGP-LS NLRI codec substrate (RFC 9552).

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -52,7 +52,11 @@ pub fn malformed_attr_disposition(type_code: u8, is_ibgp: bool) -> ErrorDisposit
         | attr_type::AGGREGATOR
         | attr_type::AS4_PATH
         | attr_type::AS4_AGGREGATOR
-        | attr_type::BGP_LS => ErrorDisposition::AttributeDiscard,
+        | attr_type::BGP_LS
+        | attr_type::BFD_DISCRIMINATOR
+        | attr_type::NHC
+        | attr_type::PREFIX_SID
+        | attr_type::BIER => ErrorDisposition::AttributeDiscard,
         attr_type::LOCAL_PREF | attr_type::ORIGINATOR_ID | attr_type::CLUSTER_LIST if !is_ibgp => {
             ErrorDisposition::AttributeDiscard
         }

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -61,6 +61,60 @@ fn extended_attribute(flags: u8, code: u8, value: &[u8]) -> Vec<u8> {
     bytes
 }
 
+fn assigned_value(code: u8) -> Vec<u8> {
+    match code {
+        36 => vec![1, 0, 0, 0, 0, 0, 0, 0],
+        37 => vec![2, 0, 4, 1, 99, 0, 0],
+        38 => vec![1, 0, 0, 0, 1, 1, 4, 192, 0, 2, 1],
+        39 => vec![0, 1, 1, 4, 192, 0, 2, 1, 0, 1, 0, 0],
+        40 => vec![99, 0, 0],
+        41 => vec![0, 1, 0, 12, 0, 0, 0, 0, 0, 4, 0, 4, 192, 0, 2, 1],
+        42 => vec![0xaa],
+        _ => vec![0xde, 0xad, 0xbe, 0xef],
+    }
+}
+
+fn assigned_malformed(code: u8) -> Option<(Vec<u8>, ErrorDisposition)> {
+    match code {
+        36 => Some((vec![0; 8], ErrorDisposition::TreatAsWithdraw)),
+        37 => Some((vec![2, 0, 1, 1], ErrorDisposition::TreatAsWithdraw)),
+        38 => Some((vec![1, 0, 0, 0, 1], ErrorDisposition::AttributeDiscard)),
+        39 => Some((
+            vec![0, 1, 1, 4, 192, 0, 2, 1],
+            ErrorDisposition::AttributeDiscard,
+        )),
+        40 => Some((vec![1, 0, 6, 0], ErrorDisposition::AttributeDiscard)),
+        41 => Some((
+            vec![0, 1, 0, 8, 0, 0, 0, 0, 0, 2, 0, 1],
+            ErrorDisposition::AttributeDiscard,
+        )),
+        _ => None,
+    }
+}
+
+fn assigned_payload_contract(code: u8) -> &'static str {
+    match code {
+        36 => "non-empty sequence of nonzero-count domain segments, each exactly `1 + 7*n` octets",
+        37 => {
+            "exact one-octet-type/two-octet-length TLVs, at least one Hop TLV, and at least one exactly framed sub-TLV after every Hop service index"
+        }
+        38 => {
+            "five-octet base, exact one-octet-type/length optional TLVs, and a Source IP TLV of length 4 or 16"
+        }
+        39 => {
+            "AFI/SAFI/next-hop-length boundary followed by one or more exact two-octet-type/two-octet-length characteristic TLVs"
+        }
+        40 => {
+            "exact one-octet-type/two-octet-length TLVs; Label-Index length 7; Originator SRGB length `2 + nonzero*6`"
+        }
+        41 => {
+            "zero or more exact two-octet-type/length TLVs; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque"
+        }
+        42 => "no payload validation; exact registered class is dropped before value decoding",
+        _ => panic!("no assigned framing contract for code {code}"),
+    }
+}
+
 fn disposition(value: &str) -> ErrorDisposition {
     match value {
         "attribute-discard" => ErrorDisposition::AttributeDiscard,
@@ -312,14 +366,15 @@ fn assigned_and_unknown_behavior_fences_are_explicit() {
         .unwrap();
     assert!(aigp.attributes.is_empty() && aigp.malformed.is_empty());
 
-    let prefix_sid = attribute(0xc0, 40, &[1, 0, 0]);
+    let prefix_sid_value = assigned_value(40);
+    let prefix_sid = attribute(0xc0, 40, &prefix_sid_value);
     let decoded = decode_path_attributes_revised(&prefix_sid, true, false, &[]).unwrap();
     assert!(
         matches!(&decoded.attributes[..], [PathAttribute::Unknown(raw)] if raw.type_code == 40)
     );
     let mut emitted = Vec::new();
     encode_path_attributes(&decoded.attributes, &mut emitted, true, false).unwrap();
-    assert_eq!(emitted, attribute(0xe0, 40, &[1, 0, 0]));
+    assert_eq!(emitted, attribute(0xe0, 40, &prefix_sid_value));
 
     let unknown =
         decode_path_attributes_revised(&attribute(0x40, 200, &[0xaa]), true, false, &[]).unwrap();
@@ -368,9 +423,8 @@ fn assigned_unsupported_class_matrix_is_fail_closed_without_semantic_support() {
             transitive_conflict: ErrorDisposition::TreatAsWithdraw,
         },
     ];
-    let value = [0xde, 0xad, 0xbe, 0xef];
-
     for case in cases {
+        let value = assigned_value(case.code);
         let canonical = attribute(case.canonical, case.code, &value);
         let decoded = decode_path_attributes_revised(&canonical, true, false, &[]).unwrap();
         assert!(decoded.malformed.is_empty(), "canonical type {}", case.code);
@@ -438,8 +492,8 @@ fn assigned_unsupported_class_matrix_is_fail_closed_without_semantic_support() {
 
 #[test]
 fn assigned_unsupported_opaque_flags_and_neighboring_fences_stay_orthogonal() {
-    let value = [0xaa, 0xbb, 0xcc];
     for code in [23, 27, 40, 128] {
+        let value = assigned_value(code);
         for flags in [0xe0, 0xf0] {
             let input = if flags == 0xf0 {
                 extended_attribute(flags, code, &value)
@@ -475,5 +529,264 @@ fn assigned_unsupported_opaque_flags_and_neighboring_fences_stay_orthogonal() {
     assert_eq!(
         wrong_pmsi.malformed[0].disposition,
         ErrorDisposition::TreatAsWithdraw
+    );
+}
+
+#[test]
+fn assigned_rows_36_through_42_enforce_class_framing_and_disposition() {
+    for code in 36_u8..=42 {
+        let canonical = if code == 42 { 0x80 } else { 0xc0 };
+        let value = assigned_value(code);
+        let flag_inputs: &[u8] = if code == 42 { &[0x80] } else { &[0xc0, 0xe0] };
+        for (&input_flags, extended) in flag_inputs
+            .iter()
+            .flat_map(|flags| [(flags, false), (flags, true)])
+        {
+            let input = if extended {
+                extended_attribute(input_flags, code, &value)
+            } else {
+                attribute(input_flags, code, &value)
+            };
+            let strict = decode_path_attributes(&input, true, &[]).unwrap();
+            let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+            assert!(revised.malformed.is_empty(), "canonical type {code}");
+            if code == 42 {
+                assert!(strict.is_empty() && revised.attributes.is_empty());
+            } else {
+                let [PathAttribute::Unknown(raw)] = strict.as_slice() else {
+                    panic!("type {code} must remain opaque");
+                };
+                assert_eq!(raw.data.as_ref(), value);
+                assert_eq!(raw.flags, input[0]);
+                let mut emitted = Vec::new();
+                encode_path_attributes(&revised.attributes, &mut emitted, true, false).unwrap();
+                let mut expected = input.clone();
+                expected[0] |= 0x20;
+                assert_eq!(emitted, expected, "type {code} exact opaque egress");
+            }
+        }
+
+        for flags in [canonical ^ 0x80, canonical ^ 0x40, canonical ^ 0xc0] {
+            let input = attribute(flags, code, &value);
+            let error = decode_path_attributes(&input, true, &[]).unwrap_err();
+            assert!(
+                matches!(error, DecodeError::UpdateAttributeError { subcode, .. }
+                if subcode == update_subcode::ATTRIBUTE_FLAGS_ERROR)
+            );
+            let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+            assert!(revised.attributes.is_empty());
+            assert_eq!(revised.malformed.len(), 1);
+            assert_eq!(
+                revised.malformed[0].disposition,
+                ErrorDisposition::TreatAsWithdraw,
+                "wrong class type {code} flags {flags:#x}"
+            );
+        }
+    }
+
+    for code in [26_u8, 33, 42] {
+        let partial = attribute(0xa0, code, &assigned_value(code));
+        assert!(matches!(
+            decode_path_attributes(&partial, true, &[]),
+            Err(DecodeError::UpdateAttributeError { subcode, .. })
+                if subcode == update_subcode::ATTRIBUTE_FLAGS_ERROR
+        ));
+        let revised = decode_path_attributes_revised(&partial, true, false, &[]).unwrap();
+        assert_eq!(revised.malformed.len(), 1, "type {code}");
+        assert_eq!(
+            revised.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw,
+            "type {code}"
+        );
+    }
+    let mut defensive = Vec::new();
+    encode_path_attributes(
+        &[PathAttribute::Unknown(rustbgpd_wire::RawAttribute {
+            flags: 0xe0,
+            type_code: 42,
+            data: bytes::Bytes::from_static(&[0xaa]),
+        })],
+        &mut defensive,
+        true,
+        false,
+    )
+    .unwrap();
+    assert!(defensive.is_empty(), "type 42 must never egress");
+
+    let wrong_class_and_payload = attribute(0x80, 38, &[1]);
+    assert!(matches!(
+        decode_path_attributes(&wrong_class_and_payload, true, &[]),
+        Err(DecodeError::UpdateAttributeError { subcode, .. })
+            if subcode == update_subcode::ATTRIBUTE_FLAGS_ERROR
+    ));
+    let revised =
+        decode_path_attributes_revised(&wrong_class_and_payload, true, false, &[]).unwrap();
+    assert_eq!(revised.malformed.len(), 1);
+    assert_eq!(
+        revised.malformed[0].disposition,
+        ErrorDisposition::TreatAsWithdraw
+    );
+
+    for code in 36_u8..=41 {
+        let (value, expected) = assigned_malformed(code).unwrap();
+        let input = attribute(0xc0, code, &value);
+        assert!(matches!(
+            decode_path_attributes(&input, true, &[]),
+            Err(DecodeError::UpdateAttributeError { subcode, .. })
+                if subcode == update_subcode::ATTRIBUTE_LENGTH_ERROR
+        ));
+        let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+        assert!(revised.attributes.is_empty());
+        assert_eq!(revised.malformed.len(), 1);
+        assert_eq!(revised.malformed[0].disposition, expected, "type {code}");
+    }
+
+    for (code, value) in [
+        (38_u8, vec![1, 0, 0, 0, 1, 2, 4, 192, 0, 2, 1]),
+        (38, vec![1, 0, 0, 0, 1, 1, 3, 192, 0, 2]),
+        (40, vec![1, 0, 6, 0, 0, 0, 0, 0, 0]),
+        (40, vec![3, 0, 7, 0, 0, 0, 0, 0, 0, 0]),
+    ] {
+        let revised =
+            decode_path_attributes_revised(&attribute(0xc0, code, &value), true, false, &[])
+                .unwrap();
+        assert!(revised.attributes.is_empty());
+        assert_eq!(revised.malformed.len(), 1);
+        assert_eq!(
+            revised.malformed[0].disposition,
+            ErrorDisposition::AttributeDiscard
+        );
+    }
+
+    let unknown_mode_without_source = [99, 0, 0, 0, 1, 2, 4, 0, 0, 0, 0];
+    let revised = decode_path_attributes_revised(
+        &attribute(0xc0, 38, &unknown_mode_without_source),
+        true,
+        false,
+        &[],
+    )
+    .unwrap();
+    assert!(revised.attributes.is_empty());
+    assert_eq!(revised.malformed.len(), 1);
+    assert_eq!(
+        revised.malformed[0].disposition,
+        ErrorDisposition::AttributeDiscard
+    );
+    let unknown_mode_with_source = [99, 0, 0, 0, 1, 1, 4, 192, 0, 2, 1];
+    let decoded = decode_path_attributes_revised(
+        &attribute(0xc0, 38, &unknown_mode_with_source),
+        true,
+        false,
+        &[],
+    )
+    .unwrap();
+    assert!(decoded.malformed.is_empty());
+    assert!(
+        matches!(decoded.attributes.as_slice(), [PathAttribute::Unknown(raw)] if raw.type_code == 38)
+    );
+
+    let semantically_invalid_bier = vec![
+        0, 1, 0, 1, 0xaa, // known BIER TLV without its fixed prefix
+        0, 4, 0, 1, 0xbb, // known nexthop with a semantic-invalid length
+        0, 99, 0, 1, 0xcc, // unknown TLV preserved
+    ];
+    let input = attribute(0xc0, 41, &semantically_invalid_bier);
+    let decoded = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+    assert!(decoded.malformed.is_empty());
+    let mut emitted = Vec::new();
+    encode_path_attributes(&decoded.attributes, &mut emitted, true, false).unwrap();
+    let mut expected = input;
+    expected[0] |= 0x20;
+    assert_eq!(emitted, expected);
+    let empty =
+        decode_path_attributes_revised(&attribute(0xc0, 41, &[]), true, false, &[]).unwrap();
+    assert!(empty.malformed.is_empty());
+    assert!(
+        matches!(empty.attributes.as_slice(), [PathAttribute::Unknown(raw)] if raw.data.is_empty())
+    );
+}
+
+#[test]
+fn assigned_framing_documentation_matches_executable_cases() {
+    let framing = rows(
+        section(
+            "<!-- assigned-framing:start -->",
+            "<!-- assigned-framing:end -->",
+        ),
+        4,
+    );
+    assert_eq!(framing.len(), 7);
+    for (index, row) in framing.iter().enumerate() {
+        let code = u8::try_from(index + 36).unwrap();
+        assert_eq!(row[0], code.to_string());
+        let canonical = if code == 42 { 0x80 } else { 0xc0 };
+        assert!(row[1].contains(&format!("flags `{canonical:#04x}`")));
+        assert_eq!(
+            row[2],
+            assigned_payload_contract(code),
+            "payload contract drift for row {code}"
+        );
+        let expected = if matches!(code, 38..=41) {
+            "attribute-discard"
+        } else {
+            "treat-as-withdraw"
+        };
+        assert!(row[3].contains(expected), "row {code}");
+
+        let decoded = decode_path_attributes_revised(
+            &attribute(canonical, code, &assigned_value(code)),
+            true,
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(decoded.malformed.is_empty(), "documented valid row {code}");
+
+        if let Some((malformed, expected_disposition)) = assigned_malformed(code) {
+            let decoded = decode_path_attributes_revised(
+                &attribute(canonical, code, &malformed),
+                true,
+                false,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(decoded.malformed.len(), 1);
+            assert_eq!(decoded.malformed[0].disposition, expected_disposition);
+        } else {
+            let decoded = decode_path_attributes_revised(
+                &attribute(0xc0, code, &assigned_value(code)),
+                true,
+                false,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(decoded.malformed.len(), 1);
+            assert_eq!(
+                decoded.malformed[0].disposition,
+                ErrorDisposition::TreatAsWithdraw
+            );
+        }
+    }
+}
+
+#[test]
+fn deeply_nested_bier_framing_is_bounded_and_non_recursive() {
+    let mut nested = vec![0, 4, 0, 4, 192, 0, 2, 1];
+    for _ in 0..2_000 {
+        let mut container = vec![0, 2];
+        container.extend_from_slice(&u16::try_from(4 + nested.len()).unwrap().to_be_bytes());
+        container.extend_from_slice(&[0; 4]);
+        container.extend_from_slice(&nested);
+        nested = container;
+    }
+    let mut value = vec![0, 1];
+    value.extend_from_slice(&u16::try_from(4 + nested.len()).unwrap().to_be_bytes());
+    value.extend_from_slice(&[0; 4]);
+    value.extend_from_slice(&nested);
+    let input = extended_attribute(0xc0, 41, &value);
+    let decoded = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+    assert!(decoded.malformed.is_empty());
+    assert!(
+        matches!(decoded.attributes.as_slice(), [PathAttribute::Unknown(raw)] if raw.type_code == 41)
     );
 }

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -64,13 +64,13 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 33 | BGPsec_Path | optional non-transitive; flags `0x80`; RFC 8205 | payload semantics unsupported; correct class ignored; wrong class is treat-as-withdraw | assigned-class matrix below |
 | 34 | BGP Community Container Attribute (TEMPORARY - registered 2017-07-28, extension registered 2024-08-22, expires 2025-07-28) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 35 | Only to Customer (OTC) | optional transitive; flags `0xc0`; exactly one four-octet ASN; RFC 9234 §5 | typed ASN + Partial round-trip; Extended Length and reserved low bits canonicalize; wrong class or length is treat-as-withdraw | OTC codec and transport matrices |
-| 36 | BGP Domain Path (D-PATH) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 37 | SFP attribute | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 38 | BFD Discriminator | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 39 | Next Hop Dependent Characteristic (NHC) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 40 | BGP Prefix-SID | optional transitive; flags `0xc0`; RFC 8669 §3 | payload semantics unsupported; correct class retained opaque and emitted with Partial; wrong class is treat-as-withdraw | assigned-class matrix below |
-| 41 | BIER | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 42 | Edge Metadata Path Attribute (TEMPORARY - registered 2025-04-23, extension registered 2026-04-03, expires 2027-04-23) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 36 | BGP Domain Path (D-PATH) | optional transitive; flags `0xc0`; draft-ietf-bess-evpn-ipvpn-interworking-18 | opaque retention with bounded domain-segment framing; malformed is treat-as-withdraw | assigned framing matrix below |
+| 37 | SFP attribute | optional transitive; flags `0xc0`; RFC 9015 §3.2.1 | opaque retention with TLV, Hop, and Hop sub-TLV framing; malformed is treat-as-withdraw | assigned framing matrix below |
+| 38 | BFD Discriminator | optional transitive; flags `0xc0`; RFC 9026 §3.1.6 | opaque retention with base and Source-IP TLV framing; malformed is attribute-discard | assigned framing matrix below |
+| 39 | Next Hop Dependent Characteristic (NHC) | optional transitive; flags `0xc0`; draft-ietf-idr-nhc-07 | opaque retention with next-hop and characteristic-TLV framing; malformed or empty characteristics is attribute-discard | assigned framing matrix below |
+| 40 | BGP Prefix-SID | optional transitive; flags `0xc0`; RFC 8669 §§3, 6 | opaque retention with complete TLV framing and known-length checks; malformed is attribute-discard | assigned framing matrix below |
+| 41 | BIER | optional transitive; flags `0xc0`; RFC 9793 §§3-4 | opaque retention with exact TLV/sub-TLV length-boundary framing; boundary failure is attribute-discard | assigned framing matrix below |
+| 42 | Edge Metadata Path Attribute (TEMPORARY - registered 2025-04-23, extension registered 2026-04-03, expires 2027-04-23) | optional non-transitive; flags `0x80`; draft-ietf-idr-5g-edge-service-metadata-27 | payload unsupported; correct class ignored and never emitted; every class or Partial conflict is treat-as-withdraw | assigned framing matrix below |
 | 43-127 | Unassigned | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 128 | ATTR_SET | optional transitive; flags `0xc0`; RFC 6368 | payload semantics unsupported; correct class retained opaque and emitted with Partial; wrong class is treat-as-withdraw | assigned-class matrix below |
 | 129 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
@@ -114,9 +114,27 @@ negotiation. "Wrong O" toggles Optional, "wrong T" toggles Transitive, and
 
 | Codes | Class | Correct-class retention and egress | Wrong O | Wrong T | Both wrong | Legacy decoder |
 |---|---|---|---|---|---|---|
-| 23, 27, 40, 128 | optional transitive (`0xc0`) | opaque retention; Partial set on egress; input Partial and Extended Length preserved | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+| 23, 27, 36-41, 128 | optional transitive (`0xc0`) | opaque retention; Partial set on egress; input Partial and Extended Length preserved | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 | 26 | optional non-transitive (`0x80`) | ignored; no retention or egress | treat-as-withdraw | attribute-discard | attribute-discard | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 | 33 | optional non-transitive (`0x80`) | ignored; no retention or egress | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+| 42 | optional non-transitive (`0x80`) | ignored; no retention or egress; Partial rejected | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+
+## Assigned framing matrix (36-42)
+
+These checks are syntax-only. They do not implement route-family applicability,
+stateful lookup, policy, or attribute semantics. Unknown TLVs remain opaque.
+
+<!-- assigned-framing:start -->
+| Code | Registered class | Bounded structural fence | Revised malformed action |
+|---|---|---|---|
+| 36 | optional transitive; flags `0xc0` | non-empty sequence of nonzero-count domain segments, each exactly `1 + 7*n` octets | treat-as-withdraw |
+| 37 | optional transitive; flags `0xc0` | exact one-octet-type/two-octet-length TLVs, at least one Hop TLV, and at least one exactly framed sub-TLV after every Hop service index | treat-as-withdraw |
+| 38 | optional transitive; flags `0xc0` | five-octet base, exact one-octet-type/length optional TLVs, and a Source IP TLV of length 4 or 16 | attribute-discard |
+| 39 | optional transitive; flags `0xc0` | AFI/SAFI/next-hop-length boundary followed by one or more exact two-octet-type/two-octet-length characteristic TLVs | attribute-discard |
+| 40 | optional transitive; flags `0xc0` | exact one-octet-type/two-octet-length TLVs; Label-Index length 7; Originator SRGB length `2 + nonzero*6` | attribute-discard |
+| 41 | optional transitive; flags `0xc0` | zero or more exact two-octet-type/length TLVs; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque | attribute-discard |
+| 42 | optional non-transitive; flags `0x80` | no payload validation; exact registered class is dropped before value decoding | class conflict is treat-as-withdraw |
+<!-- assigned-framing:end -->
 
 ## PMSI tunnel-type matrix
 


### PR DESCRIPTION
## Summary

- enforce registered propagation classes for assigned BGP path attributes 36 through 42
- retain D-PATH, SFP, BFD Discriminator, NHC, Prefix-SID, and BIER opaquely only after bounded structural framing checks
- discard Edge Metadata before value decoding and defensive egress, and centralize assigned optional-non-transitive Partial handling
- carry the corrected opaque attributes through the real RIB/session export path while applying their RFC 7606 recovery actions
- bind the documented registry matrix to executable class, framing, and disposition fixtures

## Validation

- cargo test -p rustbgpd-wire
- cargo test -p rustbgpd-transport session::tests::rfc7606
- cargo test --workspace --lib --tests --examples --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- pinned decode_update fuzz campaign: 2,722,245 executions in 61 seconds with no findings
- repository commit and pre-push hooks

## Linear

- LAN-1236
- LAN-1286

No version bump; both changelog layers describe the unreleased behavior.