### PR TITLE
perf: observe session notification backlog

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -396,7 +396,7 @@ All inter-task communication uses bounded `tokio::mpsc` channels (capacity 4096 
 | PeerManager commands | API | PeerManager | `send().await` blocks. gRPC call waits. |
 | BMP events | Transport | BmpManager | `try_send()` — event dropped, warning logged. |
 
-The small set of intentional unbounded channels is enumerated in Design Invariant #3 above; the `session_notify` channel used for TCP collision detection remains intentionally unbounded because a bounded send would deadlock with synchronous `QueryState` peer-state queries during collision resolution.
+The small set of intentional unbounded channels is enumerated in Design Invariant #3 above; the `session_notify` channel used for TCP collision detection remains intentionally unbounded because a bounded send would deadlock with synchronous `QueryState` peer-state queries during collision resolution. Its domain wrapper accounts from sender entry through successful PeerManager dequeue, including synchronous in-flight reservations and queued notifications; the exported high-water mark is monotonic for the daemon lifetime and is not a per-flap or per-round peak.
 
 ### Dirty-peer resync
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2228,7 +2228,9 @@ branch is between features.
     justified `unsafe` outside any shipped path.
   - LAN-1162 tranche A bounds the peer-manager private command lane and the
     config-bridge replacement lane at capacity one with lossless FIFO sends.
-    LAN-1162 remains open for tranche B observability and sustained-flap proof;
+    LAN-1162 B1 adds daemon-lifetime current/high-water depth accounting around
+    `session_notify` without changing delivery semantics. LAN-1162 remains open
+    for B2's optional handshake and real 700/400400 three-round flap proof;
     `session_notify` remains intentionally unbounded for the `QueryState`
     collision-resolution deadlock constraint.
 

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -2,13 +2,74 @@
 
 use std::cell::RefCell;
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use prometheus::{
     HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
+    core::{Collector, Desc},
+    proto::MetricFamily,
 };
+
+#[derive(Debug)]
+struct SessionNotificationDepthCollector {
+    current: Arc<AtomicI64>,
+    high_watermark: Arc<AtomicI64>,
+    descs: Vec<Desc>,
+}
+
+impl SessionNotificationDepthCollector {
+    fn new(current: Arc<AtomicI64>, high_watermark: Arc<AtomicI64>) -> Self {
+        let descs = vec![
+            Desc::new(
+                "bgp_session_notification_outstanding".to_string(),
+                "Current session notifications from sender entry through successful PeerManager dequeue, including synchronous in-flight reservations and queued notifications".to_string(),
+                Vec::new(),
+                std::collections::HashMap::new(),
+            )
+            .expect("valid metric descriptor"),
+            Desc::new(
+                "bgp_session_notification_outstanding_high_watermark".to_string(),
+                "Monotonic daemon-lifetime high-water mark of session notifications outstanding until process restart".to_string(),
+                Vec::new(),
+                std::collections::HashMap::new(),
+            )
+            .expect("valid metric descriptor"),
+        ];
+        Self {
+            current,
+            high_watermark,
+            descs,
+        }
+    }
+}
+
+impl Collector for SessionNotificationDepthCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let current = self.current.load(Ordering::Acquire);
+        let high_watermark = self.high_watermark.load(Ordering::Acquire).max(current);
+        let current_gauge = IntGauge::new(
+            "bgp_session_notification_outstanding",
+            "Current session notifications from sender entry through successful PeerManager dequeue, including synchronous in-flight reservations and queued notifications",
+        )
+        .expect("valid metric definition");
+        current_gauge.set(current);
+        let high_watermark_gauge = IntGauge::new(
+            "bgp_session_notification_outstanding_high_watermark",
+            "Monotonic daemon-lifetime high-water mark of session notifications outstanding until process restart",
+        )
+        .expect("valid metric definition");
+        high_watermark_gauge.set(high_watermark);
+        let mut families = current_gauge.collect();
+        families.extend(high_watermark_gauge.collect());
+        families
+    }
+}
 
 /// Canonical `peer` label value: the neighbor's bare IP address.
 ///
