### PR TITLE
fix: make guardrail checks bidirectional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Outbound route commits now make mismatched announcement and next-hop
+  override inventories unrepresentable, catching the internal invariant at
+  construction instead of silently truncating the longer inventory. (LAN-1280)
+
 - Assigned BGP attributes 36-42 now use their registered propagation classes;
   D-PATH, SFP, BFD Discriminator, NHC, Prefix-SID, and BIER receive bounded
   structural framing checks before opaque propagation, while Edge Metadata is
@@ -28,7 +32,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Use `Route.local_pref_attr` when attribute presence matters;
   `Route.local_pref` is the effective value and defaults to 100 when the
-  attribute is absent.
+  attribute is absent (previously it was 0).
 - Migrate removed `RibService.WatchRoutes` and `RibService.WatchRouteEvents`
   consumers to `EventService.WatchEvents` for live deltas or
   `EventService.SubscribeFromEvent` for durable replay. Update route-stream

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -127,16 +127,12 @@ pub(in crate::manager) struct SharedUnicastPrecommit<'a> {
 /// the send-ladder methods; this value only keeps the family inventories
 /// together as they move through that ladder.
 ///
-/// `announce` and `next_hop_override` are parallel slices: they must have the
-/// same length, and each override applies to the announcement at the same
-/// index. Callers using `..OutboundCommitBatch::default()` must populate both
-/// fields together when adding unicast announcements.
+/// Unicast announcements and next-hop overrides can only be populated through
+/// [`OutboundCommitBatch::with_unicast`], which enforces their parallel-slice
+/// invariant before a commit batch can be represented.
 #[derive(Default)]
 pub(in crate::manager) struct OutboundCommitBatch {
-    /// Next-hop actions indexed exactly like `announce`.
-    pub(in crate::manager) next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
-    /// Unicast announcements indexed exactly like `next_hop_override`.
-    pub(in crate::manager) announce: Arc<[crate::route::Route]>,
+    pub(in crate::manager) unicast: AlignedUnicastPayload,
     pub(in crate::manager) withdraw: Vec<(Prefix, u32)>,
     pub(in crate::manager) end_of_rib: Vec<(Afi, Safi)>,
     pub(in crate::manager) refresh_markers: Vec<(Afi, Safi, RouteRefreshSubtype)>,
@@ -152,6 +148,36 @@ pub(in crate::manager) struct OutboundCommitBatch {
     pub(in crate::manager) labeled_withdraw: Vec<crate::route::LabeledRibRouteKey>,
     pub(in crate::manager) rtc_announce: Vec<crate::route::RtcRibRoute>,
     pub(in crate::manager) rtc_withdraw: Vec<crate::route::RtcRibRouteKey>,
+}
+
+/// Structurally aligned unicast payload for one outbound commit.
+#[derive(Default)]
+pub(in crate::manager) struct AlignedUnicastPayload {
+    /// Unicast announcements indexed exactly like `next_hop_override`.
+    announce: Arc<[crate::route::Route]>,
+    /// Next-hop actions indexed exactly like `announce`.
+    next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
+}
+
+impl OutboundCommitBatch {
+    #[track_caller]
+    pub(in crate::manager) fn with_unicast(
+        announce: Arc<[crate::route::Route]>,
+        next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
+    ) -> Self {
+        assert_eq!(
+            announce.len(),
+            next_hop_override.len(),
+            "outbound unicast announcements and next-hop overrides must stay aligned"
+        );
+        Self {
+            unicast: AlignedUnicastPayload {
+                announce,
+                next_hop_override,
+            },
+            ..Self::default()
+        }
+    }
 }
 
 struct SharedUnicastProbeCacheEntry {
@@ -2081,8 +2107,11 @@ impl RibManager {
         otc_reconcile_prefixes: Option<&HashSet<Prefix>>,
     ) -> bool {
         let OutboundCommitBatch {
-            mut next_hop_override,
-            mut announce,
+            unicast:
+                AlignedUnicastPayload {
+                    mut announce,
+                    mut next_hop_override,
+                },
             mut withdraw,
             end_of_rib,
             refresh_markers,
@@ -2221,7 +2250,6 @@ impl RibManager {
                 "single-best group staging must reject OTC before its shared table commit; \
                  per-client-best groups defer to this backstop by design"
             );
-            debug_assert_eq!(announce.len(), next_hop_override.len());
             let mut permitted = Vec::with_capacity(announce.len());
             let mut permitted_next_hops = Vec::with_capacity(next_hop_override.len());
             // Preserve the caller's withdrawal order while making duplicate
@@ -2320,7 +2348,6 @@ impl RibManager {
 
             #[cfg(feature = "bench-internals")]
             let bench_exact_started = bench_per_client_best_resync.then(std::time::Instant::now);
-            debug_assert_eq!(announce.len(), next_hop_override.len());
             let family_lengths = [
                 announce.len(),
                 flowspec_announce.len(),
@@ -5638,8 +5665,6 @@ impl RibManager {
                 if self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
                     peer,
                     OutboundCommitBatch {
-                        next_hop_override: nh_override_flags,
-                        announce,
                         withdraw: unicast.withdraw,
                         end_of_rib: pending_eor.clone(),
                         flowspec_announce: fs_announce,
@@ -5654,7 +5679,7 @@ impl RibManager {
                         labeled_withdraw,
                         rtc_announce,
                         rtc_withdraw,
-                        ..OutboundCommitBatch::default()
+                        ..OutboundCommitBatch::with_unicast(announce, nh_override_flags)
                     },
                     group_prior,
                     shared_unicast_cache_group.map(|group_id| SharedUnicastPrecommit {

--- a/crates/rib/src/manager/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/outbound_prefix_limits.rs
@@ -449,7 +449,6 @@ impl RibManager {
             .flat_map(|family| family.verdict.blocked.iter().copied())
             .collect();
         if !blocked.is_empty() {
-            debug_assert_eq!(announce.len(), next_hop_override.len());
             let (kept_routes, kept_next_hops): (Vec<_>, Vec<_>) = announce
                 .iter()
                 .zip(next_hop_override.iter())

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1760,8 +1760,6 @@ impl RibManager {
             || self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
                 peer,
                 OutboundCommitBatch {
-                    next_hop_override: unicast.next_hop_override.into(),
-                    announce: unicast.announce.into(),
                     withdraw: unicast.withdraw,
                     flowspec_announce: fs_announce,
                     flowspec_withdraw: fs_withdraw,
@@ -1775,7 +1773,10 @@ impl RibManager {
                     labeled_withdraw,
                     rtc_announce,
                     rtc_withdraw,
-                    ..OutboundCommitBatch::default()
+                    ..OutboundCommitBatch::with_unicast(
+                        unicast.announce.into(),
+                        unicast.next_hop_override.into(),
+                    )
                 },
                 HashSet::new(),
                 None,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -1283,8 +1283,6 @@ impl RibManager {
         if !self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
             peer,
             OutboundCommitBatch {
-                next_hop_override: unicast.next_hop_override.into(),
-                announce: unicast.announce.into(),
                 withdraw: unicast.withdraw,
                 end_of_rib,
                 refresh_markers,
@@ -1300,6 +1298,10 @@ impl RibManager {
                 labeled_withdraw,
                 rtc_announce,
                 rtc_withdraw,
+                ..OutboundCommitBatch::with_unicast(
+                    unicast.announce.into(),
+                    unicast.next_hop_override.into(),
+                )
             },
             group_prior,
             None,

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -1099,10 +1099,8 @@ fn commit_family_gauge_fixture(
     assert!(manager.try_send_and_commit_outbound_update(
         peer,
         OutboundCommitBatch {
-            next_hop_override,
-            announce: announce.into(),
             vpn_announce,
-            ..OutboundCommitBatch::default()
+            ..OutboundCommitBatch::with_unicast(announce.into(), next_hop_override)
         },
     ));
     let gathered = metrics.registry().gather();

--- a/crates/rib/src/manager/tests/exportability.rs
+++ b/crates/rib/src/manager/tests/exportability.rs
@@ -344,8 +344,6 @@ fn commit_batch(manager: &mut RibManager, peer: IpAddr, batch: ExactBatch) -> bo
     manager.try_send_and_commit_outbound_update(
         peer,
         OutboundCommitBatch {
-            next_hop_override,
-            announce: batch.announce.into(),
             withdraw: batch.withdraw,
             flowspec_announce: batch.flowspec_announce,
             flowspec_withdraw: batch.flowspec_withdraw,
@@ -359,7 +357,7 @@ fn commit_batch(manager: &mut RibManager, peer: IpAddr, batch: ExactBatch) -> bo
             labeled_withdraw: batch.labeled_withdraw,
             rtc_announce: batch.rtc_announce,
             rtc_withdraw: batch.rtc_withdraw,
-            ..OutboundCommitBatch::default()
+            ..OutboundCommitBatch::with_unicast(batch.announce.into(), next_hop_override)
         },
     )
 }
@@ -394,11 +392,7 @@ fn commit_shared_unicast_with_precommit(
 ) -> bool {
     manager.try_send_and_commit_outbound_update_with_group_prior(
         peer,
-        OutboundCommitBatch {
-            next_hop_override,
-            announce,
-            ..OutboundCommitBatch::default()
-        },
+        OutboundCommitBatch::with_unicast(announce, next_hop_override),
         group_prior,
         Some(crate::manager::distribution::SharedUnicastPrecommit {
             group_id: 7,
@@ -763,6 +757,38 @@ fn route_bearing_commit_without_encoder_fails_closed() {
         }
     ));
     assert!(!manager.adj_ribs_out.contains_key(&peer));
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn mismatched_unicast_payload_is_unrepresentable_and_nonretryable() {
+    let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 34));
+    let route = make_route(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 0, 34, 0), 24),
+        Ipv4Addr::new(198, 51, 100, 34),
+    );
+    let encoder = MockExactExportEncoder::accepting(34);
+    let mut manager = test_manager();
+    let mut rx = register_exact_target(&mut manager, peer, encoder.clone());
+
+    let announcements_longer = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        manager.try_send_and_commit_outbound_update(
+            peer,
+            OutboundCommitBatch::with_unicast(vec![route].into(), Arc::from([])),
+        )
+    }));
+    assert!(announcements_longer.is_err());
+
+    let overrides_longer = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        manager.try_send_and_commit_outbound_update(
+            peer,
+            OutboundCommitBatch::with_unicast(Arc::from([]), vec![None].into()),
+        )
+    }));
+    assert!(overrides_longer.is_err());
+    assert!(encoder.probed().is_empty());
+    assert!(!manager.adj_ribs_out.contains_key(&peer));
+    assert!(!manager.dirty_peers.contains(&peer));
     assert!(rx.try_recv().is_err());
 }
 

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -727,11 +727,10 @@ fn deferred_selection_rejects_route_commit_until_release() {
     let commit = |manager: &mut RibManager| {
         manager.try_send_and_commit_outbound_update(
             target,
-            OutboundCommitBatch {
-                next_hop_override: vec![None].into(),
-                announce: vec![make_route_with_lp(prefix, Ipv4Addr::new(10, 0, 0, 2), 100)].into(),
-                ..OutboundCommitBatch::default()
-            },
+            OutboundCommitBatch::with_unicast(
+                vec![make_route_with_lp(prefix, Ipv4Addr::new(10, 0, 0, 2), 100)].into(),
+                vec![None].into(),
+            ),
         )
     };
     assert!(

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -5364,11 +5364,7 @@ fn single_best_group_otc_at_backstop_trips_debug_assert() {
     let nh: Arc<[Option<NextHopAction>]> = vec![None].into();
     let _ = m.try_send_and_commit_outbound_update(
         MEMBER,
-        OutboundCommitBatch {
-            next_hop_override: nh,
-            announce,
-            ..OutboundCommitBatch::default()
-        },
+        OutboundCommitBatch::with_unicast(announce, nh),
     );
 }
 
@@ -5398,11 +5394,7 @@ fn per_client_best_group_otc_at_backstop_strips_with_pending_gated_withdraw() {
     let nh: Arc<[Option<NextHopAction>]> = vec![None].into();
     assert!(m.try_send_and_commit_outbound_update(
         MEMBER,
-        OutboundCommitBatch {
-            next_hop_override: nh,
-            announce,
-            ..OutboundCommitBatch::default()
-        },
+        OutboundCommitBatch::with_unicast(announce, nh),
     ));
     let update = outbound_rx.try_recv().unwrap();
     assert!(

--- a/crates/wire/tests/readme_contract.rs
+++ b/crates/wire/tests/readme_contract.rs
@@ -1,3 +1,6 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
 use syn::{
     Attribute, FnArg, GenericArgument, GenericParam, Item, Meta, PathArguments, ReturnType, Type,
     UseTree, Visibility,
@@ -23,12 +26,17 @@ fn expected_dependency_block(version: &str) -> String {
     format!("```toml\n[dependencies]\nrustbgpd-wire = \"{version}\"\nbytes = \"1\"\n```")
 }
 
-fn has_documented_error_roster(exhaustiveness: &str) -> bool {
-    compact_whitespace(exhaustiveness).contains(
-        "The five public error enums are also non-exhaustive: `DecodeError`, `EncodeError`, \
-         `RouteDistinguisherParseError`, `ShutdownCommunicationError`, and `BgpCodecError` \
-         (available with the `tokio-codec` feature).",
-    )
+fn documented_public_error_roster(exhaustiveness: &str) -> BTreeSet<String> {
+    exhaustiveness
+        .split("\n\n")
+        .find(|paragraph| paragraph.contains("public error enums"))
+        .expect("README must name its public error enum roster")
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .filter(|name| name.ends_with("Error"))
+        .map(str::to_owned)
+        .collect()
 }
 
 fn is_public(visibility: &Visibility) -> bool {
@@ -281,17 +289,52 @@ fn lib_has_exact_codec_gate(source: &str) -> bool {
     bindings == 1 && canonical_binding
 }
 
-fn source_enum_is_public_and_non_exhaustive(source: &str, name: &str) -> bool {
+fn public_error_enums_in_source(source: &str) -> BTreeMap<String, bool> {
     syn::parse_file(source)
-        .expect("error source must remain valid Rust")
+        .expect("wire source must remain valid Rust")
         .items
         .iter()
-        .any(|item| {
-            matches!(item, Item::Enum(item)
-            if is_public(&item.vis)
-                && item.ident == name
-                && item.attrs.iter().any(|attribute| attribute.path().is_ident("non_exhaustive")))
+        .filter_map(|item| match item {
+            Item::Enum(item)
+                if is_public(&item.vis) && item.ident.to_string().ends_with("Error") =>
+            {
+                Some((
+                    item.ident.to_string(),
+                    item.attrs
+                        .iter()
+                        .any(|attribute| attribute.path().is_ident("non_exhaustive")),
+                ))
+            }
+            _ => None,
         })
+        .collect()
+}
+
+fn collect_public_error_enums(dir: &Path, roster: &mut BTreeMap<String, bool>) {
+    for entry in std::fs::read_dir(dir).expect("read wire source directory") {
+        let entry = entry.expect("read wire source entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_public_error_enums(&path, roster);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            let source = std::fs::read_to_string(&path).expect("read wire Rust source");
+            for (name, non_exhaustive) in public_error_enums_in_source(&source) {
+                assert!(
+                    roster.insert(name.clone(), non_exhaustive).is_none(),
+                    "duplicate public error enum name {name}"
+                );
+            }
+        }
+    }
+}
+
+fn source_public_error_roster() -> BTreeMap<String, bool> {
+    let mut roster = BTreeMap::new();
+    collect_public_error_enums(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src").as_path(),
+        &mut roster,
+    );
+    roster
 }
 
 #[test]
@@ -306,25 +349,20 @@ fn usage_matches_the_published_wire_contract() {
 }
 
 #[test]
-fn enum_guidance_matches_the_five_known_public_errors() {
+fn enum_guidance_matches_the_complete_public_error_roster() {
     let exhaustiveness = section(README, "## Enum exhaustiveness");
-    assert!(has_documented_error_roster(exhaustiveness));
     assert!(exhaustiveness.contains("must include\na wildcard arm"));
     assert!(exhaustiveness.contains("_ => {}"));
-    for (source, name) in [
-        (include_str!("../src/error.rs"), "DecodeError"),
-        (include_str!("../src/error.rs"), "EncodeError"),
-        (
-            include_str!("../src/evpn.rs"),
-            "RouteDistinguisherParseError",
-        ),
-        (
-            include_str!("../src/notification.rs"),
-            "ShutdownCommunicationError",
-        ),
-        (include_str!("../src/tokio_codec.rs"), "BgpCodecError"),
-    ] {
-        assert!(source_enum_is_public_and_non_exhaustive(source, name));
+    let source_roster = source_public_error_roster();
+    assert_eq!(
+        documented_public_error_roster(exhaustiveness),
+        source_roster.keys().cloned().collect()
+    );
+    for (name, non_exhaustive) in source_roster {
+        assert!(
+            non_exhaustive,
+            "public error enum {name} must remain non-exhaustive"
+        );
     }
     assert!(lib_has_exact_codec_gate(LIB_SOURCE));
 }
@@ -347,4 +385,11 @@ fn helpers_reject_contract_mutations() {
         pub use tokio_codec::BgpCodecError;
     "#;
     assert!(!lib_has_exact_codec_gate(extra_codec_cfg));
+    assert_eq!(
+        public_error_enums_in_source("pub enum SixthError { Broken }")
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["SixthError".to_owned()])
+    );
 }

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -440,8 +440,8 @@ To be the de facto Rust BGP codec, the concrete gaps:
    drives the FSM, and prints every received UPDATE. This is the "it works"
    receipt for consumers #1 and #3. The `event-bridge` example already proves the
    gRPC-client shape; this proves the library-embedding shape.
-2. **Add a `tokio_util::codec::Decoder/Encoder` impl.** Implemented for the
-   next wire release: the default-off `tokio-codec` feature exports typed
+2. **Add a `tokio_util::codec::Decoder/Encoder` impl.** Done: the default-off
+   `tokio-codec` feature exports typed
    `BgpCodec` / `BgpCodecError` framing with independent inbound and outbound
    ceilings. It adds Tokio-util's codec support graph without enabling Tokio's
    runtime, network, or I/O-util features; socket/runtime ownership remains

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -722,7 +722,8 @@ changed.
    compared the crate against its latest crates.io release on the PR, so a
    bump it reported as required is not optional.
 3. Update `version` in `crates/wire/Cargo.toml`
-4. Add a `rustbgpd-wire` entry in `CHANGELOG.md`
+4. Roll `crates/wire/CHANGELOG.md` and add a `rustbgpd-wire` entry in the
+   repository-level `CHANGELOG.md`
 5. `cargo publish -p rustbgpd-wire --dry-run`
 6. `cargo publish -p rustbgpd-wire`
 7. Verify the version is visible in the registry, update the declared current
@@ -755,7 +756,8 @@ do not force an FSM release for every daemon tag.
    The `semver-checks` workflow applies the same crates.io comparison to this
    crate on the PR.
 3. Update `version` in `crates/fsm/Cargo.toml`
-4. Add a `rustbgpd-fsm` entry in `CHANGELOG.md`
+4. Roll `crates/fsm/CHANGELOG.md` and add a `rustbgpd-fsm` entry in the
+   repository-level `CHANGELOG.md`
 5. `cargo publish -p rustbgpd-fsm --dry-run`
 6. `cargo publish -p rustbgpd-fsm`
 7. Verify the version is visible in the registry, update the declared current


### PR DESCRIPTION
## Summary

- make announcement and next-hop alignment structural so mismatches cannot enter commit, backpressure, or retry paths
- prove both mismatch directions fail before probing, sending, Adj-RIB-Out mutation, or dirty retry
- derive the public wire-error roster from source and ratchet release, embedding, and upgrade documentation

## Validation

- full RIB suite and focused mismatch regression
- wire README contract suite
- release checklist and embedding documentation contracts
- strict workspace all-target/all-feature Clippy
- formatting, diff, hooks, and independent exact-head review

Fixes LAN-1280.
