### PR TITLE
perf(rib): attribute policy identity work

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -3060,6 +3060,9 @@ impl RibManager {
         info!(target: "authoritative_batch_phase", outcome=r.outcome, classification=r.classification,
             failure_stage=r.failure_stage, total_us=r.total_us, remainder_us=r.remainder_us,
             precondition_us=r.precondition_us, registration_membership_us=r.registration_membership_us,
+            registered_peer_source_membership_scan_us=r.registered_peer_source_membership_scan_us,
+            policy_compare_install_us=r.policy_compare_install_us,
+            destination_membership_us=r.destination_membership_us,
             cohort_partition_us=r.cohort_partition_us, cohort_precheck_us=r.cohort_precheck_us,
             destination_build_us=r.destination_build_us, inventory_build_us=r.inventory_build_us,
             membership_commit_us=r.membership_commit_us, filtered_scope_build_us=r.filtered_scope_build_us,
@@ -3081,6 +3084,15 @@ impl RibManager {
             dirty_before=r.dirty_before, dirty_after=r.dirty_after,
             pending_before=r.pending_before, pending_after=r.pending_after,
             groups_before=r.groups_before, groups_after=r.groups_after,
+            policy_equality_attempts=r.policy_equality_attempts,
+            policy_equality_equal=r.policy_equality_equal,
+            policy_equality_changed=r.policy_equality_changed,
+            rpol_shared_backing=r.rpol_shared_backing,
+            rpol_detached_backing=r.rpol_detached_backing,
+            detached_prefix_set_entries=r.detached_prefix_set_entries,
+            intern_candidates=r.intern_candidates, intern_hits=r.intern_hits,
+            intern_misses=r.intern_misses, membership_grouped=r.membership_grouped,
+            membership_ungrouped=r.membership_ungrouped,
             "authoritative_batch_phase");
         #[cfg(test)]
         self.authoritative_transition_receipts.push(r);
@@ -3162,35 +3174,70 @@ impl RibManager {
                 n_skipped_unregistered += 1;
             }
         }
-
         // Previous memberships, captured before any mutation.
         let previous: Vec<Option<usize>> = present
             .iter()
             .map(|replacement| self.grouped_member_of(replacement.peer))
             .collect();
+        receipt.registered_peer_source_membership_scan_us =
+            u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX);
+        let phase = std::time::Instant::now();
         // Install the new chains (content-equal INSTANCE guard — see
         // `replace_peer_export_policy_synchronously` for the ADR-0096
         // term-hit rationale), then classify each member's destination.
         for replacement in &present {
-            if self.peer_export_policies.get(&replacement.peer) != Some(&replacement.export_policy)
-            {
+            receipt.policy_equality_attempts += 1;
+            let equal = self.peer_export_policies.get(&replacement.peer)
+                == Some(&replacement.export_policy);
+            if equal {
+                receipt.policy_equality_equal += 1;
+            } else {
+                receipt.policy_equality_changed += 1;
+            }
+            if let (Some(Some(old)), Some(new)) = (
+                self.peer_export_policies.get(&replacement.peer),
+                replacement.export_policy.as_ref(),
+            ) {
+                for (old_policy, new_policy) in old.policies.iter().zip(&new.policies) {
+                    if let (Some(old_rpol), Some(new_rpol)) = (&old_policy.rpol, &new_policy.rpol) {
+                        if std::sync::Arc::ptr_eq(old_rpol, new_rpol) {
+                            receipt.rpol_shared_backing += 1;
+                        } else {
+                            receipt.rpol_detached_backing += 1;
+                            receipt.detached_prefix_set_entries += new_rpol
+                                .prefix_sets
+                                .iter()
+                                .map(|set| set.entries().len())
+                                .sum::<usize>();
+                        }
+                    }
+                }
+            }
+            if !equal {
                 self.peer_export_policies
                     .insert(replacement.peer, replacement.export_policy.clone());
             }
         }
+        receipt.policy_compare_install_us =
+            u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX);
+        let phase = std::time::Instant::now();
         let destinations: Vec<Option<usize>> = present
             .iter()
-            .map(
-                |replacement| match self.compute_update_group_membership(replacement.peer) {
+            .map(|replacement| {
+                match self.compute_update_group_membership_with_receipt(replacement.peer, receipt) {
                     super::update_groups::GroupMembership::Grouped(gid) => Some(gid),
                     _ => None,
-                },
-            )
+                }
+            })
             .collect();
