### PR TITLE
refactor(config): isolate live policy impact execution

### DIFF
--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4,6 +4,12 @@
 //! binary-only state: the FIB reconciler command channel, config persistence,
 //! peer-manager validation, and the runtime-config lock shared with SIGHUP.
 
+mod live_policy_impact;
+
+use live_policy_impact::commit_live_policy_impact_locked;
+#[cfg(test)]
+use live_policy_impact::resolve_live_policy_targets;
+
 use std::fmt::Write as _;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -13,9 +19,11 @@ use tokio::sync::{Mutex, mpsc, oneshot, watch};
 
 use rustbgpd_api::health_probe::DaemonGate;
 use rustbgpd_api::peer_types::ConfigPersistCommitOutcome;
+#[cfg(test)]
+use rustbgpd_api::peer_types::ResolvedPeerPolicy;
 use rustbgpd_api::peer_types::{
     ConfigEvent, ConfigPersistAck, DynamicPeerBounceOutcome, DynamicRangeTarget, PeerKey,
-    PeerLifecycleError, PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
+    PeerLifecycleError, PeerManagerCommand, PeerManagerNeighborConfig,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use rustbgpd_api::proto;
@@ -3132,74 +3140,6 @@ async fn commit_static_neighbors_locked(
     Ok(())
 }
 
-/// Commit a live-impact policy/peer-group/global-chain transaction: stage the
-/// candidate snapshot, re-apply the affected static neighbors' resolved chains
-/// to their live sessions (capturing priors), persist, and roll back live +
-/// snapshot on failure. Returns the number of live sessions re-evaluated.
-async fn commit_live_policy_impact_locked(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
-    config_tx: &mpsc::Sender<ConfigEvent>,
-    candidate_toml: String,
-    candidate: &Config,
-    progress: &RuntimeConfigMutationProgress,
-) -> Result<usize, ApplyFailure> {
-    let permit = reserve_persist_permit(config_tx).await?;
-    progress.begin_mutation();
-    let rollback = stage_preloaded_config_snapshot(
-        peer_mgr_internal_tx,
-        Box::new(candidate.clone()),
-        TransactionConfigScope::Full,
-    )
-    .await?;
-
-    let targets = match resolve_live_policy_targets(rollback.previous(), candidate) {
-        Ok(targets) => targets,
-        Err(error) => {
-            progress.begin_settling();
-            return Err(rollback_snapshot_after_error(
-                peer_mgr_internal_tx,
-                rollback,
-                error.into(),
-            )
-            .await);
-        }
-    };
-
-    let priors = match send_apply_policy_impact_snapshot(peer_mgr_tx, targets).await {
-        Ok(priors) => priors,
-        Err(error) => {
-            // The peer-manager command self-heals its live mutations on a
-            // mid-fanout failure, so only the staged snapshot needs rollback.
-            progress.begin_settling();
-            return Err(rollback_snapshot_after_error(
-                peer_mgr_internal_tx,
-                rollback,
-                error.into(),
-            )
-            .await);
-        }
-    };
-
-    progress.begin_settling();
-    if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
-        if failure.fence_reason.is_some() {
-            return Err(failure);
-        }
-        return Err(rollback_live_policy_and_snapshot(
-            peer_mgr_tx,
-            peer_mgr_internal_tx,
-            priors,
-            rollback,
-            failure,
-        )
-        .await);
-    }
-    // LAN-277 window (a): candidate durable on disk from here on.
-    commit_config_snapshot_stage(peer_mgr_tx).await?;
-    Ok(priors.len())
-}
-
 /// Outcome of a committed peer-group/session reshape transaction.
 struct PeerSessionReshapeCommit {
     /// Static members reconfigured in place with captured priors.
@@ -3367,89 +3307,6 @@ async fn send_bounce_dynamic_range_peers(
     }
 }
 
