### PR TITLE
fix(wire): fence path attributes 24 and 25

### DIFF
--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -218,6 +218,7 @@ async fn assigned_opaque_attributes_reach_rib_while_edge_metadata_is_absent() {
     rfc7606_drain(&mut rib_rx);
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 42), 32);
     let values = [
+        (25_u8, (0_u8..20).collect::<Vec<_>>()),
         (36_u8, vec![1, 0, 0, 0, 0, 0, 0, 0]),
         (37, vec![2, 0, 4, 1, 99, 0, 0]),
         (38, vec![1, 0, 0, 0, 1, 1, 4, 192, 0, 2, 1]),
@@ -229,6 +230,7 @@ async fn assigned_opaque_attributes_reach_rib_while_edge_metadata_is_absent() {
         extra.extend([0xc0, *code, u8::try_from(value.len()).unwrap()]);
         extra.extend(value);
     }
+    extra.extend([0x80, 24, 1, 0xbb]);
     extra.extend([0x80, 42, 1, 0xaa]);
     session
         .process_update(rfc7606_update(rfc7606_attr_bytes(&extra), &[prefix]))
@@ -247,6 +249,12 @@ async fn assigned_opaque_attributes_reach_rib_while_edge_metadata_is_absent() {
             "assigned type {code} did not reach the RIB"
         );
     }
+    assert!(
+        announced[0]
+            .attributes
+            .iter()
+            .all(|attribute| attribute.type_code() != 24)
+    );
     assert!(
         announced[0]
             .attributes
@@ -282,6 +290,73 @@ async fn assigned_opaque_attributes_reach_rib_while_edge_metadata_is_absent() {
             .all(|attribute| attribute.type_code() != 42)
     );
     assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+#[tokio::test]
+async fn traffic_engineering_transitive_conflict_withdraws_route_and_keeps_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 24), 32);
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&[]), &[prefix]))
+        .await;
+    let _ = rib_rx.try_recv().expect("initial route");
+
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[0xc0, 24, 1, 0xaa]),
+            &[prefix],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx.try_recv().expect("treat-as-withdraw update")
+    else {
+        panic!("expected route withdrawal");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![(Prefix::V4(prefix), 0)]);
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
+}
+
+#[tokio::test]
+async fn malformed_ipv6_specific_community_withdraws_route_and_keeps_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 25), 32);
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&[]), &[prefix]))
+        .await;
+    let _ = rib_rx.try_recv().expect("initial route");
+
+    let mut malformed = vec![0xc0, 25, 19];
+    malformed.extend([0xaa; 19]);
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&malformed), &[prefix]))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx.try_recv().expect("treat-as-withdraw update")
+    else {
+        panic!("expected route withdrawal");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![(Prefix::V4(prefix), 0)]);
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
 }
 
 #[tokio::test]

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,14 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- **Traffic Engineering and IPv6-specific community fences:** Registered path
+  attributes 24 and 25 now enforce their Optional/Transitive classes. Traffic
+  Engineering remains payload-opaque and is ignored as optional
+  non-transitive; the IPv6 Address Specific Extended Community remains opaque
+  and propagates with Partial, but its payload must be a non-empty multiple of
+  20 octets. Flag and length conflicts receive RFC 7606 treat-as-withdraw
+  handling without resetting the session.
+
 - **BIER minimum cardinality:** Zero-length BIER attributes are now rejected
   and receive RFC 7606 attribute-discard handling. Non-empty unknown TLVs and
   supported framing remain opaque and continue to propagate unchanged.

