### PR TITLE
feat(ops): add Alpha EVPN operations dashboard

### DIFF
--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -78,10 +78,12 @@ Per-peer series are reaped when a peer is deleted, so stale values age out after
 the next scrape.
 
 The EVPN dashboard intentionally offers only **Instance** and configured
-**VRF** selectors. Both support multiple values and All through bounded regex
+**VRF** selectors. Both support multiple values and All through simple regex
 matching. It does not expose MAC, ESI, netdevice name, peer, or IP selectors;
-panels aggregate those dimensions away before rendering to avoid turning
-operator navigation into an unbounded-cardinality query.
+panels aggregate those dimensions away from rendered output and navigation.
+The underlying per-MAC move, first-move timestamp, and quarantine series persist
+for the daemon lifetime, however, so their Prometheus storage cardinality and
+the query scan can grow even though the displayed result is aggregated.
 
 ## Alert rules
 
@@ -211,6 +213,10 @@ inside the bounded window does.
   total, or generic reconcile-report metric today. Type-3 is therefore visible
   only inside the aggregate EVPN Loc-RIB count; the dashboard does not infer
   unsupported per-route-type or installed-object totals.
+- **Time since first recorded move for active quarantines** joins current
+  quarantine state to a process-lifetime first-move timestamp. Clearing or
+  re-quarantining the same key does not reset that timestamp, so the panel is
+  not the age of the current quarantine interval.
 
 ## Validation and load-bearing proofs
 

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -10,6 +10,15 @@ BMP/event-outbox health, RPKI/ASPA state, and core operations. Every panel
 references metrics the daemon actually exports from
 `crates/telemetry/src/metrics.rs` — no speculative series.
 
+An explicitly **Alpha** EVPN operations dashboard lives at
+[`grafana/rustbgpd-evpn.json`](grafana/rustbgpd-evpn.json)
+(uid `rustbgpd-evpn-alpha`). It covers the currently exported Type-2 local
+origination signals, aggregate Type-3-inclusive Loc-RIB state, Type-5/IP-VRF
+state, DF and attachment-circuit state, duplicate-MAC quarantine, dataplane
+repair/adoption/reap activity, ownership conflicts, and decomposed-runtime
+fail-stops. Alpha means its panels and variable contract may change with the
+VTEP surface.
+
 ## Enable the metrics endpoint
 
 Metrics are served by the daemon's built-in Prometheus listener,
@@ -48,7 +57,8 @@ scrape_configs:
 ## Import the dashboard
 
 1. Grafana → **Dashboards → New → Import**.
-2. Upload `docs/grafana/rustbgpd-overview.json` (or paste its contents).
+2. Upload `docs/grafana/rustbgpd-overview.json` or the Alpha
+   `docs/grafana/rustbgpd-evpn.json` (or paste its contents).
 3. Pick your Prometheus data source when prompted (the dashboard uses a
    `datasource` template variable, so it binds at import time).
 
@@ -66,6 +76,12 @@ Template variables:
 
 Per-peer series are reaped when a peer is deleted, so stale values age out after
 the next scrape.
+
+The EVPN dashboard intentionally offers only **Instance** and configured
+**VRF** selectors. Both support multiple values and All through bounded regex
+matching. It does not expose MAC, ESI, netdevice name, peer, or IP selectors;
+panels aggregate those dimensions away before rendering to avoid turning
+operator navigation into an unbounded-cardinality query.
 
 ## Alert rules
 
@@ -189,9 +205,12 @@ inside the bounded window does.
 - The "Memory (jemalloc)" panel shows data only for builds with the
   `jemalloc` feature (the release container image); other builds do not
   export the `jemalloc_*` gauges.
-- EVPN metrics (the `evpn_*` families) are intentionally not on this
-  overview dashboard; they are VTEP-alpha surface with per-VNI/MAC/ESI
-  cardinality better served by a dedicated dashboard.
+- EVPN metrics (the `evpn_*` families) remain off the overview dashboard; the
+  dedicated Alpha dashboard aggregates MAC, ESI, and netdevice-name dimensions.
+  There is no dedicated Type-3, VTEP-reachability, generic FDB/NHG installed
+  total, or generic reconcile-report metric today. Type-3 is therefore visible
+  only inside the aggregate EVPN Loc-RIB count; the dashboard does not infer
+  unsupported per-route-type or installed-object totals.
 
 ## Validation and load-bearing proofs
 
