### PR TITLE
refactor(rib): group VPN and labeled staging inputs

### DIFF
--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -1,7 +1,7 @@
 use super::{
-    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, OutboundCommitBatch,
-    PolicyChain, RibManager, RouteContext, Safi, gauge_val, labeled_route_family,
-    labeled_routes_equal, route_type, should_suppress_ibgp_inner, warn,
+    Afi, HashSet, IpAddr, OutboundCommitBatch, PolicyChain, RibManager, RouteContext, Safi,
+    gauge_val, labeled_route_family, labeled_routes_equal, route_type, should_suppress_ibgp_inner,
+    warn,
 };
 use crate::loc_rib::labeled_tiebreak_orr;
 use crate::route::{LabeledRibRoute, LabeledRibRouteKey};
@@ -77,33 +77,34 @@ impl RibManager {
     /// with outbound path IDs `1..=N`. Otherwise the single best is staged
     /// with `path_id = 0`.
     #[expect(
-        clippy::fn_params_excessive_bools,
-        clippy::too_many_arguments,
         clippy::too_many_lines,
         reason = "labeled staging mirrors the VPN multipath/single-best distribution context for RR/export parity"
     )]
     pub(in crate::manager) fn stage_labeled_routes(
-        loc_rib: &LocRib,
-        ribs: &HashMap<IpAddr, AdjRibIn>,
-        rib_out: &AdjRibOut,
-        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        context: &crate::manager::VpnLabeledStagingContext<'_>,
         keys: &HashSet<Prefix>,
         target: &mut super::ExportTarget<'_>,
-        target_is_ebgp: bool,
-        interpret_rfc1997: bool,
-        target_is_rr_client: bool,
-        cluster_id: Option<Ipv4Addr>,
-        sendable: Option<&Vec<(Afi, Safi)>>,
-        llgr: Option<&Vec<(Afi, Safi)>>,
-        orr_ctx: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
-        add_path_send_max: u32,
-        add_path_send_limits: Option<&HashMap<(Afi, Safi), u32>>,
-        add_path_send_families: &[(Afi, Safi)],
-        export_pol: Option<&PolicyChain>,
         labeled_announce: &mut Vec<LabeledRibRoute>,
         labeled_withdraw: &mut Vec<LabeledRibRouteKey>,
-        force: bool,
     ) {
+        let &crate::manager::VpnLabeledStagingContext {
+            loc_rib,
+            ribs,
+            rib_out,
+            peer_is_rr_client,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            orr_ctx,
+            add_path_send_max,
+            add_path_send_limits,
+            add_path_send_families,
+            export_pol,
+            force,
+        } = context;
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         let split_horizon_peer = target.split_horizon_peer();
         for key in keys {
@@ -780,6 +781,25 @@ impl RibManager {
                 .or_insert_with(|| crate::adj_rib_out::AdjRibOut::with_capacity(peer, loc_rib_len));
             let policy_stats = self.export_policy_stats.entry(peer).or_default();
 
+            let context = crate::manager::VpnLabeledStagingContext {
+                loc_rib: &self.loc_rib,
+                ribs: &self.ribs,
+                rib_out,
+                peer_is_rr_client: &self.peer_is_rr_client,
+                target_is_ebgp,
+                interpret_rfc1997,
+                target_is_rr_client,
+                cluster_id: self.cluster_id,
+                sendable: sendable.as_ref(),
+                llgr: llgr.as_ref(),
+                orr_ctx,
+                add_path_send_max,
+                add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+                add_path_send_families: &add_path_send_families,
+                export_pol: export_pol.as_ref(),
+                force: false,
+            };
+
             let mut labeled_announce = Vec::new();
             let mut labeled_withdraw = Vec::new();
             let mut target = super::ExportTarget::Peer {
@@ -791,26 +811,11 @@ impl RibManager {
                 peer_label: &target_peer_label,
             };
             Self::stage_labeled_routes(
-                &self.loc_rib,
-                &self.ribs,
-                rib_out,
-                &self.peer_is_rr_client,
+                &context,
                 staged_keys,
                 &mut target,
-                target_is_ebgp,
-                interpret_rfc1997,
-                target_is_rr_client,
-                self.cluster_id,
-                sendable.as_ref(),
-                llgr.as_ref(),
-                orr_ctx,
-                add_path_send_max,
-                self.peer_add_path_send_limits.get(&peer),
-                &add_path_send_families,
-                export_pol.as_ref(),
                 &mut labeled_announce,
                 &mut labeled_withdraw,
-                false,
             );
 
             if (!labeled_announce.is_empty() || !labeled_withdraw.is_empty())

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -5388,6 +5388,25 @@ impl RibManager {
                 );
             }
 
+            let vpn_labeled_context = super::VpnLabeledStagingContext {
+                loc_rib,
+                ribs: &self.ribs,
+                rib_out,
+                peer_is_rr_client: &self.peer_is_rr_client,
+                target_is_ebgp,
+                interpret_rfc1997,
+                target_is_rr_client,
+                cluster_id,
+                sendable: sendable.as_ref(),
+                llgr: llgr.as_ref(),
+                orr_ctx,
+                add_path_send_max: peer_add_path_send_max,
+                add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+                add_path_send_families: &peer_add_path_send_families,
+                export_pol: export_pol.as_ref(),
+                force: is_force,
+            };
+
             // A VPN-staging group member's VPN resync was assembled from
             // the group table above — no per-peer staging, no policy
             // re-evaluation.
@@ -5401,27 +5420,12 @@ impl RibManager {
                     peer_label: &target_peer_label,
                 };
                 Self::stage_vpn_routes(
-                    loc_rib,
-                    &self.ribs,
-                    rib_out,
-                    &self.peer_is_rr_client,
+                    &vpn_labeled_context,
                     &effective_l3vpn_keys,
                     &mut target,
-                    target_is_ebgp,
-                    interpret_rfc1997,
-                    target_is_rr_client,
-                    cluster_id,
-                    sendable.as_ref(),
-                    llgr.as_ref(),
                     rtc_filter.as_ref(),
-                    orr_ctx,
-                    peer_add_path_send_max,
-                    self.peer_add_path_send_limits.get(&peer),
-                    &peer_add_path_send_families,
-                    export_pol.as_ref(),
                     &mut vpn_announce,
                     &mut vpn_withdraw,
-                    is_force,
                 );
             }
 
@@ -5435,26 +5439,11 @@ impl RibManager {
                     peer_label: &target_peer_label,
                 };
                 Self::stage_labeled_routes(
-                    loc_rib,
-                    &self.ribs,
-                    rib_out,
-                    &self.peer_is_rr_client,
+                    &vpn_labeled_context,
                     &effective_labeled_keys,
                     &mut target,
-                    target_is_ebgp,
-                    interpret_rfc1997,
-                    target_is_rr_client,
-                    cluster_id,
-                    sendable.as_ref(),
-                    llgr.as_ref(),
-                    orr_ctx,
-                    peer_add_path_send_max,
-                    self.peer_add_path_send_limits.get(&peer),
-                    &peer_add_path_send_families,
-                    export_pol.as_ref(),
                     &mut labeled_announce,
                     &mut labeled_withdraw,
-                    is_force,
                 );
             }
 

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -1,7 +1,6 @@
 use super::{
-    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, OutboundCommitBatch,
-    PolicyChain, RibManager, RouteContext, Safi, gauge_val, route_type, should_suppress_ibgp_inner,
-    vpn_route_family, vpn_routes_equal, warn,
+    Afi, HashSet, IpAddr, OutboundCommitBatch, PolicyChain, RibManager, RouteContext, Safi,
+    gauge_val, route_type, should_suppress_ibgp_inner, vpn_route_family, vpn_routes_equal, warn,
 };
 use crate::loc_rib::vpn_tiebreak_orr;
 use crate::route::{VpnRibRoute, VpnRibRouteKey};
@@ -77,34 +76,35 @@ impl RibManager {
     /// a vantage is resolved — and staged with outbound path IDs `1..=N`.
     /// Otherwise the single best is staged with `path_id = 0`.
     #[expect(
-        clippy::fn_params_excessive_bools,
-        clippy::too_many_arguments,
         clippy::too_many_lines,
         reason = "VPN staging mirrors unicast multipath/single-best distribution context for RR/export parity"
     )]
     pub(in crate::manager) fn stage_vpn_routes(
-        loc_rib: &LocRib,
-        ribs: &HashMap<IpAddr, AdjRibIn>,
-        rib_out: &AdjRibOut,
-        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        context: &crate::manager::VpnLabeledStagingContext<'_>,
         keys: &HashSet<VpnRouteKey>,
         target: &mut super::ExportTarget<'_>,
-        target_is_ebgp: bool,
-        interpret_rfc1997: bool,
-        target_is_rr_client: bool,
-        cluster_id: Option<Ipv4Addr>,
-        sendable: Option<&Vec<(Afi, Safi)>>,
-        llgr: Option<&Vec<(Afi, Safi)>>,
         rtc_filter: Option<&crate::manager::RtcMembership>,
-        orr_ctx: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
-        add_path_send_max: u32,
-        add_path_send_limits: Option<&HashMap<(Afi, Safi), u32>>,
-        add_path_send_families: &[(Afi, Safi)],
-        export_pol: Option<&PolicyChain>,
         vpn_announce: &mut Vec<VpnRibRoute>,
         vpn_withdraw: &mut Vec<VpnRibRouteKey>,
-        force: bool,
     ) {
+        let &crate::manager::VpnLabeledStagingContext {
+            loc_rib,
+            ribs,
+            rib_out,
+            peer_is_rr_client,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            orr_ctx,
+            add_path_send_max,
+            add_path_send_limits,
+            add_path_send_families,
+            export_pol,
+            force,
+        } = context;
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         // `None` for group staging: split horizon is applied per member
         // at emit time by the VPN source-flip matrix.
@@ -980,6 +980,25 @@ impl RibManager {
                 .or_insert_with(|| crate::adj_rib_out::AdjRibOut::with_capacity(peer, loc_rib_len));
             let policy_stats = self.export_policy_stats.entry(peer).or_default();
 
+            let context = crate::manager::VpnLabeledStagingContext {
+                loc_rib: &self.loc_rib,
+                ribs: &self.ribs,
+                rib_out,
+                peer_is_rr_client: &self.peer_is_rr_client,
+                target_is_ebgp,
+                interpret_rfc1997,
+                target_is_rr_client,
+                cluster_id: self.cluster_id,
+                sendable: sendable.as_ref(),
+                llgr: llgr.as_ref(),
+                orr_ctx,
+                add_path_send_max,
+                add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+                add_path_send_families: &add_path_send_families,
+                export_pol: export_pol.as_ref(),
+                force: false,
+            };
+
             let mut vpn_announce = Vec::new();
             let mut vpn_withdraw = Vec::new();
             let mut target = super::ExportTarget::Peer {
@@ -991,27 +1010,12 @@ impl RibManager {
                 peer_label: &target_peer_label,
             };
             Self::stage_vpn_routes(
-                &self.loc_rib,
-                &self.ribs,
-                rib_out,
-                &self.peer_is_rr_client,
+                &context,
                 staged_keys,
                 &mut target,
-                target_is_ebgp,
-                interpret_rfc1997,
-                target_is_rr_client,
-                self.cluster_id,
-                sendable.as_ref(),
-                llgr.as_ref(),
                 rtc_filter.as_ref(),
-                orr_ctx,
-                add_path_send_max,
-                self.peer_add_path_send_limits.get(&peer),
-                &add_path_send_families,
-                export_pol.as_ref(),
                 &mut vpn_announce,
                 &mut vpn_withdraw,
-                false,
             );
 
             if (!vpn_announce.is_empty() || !vpn_withdraw.is_empty())

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -407,6 +407,30 @@ impl RtcMembership {
     }
 }
 
+/// Shared immutable inputs for VPN and labeled-unicast export staging.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "the context preserves existing independent export flags without changing their semantics"
+)]
+struct VpnLabeledStagingContext<'a> {
+    loc_rib: &'a LocRib,
+    ribs: &'a HashMap<IpAddr, AdjRibIn>,
+    rib_out: &'a AdjRibOut,
+    peer_is_rr_client: &'a HashMap<IpAddr, bool>,
+    target_is_ebgp: bool,
+    interpret_rfc1997: bool,
+    target_is_rr_client: bool,
+    cluster_id: Option<Ipv4Addr>,
+    sendable: Option<&'a Vec<(Afi, Safi)>>,
+    llgr: Option<&'a Vec<(Afi, Safi)>>,
+    orr_ctx: Option<(&'a crate::orr::OrrTopology, &'a crate::orr::SpfResult)>,
+    add_path_send_max: u32,
+    add_path_send_limits: Option<&'a HashMap<(Afi, Safi), u32>>,
+    add_path_send_families: &'a [(Afi, Safi)],
+    export_pol: Option<&'a PolicyChain>,
+    force: bool,
+}
+
 /// Central RIB manager that owns all Adj-RIB-In, Loc-RIB, and Adj-RIB-Out state.
 ///
 /// Runs as a single tokio task, receiving updates via an mpsc channel.

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1575,6 +1575,24 @@ impl RibManager {
         // Skipped when the VPN dump was replayed from the group table
         // above (VPN-staging group member — design §4: join pays no
         // per-key staging walk).
+        let vpn_labeled_context = super::VpnLabeledStagingContext {
+            loc_rib,
+            ribs: &self.ribs,
+            rib_out: &initial_view,
+            peer_is_rr_client: &self.peer_is_rr_client,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable: sendable.as_ref(),
+            llgr: llgr.as_ref(),
+            orr_ctx,
+            add_path_send_max: peer_add_path_send_max,
+            add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+            add_path_send_families: &peer_add_path_send_families,
+            export_pol: export_pol.as_ref(),
+            force: false, // initial dump — equality check is correct
+        };
         if !all_l3vpn_keys.is_empty() && !vpn_group_replayed {
             let mut target = super::distribution::ExportTarget::Peer {
                 peer,
@@ -1585,27 +1603,12 @@ impl RibManager {
                 peer_label: &target_peer_label,
             };
             Self::stage_vpn_routes(
-                loc_rib,
-                &self.ribs,
-                &initial_view,
-                &self.peer_is_rr_client,
+                &vpn_labeled_context,
                 &all_l3vpn_keys,
                 &mut target,
-                target_is_ebgp,
-                interpret_rfc1997,
-                target_is_rr_client,
-                cluster_id,
-                sendable.as_ref(),
-                llgr.as_ref(),
                 rtc_filter.as_ref(),
-                orr_ctx,
-                peer_add_path_send_max,
-                self.peer_add_path_send_limits.get(&peer),
-                &peer_add_path_send_families,
-                export_pol.as_ref(),
                 &mut vpn_announce,
                 &mut vpn_withdraw,
-                false, // initial dump — equality check is correct
             );
         }
 
@@ -1637,26 +1640,11 @@ impl RibManager {
                 peer_label: &target_peer_label,
             };
             Self::stage_labeled_routes(
-                loc_rib,
-                &self.ribs,
-                &initial_view,
-                &self.peer_is_rr_client,
+                &vpn_labeled_context,
                 &all_labeled_keys,
                 &mut target,
-                target_is_ebgp,
-                interpret_rfc1997,
-                target_is_rr_client,
-                cluster_id,
-                sendable.as_ref(),
-                llgr.as_ref(),
-                orr_ctx,
-                peer_add_path_send_max,
-                self.peer_add_path_send_limits.get(&peer),
-                &peer_add_path_send_families,
-                export_pol.as_ref(),
                 &mut labeled_announce,
                 &mut labeled_withdraw,
-                false, // initial dump — equality check is correct
             );
         }
 

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -1162,6 +1162,24 @@ impl RibManager {
             empty_rib_out = AdjRibOut::new(peer);
             &empty_rib_out
         };
+        let context = super::VpnLabeledStagingContext {
+            loc_rib: &self.loc_rib,
+            ribs: &self.ribs,
+            rib_out,
+            peer_is_rr_client: &self.peer_is_rr_client,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id: self.cluster_id,
+            sendable,
+            llgr,
+            orr_ctx,
+            add_path_send_max,
+            add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+            add_path_send_families: &add_path_send_families,
+            export_pol: self.export_policy_for(peer),
+            force: false,
+        };
 
         let mut trace = distribution::ExportGateTrace::default();
         let mut target = distribution::ExportTarget::Explain {
@@ -1176,27 +1194,12 @@ impl RibManager {
         let mut vpn_announce = Vec::new();
         let mut vpn_withdraw = Vec::new();
         Self::stage_vpn_routes(
-            &self.loc_rib,
-            &self.ribs,
-            rib_out,
-            &self.peer_is_rr_client,
+            &context,
             &keys,
             &mut target,
-            target_is_ebgp,
-            interpret_rfc1997,
-            target_is_rr_client,
-            self.cluster_id,
-            sendable,
-            llgr,
             rtc_filter.as_ref(),
-            orr_ctx,
-            add_path_send_max,
-            self.peer_add_path_send_limits.get(&peer),
-            &add_path_send_families,
-            self.export_policy_for(peer),
             &mut vpn_announce,
             &mut vpn_withdraw,
-            false,
         );
         let explanation =
             trace.into_explain(peer, prefix, Some(rd), vpn_grouped.map(|gid| gid as u64));
@@ -1256,6 +1259,24 @@ impl RibManager {
             empty_rib_out = AdjRibOut::new(peer);
             &empty_rib_out
         };
+        let context = super::VpnLabeledStagingContext {
+            loc_rib: &self.loc_rib,
+            ribs: &self.ribs,
+            rib_out,
+            peer_is_rr_client: &self.peer_is_rr_client,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id: self.cluster_id,
+            sendable,
+            llgr,
+            orr_ctx,
+            add_path_send_max,
+            add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+            add_path_send_families: &add_path_send_families,
+            export_pol: self.export_policy_for(peer),
+            force: false,
+        };
 
         let mut trace = distribution::ExportGateTrace::default();
         let mut target = distribution::ExportTarget::Explain {
@@ -1270,26 +1291,11 @@ impl RibManager {
         let mut labeled_announce = Vec::new();
         let mut labeled_withdraw = Vec::new();
         Self::stage_labeled_routes(
-            &self.loc_rib,
-            &self.ribs,
-            rib_out,
-            &self.peer_is_rr_client,
+            &context,
             &keys,
             &mut target,
-            target_is_ebgp,
-            interpret_rfc1997,
-            target_is_rr_client,
-            self.cluster_id,
-            sendable,
-            llgr,
-            orr_ctx,
-            add_path_send_max,
-            self.peer_add_path_send_limits.get(&peer),
-            &add_path_send_families,
-            self.export_policy_for(peer),
             &mut labeled_announce,
             &mut labeled_withdraw,
-            false,
         );
         let explanation = trace.into_explain(peer, prefix, None, None);
         self.apply_exact_export_overlay_to_explain(

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -898,6 +898,24 @@ impl RibManager {
                     }
                 }
                 if !vpn_keys.is_empty() {
+                    let context = super::VpnLabeledStagingContext {
+                        loc_rib,
+                        ribs: &self.ribs,
+                        rib_out: &refresh_view,
+                        peer_is_rr_client: &self.peer_is_rr_client,
+                        target_is_ebgp,
+                        interpret_rfc1997,
+                        target_is_rr_client,
+                        cluster_id,
+                        sendable: sendable.as_ref(),
+                        llgr: llgr.as_ref(),
+                        orr_ctx,
+                        add_path_send_max: peer_add_path_send_max,
+                        add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+                        add_path_send_families: &peer_add_path_send_families,
+                        export_pol: export_pol.as_ref(),
+                        force: false, // route refresh re-emits via empty refresh_view
+                    };
                     let mut target = super::distribution::ExportTarget::Peer {
                         peer,
                         peer_asn: target_peer_asn,
@@ -907,27 +925,12 @@ impl RibManager {
                         peer_label: &target_peer_label,
                     };
                     Self::stage_vpn_routes(
-                        loc_rib,
-                        &self.ribs,
-                        &refresh_view,
-                        &self.peer_is_rr_client,
+                        &context,
                         &vpn_keys,
                         &mut target,
-                        target_is_ebgp,
-                        interpret_rfc1997,
-                        target_is_rr_client,
-                        cluster_id,
-                        sendable.as_ref(),
-                        llgr.as_ref(),
                         rtc_filter.as_ref(),
-                        orr_ctx,
-                        peer_add_path_send_max,
-                        self.peer_add_path_send_limits.get(&peer),
-                        &peer_add_path_send_families,
-                        export_pol.as_ref(),
                         &mut vpn_announce,
                         &mut vpn_withdraw,
-                        false, // route refresh re-emits via empty refresh_view
                     );
                 }
             }
@@ -954,6 +957,24 @@ impl RibManager {
                 }
             }
             if !labeled_keys.is_empty() {
+                let context = super::VpnLabeledStagingContext {
+                    loc_rib,
+                    ribs: &self.ribs,
+                    rib_out: &refresh_view,
+                    peer_is_rr_client: &self.peer_is_rr_client,
+                    target_is_ebgp,
+                    interpret_rfc1997,
+                    target_is_rr_client,
+                    cluster_id,
+                    sendable: sendable.as_ref(),
+                    llgr: llgr.as_ref(),
+                    orr_ctx,
+                    add_path_send_max: peer_add_path_send_max,
+                    add_path_send_limits: self.peer_add_path_send_limits.get(&peer),
+                    add_path_send_families: &peer_add_path_send_families,
+                    export_pol: export_pol.as_ref(),
+                    force: false, // route refresh re-emits via empty refresh_view
+                };
                 let mut target = super::distribution::ExportTarget::Peer {
                     peer,
                     peer_asn: target_peer_asn,
@@ -963,26 +984,11 @@ impl RibManager {
                     peer_label: &target_peer_label,
                 };
                 Self::stage_labeled_routes(
-                    loc_rib,
-                    &self.ribs,
-                    &refresh_view,
-                    &self.peer_is_rr_client,
+                    &context,
                     &labeled_keys,
                     &mut target,
-                    target_is_ebgp,
-                    interpret_rfc1997,
-                    target_is_rr_client,
-                    cluster_id,
-                    sendable.as_ref(),
-                    llgr.as_ref(),
-                    orr_ctx,
-                    peer_add_path_send_max,
-                    self.peer_add_path_send_limits.get(&peer),
-                    &peer_add_path_send_families,
-                    export_pol.as_ref(),
                     &mut labeled_announce,
                     &mut labeled_withdraw,
-                    false, // route refresh re-emits via empty refresh_view
                 );
             }
         } else if safi == Safi::RtConstrain {

--- a/crates/rib/src/manager/update_groups/staging.rs
+++ b/crates/rib/src/manager/update_groups/staging.rs
@@ -413,6 +413,24 @@ impl RibManager {
             let mut announce: Vec<VpnRibRoute> = Vec::new();
             let mut withdraw: Vec<VpnRibRouteKey> = Vec::new();
             let mut ignored_otc_blocked = Vec::new();
+            let context = crate::manager::VpnLabeledStagingContext {
+                loc_rib: &self.loc_rib,
+                ribs: &self.ribs,
+                rib_out: &group.table,
+                peer_is_rr_client: &self.peer_is_rr_client,
+                target_is_ebgp: group.is_ebgp,
+                interpret_rfc1997: group.interpret_rfc1997,
+                target_is_rr_client: group.is_rr_client,
+                cluster_id: self.cluster_id,
+                sendable: Some(&group.sendable),
+                llgr: Some(&group.llgr),
+                orr_ctx: None,              // ORR disqualifies from grouping.
+                add_path_send_max: 0,       // Add-Path send disqualifies from grouping.
+                add_path_send_limits: None, // Effective cap is inapplicable to grouped peers.
+                add_path_send_families: &[],
+                export_pol: chain.as_ref(),
+                force: false,
+            };
             // Reused single-key set: the staging body iterates a key set,
             // but the delta needs per-key `old` capture and eval labels.
             let mut key_set: HashSet<VpnRouteKey> = HashSet::with_capacity(1);
@@ -425,30 +443,15 @@ impl RibManager {
                     otc_blocked: &mut ignored_otc_blocked,
                 };
                 Self::stage_vpn_routes(
-                    &self.loc_rib,
-                    &self.ribs,
-                    &group.table,
-                    &self.peer_is_rr_client,
+                    &context,
                     &key_set,
                     &mut target,
-                    group.is_ebgp,
-                    group.interpret_rfc1997,
-                    group.is_rr_client,
-                    self.cluster_id,
-                    Some(&group.sendable),
-                    Some(&group.llgr),
                     // RT gate deferred to member emit: Φ is per-member
                     // state, applied by the RT-pass matrix (the delta
                     // carries `old` for exactly that).
                     None,
-                    None, // ORR disqualifies from grouping
-                    0,    // Add-Path send disqualifies from grouping
-                    None, // Effective cap is inapplicable to grouped peers.
-                    &[],
-                    chain.as_ref(),
                     &mut announce,
                     &mut withdraw,
-                    false,
                 );
                 // Single-best stages at most one eval per key: a Permit
                 // labels the staged entry; a Deny lands in the persistent


### PR DESCRIPTION
## Summary

- replace the 20-21 argument VPN and labeled export-staging seam with one private borrowed immutable context
- convert all 11 call sites across the existing eight-file RIB boundary
- reuse a context across adjacent VPN/labeled calls while keeping keys, targets, VPN RTC filtering, and announce/withdraw buffers explicit

No policy, ordering, runtime behavior, public API, or visibility boundary changes.

## Validation

- exact relevant RIB test roster unchanged: 461 before and after
- full rustbgpd-rib library suite: 1,206 passed, 2 ignored
- focused VPN, labeled, export-explain, route-refresh, initial-table, and update-group suites passed
- strict all-target/all-feature RIB Clippy and all-feature bench compile passed
- full pre-commit and pre-push fmt, Clippy, test, and rustdoc gates passed
- independent exact-head review passed

Linear: LAN-866