### PR TITLE
fix(wire): validate community container framing

### DIFF
--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -219,6 +219,7 @@ async fn assigned_opaque_attributes_reach_rib_while_edge_metadata_is_absent() {
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 42), 32);
     let values = [
         (25_u8, (0_u8..20).collect::<Vec<_>>()),
+        (34_u8, vec![0, 2, 0x5a, 0xa5, 0, 6]),
         (36_u8, vec![1, 0, 0, 0, 0, 0, 0, 0]),
         (37, vec![2, 0, 4, 1, 99, 0, 0]),
         (38, vec![1, 0, 0, 0, 1, 1, 4, 192, 0, 2, 1]),
@@ -290,6 +291,62 @@ async fn assigned_opaque_attributes_reach_rib_while_edge_metadata_is_absent() {
             .all(|attribute| attribute.type_code() != 42)
     );
     assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+#[tokio::test]
+async fn malformed_community_container_withdraws_dual_stack_replacements() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    install_dual_stack_session(&mut session, false);
+    rfc7606_drain(&mut rib_rx);
+    let ipv4 = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let ipv6 = Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32);
+    let ipv6_nlri = [32, 0x20, 0x01, 0x0d, 0xb8];
+
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&[]), &[ipv4]))
+        .await;
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&rfc7606_mp_reach(&ipv6_nlri)),
+            &[],
+        ))
+        .await;
+    for expected in [Prefix::V4(ipv4), Prefix::V6(ipv6)] {
+        let RibUpdate::RoutesReceived { announced, .. } =
+            rib_rx.try_recv().expect("initial route must reach RIB")
+        else {
+            panic!("expected initial route");
+        };
+        assert_eq!(announced.len(), 1);
+        assert_eq!(announced[0].prefix, expected);
+    }
+
+    let mut replacement = vec![0xc0, 34, 5, 0, 1, 0, 0, 0];
+    replacement.extend(rfc7606_mp_reach(&ipv6_nlri));
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&replacement), &[ipv4]))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("replacement withdrawals must reach RIB")
+    else {
+        panic!("expected replacement withdrawals");
+    };
+    assert!(announced.is_empty(), "malformed attribute must stay absent");
+    assert_eq!(withdrawn.len(), 2);
+    assert!(withdrawn.contains(&(Prefix::V4(ipv4), 0)));
+    assert!(withdrawn.contains(&(Prefix::V6(ipv6), 0)));
+    assert!(rib_rx.try_recv().is_err());
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
 }
 
 #[tokio::test]

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,13 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- **Community Container framing fence:** Registered temporary path attribute
+  34 as optional transitive and retained valid values opaquely with Partial on
+  egress. Bounded container, Type 1 subtype, atom, and prefix framing failures,
+  class conflicts, and duplicate attributes now receive treat-as-withdraw.
+  This syntax-only handling follows a work-in-progress draft and does not claim
+  stable standards support or expose a typed model.
+
 - **Traffic Engineering and IPv6-specific community fences:** Registered path
   attributes 24 and 25 now enforce their Optional/Transitive classes. Traffic
   Engineering remains payload-opaque and is ignored as optional