-#[derive(Default)]
-struct LivePolicyTargets {
-    static_targets: Vec<ResolvedPeerPolicy>,
-    dynamic_ranges: Vec<DynamicRangeTarget>,
-}
-
-/// Build the resolved-chain apply set from a live-impact diff:
-/// every static neighbor whose resolved import/export policy moved and every
-/// dynamic range whose accepted live peers need candidate policy resolution.
-fn resolve_live_policy_targets(
-    previous: &Config,
-    candidate: &Config,
-) -> Result<LivePolicyTargets, ConfigTransactionApplyError> {
-    let diff = diff_config(previous, candidate);
-    let candidate_by_addr: std::collections::HashMap<&str, &Neighbor> = candidate
-        .neighbors
-        .iter()
-        .map(|neighbor| (neighbor.address.as_str(), neighbor))
-        .collect();
-    let dynamic_range_by_key: std::collections::HashMap<_, _> = candidate
-        .dynamic_neighbors
-        .iter()
-        .filter_map(|range| {
-            crate::config::effective_prefix_str(&range.prefix).map(|key| (key, range))
-        })
-        .collect();
-    let mut targets = LivePolicyTargets::default();
-    for impact in &diff.effective_neighbor_impact {
-        if !impact.kind.is_policy_chain() {
-            // A committable live-impact plan only carries policy-chain-only
-            // impacts; anything else is an internal inconsistency — fail closed
-            // rather than silently skip.
-            return Err(ConfigTransactionApplyError::Internal(format!(
-                "live-policy executor received an unsupported impact for {}",
-                impact.address
-            )));
-        }
-        if impact.is_dynamic_range {
-            let Some((addr, prefix_len)) = crate::config::effective_prefix_str(&impact.address)
-            else {
-                return Err(ConfigTransactionApplyError::Internal(format!(
-                    "live-policy impact references invalid dynamic range {}",
-                    impact.address
-                )));
-            };
-            let Some(range) = dynamic_range_by_key.get(&(addr, prefix_len)) else {
-                return Err(ConfigTransactionApplyError::Internal(format!(
-                    "live-policy impact references dynamic range {} absent from the candidate",
-                    impact.address
-                )));
-            };
-            targets.dynamic_ranges.push(DynamicRangeTarget {
-                addr,
-                prefix_len,
-                peer_group: range.peer_group.clone(),
-            });
-            continue;
-        }
-        let Some(neighbor) = candidate_by_addr.get(impact.address.as_str()) else {
-            return Err(ConfigTransactionApplyError::Internal(format!(
-                "live-policy impact references neighbor {} absent from the candidate",
-                impact.address
-            )));
-        };
-        let address = neighbor.address.parse().map_err(|error| {
-            ConfigTransactionApplyError::InvalidArgument(format!(
-                "invalid neighbor address {:?}: {error}",
-                neighbor.address
-            ))
-        })?;
-        let resolved = candidate
-            .resolve_neighbor(neighbor)
-            .map_err(|error| ConfigTransactionApplyError::InvalidArgument(error.to_string()))?;
-        targets.static_targets.push(ResolvedPeerPolicy {
-            address,
-            interface: neighbor.interface.clone(),
-            import_policy: resolved.import_policy,
-            export_policy: resolved.export_policy,
-        });
-    }
-    Ok(targets)
-}
-
 /// Resolved commit set for a peer-group/session reshape transaction: static
 /// members reconfigured in place (rollback-capable) plus the dynamic ranges
 /// whose live sessions are gracefully reset after persist.
@@ -3568,58 +3425,6 @@ fn resolve_peer_session_reshape_targets(
     Ok(targets)
 }
 
-/// Send `ApplyPolicyImpactSnapshot` and return the captured prior chains.
-async fn send_apply_policy_impact_snapshot(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    targets: LivePolicyTargets,
-) -> Result<Vec<ResolvedPeerPolicy>, ConfigTransactionApplyError> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::ApplyPolicyImpactSnapshot {
-            static_targets: targets.static_targets,
-            dynamic_ranges: targets.dynamic_ranges,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
-        })?;
-    reply_rx
-        .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped policy-impact reply".to_string(),
-            )
-        })?
-        .map_err(ConfigTransactionApplyError::Internal)
-}
-
-/// Send `ApplyResolvedPolicySnapshot` and return the captured prior chains.
-/// Used in reverse to restore captured priors during rollback.
-async fn send_apply_resolved_policy_snapshot(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    targets: Vec<ResolvedPeerPolicy>,
-) -> Result<Vec<ResolvedPeerPolicy>, ConfigTransactionApplyError> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
-            targets,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
-        })?;
-    reply_rx
-        .await
-        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
-            reason: RuntimeConfigFenceReason::AcknowledgementLost,
-            message: "peer manager accepted resolved-policy apply but dropped its reply"
-                .to_string(),
-        })?
-        .map_err(ConfigTransactionApplyError::Internal)
-}
-
 async fn send_apply_peer_reshape_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     targets: Vec<PeerManagerNeighborConfig>,
