### PR TITLE
bench: simplify rrtransport receipt evidence

### DIFF
--- a/bench/scale/rrtransport/README.md
+++ b/bench/scale/rrtransport/README.md
@@ -64,15 +64,17 @@ transport-session encoder. Its schema-2 receipt separates the one-dispatch
 transition records its native shared plan, exact probes, route-shell
 materialization, and zero authoritative per-peer fallback. Concrete transport
 snapshots plus common group-token and announce-vector identities prove the
-shared envelope path. The full-shape leg runs once and its immutable receipt is
+shared envelope path. The full-shape leg runs once and its result is
 copied into each attempt.
 
 Each measured target records direct-PID `VmRSS`/`VmHWM` and jemalloc allocated,
 active, resident, and mapped bytes at established, staged, and wire
 checkpoints. The runner's process-tree target sampler remains separately named
-and reported. Receipts also retain per-peer evidence, logs, source/binary
-provenance, verifier output, and checksums. Results are not comparable to the
-historical unavailable scratch harness and must not be published as an A/B.
+and reported. Receipts also retain per-peer evidence, logs, the exact source
+commit, workload and host conditions. A `COMPLETED` file containing `pass` is
+written only after all three attempts pass the semantic verifier. Results are
+not comparable to the historical unavailable scratch harness and must not be
+published as an A/B.
 
 CI never runs the scale shape. It runs the original smoke, a 4×100 real-TCP
 fixture through the same scale collector/verifier/RSS seams, and destructive

--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -6,21 +6,6 @@ verifier="$root/bench/scale/rrtransport/verify_receipt.py"
 manifest="$root/bench/scale/rrtransport/Cargo.toml"
 binary="$root/bench/scale/target/release/rrtransport"
 rss_limit_kib=$((2 * 1024 * 1024))