--- a/crates/wire/src/assigned_attributes.rs
+++ b/crates/wire/src/assigned_attributes.rs
@@ -4,6 +4,9 @@ use crate::constants::attr_type;
 
 pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> {
     match type_code {
+        attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY => {
+            ipv6_address_specific_extended_community(value)
+        }
         attr_type::DOMAIN_PATH => domain_path(value),
         attr_type::SFP => sfp(value),
         attr_type::BFD_DISCRIMINATOR => bfd_discriminator(value),
@@ -12,6 +15,15 @@ pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> 
         attr_type::BIER => bier(value),
         _ => Ok(()),
     }
+}
+
+fn ipv6_address_specific_extended_community(value: &[u8]) -> Result<(), &'static str> {
+    if value.is_empty() || !value.len().is_multiple_of(20) {
+        return Err(
+            "IPv6 Address Specific Extended Community length is not a non-zero multiple of 20",
+        );
+    }
+    Ok(())
 }
 
 fn domain_path(mut value: &[u8]) -> Result<(), &'static str> {

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1278,10 +1278,12 @@ fn is_assigned_unsupported_optional_non_transitive(type_code: u8) -> bool {
 /// prevents registry recognition from becoming a typed-codec support claim.
 fn assigned_unsupported_flags(type_code: u8) -> Option<u8> {
     match type_code {
-        attr_type::AIGP | attr_type::BGPSEC_PATH | attr_type::EDGE_METADATA => {
-            Some(attr_flags::OPTIONAL)
-        }
+        attr_type::TRAFFIC_ENGINEERING
+        | attr_type::AIGP
+        | attr_type::BGPSEC_PATH
+        | attr_type::EDGE_METADATA => Some(attr_flags::OPTIONAL),
         attr_type::TUNNEL_ENCAPSULATION
+        | attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY
         | attr_type::PE_DISTINGUISHER_LABELS
         | attr_type::DOMAIN_PATH
         | attr_type::SFP
@@ -1646,7 +1648,8 @@ fn decode_attribute_value(
     }
     if matches!(
         type_code,
-        attr_type::DOMAIN_PATH
+        attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY
+            | attr_type::DOMAIN_PATH
             | attr_type::SFP
             | attr_type::BFD_DISCRIMINATOR
             | attr_type::NHC
@@ -1954,15 +1957,16 @@ fn decode_attribute_value(
         }
         // Correctly-classed assigned optional non-transitive attributes whose
         // payload semantics are unsupported are ignored, never retained.
-        attr_type::AIGP | attr_type::BGPSEC_PATH | attr_type::EDGE_METADATA => {
-            Err(DecodeError::UpdateAttributeError {
-                subcode: update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
-                data: attr_error_data(flags, type_code, value),
-                detail: format!(
-                    "assigned optional non-transitive attribute type {type_code} reached value decoding"
-                ),
-            })
-        }
+        attr_type::TRAFFIC_ENGINEERING
+        | attr_type::AIGP
+        | attr_type::BGPSEC_PATH
+        | attr_type::EDGE_METADATA => Err(DecodeError::UpdateAttributeError {
+            subcode: update_subcode::OPTIONAL_ATTRIBUTE_ERROR,
+            data: attr_error_data(flags, type_code, value),
+            detail: format!(
+                "assigned optional non-transitive attribute type {type_code} reached value decoding"
+            ),
+        }),
         // Any unknown type -> RawAttribute. AS4_PATH and AS4_AGGREGATOR are
         // kept raw only until the shared post-decode RFC 6793 normalizer
         // consumes them.

--- a/crates/wire/src/constants.rs
+++ b/crates/wire/src/constants.rs
@@ -161,6 +161,10 @@ pub mod attr_type {
     pub const PMSI_TUNNEL: u8 = 22;
     /// RFC 9012: Tunnel Encapsulation attribute.
     pub const TUNNEL_ENCAPSULATION: u8 = 23;
+    /// RFC 5543: Traffic Engineering attribute.
+    pub const TRAFFIC_ENGINEERING: u8 = 24;
+    /// RFC 5701: IPv6 Address Specific Extended Community attribute.
+    pub const IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY: u8 = 25;
     /// RFC 7311: Accumulated IGP Metric attribute.
     pub const AIGP: u8 = 26;
     /// RFC 6514: PE Distinguisher Labels attribute.

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -63,6 +63,7 @@ fn extended_attribute(flags: u8, code: u8, value: &[u8]) -> Vec<u8> {
 
 fn assigned_value(code: u8) -> Vec<u8> {
     match code {
+        25 => (0_u8..20).collect(),
         36 => vec![1, 0, 0, 0, 0, 0, 0, 0],
         37 => vec![2, 0, 4, 1, 99, 0, 0],
         38 => vec![1, 0, 0, 0, 1, 1, 4, 192, 0, 2, 1],
@@ -398,6 +399,16 @@ fn assigned_unsupported_class_matrix_is_fail_closed_without_semantic_support() {
             transitive_conflict: ErrorDisposition::TreatAsWithdraw,
         },
         Case {
+            code: 24,
+            canonical: 0x80,
+            transitive_conflict: ErrorDisposition::TreatAsWithdraw,
+        },
+        Case {
+            code: 25,
+            canonical: 0xc0,
+            transitive_conflict: ErrorDisposition::TreatAsWithdraw,
+        },
+        Case {
             code: 26,
             canonical: 0x80,
             transitive_conflict: ErrorDisposition::AttributeDiscard,
@@ -492,7 +503,7 @@ fn assigned_unsupported_class_matrix_is_fail_closed_without_semantic_support() {
 
 #[test]
 fn assigned_unsupported_opaque_flags_and_neighboring_fences_stay_orthogonal() {
-    for code in [23, 27, 40, 128] {
+    for code in [23, 25, 27, 40, 128] {
         let value = assigned_value(code);
         for flags in [0xe0, 0xf0] {
             let input = if flags == 0xf0 {
@@ -530,6 +541,68 @@ fn assigned_unsupported_opaque_flags_and_neighboring_fences_stay_orthogonal() {
         wrong_pmsi.malformed[0].disposition,
         ErrorDisposition::TreatAsWithdraw
     );
+
+    let traffic_engineering = rustbgpd_wire::RawAttribute {
+        flags: 0x80,
+        type_code: 24,
+        data: bytes::Bytes::from_static(&[0xaa]),
+    };
+    let mut defensive = Vec::new();
+    encode_path_attributes(
+        &[PathAttribute::Unknown(traffic_engineering)],
+        &mut defensive,
+        true,
+        false,
+    )
+    .unwrap();
+    assert!(
+        defensive.is_empty(),
+        "assigned optional non-transitive type 24 must never egress"
+    );
+}
+
+#[test]
+fn ipv6_specific_extended_community_enforces_length_and_opaque_propagation() {
+    for length in [20_usize, 40] {
+        let value: Vec<u8> = (0..length)
+            .map(|octet| u8::try_from(octet).unwrap())
+            .collect();
+        for (flags, extended) in [(0xc0, false), (0xe0, false), (0xc0, true), (0xe0, true)] {
+            let input = if extended {
+                extended_attribute(flags, 25, &value)
+            } else {
+                attribute(flags, 25, &value)
+            };
+            let strict = decode_path_attributes(&input, true, &[]).unwrap();
+            let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+            assert!(revised.malformed.is_empty());
+            let [PathAttribute::Unknown(raw)] = strict.as_slice() else {
+                panic!("type 25 must remain opaque");
+            };
+            assert_eq!(raw.data.as_ref(), value);
+            let mut emitted = Vec::new();
+            encode_path_attributes(&revised.attributes, &mut emitted, true, false).unwrap();
+            let mut expected = input;
+            expected[0] |= 0x20;
+            assert_eq!(emitted, expected);
+        }
+    }
+
+    for length in [0_usize, 19, 21, 39] {
+        let input = attribute(0xc0, 25, &vec![0; length]);
+        assert!(matches!(
+            decode_path_attributes(&input, true, &[]),
+            Err(DecodeError::UpdateAttributeError { subcode, .. })
+                if subcode == update_subcode::ATTRIBUTE_LENGTH_ERROR
+        ));
+        let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+        assert!(revised.attributes.is_empty());
+        assert_eq!(revised.malformed.len(), 1);
+        assert_eq!(
+            revised.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+    }
 }
 
 #[test]
@@ -584,7 +657,7 @@ fn assigned_rows_36_through_42_enforce_class_framing_and_disposition() {
         }
     }
 
-    for code in [26_u8, 33, 42] {
+    for code in [24_u8, 26, 33, 42] {
         let partial = attribute(0xa0, code, &assigned_value(code));
         assert!(matches!(
             decode_path_attributes(&partial, true, &[]),

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -52,8 +52,8 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 21 | AS_PATHLIMIT (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 22 | PMSI_TUNNEL | optional transitive; flags `0xc0`; RFC 6514 §5 / RFC 7385 | typed canonical + Partial round-trip; Extended Length and reserved low bits canonicalize; malformed tunnel type or identifier is treat-as-withdraw | typed-Partial and PMSI tunnel-type matrices |
 | 23 | Tunnel Encapsulation | optional transitive; flags `0xc0`; RFC 9012 | payload semantics unsupported; correct class retained opaque and emitted with Partial; wrong class is treat-as-withdraw | assigned-class matrix below |
-| 24 | Traffic Engineering | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 25 | IPv6 Address Specific Extended Community | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 24 | Traffic Engineering | optional non-transitive; flags `0x80`; RFC 5543 §3 / RFC 7606 §7.13 | payload semantics unsupported; correct class ignored and never emitted; class or Partial conflict is treat-as-withdraw | assigned-class matrix below |
+| 25 | IPv6 Address Specific Extended Community | optional transitive; flags `0xc0`; values are non-empty multiples of 20 octets; RFC 5701 §2 / RFC 7606 §7.15 | opaque retention with Partial on egress; zero or non-multiple-of-20 length and class conflicts are treat-as-withdraw | assigned-class and IPv6-community length matrices below |
 | 26 | AIGP | optional non-transitive; flags `0x80`; RFC 7311 §3 | payload semantics unsupported; correct class ignored; Transitive-set conflicts are attribute-discard, other class conflicts are treat-as-withdraw | assigned-class matrix below |
 | 27 | PE Distinguisher Labels | optional transitive; flags `0xc0`; RFC 6514 | payload semantics unsupported; correct class retained opaque and emitted with Partial; wrong class is treat-as-withdraw | assigned-class matrix below |
 | 28 | BGP Entropy Label Capability Attribute (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
@@ -114,10 +114,20 @@ negotiation. "Wrong O" toggles Optional, "wrong T" toggles Transitive, and
 
 | Codes | Class | Correct-class retention and egress | Wrong O | Wrong T | Both wrong | Legacy decoder |
 |---|---|---|---|---|---|---|
-| 23, 27, 36-41, 128 | optional transitive (`0xc0`) | opaque retention; Partial set on egress; input Partial and Extended Length preserved | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+| 23, 25, 27, 36-41, 128 | optional transitive (`0xc0`) | opaque retention; Partial set on egress; input Partial and Extended Length preserved | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 | 26 | optional non-transitive (`0x80`) | ignored; no retention or egress | treat-as-withdraw | attribute-discard | attribute-discard | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
-| 33 | optional non-transitive (`0x80`) | ignored; no retention or egress | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
-| 42 | optional non-transitive (`0x80`) | ignored; no retention or egress; Partial rejected | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+| 24, 33, 42 | optional non-transitive (`0x80`) | ignored; no retention or egress; Partial rejected | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+
+## IPv6 Address Specific Extended Community length matrix
+
+The type-25 payload remains opaque: only the RFC 5701/RFC 7606 cardinality
+boundary is enforced, and unrecognized community types or sub-types are not
+errors.
+
+| Payload length | Result |
+|---|---|
+| 20, 40, ... | retained opaquely and propagated with Partial |
+| 0 or any non-multiple of 20 | Attribute Length Error; revised treat-as-withdraw |
 
 ## Assigned framing matrix (36-42)
 


### PR DESCRIPTION
## Summary

- recognize Traffic Engineering (type 24) as optional non-transitive, ignore correct input, and reject propagation/class conflicts
- recognize IPv6 Address Specific Extended Community (type 25) as optional transitive, retain it opaquely, and enforce its non-zero 20-octet cardinality
- apply exact strict and revised RFC 7606 dispositions with live replacement-withdraw/session-retention proofs

The two numeric type constants are intentional additive public API. No typed
payload models, version bump, or other registry rows are included.

## Validation

- focused type 24/25 wire and transport tests
- full wire package and registry/property/contract suites
- full transport package and integrations
- strict workspace all-target/all-feature Clippy
- formatting, diff, tracker guard, and commit hooks

Refs LAN-1236.