@@ -211,6 +272,8 @@ struct BgpMetricsInner {
     peer_admin_enabled: IntGaugeVec,
     peer_session_established: IntGaugeVec,
     stale_timer_events: IntCounterVec,
+    session_notification_outstanding_value: Arc<AtomicI64>,
+    session_notification_outstanding_high_watermark_value: Arc<AtomicI64>,
 
     // ── Dynamic-neighbor capacity ─────────────────────────────────
     dynamic_neighbor_slots_used: IntGauge,
@@ -509,6 +572,8 @@ impl BgpMetrics {
             &["peer", "from", "to"],
         )
         .expect("valid metric definition");
+        let session_notification_outstanding_value = Arc::new(AtomicI64::new(0));
+        let session_notification_outstanding_high_watermark_value = Arc::new(AtomicI64::new(0));
 
         let session_flaps = IntCounterVec::new(
             Opts::new(
@@ -2108,6 +2173,12 @@ impl BgpMetrics {
             .register(Box::new(state_transitions.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(SessionNotificationDepthCollector::new(
+                Arc::clone(&session_notification_outstanding_value),
+                Arc::clone(&session_notification_outstanding_high_watermark_value),
+            )))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(session_flaps.clone()))
             .expect("metric not already registered");
         registry
@@ -2656,6 +2727,8 @@ impl BgpMetrics {
             registry,
             instance_id: NEXT_METRICS_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
             state_transitions,
+            session_notification_outstanding_value,
+            session_notification_outstanding_high_watermark_value,
             session_flaps,
             session_established,
             peer_admin_enabled,
@@ -2841,6 +2914,31 @@ impl BgpMetrics {
     #[must_use]
     pub fn registry(&self) -> &Registry {
         &self.0.registry
+    }
+
+    /// Reserve one session notification before its lossless channel send.
+    pub fn reserve_session_notification(&self) {
+        let outstanding = self
+            .0
+            .session_notification_outstanding_value
+            .fetch_add(1, Ordering::AcqRel)
+            + 1;
+        self.0
+            .session_notification_outstanding_high_watermark_value
+            .fetch_max(outstanding, Ordering::AcqRel);
+    }
+
+    /// Release one reservation after dequeue or a failed channel send.
+    pub fn release_session_notification(&self) {
+        let released = self.0.session_notification_outstanding_value.fetch_update(
+            Ordering::AcqRel,
+            Ordering::Acquire,
+            |current| current.checked_sub(1).filter(|next| *next >= 0),
+        );
+        debug_assert!(
+            released.is_ok(),
+            "session notification accounting underflow"
+        );
     }
 
     /// Publish the authoritative process-global dynamic-neighbor slot state.
@@ -5205,6 +5303,71 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use prometheus::{Encoder, core::Collector};
+
+    fn unlabeled_gauge(metrics: &BgpMetrics, name: &str) -> f64 {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| family.get_metric().first().cloned())
+            .map(|metric| metric.get_gauge().value())
+            .unwrap()
+    }
+
+    fn assert_unlabeled_gauge(metrics: &BgpMetrics, name: &str, expected: f64) {
+        let actual = unlabeled_gauge(metrics, name);
+        assert!((actual - expected).abs() < f64::EPSILON, "{name}: {actual}");
+    }
+
+    #[test]
+    fn session_notification_depth_metrics_register_unlabeled_at_zero() {
+        let metrics = BgpMetrics::new();
+        assert_unlabeled_gauge(&metrics, "bgp_session_notification_outstanding", 0.0);
+        assert_unlabeled_gauge(
+            &metrics,
+            "bgp_session_notification_outstanding_high_watermark",
+            0.0,
+        );
+        let mut encoded = Vec::new();
+        prometheus::TextEncoder::new()
+            .encode(&metrics.registry().gather(), &mut encoded)
+            .unwrap();
+        let encoded = String::from_utf8(encoded).unwrap();
+        assert!(encoded.contains("# HELP bgp_session_notification_outstanding Current session notifications from sender entry through successful PeerManager dequeue, including synchronous in-flight reservations and queued notifications"));
+        assert!(encoded.contains("# TYPE bgp_session_notification_outstanding gauge"));
+        assert!(encoded.contains("# HELP bgp_session_notification_outstanding_high_watermark Monotonic daemon-lifetime high-water mark of session notifications outstanding until process restart"));
+        assert!(
+            encoded.contains("# TYPE bgp_session_notification_outstanding_high_watermark gauge")
+        );
+    }
+
+    #[test]
+    fn session_notification_depth_atomic_lifecycle_is_monotonic() {
+        let metrics = BgpMetrics::new();
+        metrics.reserve_session_notification();
+        metrics.reserve_session_notification();
+        metrics.release_session_notification();
+        assert_unlabeled_gauge(&metrics, "bgp_session_notification_outstanding", 1.0);
+        assert_unlabeled_gauge(
+            &metrics,
+            "bgp_session_notification_outstanding_high_watermark",
+            2.0,
+        );
+        assert!(
+            unlabeled_gauge(
+                &metrics,
+                "bgp_session_notification_outstanding_high_watermark"
+            ) >= unlabeled_gauge(&metrics, "bgp_session_notification_outstanding")
+        );
+        metrics.release_session_notification();
+        assert_unlabeled_gauge(&metrics, "bgp_session_notification_outstanding", 0.0);
+        assert_unlabeled_gauge(
+            &metrics,
+            "bgp_session_notification_outstanding_high_watermark",
+            2.0,
+        );
+    }
 
     use super::*;
 

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -291,6 +291,89 @@ pub enum SessionNotification {
     },
 }
 
+/// Lossless, nonblocking sender for peer-session coordination notifications.
+#[derive(Debug, Clone)]
+pub struct SessionNotificationSender {
+    inner: mpsc::UnboundedSender<SessionNotification>,
+    metrics: BgpMetrics,
+}
+
+impl SessionNotificationSender {
+    /// Send exactly one notification while accounting for its outstanding lifetime.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original notification when the receiver is closed.
+    pub fn send(
+        &self,
+        notification: SessionNotification,
+    ) -> Result<(), mpsc::error::SendError<SessionNotification>> {
+        self.metrics.reserve_session_notification();
+        match self.inner.send(notification) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.metrics.release_session_notification();
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Receiver half of the lossless session-notification channel.
+#[derive(Debug)]
+pub struct SessionNotificationReceiver {
+    inner: mpsc::UnboundedReceiver<SessionNotification>,
+    metrics: BgpMetrics,
+}
+
+impl SessionNotificationReceiver {
+    /// Receive one notification, releasing its reservation only after dequeue.
+    pub async fn recv(&mut self) -> Option<SessionNotification> {
+        let notification = self.inner.recv().await;
+        if notification.is_some() {
+            self.metrics.release_session_notification();
+        }
+        notification
+    }
+
+    /// Try to receive one notification without waiting.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Empty` when no notification is queued and `Disconnected` when
+    /// every sender has closed and the queue is drained.
+    pub fn try_recv(&mut self) -> Result<SessionNotification, mpsc::error::TryRecvError> {
+        let notification = self.inner.try_recv()?;
+        self.metrics.release_session_notification();
+        Ok(notification)
+    }
+}
+
+impl Drop for SessionNotificationReceiver {
+    fn drop(&mut self) {
+        self.inner.close();
+        while self.try_recv().is_ok() {}
+    }
+}
+
+/// Create the intentionally unbounded lossless session-notification lane.
+#[must_use]
+pub fn session_notification_channel(
+    metrics: BgpMetrics,
+) -> (SessionNotificationSender, SessionNotificationReceiver) {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    (
+        SessionNotificationSender {
+            inner: sender,
+            metrics: metrics.clone(),
+        },
+        SessionNotificationReceiver {
+            inner: receiver,
+            metrics,
+        },
+    )
+}
+
 /// Bounded lifecycle notification sent from a peer session to `PeerManager`.
 ///
 /// These events back operator-facing streams such as
@@ -850,7 +933,7 @@ impl PeerHandle {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
         validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
         advertise_graceful_shutdown: bool,
@@ -882,7 +965,7 @@ impl PeerHandle {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
         validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
@@ -918,7 +1001,7 @@ impl PeerHandle {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -960,7 +1043,7 @@ impl PeerHandle {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -1001,7 +1084,7 @@ impl PeerHandle {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -1060,7 +1143,7 @@ impl PeerHandle {
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
         stream: TcpStream,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
         validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
         advertise_graceful_shutdown: bool,
@@ -1094,7 +1177,7 @@ impl PeerHandle {
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
         stream: TcpStream,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
         validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
@@ -1132,7 +1215,7 @@ impl PeerHandle {
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
         stream: TcpStream,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -1176,7 +1259,7 @@ impl PeerHandle {
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
         stream: TcpStream,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -1222,7 +1305,7 @@ impl PeerHandle {
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
         stream: TcpStream,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -2034,7 +2117,158 @@ impl PeerHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::sync::Barrier;
     use std::time::Instant;
+
+    fn gauge(metrics: &BgpMetrics, name: &str) -> f64 {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| family.get_metric().first().cloned())
+            .map(|metric| metric.get_gauge().value())
+            .unwrap()
+    }
+
+    fn assert_gauge(metrics: &BgpMetrics, name: &str, expected: f64) {
+        let actual = gauge(metrics, name);
+        assert!((actual - expected).abs() < f64::EPSILON, "{name}: {actual}");
+    }
+
+    fn notification(producer: u64, ordinal: u8) -> SessionNotification {
+        let host = u8::try_from(producer % 250 + 1).unwrap();
+        let peer_addr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, host));
+        match ordinal {
+            0 => SessionNotification::OpenReceived {
+                session_id: producer,
+                role: SessionRole::Primary,
+                peer_addr,
+                remote_router_id: Ipv4Addr::new(198, 51, 100, 1),
+                peer_asn: 65_000,
+            },
+            1 => SessionNotification::BackToIdle {
+                session_id: producer,
+                role: SessionRole::Primary,
+                peer_addr,
+            },
+            2 => SessionNotification::MaxPrefixExceeded {
+                session_id: producer,
+                role: SessionRole::Primary,
+                peer_addr,
+                count: usize::try_from(producer).unwrap(),
+                bound: 1,
+                family: None,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn identity(notification: &SessionNotification) -> (u64, u8) {
+        match notification {
+            SessionNotification::OpenReceived { session_id, .. } => (*session_id, 0),
+            SessionNotification::BackToIdle { session_id, .. } => (*session_id, 1),
+            SessionNotification::MaxPrefixExceeded { session_id, .. } => (*session_id, 2),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_notification_depth_tracks_700_by_3_exact_fifo_roster() {
+        let metrics = BgpMetrics::new();
+        let (sender, mut receiver) = session_notification_channel(metrics.clone());
+        let mut producers = Vec::new();
+        for producer in 0..700 {
+            let sender = sender.clone();
+            producers.push(tokio::spawn(async move {
+                for ordinal in 0..3 {
+                    sender.send(notification(producer, ordinal)).unwrap();
+                }
+            }));
+        }
+        for producer in producers {
+            producer.await.unwrap();
+        }
+        assert_gauge(&metrics, "bgp_session_notification_outstanding", 2_100.0);
+        assert_gauge(
+            &metrics,
+            "bgp_session_notification_outstanding_high_watermark",
+            2_100.0,
+        );
+
+        let mut roster = HashMap::<u64, Vec<u8>>::new();
+        while let Ok(notification) = receiver.try_recv() {
+            let (producer, ordinal) = identity(&notification);
+            roster.entry(producer).or_default().push(ordinal);
+        }
+        assert_eq!(roster.len(), 700);
+        assert!(roster.values().all(|ordinals| ordinals == &[0, 1, 2]));
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+        assert_gauge(&metrics, "bgp_session_notification_outstanding", 0.0);
+        assert_gauge(
+            &metrics,
+            "bgp_session_notification_outstanding_high_watermark",
+            2_100.0,
+        );
+    }
+
+    #[tokio::test]
+    async fn session_notification_async_recv_releases_exactly_once() {
+        let metrics = BgpMetrics::new();
+        let (sender, mut receiver) = session_notification_channel(metrics.clone());
+        sender.send(notification(1, 0)).unwrap();
+        assert_gauge(&metrics, "bgp_session_notification_outstanding", 1.0);
+        assert_eq!(identity(&receiver.recv().await.unwrap()), (1, 0));
+        assert_gauge(&metrics, "bgp_session_notification_outstanding", 0.0);
+    }
+
+    #[test]
+    fn session_notification_receiver_drop_drains_and_closed_send_rolls_back() {
+        let metrics = BgpMetrics::new();
+        let (sender, receiver) = session_notification_channel(metrics.clone());
+        sender.send(notification(1, 0)).unwrap();
+        let remaining = sender.clone();
+        drop(receiver);
+        assert!(remaining.send(notification(2, 0)).is_err());
+        assert_gauge(&metrics, "bgp_session_notification_outstanding", 0.0);
+        assert_gauge(
+            &metrics,
+            "bgp_session_notification_outstanding_high_watermark",
+            1.0,
+        );
+
+        let (sender, receiver) = session_notification_channel(metrics.clone());
+        let barrier = Arc::new(Barrier::new(65));
+        let mut producers = Vec::new();
+        for producer in 0..64 {
+            let sender = sender.clone();
+            let barrier = Arc::clone(&barrier);
+            producers.push(std::thread::spawn(move || {
+                barrier.wait();
+                sender.send(notification(producer, 0)).is_ok()
+            }));
+        }
+        barrier.wait();
+        drop(receiver);
+        let outcomes = producers
+            .into_iter()
+            .map(|producer| producer.join().unwrap())
+            .collect::<Vec<_>>();
+        drop(sender);
+        let succeeded = outcomes.iter().filter(|outcome| **outcome).count();
+        let failed = outcomes.len() - succeeded;
+        assert_eq!(succeeded + failed, 64);
+        assert_gauge(&metrics, "bgp_session_notification_outstanding", 0.0);
+        assert!(
+            gauge(
+                &metrics,
+                "bgp_session_notification_outstanding_high_watermark"
+            ) >= 1.0
+        );
+    }
 
     #[test]
     fn peer_command_error_display_preserves_operator_text() {

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -47,8 +47,9 @@ pub use handle::{
     ImportPolicyTermHits, NegotiatedGracefulRestartState, NegotiatedSessionState, PeerCommand,
     PeerCommandError, PeerHandle, PeerSessionState, PeerShutdownError, SessionIdentity,
     SessionLifecycleNotification, SessionNotification, SessionNotificationDirection,
-    SessionNotificationEvent, SessionQueryOutcome, SessionRole, StateQueryOutcome,
-    WarmCheckpointSessionState,
+    SessionNotificationEvent, SessionNotificationReceiver, SessionNotificationSender,
+    SessionQueryOutcome, SessionRole, StateQueryOutcome, WarmCheckpointSessionState,
+    session_notification_channel,
 };
 pub use listener::{
     AcceptedConnection, BgpListener, ListenerSocketOptions, Md5ListenerKey,

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -47,7 +47,8 @@ use crate::event_sink::{NoopTransportEventSink, TransportEventSink};
 use crate::framing::ReadBuffer;
 use crate::handle::{
     PeerCommand, PeerSessionState, SessionIdentity, SessionLifecycleNotification,
-    SessionNotification, SessionNotificationDirection, SessionNotificationEvent, SessionRole,
+    SessionNotification, SessionNotificationDirection, SessionNotificationEvent,
+    SessionNotificationSender, SessionRole,
 };
 use crate::timer::{Timers, poll_timer};
 
@@ -266,7 +267,7 @@ pub(crate) struct PeerSession {
     /// Channel to notify `PeerManager` of lossless collision-coordination events.
     /// Unbounded so notifications are never dropped and never block (avoids
     /// deadlock with `QueryState`).
-    session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+    session_notify_tx: Option<SessionNotificationSender>,
     /// Bounded operator-facing lifecycle event channel.
     ///
     /// This carries ordinary FSM `StateChanged` observations used by
@@ -971,7 +972,7 @@ impl PeerSession {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
         validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
         advertise_graceful_shutdown: bool,
@@ -1005,7 +1006,7 @@ impl PeerSession {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -1043,7 +1044,7 @@ impl PeerSession {
         rib_tx: mpsc::Sender<RibUpdate>,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,
@@ -1194,7 +1195,7 @@ impl PeerSession {
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
         stream: TcpStream,
-        session_notify_tx: Option<mpsc::UnboundedSender<SessionNotification>>,
+        session_notify_tx: Option<SessionNotificationSender>,
         session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
         session_lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
         bmp_tx: Option<mpsc::Sender<BmpEvent>>,

--- a/crates/transport/src/session/tests/max_prefix.rs
+++ b/crates/transport/src/session/tests/max_prefix.rs
@@ -543,10 +543,11 @@ async fn max_prefix_with_notification_gr_latches_and_sends_encapsulated_hard_res
     config.max_prefixes_ipv4 = Some(1);
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
-    let (notify_tx, mut notify_rx) = mpsc::unbounded_channel();
+    let metrics = BgpMetrics::new();
+    let (notify_tx, mut notify_rx) = crate::session_notification_channel(metrics.clone());
     let mut session = PeerSession::new_with_identity_and_lifecycle(
         config,
-        BgpMetrics::new(),
+        metrics,
         cmd_rx,
         rib_tx,
         None,

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -9,7 +9,7 @@ use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_transport::{
     PeerHandle, SessionIdentity, SessionLifecycleNotification, SessionNotification,
-    SessionNotificationDirection, TransportConfig,
+    SessionNotificationDirection, TransportConfig, session_notification_channel,
 };
 use rustbgpd_wire::{
     Afi, Capability, Message, NotificationMessage, OpenMessage, Safi, decode_message,
@@ -635,7 +635,7 @@ async fn state_changed_uses_bounded_lifecycle_channel() {
     let addr = listener.local_addr().unwrap();
     let metrics = BgpMetrics::new();
 
-    let (notify_tx, mut notify_rx) = mpsc::unbounded_channel::<SessionNotification>();
+    let (notify_tx, mut notify_rx) = session_notification_channel(metrics.clone());
     let (lifecycle_tx, mut lifecycle_rx) = mpsc::channel::<SessionLifecycleNotification>(8);
 
     let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
@@ -687,7 +687,7 @@ async fn constructor_without_lifecycle_sender_keeps_state_changes_off_lossless_l
     let addr = listener.local_addr().unwrap();
     let metrics = BgpMetrics::new();
 
-    let (notify_tx, mut notify_rx) = mpsc::unbounded_channel::<SessionNotification>();
+    let (notify_tx, mut notify_rx) = session_notification_channel(metrics.clone());
     let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
     let handle = PeerHandle::spawn_with_identity(
         transport_config(addr),
@@ -809,7 +809,7 @@ async fn open_confirm_sends_session_notification() {
     let addr = listener.local_addr().unwrap();
     let metrics = BgpMetrics::new();
 
-    let (notify_tx, mut notify_rx) = mpsc::unbounded_channel::<SessionNotification>();
+    let (notify_tx, mut notify_rx) = session_notification_channel(metrics.clone());
 
     let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
     let mut config = transport_config(addr);
@@ -885,7 +885,7 @@ async fn query_state_returns_router_id_at_open_confirm() {
     let addr = listener.local_addr().unwrap();
     let metrics = BgpMetrics::new();
 
-    let (notify_tx, mut notify_rx) = mpsc::unbounded_channel::<SessionNotification>();
+    let (notify_tx, mut notify_rx) = session_notification_channel(metrics.clone());
 
     let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
     let handle = PeerHandle::spawn(

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1463,6 +1463,8 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_kernel_route_notify_dropped_total{actor,reason="channel_full"}` | Kernel route-event wake feed dropped an event before the FIB or BLACKHOLE reconciler could consume it; periodic reconcile remains the repair backstop |
 | `bgp_kernel_route_notify_subscription_failures_total{actor,group}` | The FIB or BLACKHOLE reconciler failed to subscribe to an IPv4/IPv6 route multicast group and is running with periodic-only kernel-drift repair |
 | `bgp_netlink_subscription_overruns_total{actor}` | The kernel reported a receive-buffer overrun to the `link_carrier`, `general_fib`, or `blackhole_discard` NETLINK_ROUTE actor. Each increment is one overrun notification—not a count of lost events—and proves only that one or more multicast events may have been lost |
+| `bgp_session_notification_outstanding` | Current lossless session notifications from sender entry through successful PeerManager dequeue. This includes synchronous in-flight reservations plus queued notifications; handling occurs after the value is decremented. |
+| `bgp_session_notification_outstanding_high_watermark` | Monotonic daemon-lifetime high-water mark of that outstanding population. It resets only when the daemon restarts and is not an exact per-flap or per-round peak. |
 
 The three netlink-overrun series are materialized at zero. A non-zero value
 does not identify which multicast group lost events and does not prove that a

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -46,17 +46,20 @@ EMITTER_FILES = frozenset({TELEMETRY, SETTLEMENT})
 CUSTOM_COLLECTORS = frozenset(
     {
         (TELEMETRY, "JemallocCollector"),
+        (TELEMETRY, "SessionNotificationDepthCollector"),
         (SETTLEMENT, "RuntimeConfigSettlementCollector"),
     }
 )
 CUSTOM_COLLECTOR_PREFIXES = {
     (TELEMETRY, "JemallocCollector"): "jemalloc_",
+    (TELEMETRY, "SessionNotificationDepthCollector"): "bgp_session_notification_",
     (SETTLEMENT, "RuntimeConfigSettlementCollector"): "bgp_runtime_config_settlement_",
 }
 SPECIAL_REGISTRATIONS = {
     TELEMETRY: (
         "prometheus::process_collector::ProcessCollector::for_self()",
         "jemalloc_stats::JemallocCollector::new()",
+        "SessionNotificationDepthCollector::new(Arc::clone(&session_notification_outstanding_value),Arc::clone(&session_notification_outstanding_high_watermark_value),)",
     ),
     SETTLEMENT: (
         "RuntimeConfigSettlementCollector::new(Arc::clone(&self.registry,))",
@@ -354,6 +357,55 @@ def registered_metric_variables(
     return set(variables)
 
 
+def session_notification_depth_inventory(source: str) -> tuple[dict[str, str], set[str]]:
+    """Validate the two fresh local gauges emitted by the atomic depth collector."""
+    source = production_source(source)
+    syntax, _ = DASHBOARD_CHECK.rust_lex(source)
+    collector_impl = braced_body(
+        syntax,
+        r"\bimpl\s+Collector\s+for\s+SessionNotificationDepthCollector\s*\{",
+        "Collector impl for SessionNotificationDepthCollector",
+    )
+    collect_body = braced_body(
+        collector_impl,
+        r"\bfn\s+collect\s*\(\s*&self\s*\)\s*->\s*Vec\s*<\s*MetricFamily\s*>\s*\{",
+        "collect method for SessionNotificationDepthCollector",
+    )
+    definitions = static_metric_definitions(source)
+    emitted = {
+        variable: definition
+        for variable, definition in definitions.items()
+        if definition[0].startswith("bgp_session_notification_")
+    }
+    expected = {
+        "current_gauge": ("bgp_session_notification_outstanding", "ordinary"),
+        "high_watermark_gauge": (
+            "bgp_session_notification_outstanding_high_watermark",
+            "ordinary",
+        ),
+    }
+    if emitted != expected:
+        raise ValueError(
+            "SessionNotificationDepthCollector must construct exactly two uniquely "
+            f"named local gauges: expected {expected}, got {emitted}"
+        )
+    if collect_body.count("IntGauge::new(") != 2:
+        raise ValueError(
+            "SessionNotificationDepthCollector must construct exactly two local IntGauge encoders"
+        )
+    initial = "let mut families = current_gauge.collect();"
+    extension = "families.extend(high_watermark_gauge.collect());"
+    if collect_body.count(initial) != 1 or collect_body.count(extension) != 1:
+        raise ValueError(
+            "SessionNotificationDepthCollector must assemble each local gauge exactly once"
+        )
+    if re.search(r"\bfamilies\s*$", collect_body.strip()) is None:
+        raise ValueError(
+            "SessionNotificationDepthCollector must return its assembled families"
+        )
+    return {name: kind for name, kind in emitted.values()}, set(emitted)
+
+
 def candidate_emitter_sources(root: Path = ROOT) -> dict[str, str]:
     """Discover tracked production Rust files that can define metric families."""
     result = subprocess.run(
@@ -467,7 +519,12 @@ def workspace_metric_inventory(
         "JemallocCollector",
         CUSTOM_COLLECTOR_PREFIXES[(TELEMETRY, "JemallocCollector")],
     )
-    expected_registered = set(telemetry_definitions) - jemalloc_variables
+    session_depth, session_depth_variables = session_notification_depth_inventory(
+        sources[TELEMETRY]
+    )
+    expected_registered = (
+        set(telemetry_definitions) - jemalloc_variables - session_depth_variables
+    )
     if registered != expected_registered:
         missing = sorted(
             telemetry_definitions[variable][0]
@@ -486,6 +543,7 @@ def workspace_metric_inventory(
         for variable in registered
     }
     telemetry.update(jemalloc)
+    telemetry.update(session_depth)
 
     settlement = settlement_metric_inventory(sources[SETTLEMENT])
     overlap = sorted(set(telemetry) & set(settlement))
@@ -499,8 +557,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 193:
-        raise ValueError(f"emitted metric roster changed: expected 193, got {len(inventory)}")
+    if len(inventory) != 195:
+        raise ValueError(f"emitted metric roster changed: expected 195, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,7 +47,7 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 193)
+        self.assertEqual(len(self.inventory), 195)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
             182,
@@ -58,10 +58,10 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 94)
         self.assertEqual(len(self.rule_refs), 40)
-        self.assertEqual(len(self.public_doc_refs), 182)
-        self.assertEqual(len(self.doc_refs), 182)
+        self.assertEqual(len(self.public_doc_refs), 184)
+        self.assertEqual(len(self.doc_refs), 184)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 187)
+        self.assertEqual(len(consumers), 189)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("193 emitted families", stdout.getvalue())
-        self.assertIn("182 normative-doc families", stdout.getvalue())
-        self.assertIn("187 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("195 emitted families", stdout.getvalue())
+        self.assertIn("184 normative-doc families", stdout.getvalue())
+        self.assertIn("189 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"
@@ -212,6 +212,63 @@ fn alias_metric(registry: &Registry) {
         )
         with self.assertRaisesRegex(ValueError, "constructs MetricFamily values directly"):
             CHECK.settlement_metric_inventory(direct_proto)
+
+    def test_session_notification_depth_collector_shape_is_fail_closed(self):
+        telemetry = self.sources[CHECK.TELEMETRY]
+        emitted, variables = CHECK.session_notification_depth_inventory(telemetry)
+        self.assertEqual(
+            emitted,
+            {
+                "bgp_session_notification_outstanding": "ordinary",
+                "bgp_session_notification_outstanding_high_watermark": "ordinary",
+            },
+        )
+        self.assertEqual(variables, {"current_gauge", "high_watermark_gauge"})
+
+        duplicate_collect = telemetry.replace(
+            "families.extend(high_watermark_gauge.collect());",
+            "families.extend(current_gauge.collect());",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "assemble each local gauge exactly once"):
+            CHECK.session_notification_depth_inventory(duplicate_collect)
+
+        discarded = telemetry.replace(
+            "let mut families = current_gauge.collect();",
+            "let _ = current_gauge.collect();\n        let mut families = Vec::new();",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "assemble each local gauge exactly once"):
+            CHECK.session_notification_depth_inventory(discarded)
+
+        renamed = telemetry.replace(
+            '"bgp_session_notification_outstanding_high_watermark",',
+            '"bgp_session_notification_outstanding_peak",',
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "exactly two uniquely named local gauges"):
+            CHECK.session_notification_depth_inventory(renamed)
+
+        third = telemetry.replace(
+            "let mut families = current_gauge.collect();",
+            '''let extra_gauge = IntGauge::new(
+            "bgp_session_notification_extra", "help"
+        ).expect("valid metric definition");
+        let mut families = current_gauge.collect();''',
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "exactly two uniquely named local gauges"):
+            CHECK.session_notification_depth_inventory(third)
+
+    def test_session_notification_depth_registration_is_pinned(self):
+        sources = dict(self.sources)
+        sources[CHECK.TELEMETRY] = sources[CHECK.TELEMETRY].replace(
+            "SessionNotificationDepthCollector::new(",
+            "RenamedSessionNotificationDepthCollector::new(",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "special collector registrations changed"):
+            CHECK.workspace_metric_inventory(sources, self.lock_text)
 
     def test_process_dependency_drift_is_rejected(self):
         drifted = self.lock_text.replace(

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -16,9 +16,12 @@ use rustbgpd_fsm::PeerConfig;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
+#[cfg(test)]
+use rustbgpd_transport::SessionNotification;
 use rustbgpd_transport::{
-    PeerHandle, SessionLifecycleNotification, SessionNotification,
-    SessionNotificationEvent as TransportNotificationEvent, SessionQueryOutcome, TransportConfig,
+    PeerHandle, SessionLifecycleNotification,
+    SessionNotificationEvent as TransportNotificationEvent, SessionNotificationReceiver,
+    SessionNotificationSender, SessionQueryOutcome, TransportConfig, session_notification_channel,
 };
 use rustbgpd_wire::{Afi, Safi};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
@@ -362,8 +365,8 @@ pub struct PeerManager {
     bmp_tx: Option<mpsc::Sender<BmpEvent>>,
     /// RPKI/ASPA validation snapshot receiver, cloned to each peer session.
     validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
-    session_notify_tx: mpsc::UnboundedSender<SessionNotification>,
-    session_notify_rx: mpsc::UnboundedReceiver<SessionNotification>,
+    session_notify_tx: SessionNotificationSender,
+    session_notify_rx: SessionNotificationReceiver,
     session_lifecycle_tx: mpsc::Sender<SessionLifecycleNotification>,
     session_lifecycle_rx: mpsc::Receiver<SessionLifecycleNotification>,
     session_notification_event_tx: mpsc::Sender<TransportNotificationEvent>,
@@ -684,7 +687,7 @@ impl PeerManager {
         validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
         current_config: Config,
     ) -> Self {
-        let (session_notify_tx, session_notify_rx) = mpsc::unbounded_channel();
+        let (session_notify_tx, session_notify_rx) = session_notification_channel(metrics.clone());
         let (session_lifecycle_tx, session_lifecycle_rx) = mpsc::channel(4096);
         let (session_notification_event_tx, session_notification_event_rx) = mpsc::channel(4096);
         let (session_events_tx, _) = broadcast::channel(4096);

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -755,7 +755,7 @@ fn max_prefix_on_command_peer_handle(
     session_id: u64,
     role: rustbgpd_transport::SessionRole,
     trigger: MaxPrefixTrigger,
-    notify_tx: mpsc::UnboundedSender<SessionNotification>,
+    notify_tx: rustbgpd_transport::SessionNotificationSender,
     counters: Arc<FakePeerCounters>,
 ) -> PeerHandle {
     use rustbgpd_transport::PeerCommand;


### PR DESCRIPTION
## Summary

- wrap the intentionally unbounded lossless session-notification lane with exact outstanding accounting
- export current depth and daemon-lifetime high-water metrics without changing delivery, ordering, or deadlock constraints
- prove 700 producers and 2,100 ordered notifications drain exactly once to zero, including async receive and receiver-drop/send races
- document the metric boundary and preserve the separate real-flap receipt tranche

## Verification

- focused telemetry registration and monotonicity tests
- focused 700 x 3 FIFO/exact-once, async receive, closed-send, and receiver-drop race tests
- `cargo test --locked -p rustbgpd-transport`
- `cargo test --locked -p rustbgpd-telemetry`
- `cargo test --locked -p rustbgpd`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs LAN-1162

LAN-1162 remains open for B2: the real 700-peer, 400,400-route, three-round FLAPSTORM50 receipt.