### PR TITLE
docs: note validation-posture RPC and three metric families in 0.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,12 +140,52 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   event-drop alert, and a focused Grafana panel. The gauge clears after repair
   or genuine teardown and is reaped with the peer. (LAN-1241)
 
+- Per-cache RPKI readiness is now exported as
+  `bgp_rpki_cache_end_of_data_ready{cache}`, with a matching
+  `RpkiCacheEndOfDataNotReady` warning rule in the shipped alert bundle. The
+  gauge is `0` at startup, becomes `1` only after an accepted, complete,
+  validated End of Data — including an empty table — and stays `1` across
+  disconnect and resynchronization while that cache's retained contribution
+  remains usable, returning to `0` after flush or expiry. It reports cache
+  readiness only, not connectivity, merged-table availability, or policy
+  matchability.
+
+- Session notification depth is now visible through
+  `bgp_session_notification_outstanding` and
+  `bgp_session_notification_outstanding_high_watermark`. The gauges account
+  for the intentionally unbounded `session_notify` collision-detection channel
+  from sender entry through successful PeerManager dequeue, including
+  synchronous in-flight reservations and queued notifications. The high-water
+  mark is monotonic for the daemon lifetime and resets only when the daemon
+  restarts; it is not a per-flap or per-round peak.
+
+- `bgp_netlink_subscription_overruns_total{actor}` counts NETLINK_ROUTE
+  receive-buffer overrun notifications for the `link_carrier`, `general_fib`,
+  and `blackhole_discard` actors. All three series are materialized at zero and
+  are captured in `rbgp doctor`'s `system/metrics.prom`. Each increment is one
+  overrun notification, not a count of lost events: it proves only that one or
+  more multicast events may have been lost, does not identify which group lost
+  them, and does not prove that a later periodic reconcile repaired the
+  resulting drift.
+
 - `RibService` route detail now carries the RFC 4271 AGGREGATOR and
   ATOMIC_AGGREGATE path attributes (`Route.aggregator` with AS number and
   router ID, `Route.atomic_aggregate`), and the Bird's Eye adapter renders
   them as `bgp.aggregator` / `bgp.atomic_aggr` exactly as the pinned
   BIRD 2.0.12 + Bird's Eye oracle prints them, closing the two matching
   runtime-divergence allow-list entries. (LAN-1232)
+
+- `PolicyService.GetValidationPolicyPosture` conservatively reports whether the
+  live installed import policies and accepted dynamic ranges reject
+  RPKI-invalid and ASPA-invalid routes, per scope and in aggregate, as
+  `ENFORCED`, `UNENFORCED`, or `UNKNOWN`. The bounded response carries
+  `complete` and `omitted`, and an incomplete aggregate is never `ENFORCED`.
+  `rbgp doctor` consumes it as the advisory `rpki.invalid_route_policy` and
+  `aspa.invalid_route_policy` checks, which warn on missing or uncertain
+  evidence — including `UNIMPLEMENTED` from an older daemon — and retain exit
+  status 0. This is a policy-disposition proof only, not an assertion about
+  validator readiness, connectivity, configured intent, FIB state, or runtime
+  enforcement.
 
 ### Changed
 


### PR DESCRIPTION
## What was missing

The GitHub release body is awk-extracted from the `## [0.67.0]` CHANGELOG
section (`.github/workflows/release.yml:305-315`), so anything absent from that
section ships unannounced. Four operator-facing surfaces that landed after
`v0.66.0` had no entry:

