### PR TITLE
docs: correct the unsafe-code, fuzz, and RPC inventories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,25 +73,42 @@ input from the network. It runs under continuous fuzzing in CI.
   Locator absence carries no v3 authority. A retired v2 locator or locator-free
   v1/v2 journal makes v0.65.0 and every later release refuse boot before
   candidate mutation, and remains untouched for recovery with rustbgpd v0.64.0.
-- **No `unsafe` code in shipped paths, with two scoped exceptions.** Every
+- **No `unsafe` code in shipped paths outside three scoped modules.** Every
   workspace crate root carries `#![deny(unsafe_code)]`, so `unsafe` cannot enter
-  a crate without a visible, reviewed opt-out. There are two:
-  - `crates/transport`'s `socket_opts` module carries a documented
-    `#[allow(unsafe_code)]` for socket-option FFI (`TCP_MD5SIG`, `IP_MINTTL`,
-    TCP-AO) that has no safe Rust API. This is the only `unsafe` in any library
-    crate.
-  - The daemon binary's deny is `cfg_attr`-gated off when the `jemalloc` (the
-    default) or `dhat-heap` feature is on, because registering a
-    `#[global_allocator]` is itself an `unsafe` construct. Building with
-    `--no-default-features` re-arms the deny; the daemon writes no `unsafe`
-    blocks of its own under either configuration.
+  a crate without a visible, reviewed opt-out. Three modules hold one:
+  - `crates/transport`'s `socket_opts` module, opted out by a module-level
+    `#[allow(unsafe_code)]` in the crate root and a per-function
+    `#[allow(unsafe_code, reason = ...)]` on each site inside it. Every site is
+    Linux socket-option ABI with no safe Rust wrapper: `TCP_MD5SIG` /
+    `TCP_MD5SIG_EXT`, TCP-AO key installation, deletion, inspection and RNext
+    selection, GTSM (`IP_MINTTL` / `IPV6_MINHOPCOUNT`), and the `sockaddr_in` /
+    `sockaddr_in6` encoding those options take.
+  - `crates/api`'s `runtime_config_settlement` module: the
+    ambiguous-configuration watchdog's terminal boundary is
+    `#[cfg(not(test))] fn terminate_process()`, whose entire body is
+    `unsafe { libc::_exit(70) }`. It is exit-only by construction, and that is
+    enforced rather than asserted — a unit test parses the production source and
+    requires the body to be exactly that call and to contain no allocation,
+    lock, drop, panic, logging, or metric term, so nothing runs between the
+    fence decision and process exit.
+  - The daemon binary's `bfd_runtime` module: one raw `setsockopt` enabling
+    `IP_RECVTTL` / `IPV6_RECVHOPLIMIT`, which `socket2` does not expose. BFD
+    needs the received TTL delivered as ancillary data to enforce the RFC 5881
+    exact-255 receive check.
+
+  The daemon binary's own crate-root deny is additionally `cfg_attr`-gated off
+  when the `jemalloc` (the default) or `dhat-heap` feature is on, because
+  registering a `#[global_allocator]` is itself an `unsafe` construct. Building
+  with `--no-default-features` re-arms that deny; the `bfd_runtime` block above
+  carries its own `#[allow]`, so it stays a visible, reviewed opt-out under
+  either configuration.
 
   Test and benchmark targets are separate compilation units and are not covered
   by a crate root's deny. Several carry justified `unsafe`: allocation-tracking
-  `GlobalAlloc` wrappers used by the memory-profile receipts (`crates/mrt`
-  benches, `crates/rib` tests, the standalone `bench/scale` harnesses) and
-  `libc` socket/netns helpers in the privileged `crates/evpn-linux` tests. None
-  of that code ships in the daemon or in any published library crate.
+  `GlobalAlloc` wrappers used by the memory-profile receipts (crate benches and
+  tests, plus the standalone `bench/scale` harnesses) and `libc` socket/netns
+  helpers in the privileged `crates/evpn-linux` tests. None of that code ships
+  in the daemon or in any published library crate.
 - **Structured errors, not strings.** Every failure produces a
   machine-parseable event for forensic analysis.
 
