### PR TITLE
chore: prepare v0.67.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.67.0] — 2026-08-26
+
+> **Release framing — strict wire input, explicit migrations.** The wire crate
+> moves to 0.18.0 and the FSM to 0.5.0 so downstream consumers opt into the
+> assigned-attribute correctness wave instead of receiving changed decode
+> acceptance through a compatible patch update. Operators should review the
+> stable route-stream RPC migration, generated-dataset activation boundary,
+> startup-only BLACKHOLE controls, and BFD Down teardown behavior below.
+
 ### Fixed
 
 - Outbound route commits now make mismatched announcement and next-hop
@@ -22,6 +31,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   reaching an impossible branch, and revised decoding applies each row's
   treat-as-withdraw or attribute-discard action. (LAN-1236, LAN-1286)
 
+- Traffic Engineering (type 24) and IPv6 Address Specific Extended Community
+  (type 25) now enforce their registered propagation classes. Type 25 also
+  requires a nonempty payload in 20-octet units; malformed or mis-classed
+  values receive RFC 7606 treat-as-withdraw handling. Community Container
+  (temporary type 34) likewise receives bounded container, subtype, atom, and
+  prefix framing checks while valid values remain opaque and propagate with
+  Partial.
+
+- Zero-length BIER attributes are now discarded under RFC 7606 instead of
+  being retained as if they contained a valid TLV sequence.
+
+- MP_REACH_NLRI / MP_UNREACH_NLRI framing overruns now reset the session with
+  exact Optional Attribute Error data, illegal Partial flags reset with an
+  Attribute Flags Error, and empty MP_UNREACH marks End-of-RIB only for a
+  negotiated non-IPv4-unicast family; IPv4 keeps its empty UPDATE marker.
+  (LAN-1236)
+
+- Recognized optional-transitive Communities, Extended Communities, PMSI
+  Tunnel, and Large Communities attributes now preserve a received Partial
+  bit as typed state through policy and the RIB to egress. PMSI tunnel type,
+  composite, and identifier validation now follows the assigned and
+  experimental registry boundaries. (LAN-1285)
+
+- Malformed Only-to-Customer framing is handled before BGP Role logic:
+  revised decoding omits it and treats reachable NLRI as withdrawn, or resets
+  the session when none is reachable. Valid Partial-bearing OTC remains typed
+  and propagates normally. (LAN-1284)
+
 - General unicast FIB Add/Replace operations whose unscoped, same-family,
   non-link-local next-hop target receives Linux's family-specific unreachable
   errno are now held as `unresolved` and retried on relevant route notifications
@@ -30,6 +67,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Upgrade notes
 
+- **Wire strictness:** peers sending malformed or mis-classed assigned path
+  attributes — including the newly fenced types 24, 25, 34, and 36-42 plus
+  corrected class handling for Tunnel Encapsulation, AIGP, PE Distinguisher
+  Labels, BGPsec_Path, Prefix-SID, and ATTR_SET — can now have affected routes
+  withdrawn, attributes discarded, or sessions reset according to the
+  applicable RFC 7606 outcome. MP_REACH / MP_UNREACH Partial and framing errors
+  are also rejected. Review captured traffic before upgrading parsers that
+  depended on the former permissive acceptance.
 - Use `Route.local_pref_attr` when attribute presence matters;
   `Route.local_pref` is the effective value and defaults to 100 when the
   attribute is absent (previously it was 0).
@@ -43,6 +88,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Revalidate custom Bird's Eye consumers against the verified IXP Manager 7.4
   compatibility contract: route shapes and longest-match lookup behavior now
   converge on the pinned oracle.
+- Install an `rs-config-render` generation as one atomic tree containing
+  `config.toml`, `policy/`, and `datasets/`. Generated rpol files now bind IRR
+  origins and prefixes through relative dataset files; copying only the old
+  config-and-policy inventory leaves the candidate incomplete.
+- Restart rustbgpd after changing `blackhole_discard_max_active`,
+  `blackhole_discard_install_rate_per_minute`, or
+  `blackhole_discard_install_burst`. These controls are startup-only; SIGHUP
+  retains the live values and logs the restart requirement.
+- BFD-triggered teardown now sends Cease/BFD Down (or an RFC 8538 Hard Reset
+  carrying that reason) instead of Administrative Shutdown. Update automation
+  that classifies the prior notification subcode.
+- `bgp_fib_kernel_failures_total{action="install"}` and
+  `bgp_fib_kernel_failures_total{action="replace"}` no longer count next-hop-
+  unreachable outcomes that are retained as `unresolved` and retried. Alerting
+  for unresolved routes should use the current FIB state surfaces; the failure
+  counter now represents terminal or unclassified kernel errors.
 
 ### Added
 
@@ -87,6 +148,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   runtime-divergence allow-list entries. (LAN-1232)
 
 ### Changed