-sources=(
-  bench/scale/rrtransport/src/main.rs
-  bench/scale/rrtransport/src/rr1000.rs
-  bench/scale/rrtransport/src/rr1000_support.rs
-  bench/scale/rrtransport/Cargo.toml
-  bench/scale/Cargo.toml
-  bench/scale/Cargo.lock
-  bench/scale/rrtransport/run-receipt.sh
-  bench/scale/rrtransport/verify_receipt.py
-)
-
-source_snapshot() {
-  (cd "$root" && sha256sum "${sources[@]}")
-}
-
 classify_rss() {
   local rss=$1 output=$2
   mkdir -p "$output"
@@ -613,35 +598,30 @@ stop_reap_fixture() {
 }
 
 check_seam() {
-  local script=$1 outer verify_call verify_body checksums_call checksums_body
+  local script=$1 outer verify_call completion
   local direct_rss_call direct_rss_exit direct_rss_resolver
   outer="timeout -k 10 1200 \"\$scr"
   outer+="ipt\" --campaign-inner \"\$output\""
   verify_call="full_ver"
   verify_call+="ify \"\$receipt\""
-  verify_body="python3 \"\$ver"
-  verify_body+="ifier\" \"\$receipt\" --full | tee \"\$receipt/verifier.txt\""
-  checksums_call="full_check"
-  checksums_call+="sums \"\$receipt\""
-  checksums_body="sha256sum -c SHA"
-  checksums_body+="256SUMS --strict"
+  completion="printf 'pass\\n' >\"\$output/COMPLETED\""
   direct_rss_call="sample_direct_rss \"\$pid\" \"\$tiny_validated_starttime\" \"\$receipt\""
   direct_rss_exit="[[ \$direct_rss_action != exited ]] || break"
   direct_rss_resolver='resolve_direct_'
   direct_rss_resolver+="rss \"\$process\" \"\$expected_start\""
   if ! grep -Fq "$outer" "$script" || ! grep -Fq "$verify_call" "$script" ||
-    ! grep -Fq "$verify_body" "$script" || ! grep -Fq "$checksums_call" "$script" ||
-    ! grep -Fq "$checksums_body" "$script" || ! grep -Fq "$direct_rss_call" "$script" ||
+    ! grep -Fq "$completion" "$script" ||
+    ! grep -Fq "$direct_rss_call" "$script" ||
     ! grep -Fq "$direct_rss_exit" "$script" ||
     ! grep -Fq "$direct_rss_resolver" "$script"; then
-    echo "runner lacks production verifier/checksum/RSS seam" >&2
+    echo "runner lacks production verifier/completion/RSS seam" >&2
     return 1
   fi
 }
 
 full_verify() {
   local receipt=$1
-  python3 "$verifier" "$receipt" --full | tee "$receipt/verifier.txt"
+  python3 "$verifier" "$receipt" --full
 }
 
 run_grouped_commit_fixture() {
@@ -650,13 +630,6 @@ run_grouped_commit_fixture() {
     cargo test --manifest-path "$manifest" --locked \
       rr1000::tests::grouped_commit_receipt_fixture -- --exact
   [[ -s $1/grouped-commit.json ]]
-}
-
-full_checksums() {
-  local receipt=$1
-  (cd "$receipt" && sha256sum phase.json grouped-commit.json per-peer.tsv rss.json rss.tsv \
-    provenance.json source.snapshot rrtransport.bin verifier.txt harness.log >SHA256SUMS &&
-    sha256sum -c SHA256SUMS --strict)
 }
 
 host_state() {
@@ -781,17 +754,6 @@ case ${1:-} in
     startup_gate_fixture "$2" "$3"
     exit
     ;;
-  --verify-fixture)
-    [[ $# == 3 ]] || exit 2
-    rm -rf "$3"
-    cp -a "$2" "$3"
-    receipt=$3
-    python3 "$verifier" "$receipt" | tee "$receipt/verifier.txt"
-    (cd "$receipt" && sha256sum phase.json grouped-commit.json per-peer.tsv rss.json rss.tsv \
-      provenance.json source.snapshot rrtransport.bin verifier.txt >SHA256SUMS &&
-      sha256sum -c SHA256SUMS --strict)
-    exit
-    ;;
   --real-smoke)
     [[ $# == 2 ]] || exit 2
     cargo build --manifest-path "$manifest" --locked
@@ -826,17 +788,12 @@ case ${1:-} in
     fi
     pid=
     rm -f "$tiny_ready" "$tiny_go"
-    cp "$tiny_binary" "$receipt/rrtransport.bin"
-    source_snapshot >"$receipt/source.snapshot"
     cp "$receipt/phase.json" "$receipt/phase.saved"
     python3 "$verifier" "$receipt" --write-rss "$max_rss"
-    head=$(git -C "$root" rev-parse HEAD); tree=$(git -C "$root" write-tree)
-    source_hash=$(sha256sum "$receipt/source.snapshot"|cut -d' ' -f1)
-    binary_hash=$(sha256sum "$receipt/rrtransport.bin"|cut -d' ' -f1)
-    printf '{"head_before":"%s","head_after":"%s","tree_before":"%s","tree_after":"%s","source_sha256":"%s","source_after_sha256":"%s","binary_sha256":"%s","governors":["performance"],"load_before":"fixture","load_after":"fixture","pswpin_before":0,"pswpin_after":0,"pswpout_before":0,"pswpout_after":0,"rustc":"fixture","host":"fixture","competitors":[]}\n' \
-      "$head" "$head" "$tree" "$tree" "$source_hash" "$source_hash" "$binary_hash" >"$receipt/provenance.json"
-    : >"$receipt/verifier.txt"
-    python3 "$verifier" "$receipt" --tiny | tee "$receipt/verifier.txt"
+    head=$(git -C "$root" rev-parse HEAD)
+    printf '{"commit":"%s","governors":["performance"],"load_before":"fixture","load_after":"fixture","pswpin_before":0,"pswpin_after":0,"pswpout_before":0,"pswpout_after":0,"rustc":"fixture","host":"fixture","competitors":[]}\n' \
+      "$head" >"$receipt/provenance.json"
+    python3 "$verifier" "$receipt" --tiny
     exit
     ;;
   --campaign-inner)
@@ -863,8 +820,7 @@ available=$(awk '/MemAvailable:/ {print $2}' /proc/meminfo)
 (( available >= 16 * 1024 * 1024 )) || { echo "need 16 GiB available" >&2; exit 1; }
 [[ -z $(git -C "$root" status --porcelain) ]] || { echo "tree must be clean" >&2; exit 1; }
 
-head_before=$(git -C "$root" rev-parse HEAD); tree_before=$(git -C "$root" write-tree)
-source_before=$(source_snapshot)
+head_before=$(git -C "$root" rev-parse HEAD)
 timeout -k 10 300 cargo build --manifest-path "$manifest" --locked --release
 mkdir -p "$output"; campaign_started=$SECONDS
 run_grouped_commit_fixture "$output" 1000 100000
@@ -880,7 +836,6 @@ for run in 1 2 3; do
   host_state before
   require_quiet before || { echo "host not quiet before attempt" >&2; exit 1; }
   receipt="$output/run-$run"; mkdir -p "$receipt"
-  printf '%s\n' "$source_before" >"$receipt/source.snapshot"; cp "$binary" "$receipt/rrtransport.bin"
   cp "$output/grouped-commit.json" "$receipt/grouped-commit.json"
   printf 'observer\trss_kib\n' >"$receipt/rss.tsv"
   launch_supervised "$receipt/harness.log" timeout -k 10 300 "$binary" rr1000 "$receipt"
@@ -888,19 +843,14 @@ for run in 1 2 3; do
   sampler_observation_reader=read_live_sampler_observation
   sample_supervisor "$binary" "$receipt" "$run" || exit 1
   python3 "$verifier" "$receipt" --write-rss "$max_rss"
-  head_after=$(git -C "$root" rev-parse HEAD); tree_after=$(git -C "$root" write-tree)
-  source_after=$(source_snapshot)
+  head_after=$(git -C "$root" rev-parse HEAD)
   [[ -z $(git -C "$root" status --porcelain) ]] || { echo "tree dirtied during run" >&2; exit 1; }
-  source_hash=$(sha256sum "$receipt/source.snapshot"|cut -d' ' -f1)
-  source_after_hash=$(printf '%s\n' "$source_after"|sha256sum|cut -d' ' -f1)
-  binary_hash=$(sha256sum "$receipt/rrtransport.bin"|cut -d' ' -f1)
+  [[ $head_before == "$head_after" ]] || { echo "HEAD changed during run" >&2; exit 1; }
   host_state after
   require_quiet after || { echo "host not quiet after attempt" >&2; exit 1; }
   [[ $before_pswpin == "$after_pswpin" && $before_pswpout == "$after_pswpout" ]] || { echo "swap I/O changed" >&2; exit 1; }
-  printf '{"head_before":"%s","head_after":"%s","tree_before":"%s","tree_after":"%s","source_sha256":"%s","source_after_sha256":"%s","binary_sha256":"%s","governors":["performance"],"load_before":"%s","load_after":"%s","pswpin_before":%s,"pswpin_after":%s,"pswpout_before":%s,"pswpout_after":%s,"rustc":"%s","host":"%s","competitors":[]}\n' \
-    "$head_before" "$head_after" "$tree_before" "$tree_after" "$source_hash" "$source_after_hash" "$binary_hash" "$before_load" "$after_load" "$before_pswpin" "$after_pswpin" "$before_pswpout" "$after_pswpout" "$(rustc -V)" "$(uname -srvmo)" >"$receipt/provenance.json"
-  [[ $source_before == "$source_after" ]] || { echo "declared sources changed" >&2; exit 1; }
-  : >"$receipt/verifier.txt"
+  printf '{"commit":"%s","governors":["performance"],"load_before":"%s","load_after":"%s","pswpin_before":%s,"pswpin_after":%s,"pswpout_before":%s,"pswpout_after":%s,"rustc":"%s","host":"%s","competitors":[]}\n' \
+    "$head_before" "$before_load" "$after_load" "$before_pswpin" "$after_pswpin" "$before_pswpout" "$after_pswpout" "$(rustc -V)" "$(uname -srvmo)" >"$receipt/provenance.json"
   full_verify "$receipt"
-  full_checksums "$receipt"
 done
+printf 'pass\n' >"$output/COMPLETED"

--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -5,6 +5,7 @@ import csv
 import hashlib
 import json
 import pathlib
+import re
 import sys
 
 PEERS = 1000
@@ -65,27 +66,17 @@ def verify(directory, tiny=False):
         "rss.tsv",
         "rss.json",
         "provenance.json",
-        "verifier.txt",
     }
     missing = sorted(name for name in required if not (directory / name).is_file())
     if missing:
         fail(f"missing evidence: {', '.join(missing)}")
 
     phase = load(directory / "phase.json")
-    expected_phase = {
-        "schema": 2,
-        "shape": shape,
-        "shape_digest": shape_digest,
-        "sessions": peers,
-        "established_before": peers,
-        "established_after": peers,
-        "prefixes": prefixes,
-        "sources": SOURCES,
-        "workers": WORKERS,
-        "groups": 1,
-        "initial_eors": peers,
-        "wire_completion": "first_exact_bitmap",
-    }
+    expected_phase = dict(schema=2, shape=shape, shape_digest=shape_digest,
+                          sessions=peers, established_before=peers,
+                          established_after=peers, prefixes=prefixes,
+                          sources=SOURCES, workers=WORKERS, groups=1,
+                          initial_eors=peers, wire_completion="first_exact_bitmap")
     for key, expected in expected_phase.items():
         if phase.get(key) != expected:
             fail(f"phase {key}: expected {expected!r}, got {phase.get(key)!r}")
@@ -101,40 +92,24 @@ def verify(directory, tiny=False):
         "timing": "test_profile_untimed_rpol_community_transition",
         "fixture_peers": peers,
         "fixture_prefixes": prefixes,
-        "seed": {
-            "routes_received_dispatches": 1,
-            "routes_received_withdrawals": 0,
-            "envelopes": peers,
-            "routes_per_envelope": prefixes,
-            "shared_group_encode": False,
-            "community": "65000:100",
-        },
+        "seed": {"routes_received_dispatches": 1,
+                 "routes_received_withdrawals": 0, "envelopes": peers,
+                 "routes_per_envelope": prefixes, "shared_group_encode": False,
+                 "community": "65000:100"},
         "transition": {
-            "fast_path": True,
-            "routes_received_dispatches": 0,
-            "routes_received_withdrawals": 0,
-            "probe_accounting": "policy_transition_receipt",
-            "plan_builds": 1,
-            "full_exact_probes": prefixes,
-            "route_shell_materializations": prefixes,
-            "authoritative_peer_applies": 0,
-            "envelopes": peers,
-            "routes_per_envelope": prefixes,
-            "shared_encode_proof": "collected",
-            "snapshot_classification": "concrete_transport_session",
-            "snapshot_owner_nonzero": True,
-            "snapshot_generation": 0,
-            "snapshot_max_message_len": 4096,
-            "snapshot_add_path": False,
+            "fast_path": True, "routes_received_dispatches": 0,
+            "routes_received_withdrawals": 0, "probe_accounting": "policy_transition_receipt",
+            "plan_builds": 1, "full_exact_probes": prefixes,
+            "route_shell_materializations": prefixes, "authoritative_peer_applies": 0,
+            "envelopes": peers, "routes_per_envelope": prefixes,
+            "shared_encode_proof": "collected", "snapshot_owner_nonzero": True,
+            "snapshot_classification": "concrete_transport_session", "snapshot_generation": 0,
+            "snapshot_max_message_len": 4096, "snapshot_add_path": False,
             "shared_group_encode_classification": "one_arc_all_members",
             "shared_announce_classification": "one_arc_all_members",
-            "shared_route_count": prefixes,
-            "community": "65000:200",
-            "update_groups": 1,
-            "grouped_peers": peers,
-            "ungrouped_peers": 0,
-            "dirty_peers": 0,
-            "grouped_unicast_routes": prefixes,
+            "shared_route_count": prefixes, "community": "65000:200",
+            "update_groups": 1, "grouped_peers": peers, "ungrouped_peers": 0,
+            "dirty_peers": 0, "grouped_unicast_routes": prefixes,
             "private_unicast_routes": 0,
         },
     }
@@ -237,8 +212,7 @@ def verify(directory, tiny=False):
         fail("direct-PID RSS TSV checkpoints disagree")
 
     provenance = load(directory / "provenance.json")
-    for key in ("head_before", "head_after", "tree_before", "tree_after", "source_sha256",
-                "source_after_sha256", "binary_sha256", "governors", "load_before", "load_after"):
+    for key in ("commit", "governors", "load_before", "load_after"):
         if not provenance.get(key):
             fail(f"provenance {key} is missing")
     for key in ("pswpin_before", "pswpin_after", "pswpout_before", "pswpout_after"):
@@ -246,23 +220,15 @@ def verify(directory, tiny=False):
             fail(f"provenance {key} is missing")
     if not provenance.get("rustc") or not provenance.get("host") or provenance.get("competitors") != []:
         fail("toolchain, host, or empty competitor provenance is missing")
-    if provenance["head_before"] != provenance["head_after"]:
-        fail("HEAD changed during run")
-    if provenance["tree_before"] != provenance["tree_after"]:
-        fail("tree changed during run")
-    if provenance["source_sha256"] != provenance["source_after_sha256"]:
-        fail("declared source set changed during run")
+    if not isinstance(provenance["commit"], str) or not re.fullmatch(
+        r"[0-9a-f]{40}", provenance["commit"]
+    ):
+        fail("provenance commit is not an exact lowercase commit SHA")
     if provenance["governors"] != ["performance"]:
         fail("not all CPU governors were performance")
     if (provenance["pswpin_before"], provenance["pswpout_before"]) != (
             provenance["pswpin_after"], provenance["pswpout_after"]):
         fail("kernel swap I/O changed during run")
-    source = directory / "source.snapshot"
-    binary = directory / "rrtransport.bin"
-    if hashlib.sha256(source.read_bytes()).hexdigest() != provenance["source_sha256"]:
-        fail("source hash mismatch")
-    if hashlib.sha256(binary.read_bytes()).hexdigest() != provenance["binary_sha256"]:
-        fail("binary hash mismatch")
 
 
 if __name__ == "__main__":

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -50,52 +50,36 @@ fixture="$tmp/fixture"
 mkdir -p "$fixture"
 
 python3 - "$fixture" <<'PY'
-import hashlib, json, pathlib, sys
+import json, pathlib, sys
 d = pathlib.Path(sys.argv[1])
 shape = "rr1000-v1:peers=1000;prefixes=100000;sources=4;workers=12;afi=ipv4-unicast;role=ibgp-rr"
 def point(rss, hwm, allocated, active, resident, mapped):
- return {"direct_pid_vmrss_kib":rss,"direct_pid_vmhwm_kib":hwm,
-  "jemalloc_allocated_bytes":allocated,"jemalloc_active_bytes":active,
-  "jemalloc_resident_bytes":resident,"jemalloc_mapped_bytes":mapped}
+ return dict(direct_pid_vmrss_kib=rss,direct_pid_vmhwm_kib=hwm,jemalloc_allocated_bytes=allocated,
+  jemalloc_active_bytes=active,jemalloc_resident_bytes=resident,jemalloc_mapped_bytes=mapped)
 checkpoints={"established":point(100,105,1000,1100,1200,1300),
  "staged":point(110,115,2000,2100,2200,2300),
  "wire":point(120,125,3000,3100,3200,3300)}
-(d/"phase.json").write_text(json.dumps({"schema":2,"shape":shape,"shape_digest":"109e38772e3bd819",
- "wire_completion":"first_exact_bitmap","sessions":1000,"established_before":1000,"established_after":1000,"prefixes":100000,"sources":4,"workers":12,"groups":1,"initial_eors":1000,
- "injection_ms":1,"staged_ms":2,"wire_ms":3,"resource_observer_schema":1,
- "resource_observer":checkpoints})+"\n")
+(d/"phase.json").write_text(json.dumps({"schema":2,"shape":shape,"shape_digest":"109e38772e3bd819","wire_completion":"first_exact_bitmap","sessions":1000,"established_before":1000,"established_after":1000,"prefixes":100000,"sources":4,"workers":12,"groups":1,"initial_eors":1000,"injection_ms":1,"staged_ms":2,"wire_ms":3,"resource_observer_schema":1,"resource_observer":checkpoints})+"\n")
 (d/"grouped-commit.json").write_text(json.dumps({"schema":2,
  "timing":"test_profile_untimed_rpol_community_transition",
  "fixture_peers":1000,"fixture_prefixes":100000,
- "seed":{"routes_received_dispatches":1,"routes_received_withdrawals":0,
-  "envelopes":1000,"routes_per_envelope":100000,"shared_group_encode":False,
-  "community":"65000:100"},
+ "seed":{"routes_received_dispatches":1,"routes_received_withdrawals":0,"envelopes":1000,"routes_per_envelope":100000,"shared_group_encode":False,"community":"65000:100"},
  "transition":{"fast_path":True,"routes_received_dispatches":0,
   "routes_received_withdrawals":0,"probe_accounting":"policy_transition_receipt",
   "plan_builds":1,"full_exact_probes":100000,"route_shell_materializations":100000,
-  "authoritative_peer_applies":0,"envelopes":1000,"routes_per_envelope":100000,
-  "shared_encode_proof":"collected","snapshot_classification":"concrete_transport_session",
+  "authoritative_peer_applies":0,"envelopes":1000,"routes_per_envelope":100000,"shared_encode_proof":"collected","snapshot_classification":"concrete_transport_session",
   "snapshot_owner_nonzero":True,"snapshot_generation":0,"snapshot_max_message_len":4096,
   "snapshot_add_path":False,"shared_group_encode_classification":"one_arc_all_members",
   "shared_announce_classification":"one_arc_all_members","shared_route_count":100000,
-  "community":"65000:200","update_groups":1,"grouped_peers":1000,
-  "ungrouped_peers":0,"dirty_peers":0,"grouped_unicast_routes":100000,
-  "private_unicast_routes":0}})+"\n")
+  "community":"65000:200","update_groups":1,"grouped_peers":1000,"ungrouped_peers":0,"dirty_peers":0,"grouped_unicast_routes":100000,"private_unicast_routes":0}})+"\n")
 header="peer\tstaged\tnlri\tmessages\twithdrawals\tduplicates\toutside\tdecode_failures\tcoverage\tbitmap_digest\tinitial_eor\twire_ms\n"
 rows=[f"127.{2+i//254}.{1+i%254}.1\t100000\t100000\t391\t0\t0\t0\t0\t100000\t7c50a897bc4a4e51\ttrue\t3\n" for i in range(1000)]
 (d/"per-peer.tsv").write_text(header+"".join(rows))
 (d/"rss.tsv").write_text("observer\trss_kib\nprocess_tree_target_rss_sample\t90\nprocess_tree_target_rss_sample\t125\ndirect_pid_established_vmrss\t100\ndirect_pid_staged_vmrss\t110\ndirect_pid_wire_vmrss\t120\n")
