### PR TITLE
fix: attribute BGP listener channel closure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3002,6 +3002,12 @@ enum TestBgpIngressExit {
     ForwarderPanic,
 }
 
+#[derive(Debug)]
+enum BgpForwarderOutcome {
+    AcceptChannelClosed,
+    Returned,
+}
+
 fn parse_test_bgp_ingress_exit(raw: Option<&str>) -> Result<Option<TestBgpIngressExit>, ()> {
     match raw {
         None => Ok(None),
@@ -5077,7 +5083,7 @@ async fn run<T>(
                 continue;
             }
             if test_bgp_ingress_exit == Some(TestBgpIngressExit::ForwarderReturn) {
-                return;
+                return BgpForwarderOutcome::Returned;
             }
             let result = listener_peer_mgr_tx
                 .send(PeerManagerCommand::AcceptInbound {
@@ -5097,6 +5103,7 @@ async fn run<T>(
                 );
             }
         }
+        BgpForwarderOutcome::AcceptChannelClosed
     });
     let mut bgp_listener_handle = tokio::spawn(async move {
         if initial_peer_boot_failed {
@@ -5218,6 +5225,19 @@ async fn run<T>(
                 break;
             }
             result = &mut bgp_forwarder_handle => {
+                let result = match result {
+                    Ok(BgpForwarderOutcome::AcceptChannelClosed) => {
+                        // The listener owns the sole accept sender. Its exit
+                        // closed the channel, so its JoinHandle is ready and
+                        // owns the exact failure attribution.
+                        let result = (&mut bgp_listener_handle).await;
+                        error!(?result, "BGP listener task exited unexpectedly");
+                        info!("initiating shutdown due to BGP listener task failure");
+                        component_failed = true;
+                        break;
+                    }
+                    result => result,
+                };
                 error!(?result, "BGP accept-forwarding task exited unexpectedly");
                 info!("initiating shutdown due to BGP accept-forwarding task failure");
                 component_failed = true;

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -670,6 +670,14 @@ fn bgp_ingress_tasks_are_retained_unconditionally_supervised_and_torn_down() {
             .count(),
         1
     );
+    assert_eq!(production.matches("accept_tx.clone()").count(), 0);
+    assert_eq!(
+        production
+            .matches("BgpForwarderOutcome::AcceptChannelClosed")
+            .count(),
+        2
+    );
+    assert!(production.contains("let result = (&mut bgp_listener_handle).await;"));
     let teardown = production
         .find("send(PeerManagerCommand::Shutdown)")
         .unwrap();
@@ -733,6 +741,11 @@ fn bound_bgp_listener_panic_uses_common_shutdown_and_exits_nonzero() {
         logs.contains("initiating shutdown due to BGP listener task failure"),
         "{logs}"
     );
+    assert!(
+        !logs.contains("BGP accept-forwarding task exited unexpectedly"),
+        "{logs}"
+    );
+    assert!(!logs.contains("AcceptChannelClosed"), "{logs}");
 }
 
 #[test]
@@ -749,6 +762,10 @@ fn accepted_connection_forwarder_return_uses_common_shutdown_and_exits_nonzero()
     );
     assert!(
         logs.contains("initiating shutdown due to BGP accept-forwarding task failure"),
+        "{logs}"
+    );
+    assert!(
+        !logs.contains("BGP listener task exited unexpectedly"),
         "{logs}"
     );
     assert_eq!(logs.matches("shutdown requested").count(), 1, "{logs}");
@@ -777,6 +794,10 @@ fn accepted_connection_forwarder_panic_drains_half_admitted_candidate_and_exits_
     ] {
         assert!(logs.contains(message), "missing {message:?}\n{logs}");
     }
+    assert!(
+        !logs.contains("BGP listener task exited unexpectedly"),
+        "{logs}"
+    );
     let peer_shutdown = logs.find("peer manager shutting down 1 peers").unwrap();
     let exit = logs.find("rustbgpd exiting").unwrap();
     let shutdowns = logs


### PR DESCRIPTION
## Summary\n\n- distinguish accept-channel closure from an independent forwarder return\n- attribute sole-sender channel closure through the listener JoinHandle\n- preserve direct forwarder return/panic diagnostics, exit status, and coordinated teardown\n\n## Validation\n\n- listener panic, forwarder return, and forwarder panic tests run separately\n- structural BGP ingress supervision proof\n- full grpc_failure_exit_code target: 17 passed\n- rustbgpd binary tests: 2,068 passed, 4 ignored\n- strict workspace all-target/all-feature Clippy\n- formatting, diff, commit, and push hooks\n\nFixes LAN-1289.