+
+- Accepted reloads reuse the immediately prior parsed rpol file and its
+  immutable compiled set tables when every source path, imported file,
+  parameter, and byte fingerprint is unchanged. Dataset bindings remain owned
+  by the new candidate, and any identity mismatch takes the full fresh path.
+
+- `rs-config-render` emits generated IRR origin and prefix membership under
+  `datasets/` and binds those files from the generated rpol. A one-member IRR
+  change now replaces only that member's dataset artifact plus the receipt;
+  `config.toml` and unchanged policy source remain byte-identical.
+
+- The peer-manager private command lane and config-bridge replacement lane are
+  lossless capacity-one FIFO channels. Concurrent configuration work waits for
+  the current control operation instead of accumulating an unbounded private
+  queue; command ordering and transactional authority are unchanged.
 
 - On Linux kernels that accept strict netlink dump checking, general-unicast
   FIB reconciliation now requests each unique managed table from the kernel
@@ -503,22 +579,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- MP_REACH_NLRI / MP_UNREACH_NLRI framing overruns now reset the session with
-  exact Optional Attribute Error data, illegal Partial flags reset with an
-  Attribute Flags Error, and empty MP_UNREACH marks End-of-RIB only for a
-  negotiated non-IPv4-unicast family; IPv4 keeps its empty UPDATE marker.
-  (LAN-1236)
-- Recognized optional-transitive Communities, Extended Communities, PMSI
-  Tunnel, and Large Communities attributes now preserve a received Partial
-  bit as typed state through policy and the RIB to egress; existing read
-  projections continue to expose recognized community values. Local synthesis
-  remains canonical, malformed recognized values retain their RFC 7606
-  dispositions, and PMSI tunnel-type/identifier validation now follows the
-  assigned, experimental, and composite registry boundaries. (LAN-1285)
-- Malformed Only-to-Customer (OTC) framing is now handled before BGP Role
-  logic: revised decoding omits it and treats reachable NLRI as withdrawn, or
-  resets the session per RFC 7606 section 5.2 when none is reachable. Valid
-  Partial-bearing OTC remains typed and propagates normally. (LAN-1284)
 - `MrtDumpStale` in the shipped alert pack no longer fires on instances
   without `[mrt]` configured: the `mrt_*` gauges are exported as 0 on every
   instance, so the unguarded rule anchored dump age on process start with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "birdwatcher-adapter"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "axum",
  "clap",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "event-bridge"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "clap",
  "rustbgpd-api",
@@ -2904,7 +2904,7 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rs-config-render"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "clap",
  "rustbgpd-policy",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpctl"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "axum",
  "bgpkit-parser",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-api"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bfd"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-event-history"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "rusqlite",
  "rustbgpd-telemetry",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.20",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-linux"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "futures",
  "libc",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-mrt"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "criterion",
  "rustbgpd-wire",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.20",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.66.0"
+version = "0.67.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -34,20 +34,20 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-rustbgpd-wire = { path = "crates/wire", version = "0.17.2" }
-rustbgpd-bfd = { path = "crates/bfd", version = "0.66.0" }
-rustbgpd-fsm = { path = "crates/fsm", version = "0.4.1" }
-rustbgpd-transport = { path = "crates/transport", version = "0.66.0" }
-rustbgpd-rib = { path = "crates/rib", version = "0.66.0" }
-rustbgpd-policy = { path = "crates/policy", version = "0.66.0" }
-rustbgpd-api = { path = "crates/api", version = "0.66.0" }
-rustbgpd-telemetry = { path = "crates/telemetry", version = "0.66.0" }
-rustbgpd-rpki = { path = "crates/rpki", version = "0.66.0" }
-rustbgpd-bmp = { path = "crates/bmp", version = "0.66.0" }
-rustbgpd-mrt = { path = "crates/mrt", version = "0.66.0" }
-rustbgpd-evpn = { path = "crates/evpn", version = "0.66.0" }
-rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.66.0" }
-rustbgpd-event-history = { path = "crates/event-history", version = "0.66.0" }
+rustbgpd-wire = { path = "crates/wire", version = "0.18.0" }
+rustbgpd-bfd = { path = "crates/bfd", version = "0.67.0" }
+rustbgpd-fsm = { path = "crates/fsm", version = "0.5.0" }
+rustbgpd-transport = { path = "crates/transport", version = "0.67.0" }
+rustbgpd-rib = { path = "crates/rib", version = "0.67.0" }
+rustbgpd-policy = { path = "crates/policy", version = "0.67.0" }
+rustbgpd-api = { path = "crates/api", version = "0.67.0" }
+rustbgpd-telemetry = { path = "crates/telemetry", version = "0.67.0" }
+rustbgpd-rpki = { path = "crates/rpki", version = "0.67.0" }
+rustbgpd-bmp = { path = "crates/bmp", version = "0.67.0" }
+rustbgpd-mrt = { path = "crates/mrt", version = "0.67.0" }
+rustbgpd-evpn = { path = "crates/evpn", version = "0.67.0" }
+rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.67.0" }
+rustbgpd-event-history = { path = "crates/event-history", version = "0.67.0" }
 
 # External dependencies — pinned across workspace
 bytes = "1"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ reproducible receipt:
   live churn, same harness / same host — the policy-file reload, not the IRR
   filter refresh below): new policy fully delivered to every member in
   **1.28–1.57 s p50** vs BIRD 3.3.1's 64–85 s and OpenBGPD 9.1's 244–251 s —