@@ -102,7 +119,7 @@ published by CISA and partner agencies recommending memory-safe languages
 for software that processes untrusted network input. The enforcement
 mechanism is the crate-root `#![deny(unsafe_code)]` invariant described
 under Design Principles above: no `unsafe` in shipped paths beyond the
-two documented, scoped exceptions.
+three documented, scoped modules.
 
 One concrete bound this pins: `AS_PATH` matching is length-bounded under
 RFC 8654 Extended Messages. The policy engine matches the rendered path
@@ -114,12 +131,13 @@ see the full ~16,000-ASN path.
 ### Fuzzing
 
 Six fuzz crates (`crates/wire`, `crates/policy`, `crates/mrt`,
-`crates/evpn`, `crates/bfd`, `crates/rpki`) carry 19 fuzz targets covering
-the message decoders, the policy frontend, MRT snapshot and warm-bundle
+`crates/evpn`, `crates/bfd`, `crates/rpki`) carry 21 fuzz targets covering
+the message decoders, the policy frontend, structure-aware policy-chain
+compilation and explain-walk agreement, MRT snapshot and warm-bundle
 readers, EVPN parsing, the BFD control-packet decoder, and the RTR PDU
-decoder. A nightly CI campaign (`.github/workflows/fuzz.yml`) runs every target
-in each crate against tracked seed corpora and fails loudly if target
-enumeration returns nothing. A ClusterFuzzLite workflow builds all
+decoder. A nightly CI campaign (`.github/workflows/fuzz.yml`) runs every
+target in each crate against tracked seed corpora and fails loudly if
+target enumeration returns nothing. A ClusterFuzzLite workflow builds all
 targets with AddressSanitizer for on-demand campaigns. The target
 inventory is fail-closed: `scripts/check_fuzz_target_inventory.py` runs
 in CI and fails when the inventory drifts from the reviewed list.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -15,7 +15,7 @@ A modern, API-first BGP daemon in Rust, inspired by GoBGP's ergonomics and "driv
 
 **Observable by default.** Prometheus metrics, structured logs, and machine-parseable errors everywhere. Operators should never have to guess what the daemon is doing or why a session flapped.
 
