### PR TITLE
docs: refresh public service and reload contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,9 @@ Microbenchmarks, memory scaling, and the bgperf2 cross-daemon comparison:
 ## gRPC API
 
 Eleven native `rustbgpd.v1` services cover the daemon's operational surface —
-Global, Config, Neighbor, Policy (22 RPCs including explain, dry-run, and
-per-term stats), PeerGroup, Rib, BFD, Event, Injection, Control, and Evpn —
+Global, Config, Neighbor, Policy (23 RPCs including explain, dry-run, per-term
+stats, and bounded validation-policy posture), PeerGroup, Rib, BFD, Event,
+Injection, Control, and Evpn —
 plus a separate `gnmi.gNMI` service for OpenConfig BGP telemetry and the first
 transaction-backed config subset.
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -252,6 +252,9 @@ that are stood up once at startup. Two flags are hot-pluggable.
 | `ebgp_requires_policy` | restart-required | ADR-0112/0119 RFC 8212 enforcement mode and raw-presence verdict. Pinned with `config_epoch` as one startup tuple: a SIGHUP reports value or representation drift in `--diff` and the v1 transaction rejection, logs an `ERROR`, and keeps the running import/export treatment and source verdict at startup. |
 | `install_blackhole_discard` | restart-required | The RFC 7999 kernel-discard reconciler spawns once at startup. |
 | `allow_blackhole_broad_prefixes` | restart-required | Same — feeds the discard-spawn gate. |
+| `blackhole_discard_max_active` | restart-required | The reconciler captures the active-discard cap at startup; SIGHUP pins the running value. |
+| `blackhole_discard_install_rate_per_minute` | restart-required | The reconciler captures the install-attempt rate at startup; SIGHUP pins the running value. |
+| `blackhole_discard_install_burst` | restart-required | The reconciler captures the install-attempt burst at startup; SIGHUP pins the running value. |
 | `multipath_relax` | restart-required | RIB best-path tie-break behavior; reconciling mid-flight would require an Adj-RIB-Out rebuild. |
 | `link_bandwidth_weighted` | restart-required | Weighted-multipath behavior (ADR-0068). |
 | `dynamic_neighbor_limit` | restart-required | Admission cap compared live against the dynamic-peer counter (inbound admission and LRU eviction bound); nothing is pre-allocated. SIGHUP pins the runtime snapshot to the startup value while retaining the edited desired value for restart. |


### PR DESCRIPTION
## Summary

- update the README PolicyService roster to the shipped 23-RPC surface and include bounded validation-policy posture
- classify the three BLACKHOLE discard admission controls as startup-captured, restart-required settings pinned across SIGHUP
- keep the changes to one coherent public-doc contract batch

## Validation

- PolicyService proto roster: exactly 23 RPCs
- each added reload-matrix key appears exactly once
- public documentation contract suite and live checkers
- workspace formatting and strict Clippy commit hooks
- push documentation hook and diff checks
- independent exact-head review

Linear: LAN-1288, LAN-1295