+  measured 2026-07-17,
   [IXP receipt matrix](docs/perf/ixp-matrix-2026-07.md)
 - **IRR-scale filter reload** (320 route-server members × 183,040 prefixes ×
   3,218,965 IRR filter entries, same harness / same host): steady-state reload
@@ -42,9 +43,11 @@ reproducible receipt:
   [grouped per-client-best receipt](docs/perf/irr-reload-grouped-per-client-best-2026-08.md)
 - **Member-flap propagation** (50 members flap, 650 observers): re-announce
   p50 **0.49–0.55 s** vs BIRD's 2.9–3.7 s and OpenBGPD's 21.1–21.6 s;
-  withdraw p50 0.31–0.47 s, also fastest — [same matrix](docs/perf/ixp-matrix-2026-07.md#s3--flapstorm-member-down--member-up-propagation)
+  withdraw p50 0.31–0.47 s, also fastest — measured 2026-07-17,
+  [same matrix](docs/perf/ixp-matrix-2026-07.md#s3--flapstorm-member-down--member-up-propagation)
 - **Cold start**: full 400,400-route table delivered to all 700 members in
   **4.8–5.0 s** vs 60.9–63.3 s (BIRD) and 338.0–352.1 s (OpenBGPD) —
+  measured 2026-07-17,
   [same matrix](docs/perf/ixp-matrix-2026-07.md#s1--cold-convergence)
 - **Route-reflector scale**: 1,000 RR clients × 100k routes converge on the
   wire in **1.82 s** at **419 MiB** whole-process RSS — measured 2026-07-03
@@ -282,7 +285,7 @@ cargo build --release -p rustbgpd -p rustbgpctl -p rs-config-render -p birdwatch
 ### Docker
 
 Release images are published to GHCR (versioned tags, e.g.
-`ghcr.io/lance0/rustbgpd:0.66.0`), or build locally:
+`ghcr.io/lance0/rustbgpd:0.67.0`), or build locally:
 
 ```bash
 docker build -t rustbgpd .                    # daemon + rbgp + birdwatcher-adapter, nonroot
@@ -474,7 +477,7 @@ evolving API.**
 | Dimension | Current state |
 |-----------|---------------|
 | **Target use case** | Data-center fabric pilots, IXP route servers, programmable BGP control planes, lab/test environments |
-| **Maturity** | Public alpha (v0.66.0) |
+| **Maturity** | Public alpha (v0.67.0) |
 | **Adopter support** | Reporting channels, compatibility boundaries, and proof limits are documented in [SUPPORT.md](SUPPORT.md). |
 | **Narrow stable contract** | The machine-pinned [route-server / route-reflector v1 contract](docs/v1-stable-contract.md) covers only its inventoried control-plane roles and surfaces; the project and all unlisted features remain alpha. |
 | **Implemented** | Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full gRPC/CLI management. Linux FIB integration is default-off and scoped to RFC 7999 discard routes and configured unicast tables (including ECMP and weighted multipath); broader routing-suite features remain future work. |

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "rustbgpd-wire",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "rustbgpd-wire",
  "rustc-hash",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.20",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "bytes",
  "libc",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "thiserror 2.0.20",

--- a/crates/fsm/CHANGELOG.md
+++ b/crates/fsm/CHANGELOG.md
@@ -5,6 +5,8 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+## 0.5.0 - 2026-08-26
+
 - **Additive FSM API:** Added `Event::BfdDown`. A BFD-triggered teardown in
   `OpenSent`, `OpenConfirm`, or `Established` emits the typed Cease notification
   and authoritative session-down cleanup; earlier connection states return to

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-fsm"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -77,6 +77,14 @@ length type 6 is an attribute-length error in the current decoder. See the
 "0.17.2 compatibility note" in the `rustbgpd-wire` README, since the FSM
 surfaces wire decode results to its callers.
 
+`rustbgpd-fsm 0.5.0` moves the exposed wire-type boundary to
+`rustbgpd-wire 0.18.0`, so consumers must upgrade the two crates together for
+their shared types to unify. The direct FSM API addition is `Event::BfdDown`;
+the public event enum is `#[non_exhaustive]`, and no existing variant or method
+is removed. The paired wire release is API-additive but changes decode
+acceptance and RFC 7606 classification across assigned attributes; review the
+itemized "0.18.0 compatibility note" in the wire README.
+
 ## Key types
 
 - **`Session`** — the state machine: `handle_event(&mut self, Event) -> Vec<Action>` (state is mutated in place on `&mut self`)

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,8 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+## 0.18.0 - 2026-08-26
+
 - **Community Container framing fence:** Registered temporary path attribute
   34 as optional transitive and retained valid values opaquely with Partial on
   egress. Bounded container, Type 1 subtype, atom, and prefix framing failures,

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-wire"
-version = "0.17.2"
+version = "0.18.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -16,15 +16,43 @@ Requires Rust 1.95 or newer.
 
 Release-by-release crate changes are recorded in the [changelog](CHANGELOG.md).
 
-### Unreleased compatibility note
+### 0.18.0 compatibility note
 
-The unreleased API addition is non-breaking:
-`UpdateMessage::try_build_from_attribute_iter` accepts an `IntoIterator` that
-yields borrowed `PathAttribute` values. The iterator is consumed once, in
-yielded order, without requiring `Clone`, `ExactSizeIterator`, or a rewind.
-Encoding retains the existing attribute filtering, compatibility sidecars,
-wire order, and `EncodeError` behavior. `UpdateMessage::try_build` remains the
-slice-oriented entry point and delegates to the same encoder.
+`rustbgpd-wire` 0.18.0 is API-additive but deliberately uses the next 0.x
+compatibility line because decode acceptance and RFC 7606 classification change
+in several places. No public item is removed, and the enums receiving variants
+are `#[non_exhaustive]`; consumers that assert on accepted bytes or exact
+`PathAttribute` variants should diff this complete list before upgrading:
+
+- `UpdateMessage::try_build_from_attribute_iter` accepts one single-pass
+  iterator of borrowed attributes. The existing slice builder remains and
+  delegates to the same transactional encoder.
+- Received Partial-bearing Communities, Extended Communities, PMSI Tunnel,
+  Large Communities, and OTC values remain typed through propagation via new
+  `PathAttribute` variants; locally built canonical variants are unchanged.
+- The default-off `tokio-codec` feature adds `BgpCodec` / `BgpCodecError` with
+  independent inbound and outbound Extended Message ceilings. The default
+  dependency surface is unchanged.
+- `cease_subcode::BFD_DOWN` and assigned path-attribute registry constants are
+  added.
+- Traffic Engineering (24), IPv6 Address Specific Extended Community (25),
+  temporary Community Container (34), and assigned attributes 36-42 now enforce
+  their registered Optional/Transitive class and bounded syntax. Type 25 must
+  contain a nonempty multiple of 20 octets; type 34 validates its container,
+  subtype, atom, and prefix framing; empty BIER is attribute-discard.
+- MP_REACH_NLRI / MP_UNREACH_NLRI framing overruns carry exact Optional
+  Attribute Error data. Partial is rejected on both optional non-transitive MP
+  attributes, complete undersized values are Attribute Length Error, and empty
+  MP_UNREACH is End-of-RIB only for a negotiated non-IPv4-unicast family.
+- PMSI decoding enforces assigned, experimental, composite, and identifier
+  boundaries. Malformed OTC is classified before role processing; valid
+  Partial-bearing OTC remains typed.
+- Unknown optional non-transitive attributes are ignored by strict/revised
+  decode and defensive encode. Unknown optional transitive attributes remain
+  preserved with Partial.
+- Tunnel Encapsulation, AIGP, PE Distinguisher Labels, BGPsec_Path, Prefix-SID,
+  and ATTR_SET class conflicts now produce their registered RFC 7606 outcomes
+  instead of being silently ignored or retained opaquely.
 
 ## Supported RFCs
 
@@ -200,7 +228,7 @@ Add the codec and its buffer type as direct dependencies:
 
 ```toml
 [dependencies]
-rustbgpd-wire = "0.17.2"
+rustbgpd-wire = "0.18.0"
 bytes = "1"
 ```
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -371,9 +371,11 @@ and `policy` are later.**
    boundary while the session is live. `Session::negotiated()` keeps its
    `Option<&NegotiatedSession>` signature, nothing was removed or changed,
    and `0.4.1` re-pins `rustbgpd-wire ^0.17.1` — a patch-level wire move with
-   no API change, so there is nothing to migrate. The FSM does not move for
-   wire `0.17.2`: its `^0.17.1` requirement already resolves to the new patch
-   and the FSM's own source is unchanged since `0.4.1`. (History: `0.3.1` added
+   no API change, so there is nothing to migrate. That requirement admits wire
+   `0.17.2` without another FSM release. Main has since added
+   `Event::BfdDown`, so the next publish pairs FSM 0.5.0 with wire 0.18.0; the
+   current FSM source is no longer identical to published 0.4.1. (History:
+   `0.3.1` added
    `min_hold_time` and `required_families` to the `#[non_exhaustive]`
    `PeerConfig`, made the last duplicate Graceful Restart capability win, and
    rejected invalid OPEN identities.) Why the FSM was the second published crate:

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -90,6 +90,16 @@ full gate ladder.
 - BGP unnumbered supports static IPv6 link-local neighbors for IPv4 unicast.
   Interface-neighbor autodiscovery and capability 77 remain follow-up work.
 
+## Configuration control
+
+- The peer-manager private command lane and config-bridge replacement lane are
+  lossless capacity-one FIFO channels. A planning, apply, rollback, or reload
+  operation already using one of these lanes serializes later control work;
+  callers wait instead of commands being dropped or an unbounded queue growing.
+  Under a slow configuration operation this can increase concurrent management
+  request latency even though routing-session work continues on its own actor
+  paths.
+
 ## Operational proof
 
 Published benchmarks and receipts cover the main protocol, interop, scale, and

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1668,17 +1668,17 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 | Message | Level | Meaning |
 |---------|-------|---------|
 | `starting rustbgpd` | INFO | Daemon started successfully |
-| `peer session established` | INFO | BGP session reached Established |
-| `peer session down` | INFO | BGP session left Established |
-| `received shutdown signal` | INFO | SIGTERM/SIGINT received |
+| `session established` | INFO | BGP session reached Established |
+| `session down` | INFO | BGP session left Established |
+| `received SIGTERM` / `received SIGINT` | INFO | Process signal received |
 | `shutdown initiated via gRPC` | INFO | `Shutdown` RPC called |
 | `gRPC server exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `RIB manager exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `peer manager task exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `BGP listener task exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `BGP accept-forwarding task exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
-| `config reloaded` | INFO | SIGHUP reload succeeded |
-| `config reload failed` | ERROR | SIGHUP reload failed — previous config kept |
+| `config reload complete` | INFO | SIGHUP reload completed |
+| `config reload stopped at this step; settling the acknowledged partial runtime authority before another reload may begin` | ERROR | A reload step failed after the coordinator established the resulting authority; inspect the structured `bucket`, `target`, and `error` fields |
 | `GR restart marker` | INFO | Restart marker written or read |
 | `published GR restart marker with wall-clock fallback because boottime protection was unavailable` | WARN | Clock-domain sampling or representation failed; a complete bounded v1/v2 marker was selected. Check `publication_durability` on the final publication log for directory-sync status. |
 | `max-prefix limit exceeded` | WARN | Peer exceeded prefix limit |

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -25,7 +25,7 @@ general.yml + clients.yml
 context.yml
         │  rs-config-render                  (fail-stale rendering)
         ▼
-config.toml + policy/*.rpol + render-receipt.json
+config.toml + policy/*.rpol + datasets/*.list + render-receipt.json
         │  rustbgpd --check --strict         (full config validation)
         ▼
 swap + SIGHUP                                (parse-then-swap reload)
@@ -98,7 +98,10 @@ per-family max-prefix ceilings and a per-client import chain),
 `policy/rs-hygiene.rpol` (the shared hygiene chain: AS_SET reject,
 bogons, transit-free, path-length cap, RPKI origin validation),
 `policy/client-<id>.rpol` (the client's IRR-derived prefix/origin
-sets), and `render-receipt.json` (fingerprint, cardinalities,
+tests and dataset bindings), `datasets/client-<id>-origins.list` and
+`datasets/client-<id>-prefixes.list` (the generated IRR membership, plus a
+blackhole-cover dataset when configured), and `render-receipt.json`
+(fingerprint, cardinalities,
 warnings). `--rtr-cache` is required whenever the context enables
 RPKI origin validation — the context carries no cache address. The
 renderer ships in the release tarball alongside `rustbgpd` and `rbgp`
@@ -129,7 +132,9 @@ no output written; the last good configuration stays live (fail-stale)
 What a *successful* render of the same context (minus the broken
 client) emits is checked in verbatim as the golden outputs —
 [`tools/rs-config-render/tests/golden/`](../../tools/rs-config-render/tests/golden/):
-`config.toml`, `rs-hygiene.rpol`, and two `client-*.rpol` files. The
+`config.toml`, `rs-hygiene.rpol`, two `client-*.rpol` files, and each
+client's origin and prefix dataset files. The test maps the flat checked-in
+fixture names to their rendered `policy/` and `datasets/` paths. The
 generated policies carry in-language `test` blocks derived from the
 site's own data, runnable offline:
 
@@ -153,6 +158,8 @@ rs-config-render --context "$STATE/context.yml" \
 # --strict: warnings fail the gate, so a refresh never swaps in a config
 # the daemon had something to say about. Rendered output is clean.
 rustbgpd --check --strict "$STATE/candidate/config.toml"
+# The generated rpol resolves dataset paths relative to this tree. Install the
+# config, policy, and datasets together; never update only one directory.
 rsync -a --delete "$STATE/candidate/" /etc/rustbgpd/
 systemctl reload rustbgpd        # SIGHUP: parse-then-swap
 ```

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "rustbgpd-rs-rr-v1",
-  "baseline_release": "v0.66.0",
+  "baseline_release": "v0.67.0",
   "scope": "Narrow route-server and route-reflector product contract; unlisted surfaces are not stable by implication.",
   "roles": [
     {
@@ -387,6 +387,20 @@
       "semantic_toml_sha256": "c95411fc1f1b08f3e9370ea8aaa6ac405d8302fe42cddb6038c559c5ba0a5927",
       "validation_source": "src/config/tests/mod.rs",
       "validation_test": "config::tests::v1_stable_v0_65_route_server_fixture_parses",
+      "result": "accepted_without_config_migration"
+    },
+    {
+      "from_release": "v0.66.0",
+      "to_release": "v0.67.0",
+      "fixture_directory": "tests/fixtures/v1-stable/v0.66.0/route-server",
+      "source_directory": "examples/route-server",
+      "files": [
+        {"path": "config.toml", "sha256": "09d3a3a57247e18f7941f6594d659e5867e2b6e2835025809a74d9dbb010adee"},
+        {"path": "hygiene.rpol", "sha256": "9035313c7813273a64856780be66d790f25cafcb8a7f04e44ada16efb083e515"}
+      ],
+      "semantic_toml_sha256": "c95411fc1f1b08f3e9370ea8aaa6ac405d8302fe42cddb6038c559c5ba0a5927",
+      "validation_source": "src/config/tests/mod.rs",
+      "validation_test": "config::tests::v1_stable_v0_66_route_server_fixture_parses",
       "result": "accepted_without_config_migration"
     }
   ]

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -363,6 +363,27 @@ fn v1_stable_v0_65_route_server_fixture_parses() {
         .unwrap_or_else(|err| panic!("v0.65.0 route-server config no longer validates: {err}"));
 }
 
+#[test]
+fn v1_stable_v0_66_route_server_fixture_parses() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/v1-stable/v0.66.0/route-server");
+    let config_path = fixture.join("config.toml");
+    let source = fs::read_to_string(&config_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read immutable v0.66.0 route-server fixture {}: {err}",
+            config_path.display()
+        );
+    });
+    let mut config: Config = toml::from_str(&source)
+        .unwrap_or_else(|err| panic!("v0.66.0 route-server config no longer parses: {err}"));
+    config
+        .load_rpol_files(Some(&fixture))
+        .unwrap_or_else(|err| panic!("v0.66.0 route-server rpol no longer loads: {err}"));
+    config
+        .validate()
+        .unwrap_or_else(|err| panic!("v0.66.0 route-server config no longer validates: {err}"));
+}
+
 const V1_EFFECTIVE_DEFAULTS_TOML: &str = r#"
 [global]
 asn = 65001

