### PR TITLE
fix: bound serialized configuration control lanes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,7 +142,7 @@ These are not negotiable. Every contributor and every PR is measured against the
 
 2. **The wire crate is independently usable.** Zero internal dependencies. `cargo add rustbgpd-wire` works without the daemon.
 
-3. **No accidental unbounded channels.** Channels are bounded by default. A small, documented set of intentional unbounded channels exists where a bounded `send().await` would deadlock the owning session/state task — collision-resolution notifications (`peer_manager`, `transport`), peer-manager internal commands, the config/reload coordinator (`reload.rs`), the transport writer's priority channel, and BFD state-change fan-out. Each is justified in an inline comment at its construction.
+3. **No accidental unbounded channels.** Channels are bounded by default. The peer-manager private command lane and config-bridge replacement lane are lossless capacity-one channels. A small, documented set of intentional unbounded channels remains where a bounded `send().await` would deadlock the owning session/state task — collision-resolution notifications (`peer_manager`, `transport`), the transport writer's priority channel, and BFD state-change fan-out. Each is justified in an inline comment at its construction.
 
 4. **No silent attribute drops.** Every ignored, filtered, or rejected attribute emits a structured event. Operators can explain every routing decision from logs alone.
 
@@ -396,7 +396,7 @@ All inter-task communication uses bounded `tokio::mpsc` channels (capacity 4096 
 | PeerManager commands | API | PeerManager | `send().await` blocks. gRPC call waits. |
 | BMP events | Transport | BmpManager | `try_send()` — event dropped, warning logged. |
 
-The small set of intentional unbounded channels is enumerated in Design Invariant #3 above; the session-notification channel used for TCP collision detection exists because a bounded send would deadlock with synchronous peer-state queries during collision resolution.
+The small set of intentional unbounded channels is enumerated in Design Invariant #3 above; the `session_notify` channel used for TCP collision detection remains intentionally unbounded because a bounded send would deadlock with synchronous `QueryState` peer-state queries during collision resolution.
 
 ### Dirty-peer resync
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2210,8 +2210,7 @@ branch is between features.
   documentation/policy drift, all low-risk. The documentation and lint-policy
   sub-items are closed:
   - ARCHITECTURE.md design-invariant #3 re-enumerates the intentional
-    unbounded-channel set (collision notifications, `peer_manager` internals,
-    the `reload.rs` coordinator, the transport writer's priority channel, BFD
+    unbounded-channel set (collision notifications, the transport writer's priority channel, BFD
     state-change fan-out), so the invariant reads as a usable review gate.
   - The ARCHITECTURE.md ownership table is trued up against the actors at HEAD:
     the BLACKHOLE reconciler, EVPN runtime converger, EVPN dataplane supervisor,
@@ -2227,6 +2226,11 @@ branch is between features.
     FFI allow, the daemon binary's `cfg_attr` gate under the `jemalloc` /
     `dhat-heap` allocator features, and the test/bench targets that carry
     justified `unsafe` outside any shipped path.
+  - LAN-1162 tranche A bounds the peer-manager private command lane and the
+    config-bridge replacement lane at capacity one with lossless FIFO sends.
+    LAN-1162 remains open for tranche B observability and sustained-flap proof;
+    `session_notify` remains intentionally unbounded for the `QueryState`
+    collision-resolution deadlock constraint.
 
   Dependency-hygiene note, not a work item: the lockfile resolves both
   `thiserror` 1.x and 2.x. Every first-party crate that derives with it

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -71,7 +71,7 @@ pub struct ConfigTransactionController {
     metrics: BgpMetrics,
     state: Arc<Mutex<ConfirmedState>>,
     accepted_rx: Option<watch::Receiver<Arc<AcceptedConfigSnapshot>>>,
-    peer_mgr_internal_tx: Option<mpsc::UnboundedSender<InternalCommand>>,
+    peer_mgr_internal_tx: Option<mpsc::Sender<InternalCommand>>,
     confirm_v3_launch: Option<crate::confirm_journal::v3::LaunchIdentity>,
     v3_residue_cleanup_active: Arc<AtomicBool>,
     settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
@@ -325,10 +325,7 @@ impl ConfigTransactionController {
     }
 
     #[must_use]
-    pub(crate) fn with_preloaded_planner(
-        mut self,
-        tx: mpsc::UnboundedSender<InternalCommand>,
-    ) -> Self {
+    pub(crate) fn with_preloaded_planner(mut self, tx: mpsc::Sender<InternalCommand>) -> Self {
         self.peer_mgr_internal_tx = Some(tx);
         self
     }
@@ -374,6 +371,7 @@ impl ConfigTransactionController {
             expected_runtime_snapshot_token: Some(expected_runtime_snapshot_token),
             reply: reply_tx,
         })
+        .await
         .map_err(|_| {
             ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
         })?;
@@ -2195,7 +2193,7 @@ async fn apply_config_transaction(
 async fn apply_config_transaction_with_internal(
     deps: Arc<FibTableControlDeps>,
     request: proto::ApplyConfigTransactionRequest,
-    peer_mgr_internal_tx: mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: mpsc::Sender<InternalCommand>,
 ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
     validate_apply_request(&request)?;
     let join = tokio::spawn(async move {
@@ -2219,7 +2217,7 @@ async fn apply_config_transaction_with_internal(
 async fn apply_config_transaction_locked(
     deps: &FibTableControlDeps,
     request: proto::ApplyConfigTransactionRequest,
-    peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
+    peer_mgr_internal_tx: Option<&mpsc::Sender<InternalCommand>>,
     progress: &RuntimeConfigMutationProgress,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     apply_config_transaction_locked_with_preloaded(
@@ -2240,7 +2238,7 @@ async fn apply_config_transaction_locked_with_preloaded(
     deps: &FibTableControlDeps,
     request: proto::ApplyConfigTransactionRequest,
     preloaded: Option<PlannedTransactionConfig>,
-    peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
+    peer_mgr_internal_tx: Option<&mpsc::Sender<InternalCommand>>,
     progress: &RuntimeConfigMutationProgress,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     let (plan, candidate, typed_plan) = if let Some(planned) = preloaded {
@@ -2365,7 +2363,7 @@ async fn apply_config_transaction_locked_with_preloaded(
 )]
 async fn commit_apply_family(
     deps: &FibTableControlDeps,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     family: ApplyFamily,
     candidate_toml: String,
@@ -2471,7 +2469,7 @@ async fn finish_outbound_prefix_limit_transaction(
 )]
 async fn commit_apply_family_inner(
     deps: &FibTableControlDeps,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     family: ApplyFamily,
     candidate_toml: String,
@@ -2600,7 +2598,7 @@ async fn commit_apply_family_inner(
 )]
 async fn commit_fib_transaction(
     deps: &FibTableControlDeps,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: Config,
@@ -2679,7 +2677,7 @@ async fn commit_fib_transaction(
 }
 
 async fn stage_preloaded_config_snapshot(
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     candidate: Box<Config>,
     scope: TransactionConfigScope,
 ) -> Result<TransactionConfigRollbackToken, ApplyFailure> {
@@ -2690,6 +2688,7 @@ async fn stage_preloaded_config_snapshot(
             scope,
             reply: reply_tx,
         })
+        .await
         .map_err(|_| {
             ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
         })?;
@@ -2708,7 +2707,7 @@ async fn stage_preloaded_config_snapshot(
 }
 
 async fn restore_preloaded_config_snapshot(
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     rollback: TransactionConfigRollbackToken,
 ) -> Result<(), ConfigTransactionApplyError> {
     let (reply_tx, reply_rx) = oneshot::channel();
@@ -2717,6 +2716,7 @@ async fn restore_preloaded_config_snapshot(
             rollback,
             reply: reply_tx,
         })
+        .await
         .map_err(|_| {
             ConfigTransactionApplyError::Unavailable(
                 "peer manager is unavailable during config transaction rollback".to_string(),
@@ -2732,7 +2732,7 @@ async fn restore_preloaded_config_snapshot(
 }
 
 async fn restore_preloaded_snapshot_after_error(
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     rollback: TransactionConfigRollbackToken,
     original: ApplyFailure,
 ) -> ApplyFailure {
@@ -2753,7 +2753,7 @@ async fn restore_preloaded_snapshot_after_error(
 
 async fn rollback_fib_transaction_after_error(
     fib_cmd_tx: &mpsc::Sender<crate::fib_runtime::FibRuntimeCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     previous_tables: Vec<crate::config::FibTableConfig>,
     rollback: TransactionConfigRollbackToken,
     original: ApplyFailure,
@@ -2856,7 +2856,7 @@ fn apply_family(sections: &[String]) -> Option<ApplyFamily> {
 }
 
 async fn plan_loaded_candidate(
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     candidate: Box<Config>,
     expected_runtime_snapshot_token: String,
 ) -> Result<PlannedTransactionConfig, ConfigTransactionApplyError> {
@@ -2867,6 +2867,7 @@ async fn plan_loaded_candidate(
             expected_runtime_snapshot_token: Some(expected_runtime_snapshot_token),
             reply: reply_tx,
         })
+        .await
         .map_err(|_| {
             ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
         })?;
@@ -2908,7 +2909,7 @@ async fn plan_candidate(
 
 async fn commit_candidate_snapshot_locked(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
@@ -2949,7 +2950,7 @@ async fn commit_candidate_snapshot_locked(
 /// a protection boundary).
 async fn commit_dynamic_neighbors_locked(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
@@ -2996,7 +2997,7 @@ async fn commit_dynamic_neighbors_locked(
 )]
 async fn commit_static_neighbors_locked(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
@@ -3137,7 +3138,7 @@ async fn commit_static_neighbors_locked(
 /// snapshot on failure. Returns the number of live sessions re-evaluated.
 async fn commit_live_policy_impact_locked(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
@@ -3246,7 +3247,7 @@ fn peer_session_reshape_commit_message(commit: &PeerSessionReshapeCommit) -> Str
 /// already-durable transaction.
 async fn commit_peer_session_reshape_locked(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
@@ -3644,7 +3645,7 @@ async fn send_apply_peer_reshape_snapshot(
 
 async fn rollback_live_policy_and_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     priors: Vec<ResolvedPeerPolicy>,
     rollback: TransactionConfigRollbackToken,
     original: ApplyFailure,
@@ -3669,7 +3670,7 @@ async fn rollback_live_policy_and_snapshot(
 
 async fn rollback_peer_reshape_and_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     priors: Vec<PeerManagerNeighborConfig>,
     rollback: TransactionConfigRollbackToken,
     original: ApplyFailure,
@@ -3820,7 +3821,7 @@ async fn commit_config_snapshot_stage(
 }
 
 async fn rollback_snapshot_after_error(
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     rollback: TransactionConfigRollbackToken,
     original: ApplyFailure,
 ) -> ApplyFailure {
@@ -4006,7 +4007,7 @@ async fn rollback_static_ops(
 
 async fn rollback_static_and_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
     applied: Vec<AppliedStaticOp>,
     rollback: TransactionConfigRollbackToken,
     original: ApplyFailure,
@@ -5698,7 +5699,7 @@ peer_group = "edge"
     fn spawn_typed_transaction_manager(
         snapshot_toml: Arc<Mutex<String>>,
         response: RuntimeConfigTransactionPlan,
-    ) -> mpsc::UnboundedSender<InternalCommand> {
+    ) -> mpsc::Sender<InternalCommand> {
         spawn_typed_transaction_manager_controlled(
             snapshot_toml,
             response,
@@ -5718,7 +5719,7 @@ peer_group = "edge"
         snapshot_toml: Arc<Mutex<String>>,
         response: RuntimeConfigTransactionPlan,
         control: TypedTransactionFakeControl,
-    ) -> mpsc::UnboundedSender<InternalCommand> {
+    ) -> mpsc::Sender<InternalCommand> {
         let initial = Config::load_toml_with_diagnostics(
             snapshot_toml
                 .try_lock()
@@ -5728,7 +5729,7 @@ peer_group = "edge"
         )
         .expect("typed transaction fake initial config must load");
         let current = Arc::new(Mutex::new(initial));
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1);
         tokio::spawn(fake_typed_transaction_manager_actor(
             rx,
             current,
@@ -5742,7 +5743,7 @@ peer_group = "edge"
     fn spawn_typed_transaction_manager_with_current(
         current: Arc<Mutex<Config>>,
         response: RuntimeConfigTransactionPlan,
-    ) -> mpsc::UnboundedSender<InternalCommand> {
+    ) -> mpsc::Sender<InternalCommand> {
         let snapshot_toml = Arc::new(Mutex::new(
             crate::config::persisted_config_document(
                 &current
@@ -5751,7 +5752,7 @@ peer_group = "edge"
             )
             .expect("typed transaction fake config must serialize"),
         ));
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1);
         tokio::spawn(fake_typed_transaction_manager_actor(
             rx,
             current,
@@ -5763,7 +5764,7 @@ peer_group = "edge"
     }
 
     async fn fake_typed_transaction_manager_actor(
-        mut rx: mpsc::UnboundedReceiver<InternalCommand>,
+        mut rx: mpsc::Receiver<InternalCommand>,
         current: Arc<Mutex<Config>>,
         snapshot_toml: Arc<Mutex<String>>,
         response: RuntimeConfigTransactionPlan,
@@ -7480,7 +7481,7 @@ families = ["ipv4_unicast"]
         let seen_preloaded = Arc::new(Mutex::new(None));
         let seen = seen_preloaded.clone();
         let current = runtime_config.clone();
-        let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
+        let (internal_tx, mut internal_rx) = mpsc::channel(1);
         tokio::spawn(async move {
             while let Some(command) = internal_rx.recv().await {
                 match command {
@@ -11333,7 +11334,7 @@ families = ["ipv4_unicast"]
                 "stage rejection must precede typed FIB replacement"
             );
         });
-        let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
+        let (internal_tx, mut internal_rx) = mpsc::channel(1);
         tokio::spawn(async move {
             let Some(InternalCommand::StageTransactionConfig { reply, .. }) =
                 internal_rx.recv().await
@@ -11632,7 +11633,7 @@ peer_group = "ge"
         let rib_task = tokio::spawn(rib_manager.run());
 
         let (peer_tx, peer_rx) = mpsc::channel(64);
-        let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+        let (internal_tx, internal_rx) = mpsc::channel(1);
         let mut peer_manager = crate::peer_manager::PeerManager::new_with_config(
             peer_rx,
             internal_rx,
@@ -12003,7 +12004,7 @@ log_format = "json"
             rustbgpd_rib::RibManager::new(rib_rx, query_rx, None, None, BgpMetrics::new()).run(),
         );
         let (peer_tx, peer_rx) = mpsc::channel(64);
-        let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+        let (internal_tx, internal_rx) = mpsc::channel(1);
         let mut peer_manager = crate::peer_manager::PeerManager::new_with_config(
             peer_rx,
             internal_rx,
@@ -12220,7 +12221,7 @@ log_format = "json"
         let config = Config::load_toml_with_diagnostics(&base_toml(""), "barrier test").unwrap();
         let snapshot = AcceptedConfigSnapshot::from_config_for_test(config);
         let (peer_tx, mut peer_rx) = mpsc::channel(2);
-        let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
+        let (internal_tx, mut internal_rx) = mpsc::channel(1);
         let controller = ConfigTransactionController::new(
             deps_value(None, peer_tx, None, Vec::new()),
             BgpMetrics::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3778,7 +3778,7 @@ async fn run<T>(
     let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
     let (peer_mgr_readiness_tx, peer_mgr_readiness_rx) =
         mpsc::channel::<PeerManagerReadinessQuery>(64);
-    let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::unbounded_channel();
+    let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::channel(1);
 
     // Spawn RPKI subsystem (VRP manager + per-cache RTR clients)
     if let Some(ref rpki_config) = config.rpki
@@ -3970,7 +3970,7 @@ async fn run<T>(
     {
         let (event_tx, event_rx) = mpsc::channel::<rustbgpd_api::peer_types::ConfigEvent>(64);
         let (mutation_tx, mutation_rx) = mpsc::channel::<ConfigMutation>(64);
-        let (bridge_replace_tx, bridge_replace_rx) = mpsc::unbounded_channel();
+        let (bridge_replace_tx, bridge_replace_rx) = mpsc::channel(1);
         let (accepted_tx, accepted_rx) = watch::channel(Arc::clone(&accepted));
         let persister = ConfigPersister::new_accepted(
             mutation_rx,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -348,7 +348,7 @@ pub struct PeerManager {
     /// commands remain on `rx` and therefore stay ordered behind a policy
     /// transaction until it either commits or rolls back.
     readiness_rx: Option<mpsc::Receiver<PeerManagerReadinessQuery>>,
-    internal_rx: Option<mpsc::UnboundedReceiver<InternalCommand>>,
+    internal_rx: Option<mpsc::Receiver<InternalCommand>>,
     local_asn: u32,
     router_id: Ipv4Addr,
     /// Local cluster ID for route reflection (RFC 4456). `None` when not an RR.
@@ -465,7 +465,7 @@ impl PeerManager {
         rib_tx: mpsc::Sender<RibUpdate>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
     ) -> Self {
-        let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+        let (_internal_tx, internal_rx) = mpsc::channel(1);
         Self::new_with_config(
             rx,
             internal_rx,
@@ -654,7 +654,7 @@ impl PeerManager {
     }
 
     async fn receive_internal_command(
-        internal_rx: &mut Option<mpsc::UnboundedReceiver<InternalCommand>>,
+        internal_rx: &mut Option<mpsc::Receiver<InternalCommand>>,
     ) -> Option<InternalCommand> {
         let command = match internal_rx.as_mut() {
             Some(rx) => rx.recv().await,
@@ -673,7 +673,7 @@ impl PeerManager {
     )]
     pub fn new_with_config(
         rx: mpsc::Receiver<PeerManagerCommand>,
-        internal_rx: mpsc::UnboundedReceiver<InternalCommand>,
+        internal_rx: mpsc::Receiver<InternalCommand>,
         local_asn: u32,
         router_id: Ipv4Addr,
         cluster_id: Option<Ipv4Addr>,

--- a/src/peer_manager/tests/collision.rs
+++ b/src/peer_manager/tests/collision.rs
@@ -1341,7 +1341,7 @@ async fn peer_presence_dynamic_inbound_added_then_back_to_idle_removed_fifo() {
     let metrics_view = metrics.clone();
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -1446,7 +1446,7 @@ async fn saturated_dynamic_neighbor_accept_counts_rejection_without_consuming_ca
     config.global.dynamic_neighbor_limit = Some(1);
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,

--- a/src/peer_manager/tests/config_mutation.rs
+++ b/src/peer_manager/tests/config_mutation.rs
@@ -1317,7 +1317,7 @@ peer_group = "edge"
 "#,
     );
     let (_tx, rx) = mpsc::channel(16);
-    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (_internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let metrics = BgpMetrics::new();
     let mut mgr = PeerManager::new_with_config(

--- a/src/peer_manager/tests/config_transaction.rs
+++ b/src/peer_manager/tests/config_transaction.rs
@@ -16,7 +16,7 @@ log_format = "json"
     );
     let candidate = toml::to_string_pretty(&config).unwrap();
     let (_tx, rx) = mpsc::channel(4);
-    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (_internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
     let mut mgr = PeerManager::new_with_config(
         rx,
@@ -120,7 +120,7 @@ remote_asn = 65002
 "#,
     );
     let (_tx, rx) = mpsc::channel(4);
-    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (_internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
     let mut mgr = PeerManager::new_with_config(
         rx,
@@ -213,7 +213,7 @@ import_policy_chain = ["edge-in"]
     candidate.neighbors[0].description = Some("after".to_string());
     let candidate = toml::to_string_pretty(&candidate).unwrap();
     let (_tx, rx) = mpsc::channel(4);
-    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (_internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
     let mut mgr = PeerManager::new_with_config(
         rx,
@@ -346,7 +346,7 @@ export_policy_chain = ["dataset-export"]
     };
     let live_classification = rustbgpd_rib::classify_update_group(live_input.clone());
     let (tx, rx) = mpsc::channel(4);
-    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
     let raw_prior = current.clone();
     let mut mgr = PeerManager::new_with_config(
@@ -499,6 +499,7 @@ export_policy_chain = ["dataset-export"]
             expected_runtime_snapshot_token: None,
             reply: reply_tx,
         })
+        .await
         .unwrap();
     let preloaded = reply_rx.await.unwrap().unwrap();
     assert_eq!(
@@ -531,6 +532,7 @@ export_policy_chain = ["dataset-export"]
             scope: TransactionConfigScope::Full,
             reply: stage_tx,
         })
+        .await
         .unwrap();
     let rollback = stage_rx.await.unwrap().unwrap();
     let (snapshot_tx, snapshot_rx) = oneshot::channel();
@@ -546,6 +548,7 @@ export_policy_chain = ["dataset-export"]
             rollback,
             reply: restore_tx,
         })
+        .await
         .unwrap();
     restore_rx.await.unwrap();
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
@@ -556,7 +559,7 @@ export_policy_chain = ["dataset-export"]
 #[tokio::test]
 async fn transaction_fib_stage_overlays_only_tables_and_posture_and_restores_raw_prior() {
     let (tx, rx) = mpsc::channel(8);
-    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, _rib_rx) = mpsc::channel(8);
     let mut live = make_dynamic_manager_config();
     live.policy.rpol_files = vec!["live-source.rpol".to_string()];
@@ -590,6 +593,7 @@ async fn transaction_fib_stage_overlays_only_tables_and_posture_and_restores_raw
             scope: TransactionConfigScope::FibTablesOnly,
             reply: stage_tx,
         })
+        .await
         .unwrap();
     let rollback = stage_rx.await.unwrap().unwrap();
     assert_eq!(rollback.previous().config_epoch, None);
@@ -613,6 +617,7 @@ async fn transaction_fib_stage_overlays_only_tables_and_posture_and_restores_raw
             rollback,
             reply: restore_tx,
         })
+        .await
         .unwrap();
     restore_rx.await.unwrap();
     let (snapshot_tx, snapshot_rx) = oneshot::channel();
@@ -631,7 +636,7 @@ async fn transaction_fib_stage_overlays_only_tables_and_posture_and_restores_raw
 #[tokio::test]
 async fn stage_config_snapshot_rebuilds_matcher_and_returns_previous_toml() {
     let (tx, rx) = mpsc::channel(16);
-    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let config = make_dynamic_manager_config();
     let mut replacement = config.clone();
@@ -665,6 +670,7 @@ async fn stage_config_snapshot_rebuilds_matcher_and_returns_previous_toml() {
             scope: TransactionConfigScope::Full,
             reply: reply_tx,
         })
+        .await
         .unwrap();
     let rollback = reply_rx.await.unwrap().unwrap();
     assert_eq!(
@@ -693,7 +699,7 @@ async fn stage_config_snapshot_rebuilds_matcher_and_returns_previous_toml() {
 )]
 async fn staged_snapshot_fences_dynamic_accept_and_restore_reaps_candidate_dynamic_peer() {
     let (tx, rx) = mpsc::channel(16);
-    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let mut initial = make_dynamic_manager_config();
     initial.dynamic_neighbors.clear();
@@ -729,6 +735,7 @@ async fn staged_snapshot_fences_dynamic_accept_and_restore_reaps_candidate_dynam
             scope: TransactionConfigScope::Full,
             reply: stage_tx,
         })
+        .await
         .unwrap();
     let rollback = stage_rx.await.unwrap().unwrap();
 
@@ -791,6 +798,7 @@ async fn staged_snapshot_fences_dynamic_accept_and_restore_reaps_candidate_dynam
             rollback,
             reply: restore_tx,
         })
+        .await
         .unwrap();
     restore_rx.await.unwrap();
 
@@ -812,7 +820,7 @@ async fn staged_snapshot_fences_dynamic_accept_and_restore_reaps_candidate_dynam
 #[tokio::test]
 async fn runtime_config_snapshot_returns_current_staged_config() {
     let (tx, rx) = mpsc::channel(16);
-    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let config = make_dynamic_manager_config();
     let mut replacement = config.clone();
@@ -846,6 +854,7 @@ async fn runtime_config_snapshot_returns_current_staged_config() {
             scope: TransactionConfigScope::Full,
             reply: stage_tx,
         })
+        .await
         .unwrap();
     stage_rx.await.unwrap().unwrap();
 
@@ -890,7 +899,7 @@ md5_password = "old-secret"
     );
     let mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -995,7 +1004,7 @@ log_format = "json"
     let drift_candidate_toml = toml::to_string_pretty(&drift_candidate).unwrap();
 
     let (_tx, rx) = mpsc::channel(4);
-    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (_internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
     let mut mgr = PeerManager::new_with_config(
         rx,

--- a/src/peer_manager/tests/dynamic_ranges.rs
+++ b/src/peer_manager/tests/dynamic_ranges.rs
@@ -433,7 +433,7 @@ fn runtime_dynamic_add_rejects_static_tcp_ao_neighbor_coverage() {
 #[tokio::test]
 async fn dynamic_tcp_ao_snapshot_reports_protected_from_explicit_range_keyring() {
     let (tx, rx) = mpsc::channel(16);
-    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (_internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let mut config = make_dynamic_manager_config();
     config.dynamic_neighbors[0].tcp_ao = Some(test_tcp_ao().into());
@@ -549,7 +549,7 @@ fn delete_dynamic_range_unknown_returns_error() {
 #[tokio::test]
 async fn replace_config_snapshot_rebuilds_dynamic_range_matcher() {
     let (tx, rx) = mpsc::channel(16);
-    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (internal_tx, internal_rx) = mpsc::channel(1);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let config = make_dynamic_manager_config();
     let mut replacement = config.clone();
@@ -582,6 +582,7 @@ async fn replace_config_snapshot_rebuilds_dynamic_range_matcher() {
             config: Box::new(replacement),
             ack: Some(ack_tx),
         })
+        .await
         .unwrap();
     ack_rx.await.unwrap();
 

--- a/src/peer_manager/tests/inbound_admission.rs
+++ b/src/peer_manager/tests/inbound_admission.rs
@@ -18,7 +18,7 @@ fn dynamic_tcp_ao_test_manager(protected: bool) -> PeerManager {
     }
     PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -141,7 +141,7 @@ async fn unmatched_inbound_source_counts_unconfigured_drop() {
     config.dynamic_neighbors.clear();
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -181,7 +181,7 @@ async fn inbound_admission_disabled_by_default_admits_rapid_dynamic_reaccepts() 
     let metrics_view = metrics.clone();
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -241,7 +241,7 @@ async fn enabled_inbound_admission_rate_limits_dynamic_source_but_exempts_static
     };
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -347,7 +347,7 @@ async fn dynamic_inbound_peer_records_most_specific_accepted_range() {
     ];
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -426,7 +426,7 @@ async fn fresh_dynamic_tcp_ao_inbound_seeds_selected_owner_keyring_for_manager_a
     ]));
     let mut manager = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -564,7 +564,7 @@ async fn queued_dynamic_selection_accept_reconciles_metadata_and_rotation_status
     ]));
     let mut manager = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -686,7 +686,7 @@ async fn inbound_link_local_is_not_accepted_as_dynamic_peer() {
     }];
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -785,7 +785,7 @@ async fn dead_lettered_pending_survives_dynamic_peer_auto_removal_and_re_establi
     let metrics = BgpMetrics::new();
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -883,7 +883,7 @@ async fn dead_lettered_gshut_survives_dynamic_peer_auto_removal_and_re_establish
     let metrics = BgpMetrics::new();
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,
@@ -971,7 +971,7 @@ async fn dead_lettered_pending_over_cap_evicts_oldest_entry() {
     config.global.dynamic_neighbor_limit = Some(2);
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -273,7 +273,7 @@ fn dynamic_test_manager() -> PeerManager {
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,

--- a/src/peer_manager/tests/peer_groups.rs
+++ b/src/peer_manager/tests/peer_groups.rs
@@ -45,7 +45,7 @@ fn peer_group_reshape_manager(config: Config) -> PeerManager {
     Box::leak(Box::new(rib_rx));
     PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,

--- a/src/peer_manager/tests/queries.rs
+++ b/src/peer_manager/tests/queries.rs
@@ -4,7 +4,7 @@ use super::*;
 async fn closed_internal_command_lane_disables_after_first_poll() {
     // Load-bearing: removing the close-to-disabled transition leaves the
     // receiver present and makes every later receive immediately ready.
-    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (internal_tx, internal_rx) = mpsc::channel(1);
     drop(internal_tx);
     let mut internal_rx = Some(internal_rx);
 
@@ -517,7 +517,7 @@ log_format = "json"
     let (rib_tx, mut rib_rx) = mpsc::channel(8);
     let manager = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,

--- a/src/peer_manager/tests/snapshots.rs
+++ b/src/peer_manager/tests/snapshots.rs
@@ -402,7 +402,7 @@ async fn effective_posture_snapshot_keeps_dynamic_inheritance_at_static_parity()
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let mut mgr = PeerManager::new_with_config(
         rx,
-        mpsc::unbounded_channel().1,
+        mpsc::channel(1).1,
         65001,
         Ipv4Addr::new(10, 0, 0, 1),
         None,

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1451,7 +1451,7 @@ pub(crate) struct AcceptedBridgeReplacement {
 )]
 pub(crate) async fn run_config_bridge_accepted(
     mut event_rx: mpsc::Receiver<rustbgpd_api::peer_types::ConfigEvent>,
-    mut bridge_replace_rx: mpsc::UnboundedReceiver<AcceptedBridgeReplacement>,
+    mut bridge_replace_rx: mpsc::Receiver<AcceptedBridgeReplacement>,
     mutation_tx: mpsc::Sender<ConfigMutation>,
     accepted_tx: watch::Sender<Arc<AcceptedConfigSnapshot>>,
 ) {
@@ -1597,7 +1597,7 @@ pub(crate) async fn run_config_bridge(
 ) {
     let initial = AcceptedConfigSnapshot::from_config_for_test(initial);
     let (accepted_tx, _accepted_rx) = watch::channel(Arc::clone(&initial));
-    let (replace_tx, accepted_replace_rx) = mpsc::unbounded_channel();
+    let (replace_tx, accepted_replace_rx) = mpsc::channel(1);
     tokio::spawn(async move {
         let mut bridge_replace_rx = bridge_replace_rx;
         while let Some(config) = bridge_replace_rx.recv().await {
@@ -1609,6 +1609,7 @@ pub(crate) async fn run_config_bridge(
                         .expect("test config serializes"),
                     adopted,
                 })
+                .await
                 .is_err()
             {
                 break;
@@ -1620,11 +1621,9 @@ pub(crate) async fn run_config_bridge(
 
 /// Acknowledge a freshly reloaded authority across every runtime consumer.
 ///
-/// Order matters. `peer_mgr_internal_tx` is unbounded and can only fail
-/// on receiver-drop (peer manager task is dead — fatal anyway). The
-/// bridge channel is also unbounded; it can only fail on receiver-drop
-/// (bridge task is dead — same fatality class as a dead persister, since
-/// the bridge owns the persister-facing channel). Sending the peer
+/// Order matters. Both private control lanes are lossless capacity-one
+/// channels; a send can fail only on receiver-drop (the owning peer-manager
+/// or bridge task is dead). Sending the peer
 /// manager first means the authoritative runtime view always advances
 /// first.
 ///
@@ -1647,8 +1646,8 @@ pub(crate) async fn run_config_bridge(
 pub(crate) async fn finalize_sighup_authority(
     operation: &OwnedRuntimeConfigOperation,
     authority: SighupAuthority,
-    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
-    bridge_replace_tx: &mpsc::UnboundedSender<AcceptedBridgeReplacement>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
+    bridge_replace_tx: &mpsc::Sender<AcceptedBridgeReplacement>,
     dialout_manager: &Arc<tokio::sync::Mutex<rustbgpd_api::gnmi_dialout::DialoutManager>>,
 ) -> OwnedRuntimeConfigOutcome<SighupAuthority, SighupReloadError> {
     operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
@@ -1671,6 +1670,7 @@ pub(crate) async fn finalize_sighup_authority(
             config: Box::new(authority.runtime.clone()),
             ack: Some(ack_tx),
         })
+        .await
         .is_err()
     {
         return fenced(
@@ -1692,6 +1692,7 @@ pub(crate) async fn finalize_sighup_authority(
             snapshot: Arc::clone(&authority.desired),
             adopted,
         })
+        .await
         .is_err()
     {
         return fenced(
@@ -3995,13 +3996,112 @@ local_vtep_ip = "10.0.0.1"
 "#;
 
     #[tokio::test]
+    async fn bounded_control_lanes_apply_capacity_one_fifo_backpressure() {
+        use tokio::time::{Duration, timeout};
+
+        let config = load_config_from_toml("bounded-control-lane", baseline_toml());
+        let (internal_tx, mut internal_rx) = mpsc::channel(1);
+        let (first_ack, first_ack_rx) = oneshot::channel();
+        internal_tx
+            .send(InternalCommand::ReplaceConfigSnapshot {
+                config: Box::new(config.clone()),
+                ack: Some(first_ack),
+            })
+            .await
+            .unwrap();
+        let (second_ack, second_ack_rx) = oneshot::channel();
+        let mut second = Box::pin(internal_tx.send(InternalCommand::ReplaceConfigSnapshot {
+            config: Box::new(config.clone()),
+            ack: Some(second_ack),
+        }));
+        assert!(
+            timeout(Duration::from_millis(10), &mut second)
+                .await
+                .is_err()
+        );
+        let InternalCommand::ReplaceConfigSnapshot { ack, .. } = internal_rx.recv().await.unwrap()
+        else {
+            panic!("first internal command must retain its identity");
+        };
+        ack.unwrap().send(()).unwrap();
+        second.await.unwrap();
+        let InternalCommand::ReplaceConfigSnapshot { ack, .. } = internal_rx.recv().await.unwrap()
+        else {
+            panic!("second internal command must retain its identity");
+        };
+        ack.unwrap().send(()).unwrap();
+        first_ack_rx.await.unwrap();
+        second_ack_rx.await.unwrap();
+
+        let snapshot = AcceptedConfigSnapshot::from_config_for_test(config);
+        let (replace_tx, mut replace_rx) = mpsc::channel(1);
+        let (first_adopted, first_adopted_rx) = oneshot::channel();
+        replace_tx
+            .send(AcceptedBridgeReplacement {
+                snapshot: Arc::clone(&snapshot),
+                adopted: first_adopted,
+            })
+            .await
+            .unwrap();
+        let (second_adopted, second_adopted_rx) = oneshot::channel();
+        let mut second = Box::pin(replace_tx.send(AcceptedBridgeReplacement {
+            snapshot,
+            adopted: second_adopted,
+        }));
+        assert!(
+            timeout(Duration::from_millis(10), &mut second)
+                .await
+                .is_err()
+        );
+        let first = replace_rx.recv().await.unwrap();
+        first.adopted.send(ReloadDispatch::Replied(())).unwrap();
+        second.await.unwrap();
+        let second = replace_rx.recv().await.unwrap();
+        second.adopted.send(ReloadDispatch::Replied(())).unwrap();
+        assert!(matches!(
+            first_adopted_rx.await.unwrap(),
+            ReloadDispatch::Replied(())
+        ));
+        assert!(matches!(
+            second_adopted_rx.await.unwrap(),
+            ReloadDispatch::Replied(())
+        ));
+    }
+
+    #[test]
+    fn bounded_control_lane_source_inventory_is_closed() {
+        let main = include_str!("main.rs");
+        let reload = include_str!("reload.rs");
+        let transaction = include_str!("config_transaction_control.rs");
+        assert!(
+            main.contains("let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::channel(1)")
+        );
+        assert!(main.contains("let (bridge_replace_tx, bridge_replace_rx) = mpsc::channel(1)"));
+        assert!(reload.contains("mpsc::Receiver<AcceptedBridgeReplacement>"));
+        assert!(reload.contains("mpsc::Sender<AcceptedBridgeReplacement>"));
+        assert!(!reload.contains(concat!(
+            "mpsc::Unbounded",
+            "Sender<AcceptedBridgeReplacement>"
+        )));
+        assert!(!reload.contains(concat!(
+            "mpsc::Unbounded",
+            "Receiver<AcceptedBridgeReplacement>"
+        )));
+        assert!(!transaction.contains(concat!("mpsc::Unbounded", "Sender<InternalCommand>")));
+        assert!(!transaction.contains(concat!("mpsc::Unbounded", "Receiver<InternalCommand>")));
+        assert!(!reload.contains(concat!("try_", "send(AcceptedBridgeReplacement")));
+        assert!(!transaction.contains(concat!("try_", "send(InternalCommand")));
+        assert!(reload.contains(concat!("mpsc::Unbounded", "Receiver<Box<Config>>")));
+    }
+
+    #[tokio::test]
     async fn sighup_runtime_baseline_reads_peer_manager_snapshot_after_typed_stage() {
         let initial = load_config_from_toml("runtime-baseline-initial", baseline_toml());
         let mut candidate = initial.clone();
         candidate.neighbors[0].hold_time = Some(45);
 
         let (tx, rx) = mpsc::channel(16);
-        let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+        let (internal_tx, internal_rx) = mpsc::channel(1);
         let (rib_tx, _rib_rx) = mpsc::channel(64);
         let manager = PeerManager::new_with_config(
             rx,
@@ -4025,6 +4125,7 @@ local_vtep_ip = "10.0.0.1"
                 scope: TransactionConfigScope::Full,
                 reply: stage_tx,
             })
+            .await
             .unwrap();
         let rollback_token = stage_rx.await.unwrap().unwrap();
         drop(rollback_token);
@@ -8883,7 +8984,7 @@ peer_group = "secure"
         );
 
         let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
-        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
+        let (replace_tx, replace_rx) = mpsc::channel(1);
         let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
         let initial = AcceptedConfigSnapshot::from_config_for_test(stale);
         let (accepted_tx, _accepted_rx) = watch::channel(initial);
@@ -8902,6 +9003,7 @@ peer_group = "secure"
                 snapshot: AcceptedConfigSnapshot::from_config_for_test(reloaded.clone()),
                 adopted,
             })
+            .await
             .unwrap();
         let replace_msg = mutation_rx.recv().await.expect("replacement forwarded");
         let ConfigMutation::AdoptReloadSnapshot {
@@ -9078,7 +9180,7 @@ peer_group = "secure"
         let initial = Arc::new(AcceptedConfigSnapshot::load(&path, None).unwrap());
         std::fs::remove_file(&path).ok();
         let (event_tx, event_rx) = mpsc::channel(4);
-        let (replace_tx, replace_rx) = mpsc::unbounded_channel();
+        let (replace_tx, replace_rx) = mpsc::channel(1);
         let (mutation_tx, mut mutation_rx) = mpsc::channel(4);
         let (accepted_tx, mut accepted_rx) = watch::channel(Arc::clone(&initial));
         let bridge = tokio::spawn(run_config_bridge_accepted(
@@ -9662,7 +9764,7 @@ remote_asn = 65002
         let initial_accepted = AcceptedConfigSnapshot::from_config_for_test(initial.clone());
 
         let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
-        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
+        let (replace_tx, replace_rx) = mpsc::channel(1);
         let (mutation_tx, mutation_rx) = mpsc::channel::<ConfigMutation>(8);
         let persister = tokio::spawn(
             ConfigPersister::new_accepted(
@@ -9702,6 +9804,7 @@ remote_asn = 65002
                 snapshot: Arc::clone(&reloaded.desired),
                 adopted,
             })
+            .await
             .unwrap();
         assert!(matches!(
             adopted_rx.await.unwrap(),


### PR DESCRIPTION
## Summary

- bound the peer-manager private command lane at capacity one
- bound config-bridge authority replacement at capacity one
- preserve lossless FIFO delivery, awaited acknowledgements, and existing failure fencing
- retain the intentionally unbounded session notification lane for the QueryState collision-resolution deadlock constraint

## Why capacity one

Both converted lanes have serialized producers and at most one queued command. Capacity one makes that ownership invariant explicit without hiding queue growth behind a larger arbitrary bound.

## Verification

- focused capacity-one FIFO and backpressure proof with distinct acknowledgements
- private-lane closure and public actor liveness tests
- config-bridge replacement ordering and persisted adoption tests
- structural source inventory for the two production channel constructions
- cargo test --locked -p rustbgpd
- cargo test --locked --workspace
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check

Refs LAN-1162. Tranche B remains open for session-notification queue observability and sustained-flap evidence without changing its delivery semantics.