| Surface | Shipped in |
|---|---|
| `PolicyService.GetValidationPolicyPosture` + `rbgp doctor` checks | `07b5a564` (#2023), `2c5d018f` (#2024) |
| `bgp_rpki_cache_end_of_data_ready{cache}` + alert rule | `3738a58f` (#2007) |
| `bgp_session_notification_outstanding` (+ high-water mark) | `32664ee2` (#2002) |
| `bgp_netlink_subscription_overruns_total{actor}` | `bc393eb5` (#1896), `542cc781` (#1909) |

All four are in `v0.66.0..HEAD`, so they belong to this release. None of the
names appeared anywhere in the section before this change.

`README.md:375-376` already advertises "Policy (23 RPCs including ... bounded
validation-policy posture)", so the RPC was being announced in the README while
the release notes stayed silent about it.

## Verified against

- **Posture RPC** — `proto/rustbgpd.proto:1088-1093` (RPC + its
  "bounded disposition proof, not a readiness or forwarding-state assertion"
  comment), `1234-1261` (enum and messages); `docs/API.md:992`;
  `docs/grpc-method-inventory.md:150`; `crates/api/src/authz.rs:409-414`
  (`SensitiveRead`).
- **Doctor checks** — `crates/cli/src/commands/doctor.rs` check names
  `rpki.invalid_route_policy` / `aspa.invalid_route_policy`;
  `docs/OPERATIONS.md:1738-1743` for the advisory-and-exit-0 semantics and the
  `UNIMPLEMENTED`-from-an-older-daemon case.
- **RPKI readiness** — `crates/telemetry/src/metrics.rs:1609-1615` (help text
  and the explicit "not connectivity, merged-table availability, or policy
  readiness" ceiling); `docs/OPERATIONS.md:731-737`;
  `examples/prometheus/rustbgpd-alerts.yml:318-330` for
  `RpkiCacheEndOfDataNotReady`.
- **Session notification depth** — `crates/telemetry/src/metrics.rs:22-72`;
  `ARCHITECTURE.md:399`; `docs/OPERATIONS.md:1466-1467`.
- **Netlink overruns** — `crates/telemetry/src/metrics.rs:1328-1340`;
  `docs/OPERATIONS.md:1448-1454`.

Each bullet carries the ceiling its source of truth states rather than the
stronger claim: the posture RPC proves policy disposition only; the
notification high-water mark is daemon-lifetime monotonic and explicitly not a
per-flap or per-round peak; the readiness gauge is cache readiness, not
connectivity or policy matchability; an overrun increment is one notification,
not a lost-event count.

Bullets carry no tracker ID because none of the five source commits references
one. This matches the existing `blackhole_discard_*` bullet in the same
subsection, which likewise carries none.

## Upgrade-notes call: none needed

The existing `### Upgrade notes` bullets all describe something a consumer must
act on — a changed default, a removed RPC, a redefined label value, a changed
notification subcode. All four additions here are purely additive: three new
metric families that never existed in a released build, and a new RPC on an
existing service. No existing series changes meaning, and nothing breaks by
ignoring them.

One case looked like a candidate and is not. The netlink overrun metric shipped
as `{subscriber}` in `bc393eb5` (#1896) and was renamed to `{actor}` in
`542cc781` (#1909) — but both commits post-date the `v0.66.0` tag, so no
released consumer ever saw the `subscriber` label. There is nothing to migrate,
and an upgrade note would invent a break that never reached anyone. The bullet
documents the final `{actor}` shape only.

## Gates

Run from the branch; each captured to a file, exit code checked directly.

| Command | Exit |
|---|---|
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `python3 scripts/check-metric-consumers.py` | 0 |
| `python3 scripts/check-v1-stable-surface.py` | 0 |
| `python3 scripts/reflow-release-notes.py --selftest` | 0 |
| `python3 scripts/check_release_checklist_paths.py` | 0 |
| `python3 scripts/check_ixp_manager_docs.py` | 0 |
| `python3 -m unittest -v scripts/test_check_public_tracker_ids.py` | 0 |
| `python3 -m unittest -v scripts/test_check_metric_consumers.py` | 0 |

The pre-commit and pre-push hooks additionally ran `cargo fmt`, `cargo clippy`,
and `cargo doc` — all passed.

End-to-end proof of the actual failure mode: replaying the release workflow's
own extraction (`awk` for `## [0.67.0]`, then `reflow-release-notes.py`) over
the edited file exits 0 and the rendered body now contains
`bgp_rpki_cache_end_of_data_ready`,
`bgp_session_notification_outstanding_high_watermark`,
`bgp_netlink_subscription_overruns_total`, `GetValidationPolicyPosture`, and
`RpkiCacheEndOfDataNotReady`.

`check-metric-consumers.py` is unaffected by design — it excludes `CHANGELOG.md`
from the certifying document surface
(`scripts/check-metric-consumers.py:25-29`), so these bullets cannot
false-certify a metric family. All three metrics were already certified by
`docs/OPERATIONS.md` and the alert/dashboard bundle.

## Scope

`CHANGELOG.md` only — 40 insertions, 0 deletions, no other file touched.