--- a/tests/fixtures/v1-stable/v0.66.0/route-server/config.toml
+++ b/tests/fixtures/v1-stable/v0.66.0/route-server/config.toml
@@ -1,0 +1,175 @@
+# IXP route server configuration
+#
+# rustbgpd as an IX route server with two members. Every member gets:
+# - transparent route-server mode (preserve original NEXT_HOP, no AS prepend)
+# - local BGP role "route_server" (RFC 9234: OTC attached on egress,
+#   role capability negotiated when the member also sets its role)
+# - dual-stack (IPv4 + IPv6 unicast)
+# - RPKI origin validation (drop invalid, prefer valid) and import
+#   hygiene (reject AS_SET, ASPA-invalid, and a dated dual-stack
+#   special-purpose prefix snapshot — see hygiene.rpol)
+#
+# Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
+# - member-alpha negotiates Add-Path send: it sees up to the eight best
+#   export-permitted candidates, subject to configured and negotiated
+#   Paths-Limit, and runs its own selection (the preferred mitigation);
+# - member-beta cannot do Add-Path, so it opts into per_client_best:
+#   when its export policy denies the best path, the route server
+#   advertises the best *permitted* candidate instead of hiding the
+#   prefix (the BIRD-`secondary` equivalent).
+#
+# Add more [[neighbors]] blocks for additional IXP members, or manage
+# them dynamically via gRPC at runtime.
+
+[global]
+asn = 65500
+router_id = "198.51.100.1"
+listen_port = 179
+# Optional exact bind/source endpoints (at most one per family). Useful when
+# two route-server instances share a host; changing these requires restart.
+# listen_addresses = ["198.51.100.1", "2001:db8::1"]
+# RFC 8212: a member session with no explicit policy carries nothing in
+# that direction. The export chain below is deliberately permit-all, and
+# this knob is what keeps that a decision: delete the chain and members
+# stop receiving routes, loudly, instead of inheriting the same permit-all
+# by omission. Startup-only — SIGHUP keeps the running value, so changing
+# it takes a daemon restart.
+ebgp_requires_policy = true
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# For remote management, prefer an mTLS proxy (see examples/envoy-mtls/).
+# For a loopback-only bearer listener, create the token file and uncomment
+# this complete principal-to-role mapping:
+# [global.telemetry.grpc_tcp]
+# address = "127.0.0.1:50051"
+# token_file = "/etc/rustbgpd/grpc-token"
+# principal = "remote-operator"
+# [security.grpc.roles]
+# remote-operator = "operator"
+
+# Local gRPC uses the implicit owner-only socket at
+# <runtime_state_dir>/grpc.sock and the local-operator identity.
+
+# --- RPKI origin validation ---
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"       # Routinator, rpki-client, etc.
+
+# --- Named policy definitions ---
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.reject-long-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "0.0.0.0/0"
+ge = 25
+le = 32
+action = "deny"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "::/0"
+ge = 49
+le = 128
+action = "deny"
+
+[policy.definitions.prefer-rpki-valid]
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "valid"
+action = "permit"
+set_local_pref = 200
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "not_found"
+action = "permit"
+set_local_pref = 100
+
+# --- Export policy: permit-all, on purpose ---
+#
+# An IX route server is transparent by design (RFC 7947): it hands each
+# member what that member's own filters selected, without imposing the
+# route server's opinion on top. So permit-all is the correct export
+# posture here — but it is *declared*, not inherited. A route server that
+# is permit-all because nobody wrote an export chain behaves identically
+# on the wire; only this chain, and this comment, record that it was a
+# choice rather than an omission.
+#
+# Per-member filtering (a member that wants a subset, or a bilateral
+# arrangement) belongs in that neighbor's `export_policy_chain`, which
+# overrides this globally applied one. member-beta's `per_client_best`
+# below is what makes such a per-member denial advertise the best
+# permitted candidate rather than hide the prefix.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
+[policy]
+# ixp-hygiene and reject-special-purpose live in hygiene.rpol; rpol and
+# TOML policies share one namespace and compose in one ordered chain.
+rpol_files = ["hygiene.rpol"]
+import_chain = [
+    "reject-rpki-invalid",
+    "ixp-hygiene",
+    "reject-special-purpose",
+    "reject-long-prefixes",
+    "prefer-rpki-valid",
+]
+export_chain = ["rs-transparent-export"]
+
+# Import-decision explain, off — stated rather than inherited, because on
+# a route server it is the memory decision that matters most. The cache is
+# per session, so its cost is multiplied by member count, and 4096 entries
+# cannot retain a member's full table anyway: a query for an arbitrary
+# prefix would be a coin-flip against an evicted answer. On a 1000-member
+# fleet whose members each announce more than 4096 prefixes, an enabled
+# cache at the default size saturates in the low gigabytes.
+#
+# For the member-facing "why is my route filtered?" question, prefer
+# `[policy.reject_retention]` (on by default) and
+# `rbgp rib received <member> --rejected` — it enumerates rejections with
+# reasons and does not need the prefix known in advance.
+#
+# Turn this on deliberately, with `cache_size` raised toward the member's
+# retained-prefix count, while you are diagnosing — not as a standing cost.
+[policy.explain]
+enabled = false
+
+# --- IXP member peers ---
+
+# Add-Path-capable member: sees up to the eight best export-permitted
+# candidates, subject to configured and negotiated Paths-Limit (preferred
+# path-hiding mitigation). Like `per_client_best`, Add-Path send places
+# the member on the per-peer distribution path (the `add_path_send`
+# fallback reason); update-group sharing applies to members using
+# neither mitigation.
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64501
+description = "member-alpha"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+role = "route_server"
+max_prefixes = 50000
+
+[neighbors.add_path]
+send = true
+send_max = 8
+
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied
+# (RFC 7947 §2.3.2 per-client best-path). Requires route_server_client.
+[[neighbors]]
+address = "198.51.100.3"
+remote_asn = 64502
+description = "member-beta"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+per_client_best = true
+role = "route_server"
+max_prefixes = 50000

