### PR TITLE
perf(policy): reuse unchanged RPOL files on reload

### DIFF
--- a/crates/policy/benches/policy_eval.rs
+++ b/crates/policy/benches/policy_eval.rs
@@ -753,6 +753,104 @@ fn bench_dataset_parity(c: &mut Criterion) {
     group.finish();
 }
 
+/// LAN-1165 reload identity: 320 separately compiled chains whose source file
+/// is reused share large set-table Arcs, while detached equal files take the
+/// structural equality path. Both arms retain identical policy semantics.
+fn bench_rpol_reload_equality(c: &mut Criterion) {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rustbgpd_policy::NamedPolicy;
+    use rustbgpd_policy::datasets::DatasetBindings;
+    use rustbgpd_policy::rpol::RpolFile;
+
+    fn source(changed_first: bool) -> String {
+        let first = if changed_first {
+            "11.0.0.0/24".to_string()
+        } else {
+            "10.0.0.0/24".to_string()
+        };
+        let members = std::iter::once(first)
+            .chain((1..4_096_u32).map(|i| format!("10.{}.{}.0/24", i / 256, i % 256)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "prefix-set large {{ {members} }}\n\
+             policy p {{ term hit {{ if route.prefix in large {{ accept }} }} term rest {{ reject }} }}"
+        )
+    }
+
+    fn chain(file: &RpolFile) -> PolicyChain {
+        let compiled = file
+            .compile_policy_bound_cached_tables(
+                "p",
+                &[],
+                &mut SetStore::new(),
+                &DatasetBindings::new(),
+            )
+            .expect("policy exists")
+            .expect("no datasets");
+        PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+            "p".to_string(),
+            Arc::new(compiled),
+        )])
+    }
+
+    fn outer(chain: &PolicyChain) -> &Arc<CompiledChain> {
+        chain.policies[0].rpol.as_ref().unwrap()
+    }
+
+    let unchanged = source(false);
+    let reused_file = RpolFile::parse(&unchanged).expect("reused file parses");
+    let reused_left = chain(&reused_file);
+    let reused_right = chain(&reused_file);
+    let detached_left = chain(&RpolFile::parse(&unchanged).expect("left parses"));
+    let detached_right = chain(&RpolFile::parse(&unchanged).expect("right parses"));
+    let changed = chain(&RpolFile::parse(&source(true)).expect("changed parses"));
+
+    assert!(!Arc::ptr_eq(outer(&reused_left), outer(&reused_right)));
+    assert!(Arc::ptr_eq(
+        &outer(&reused_left).prefix_sets[0],
+        &outer(&reused_right).prefix_sets[0]
+    ));
+    assert!(!Arc::ptr_eq(
+        &outer(&detached_left).prefix_sets[0],
+        &outer(&detached_right).prefix_sets[0]
+    ));
+    assert_eq!(reused_left, reused_right);
+    assert_eq!(detached_left, detached_right);
+    assert_ne!(reused_left, changed);
+
+    let communities = Vec::new();
+    let as_path = String::new();
+    let ctx = predicate_ctx(
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 5, 6, 0), 24)),
+        &communities,
+        &as_path,
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+    );
+    assert_eq!(reused_left.evaluate(&ctx), detached_left.evaluate(&ctx));
+
+    let roster = |chain: &PolicyChain| (0..320).map(|_| chain.clone()).collect::<Vec<_>>();
+    let reused = (roster(&reused_left), roster(&reused_right));
+    let detached = (roster(&detached_left), roster(&detached_right));
+    let mut group = c.benchmark_group("rpol_reload_equality_320");
+    group
+        .sample_size(20)
+        .measurement_time(Duration::from_secs(3));
+    for (name, pair) in [("reused", &reused), ("detached", &detached)] {
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                std::hint::black_box(&pair.0)
+                    .iter()
+                    .zip(std::hint::black_box(&pair.1))
+                    .all(|(left, right)| left == right)
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_policy_eval,
@@ -761,6 +859,7 @@ criterion_group!(
     bench_value_expr,
     bench_loop_eval,
     bench_fn_eval,
-    bench_dataset_parity
+    bench_dataset_parity,
+    bench_rpol_reload_equality
 );
 criterion_main!(benches);

--- a/crates/policy/src/rpol/mod.rs
+++ b/crates/policy/src/rpol/mod.rs
@@ -371,6 +371,71 @@ pub struct RpolPolicySet {
     pub policies: HashMap<String, RpolPolicyEntry>,
 }
 
+impl RpolPolicySet {
+    /// Reuse parsed files from the immediately prior accepted registry when
+    /// their complete source identity is unchanged.
+    #[doc(hidden)]
+    pub fn reuse_unchanged_files_from(&mut self, prior: &Self) {
+        let mut seen_files = Vec::new();
+        let mut replacements = Vec::new();
+        for candidate in self.policies.values() {
+            let candidate_ptr = Arc::as_ptr(&candidate.file);
+            if seen_files.contains(&candidate_ptr) {
+                continue;
+            }
+            seen_files.push(candidate_ptr);
+
+            let members: Vec<_> = self
+                .policies
+                .iter()
+                .filter(|(_, entry)| Arc::as_ptr(&entry.file) == candidate_ptr)
+                .collect();
+            let Some((_, first)) = members.first() else {
+                continue;
+            };
+            let Some(accepted_file) = prior
+                .policies
+                .get(members[0].0)
+                .map(|entry| Arc::clone(&entry.file))
+            else {
+                continue;
+            };
+            let accepted_ptr = Arc::as_ptr(&accepted_file);
+            let all_members_match = members.iter().all(|(name, entry)| {
+                prior.policies.get(*name).is_some_and(|accepted| {
+                    accepted.params == entry.params
+                        && accepted.path == entry.path
+                        && Arc::as_ptr(&accepted.file) == accepted_ptr
+                })
+            });
+            let accepted_members = prior
+                .policies
+                .values()
+                .filter(|entry| Arc::as_ptr(&entry.file) == accepted_ptr)
+                .count();
+            if all_members_match
+                && accepted_members == members.len()
+                && first
+                    .file
+                    .source_fingerprints()
+                    .eq(accepted_file.source_fingerprints())
+                && first.file.content_eq(&accepted_file)
+            {
+                replacements.push((candidate_ptr, accepted_file));
+            }
+        }
+
+        for entry in self.policies.values_mut() {
+            if let Some((_, accepted)) = replacements
+                .iter()
+                .find(|(candidate, _)| *candidate == Arc::as_ptr(&entry.file))
+            {
+                entry.file = Arc::clone(accepted);
+            }
+        }
+    }
+}
+
 /// Split a policy chain reference into base name + `u32` arguments:
 /// `"bogon-filter"` → `("bogon-filter", [])`,
 /// `"customer-in(200)"` → `("customer-in", [200])`. Used by the daemon

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -54,6 +54,133 @@ test bogons-rejected {
 }
 ";
 
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one matrix keeps every atomic source-identity rejection beside the reuse control"
+)]
+fn accepted_file_reuse_requires_every_source_identity_axis() {
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::Path;
+
+    use super::{DEFAULT_MAX_GRAPH_BYTES, RpolPolicyEntry, RpolPolicySet};
+
+    fn write_graph(dir: &Path, main: &str, leaf: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("main.rpol"), main).unwrap();
+        fs::write(dir.join("leaf.rpol"), leaf).unwrap();
+    }
+
+    fn load(dir: &Path) -> Arc<RpolFile> {
+        Arc::new(
+            RpolFile::load(&dir.join("main.rpol"), &[], DEFAULT_MAX_GRAPH_BYTES)
+                .expect("graph loads"),
+        )
+    }
+
+    fn policy_set(file: Arc<RpolFile>, name: &str, params: usize, path: &str) -> RpolPolicySet {
+        RpolPolicySet {
+            policies: HashMap::from([(
+                name.to_string(),
+                RpolPolicyEntry {
+                    file,
+                    params,
+                    path: path.to_string(),
+                },
+            )]),
+        }
+    }
+
+    fn unit_set(file: Arc<RpolFile>, q_params: usize, q_path: &str) -> RpolPolicySet {
+        RpolPolicySet {
+            policies: HashMap::from([
+                (
+                    "p".to_string(),
+                    RpolPolicyEntry {
+                        file: Arc::clone(&file),
+                        params: 0,
+                        path: "main.rpol".to_string(),
+                    },
+                ),
+                (
+                    "q".to_string(),
+                    RpolPolicyEntry {
+                        file,
+                        params: q_params,
+                        path: q_path.to_string(),
+                    },
+                ),
+            ]),
+        }
+    }
+
+    let main = "import \"leaf.rpol\"\npolicy p { term t { accept } }\n";
+    let leaf = "policy q { term t { accept } }\n";
+    let dir = tempfile::tempdir().unwrap();
+    write_graph(dir.path(), main, leaf);
+    let prior_file = load(dir.path());
+    let prior = policy_set(Arc::clone(&prior_file), "p", 0, "main.rpol");
+
+    let same_file = load(dir.path());
+    let mut same = policy_set(Arc::clone(&same_file), "p", 0, "main.rpol");
+    same.reuse_unchanged_files_from(&prior);
+    assert!(Arc::ptr_eq(&same.policies["p"].file, &prior_file));
+
+    let prior_unit = unit_set(Arc::clone(&prior_file), 0, "main.rpol");
+    let exact_unit_file = load(dir.path());
+    let mut exact_unit = unit_set(Arc::clone(&exact_unit_file), 0, "main.rpol");
+    exact_unit.reuse_unchanged_files_from(&prior_unit);
+    assert!(Arc::ptr_eq(&exact_unit.policies["p"].file, &prior_file));
+    assert!(Arc::ptr_eq(&exact_unit.policies["q"].file, &prior_file));
+
+    let partial_unit_file = load(dir.path());
+    let mut partial_unit = unit_set(Arc::clone(&partial_unit_file), 1, "main.rpol");
+    partial_unit.reuse_unchanged_files_from(&prior_unit);
+    assert!(Arc::ptr_eq(
+        &partial_unit.policies["p"].file,
+        &partial_unit_file
+    ));
+    assert!(Arc::ptr_eq(
+        &partial_unit.policies["q"].file,
+        &partial_unit_file
+    ));
+
+    fs::write(
+        dir.path().join("main.rpol"),
+        "import \"leaf.rpol\"\npolicy p { term t { reject } }\n",
+    )
+    .unwrap();
+    let changed_main = load(dir.path());
+    let mut candidate = policy_set(Arc::clone(&changed_main), "p", 0, "main.rpol");
+    candidate.reuse_unchanged_files_from(&prior);
+    assert!(Arc::ptr_eq(&candidate.policies["p"].file, &changed_main));
+
+    write_graph(dir.path(), main, "policy q { term t { reject } }\n");
+    let changed_leaf = load(dir.path());
+    let mut candidate = policy_set(Arc::clone(&changed_leaf), "p", 0, "main.rpol");
+    candidate.reuse_unchanged_files_from(&prior);
+    assert!(Arc::ptr_eq(&candidate.policies["p"].file, &changed_leaf));
+
+    let moved = tempfile::tempdir().unwrap();
+    write_graph(moved.path(), main, leaf);
+    let moved_file = load(moved.path());
+    let mut candidate = policy_set(Arc::clone(&moved_file), "p", 0, "main.rpol");
+    candidate.reuse_unchanged_files_from(&prior);
+    assert!(Arc::ptr_eq(&candidate.policies["p"].file, &moved_file));
+
+    for (name, params, path) in [
+        ("renamed", 0, "main.rpol"),
+        ("p", 1, "main.rpol"),
+        ("p", 0, "other.rpol"),
+    ] {
+        let fresh = Arc::clone(&same_file);
+        let mut candidate = policy_set(Arc::clone(&fresh), name, params, path);
+        candidate.reuse_unchanged_files_from(&prior);
+        assert!(Arc::ptr_eq(&candidate.policies[name].file, &fresh));
+    }
+}
+
 fn route_ctx(prefix: Prefix, communities: &[u32], rpki: RpkiValidation) -> RouteContext<'static> {
     RouteContext {
         prefix: Some(prefix),

--- a/src/config/source_provenance.rs
+++ b/src/config/source_provenance.rs
@@ -291,6 +291,12 @@ impl AcceptedConfigSnapshot {
         )?;
         config.file_path = Some(path.to_path_buf());
         after_capture();
+        if let Some(prior) = prior {
+            config
+                .policy
+                .rpol
+                .reuse_unchanged_files_from(&prior.config.policy.rpol);
+        }
         config.policy.dataset_bindings = config.policy.dataset_bindings.detached_clone();
 
         let normalized_toml = Arc::new(
@@ -500,6 +506,60 @@ path = "customers.txt"
         path
     }
 
+    fn reuse_fixture(dir: &Path) -> PathBuf {
+        fs::write(
+            dir.join("policy.rpol"),
+            "import \"lib.rpol\"\npolicy outbound { term rest { accept } }\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("lib.rpol"),
+            "dataset asn-set customers\n\
+             prefix-set edge { 10.0.0.0/8 ge 8 le 32 }\n\
+             community-set marked { 65000:1 }\n\
+             asn-set origins { 64500 }\n\
+             policy inbound {\n\
+               term customer { if route.prefix in edge && route.communities in marked && route.origin-as in origins && route.origin-as in customers { accept } }\n\
+               term rest { reject }\n\
+             }\n",
+        )
+        .unwrap();
+        fs::write(dir.join("customers.txt"), "64500\n").unwrap();
+        let config = tier_authorized_uds_test_config(
+            r#"
+[global]
+asn = 65000
+router_id = "192.0.2.1"
+listen_port = 179
+[global.telemetry]
+log_format = "json"
+[policy]
+rpol_files = ["policy.rpol"]
+[policy.datasets.customers]
+path = "customers.txt"
+[[neighbors]]
+address = "192.0.2.2"
+remote_asn = 65001
+import_policy_chain = ["inbound"]
+[[neighbors]]
+address = "192.0.2.3"
+remote_asn = 65002
+import_policy_chain = ["inbound"]
+[[neighbors]]
+address = "192.0.2.4"
+remote_asn = 65003
+import_policy_chain = ["inbound"]
+[[neighbors]]
+address = "192.0.2.5"
+remote_asn = 65004
+import_policy_chain = ["inbound"]
+"#,
+        );
+        let path = dir.join("config.toml");
+        fs::write(&path, config).unwrap();
+        path
+    }
+
     fn fingerprint(path: &Path, bytes: &[u8]) -> DatasetFileFingerprint {
         DatasetFileFingerprint {
             canonical_path: path.to_path_buf(),
@@ -524,6 +584,140 @@ path = "customers.txt"
             .iter()
             .map(|module| module.path.file_name().unwrap().to_str().unwrap())
             .collect()
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one scenario proves reuse, candidate dataset ownership, evaluation, and rejection isolation"
+    )]
+    fn accepted_reload_reuses_rpol_storage_without_reusing_dataset_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = reuse_fixture(dir.path());
+        let prior = AcceptedConfigSnapshot::load(&path, None).unwrap();
+        let prior_file = Arc::clone(&prior.policy.rpol.policies["inbound"].file);
+        let prior_dataset = dataset(&prior);
+        let prior_resolved = prior.resolved_neighbors().unwrap();
+        let compiled = |neighbor: &crate::config::ResolvedNeighbor| {
+            Arc::clone(
+                neighbor.import_policy.as_ref().unwrap().policies[0]
+                    .rpol
+                    .as_ref()
+                    .unwrap(),
+            )
+        };
+        let prior_compiled: Vec<_> = prior_resolved.iter().map(compiled).collect();
+        assert!(
+            prior_compiled[1..]
+                .iter()
+                .all(|chain| Arc::ptr_eq(&chain.prefix_sets[0], &prior_compiled[0].prefix_sets[0]))
+        );
+
+        let unchanged = AcceptedConfigSnapshot::load(&path, Some(&prior)).unwrap();
+        assert!(Arc::ptr_eq(
+            &unchanged.policy.rpol.policies["inbound"].file,
+            &prior_file
+        ));
+        assert!(Arc::ptr_eq(
+            &unchanged.policy.rpol.policies["outbound"].file,
+            &prior_file
+        ));
+        let unchanged_resolved = unchanged.resolved_neighbors().unwrap();
+        for (old, new) in prior_compiled
+            .iter()
+            .zip(unchanged_resolved.iter().map(compiled))
+        {
+            assert!(!Arc::ptr_eq(old, &new));
+            assert!(Arc::ptr_eq(&old.prefix_sets[0], &new.prefix_sets[0]));
+            assert!(Arc::ptr_eq(&old.community_sets[0], &new.community_sets[0]));
+            assert!(Arc::ptr_eq(&old.asn_sets[0], &new.asn_sets[0]));
+        }
+
+        fs::write(dir.path().join("customers.txt"), "64501\n").unwrap();
+        let changed_dataset = AcceptedConfigSnapshot::load(&path, Some(&prior)).unwrap();
+        assert!(Arc::ptr_eq(
+            &changed_dataset.policy.rpol.policies["inbound"].file,
+            &prior_file
+        ));
+        let candidate_dataset = dataset(&changed_dataset);
+        assert!(!Arc::ptr_eq(&candidate_dataset, &prior_dataset));
+        assert_ne!(
+            changed_dataset.manifest.datasets[0].sha256,
+            prior.manifest.datasets[0].sha256
+        );
+        let candidate = changed_dataset.resolved_neighbors().unwrap();
+        let candidate_compiled = candidate[0].import_policy.as_ref().unwrap().policies[0]
+            .rpol
+            .as_ref()
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            &candidate_compiled.datasets[0].handle,
+            &candidate_dataset
+        ));
+        let communities = [(65_000_u32 << 16) | 1];
+        let ctx = |origin_asn| rustbgpd_policy::RouteContext {
+            prefix: Some(rustbgpd_wire::Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(
+                "10.1.0.0".parse().unwrap(),
+                24,
+            ))),
+            next_hop: None,
+            extended_communities: &[],
+            communities: &communities,
+            large_communities: &[],
+            as_path_str: "",
+            as_path: None,
+            as_path_len: 0,
+            origin_asn: Some(origin_asn),
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            family: None,
+            evpn_route_type: None,
+            local_pref: None,
+            med: None,
+        };
+        assert_eq!(
+            prior_resolved[0]
+                .import_policy
+                .as_ref()
+                .unwrap()
+                .evaluate(&ctx(64500))
+                .action,
+            rustbgpd_policy::PolicyAction::Permit
+        );
+        assert_eq!(
+            candidate[0]
+                .import_policy
+                .as_ref()
+                .unwrap()
+                .evaluate(&ctx(64500))
+                .action,
+            rustbgpd_policy::PolicyAction::Deny
+        );
+
+        let prior_config = fs::read_to_string(&path).unwrap();
+        fs::write(
+            &path,
+            prior_config.replace("remote_asn = 65001", "remote_asn = 0"),
+        )
+        .unwrap();
+        assert!(AcceptedConfigSnapshot::load(&path, Some(&prior)).is_err());
+        assert!(Arc::ptr_eq(
+            &prior.policy.rpol.policies["inbound"].file,
+            &prior_file
+        ));
+        assert_eq!(
+            prior_dataset.pin().data,
+            DatasetData::Asn(AsnSet::new([64500]))
+        );
+        let after_rejection = prior.resolved_neighbors().unwrap();
+        assert!(Arc::ptr_eq(
+            &prior_compiled[0].prefix_sets[0],
+            &compiled(&after_rejection[0]).prefix_sets[0]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the freshly loaded, captured, dataset-bound, and validated reload candidate
- after validation, reuse the immediately prior accepted RpolFile Arc only when the complete multi-policy unit has exact name, arity, display path, ordered module path, raw length, SHA-256, and source-content identity
- keep fresh provenance and candidate-owned dataset handles while letting later policy resolution share immutable literal set-table backing

This changes no policy equality semantics, RIB behavior, public API, config surface, or dependency. There is no global cache and changed units remain fresh.

## Validation

- atomic whole-unit reuse and every non-reuse identity axis are covered
- integrated reload proof keeps outer compiled chains fresh while prefix, community, and ASN set Arcs share; changed dataset state remains candidate-owned and changes evaluation
- invalid candidates reject without mutating prior state
- existing four-generation LAN-1165 RIB discriminator remains green
- policy library: 414 passed
- config RPOL: 18 passed; source provenance: 13 passed
- strict policy and daemon Clippy, benchmark compile, full commit and push gates passed
- independent exact-head review passed

Exact-head Criterion result for 320 equality comparisons:

- reused literal-set backing: about 50 microseconds
- detached equal backing: about 1.288 milliseconds
- isolated equality-path improvement: about 25.8x

This benchmark does not claim an end-to-end daemon reload speedup.

Linear: LAN-1165