@@ -3641,31 +3446,6 @@ async fn send_apply_peer_reshape_snapshot(
             message: "peer manager accepted peer reshape but dropped its reply".to_string(),
         })?
         .map_err(peer_lifecycle_error_to_apply_error)
-}
-
-async fn rollback_live_policy_and_snapshot(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
-    priors: Vec<ResolvedPeerPolicy>,
-    rollback: TransactionConfigRollbackToken,
-    original: ApplyFailure,
-) -> ApplyFailure {
-    if original.fence_reason.is_some() {
-        return original;
-    }
-    let live_rollback = send_apply_resolved_policy_snapshot(peer_mgr_tx, priors)
-        .await
-        .map(|_| ());
-    let snapshot_rollback = restore_preloaded_config_snapshot(peer_mgr_internal_tx, rollback).await;
-    match (live_rollback, snapshot_rollback) {
-        (Ok(()), Ok(())) => original,
-        (live_result, snapshot_result) => combine_rollback_errors(
-            &original.error,
-            "live policy rollback",
-            live_result.err(),
-            snapshot_result.err(),
-        ),
-    }
 }
 
 async fn rollback_peer_reshape_and_snapshot(
@@ -4281,40 +4061,63 @@ remote_asn = 65002
 
     #[test]
     fn production_snapshot_callers_are_fenced_to_the_accepted_helper() {
+        fn count_all(sources: &[&str], needle: &str) -> usize {
+            sources
+                .iter()
+                .map(|source| source.matches(needle).count())
+                .sum()
+        }
+
         let source = include_str!("config_transaction_control.rs");
         let production = source.split("#[cfg(test)]\nmod tests {").next().unwrap();
+        let live_policy_impact = include_str!("config_transaction_control/live_policy_impact.rs");
+        let production_sources = [production, live_policy_impact];
         assert_eq!(
-            production.matches(".accepted_runtime_snapshot()").count(),
+            count_all(&production_sources, ".accepted_runtime_snapshot()"),
             2,
             "gNMI Set construction plus the test-only authority fallback use the accepted helper"
         );
         assert_eq!(
-            production.matches(".accepted_prior_snapshot()").count(),
+            count_all(&production_sources, ".accepted_prior_snapshot()"),
             1,
             "confirmed rollback must bind one accepted provenance generation"
         );
-        assert!(!production.contains("use crate::reload::runtime_config_snapshot;"));
+        assert_eq!(
+            count_all(
+                &production_sources,
+                "use crate::reload::runtime_config_snapshot;"
+            ),
+            0
+        );
         let apply = production
             .rsplit_once("let committed_candidate_toml")
             .unwrap()
             .1;
         assert!(!apply.contains("request.candidate_toml"));
         assert_eq!(
-            production
-                .matches("stage_preloaded_config_snapshot(")
-                .count(),
+            count_all(&production_sources, "stage_preloaded_config_snapshot("),
             7,
             "one typed staging helper plus all six transaction-family calls"
         );
         assert_eq!(
-            production
-                .matches("TransactionConfigScope::FibTablesOnly")
-                .count(),
+            count_all(&production_sources, "TransactionConfigScope::FibTablesOnly"),
             1,
             "only the pure-FIB family may use the overlay scope"
         );
-        assert!(!production.contains("PeerManagerCommand::StageConfigSnapshot"));
-        assert!(!production.contains("PeerManagerCommand::RestoreConfigSnapshot"));
+        assert_eq!(
+            count_all(
+                &production_sources,
+                "PeerManagerCommand::StageConfigSnapshot"
+            ),
+            0
+        );
+        assert_eq!(
+            count_all(
+                &production_sources,
+                "PeerManagerCommand::RestoreConfigSnapshot"
+            ),
+            0
+        );
 
         let reload = include_str!("reload.rs");
         let legacy = reload
@@ -4357,6 +4160,7 @@ remote_asn = 65002
         }
 
         let source = include_str!("config_transaction_control.rs");
+        let live_policy_impact = include_str!("config_transaction_control/live_policy_impact.rs");
         let apply = body(
             source,
             "async fn apply_config_transaction_locked_with_preloaded",
@@ -4508,39 +4312,45 @@ remote_asn = 65002
                 < commit_path.find("converger.converge(").unwrap()
         );
 
-        for (start, end, first_mutation) in [
+        for (family_source, start, end, first_mutation) in [
             (
+                source,
                 "async fn commit_fib_transaction(",
                 "fn apply_family(",
                 "stage_preloaded_config_snapshot(",
             ),
             (
+                source,
                 "async fn commit_candidate_snapshot_locked(",
                 "async fn commit_dynamic_neighbors_locked(",
                 "stage_preloaded_config_snapshot(",
             ),
             (
+                source,
                 "async fn commit_dynamic_neighbors_locked(",
                 "async fn commit_static_neighbors_locked(",
                 "stage_preloaded_config_snapshot(",
             ),
             (
+                source,
                 "async fn commit_static_neighbors_locked(",
-                "async fn commit_live_policy_impact_locked(",
-                "stage_preloaded_config_snapshot(",
-            ),
-            (
-                "async fn commit_live_policy_impact_locked(",
                 "struct PeerSessionReshapeCommit",
                 "stage_preloaded_config_snapshot(",
             ),
             (
+                live_policy_impact,
+                "async fn commit_live_policy_impact_locked(",
+                "#[derive(Default)]",
+                "stage_preloaded_config_snapshot(",
+            ),
+            (
+                source,
                 "async fn commit_peer_session_reshape_locked(",
                 "async fn send_bounce_dynamic_range_peers(",
                 "stage_preloaded_config_snapshot(",
             ),
         ] {
-            let owned = body(source, start, end);
+            let owned = body(family_source, start, end);
             let reserve = owned.find("reserve_persist_permit(").unwrap();
             let mutation = owned.find("progress.begin_mutation()").unwrap();
             let first_mutation = owned.find(first_mutation).unwrap();
@@ -4550,45 +4360,51 @@ remote_asn = 65002
             assert!(mutation < settling && settling < publication, "{start}");
         }
 
-        for (start, end, rollback, expected) in [
+        for (family_source, start, end, rollback, expected) in [
             (
+                source,
                 "async fn commit_fib_transaction(",
                 "fn apply_family(",
                 "restore_preloaded_snapshot_after_error(",
                 1,
             ),
             (
+                source,
                 "async fn commit_dynamic_neighbors_locked(",
                 "async fn commit_static_neighbors_locked(",
                 "rollback_snapshot_after_error(",
                 1,
             ),
             (
+                source,
                 "async fn commit_static_neighbors_locked(",
-                "async fn commit_live_policy_impact_locked(",
-                "rollback_snapshot_after_error(",
-                2,
-            ),
-            (
-                "async fn commit_static_neighbors_locked(",
-                "async fn commit_live_policy_impact_locked(",
-                "rollback_static_and_snapshot(",
-                5,
-            ),
-            (
-                "async fn commit_live_policy_impact_locked(",
                 "struct PeerSessionReshapeCommit",
                 "rollback_snapshot_after_error(",
                 2,
             ),
             (
+                source,
+                "async fn commit_static_neighbors_locked(",
+                "struct PeerSessionReshapeCommit",
+                "rollback_static_and_snapshot(",
+                5,
+            ),
+            (
+                live_policy_impact,
+                "async fn commit_live_policy_impact_locked(",
+                "#[derive(Default)]",
+                "rollback_snapshot_after_error(",
+                2,
+            ),
+            (
+                source,
                 "async fn commit_peer_session_reshape_locked(",
                 "async fn send_bounce_dynamic_range_peers(",
                 "rollback_snapshot_after_error(",
                 3,
             ),
         ] {
-            let owned = body(source, start, end);
+            let owned = body(family_source, start, end);
             let pre_persist = owned.split_once("persist_candidate_config(").unwrap().0;
             assert_eq!(pre_persist.matches(rollback).count(), expected, "{start}");
             for prefix in pre_persist.split(rollback).take(expected) {

--- a/src/config_transaction_control/live_policy_impact.rs
+++ b/src/config_transaction_control/live_policy_impact.rs
@@ -1,0 +1,247 @@
+use tokio::sync::{mpsc, oneshot};
+
+use rustbgpd_api::peer_types::{
+    ConfigEvent, DynamicRangeTarget, PeerManagerCommand, ResolvedPeerPolicy,
+};
+use rustbgpd_api::runtime_config_settlement::RuntimeConfigFenceReason;
+use rustbgpd_api::server::ConfigTransactionApplyError;
+
+use crate::config::{Config, Neighbor, diff_config};
+use crate::peer_manager::{
+    InternalCommand, TransactionConfigRollbackToken, TransactionConfigScope,
+};
+
+use super::{
+    ApplyFailure, RuntimeConfigMutationProgress, combine_rollback_errors,
+    commit_config_snapshot_stage, persist_candidate_config, reserve_persist_permit,
+    restore_preloaded_config_snapshot, rollback_snapshot_after_error,
+    stage_preloaded_config_snapshot,
+};
+
+/// Commit a live-impact policy/peer-group/global-chain transaction: stage the
+/// candidate snapshot, re-apply the affected static neighbors' resolved chains
+/// to their live sessions (capturing priors), persist, and roll back live +
+/// snapshot on failure. Returns the number of live sessions re-evaluated.
+pub(super) async fn commit_live_policy_impact_locked(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    candidate_toml: String,
+    candidate: &Config,
+    progress: &RuntimeConfigMutationProgress,
+) -> Result<usize, ApplyFailure> {
+    let permit = reserve_persist_permit(config_tx).await?;
+    progress.begin_mutation();
+    let rollback = stage_preloaded_config_snapshot(
+        peer_mgr_internal_tx,
+        Box::new(candidate.clone()),
+        TransactionConfigScope::Full,
+    )
+    .await?;
+
+    let targets = match resolve_live_policy_targets(rollback.previous(), candidate) {
+        Ok(targets) => targets,
+        Err(error) => {
+            progress.begin_settling();
+            return Err(rollback_snapshot_after_error(
+                peer_mgr_internal_tx,
+                rollback,
+                error.into(),
+            )
+            .await);
+        }
+    };
+
+    let priors = match send_apply_policy_impact_snapshot(peer_mgr_tx, targets).await {
+        Ok(priors) => priors,
+        Err(error) => {
+            // The peer-manager command self-heals its live mutations on a
+            // mid-fanout failure, so only the staged snapshot needs rollback.
+            progress.begin_settling();
+            return Err(rollback_snapshot_after_error(
+                peer_mgr_internal_tx,
+                rollback,
+                error.into(),
+            )
+            .await);
+        }
+    };
+
+    progress.begin_settling();
+    if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        if failure.fence_reason.is_some() {
+            return Err(failure);
+        }
+        return Err(rollback_live_policy_and_snapshot(
+            peer_mgr_tx,
+            peer_mgr_internal_tx,
+            priors,
+            rollback,
+            failure,
+        )
+        .await);
+    }
+    // Ambiguous-persistence window (a): candidate durable on disk from here on.
+    commit_config_snapshot_stage(peer_mgr_tx).await?;
+    Ok(priors.len())
+}
+
+#[derive(Default)]
+pub(super) struct LivePolicyTargets {
+    pub(super) static_targets: Vec<ResolvedPeerPolicy>,
+    dynamic_ranges: Vec<DynamicRangeTarget>,
+}
+
+/// Build the resolved-chain apply set from a live-impact diff:
+/// every static neighbor whose resolved import/export policy moved and every
+/// dynamic range whose accepted live peers need candidate policy resolution.
+pub(super) fn resolve_live_policy_targets(
+    previous: &Config,
+    candidate: &Config,
+) -> Result<LivePolicyTargets, ConfigTransactionApplyError> {
+    let diff = diff_config(previous, candidate);
+    let candidate_by_addr: std::collections::HashMap<&str, &Neighbor> = candidate
+        .neighbors
+        .iter()
+        .map(|neighbor| (neighbor.address.as_str(), neighbor))
+        .collect();
+    let dynamic_range_by_key: std::collections::HashMap<_, _> = candidate
+        .dynamic_neighbors
+        .iter()
+        .filter_map(|range| {
+            crate::config::effective_prefix_str(&range.prefix).map(|key| (key, range))
+        })
+        .collect();
+    let mut targets = LivePolicyTargets::default();
+    for impact in &diff.effective_neighbor_impact {
+        if !impact.kind.is_policy_chain() {
+            // A committable live-impact plan only carries policy-chain-only
+            // impacts; anything else is an internal inconsistency — fail closed
+            // rather than silently skip.
+            return Err(ConfigTransactionApplyError::Internal(format!(
+                "live-policy executor received an unsupported impact for {}",
+                impact.address
+            )));
+        }
+        if impact.is_dynamic_range {
+            let Some((addr, prefix_len)) = crate::config::effective_prefix_str(&impact.address)
+            else {
+                return Err(ConfigTransactionApplyError::Internal(format!(
+                    "live-policy impact references invalid dynamic range {}",
+                    impact.address
+                )));
+            };
+            let Some(range) = dynamic_range_by_key.get(&(addr, prefix_len)) else {
+                return Err(ConfigTransactionApplyError::Internal(format!(
+                    "live-policy impact references dynamic range {} absent from the candidate",
+                    impact.address
+                )));
+            };
+            targets.dynamic_ranges.push(DynamicRangeTarget {
+                addr,
+                prefix_len,
+                peer_group: range.peer_group.clone(),
+            });
+            continue;
+        }
+        let Some(neighbor) = candidate_by_addr.get(impact.address.as_str()) else {
+            return Err(ConfigTransactionApplyError::Internal(format!(
+                "live-policy impact references neighbor {} absent from the candidate",
+                impact.address
+            )));
+        };
+        let address = neighbor.address.parse().map_err(|error| {
+            ConfigTransactionApplyError::InvalidArgument(format!(
+                "invalid neighbor address {:?}: {error}",
+                neighbor.address
+            ))
+        })?;
+        let resolved = candidate
+            .resolve_neighbor(neighbor)
+            .map_err(|error| ConfigTransactionApplyError::InvalidArgument(error.to_string()))?;
+        targets.static_targets.push(ResolvedPeerPolicy {
+            address,
+            interface: neighbor.interface.clone(),
+            import_policy: resolved.import_policy,
+            export_policy: resolved.export_policy,
+        });
+    }
+    Ok(targets)
+}
+
+/// Send `ApplyPolicyImpactSnapshot` and return the captured prior chains.
+async fn send_apply_policy_impact_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    targets: LivePolicyTargets,
+) -> Result<Vec<ResolvedPeerPolicy>, ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::ApplyPolicyImpactSnapshot {
+            static_targets: targets.static_targets,
+            dynamic_ranges: targets.dynamic_ranges,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager dropped policy-impact reply".to_string(),
+            )
+        })?
+        .map_err(ConfigTransactionApplyError::Internal)
+}
+
+/// Send `ApplyResolvedPolicySnapshot` and return the captured prior chains.
+/// Used in reverse to restore captured priors during rollback.
+async fn send_apply_resolved_policy_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    targets: Vec<ResolvedPeerPolicy>,
+) -> Result<Vec<ResolvedPeerPolicy>, ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
+            targets,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted resolved-policy apply but dropped its reply"
+                .to_string(),
+        })?
+        .map_err(ConfigTransactionApplyError::Internal)
+}
+
+async fn rollback_live_policy_and_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    peer_mgr_internal_tx: &mpsc::Sender<InternalCommand>,
+    priors: Vec<ResolvedPeerPolicy>,
+    rollback: TransactionConfigRollbackToken,
+    original: ApplyFailure,
+) -> ApplyFailure {
+    if original.fence_reason.is_some() {
+        return original;
+    }
+    let live_rollback = send_apply_resolved_policy_snapshot(peer_mgr_tx, priors)
+        .await
+        .map(|_| ());
+    let snapshot_rollback = restore_preloaded_config_snapshot(peer_mgr_internal_tx, rollback).await;
+    match (live_rollback, snapshot_rollback) {
+        (Ok(()), Ok(())) => original,
+        (live_result, snapshot_result) => combine_rollback_errors(
+            &original.error,
+            "live policy rollback",
+            live_result.err(),
+            snapshot_result.err(),
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

- move the private live-policy-impact commit, target resolution, send, and rollback concern into one sibling module
- preserve transaction ordering, rollback ordering, error text, tracing, visibility, and the 94-test controller roster
- keep the structural source guard load-bearing across both the parent controller and extracted child

## Scope

This is the first bounded extraction tranche only. The other transaction families, generic rollback helpers, public APIs, behavior, docs, dependencies, and state machine remain unchanged.

## Validation

- both structural source-fence tests
- all five live-policy-impact tests plus confirmed apply and rollback coverage
- full binary suite: 2,073 passed, 4 ignored
- byte-identical 94-test controller roster
- `cargo test --locked --workspace --no-fail-fast`
- strict workspace/all-targets/all-features Clippy
- warning-denied workspace library docs
- formatting and diff checks
- independent exact-head review

Linear: [LAN-1186](https://linear.app/lance0/issue/LAN-1186/split-the-127k-line-config-transaction-controller-no-test-extraction) — first tranche; the broader issue remains open.