--- a/tests/fixtures/v1-stable/v0.66.0/route-server/hygiene.rpol
+++ b/tests/fixtures/v1-stable/v0.66.0/route-server/hygiene.rpol
@@ -1,0 +1,166 @@
+# IXP import hygiene (rpol policy language, ADR-0096).
+#
+# Referenced from config.toml via `[policy] rpol_files` and the import
+# chain; edits hot-apply via SIGHUP. Run the in-language tests below
+# with `rbgp policy check hygiene.rpol`.
+
+# Dated starter snapshot of the IANA IPv4 and IPv6 Special-Purpose Address
+# Registries (both updated 2025-10-09; reviewed here 2026-07-15). The reject
+# set contains the two default routes plus active rows whose "Globally
+# Reachable" value is False. It is deliberately not a complete bogon feed:
+# terminated rows, unallocated space, multicast, and True/N/A rows outside a
+# rejected parent are omitted. Active True/N/A children of a rejected parent
+# must stay in this first set so the policy accepts them before the broad deny.
+prefix-set special-purpose-parent-exceptions {
+    192.0.0.9/32,
+    192.0.0.10/32,
+    2001::/32 le 128,
+    2001:1::1/128,
+    2001:1::2/128,
+    2001:1::3/128,
+    2001:3::/32 le 128,
+    2001:4:112::/48 le 128,
+    2001:20::/28 le 128,
+    2001:30::/28 le 128,
+}
+
+prefix-set non-global-special-purpose {
+    0.0.0.0/0,
+    0.0.0.0/8 le 32,
+    10.0.0.0/8 le 32,
+    100.64.0.0/10 le 32,
+    127.0.0.0/8 le 32,
+    169.254.0.0/16 le 32,
+    172.16.0.0/12 le 32,
+    192.0.0.0/24 le 32,
+    192.0.2.0/24 le 32,
+    192.88.99.2/32,
+    192.168.0.0/16 le 32,
+    198.18.0.0/15 le 32,
+    198.51.100.0/24 le 32,
+    203.0.113.0/24 le 32,
+    240.0.0.0/4 le 32,
+    ::/0,
+    ::/128,
+    ::1/128,
+    ::ffff:0:0/96 le 128,
+    64:ff9b:1::/48 le 128,
+    100::/64 le 128,
+    100:0:0:1::/64 le 128,
+    2001::/23 le 128,
+    2001:db8::/32 le 128,
+    3fff::/20 le 128,
+    5f00::/16 le 128,
+    fc00::/7 le 128,
+    fe80::/10 le 128,
+}
+
+policy reject-special-purpose {
+    term preserve-active-parent-exception {
+        if route.prefix in special-purpose-parent-exceptions { accept }
+    }
+    term reject-non-global { if route.prefix in non-global-special-purpose { reject } }
+}
+
+policy ixp-hygiene {
+    # Reject routes carrying an AS_SET (deprecated by RFC 9774; common
+    # IXP hygiene, arouteserver rejects them too). AS_PATHs render
+    # AS_SETs in braces — "65001 {65002 65003}" — so a literal `{`
+    # (escaped for the regex) matches any AS_SET segment.
+    term reject-as-set { if route.as-path matches "\\{" { reject } }
+    # Reject ASPA-invalid AS paths (draft-ietf-sidrops-aspa-verification).
+    # Inert (state = unknown) until ASPA objects are loaded from the
+    # RPKI cache; activates automatically once they are.
+    term reject-aspa-invalid { if route.aspa == invalid { reject } }
+    # Tag the RPKI origin-validation outcome as an RFC 8097 extended
+    # community (non-transitive opaque, type 0x43) so route-server
+    # clients can act on it without running their own validator.
+    # OV_INVALID never reaches clients here — the TOML import chain
+    # drops rpki-invalid routes — but tagging is harmless and keeps
+    # the terms uniform if that drop is ever relaxed.
+    term tag-ov-valid { if route.rpki == valid { add ext-community OV_VALID } }
+    term tag-ov-not-found { if route.rpki == not-found { add ext-community OV_NOT_FOUND } }
+    term tag-ov-invalid { if route.rpki == invalid { add ext-community OV_INVALID } }
+}
+
+test as-set-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501 {64502 64503}" }
+    expect ixp-hygiene == reject
+}
+
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
+test clean-route-falls-through {
+    route { prefix 203.0.113.0/24; as-path "64501 64510" }
+    expect ixp-hygiene == accept
+}
+
+test rpki-valid-is-tagged-ov-valid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki valid }
+    expect ixp-hygiene == accept with ext-community OV_VALID
+}
+
+test rpki-not-found-is-tagged-ov-not-found {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
+}
+
+test rpki-invalid-is-tagged-ov-invalid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki invalid }
+    expect ixp-hygiene == accept with ext-community OV_INVALID
+}
+
+test ipv4-default-is-rejected {
+    route { prefix 0.0.0.0/0 }
+    expect reject-special-purpose == reject
+}
+
+test ipv6-default-is-rejected {
+    route { prefix ::/0 }
+    expect reject-special-purpose == reject
+}
+
+test shared-address-more-specific-is-rejected {
+    route { prefix 100.65.0.0/24 }
+    expect reject-special-purpose == reject
+}
+
+test unique-local-more-specific-is-rejected {
+    route { prefix fd00:1::/48 }
+    expect reject-special-purpose == reject
+}
+
+test pcp-parent-exception-is-preserved {
+    route { prefix 192.0.0.9/32 }
+    expect reject-special-purpose == accept
+}
+
+test teredo-parent-exception-is-preserved {
+    route { prefix 2001:0:1234::/48 }
+    expect reject-special-purpose == accept
+}
+
+test as112-parent-exception-is-preserved {
+    route { prefix 2001:4:112::/48 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv4-falls-through {
+    route { prefix 8.8.8.0/24 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv6-falls-through {
+    route { prefix 2001:4860::/32 }
+    expect reject-special-purpose == accept
+}
+
+# This policy only classifies the dated special-purpose snapshot. The later
+# reject-long-prefixes chain member remains responsible for prefix-length caps.
+test too-long-parent-exception-falls-through {
+    route { prefix 2001:4:112::1/128 }
+    expect reject-special-purpose == accept
+}


### PR DESCRIPTION
## Summary

- bump the workspace to 0.67.0, `rustbgpd-wire` to 0.18.0, and `rustbgpd-fsm` to 0.5.0, including tracked lockfiles and crate compatibility notes
- roll the changelogs forward and group the wire strictness, route-stream RPC, renderer dataset, blackhole control, BFD teardown, and FIB metric migrations under the correct release
- date the retained README performance claims and correct the embedding, renderer, logging, and capacity-one control-lane documentation
- add the immutable v0.66.0 route-server fixture and consecutive v0.66.0 to v0.67.0 stable-surface exercise

## Compatibility review

Approve the removal of `RibService.WatchRoutes` and `RibService.WatchRouteEvents` from the narrow v1-stable surface as an intentional pre-1.0 compatibility break for v0.67.0. Consumers migrate to `EventService.WatchEvents` or resumable `EventService.SubscribeFromEvent`; the removed protobuf names and method numbers remain reserved. The changelog and upgrade-note index make the boundary explicit.

The crate line moves are also intentional: wire 0.18.0 contains additive Rust APIs but changed decode acceptance, and FSM 0.5.0 exposes `Event::BfdDown` while pairing its public wire types with 0.18.0. Publish order remains wire, then FSM; `docs/EMBEDDING.md` continues to name the currently published 0.17.2/0.4.1 pair until registry publication completes.

## Validation

- `cargo test --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- focused all-feature, feature-combination, and bench-internals checks for wire, FSM, API, RIB, transport, and the root crate
- warning-clean workspace and wire `tokio-codec` rustdoc builds
- local published-baseline `cargo-semver-checks` for wire and FSM
- verified `cargo package` for `rustbgpd-wire` 0.18.0
- release checklist path, install contract, changelog reflow, embedding version, and v1-stable-surface checks
- v0.66.0 fixture bytes and checksums verified against the release tag

Tagging and publishing are intentionally outside this PR.
