### PR TITLE
feat: expose per-cache RPKI readiness

### DIFF
--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -67,6 +67,7 @@ pub struct VrpManager {
     rib_tx: mpsc::Sender<RpkiTableUpdate>,
     /// Sender for ASPA table snapshots to the RIB manager.
     aspa_rib_tx: Option<mpsc::Sender<AspaTableUpdate>>,
+    readiness_observer: Option<Box<dyn Fn(SocketAddr, bool) + Send + Sync>>,
 }
 
 impl VrpManager {
@@ -84,6 +85,7 @@ impl VrpManager {
             update_rx,
             rib_tx,
             aspa_rib_tx: None,
+            readiness_observer: None,
         }
     }
 
@@ -91,6 +93,17 @@ impl VrpManager {
     #[must_use]
     pub fn with_aspa_tx(mut self, tx: mpsc::Sender<AspaTableUpdate>) -> Self {
         self.aspa_rib_tx = Some(tx);
+        self
+    }
+
+    /// Observe per-cache readiness after its retained contribution and both
+    /// merged validation tables have been updated.
+    #[must_use]
+    pub fn with_readiness_observer(
+        mut self,
+        observer: impl Fn(SocketAddr, bool) + Send + Sync + 'static,
+    ) -> Self {
+        self.readiness_observer = Some(Box::new(observer));
         self
     }
 
@@ -103,7 +116,7 @@ impl VrpManager {
     }
 
     async fn handle_update(&mut self, update: VrpUpdate) {
-        let (vrp_delta, changed_customer_asns) = match update {
+        let (server, ready, vrp_delta, changed_customer_asns) = match update {
             VrpUpdate::FullTable {
                 server,
                 entries,
@@ -128,7 +141,7 @@ impl VrpManager {
                 );
                 // A full snapshot replaces the server's whole set — there is
                 // no bounded changed-entry list, so downstream must rescan.
-                (None, None)
+                (server, true, None, None)
             }
             VrpUpdate::IncrementalUpdate {
                 server,
@@ -179,7 +192,7 @@ impl VrpManager {
                 for a in aspa_announced {
                     aspa_table.insert(a.customer_asn, a.provider_asns);
                 }
-                (Some(delta), Some(changed_customer_asns))
+                (server, true, Some(delta), Some(changed_customer_asns))
             }
             VrpUpdate::ServerDown { server } => {
                 info!(%server, "cache server down — removing entries");
@@ -188,13 +201,16 @@ impl VrpManager {
                 // ponytail: the removed set IS the exact delta, but server
                 // loss is rare and multi-cache overlap makes it usually a
                 // no-op distribution; wire it through if it ever shows up.
-                (None, None)
+                (server, false, None, None)
             }
         };
 
         self.rebuild_and_distribute_vrp(vrp_delta).await;
         self.rebuild_and_distribute_aspa(changed_customer_asns)
             .await;
+        if let Some(observer) = &self.readiness_observer {
+            observer(server, ready);
+        }
     }
 
     // Full rebuild (clone + sort of every entry) on every update, even a
@@ -279,6 +295,7 @@ impl VrpManager {
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::{Arc, Mutex};
 
     use super::*;
 
@@ -297,6 +314,46 @@ mod tests {
 
     fn server2() -> SocketAddr {
         "10.0.0.2:3323".parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn readiness_follows_completed_retained_contribution_lifecycle() {
+        let (_vrp_tx, vrp_rx) = mpsc::channel(16);
+        let (rib_tx, mut rib_rx) = mpsc::channel(16);
+        let (aspa_tx, mut aspa_rx) = mpsc::channel(16);
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&observed);
+        let mut mgr = VrpManager::new(vrp_rx, rib_tx)
+            .with_aspa_tx(aspa_tx)
+            .with_readiness_observer(move |server, ready| {
+                sink.lock().unwrap().push((server, ready));
+            });
+
+        mgr.handle_update(VrpUpdate::FullTable {
+            server: server1(),
+            entries: vec![],
+            aspa_records: vec![],
+        })
+        .await;
+        assert_eq!(*observed.lock().unwrap(), [(server1(), true)]);
+
+        mgr.handle_update(VrpUpdate::IncrementalUpdate {
+            server: server1(),
+            announced: vec![entry(Ipv4Addr::new(10, 0, 0, 0), 24, 24, 65001)],
+            withdrawn: vec![],
+            aspa_announced: vec![],
+            aspa_withdrawn: vec![],
+        })
+        .await;
+        let _ = rib_rx.try_recv();
+        let _ = aspa_rx.try_recv();
+        assert_eq!(observed.lock().unwrap().last(), Some(&(server1(), true)));
+
+        mgr.handle_update(VrpUpdate::ServerDown { server: server1() })
+            .await;
+        assert!(!mgr.server_tables.contains_key(&server1()));
+        assert!(!mgr.server_aspa_tables.contains_key(&server1()));
+        assert_eq!(observed.lock().unwrap().last(), Some(&(server1(), false)));
     }
 
     #[tokio::test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -413,6 +413,7 @@ struct BgpMetricsInner {
     // ── RPKI ───────────────────────────────────────────────────
     rpki_vrp_count: IntGaugeVec,
     rpki_cache_effective_expire_seconds: IntGaugeVec,
+    rpki_cache_end_of_data_ready: IntGaugeVec,
 
     // ── ASPA ───────────────────────────────────────────────────
     aspa_records: IntGauge,
@@ -1605,6 +1606,15 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let rpki_cache_end_of_data_ready = IntGaugeVec::new(
+            Opts::new(
+                "bgp_rpki_cache_end_of_data_ready",
+                "Whether this cache has a retained contribution from an accepted, complete, validated RTR End of Data transaction (1 ready, 0 not ready); not connectivity, merged-table availability, or policy readiness",
+            ),
+            &["cache"],
+        )
+        .expect("valid metric definition");
+
         let aspa_records = IntGauge::new(
             "bgp_aspa_records",
             "Number of ASPA customer records in the merged table",
@@ -2515,6 +2525,9 @@ impl BgpMetrics {
             .register(Box::new(rpki_cache_effective_expire_seconds.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(rpki_cache_end_of_data_ready.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(aspa_records.clone()))
             .expect("metric not already registered");
         registry
@@ -2839,6 +2852,7 @@ impl BgpMetrics {
             selection_deferral_ledger_overflows,
             rpki_vrp_count,
             rpki_cache_effective_expire_seconds,
+            rpki_cache_end_of_data_ready,
             aspa_records,
             validation_import_refreshes,
             policy_dataset_refresh_errors,
@@ -4343,6 +4357,15 @@ impl BgpMetrics {
             .rpki_cache_effective_expire_seconds
             .with_label_values(&[cache])
             .set(i64::try_from(secs).unwrap_or(i64::MAX));
+    }
+
+    /// Set whether one RPKI cache has a retained, validated End-of-Data
+    /// contribution. This is cache readiness, not connectivity.
+    pub fn set_rpki_cache_end_of_data_ready(&self, cache: &str, ready: bool) {
+        self.0
+            .rpki_cache_end_of_data_ready
+            .with_label_values(&[cache])
+            .set(i64::from(ready));
     }
 
     /// Set ASPA record count.
@@ -5980,6 +6003,19 @@ mod tests {
                 .get(),
             0
         );
+    }
+
+    #[test]
+    fn rpki_cache_end_of_data_readiness_is_registered_and_label_scoped() {
+        let m = BgpMetrics::new();
+        m.set_rpki_cache_end_of_data_ready("192.0.2.10:3323", false);
+        m.set_rpki_cache_end_of_data_ready("192.0.2.11:3323", true);
+        let text = gather_text(&m);
+        assert!(text.contains(
+            "# HELP bgp_rpki_cache_end_of_data_ready Whether this cache has a retained contribution from an accepted, complete, validated RTR End of Data transaction (1 ready, 0 not ready); not connectivity, merged-table availability, or policy readiness"
+        ));
+        assert!(text.contains("bgp_rpki_cache_end_of_data_ready{cache=\"192.0.2.10:3323\"} 0"));
+        assert!(text.contains("bgp_rpki_cache_end_of_data_ready{cache=\"192.0.2.11:3323\"} 1"));
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2285,6 +2285,11 @@ Prometheus metrics exposed at the configured metrics endpoint:
 |--------|-------------|
 | `bgp_rpki_vrp_count{af="ipv4\|ipv6"}` | Current VRP entries by address family |
 | `bgp_rpki_cache_effective_expire_seconds{cache}` | Effective expire interval per cache after the two-day maximum and `max_expire_interval` are applied |
+| `bgp_rpki_cache_end_of_data_ready{cache}` | Retained validated End-of-Data readiness per cache; includes empty tables and remains ready through reconnect until flush or expiry |
+
+`NotFound` includes startup before validated data and the state after all
+applicable retained cache contributions flush or expire. The readiness gauge
+is operational state and cannot be matched in policy.
 
 See [ADR-0034](adr/0034-rpki-origin-validation.md) for design details.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -728,6 +728,13 @@ prefer `Valid`, leaving `NotFound` as a neutral fallback.
 CLI-network-vantage check and warns on failure; use the daemon-side
 `rpki.vrp_table` check to assess whether rustbgpd has synchronized VRPs.
 
+`bgp_rpki_cache_end_of_data_ready{cache}` is `0` at startup, becomes `1` only
+after an accepted, complete, validated End of Data (including an empty table),
+and remains `1` while that cache's retained contribution stays usable through
+disconnect or resynchronization. It returns to `0` after flush or expiry. This
+is cache readiness, not connectivity, merged-table availability, policy
+matchability, or a startup gate.
+
 ### BMP collector unreachable
 
 Each BMP client reconnects independently with backoff (default
@@ -1579,6 +1586,7 @@ details stay in the structured daemon log and RPC status.
 | `bgp_rpki_vrp_count{af="ipv4"}` | IPv4 VRP entries loaded |
 | `bgp_rpki_vrp_count{af="ipv6"}` | IPv6 VRP entries loaded |
 | `bgp_rpki_cache_effective_expire_seconds{cache}` | Effective RTR expire per cache (`IP:port`): the cache-advertised expire after the RFC 8210 two-day maximum and the configured `max_expire_interval` ceiling. Set at client start and after every End of Data |
+| `bgp_rpki_cache_end_of_data_ready{cache}` | Per-cache retained End-of-Data readiness: `0` at startup and after flush/expiry; `1` after validated End of Data, including an empty table, and through reconnect/resync |
 | `bgp_aspa_records` | ASPA customer records loaded in the merged table. Renamed from `bgp_aspa_records_total` (a gauge must not carry the counter `_total` suffix) |
 | `bgp_validation_import_refreshes_total{dependency, outcome}` | Inbound Route Refresh work triggered by VRP / ASPA cache updates for peers whose import policy matches validation state. `dependency` is `rpki` or `aspa`; `outcome` is `eligible`, `refreshed`, `skipped_not_established`, or `failed`. |
 
@@ -1587,6 +1595,9 @@ cache itself has stale data. A non-zero `failed` outcome on
 `bgp_validation_import_refreshes_total` means the cache update arrived, but one
 or more validation-dependent peers could not be refreshed immediately; check the
 daemon log for the peer-specific reason.
+`NotFound` includes startup/no validated data and after all applicable retained
+cache contributions flush or expire. The readiness gauge cannot be matched in
+policy.
 
 ### EVPN VTEP alpha
 

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -315,6 +315,19 @@ groups:
             expired, or delivering no data; prefix origin validation is
             not filtering anything.
 
+      - alert: RpkiCacheEndOfDataNotReady
+        expr: bgp_rpki_cache_end_of_data_ready == 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "RPKI cache {{ $labels.cache }} has no validated End of Data"
+          description: >-
+            RPKI cache {{ $labels.cache }} on {{ $labels.instance }} has had no
+            usable retained contribution for 15 minutes. Check this cache
+            independently; other configured caches may still be ready and
+            contributing to the merged validation table.
+
       - alert: BgpEventOutboxDegraded
         # Latches to 1 on any durability-impacting drop, decode/codec
         # failure, or DB-open failure; does not auto-clear (operator

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -761,6 +761,35 @@ tests:
                 expired, or delivering no data; prefix origin validation
                 is not filtering anything.
 
+  # ── RpkiCacheEndOfDataNotReady ────────────────────────────────
+  - interval: 1m
+    input_series:
+      - series: 'bgp_rpki_cache_end_of_data_ready{cache="192.0.2.10:3323", instance="edge1:9179"}'
+        values: "0x16 1x4"
+      - series: 'bgp_rpki_cache_end_of_data_ready{cache="192.0.2.11:3323", instance="edge1:9179"}'
+        values: "1x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RpkiCacheEndOfDataNotReady
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: RpkiCacheEndOfDataNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              cache: "192.0.2.10:3323"
+              instance: "edge1:9179"
+            exp_annotations:
+              summary: "RPKI cache 192.0.2.10:3323 has no validated End of Data"
+              description: >-
+                RPKI cache 192.0.2.10:3323 on edge1:9179 has had no usable
+                retained contribution for 15 minutes. Check this cache
+                independently; other configured caches may still be ready and
+                contributing to the merged validation table.
+      - eval_time: 18m
+        alertname: RpkiCacheEndOfDataNotReady
+        exp_alerts: []
+
   # ── BgpEventOutboxDegraded ────────────────────────────────────
   - interval: 1m
     input_series:

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -557,8 +557,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 195:
-        raise ValueError(f"emitted metric roster changed: expected 195, got {len(inventory)}")
+    if len(inventory) != 196:
+        raise ValueError(f"emitted metric roster changed: expected 196, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,21 +47,21 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 195)
+        self.assertEqual(len(self.inventory), 196)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            182,
+            183,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
         )
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 94)
-        self.assertEqual(len(self.rule_refs), 40)
-        self.assertEqual(len(self.public_doc_refs), 184)
-        self.assertEqual(len(self.doc_refs), 184)
+        self.assertEqual(len(self.rule_refs), 41)
+        self.assertEqual(len(self.public_doc_refs), 185)
+        self.assertEqual(len(self.doc_refs), 185)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 189)
+        self.assertEqual(len(consumers), 190)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("195 emitted families", stdout.getvalue())
-        self.assertIn("184 normative-doc families", stdout.getvalue())
-        self.assertIn("189 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("196 emitted families", stdout.getvalue())
+        self.assertIn("185 normative-doc families", stdout.getvalue())
+        self.assertIn("190 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3797,8 +3797,12 @@ async fn run<T>(
         let (aspa_table_tx, mut aspa_table_rx) = mpsc::channel(16);
 
         // Spawn VRP + ASPA manager
+        let readiness_metrics = metrics.clone();
         let vrp_mgr = rustbgpd_rpki::VrpManager::new(vrp_update_rx, rpki_table_tx)
-            .with_aspa_tx(aspa_table_tx);
+            .with_aspa_tx(aspa_table_tx)
+            .with_readiness_observer(move |server, ready| {
+                readiness_metrics.set_rpki_cache_end_of_data_ready(&server.to_string(), ready);
+            });
         tokio::spawn(vrp_mgr.run());
 
         // Forward VRP table updates to RIB manager + validation watch
@@ -3869,6 +3873,7 @@ async fn run<T>(
             };
             let expire_metrics = metrics.clone();
             let cache_label = addr.to_string();
+            metrics.set_rpki_cache_end_of_data_ready(&cache_label, false);
             let client = rustbgpd_rpki::RtrClient::new(client_config, vrp_update_tx.clone())
                 .with_expire_observer(move |secs| {
                     expire_metrics.set_rpki_cache_effective_expire_seconds(&cache_label, secs);


### PR DESCRIPTION
## Summary

- expose per-cache readiness after an accepted, complete, validated RTR End of Data
- retain readiness through reconnect/resync and clear it only after the cache contribution is flushed
- add a per-cache alert, document the existing `NotFound` semantics, and update metric-consumer contracts

The metric is operational cache state only; it does not change the RPKI verdict model, policy behavior, startup, APIs, or enforcement.

## Validation

- focused RPKI manager and telemetry tests
- full `rustbgpd-rpki` package (163 tests)
- full `rustbgpd-telemetry` package (108 tests)
- rustbgpd binary tests (2,068 passed; 4 ignored)
- metric consumer checker and 30 unit tests
- strict workspace Clippy
- alert YAML parsing
- formatting and diff checks

Fixes LAN-1242.