-**Safe, boring, maintainable.** Minimal `unsafe` (one module for TCP MD5/GTSM socket options). Fuzzed wire decoder. Explicit resource limits. No clever tricks — just correct, auditable Rust.
+**Safe, boring, maintainable.** Minimal `unsafe` — every crate root denies it, and exactly three modules take a reviewed opt-out (transport socket options, the settlement watchdog's terminal `_exit`, the BFD receive-TTL socket option). Fuzzed wire decoder. Explicit resource limits. No clever tricks — just correct, auditable Rust.
 
 ## Non-Goals (v1)
 
@@ -87,7 +87,7 @@ and mirrors internal architecture.
 
 ```protobuf
 // Abridged — proto/rustbgpd.proto is authoritative; NeighborService has
-// 12 RPCs and RibService 23, only representative subsets are shown here.
+// 12 RPCs and RibService 21, only representative subsets are shown here.
 
 // Global daemon configuration and identity
 service GlobalService {
@@ -454,7 +454,7 @@ Inject and withdraw routes via gRPC (`AddPath` / `DeletePath`). Build Adj-RIB-Ou
 - `UpdateMessage::build()` high-level constructor for outbound UPDATEs.
 - eBGP outbound: prepend local ASN to AS_PATH, set NEXT_HOP to session's local IPv4 socket address (reachable, not router-id), strip LOCAL_PREF.
 - iBGP outbound: ensure LOCAL_PREF present (default 100), pass NEXT_HOP through.
-- TCP MD5 and GTSM require `socket2::Socket` for pre-connect `setsockopt` calls (ADR-0016). Only `unsafe` code in the project, isolated to `socket_opts` module.
+- TCP MD5 and GTSM require `socket2::Socket` for pre-connect `setsockopt` calls (ADR-0016). The `unsafe` this needs is isolated to the `socket_opts` module — one of the project's three scoped `unsafe` modules, and the only one in the transport path. `SECURITY.md` carries the full inventory.
 - Policy engine: first-match-wins evaluation with match conditions (prefix, community, AS_PATH regex) and route modifications (LOCAL_PREF, MED, communities, AS_PATH prepend, next-hop). Separate import/export policies.
 
 **Exit criteria:**


### PR DESCRIPTION
Three claims in the public security-posture documents were false or stale. This corrects them against the source.

## 1. The `unsafe` inventory undercounted, and two claims were flatly false

**`SECURITY.md:76`** — "No `unsafe` code in shipped paths, **with two scoped exceptions**"
**`SECURITY.md:81`** — the transport `socket_opts` module "is **the only `unsafe` in any library crate**"
**`SECURITY.md:86`** — "the daemon writes **no `unsafe` blocks of its own** under either configuration"
**`docs/DESIGN.md:18`** — "Minimal `unsafe` (**one module** for TCP MD5/GTSM socket options)"
**`docs/DESIGN.md:457`** — "**Only** `unsafe` code in the project, isolated to `socket_opts` module"

Verified reality: **three** modules in shipped paths carry a scoped `unsafe` opt-out, not one and not two.

```
$ grep -rn "allow(unsafe_code)" --include='*.rs' src crates
src/bfd_runtime.rs:1219
crates/api/src/runtime_config_settlement.rs:1757
crates/transport/src/lib.rs:19
crates/transport/src/socket_opts.rs:3139
```

That grep also undercounts: it misses multi-line `#[allow(unsafe_code, reason = ...)]` attributes. Scanning for the bare lint name finds eleven function-level sites inside `socket_opts.rs` alone (lines 80, 847, 1400, 1637, 1678, 2705, 3139, 3164, 3201, 3214, 3254), all under the module-level opt-out at `crates/transport/src/lib.rs:19`.

The two false claims, specifically:

- **"the only `unsafe` in any library crate"** — `crates/api` is a library crate with `#![deny(unsafe_code)]` at `crates/api/src/lib.rs:10` and a scoped opt-out at `crates/api/src/runtime_config_settlement.rs:1757`.
- **"the daemon writes no `unsafe` blocks of its own"** — `src/bfd_runtime.rs:1219` is an `unsafe` block in the binary crate, present under both allocator configurations.

The corrected text states the real inventory with a justification per module, each verified against the source:

- **`crates/transport::socket_opts`** — Linux socket-option ABI with no safe Rust wrapper: `TCP_MD5SIG`/`TCP_MD5SIG_EXT`, TCP-AO key install/delete/inspect/RNext-select, GTSM (`IP_MINTTL`/`IPV6_MINHOPCOUNT`), and the `sockaddr_in`/`sockaddr_in6` encode-decode those options take.
- **`crates/api::runtime_config_settlement`** — the ambiguous-configuration watchdog's terminal boundary, `#[cfg(not(test))] fn terminate_process()`, whose entire body is `unsafe { libc::_exit(AMBIGUOUS_CONFIG_EXIT_STATUS) }` (status 70, `runtime_config_settlement.rs:612`). Exit-only is enforced, not merely asserted: `production_terminal_wrapper_is_an_exact_exit_only_boundary` parses the production source and requires the body to be exactly that call and to contain none of `lock`, `alloc`, `clone`, `drop`, `tracing`, `metric`, `write`, `wait`, `park`, `sleep`, `spawn`, `dispatch`, `panic`, `unwrap`.
- **`src/bfd_runtime`** — one raw `setsockopt` enabling `IP_RECVTTL` / `IPV6_RECVHOPLIMIT`, which `socket2` does not expose. BFD needs the received TTL as ancillary data for the RFC 5881 exact-255 receive check at `src/bfd_runtime.rs:1096`.

The `#[global_allocator]` note is retained and made precise: the binary's crate-root deny is `cfg_attr`-gated off under `jemalloc` (the default) or `dhat-heap` (`src/main.rs:5-8`), and `--no-default-features` re-arms it — at which point the `bfd_runtime` block is still a visible opt-out because it carries its own `#[allow]`.

The test/bench paragraph's illustrative crate list is broadened so it does not read as an exhaustive census — `unsafe` in non-shipped targets also lives in `crates/policy/tests`, `crates/api/benches`, `crates/wire/benches`, and the workspace `tests/`.

## 2. Stale fuzz-target count

**`SECURITY.md:117`** — fuzz crates "carry **19** fuzz targets"

Verified reality: **21**. `scripts/check_fuzz_target_inventory.py:37` sets `EXPECTED_COUNT = 21` and is fail-closed on that exact number.

```
$ grep -rc '^\[\[bin\]\]' crates/*/fuzz/Cargo.toml
crates/bfd/fuzz/Cargo.toml:1
crates/mrt/fuzz/Cargo.toml:2
crates/evpn/fuzz/Cargo.toml:1
crates/rpki/fuzz/Cargo.toml:1
crates/wire/fuzz/Cargo.toml:12
crates/policy/fuzz/Cargo.toml:4
```

12 + 4 + 2 + 1 + 1 + 1 = 21. The two structural policy targets `compile_chain` and `explain_walk` landed after v0.66.0, so the coverage sentence now names them. `docs/FUZZING.md:113` already said "the exact 21-target inventory" — `SECURITY.md` was the straggler. The crate count (six) was already correct and is unchanged.

## 3. Stale RPC count

**`docs/DESIGN.md:90`** — "NeighborService has 12 RPCs and **RibService 23**"

Verified reality: NeighborService **12** (correct, unchanged), RibService **21**. Re-derived from the proto and cross-checked against the test-enforced inventory:

```
$ awk '/^service /{svc=$2; c=0} /^  rpc /{c++} /^}/{if(svc!=""){print svc, c; svc=""}}' proto/rustbgpd.proto
NeighborService 12
RibService 21
PolicyService 23
```

`docs/grpc-method-inventory.json` agrees: `rustbgpd.v1.RibService 21`, `rustbgpd.v1.NeighborService 12`. The stale 23 looks like PolicyService's count, which `docs/DESIGN.md:130` states correctly and which is left alone.

## Gates

All captured to files; exit codes checked directly, not through a pipe.

| Command | Exit |
| --- | --- |
| `python3 scripts/check_fuzz_target_inventory.py` | 0 — "fuzz target inventory check passed: exactly 21 targets" |
| `python3 -m unittest -v scripts/test_check_fuzz_target_inventory.py` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `python3 -m unittest -v scripts/test_check_public_tracker_ids.py` | 0 |
| `python3 scripts/check_ixp_manager_docs.py` | 0 |
| `python3 -m unittest -v scripts/test_check_ixp_manager_docs.py` | 0 |
| `python3 scripts/check-v1-stable-surface.py` | 0 |
| `python3 scripts/check_release_checklist_paths.py` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `python3 scripts/check-metric-consumers.py` | 0 |
| `cargo test --locked -p rustbgpd-api inventory` | 0 — 4 passed (gRPC method-matrix / JSON / Markdown inventory agreement) |
| `cargo test --locked -p rustbgpd-api production_terminal_wrapper_is_an_exact_exit_only_boundary` | 0 — 1 passed |
| pre-commit hook: `cargo fmt --check`, `cargo clippy`, `cargo doc` | 0 |

`just` is not installed on this machine; the `justfile` doc/contract recipes were run directly as the individual commands above.

## Out of scope, reported not fixed

`scripts/check_fuzz_target_inventory.py:280` still carries a stale argparse description, "Verify the exact 19-target cargo-fuzz inventory", while the same file enforces `EXPECTED_COUNT = 21`. Cosmetic — it is help text, not the gate — but it is the last surviving "19" in the repo. Left untouched to keep this change to the two documentation files.

Documentation only. No `.rs` file changed.