--- a/crates/wire/src/assigned_attributes.rs
+++ b/crates/wire/src/assigned_attributes.rs
@@ -4,6 +4,7 @@ use crate::constants::attr_type;
 
 pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> {
     match type_code {
+        attr_type::COMMUNITY_CONTAINER => community_container(value),
         attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY => {
             ipv6_address_specific_extended_community(value)
         }
@@ -15,6 +16,81 @@ pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> 
         attr_type::BIER => bier(value),
         _ => Ok(()),
     }
+}
+
+fn community_container(mut value: &[u8]) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("Community Container attribute contains no containers");
+    }
+    while !value.is_empty() {
+        if value.len() < 6 {
+            return Err("Community Container header is truncated");
+        }
+        let kind = u16::from_be_bytes([value[0], value[1]]);
+        let length = usize::from(u16::from_be_bytes([value[4], value[5]]));
+        if length < 6 {
+            return Err("Community Container total length is shorter than its header");
+        }
+        if value.len() < length {
+            return Err("Community Container overruns attribute");
+        }
+        if kind == 1 {
+            community_container_type_one(&value[6..length])?;
+        }
+        value = &value[length..];
+    }
+    Ok(())
+}
+
+fn community_container_type_one(body: &[u8]) -> Result<(), &'static str> {
+    if body.len() < 12 {
+        return Err("Community Container Type 1 fixed body is truncated");
+    }
+    let mut seen = [false; 256];
+    let mut subtypes = &body[12..];
+    while !subtypes.is_empty() {
+        let (kind, value, rest) = tlv_u8_u16(subtypes)?;
+        if std::mem::replace(&mut seen[usize::from(kind)], true) {
+            return Err("Community Container Type 1 repeats a subtype");
+        }
+        if matches!(kind, 1..=3) {
+            community_atom_stream(value)?;
+        }
+        subtypes = rest;
+    }
+    Ok(())
+}
+
+fn community_atom_stream(mut value: &[u8]) -> Result<(), &'static str> {
+    while !value.is_empty() {
+        let (kind, body, rest) = tlv_u8_u16(value)?;
+        match kind {
+            0 | 255 => return Err("Community atom type is reserved"),
+            1 | 4 | 5 | 6 | 7 if body.is_empty() || !body.len().is_multiple_of(4) => {
+                return Err("Community atom length is not a positive multiple of four");
+            }
+            2 => community_prefixes(body, 32)?,
+            3 => community_prefixes(body, 128)?,
+            _ => {}
+        }
+        value = rest;
+    }
+    Ok(())
+}
+
+fn community_prefixes(mut value: &[u8], maximum: u8) -> Result<(), &'static str> {
+    while !value.is_empty() {
+        let prefix_length = value[0];
+        if prefix_length > maximum {
+            return Err("Community atom prefix length exceeds its address family");
+        }
+        let octets = usize::from(prefix_length).div_ceil(8);
+        if value.len() < 1 + octets {
+            return Err("Community atom prefix is truncated");
+        }
+        value = &value[1 + octets..];
+    }
+    Ok(())
 }
 
 fn ipv6_address_specific_extended_community(value: &[u8]) -> Result<(), &'static str> {

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -924,8 +924,18 @@ pub fn decode_path_attributes_counted(
 ) -> Result<(Vec<PathAttribute>, u32), DecodeError> {
     let mut attrs = Vec::new();
     let mut bgpls_discarded = 0_u32;
+    let mut seen_community_container = false;
     while !buf.is_empty() {
         let (flags, type_code, value) = split_next_attribute_mp_aware(&mut buf)?;
+        if type_code == attr_type::COMMUNITY_CONTAINER
+            && std::mem::replace(&mut seen_community_container, true)
+        {
+            return Err(DecodeError::UpdateAttributeError {
+                subcode: update_subcode::MALFORMED_ATTRIBUTE_LIST,
+                data: vec![],
+                detail: "duplicate attribute type 34".to_string(),
+            });
+        }
         if is_unknown_optional_non_transitive(flags, type_code) {
             continue;
         }
@@ -1149,9 +1159,9 @@ pub fn decode_path_attributes_revised(
         }
         let duplicate = std::mem::replace(&mut seen[usize::from(type_code)], true);
         if duplicate {
-            // RFC 7606 §3 (g): duplicate MP_REACH/MP_UNREACH is fatal; any
-            // other duplicate keeps the first occurrence and discards the
-            // rest while the UPDATE continues to be processed.
+            // RFC 7606 §3 (g): duplicate MP_REACH/MP_UNREACH is fatal.
+            // A duplicate Community Container is treat-as-withdraw; other
+            // duplicates keep the first occurrence and discard the rest.
             let error = DecodeError::UpdateAttributeError {
                 subcode: update_subcode::MALFORMED_ATTRIBUTE_LIST,
                 data: vec![],
@@ -1165,7 +1175,11 @@ pub fn decode_path_attributes_revised(
             }
             malformed.push(MalformedAttribute {
                 type_code,
-                disposition: ErrorDisposition::AttributeDiscard,
+                disposition: if type_code == attr_type::COMMUNITY_CONTAINER {
+                    ErrorDisposition::TreatAsWithdraw
+                } else {
+                    ErrorDisposition::AttributeDiscard
+                },
                 error,
             });
             continue;
@@ -1285,6 +1299,7 @@ fn assigned_unsupported_flags(type_code: u8) -> Option<u8> {
         attr_type::TUNNEL_ENCAPSULATION
         | attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY
         | attr_type::PE_DISTINGUISHER_LABELS
+        | attr_type::COMMUNITY_CONTAINER
         | attr_type::DOMAIN_PATH
         | attr_type::SFP
         | attr_type::BFD_DISCRIMINATOR
@@ -1649,6 +1664,7 @@ fn decode_attribute_value(
     if matches!(
         type_code,
         attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY
+            | attr_type::COMMUNITY_CONTAINER
             | attr_type::DOMAIN_PATH
             | attr_type::SFP
             | attr_type::BFD_DISCRIMINATOR

--- a/crates/wire/src/constants.rs
+++ b/crates/wire/src/constants.rs
@@ -173,6 +173,9 @@ pub mod attr_type {
     pub const BGP_LS: u8 = 29;
     /// RFC 8205: `BGPsec_PATH` attribute.
     pub const BGPSEC_PATH: u8 = 33;
+    /// Community Container attribute (temporary IANA assignment for a
+    /// work-in-progress specification).
+    pub const COMMUNITY_CONTAINER: u8 = 34;
     /// RFC 9234 §5: Only-to-Customer (OTC).
     pub const ONLY_TO_CUSTOMER: u8 = 35;
     /// D-PATH (draft-ietf-bess-evpn-ipvpn-interworking).

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -61,9 +61,31 @@ fn extended_attribute(flags: u8, code: u8, value: &[u8]) -> Vec<u8> {
     bytes
 }
 
+fn community_tlv(kind: u8, value: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![kind];
+    bytes.extend_from_slice(&u16::try_from(value.len()).unwrap().to_be_bytes());
+    bytes.extend_from_slice(value);
+    bytes
+}
+
+fn community_container(kind: u16, body: &[u8]) -> Vec<u8> {
+    let mut bytes = kind.to_be_bytes().to_vec();
+    bytes.extend([0x5a, 0xa5]);
+    bytes.extend_from_slice(&u16::try_from(body.len() + 6).unwrap().to_be_bytes());
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+fn community_type_one(subtypes: &[u8]) -> Vec<u8> {
+    let mut body = vec![0; 12];
+    body.extend_from_slice(subtypes);
+    community_container(1, &body)
+}
+
 fn assigned_value(code: u8) -> Vec<u8> {
     match code {
         25 => (0_u8..20).collect(),
+        34 => community_container(2, &[]),
         36 => vec![1, 0, 0, 0, 0, 0, 0, 0],
         37 => vec![2, 0, 4, 1, 99, 0, 0],
         38 => vec![1, 0, 0, 0, 1, 1, 4, 192, 0, 2, 1],
@@ -424,6 +446,11 @@ fn assigned_unsupported_class_matrix_is_fail_closed_without_semantic_support() {
             transitive_conflict: ErrorDisposition::TreatAsWithdraw,
         },
         Case {
+            code: 34,
+            canonical: 0xc0,
+            transitive_conflict: ErrorDisposition::TreatAsWithdraw,
+        },
+        Case {
             code: 40,
             canonical: 0xc0,
             transitive_conflict: ErrorDisposition::TreatAsWithdraw,
@@ -503,7 +530,7 @@ fn assigned_unsupported_class_matrix_is_fail_closed_without_semantic_support() {
 
 #[test]
 fn assigned_unsupported_opaque_flags_and_neighboring_fences_stay_orthogonal() {
-    for code in [23, 25, 27, 40, 128] {
+    for code in [23, 25, 27, 34, 40, 128] {
         let value = assigned_value(code);
         for flags in [0xe0, 0xf0] {
             let input = if flags == 0xf0 {
@@ -559,6 +586,137 @@ fn assigned_unsupported_opaque_flags_and_neighboring_fences_stay_orthogonal() {
         defensive.is_empty(),
         "assigned optional non-transitive type 24 must never egress"
     );
+}
+
+#[test]
+fn community_container_accepts_bounded_opaque_and_known_atom_streams() {
+    let mut atoms = Vec::new();
+    for kind in [1_u8, 4, 5, 6, 7] {
+        atoms.extend(community_tlv(kind, &[0, 0, 0, kind]));
+    }
+    atoms.extend(community_tlv(2, &[]));
+    atoms.extend(community_tlv(
+        2,
+        &[0, 17, 10, 0, 0, 24, 192, 0, 2, 32, 203, 0, 113, 9],
+    ));
+    let mut ipv6 = vec![0, 64];
+    ipv6.extend([0x20, 1, 0x0d, 0xb8, 0, 0, 0, 1]);
+    ipv6.push(65);
+    ipv6.extend([0x20, 1, 0x0d, 0xb8, 0, 1, 0, 2, 0]);
+    ipv6.push(128);
+    ipv6.extend([0x20, 1, 0x0d, 0xb8, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6]);
+    atoms.extend(community_tlv(3, &[]));
+    atoms.extend(community_tlv(3, &ipv6));
+    atoms.extend(community_tlv(8, &[0, 0xff, 0x80]));
+    atoms.extend(community_tlv(9, &[]));
+    atoms.extend(community_tlv(254, &[0xff]));
+
+    let mut empty_known = Vec::new();
+    for kind in 1_u8..=3 {
+        empty_known.extend(community_tlv(kind, &[]));
+    }
+    empty_known.extend(community_tlv(255, &[0, 1]));
+    let mut value = community_type_one(&empty_known);
+    value.extend(community_container(65000, &[0, 1, 2]));
+    value.extend(community_type_one(&community_tlv(1, &atoms)));
+
+    for flags in [0xc0, 0xe0] {
+        let input = attribute(flags, 34, &value);
+        let strict = decode_path_attributes(&input, true, &[]).unwrap();
+        let [PathAttribute::Unknown(raw)] = strict.as_slice() else {
+            panic!("type 34 must remain opaque");
+        };
+        assert_eq!((raw.flags, raw.data.as_ref()), (flags, &value[..]));
+        let mut emitted = Vec::new();
+        encode_path_attributes(&strict, &mut emitted, true, false).unwrap();
+        assert_eq!(emitted[0], flags | 0x20);
+        assert_eq!(&emitted[3..], value.as_slice());
+    }
+}
+
+#[test]
+fn community_container_rejects_every_framing_boundary_and_duplicate() {
+    let mut invalid = vec![Vec::new()];
+    invalid.extend((1_usize..6).map(|length| vec![0; length]));
+    invalid.extend([
+        vec![0, 2, 0, 0, 0, 0],
+        vec![0, 2, 0, 0, 0, 5],
+        vec![0, 2, 0, 0, 0, 7],
+        [community_container(2, &[]), vec![0]].concat(),
+        community_container(1, &[0; 11]),
+    ]);
+    for subtype in [vec![1], vec![1, 0], vec![1, 0, 1]] {
+        invalid.push(community_type_one(&subtype));
+    }
+    invalid.push(community_type_one(
+        &[community_tlv(1, &[]), community_tlv(1, &[])].concat(),
+    ));
+    for atom in [
+        vec![1],
+        vec![1, 0],
+        vec![1, 0, 1],
+        community_tlv(0, &[]),
+        community_tlv(255, &[]),
+    ] {
+        invalid.push(community_type_one(&community_tlv(1, &atom)));
+    }
+    for kind in [1_u8, 4, 5, 6, 7] {
+        for body in [&[][..], &[0; 5][..]] {
+            invalid.push(community_type_one(&community_tlv(
+                1,
+                &community_tlv(kind, body),
+            )));
+        }
+    }
+    for (kind, prefixes) in [
+        (2_u8, vec![33]),
+        (2, vec![32, 192, 0, 2]),
+        (2, vec![0, 24, 192, 0]),
+        (3, vec![129]),
+        (3, vec![128; 16]),
+    ] {
+        invalid.push(community_type_one(&community_tlv(
+            1,
+            &community_tlv(kind, &prefixes),
+        )));
+    }
+
+    for value in invalid {
+        let input = attribute(0xc0, 34, &value);
+        assert!(matches!(
+            decode_path_attributes(&input, true, &[]),
+            Err(DecodeError::UpdateAttributeError { subcode, data, .. })
+                if subcode == update_subcode::ATTRIBUTE_LENGTH_ERROR && data == input
+        ));
+        let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+        assert!(revised.attributes.is_empty());
+        assert_eq!(revised.malformed.len(), 1);
+        assert_eq!(
+            revised.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+    }
+
+    let values = [community_container(2, &[]), community_container(3, &[1])];
+    for (first, second) in [(&values[0], &values[1]), (&values[1], &values[0])] {
+        let bytes = [attribute(0xc0, 34, first), attribute(0xc0, 34, second)].concat();
+        assert!(matches!(
+            decode_path_attributes(&bytes, true, &[]),
+            Err(DecodeError::UpdateAttributeError { subcode, .. })
+                if subcode == update_subcode::MALFORMED_ATTRIBUTE_LIST
+        ));
+        let revised = decode_path_attributes_revised(&bytes, true, false, &[]).unwrap();
+        assert_eq!(revised.attributes.len(), 1);
+        assert_eq!(revised.malformed.len(), 1);
+        assert_eq!(
+            revised.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+        assert!(matches!(
+            &revised.attributes[0],
+            PathAttribute::Unknown(raw) if raw.data.as_ref() == first.as_slice()
+        ));
+    }
 }
 
 #[test]

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -62,7 +62,7 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 31 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 32 | LARGE_COMMUNITY | optional transitive; flags `0xc0`; values are twelve-octet communities; RFC 8092 §6 | typed canonical + Partial round-trip; duplicate values normalize first-seen; malformed length is treat-as-withdraw | typed-Partial matrix |
 | 33 | BGPsec_Path | optional non-transitive; flags `0x80`; RFC 8205 | payload semantics unsupported; correct class ignored; wrong class is treat-as-withdraw | assigned-class matrix below |
-| 34 | BGP Community Container Attribute (TEMPORARY - registered 2017-07-28, extension registered 2024-08-22, expires 2025-07-28) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
+| 34 | BGP Community Container Attribute (temporary assignment in the live IANA registry) | optional transitive; flags `0xc0`; draft-ietf-idr-wide-bgp-communities-11 (work in progress) | opaque retention with Partial on egress; bounded container, Type 1 subtype, atom, and prefix framing; wrong class, malformed framing, or a duplicate attribute is treat-as-withdraw | Community Container framing matrix below; this is not a stable standards-support claim |
 | 35 | Only to Customer (OTC) | optional transitive; flags `0xc0`; exactly one four-octet ASN; RFC 9234 §5 | typed ASN + Partial round-trip; Extended Length and reserved low bits canonicalize; wrong class or length is treat-as-withdraw | OTC codec and transport matrices |
 | 36 | BGP Domain Path (D-PATH) | optional transitive; flags `0xc0`; draft-ietf-bess-evpn-ipvpn-interworking-18 | opaque retention with bounded domain-segment framing; malformed is treat-as-withdraw | assigned framing matrix below |
 | 37 | SFP attribute | optional transitive; flags `0xc0`; RFC 9015 §3.2.1 | opaque retention with TLV, Hop, and Hop sub-TLV framing; malformed is treat-as-withdraw | assigned framing matrix below |
@@ -114,7 +114,7 @@ negotiation. "Wrong O" toggles Optional, "wrong T" toggles Transitive, and
 
 | Codes | Class | Correct-class retention and egress | Wrong O | Wrong T | Both wrong | Legacy decoder |
 |---|---|---|---|---|---|---|
-| 23, 25, 27, 36-41, 128 | optional transitive (`0xc0`) | opaque retention; Partial set on egress; input Partial and Extended Length preserved | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
+| 23, 25, 27, 34, 36-41, 128 | optional transitive (`0xc0`) | opaque retention; Partial set on egress; input Partial and Extended Length preserved | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 | 26 | optional non-transitive (`0x80`) | ignored; no retention or egress | treat-as-withdraw | attribute-discard | attribute-discard | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 | 24, 33, 42 | optional non-transitive (`0x80`) | ignored; no retention or egress; Partial rejected | treat-as-withdraw | treat-as-withdraw | treat-as-withdraw | `ATTRIBUTE_FLAGS_ERROR` for every conflict |
 
@@ -128,6 +128,19 @@ errors.
 |---|---|
 | 20, 40, ... | retained opaquely and propagated with Partial |
 | 0 or any non-multiple of 20 | Attribute Length Error; revised treat-as-withdraw |
+
+## Community Container framing matrix
+
+Type 34 remains an unsupported opaque attribute under a temporary live IANA
+assignment and a work-in-progress draft. The checks below validate only bounded
+framing; they do not expose a typed model or claim stable standards support.
+
+| Layer | Accepted boundary | Rejected boundary |
+|---|---|---|
+| Container stream | one or more exact six-octet-header containers; unknown types opaque | truncated header, total length below six, overrun, or trailing bytes |
+| Type 1 | twelve-octet fixed body followed by uniquely typed subtype TLVs; repeated Type 1 containers allowed | short fixed body, subtype framing error, or repeated subtype within one Type 1 |
+| Known subtypes 1-3 | empty or an exact atom stream; unknown subtypes opaque | atom framing error or reserved atom type 0/255 |
+| Atom values | types 1/4/5/6/7: positive multiples of four; types 2/3: complete IPv4/IPv6 prefix sequences; type 8 and types 9-254 opaque | fixed-width mismatch, prefix length above 32/128, or truncated prefix octets |
 
 ## Assigned framing matrix (36-42)
 


### PR DESCRIPTION
## Summary\n\n- recognize live IANA path-attribute type 34 as temporary assigned optional-transitive\n- retain valid Community Container payloads opaquely while validating bounded container, Type 1, subtype, atom, and prefix framing\n- apply treat-as-withdraw to wrong flags, malformed framing, duplicate subtypes, reserved atoms, and duplicate attributes\n- prove malformed replacements withdraw accepted IPv4 and IPv6 routes without resetting the session\n\nThis is framing-only handling for a work-in-progress draft. It does not add a typed model or claim stable standards support.\n\n## Validation\n\n- focused positive and negative Community Container registry tests\n- full path-attribute registry suite\n- full rustbgpd-wire suite\n- focused dual-stack replacement test\n- full RFC 7606 transport module\n- affected-package all-target/all-feature Clippy\n- repository format, test, Clippy, docs, and push hooks\n\nThe strict workspace all-target/all-feature Clippy command has two unchanged warnings on exact main outside this diff; the same command and warnings were reproduced on both base and candidate.\n\nLinear: LAN-1236\n\nSources: [IANA BGP Path Attributes registry](https://www.iana.org/assignments/bgp-parameters), [Community Container draft](https://datatracker.ietf.org/doc/draft-ietf-idr-wide-bgp-communities/), [RFC 7606](https://www.rfc-editor.org/rfc/rfc7606.html)