### PR TITLE
fix(wire): reject empty BIER attributes

### DIFF
--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -345,6 +345,38 @@ async fn malformed_bfd_discriminator_discards_attribute_and_keeps_route() {
     assert_single_malformed_disposition(&session, "attribute_discard");
 }
 
+#[tokio::test]
+async fn empty_bier_attribute_is_discarded_and_keeps_route_and_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 41), 32);
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[0xc0, 41, 0]),
+            &[prefix],
+        ))
+        .await;
+
+    let RibUpdate::RoutesReceived { announced, .. } =
+        rib_rx.try_recv().expect("attribute-discard announcement")
+    else {
+        panic!("expected retained route");
+    };
+    assert_eq!(announced.len(), 1);
+    assert_eq!(announced[0].prefix, Prefix::V4(prefix));
+    assert!(
+        announced[0]
+            .attributes
+            .iter()
+            .all(|attribute| attribute.type_code() != 41)
+    );
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "attribute_discard");
+}
+
 /// RFC 6793 / RFC 7606: a malformed `AS4_PATH` is discarded without losing
 /// reachable NLRI or the valid ordinary path on a legacy session.
 ///

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,10 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- **BIER minimum cardinality:** Zero-length BIER attributes are now rejected
+  and receive RFC 7606 attribute-discard handling. Non-empty unknown TLVs and
+  supported framing remain opaque and continue to propagate unchanged.
+
 - **Additive borrowed-attribute builder:** Added
   `UpdateMessage::try_build_from_attribute_iter`, which consumes one
   single-pass iterator of borrowed path attributes in yielded order and

--- a/crates/wire/src/assigned_attributes.rs
+++ b/crates/wire/src/assigned_attributes.rs
@@ -130,6 +130,9 @@ fn prefix_sid(mut value: &[u8]) -> Result<(), &'static str> {
 }
 
 fn bier(mut value: &[u8]) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("BIER attribute contains no TLVs");
+    }
     while !value.is_empty() {
         let (kind, body, rest) = tlv_u16_u16(value)?;
         if kind == 1 && body.len() >= 4 {

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -108,7 +108,7 @@ fn assigned_payload_contract(code: u8) -> &'static str {
             "exact one-octet-type/two-octet-length TLVs; Label-Index length 7; Originator SRGB length `2 + nonzero*6`"
         }
         41 => {
-            "zero or more exact two-octet-type/length TLVs; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque"
+            "non-empty exact two-octet-type/length TLV stream; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque"
         }
         42 => "no payload validation; exact registered class is dropped before value decoding",
         _ => panic!("no assigned framing contract for code {code}"),
@@ -698,12 +698,32 @@ fn assigned_rows_36_through_42_enforce_class_framing_and_disposition() {
     let mut expected = input;
     expected[0] |= 0x20;
     assert_eq!(emitted, expected);
-    let empty =
-        decode_path_attributes_revised(&attribute(0xc0, 41, &[]), true, false, &[]).unwrap();
-    assert!(empty.malformed.is_empty());
-    assert!(
-        matches!(empty.attributes.as_slice(), [PathAttribute::Unknown(raw)] if raw.data.is_empty())
+    let empty = attribute(0xc0, 41, &[]);
+    assert!(matches!(
+        decode_path_attributes(&empty, true, &[]),
+        Err(DecodeError::UpdateAttributeError { subcode, .. })
+            if subcode == update_subcode::ATTRIBUTE_LENGTH_ERROR
+    ));
+    let empty = decode_path_attributes_revised(&empty, true, false, &[]).unwrap();
+    assert!(empty.attributes.is_empty());
+    assert_eq!(empty.malformed.len(), 1);
+    assert_eq!(
+        empty.malformed[0].disposition,
+        ErrorDisposition::AttributeDiscard
     );
+
+    let unknown_value = [0, 99, 0, 0];
+    let unknown_input = attribute(0xc0, 41, &unknown_value);
+    let unknown = decode_path_attributes_revised(&unknown_input, true, false, &[]).unwrap();
+    assert!(unknown.malformed.is_empty());
+    assert!(
+        matches!(unknown.attributes.as_slice(), [PathAttribute::Unknown(raw)] if raw.data.as_ref() == unknown_value)
+    );
+    let mut emitted = Vec::new();
+    encode_path_attributes(&unknown.attributes, &mut emitted, true, false).unwrap();
+    let mut expected = unknown_input;
+    expected[0] |= 0x20;
+    assert_eq!(emitted, expected);
 }
 
 #[test]

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -132,7 +132,7 @@ stateful lookup, policy, or attribute semantics. Unknown TLVs remain opaque.
 | 38 | optional transitive; flags `0xc0` | five-octet base, exact one-octet-type/length optional TLVs, and a Source IP TLV of length 4 or 16 | attribute-discard |
 | 39 | optional transitive; flags `0xc0` | AFI/SAFI/next-hop-length boundary followed by one or more exact two-octet-type/two-octet-length characteristic TLVs | attribute-discard |
 | 40 | optional transitive; flags `0xc0` | exact one-octet-type/two-octet-length TLVs; Label-Index length 7; Originator SRGB length `2 + nonzero*6` | attribute-discard |
-| 41 | optional transitive; flags `0xc0` | zero or more exact two-octet-type/length TLVs; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque | attribute-discard |
+| 41 | optional transitive; flags `0xc0` | non-empty exact two-octet-type/length TLV stream; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque | attribute-discard |
 | 42 | optional non-transitive; flags `0x80` | no payload validation; exact registered class is dropped before value decoding | class conflict is treat-as-withdraw |
 <!-- assigned-framing:end -->
 


### PR DESCRIPTION
## Summary

- reject a zero-length BIER path attribute because RFC 9793 requires one or more BIER TLVs
- apply strict `ATTRIBUTE_LENGTH_ERROR` and revised RFC 7606 attribute-discard behavior
- retain the route/session while removing malformed BIER, and preserve nonempty unknown BIER TLVs opaquely

The other assigned-attribute structural validators were checked against their authoritative sources and need no change.

## Validation

- exact strict/revised wire registry tests
- exact live RFC 7606 transport test
- full path-attribute registry suite (10/10)
- full wire package
- full transport package (513 passed; 3 ignored) plus integration suites
- strict wire/transport Clippy
- full push hooks
- formatting and diff checks

Fixes LAN-1290.