@@ -204,8 +223,9 @@ promtool check rules examples/prometheus/rustbgpd-alerts.yml
 (cd examples/prometheus && promtool test rules rustbgpd-alerts_test.yml)
 ```
 
-The dashboard checker parses JSON, rejects non-integer and duplicate panel IDs,
-and links every target and query-variable metric to a registered constructor in
+The dashboard checker validates both dashboards independently, parses JSON,
+rejects non-integer and duplicate panel IDs, and links every target and
+query-variable metric to a registered constructor in
 `crates/telemetry/src/metrics.rs`. Histogram `_bucket`, `_count`, and `_sum`
 series resolve only from registered histograms; aliases, empty discovery,
 unregistered constructors, comments, free strings, and test literals fail
@@ -214,6 +234,13 @@ and legends, panel types, discrete state rendering, RFC 8212 mappings,
 outbound-blocking axis and exclusion, and dynamic-neighbor capacity/rejection
 semantics. Descriptions, layout, row collapsed state, and particular unique IDs
 are intentionally presentation choices rather than validation contracts.
+
+For the EVPN Alpha dashboard, the checker additionally freezes all 38 current
+`evpn_*` family names, metric kinds, and constructor labels. Counter panels must
+use `rate` or `increase` before aggregation; gauges must remain raw. It rejects
+unknown selector labels, unsafe retention of MAC/ESI/name-style dimensions,
+non-regex use of multi-value variables, metric typos, missing Alpha or operator
+rows, and loss of any required source-backed signal.
 
 The slow-peer fixture is red if its `== 1` predicate or five-minute hold is
 changed. The RFC 8212 matrix covers import-only, export-only, and healthy peers;

--- a/docs/grafana/rustbgpd-evpn.json
+++ b/docs/grafana/rustbgpd-evpn.json
@@ -254,7 +254,7 @@
       "id": 12,
       "type": "timeseries",
       "title": "Quarantined local Type-2 keys",
-      "description": "Current local Type-2 origination suppressions. VNI and MAC are aggregated away to keep the dashboard bounded.",
+      "description": "Current local Type-2 origination suppressions. The rendered result aggregates VNI and MAC away, but the daemon-lifetime per-MAC source series remain in Prometheus and the query scan can grow.",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
       "gridPos": {"h": 7, "w": 8, "x": 0, "y": 25},
       "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0, "custom": {"lineInterpolation": "stepAfter"}}, "overrides": []},
@@ -293,8 +293,8 @@
     {
       "id": 14,
       "type": "stat",
-      "title": "Oldest active quarantine age",
-      "description": "Age of the oldest first-contention timestamp whose key is still quarantined. MAC/VNI labels participate only in the exact join and are removed by max aggregation.",
+      "title": "Time since first recorded move for active quarantines",
+      "description": "Time since the process-lifetime first recorded move among keys that are currently quarantined. Clearing and re-quarantining a key does not reset or reap its first-move timestamp. MAC and VNI are used for the exact active-state join and removed only from rendered output; the underlying per-MAC series and query scan can grow for the daemon lifetime.",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
       "gridPos": {"h": 7, "w": 8, "x": 16, "y": 25},
       "fieldConfig": {"defaults": {"unit": "s", "min": 0}, "overrides": []},
@@ -303,7 +303,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "max by (instance) (clamp_min(time() - evpn_duplicate_mac_first_move_timestamp_seconds{instance=~\"$instance\"}, 0) and on (instance, vni, mac) (evpn_duplicate_mac_quarantine_active{instance=~\"$instance\"} == 1))",
-          "legendFormat": "{{instance}} oldest quarantine",
+          "legendFormat": "{{instance}} since first recorded move",
           "refId": "A"
         }
       ]

--- a/docs/grafana/rustbgpd-evpn.json
+++ b/docs/grafana/rustbgpd-evpn.json
@@ -1,0 +1,426 @@
+{
+  "uid": "rustbgpd-evpn-alpha",
+  "title": "rustbgpd EVPN Operations (Alpha)",
+  "description": "Alpha EVPN/VTEP operations dashboard. It exposes only metrics registered by rustbgpd. Type 2 has local-origination and duplicate-MAC signals; Type 5 has per-IP-VRF state. Type 3 has no dedicated metric and is visible only inside the aggregate EVPN Loc-RIB count. There is no VTEP-reachability or generic installed-FDB/NHG-total series in this Alpha contract.",
+  "tags": ["rustbgpd", "evpn", "alpha"],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {"from": "now-6h", "to": "now"},
+  "refresh": "30s",
+  "timezone": "",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "query": "label_values(bgp_rib_outbound_registered_peers, instance)",
+        "current": {},
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "vrf",
+        "label": "IP-VRF",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "query": "label_values(evpn_ip_vrf_observed_routes{instance=~\"$instance\"}, vrf)",
+        "current": {},
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "annotations": {"list": []},
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Type-2 / Type-3 / Type-5 and IP-VRF state",
+      "description": "Type 3 has no dedicated metric; the EVPN Loc-RIB panel is the only Prometheus view that includes it.",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "EVPN Loc-RIB (all route types)",
+      "description": "All selected EVPN Loc-RIB routes. This gauge combines route Types 1 through 5; it cannot isolate Type 3.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 6, "x": 0, "y": 1},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0}, "overrides": []},
+      "options": {"colorMode": "value", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance) (bgp_rib_loc_prefixes{instance=~\"$instance\",afi_safi=\"evpn\"})",
+          "legendFormat": "{{instance}} all EVPN types",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Type-2 local origination actions, errors, and drops",
+      "description": "Rates of successful Type-2 inject/withdraw actions, failed actions, and kernel local-MAC observations dropped before the originator. Counters are rated before aggregation.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 9, "x": 6, "y": 1},
+      "fieldConfig": {"defaults": {"unit": "ops", "min": 0}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, action) (rate(evpn_local_originations_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} success {{action}}/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, action) (rate(evpn_local_origination_errors_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} error {{action}}/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, reason) (rate(evpn_local_observations_dropped_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} observation drop {{reason}}/s",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Type-5 IP-VRF route state",
+      "description": "Current eligible observed kernel routes, locally originated Type-5 routes, and remotely installed Type-5 routes per configured IP-VRF.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 9, "x": 15, "y": 1},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0, "custom": {"lineInterpolation": "stepAfter"}}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vrf) (evpn_ip_vrf_observed_routes{instance=~\"$instance\",vrf=~\"$vrf\"})",
+          "legendFormat": "{{instance}} {{vrf}} observed",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vrf) (evpn_ip_vrf_originated_routes{instance=~\"$instance\",vrf=~\"$vrf\"})",
+          "legendFormat": "{{instance}} {{vrf}} originated",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vrf) (evpn_ip_vrf_installed_routes{instance=~\"$instance\",vrf=~\"$vrf\"})",
+          "legendFormat": "{{instance}} {{vrf}} installed",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Type-5 filtering, suppression, and projection drops",
+      "description": "Classifier and readiness suppressions are event rates. Remote projection drops are current gauges, including _unscoped rows that could not be tied to a configured IP-VRF.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vrf, reason) (rate(evpn_ip_vrf_observed_routes_filtered_total{instance=~\"$instance\",vrf=~\"$vrf\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} {{vrf}} filtered {{reason}}/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vrf, reason) (rate(evpn_ip_vrf_origination_suppressed_total{instance=~\"$instance\",vrf=~\"$vrf\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} {{vrf}} suppressed {{reason}}/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vrf, reason) (evpn_ip_vrf_remote_prefix_drops{instance=~\"$instance\",vrf=~\"$vrf\"})",
+          "legendFormat": "{{instance}} {{vrf}} current drop {{reason}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "DF, attachment circuits, and drain",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 16},
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Active DF assignments",
+      "description": "Count of active local DF assignments by VNI. The one-hot role=df series is selected; ESI is aggregated away.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 6, "x": 0, "y": 17},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0, "custom": {"lineInterpolation": "stepAfter"}}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vni) (evpn_df_role{instance=~\"$instance\",role=\"df\"} == 1)",
+          "legendFormat": "{{instance}} VNI {{vni}} DF assignments",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Attachment-circuit gate state",
+      "description": "Single-active AC gate states, aggregated over ESI. blocked, forwarding, and mixed-roles are one-hot per bound segment.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 6, "x": 6, "y": 17},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0, "custom": {"lineInterpolation": "stepAfter"}}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, state) (evpn_es_ac_gate{instance=~\"$instance\"} == 1)",
+          "legendFormat": "{{instance}} {{state}} segments",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Ethernet-segment drain reasons",
+      "description": "Active operator and link drain reasons, aggregated over ESI. A segment is drained while any reason is one.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 6, "x": 12, "y": 17},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0, "custom": {"lineInterpolation": "stepAfter"}}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, reason) (evpn_es_drained{instance=~\"$instance\"} == 1)",
+          "legendFormat": "{{instance}} {{reason}} drains",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "DF role changes",
+      "description": "DF/NonDF transition rate by VNI, aggregated over ESI.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 6, "x": 18, "y": 17},
+      "fieldConfig": {"defaults": {"unit": "ops", "min": 0}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, vni) (rate(evpn_df_role_changes_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} VNI {{vni}} changes/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Duplicate-MAC quarantine",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 24},
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Quarantined local Type-2 keys",
+      "description": "Current local Type-2 origination suppressions. VNI and MAC are aggregated away to keep the dashboard bounded.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 25},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0, "custom": {"lineInterpolation": "stepAfter"}}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance) (evpn_duplicate_mac_quarantine_active{instance=~\"$instance\"} == 1)",
+          "legendFormat": "{{instance}} quarantined keys",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Duplicate-MAC contention activity",
+      "description": "MAC-mobility contention and configured threshold-crossing rates. VNI/MAC are intentionally aggregated away.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 25},
+      "fieldConfig": {"defaults": {"unit": "ops", "min": 0}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance) (rate(evpn_duplicate_mac_moves_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} moves/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, action) (rate(evpn_duplicate_mac_threshold_exceeded_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} threshold {{action}}/s",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Oldest active quarantine age",
+      "description": "Age of the oldest first-contention timestamp whose key is still quarantined. MAC/VNI labels participate only in the exact join and are removed by max aggregation.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 25},
+      "fieldConfig": {"defaults": {"unit": "s", "min": 0}, "overrides": []},
+      "options": {"colorMode": "value", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "max by (instance) (clamp_min(time() - evpn_duplicate_mac_first_move_timestamp_seconds{instance=~\"$instance\"}, 0) and on (instance, vni, mac) (evpn_duplicate_mac_quarantine_active{instance=~\"$instance\"} == 1))",
+          "legendFormat": "{{instance}} oldest quarantine",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "row",
+      "title": "Dataplane repair, adoption, and single-active state",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+      "panels": []
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Managed netdev state",
+      "description": "Current managed EVPN netdev state counts by class and state. Device name and desired tuple are aggregated away; detailed reasons remain in ListManagedNetdevs/rbgp.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 8, "w": 6, "x": 0, "y": 33},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0, "custom": {"lineInterpolation": "stepAfter"}}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance, class, state) (evpn_managed_netdev_state{instance=~\"$instance\"} == 1)",
+          "legendFormat": "{{instance}} {{class}} {{state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "FDB-NHG repair and cleanup",
+      "description": "Rates of repaired members, replaced groups, cleaned orphan nexthops, and permanent dump failures that disabled drift recovery. No generic installed-NHG total is exported.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 8, "w": 6, "x": 6, "y": 33},
+      "fieldConfig": {"defaults": {"unit": "ops", "min": 0}, "overrides": []},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_fdb_nhg_drift_members_repaired_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} members repaired/s", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_fdb_nhg_drift_groups_replaced_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} groups replaced/s", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_fdb_nhg_orphans_cleaned_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} orphans cleaned/s", "refId": "C"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_fdb_nhg_drift_disabled_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} drift disabled/s", "refId": "D"}
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Startup adoption and deferred reap",
+      "description": "Startup adoption and post-deferral reap rates for single-dst FDB rows, IP-VRF routes, L3 neighbors, and L3VXLAN FDB rows.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 8, "w": 7, "x": 12, "y": 33},
+      "fieldConfig": {"defaults": {"unit": "ops", "min": 0}, "overrides": []},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_fdb_single_dst_adopted_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} FDB adopted/s", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_fdb_single_dst_reaped_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} FDB reaped/s", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_l3_route_adopted_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} routes adopted/s", "refId": "C"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_l3_route_reaped_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} routes reaped/s", "refId": "D"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_l3_neighbor_adopted_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} neighbors adopted/s", "refId": "E"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_l3_neighbor_reaped_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} neighbors reaped/s", "refId": "F"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_l3vxlan_fdb_adopted_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} L3VXLAN FDB adopted/s", "refId": "G"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_l3vxlan_fdb_reaped_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} L3VXLAN FDB reaped/s", "refId": "H"}
+      ]
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Single-active failover state",
+      "description": "Current backup-retargeted groups plus backup-swap and ordered-teardown event rates.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 8, "w": 5, "x": 19, "y": 33},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0}, "overrides": []},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (evpn_single_active_backup_active{instance=~\"$instance\"})", "legendFormat": "{{instance}} backup active", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_single_active_backup_swaps_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} swaps/s", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_single_active_teardowns_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} teardowns/s", "refId": "C"}
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Ownership conflicts and fail-stops",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 41},
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Foreign ownership conflicts",
+      "description": "Rates of fail-closed replace blocks, spared deletes, relinquished keys, and foreign objects in the reserved NHID range.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 8, "w": 16, "x": 0, "y": 42},
+      "fieldConfig": {"defaults": {"unit": "ops", "min": 0}, "overrides": []},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_foreign_replaces_blocked_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} replace blocked/s", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_foreign_deletes_skipped_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} delete skipped/s", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_foreign_owned_relinquished_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} ownership relinquished/s", "refId": "C"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (instance) (rate(evpn_foreign_nhid_range_conflicts_total{instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "{{instance}} NHID conflicts/s", "refId": "D"}
+      ]
+    },
+    {
+      "id": 22,
+      "type": "stat",
+      "title": "Runtime decomposed fail-stops",
+      "description": "Mid-sequence decomposed runtime applies that pinned the coordinator in Failed during the last 15 minutes. This is the only source-backed EVPN fail-stop metric.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 42},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "decimals": 0}, "overrides": []},
+      "options": {"colorMode": "value", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (instance) (increase(evpn_runtime_decomposed_fail_stops_total{instance=~\"$instance\"}[15m]))",
+          "legendFormat": "{{instance}} fail-stops/15m",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -823,7 +823,7 @@ def check_evpn_dashboard(
         if variable.get("multi") is not True or variable.get("includeAll") is not True:
             raise ValueError(f"EVPN ${name} must support multi-select and All")
         if variable.get("allValue") != ".*":
-            raise ValueError(f"EVPN ${name} All value must be the simple regex .* ")
+            raise ValueError(f"EVPN ${name} All value must be the simple regex .*")
     forbidden_variables = {"peer", "mac", "esi", "name", "ip"} & set(variables)
     if forbidden_variables:
         raise ValueError(

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -111,7 +111,7 @@ EVPN_REQUIRED_PANELS = {
         "evpn_duplicate_mac_moves_total",
         "evpn_duplicate_mac_threshold_exceeded_total",
     },
-    "Oldest active quarantine age": {
+    "Time since first recorded move for active quarantines": {
         "evpn_duplicate_mac_first_move_timestamp_seconds",
         "evpn_duplicate_mac_quarantine_active",
     },
@@ -145,6 +145,170 @@ EVPN_REQUIRED_PANELS = {
     },
     "Runtime decomposed fail-stops": {"evpn_runtime_decomposed_fail_stops_total"},
 }
+
+# These expressions are operator semantics, not presentation. Pinning them
+# keeps comparisons, aggregation, active-state joins, and the absence of
+# zero-fill fallbacks load-bearing without implementing a PromQL parser.
+EVPN_TARGETS: dict[tuple[str, str], tuple[str, str]] = {
+    ("EVPN Loc-RIB (all route types)", "A"): (
+        'sum by (instance) (bgp_rib_loc_prefixes{instance=~"$instance",afi_safi="evpn"})',
+        "{{instance}} all EVPN types",
+    ),
+    ("Type-2 local origination actions, errors, and drops", "A"): (
+        'sum by (instance, action) (rate(evpn_local_originations_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} success {{action}}/s",
+    ),
+    ("Type-2 local origination actions, errors, and drops", "B"): (
+        'sum by (instance, action) (rate(evpn_local_origination_errors_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} error {{action}}/s",
+    ),
+    ("Type-2 local origination actions, errors, and drops", "C"): (
+        'sum by (instance, reason) (rate(evpn_local_observations_dropped_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} observation drop {{reason}}/s",
+    ),
+    ("Type-5 IP-VRF route state", "A"): (
+        'sum by (instance, vrf) (evpn_ip_vrf_observed_routes{instance=~"$instance",vrf=~"$vrf"})',
+        "{{instance}} {{vrf}} observed",
+    ),
+    ("Type-5 IP-VRF route state", "B"): (
+        'sum by (instance, vrf) (evpn_ip_vrf_originated_routes{instance=~"$instance",vrf=~"$vrf"})',
+        "{{instance}} {{vrf}} originated",
+    ),
+    ("Type-5 IP-VRF route state", "C"): (
+        'sum by (instance, vrf) (evpn_ip_vrf_installed_routes{instance=~"$instance",vrf=~"$vrf"})',
+        "{{instance}} {{vrf}} installed",
+    ),
+    ("Type-5 filtering, suppression, and projection drops", "A"): (
+        'sum by (instance, vrf, reason) (rate(evpn_ip_vrf_observed_routes_filtered_total{instance=~"$instance",vrf=~"$vrf"}[$__rate_interval]))',
+        "{{instance}} {{vrf}} filtered {{reason}}/s",
+    ),
+    ("Type-5 filtering, suppression, and projection drops", "B"): (
+        'sum by (instance, vrf, reason) (rate(evpn_ip_vrf_origination_suppressed_total{instance=~"$instance",vrf=~"$vrf"}[$__rate_interval]))',
+        "{{instance}} {{vrf}} suppressed {{reason}}/s",
+    ),
+    ("Type-5 filtering, suppression, and projection drops", "C"): (
+        'sum by (instance, vrf, reason) (evpn_ip_vrf_remote_prefix_drops{instance=~"$instance",vrf=~"$vrf"})',
+        "{{instance}} {{vrf}} current drop {{reason}}",
+    ),
+    ("Active DF assignments", "A"): (
+        'sum by (instance, vni) (evpn_df_role{instance=~"$instance",role="df"} == 1)',
+        "{{instance}} VNI {{vni}} DF assignments",
+    ),
+    ("Attachment-circuit gate state", "A"): (
+        'sum by (instance, state) (evpn_es_ac_gate{instance=~"$instance"} == 1)',
+        "{{instance}} {{state}} segments",
+    ),
+    ("Ethernet-segment drain reasons", "A"): (
+        'sum by (instance, reason) (evpn_es_drained{instance=~"$instance"} == 1)',
+        "{{instance}} {{reason}} drains",
+    ),
+    ("DF role changes", "A"): (
+        'sum by (instance, vni) (rate(evpn_df_role_changes_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} VNI {{vni}} changes/s",
+    ),
+    ("Quarantined local Type-2 keys", "A"): (
+        'sum by (instance) (evpn_duplicate_mac_quarantine_active{instance=~"$instance"} == 1)',
+        "{{instance}} quarantined keys",
+    ),
+    ("Duplicate-MAC contention activity", "A"): (
+        'sum by (instance) (rate(evpn_duplicate_mac_moves_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} moves/s",
+    ),
+    ("Duplicate-MAC contention activity", "B"): (
+        'sum by (instance, action) (rate(evpn_duplicate_mac_threshold_exceeded_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} threshold {{action}}/s",
+    ),
+    ("Time since first recorded move for active quarantines", "A"): (
+        'max by (instance) (clamp_min(time() - evpn_duplicate_mac_first_move_timestamp_seconds{instance=~"$instance"}, 0) and on (instance, vni, mac) (evpn_duplicate_mac_quarantine_active{instance=~"$instance"} == 1))',
+        "{{instance}} since first recorded move",
+    ),
+    ("Managed netdev state", "A"): (
+        'sum by (instance, class, state) (evpn_managed_netdev_state{instance=~"$instance"} == 1)',
+        "{{instance}} {{class}} {{state}}",
+    ),
+    ("FDB-NHG repair and cleanup", "A"): (
+        'sum by (instance) (rate(evpn_fdb_nhg_drift_members_repaired_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} members repaired/s",
+    ),
+    ("FDB-NHG repair and cleanup", "B"): (
+        'sum by (instance) (rate(evpn_fdb_nhg_drift_groups_replaced_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} groups replaced/s",
+    ),
+    ("FDB-NHG repair and cleanup", "C"): (
+        'sum by (instance) (rate(evpn_fdb_nhg_orphans_cleaned_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} orphans cleaned/s",
+    ),
+    ("FDB-NHG repair and cleanup", "D"): (
+        'sum by (instance) (rate(evpn_fdb_nhg_drift_disabled_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} drift disabled/s",
+    ),
+    ("Startup adoption and deferred reap", "A"): (
+        'sum by (instance) (rate(evpn_fdb_single_dst_adopted_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} FDB adopted/s",
+    ),
+    ("Startup adoption and deferred reap", "B"): (
+        'sum by (instance) (rate(evpn_fdb_single_dst_reaped_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} FDB reaped/s",
+    ),
+    ("Startup adoption and deferred reap", "C"): (
+        'sum by (instance) (rate(evpn_l3_route_adopted_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} routes adopted/s",
+    ),
+    ("Startup adoption and deferred reap", "D"): (
+        'sum by (instance) (rate(evpn_l3_route_reaped_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} routes reaped/s",
+    ),
+    ("Startup adoption and deferred reap", "E"): (
+        'sum by (instance) (rate(evpn_l3_neighbor_adopted_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} neighbors adopted/s",
+    ),
+    ("Startup adoption and deferred reap", "F"): (
+        'sum by (instance) (rate(evpn_l3_neighbor_reaped_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} neighbors reaped/s",
+    ),
+    ("Startup adoption and deferred reap", "G"): (
+        'sum by (instance) (rate(evpn_l3vxlan_fdb_adopted_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} L3VXLAN FDB adopted/s",
+    ),
+    ("Startup adoption and deferred reap", "H"): (
+        'sum by (instance) (rate(evpn_l3vxlan_fdb_reaped_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} L3VXLAN FDB reaped/s",
+    ),
+    ("Single-active failover state", "A"): (
+        'sum by (instance) (evpn_single_active_backup_active{instance=~"$instance"})',
+        "{{instance}} backup active",
+    ),
+    ("Single-active failover state", "B"): (
+        'sum by (instance) (rate(evpn_single_active_backup_swaps_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} swaps/s",
+    ),
+    ("Single-active failover state", "C"): (
+        'sum by (instance) (rate(evpn_single_active_teardowns_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} teardowns/s",
+    ),
+    ("Foreign ownership conflicts", "A"): (
+        'sum by (instance) (rate(evpn_foreign_replaces_blocked_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} replace blocked/s",
+    ),
+    ("Foreign ownership conflicts", "B"): (
+        'sum by (instance) (rate(evpn_foreign_deletes_skipped_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} delete skipped/s",
+    ),
+    ("Foreign ownership conflicts", "C"): (
+        'sum by (instance) (rate(evpn_foreign_owned_relinquished_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} ownership relinquished/s",
+    ),
+    ("Foreign ownership conflicts", "D"): (
+        'sum by (instance) (rate(evpn_foreign_nhid_range_conflicts_total{instance=~"$instance"}[$__rate_interval]))',
+        "{{instance}} NHID conflicts/s",
+    ),
+    ("Runtime decomposed fail-stops", "A"): (
+        'sum by (instance) (increase(evpn_runtime_decomposed_fail_stops_total{instance=~"$instance"}[15m]))',
+        "{{instance}} fail-stops/15m",
+    ),
+}
+
+EVPN_TARGET_DATASOURCE = {"type": "prometheus", "uid": "${datasource}"}
 
 EVPN_DISCRETE_PANELS = {
     "Active DF assignments",
@@ -554,7 +718,7 @@ def check_evpn_promql_safety(
     definitions: dict[str, tuple[str, tuple[str, ...]]],
     context: str,
 ) -> None:
-    """Keep counter math and high-cardinality EVPN dimensions bounded."""
+    """Keep counter math correct and high-cardinality labels out of output."""
     names = expression_metric_names(expression)
     for name in names & definitions.keys():
         kind, labels = definitions[name]
@@ -655,7 +819,7 @@ def check_evpn_dashboard(
     for name, query in EVPN_VARIABLES.items():
         variable = query_variables[name]
         if variable.get("query") != query:
-            raise ValueError(f"EVPN ${name} does not use its exact bounded query")
+            raise ValueError(f"EVPN ${name} does not use its exact permitted query")
         if variable.get("multi") is not True or variable.get("includeAll") is not True:
             raise ValueError(f"EVPN ${name} must support multi-select and All")
         if variable.get("allValue") != ".*":
@@ -682,6 +846,7 @@ def check_evpn_dashboard(
         raise ValueError(f"EVPN dashboard is missing required operator rows {missing_rows}")
 
     by_title = {panel.get("title"): panel for panel in panels}
+    seen_targets: set[tuple[str, str]] = set()
     for title, required_metrics in EVPN_REQUIRED_PANELS.items():
         panel = by_title.get(title)
         if panel is None or panel.get("type") not in {"timeseries", "stat"}:
@@ -689,9 +854,31 @@ def check_evpn_dashboard(
         targets = panel.get("targets", [])
         actual_metrics: set[str] = set()
         for target in targets:
+            key = (title, target.get("refId"))
+            if key in seen_targets:
+                raise ValueError(f"duplicate EVPN target {title!r}/{key[1]}")
+            seen_targets.add(key)
             expression = target.get("expr")
             if not isinstance(expression, str) or not expression:
                 raise ValueError(f"EVPN panel {title!r} has an empty target")
+            expected = EVPN_TARGETS.get(key)
+            if expected is None:
+                raise ValueError(f"unexpected EVPN target {title!r}/{key[1]}")
+            expected_expression, expected_legend = expected
+            if normalized(expression) != normalized(expected_expression):
+                raise ValueError(
+                    f"EVPN target {title!r}/{key[1]} must retain its exact expression"
+                )
+            if target.get("legendFormat") != expected_legend:
+                raise ValueError(
+                    f"EVPN target {title!r}/{key[1]} must retain legend "
+                    f"{expected_legend!r}"
+                )
+            if target.get("datasource") != EVPN_TARGET_DATASOURCE:
+                raise ValueError(
+                    f"EVPN target {title!r}/{key[1]} must bind the Prometheus "
+                    "${datasource} template"
+                )
             actual_metrics.update(expression_metric_names(expression))
             check_evpn_promql_safety(
                 expression,
@@ -704,6 +891,11 @@ def check_evpn_dashboard(
                 f"EVPN panel {title!r} metrics must be {sorted(required_metrics)}; "
                 f"got {sorted(actual_metrics)}"
             )
+
+    if seen_targets != set(EVPN_TARGETS):
+        missing = sorted(set(EVPN_TARGETS) - seen_targets)
+        extra = sorted(seen_targets - set(EVPN_TARGETS))
+        raise ValueError(f"EVPN target roster drifted: missing={missing}, extra={extra}")
 
     for title in EVPN_DISCRETE_PANELS:
         panel = by_title[title]

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -12,7 +12,147 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "docs/grafana/rustbgpd-overview.json"
+EVPN_DASHBOARD = ROOT / "docs/grafana/rustbgpd-evpn.json"
 METRICS = ROOT / "crates/telemetry/src/metrics.rs"
+
+# Exact registered source contract at the dashboard's Alpha boundary. The
+# ticket's older family count is deliberately not trusted: any telemetry-side
+# add/remove/type/label drift must update this inventory before a panel can use
+# it. Scrape-added `instance`/`job` labels are validated separately.
+EVPN_METRICS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "evpn_local_originations_total": ("counter", ("action",)),
+    "evpn_local_origination_errors_total": ("counter", ("action",)),
+    "evpn_local_observations_dropped_total": ("counter", ("reason",)),
+    "evpn_duplicate_mac_moves_total": ("counter", ("vni", "mac")),
+    "evpn_duplicate_mac_first_move_timestamp_seconds": ("gauge", ("vni", "mac")),
+    "evpn_duplicate_mac_threshold_exceeded_total": (
+        "counter",
+        ("vni", "mac", "action"),
+    ),
+    "evpn_duplicate_mac_quarantine_active": ("gauge", ("vni", "mac")),
+    "evpn_df_role": ("gauge", ("esi", "vni", "role")),
+    "evpn_es_ac_gate": ("gauge", ("esi", "state")),
+    "evpn_df_role_changes_total": ("counter", ("esi", "vni")),
+    "evpn_es_drained": ("gauge", ("esi", "reason")),
+    "evpn_ip_vrf_observed_routes": ("gauge", ("vrf",)),
+    "evpn_ip_vrf_observed_routes_filtered_total": (
+        "counter",
+        ("vrf", "reason"),
+    ),
+    "evpn_ip_vrf_origination_suppressed_total": (
+        "counter",
+        ("vrf", "reason"),
+    ),
+    "evpn_ip_vrf_originated_routes": ("gauge", ("vrf",)),
+    "evpn_ip_vrf_installed_routes": ("gauge", ("vrf",)),
+    "evpn_ip_vrf_remote_prefix_drops": ("gauge", ("vrf", "reason")),
+    "evpn_managed_netdev_state": (
+        "gauge",
+        ("class", "name", "desired", "state"),
+    ),
+    "evpn_fdb_nhg_drift_members_repaired_total": ("counter", ()),
+    "evpn_fdb_nhg_drift_groups_replaced_total": ("counter", ()),
+    "evpn_fdb_nhg_orphans_cleaned_total": ("counter", ()),
+    "evpn_fdb_nhg_drift_disabled_total": ("counter", ()),
+    "evpn_fdb_single_dst_adopted_total": ("counter", ()),
+    "evpn_fdb_single_dst_reaped_total": ("counter", ()),
+    "evpn_l3_route_adopted_total": ("counter", ()),
+    "evpn_l3_route_reaped_total": ("counter", ()),
+    "evpn_l3_neighbor_adopted_total": ("counter", ()),
+    "evpn_l3_neighbor_reaped_total": ("counter", ()),
+    "evpn_l3vxlan_fdb_adopted_total": ("counter", ()),
+    "evpn_l3vxlan_fdb_reaped_total": ("counter", ()),
+    "evpn_single_active_backup_swaps_total": ("counter", ()),
+    "evpn_single_active_teardowns_total": ("counter", ()),
+    "evpn_foreign_replaces_blocked_total": ("counter", ()),
+    "evpn_foreign_deletes_skipped_total": ("counter", ()),
+    "evpn_foreign_owned_relinquished_total": ("counter", ()),
+    "evpn_foreign_nhid_range_conflicts_total": ("counter", ()),
+    "evpn_single_active_backup_active": ("gauge", ()),
+    "evpn_runtime_decomposed_fail_stops_total": ("counter", ()),
+}
+
+EVPN_VARIABLES = {
+    "instance": 'label_values(bgp_rib_outbound_registered_peers, instance)',
+    "vrf": 'label_values(evpn_ip_vrf_observed_routes{instance=~"$instance"}, vrf)',
+}
+
+EVPN_REQUIRED_ROWS = {
+    "Type-2 / Type-3 / Type-5 and IP-VRF state",
+    "DF, attachment circuits, and drain",
+    "Duplicate-MAC quarantine",
+    "Dataplane repair, adoption, and single-active state",
+    "Ownership conflicts and fail-stops",
+}
+
+EVPN_REQUIRED_PANELS = {
+    "EVPN Loc-RIB (all route types)": {"bgp_rib_loc_prefixes"},
+    "Type-2 local origination actions, errors, and drops": {
+        "evpn_local_originations_total",
+        "evpn_local_origination_errors_total",
+        "evpn_local_observations_dropped_total",
+    },
+    "Type-5 IP-VRF route state": {
+        "evpn_ip_vrf_observed_routes",
+        "evpn_ip_vrf_originated_routes",
+        "evpn_ip_vrf_installed_routes",
+    },
+    "Type-5 filtering, suppression, and projection drops": {
+        "evpn_ip_vrf_observed_routes_filtered_total",
+        "evpn_ip_vrf_origination_suppressed_total",
+        "evpn_ip_vrf_remote_prefix_drops",
+    },
+    "Active DF assignments": {"evpn_df_role"},
+    "Attachment-circuit gate state": {"evpn_es_ac_gate"},
+    "Ethernet-segment drain reasons": {"evpn_es_drained"},
+    "DF role changes": {"evpn_df_role_changes_total"},
+    "Quarantined local Type-2 keys": {"evpn_duplicate_mac_quarantine_active"},
+    "Duplicate-MAC contention activity": {
+        "evpn_duplicate_mac_moves_total",
+        "evpn_duplicate_mac_threshold_exceeded_total",
+    },
+    "Oldest active quarantine age": {
+        "evpn_duplicate_mac_first_move_timestamp_seconds",
+        "evpn_duplicate_mac_quarantine_active",
+    },
+    "Managed netdev state": {"evpn_managed_netdev_state"},
+    "FDB-NHG repair and cleanup": {
+        "evpn_fdb_nhg_drift_members_repaired_total",
+        "evpn_fdb_nhg_drift_groups_replaced_total",
+        "evpn_fdb_nhg_orphans_cleaned_total",
+        "evpn_fdb_nhg_drift_disabled_total",
+    },
+    "Startup adoption and deferred reap": {
+        "evpn_fdb_single_dst_adopted_total",
+        "evpn_fdb_single_dst_reaped_total",
+        "evpn_l3_route_adopted_total",
+        "evpn_l3_route_reaped_total",
+        "evpn_l3_neighbor_adopted_total",
+        "evpn_l3_neighbor_reaped_total",
+        "evpn_l3vxlan_fdb_adopted_total",
+        "evpn_l3vxlan_fdb_reaped_total",
+    },
+    "Single-active failover state": {
+        "evpn_single_active_backup_active",
+        "evpn_single_active_backup_swaps_total",
+        "evpn_single_active_teardowns_total",
+    },
+    "Foreign ownership conflicts": {
+        "evpn_foreign_replaces_blocked_total",
+        "evpn_foreign_deletes_skipped_total",
+        "evpn_foreign_owned_relinquished_total",
+        "evpn_foreign_nhid_range_conflicts_total",
+    },
+    "Runtime decomposed fail-stops": {"evpn_runtime_decomposed_fail_stops_total"},
+}
+
+EVPN_DISCRETE_PANELS = {
+    "Active DF assignments",
+    "Attachment-circuit gate state",
+    "Ethernet-segment drain reasons",
+    "Quarantined local Type-2 keys",
+    "Managed netdev state",
+}
 
 VARIABLES = {
     "peer": 'label_values(bgp_peer_admin_enabled{instance=~"$instance"}, peer)',
@@ -361,6 +501,223 @@ def rust_metric_inventory(source: str) -> dict[str, str]:
     return inventory
 
 
+def registered_metric_definitions(
+    source: str,
+) -> dict[str, tuple[str, tuple[str, ...]]]:
+    """Return directly registered Prometheus kind and constructor labels."""
+    source, strings = rust_lex(source)
+    source = source.split("#[cfg(test)]", 1)[0]
+    constructors: dict[str, tuple[str, tuple[str, ...]]] = {}
+    pattern = re.compile(
+        r"let\s+(\w+)\s*=\s*"
+        r"(IntCounter(?:Vec)?|IntGauge(?:Vec)?|HistogramVec)::new\("
+        r"(.*?)\)\s*\.expect\(",
+        re.DOTALL,
+    )
+    for variable, rust_kind, body in pattern.findall(source):
+        tokens = [int(index) for index in re.findall(r"__RUST_STRING_(\d+)__", body)]
+        if len(tokens) < 2:
+            raise ValueError(f"metric constructor {variable} lacks name/help strings")
+        name = strings[tokens[0]]
+        labels = tuple(strings[index] for index in tokens[2:]) if rust_kind.endswith("Vec") else ()
+        if rust_kind.startswith("IntCounter"):
+            kind = "counter"
+        elif rust_kind.startswith("IntGauge"):
+            kind = "gauge"
+        else:
+            kind = "histogram"
+        constructors[variable] = (name, (kind, labels))
+
+    definitions: dict[str, tuple[str, tuple[str, ...]]] = {}
+    for variable in re.findall(
+        r"\.register\(\s*Box::new\(\s*(\w+)\.clone\(\)\s*,?\s*\)\s*\)",
+        source,
+    ):
+        constructor = constructors.get(variable)
+        if constructor is None:
+            continue
+        name, definition = constructor
+        if name in definitions:
+            raise ValueError(f"duplicate registered metric name {name}")
+        definitions[name] = definition
+    return definitions
+
+
+def expression_metric_names(expression: str) -> set[str]:
+    syntax = re.sub(r'"(?:\\.|[^"\\])*"', '""', expression)
+    return set(re.findall(r"(?<![$\w:])([A-Za-z_:][A-Za-z0-9_:]*)\s*(?=\{)", syntax))
+
+
+def check_evpn_promql_safety(
+    expression: str,
+    legend: object,
+    definitions: dict[str, tuple[str, tuple[str, ...]]],
+    context: str,
+) -> None:
+    """Keep counter math and high-cardinality EVPN dimensions bounded."""
+    names = expression_metric_names(expression)
+    for name in names & definitions.keys():
+        kind, labels = definitions[name]
+        selector = re.search(rf"{re.escape(name)}\s*\{{([^}}]*)\}}", expression)
+        if selector is None:
+            raise ValueError(f"{context}: {name} must use an explicit selector")
+        matcher_labels = set(
+            re.findall(r"([A-Za-z_]\w*)\s*(?:=~|!~|!=|=)", selector.group(1))
+        )
+        allowed = set(labels) | {"instance", "job"}
+        invalid = sorted(matcher_labels - allowed)
+        if invalid:
+            raise ValueError(f"{context}: {name} uses invalid labels {invalid}")
+
+        wrapped = re.search(
+            rf"(?:rate|increase)\(\s*{re.escape(name)}\s*\{{",
+            expression,
+        )
+        if kind == "counter" and wrapped is None:
+            raise ValueError(f"{context}: counter {name} must use rate/increase before aggregation")
+        if kind != "counter" and wrapped is not None:
+            raise ValueError(f"{context}: state gauge {name} must not use rate/increase")
+
+        high_cardinality = {"mac", "esi", "name", "peer", "ip"} & set(labels)
+        if high_cardinality:
+            if not re.search(r"\b(?:sum|max|count|topk)\s*(?:by\s*\([^)]*\))?\s*\(", expression):
+                raise ValueError(
+                    f"{context}: {name} must aggregate away high-cardinality labels"
+                )
+            for grouping in re.findall(r"\bby\s*\(([^)]*)\)", expression):
+                retained = {part.strip() for part in grouping.split(",")}
+                unsafe = sorted(retained & high_cardinality)
+                if unsafe:
+                    raise ValueError(
+                        f"{context}: unsafe aggregation retains labels {unsafe}"
+                    )
+            rendered = str(legend or "")
+            unsafe_legend = sorted(
+                label for label in high_cardinality if f"{{{{{label}}}}}" in rendered
+            )
+            if unsafe_legend:
+                raise ValueError(
+                    f"{context}: legend exposes high-cardinality labels {unsafe_legend}"
+                )
+
+    if "$vrf" in expression and not re.search(r'vrf\s*=~\s*"\$vrf"', expression):
+        raise ValueError(f"{context}: multi-value $vrf must use the =~ matcher")
+
+
+def check_evpn_dashboard(
+    path: Path,
+    inventory: dict[str, str],
+    source: str,
+) -> tuple[int, int]:
+    try:
+        dashboard = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot parse {path.relative_to(ROOT)}: {error}") from error
+
+    if dashboard.get("title") != "rustbgpd EVPN Operations (Alpha)":
+        raise ValueError("EVPN dashboard title must retain its explicit Alpha marker")
+    description = str(dashboard.get("description", ""))
+    if "Alpha" not in description or "Type 3 has no dedicated metric" not in description:
+        raise ValueError(
+            "EVPN dashboard must state Alpha status and the Type-3 aggregate-only boundary"
+        )
+    if not {"rustbgpd", "evpn", "alpha"}.issubset(set(dashboard.get("tags", []))):
+        raise ValueError("EVPN dashboard tags must include rustbgpd, evpn, and alpha")
+
+    definitions = registered_metric_definitions(source)
+    actual_evpn = {
+        name: definition for name, definition in definitions.items() if name.startswith("evpn_")
+    }
+    if actual_evpn != EVPN_METRICS:
+        missing = sorted(EVPN_METRICS.keys() - actual_evpn.keys())
+        extra = sorted(actual_evpn.keys() - EVPN_METRICS.keys())
+        changed = sorted(
+            name
+            for name in EVPN_METRICS.keys() & actual_evpn.keys()
+            if EVPN_METRICS[name] != actual_evpn[name]
+        )
+        raise ValueError(
+            "EVPN telemetry inventory drifted: "
+            f"missing={missing}, extra={extra}, changed={changed}"
+        )
+
+    variables = {
+        variable.get("name"): variable
+        for variable in dashboard.get("templating", {}).get("list", [])
+    }
+    query_variables = {
+        name: variable for name, variable in variables.items() if variable.get("type") == "query"
+    }
+    if set(query_variables) != set(EVPN_VARIABLES):
+        raise ValueError(
+            f"EVPN dashboard query variables must be {sorted(EVPN_VARIABLES)}"
+        )
+    for name, query in EVPN_VARIABLES.items():
+        variable = query_variables[name]
+        if variable.get("query") != query:
+            raise ValueError(f"EVPN ${name} does not use its exact bounded query")
+        if variable.get("multi") is not True or variable.get("includeAll") is not True:
+            raise ValueError(f"EVPN ${name} must support multi-select and All")
+        if variable.get("allValue") != ".*":
+            raise ValueError(f"EVPN ${name} All value must be the simple regex .* ")
+    forbidden_variables = {"peer", "mac", "esi", "name", "ip"} & set(variables)
+    if forbidden_variables:
+        raise ValueError(
+            f"EVPN dashboard exposes forbidden high-cardinality variables {sorted(forbidden_variables)}"
+        )
+
+    panels = all_panels(dashboard.get("panels", []))
+    ids = [panel.get("id") for panel in panels]
+    if any(type(panel_id) is not int for panel_id in ids):
+        raise ValueError("every EVPN panel must have an integer id")
+    duplicates = sorted({panel_id for panel_id in ids if ids.count(panel_id) > 1})
+    if duplicates:
+        raise ValueError(f"duplicate EVPN panel ids: {duplicates}")
+
+    rows = {
+        panel.get("title") for panel in panels if panel.get("type") == "row"
+    }
+    missing_rows = sorted(EVPN_REQUIRED_ROWS - rows)
+    if missing_rows:
+        raise ValueError(f"EVPN dashboard is missing required operator rows {missing_rows}")
+
+    by_title = {panel.get("title"): panel for panel in panels}
+    for title, required_metrics in EVPN_REQUIRED_PANELS.items():
+        panel = by_title.get(title)
+        if panel is None or panel.get("type") not in {"timeseries", "stat"}:
+            raise ValueError(f"EVPN operator panel {title!r} is missing")
+        targets = panel.get("targets", [])
+        actual_metrics: set[str] = set()
+        for target in targets:
+            expression = target.get("expr")
+            if not isinstance(expression, str) or not expression:
+                raise ValueError(f"EVPN panel {title!r} has an empty target")
+            actual_metrics.update(expression_metric_names(expression))
+            check_evpn_promql_safety(
+                expression,
+                target.get("legendFormat"),
+                EVPN_METRICS,
+                f"{title}/{target.get('refId')}",
+            )
+        if actual_metrics != required_metrics:
+            raise ValueError(
+                f"EVPN panel {title!r} metrics must be {sorted(required_metrics)}; "
+                f"got {sorted(actual_metrics)}"
+            )
+
+    for title in EVPN_DISCRETE_PANELS:
+        panel = by_title[title]
+        defaults = panel.get("fieldConfig", {}).get("defaults", {})
+        if defaults.get("decimals") != 0 or defaults.get("min") != 0:
+            raise ValueError(f"EVPN discrete panel {title!r} must use whole nonnegative values")
+        if defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
+            raise ValueError(f"EVPN discrete panel {title!r} must use step interpolation")
+
+    references = dashboard_metric_references(dashboard)
+    check_metric_linkage(references, inventory)
+    return len(panels), len(references)
+
+
 def check_metric_linkage(references: dict[str, list[str]], inventory: dict[str, str]) -> None:
     unresolved: list[str] = []
     for name, contexts in sorted(references.items()):
@@ -636,14 +993,21 @@ def main() -> None:
 
     try:
         references = dashboard_metric_references(dashboard)
-        inventory = rust_metric_inventory(METRICS.read_text(encoding="utf-8"))
+        source = METRICS.read_text(encoding="utf-8")
+        inventory = rust_metric_inventory(source)
         check_metric_linkage(references, inventory)
+        evpn_panels, evpn_references = check_evpn_dashboard(
+            EVPN_DASHBOARD,
+            inventory,
+            source,
+        )
     except (OSError, ValueError) as error:
         fail(str(error))
 
     print(
         f"dashboard check: {len(panels)} unique panels, "
-        f"{len(TARGETS)} operator targets, and {len(references)} linked metrics"
+        f"{len(TARGETS)} operator targets, and {len(references)} linked metrics; "
+        f"EVPN Alpha {evpn_panels} panels and {evpn_references} linked metrics"
     )
 
 

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -845,7 +845,27 @@ def check_evpn_dashboard(
     if missing_rows:
         raise ValueError(f"EVPN dashboard is missing required operator rows {missing_rows}")
 
-    by_title = {panel.get("title"): panel for panel in panels}
+    data_panels = [panel for panel in panels if panel.get("type") != "row"]
+    data_titles = [panel.get("title") for panel in data_panels]
+    panel_titles = [panel.get("title") for panel in panels]
+    unexpected_titles = sorted(
+        {title for title in data_titles if title not in EVPN_REQUIRED_PANELS},
+        key=str,
+    )
+    if unexpected_titles:
+        raise ValueError(f"EVPN dashboard has unexpected data panels {unexpected_titles}")
+    invalid_counts = {
+        title: panel_titles.count(title)
+        for title in EVPN_REQUIRED_PANELS
+        if panel_titles.count(title) != 1
+    }
+    if invalid_counts:
+        raise ValueError(
+            "EVPN dashboard must contain exactly one of every required data panel; "
+            f"counts={invalid_counts}"
+        )
+
+    by_title = {panel.get("title"): panel for panel in data_panels}
     seen_targets: set[tuple[str, str]] = set()
     for title, required_metrics in EVPN_REQUIRED_PANELS.items():
         panel = by_title.get(title)

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -776,7 +776,11 @@ def check_evpn_dashboard(
     try:
         dashboard = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
-        raise ValueError(f"cannot parse {path.relative_to(ROOT)}: {error}") from error
+        try:
+            display_path = path.relative_to(ROOT)
+        except ValueError:
+            display_path = path
+        raise ValueError(f"cannot parse {display_path}: {error}") from error
 
     if dashboard.get("title") != "rustbgpd EVPN Operations (Alpha)":
         raise ValueError("EVPN dashboard title must retain its explicit Alpha marker")

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -170,9 +170,9 @@ let families = self.allocated.collect();'''
         panel = self.evpn_panel(dashboard, "Active DF assignments")
         expression = panel["targets"][0]["expr"]
         for replacement, error in (
-            (expression.replace("evpn_df_role", "evpn_df_roles"), "evpn_df_roles"),
+            (expression.replace("evpn_df_role", "evpn_df_roles"), "exact expression"),
             (expression.replace('role="df"', 'role="df",mac="00:00:00:00:00:01"'),
-             "invalid labels.*mac"),
+             "exact expression"),
         ):
             with self.subTest(replacement=replacement):
                 panel["targets"][0]["expr"] = replacement
@@ -203,7 +203,12 @@ let families = self.allocated.collect();'''
             "sum by (instance, vni)", "sum by (instance, vni, esi)"
         )
         with self.assertRaisesRegex(ValueError, "unsafe aggregation.*esi"):
-            self.check_evpn(dashboard)
+            CHECK.check_evpn_promql_safety(
+                panel["targets"][0]["expr"],
+                panel["targets"][0]["legendFormat"],
+                CHECK.EVPN_METRICS,
+                "test",
+            )
 
         dashboard = self.evpn_dashboard()
         panel = self.evpn_panel(dashboard, "FDB-NHG repair and cleanup")
@@ -211,7 +216,12 @@ let families = self.allocated.collect();'''
             "rate(", "("
         )
         with self.assertRaisesRegex(ValueError, "counter.*must use rate/increase"):
-            self.check_evpn(dashboard)
+            CHECK.check_evpn_promql_safety(
+                panel["targets"][0]["expr"],
+                panel["targets"][0]["legendFormat"],
+                CHECK.EVPN_METRICS,
+                "test",
+            )
 
         dashboard = self.evpn_dashboard()
         panel = self.evpn_panel(dashboard, "Type-5 IP-VRF route state")
@@ -220,7 +230,12 @@ let families = self.allocated.collect();'''
             '[$__rate_interval])'
         )
         with self.assertRaisesRegex(ValueError, "gauge.*must not use rate/increase"):
-            self.check_evpn(dashboard)
+            CHECK.check_evpn_promql_safety(
+                panel["targets"][0]["expr"],
+                panel["targets"][0]["legendFormat"],
+                CHECK.EVPN_METRICS,
+                "test",
+            )
 
     def test_evpn_multi_value_vrf_uses_regex_matching(self):
         dashboard = self.evpn_dashboard()
@@ -229,7 +244,48 @@ let families = self.allocated.collect();'''
             'vrf=~"$vrf"', 'vrf="$vrf"'
         )
         with self.assertRaisesRegex(ValueError, "multi-value.*must use the =~"):
-            self.check_evpn(dashboard)
+            CHECK.check_evpn_promql_safety(
+                panel["targets"][0]["expr"],
+                panel["targets"][0]["legendFormat"],
+                CHECK.EVPN_METRICS,
+                "test",
+            )
+
+    def test_evpn_load_bearing_promql_mutations_fail_closed(self):
+        mutations = (
+            ("Active DF assignments", ' == 1)', ' >= 0)'),
+            ("Type-5 IP-VRF route state", "sum by", "avg by"),
+            (
+                "Time since first recorded move for active quarantines",
+                " and on (instance, vni, mac) ",
+                " + on (instance, vni, mac) ",
+            ),
+            ("Quarantined local Type-2 keys", " == 1)", " == 1) or vector(0)"),
+        )
+        for title, old, new in mutations:
+            with self.subTest(panel=title):
+                dashboard = self.evpn_dashboard()
+                target = self.evpn_panel(dashboard, title)["targets"][0]
+                self.assertIn(old, target["expr"])
+                target["expr"] = target["expr"].replace(old, new, 1)
+                with self.assertRaisesRegex(ValueError, "exact expression"):
+                    self.check_evpn(dashboard)
+
+    def test_evpn_target_legend_and_datasource_are_exact(self):
+        for field, replacement, error in (
+            ("legendFormat", "{{instance}} vague", "retain legend"),
+            (
+                "datasource",
+                {"type": "prometheus", "uid": "prometheus-fixed"},
+                "bind the Prometheus.*datasource",
+            ),
+        ):
+            with self.subTest(field=field):
+                dashboard = self.evpn_dashboard()
+                target = self.evpn_panel(dashboard, "Active DF assignments")["targets"][0]
+                target[field] = replacement
+                with self.assertRaisesRegex(ValueError, error):
+                    self.check_evpn(dashboard)
 
     def test_live_dashboard_presentation_mutations_pass_full_check(self):
         dashboard = json.loads(CHECK.DASHBOARD.read_text())

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -287,6 +287,39 @@ let families = self.allocated.collect();'''
                 with self.assertRaisesRegex(ValueError, error):
                     self.check_evpn(dashboard)
 
+    def test_evpn_extra_data_panel_fails_closed(self):
+        dashboard = self.evpn_dashboard()
+        dashboard["panels"].append(
+            {
+                "id": 999,
+                "type": "timeseries",
+                "title": "Unsafe per-MAC quarantine detail",
+                "targets": [
+                    {
+                        "refId": "A",
+                        "expr": (
+                            "evpn_duplicate_mac_quarantine_active"
+                            '{instance=~"$instance"}'
+                        ),
+                        "legendFormat": "{{mac}}",
+                        "datasource": CHECK.EVPN_TARGET_DATASOURCE,
+                    }
+                ],
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "unexpected data panels.*Unsafe per-MAC"):
+            self.check_evpn(dashboard)
+
+    def test_evpn_duplicate_required_panel_title_fails_closed(self):
+        dashboard = self.evpn_dashboard()
+        duplicate = json.loads(
+            json.dumps(self.evpn_panel(dashboard, "Active DF assignments"))
+        )
+        duplicate["id"] = 999
+        dashboard["panels"].append(duplicate)
+        with self.assertRaisesRegex(ValueError, "exactly one.*counts=.*Active DF"):
+            self.check_evpn(dashboard)
+
     def test_live_dashboard_presentation_mutations_pass_full_check(self):
         dashboard = json.loads(CHECK.DASHBOARD.read_text())
         for index, panel in enumerate(CHECK.all_panels(dashboard["panels"])):

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -154,7 +154,7 @@ let families = self.allocated.collect();'''
             CHECK.rust_metric_inventory(source)
 
     def test_live_evpn_dashboard_and_frozen_source_inventory(self):
-        source = CHECK.METRICS.read_text()
+        source = CHECK.METRICS.read_text(encoding="utf-8")
         self.assertEqual(
             {
                 name: definition
@@ -164,6 +164,15 @@ let families = self.allocated.collect();'''
             CHECK.EVPN_METRICS,
         )
         self.check_evpn(self.evpn_dashboard())
+
+    def test_evpn_temp_json_parse_error_keeps_its_context(self):
+        source = CHECK.METRICS.read_text(encoding="utf-8")
+        inventory = CHECK.rust_metric_inventory(source)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "evpn-invalid.json"
+            path.write_text("{", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "cannot parse .*evpn-invalid.json"):
+                CHECK.check_evpn_dashboard(path, inventory, source)
 
     def test_evpn_metric_typo_and_invalid_label_fail_closed(self):
         dashboard = self.evpn_dashboard()
@@ -321,7 +330,7 @@ let families = self.allocated.collect();'''
             self.check_evpn(dashboard)
 
     def test_live_dashboard_presentation_mutations_pass_full_check(self):
-        dashboard = json.loads(CHECK.DASHBOARD.read_text())
+        dashboard = json.loads(CHECK.DASHBOARD.read_text(encoding="utf-8"))
         for index, panel in enumerate(CHECK.all_panels(dashboard["panels"])):
             changes = {"description": "changed",
                        "collapsed": not panel.get("collapsed", False),
@@ -345,7 +354,7 @@ let families = self.allocated.collect();'''
         blackhole_row["panels"].append(blackhole)
         with tempfile.TemporaryDirectory() as directory:
             copy = Path(directory) / "dashboard.json"
-            copy.write_text(json.dumps(dashboard))
+            copy.write_text(json.dumps(dashboard), encoding="utf-8")
             original, CHECK.DASHBOARD = CHECK.DASHBOARD, copy
             try:
                 with redirect_stdout(io.StringIO()):
@@ -355,7 +364,7 @@ let families = self.allocated.collect();'''
                 for field in ("expr", "legendFormat"):
                     saved = orr["targets"][0][field]
                     orr["targets"][0][field] = "broken"
-                    copy.write_text(json.dumps(dashboard))
+                    copy.write_text(json.dumps(dashboard), encoding="utf-8")
                     with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
                         CHECK.main()
                     orr["targets"][0][field] = saved
@@ -370,7 +379,7 @@ let families = self.allocated.collect();'''
                 for subject, field, replacement in mutations:
                     saved = subject[field]
                     subject[field] = replacement
-                    copy.write_text(json.dumps(dashboard))
+                    copy.write_text(json.dumps(dashboard), encoding="utf-8")
                     with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
                         CHECK.main()
                     subject[field] = saved
@@ -386,12 +395,12 @@ let families = self.allocated.collect();'''
                 ):
                     saved = subject[field]
                     subject[field] = replacement
-                    copy.write_text(json.dumps(dashboard))
+                    copy.write_text(json.dumps(dashboard), encoding="utf-8")
                     with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
                         CHECK.main()
                     subject[field] = saved
                 self.assertTrue(self.remove_panel(dashboard["panels"], blackhole["id"]))
-                copy.write_text(json.dumps(dashboard))
+                copy.write_text(json.dumps(dashboard), encoding="utf-8")
                 stderr = io.StringIO()
                 targets = CHECK.TARGETS
                 legends = CHECK.REQUIRED_LEGENDS

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -16,13 +16,13 @@ SPEC.loader.exec_module(CHECK)
 
 class DashboardMetricLinkTests(unittest.TestCase):
     def evpn_dashboard(self):
-        return json.loads(CHECK.EVPN_DASHBOARD.read_text())
+        return json.loads(CHECK.EVPN_DASHBOARD.read_text(encoding="utf-8"))
 
     def check_evpn(self, dashboard):
-        source = CHECK.METRICS.read_text()
+        source = CHECK.METRICS.read_text(encoding="utf-8")
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "evpn.json"
-            path.write_text(json.dumps(dashboard))
+            path.write_text(json.dumps(dashboard), encoding="utf-8")
             CHECK.check_evpn_dashboard(
                 path, CHECK.rust_metric_inventory(source), source
             )

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -15,6 +15,25 @@ SPEC.loader.exec_module(CHECK)
 
 
 class DashboardMetricLinkTests(unittest.TestCase):
+    def evpn_dashboard(self):
+        return json.loads(CHECK.EVPN_DASHBOARD.read_text())
+
+    def check_evpn(self, dashboard):
+        source = CHECK.METRICS.read_text()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "evpn.json"
+            path.write_text(json.dumps(dashboard))
+            CHECK.check_evpn_dashboard(
+                path, CHECK.rust_metric_inventory(source), source
+            )
+
+    def evpn_panel(self, dashboard, title):
+        return next(
+            panel
+            for panel in CHECK.all_panels(dashboard["panels"])
+            if panel.get("title") == title
+        )
+
     def remove_panel(self, panels, panel_id):
         for index, panel in enumerate(panels):
             if panel.get("id") == panel_id:
@@ -133,6 +152,84 @@ let families = self.allocated.collect();'''
         source = f'let text = "{escaped}"; let raw = r#"{fake}"#;'
         with self.assertRaisesRegex(ValueError, "no registered Rust metrics"):
             CHECK.rust_metric_inventory(source)
+
+    def test_live_evpn_dashboard_and_frozen_source_inventory(self):
+        source = CHECK.METRICS.read_text()
+        self.assertEqual(
+            {
+                name: definition
+                for name, definition in CHECK.registered_metric_definitions(source).items()
+                if name.startswith("evpn_")
+            },
+            CHECK.EVPN_METRICS,
+        )
+        self.check_evpn(self.evpn_dashboard())
+
+    def test_evpn_metric_typo_and_invalid_label_fail_closed(self):
+        dashboard = self.evpn_dashboard()
+        panel = self.evpn_panel(dashboard, "Active DF assignments")
+        expression = panel["targets"][0]["expr"]
+        for replacement, error in (
+            (expression.replace("evpn_df_role", "evpn_df_roles"), "evpn_df_roles"),
+            (expression.replace('role="df"', 'role="df",mac="00:00:00:00:00:01"'),
+             "invalid labels.*mac"),
+        ):
+            with self.subTest(replacement=replacement):
+                panel["targets"][0]["expr"] = replacement
+                with self.assertRaisesRegex(ValueError, error):
+                    self.check_evpn(dashboard)
+                panel["targets"][0]["expr"] = expression
+
+    def test_evpn_alpha_marker_and_required_row_fail_closed(self):
+        dashboard = self.evpn_dashboard()
+        dashboard["title"] = "rustbgpd EVPN Operations"
+        with self.assertRaisesRegex(ValueError, "title.*Alpha marker"):
+            self.check_evpn(dashboard)
+
+        dashboard = self.evpn_dashboard()
+        dashboard["panels"] = [
+            panel
+            for panel in dashboard["panels"]
+            if panel.get("title") != "Duplicate-MAC quarantine"
+        ]
+        with self.assertRaisesRegex(ValueError, "missing required operator rows.*Duplicate-MAC"):
+            self.check_evpn(dashboard)
+
+    def test_evpn_kind_and_cardinality_guards_fail_closed(self):
+        dashboard = self.evpn_dashboard()
+        panel = self.evpn_panel(dashboard, "DF role changes")
+        expression = panel["targets"][0]["expr"]
+        panel["targets"][0]["expr"] = expression.replace(
+            "sum by (instance, vni)", "sum by (instance, vni, esi)"
+        )
+        with self.assertRaisesRegex(ValueError, "unsafe aggregation.*esi"):
+            self.check_evpn(dashboard)
+
+        dashboard = self.evpn_dashboard()
+        panel = self.evpn_panel(dashboard, "FDB-NHG repair and cleanup")
+        panel["targets"][0]["expr"] = panel["targets"][0]["expr"].replace(
+            "rate(", "("
+        )
+        with self.assertRaisesRegex(ValueError, "counter.*must use rate/increase"):
+            self.check_evpn(dashboard)
+
+        dashboard = self.evpn_dashboard()
+        panel = self.evpn_panel(dashboard, "Type-5 IP-VRF route state")
+        panel["targets"][0]["expr"] = (
+            'rate(evpn_ip_vrf_observed_routes{instance=~"$instance",vrf=~"$vrf"}'
+            '[$__rate_interval])'
+        )
+        with self.assertRaisesRegex(ValueError, "gauge.*must not use rate/increase"):
+            self.check_evpn(dashboard)
+
+    def test_evpn_multi_value_vrf_uses_regex_matching(self):
+        dashboard = self.evpn_dashboard()
+        panel = self.evpn_panel(dashboard, "Type-5 IP-VRF route state")
+        panel["targets"][0]["expr"] = panel["targets"][0]["expr"].replace(
+            'vrf=~"$vrf"', 'vrf="$vrf"'
+        )
+        with self.assertRaisesRegex(ValueError, "multi-value.*must use the =~"):
+            self.check_evpn(dashboard)
 
     def test_live_dashboard_presentation_mutations_pass_full_check(self):
         dashboard = json.loads(CHECK.DASHBOARD.read_text())


### PR DESCRIPTION
## Summary

- ship a dedicated, explicitly Alpha EVPN Grafana dashboard covering all 38 source-registered EVPN metric families
- validate the complete dashboard panel and target roster, metric kinds and labels, exact PromQL/legends/datasource bindings, and bounded rendered dimensions
- document the honest telemetry boundaries for Type 3, VTEP reachability, first-move timestamps, and retained per-MAC source cardinality

## Verification

- `python3 scripts/check-grafana-dashboard.py`
- `python3 -m unittest -v scripts/test_check_grafana_dashboard.py` (24 tests)
- `python3 scripts/check-metric-consumers.py`
- `python3 -m unittest -v scripts/test_check_metric_consumers.py` (30 tests)
- public tracker checker and tests (18 tests)
- JSON parse, Python compile, diff checks, full formatting and workspace Clippy hooks
- independent exact-head review

Linear: LAN-1192