+        receipt.destination_membership_us =
+            u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX);
         receipt.present_peers = present.len();
         receipt.skipped_peers = n_skipped_unregistered;
-        receipt.registration_membership_us =
-            u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX);
+        receipt.registration_membership_us = receipt
+            .registered_peer_source_membership_scan_us
+            .saturating_add(receipt.policy_compare_install_us)
+            .saturating_add(receipt.destination_membership_us);
 
         // Candidate cohorts: batched movers of one source group whose
         // destinations agree. A source group with mixed or ungrouped

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -87,6 +87,9 @@ struct AuthoritativeTransitionReceipt {
     failure_stage: &'static str,
     precondition_us: u64,
     registration_membership_us: u64,
+    registered_peer_source_membership_scan_us: u64,
+    policy_compare_install_us: u64,
+    destination_membership_us: u64,
     cohort_partition_us: u64,
     cohort_precheck_us: u64,
     destination_build_us: u64,
@@ -131,6 +134,17 @@ struct AuthoritativeTransitionReceipt {
     pending_after: usize,
     groups_before: usize,
     groups_after: usize,
+    policy_equality_attempts: usize,
+    policy_equality_equal: usize,
+    policy_equality_changed: usize,
+    rpol_shared_backing: usize,
+    rpol_detached_backing: usize,
+    detached_prefix_set_entries: usize,
+    intern_candidates: usize,
+    intern_hits: usize,
+    intern_misses: usize,
+    membership_grouped: usize,
+    membership_ungrouped: usize,
 }
 
 /// Test/benchmark-only receipt from the authoritative outbound commit path.

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -6338,6 +6338,16 @@ fn register_direct_pcb_peer(
     export_policy: Option<PolicyChain>,
     encoder: Arc<dyn crate::update::ExactExportEncoder>,
 ) -> mpsc::Receiver<OutboundRouteUpdate> {
+    register_direct_pcb_peer_capacity(manager, peer, export_policy, encoder, 32)
+}
+
+fn register_direct_pcb_peer_capacity(
+    manager: &mut RibManager,
+    peer: IpAddr,
+    export_policy: Option<PolicyChain>,
+    encoder: Arc<dyn crate::update::ExactExportEncoder>,
+    capacity: usize,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
     manager.handle_update(RibUpdate::SetPeerExportEncoder {
         peer,
         session_id: 0,
@@ -6351,7 +6361,7 @@ fn register_direct_pcb_peer(
         session_id: 0,
         local_role: Some(rustbgpd_wire::BgpRole::RouteServer),
     });
-    let (outbound_tx, mut outbound_rx) = mpsc::channel(32);
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(capacity);
     manager.handle_update(RibUpdate::PeerUp {
         peer,
         session_id: 0,
@@ -6392,20 +6402,27 @@ struct BatchedPcbFleet {
     reuses: Arc<AtomicUsize>,
 }
 
-/// Four grouped per-client-best members, each announcing an own /24;
+/// Grouped per-client-best members, each announcing an own /24;
 /// members 0 and 1 both announce `shared_prefix`, so the group's
 /// exception lane holds one runner-up. Setup envelopes are drained.
-fn batched_pcb_fleet(export_policy: Option<&PolicyChain>) -> BatchedPcbFleet {
+fn batched_pcb_fleet_n(export_policy: Option<&PolicyChain>, member_count: u16) -> BatchedPcbFleet {
     let (_tx, rx) = mpsc::channel(1);
     let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let probes = Arc::new(AtomicUsize::new(0));
     let reuses = Arc::new(AtomicUsize::new(0));
-    let members: Vec<IpAddr> = (1..=4)
-        .map(|host| IpAddr::V4(Ipv4Addr::new(10, 40, 0, host)))
+    let members: Vec<IpAddr> = (0..member_count)
+        .map(|index| {
+            IpAddr::V4(Ipv4Addr::new(
+                10,
+                40,
+                u8::try_from(index / 254).unwrap(),
+                u8::try_from(index % 254 + 1).unwrap(),
+            ))
+        })
         .collect();
     let mut receivers = Vec::new();
     for (index, &peer) in members.iter().enumerate() {
-        receivers.push(register_direct_pcb_peer(
+        receivers.push(register_direct_pcb_peer_capacity(
             &mut manager,
             peer,
             export_policy.cloned(),
@@ -6418,20 +6435,28 @@ fn batched_pcb_fleet(export_policy: Option<&PolicyChain>) -> BatchedPcbFleet {
                 probes: Arc::clone(&probes),
                 reuses: Arc::clone(&reuses),
             }),
+            usize::from(member_count) + 8,
         ));
     }
     for (index, &peer) in members.iter().enumerate() {
         let IpAddr::V4(source) = peer else {
             unreachable!()
         };
-        let index = u8::try_from(index).unwrap();
         distribute_direct_route(
             &mut manager,
             source,
-            Ipv4Prefix::new(Ipv4Addr::new(203, 0, 110 + index, 0), 24),
+            Ipv4Prefix::new(
+                Ipv4Addr::new(
+                    203,
+                    u8::try_from(index / 256).unwrap(),
+                    u8::try_from(index % 256).unwrap(),
+                    0,
+                ),
+                24,
+            ),
         );
     }
-    let shared_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 199, 0), 24);
+    let shared_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     for &peer in &members[..2] {
         let IpAddr::V4(source) = peer else {
             unreachable!()
@@ -6451,6 +6476,10 @@ fn batched_pcb_fleet(export_policy: Option<&PolicyChain>) -> BatchedPcbFleet {
     }
 }
 
+fn batched_pcb_fleet(export_policy: Option<&PolicyChain>) -> BatchedPcbFleet {
+    batched_pcb_fleet_n(export_policy, 4)
+}
+
 fn batch_replacements(
     members: &[IpAddr],
     export_policy: &PolicyChain,
@@ -6464,26 +6493,62 @@ fn batch_replacements(
         .collect()
 }
 
+fn rpol_community_chain(community: u32) -> PolicyChain {
+    use rustbgpd_policy::NamedPolicy;
+    use rustbgpd_policy::rpol::RpolFile;
+    use rustbgpd_policy::sets::SetStore;
+
+    let mut prefixes = vec!["0.0.0.0/0 le 32".to_string()];
+    prefixes.extend((0..255).map(|index| format!("10.0.{index}.0/24")));
+    let source = format!(
+        "prefix-set all {{ {} }}\n\
+         policy export {{ term tag {{ if route.prefix in all {{ add community {}:{}; accept }} }} }}",
+        prefixes.join(", "),
+        community >> 16,
+        community & 0xffff
+    );
+    let compiled = RpolFile::parse(&source)
+        .expect("clean rpol")
+        .compile_policy("export", &[], &mut SetStore::new())
+        .expect("policy exists");
+    PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+        "export".to_string(),
+        Arc::new(compiled),
+    )])
+}
+
+fn detached_rpol_replacements(
+    members: &[IpAddr],
+    community: u32,
+) -> Vec<crate::update::PeerExportPolicyReplacement> {
+    let policy = rpol_community_chain(community);
+    batch_replacements(members, &policy)
+}
+
 fn authoritative_receipt_closes(r: &AuthoritativeTransitionReceipt) -> bool {
-    r.total_us
-        == r.remainder_us
-            + [
-                r.precondition_us,
-                r.registration_membership_us,
-                r.cohort_partition_us,
-                r.cohort_precheck_us,
-                r.destination_build_us,
-                r.inventory_build_us,
-                r.membership_commit_us,
-                r.filtered_scope_build_us,
-                r.member_emit_state_us,
-                r.cohort_finalize_us,
-                r.fallback_regroup_us,
-                r.distribution_us,
-                r.duplicate_fallback_us,
-            ]
-            .into_iter()
-            .sum::<u64>()
+    r.registration_membership_us
+        == r.registered_peer_source_membership_scan_us
+            + r.policy_compare_install_us
+            + r.destination_membership_us
+        && r.total_us
+            == r.remainder_us
+                + [
+                    r.precondition_us,
+                    r.registration_membership_us,
+                    r.cohort_partition_us,
+                    r.cohort_precheck_us,
+                    r.destination_build_us,
+                    r.inventory_build_us,
+                    r.membership_commit_us,
+                    r.filtered_scope_build_us,
+                    r.member_emit_state_us,
+                    r.cohort_finalize_us,
+                    r.fallback_regroup_us,
+                    r.distribution_us,
+                    r.duplicate_fallback_us,
+                ]
+                .into_iter()
+                .sum::<u64>()
 }
 
 #[test]
@@ -6492,36 +6557,45 @@ fn authoritative_receipt_closes(r: &AuthoritativeTransitionReceipt) -> bool {
     reason = "four generations pin the full receipt and wire contract"
 )]
 fn batched_authoritative_four_generations_emit_exact_terminal_receipts() {
-    let a = community_chain(0xFDE8_0001);
-    let b = community_chain(0xFDE8_0002);
-    let mut fleet = batched_pcb_fleet(Some(&a));
-    for (policy, community) in [
-        (&b, 0xFDE8_0002),
-        (&a, 0xFDE8_0001),
-        (&b, 0xFDE8_0002),
-        (&a, 0xFDE8_0001),
-    ] {
+    let a = rpol_community_chain(0xFDE8_0001);
+    let b = rpol_community_chain(0xFDE8_0002);
+    let mut fleet = batched_pcb_fleet_n(Some(&a), 320);
+    for (generation, (policy, community, detached)) in [
+        (&b, 0xFDE8_0002, false),
+        (&b, 0xFDE8_0002, false),
+        (&b, 0xFDE8_0002, true),
+        (&a, 0xFDE8_0001, false),
+    ]
+    .into_iter()
+    .enumerate()
+    {
         let before = fleet.manager.authoritative_transition_receipts.len();
+        let replacements = if detached {
+            detached_rpol_replacements(&fleet.members, community)
+        } else {
+            batch_replacements(&fleet.members, policy)
+        };
         fleet
             .manager
-            .apply_export_policy_replacements_synchronously(batch_replacements(
-                &fleet.members,
-                policy,
-            ))
+            .apply_export_policy_replacements_synchronously(replacements)
             .unwrap();
         assert_eq!(
             fleet.manager.authoritative_transition_receipts.len(),
             before + 1
         );
         let r = &fleet.manager.authoritative_transition_receipts[before];
-        assert_eq!((r.outcome, r.classification), ("committed", "shared"));
+        let changed = matches!(generation, 0 | 3);
+        assert_eq!(
+            (r.outcome, r.classification),
+            ("committed", if changed { "shared" } else { "fallback" })
+        );
         assert_eq!(
             (r.input_peers, r.present_peers, r.shared_cohorts),
-            (4, 4, 1)
+            (320, 320, usize::from(changed))
         );
         assert_eq!(
             (r.shared_members, r.fallback_members, r.distribution_passes),
-            (4, 0, 1)
+            if changed { (320, 0, 1) } else { (0, 320, 1) }
         );
         assert_eq!(
             (
@@ -6530,7 +6604,11 @@ fn batched_authoritative_four_generations_emit_exact_terminal_receipts() {
                 r.destination_adoptions,
                 r.membership_moves
             ),
-            (1, 1, 0, 4)
+            if changed {
+                (1, 1, 0, 320)
+            } else {
+                (0, 0, 0, 0)
+            }
         );
         assert_eq!(
             (
@@ -6538,15 +6616,48 @@ fn batched_authoritative_four_generations_emit_exact_terminal_receipts() {
                 r.inventory_withdraws,
                 r.inventory_supplements
             ),
-            (5, 0, 1)
+            if changed { (321, 0, 1) } else { (0, 0, 0) }
         );
         assert_eq!(
             (r.filtered_scope_prefixes, r.filtered_scope_member_visits),
-            (5, 20)
+            if changed { (321, 102_720) } else { (0, 0) }
         );
         assert_eq!(
             (r.emits_attempted, r.emits_succeeded, r.emits_degraded),
-            (4, 4, 0)
+            if changed { (320, 320, 0) } else { (0, 0, 0) }
+        );
+        assert_eq!(
+            (
+                r.policy_equality_attempts,
+                r.policy_equality_equal,
+                r.policy_equality_changed,
+                r.membership_grouped,
+                r.membership_ungrouped
+            ),
+            if changed {
+                (320, 0, 320, 320, 0)
+            } else {
+                (320, 320, 0, 320, 0)
+            }
+        );
+        assert_eq!(
+            (
+                r.rpol_shared_backing,
+                r.rpol_detached_backing,
+                r.detached_prefix_set_entries
+            ),
+            match generation {
+                1 => (320, 0, 0),
+                _ => (0, 320, 81_920),
+            }
+        );
+        assert_eq!(
+            (r.intern_candidates, r.intern_hits, r.intern_misses),
+            match generation {
+                0 => (639, 319, 1),
+                3 => (320, 320, 0),
+                _ => (640, 320, 0),
+            }
         );
         assert_eq!(
             (
@@ -6577,7 +6688,14 @@ fn batched_authoritative_four_generations_emit_exact_terminal_receipts() {
             .peer;
         for (peer, receiver) in fleet.members.iter().zip(&mut fleet.receivers) {
             let updates: Vec<_> = std::iter::from_fn(|| receiver.try_recv().ok()).collect();
-            assert_eq!(updates.len(), if *peer == winner { 2 } else { 1 });
+            assert_eq!(
+                updates.len(),
+                if changed {
+                    if *peer == winner { 2 } else { 1 }
+                } else {
+                    0
+                }
+            );
             assert!(updates.iter().flat_map(|update| update.announce.iter()).all(|route| {
                 route.attributes.iter().any(|attribute| {
                     matches!(attribute, PathAttribute::Communities(values) if values.contains(&community))

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -354,9 +354,24 @@ pub(super) struct UpdateGroupRegistry {
 
 impl UpdateGroupRegistry {
     /// Intern a chain by content, returning its stable index.
-    fn intern_chain(&mut self, chain: &PolicyChain) -> usize {
-        if let Some(idx) = self.chains.iter().position(|c| c == chain) {
-            return idx;
+    fn intern_chain(
+        &mut self,
+        chain: &PolicyChain,
+        mut receipt: Option<&mut super::AuthoritativeTransitionReceipt>,
+    ) -> usize {
+        for (idx, candidate) in self.chains.iter().enumerate() {
+            if let Some(r) = receipt.as_deref_mut() {
+                r.intern_candidates += 1;
+            }
+            if candidate == chain {
+                if let Some(r) = receipt {
+                    r.intern_hits += 1;
+                }
+                return idx;
+            }
+        }
+        if let Some(r) = receipt {
+            r.intern_misses += 1;
         }
         self.chains.push(chain.clone());
         self.chains.len() - 1

--- a/crates/rib/src/manager/update_groups/policy_transition.rs
+++ b/crates/rib/src/manager/update_groups/policy_transition.rs
@@ -227,7 +227,22 @@ impl RibManager {
         peer: IpAddr,
     ) -> GroupMembership {
         let chain = self.export_policy_for(peer).cloned();
-        self.compute_update_group_membership_for_policy(peer, chain.as_ref())
+        self.compute_update_group_membership_for_policy(peer, chain.as_ref(), None)
+    }
+
+    pub(in crate::manager) fn compute_update_group_membership_with_receipt(
+        &mut self,
+        peer: IpAddr,
+        receipt: &mut crate::manager::AuthoritativeTransitionReceipt,
+    ) -> GroupMembership {
+        let chain = self.export_policy_for(peer).cloned();
+        let membership =
+            self.compute_update_group_membership_for_policy(peer, chain.as_ref(), Some(receipt));
+        match membership {
+            GroupMembership::Grouped(_) => receipt.membership_grouped += 1,
+            _ => receipt.membership_ungrouped += 1,
+        }
+        membership
     }
 
     /// Classify a prospective policy without changing the peer's installed
@@ -237,6 +252,7 @@ impl RibManager {
         &mut self,
         peer: IpAddr,
         chain: Option<&PolicyChain>,
+        receipt: Option<&mut crate::manager::AuthoritativeTransitionReceipt>,
     ) -> GroupMembership {
         // Differential-oracle hook: force every peer onto the per-peer
         // fallback path so identical scenarios can be compared grouped
@@ -280,7 +296,7 @@ impl RibManager {
 
         // Clone released before the &mut intern below; chains are small
         // and this runs at config/session-lifecycle frequency only.
-        let chain_idx = chain.map(|chain| self.update_groups.intern_chain(chain));
+        let chain_idx = chain.map(|chain| self.update_groups.intern_chain(chain, receipt));
         let key = GroupKey {
             chain: chain_idx,
             target_is_ebgp: fingerprint.target_is_ebgp,
@@ -324,7 +340,7 @@ impl RibManager {
             return None;
         }
         let GroupMembership::Grouped(destination) =
-            self.compute_update_group_membership_for_policy(peer, policy)
+            self.compute_update_group_membership_for_policy(peer, policy, None)
         else {
             return None;
         };


### PR DESCRIPTION
## Summary

- split the authoritative registration/membership phase into three exclusive, exactly closing leaves
- count policy equality, RPOL backing identity, exposed prefix-set entries, interning work, and membership outcomes per invocation
- prove changed content, same-Arc equality, and freshly compiled content equality across a 320-peer four-generation production-seam fixture

This is deterministic work attribution only. It does not optimize the path or
launch another fleet campaign, and LAN-1165 remains open until the mechanism is
resolved.

## Validation

- focused four-generation discriminator and rejected/duplicate terminal tests
- full rustbgpd-rib suite: 1206 passed, 2 ignored
- strict workspace all-target/all-feature Clippy
- formatting, diff check, and commit hooks

Refs LAN-1165.