-(d/"rss.json").write_text(json.dumps({"schema":2,"checkpoints":checkpoints,
- "process_tree_sampler_max_rss_kib":125})+"\n")
-(d/"source.snapshot").write_bytes(b"source")
-(d/"rrtransport.bin").write_bytes(b"binary")
-h=lambda p: hashlib.sha256((d/p).read_bytes()).hexdigest()
-(d/"provenance.json").write_text(json.dumps({"head_before":"a","head_after":"a","tree_before":"b",
- "tree_after":"b","source_sha256":h("source.snapshot"),"source_after_sha256":h("source.snapshot"),
- "binary_sha256":h("rrtransport.bin"),"governors":["performance"],"load_before":"0.1",
+(d/"rss.json").write_text(json.dumps({"schema":2,"checkpoints":checkpoints,"process_tree_sampler_max_rss_kib":125})+"\n")
+(d/"provenance.json").write_text(json.dumps({"commit":"a"*40,"governors":["performance"],"load_before":"0.1",
  "load_after":"0.1","pswpin_before":0,"pswpin_after":0,"pswpout_before":0,"pswpout_after":0,"rustc":"rustc fixture",
  "host":"fixture","competitors":[]})+"\n")
-(d/"verifier.txt").write_text("fixture\n")
 PY
 
 expect_red() {
@@ -110,7 +94,8 @@ expect_red() {
   fi
 }
 
-"$runner" --verify-fixture "$fixture" "$tmp/accepted"
+cp -a "$fixture" "$tmp/accepted"
+python3 "$verifier" "$tmp/accepted"
 expect_red missing-internal-receipt mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])/"grouped-commit.json").unlink()'
 for field in routes_received_dispatches routes_received_withdrawals envelopes \
   routes_per_envelope; do
@@ -141,12 +126,6 @@ expect_red allocator-phase-mismatch mutate -c 'import json,pathlib,sys;p=pathlib
 expect_red allocator-nonnumeric mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["wire"]["jemalloc_resident_bytes"]="invalid";p.write_text(json.dumps(d))'
 expect_red allocator-zero mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["established"]["jemalloc_mapped_bytes"]=0;p.write_text(json.dumps(d))'
 expect_red allocator-relation mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["staged"]["jemalloc_allocated_bytes"]=2200;p.write_text(json.dumps(d))'
-cp -a "$tmp/accepted" "$tmp/stale-checksum"
-printf '\n' >>"$tmp/stale-checksum/grouped-commit.json"
-if (cd "$tmp/stale-checksum" && sha256sum -c SHA256SUMS --strict >/dev/null 2>&1); then
-  echo "false green: stale checksum" >&2
-  exit 1
-fi
 expect_red staged-count mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";r=p.read_text().splitlines();h=r[0].split("\t").index("staged");x=r[1].split("\t");x[h]="99999";r[1]="\t".join(x);p.write_text("\n".join(r)+"\n")'
 expect_red nlri-count mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";r=p.read_text().splitlines();h=r[0].split("\t").index("nlri");x=r[1].split("\t");x[h]="99999";r[1]="\t".join(x);p.write_text("\n".join(r)+"\n")'
 expect_red corrupt-prefix mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";s=p.read_text();p.write_text(s.replace("7c50a897bc4a4e51","0000000000000000",1))'
@@ -192,8 +171,7 @@ if ! grep -Fxq "FAIL: phase resource observer is missing or invalid" \
 fi
 if "$runner" --classify-rss 2097153 "$tmp/rss-over"; then echo "false green: rss ceiling" >&2; exit 1; fi
 grep -q '"root_failure":"rss_ceiling"' "$tmp/rss-over/failure.json"
-expect_red changed-head mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());d["head_after"]="changed";p.write_text(json.dumps(d))'
-expect_red changed-hash mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])/"source.snapshot").write_bytes(b"changed")'
+expect_red malformed-commit mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());d["commit"]="main";p.write_text(json.dumps(d))'
 "$runner" --check-seam "$runner"
 [[ $("$runner" --classify-child-exe /expected /expected R) == sample ]]
 [[ $("$runner" --classify-child-exe /expected /foreign R) == reject ]]
@@ -398,9 +376,7 @@ fi
 for seam in \
   "timeout -k 10 1200 \"\$script\" --campaign-inner \"\$output\"" \
   "full_verify \"\$receipt\"" \
-  "python3 \"\$verifier\" \"\$receipt\" --full | tee \"\$receipt/verifier.txt\"" \
-  "full_checksums \"\$receipt\"" \
-  "sha256sum -c SHA256SUMS --strict" \
+  "printf 'pass\\n' >\"\$output/COMPLETED\"" \
   "sample_direct_rss \"\$pid\" \"\$tiny_validated_starttime\" \"\$receipt\"" \
   "resolve_direct_rss \"\$process\" \"\$expected_start\"" \
   "[[ \$direct_rss_action != exited ]] || break"; do

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -241,3 +241,9 @@ Write the detailed source document first (interop procedure in
 [`INTEROP.md`](INTEROP.md), soak postmortem as `docs/soaks/soak-*.md` with artifacts
 under `docs/artifacts/soak/<run-id>/`, perf receipt under `docs/perf/`), then
 add the row here and in [`OPERATIONAL_PROOF.md`](OPERATIONAL_PROOF.md).
+
+Keep the evidence proportional to the claim: retain the raw CSV or log, exact
+source commit, workload and environment, and an explicit sentence bounding
+what the result proves. Runtime acceptance checks should validate the measured
+behavior directly; binary copies, source snapshots, checksum rosters, and
+self-referential verification files are not part of the receipt convention.


### PR DESCRIPTION
## Summary

- remove rrtransport source/binary snapshots, checksum rosters, verifier-output artifacts, and seal-only mutations
- retain the semantic classifier, exact workload and commit, host/resource gates, process supervision, three-attempt campaign, and completion fence
- document proportional receipt evidence without introducing a shared framework

Net change: 101 lines deleted across the five rrtransport receipt files.

## Validation

- rrtransport destructive receipt tests
- rrtransport real smoke
- rrtransport package tests (7/7)
- strict Clippy and formatting
- Bash syntax and ShellCheck
- commit hooks

Refs LAN-1293.