### PR TITLE
docs: correct statements that are false at HEAD

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -63,7 +63,13 @@ not an observation of actor scheduling or end-to-end gRPC latency. Unlike
 Criterion, the harness does not multiply the 400k route/page-size 100
 repeated-scan baseline by a minimum sample count.
 
-Use the paired driver for retained comparisons:
+Use the paired driver for retained comparisons. The invocation below
+records how the retained route-paging receipt was produced; it is not a
+runnable recipe today. The `--base` pin is a reachable `main` ancestor, but
+the `--head` pin was that comparison's PR branch tip, which squash-merged
+under a different commit ID — no clone can resolve it, and the driver
+enforces both pins exactly, so it refuses to run. Reproducing the shape
+means re-pinning both commits to objects reachable in the checkout.
 
 ```bash
 bench/compare-route-paging.sh \

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -13,7 +13,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 | **NeighborService** | Dynamic peer CRUD, enable/disable, inbound soft reset, single-peer outbound refresh, dynamic-neighbor range CRUD (`ListDynamicNeighbors` / `AddDynamicNeighbor` / `DeleteDynamicNeighbor`), and the RFC 8326 graceful-shutdown toggle (`SetGracefulShutdown`) |
 | **PolicyService** | Named policy CRUD, neighbor-set CRUD, global/per-neighbor chain assignment, import-policy explain (`ExplainImportPolicy`), rejected-route listing (`ListRejectedRoutes`), live-RIB dry-run (`TestPolicy`), per-term hit counters (`GetPolicyStats`), and bounded invalid-validation disposition posture (`GetValidationPolicyPosture`) |
 | **PeerGroupService** | Peer-group CRUD, neighbor-to-group assignment |
-| **RibService** | Received/best/advertised route queries (incl. EVPN), BLACKHOLE discard status, FIB route status, BGP-LS route queries (ListBgpLsRoutes, RFC 9552), and watch stream |
+| **RibService** | Received/best/advertised route queries (incl. EVPN), BLACKHOLE discard status, FIB route status, and BGP-LS route queries (ListBgpLsRoutes, RFC 9552); all unary — live route deltas stream through `EventService.WatchEvents` |
 | **BfdService** | BFD session queries (RFC 5880/5881/5882) |
 | **EventService** | Live event stream (`WatchEvents`), recent session/policy/EVPN history, and the durable `SubscribeFromEvent` cursor (ADR-0072) |
 | **InjectionService** | Inject/withdraw unicast, FlowSpec, and EVPN routes |

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,4 +1,4 @@
-# rustbgpd-cli (rbgp)
+# rustbgpctl (rbgp)
 
 Installs as `rbgp` — a thin gRPC wrapper over the daemon's management
 surface with human-readable and JSON output modes.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4212,13 +4212,20 @@ reload, applied in dependency order:
    re-evaluated. Operators do not need to follow up with a manual
    `softreset` after a chain swap.
 
-Reload halts at the first step failure and returns a partial-state
-snapshot, so the daemon's in-memory config tracks what the peer
-manager actually applied (operator fixes the failing TOML and
-reloads again to converge against the half-applied state). The
-neighbor-reconcile step returns `None` on partial failure because
-live state is genuinely ambiguous after a delete-then-readd partial;
-earlier reload steps still land at the manager and remain in effect.
+Reload halts at the first step failure. If no step had taken effect
+yet, the halt is a clean no-effect failure: the reload is reported
+and refused with nothing mutated. Once any step has landed at the
+peer manager, the halt instead returns an authoritative
+known-partial receipt — it records the failing bucket, target, and
+error, and carries the honest partial snapshot of what actually
+applied, so the daemon's in-memory config tracks the peer manager
+rather than the rejected candidate. Every reload step reports
+through that receipt, the neighbor reconcile included; earlier
+steps that landed at the manager remain in effect. The acknowledged
+partial authority settles before another reload may begin, and a
+lost acknowledgement fences the runtime config for recovery instead
+of leaving the authority ambiguous. Operators fix the failing TOML
+and reload again to converge against the half-applied state.
 
 `[global]` identity and daemon-wide flags (ASN, router-id, listen
 port, cluster-id, admission and multipath knobs),

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -471,7 +471,7 @@ effective-impact view:
   named policies, peer groups, global / per-neighbor policy chains, and
   the hot-applied `[global]` flags `honor_graceful_shutdown` and
   control-plane-only `honor_blackhole`. SIGHUP reconciles all of these.
-- **Restart-required changes** — `[global]` ASN/router-id/families,
+- **Restart-required changes** — `[global]` ASN/router-id/cluster-id,
   `[global.telemetry.grpc_*]` listener config (including TLS / mTLS),
   `[rpki]`, `[bmp]`, `[mrt]`, unsupported EVPN shapes, and
   `apply_bum_enforcement`. Supported EVPN edits are shape-aware and appear
@@ -535,7 +535,7 @@ It does not abort an already-owned reload: the daemon waits for its typed
 settlement before taking the warm checkpoint or tearing down required actors.
 
 **Restart-required surfaces** (logged at reload, surfaced under
-"Restart-required" in `--diff`): `[global]` ASN/router-id/families,
+"Restart-required" in `--diff`): `[global]` ASN/router-id/cluster-id,
 `[global.telemetry.grpc_tcp]` and `[global.telemetry.grpc_uds]`
 listener config (including any TLS / mTLS field), `[rpki]`, `[bmp]`,
 `[mrt]`, and `apply_bum_enforcement`. EVPN table edits are

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,7 +56,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0046](0046-notification-gr.md) | Notification GR (RFC 8538) | Accepted | 2026-03-05 |
 | [0047](0047-grpc-security-hardening.md) | gRPC Security Hardening | Accepted | 2026-03-06 |
 | [0048](0048-rib-memory-optimizations.md) | RIB Memory Optimizations | Accepted | 2026-03-08 |
-| [0049](0049-aspa-verification.md) | ASPA Upstream Path Verification | Accepted | 2026-03-13 |
+| [0049](0049-aspa-verification.md) | ASPA Path Verification | Accepted | 2026-03-13 |
 | [0050](0050-evpn-route-reflector.md) | EVPN Route Reflector (RFC 7432 Phase 1) | Accepted | 2026-04-23 |
 | [0051](0051-per-peer-outbound-writer-task.md) | Per-peer outbound writer task | Accepted | 2026-04-27 |
 | [0052](0052-evpn-vtep-foundation.md) | EVPN VTEP Foundation — Local EVI/VNI Domain Model | Accepted | 2026-05-01 |

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -108,7 +108,7 @@ releases rather than carried forward from older measurements.
 | Next-hop set/self | Yes | Yes | set_next_hop = "self" or IP |
 | Named policy definitions | Yes | Yes | TOML definitions with configurable default_action |
 | Policy chaining | Yes | Yes | GoBGP-style: permit=continue, deny=stop, implicit permit |
-| Default eBGP policy (RFC 8212) | No | Opt-in | GoBGP [v4.8.0 policy documentation](https://github.com/osrg/gobgp/blob/v4.8.0/docs/sources/policy.md#L886-L899) defaults unmatched import/export policy to `accept-route`; rustbgpd requires explicit `ebgp_requires_policy = true` |
+| Default eBGP policy (RFC 8212) | No | Opt-in | GoBGP [v4.8.0 policy documentation](https://github.com/osrg/gobgp/blob/v4.8.0/docs/sources/policy.md#L886-L899) defaults unmatched import/export policy to `accept-route`; rustbgpd enforces RFC 8212 when opted in, by either `[global] ebgp_requires_policy = true` or the ADR-0119 activated secure default — root `config_epoch = 2` with the boolean omitted resolves to effective `true`. Epoch-less and `config_epoch = 1` omission stay effective `false` |
 | Scriptable policy language | No | Yes | `.rpol` (ADR-0096): typed + compiled, named prefix/community sets as indexed matchers, parameterized policies, `apply()` composition, in-language unit tests via `rbgp policy check`; route-for-route parity vs FRR route-maps proven in M80 |
 | Policy dry-run against the live RIB | No | Yes | `rbgp policy test` / `TestPolicy` RPC — a candidate `.rpol` policy evaluated read-only over an Adj-RIB-In / Loc-RIB snapshot: counts, per-term hits, before/after diffs |
 | Live per-term policy hit counters | No | Yes | `rbgp policy stats --direction import\|export\|both` / `GetPolicyStats` — since-chain-install counters on installed import and export chains; import rows also carry the session-local policy generation |
@@ -281,8 +281,11 @@ target. Remaining gaps are narrower:
 2. **IPv6 link-local BFD for unnumbered peers** — follows naturally from the
    scoped peer identity in ADR-0069, but ADR-0067 intentionally shipped global
    IPv4 / IPv6 single-hop first.
-3. **Config transaction / diff UX** — required before any serious gNMI `Set`
-   or broader remote-mutation story.
+3. ~~**Config transaction / diff UX**~~ — *shipped in v0.35.0 (ADR-0076),
+   on the `DiffRuntimeConfig` baseline from v0.22.0.* `ConfigService` plans,
+   applies, confirms, and aborts runtime config transactions under the shared
+   runtime-config coordinator, and the gNMI `Set` subset commits through the
+   same executor.
 4. ~~**Durable event replay**~~ — *shipped in v0.30.0 (ADR-0072 + ADR-0072
    follow-up sprint).* `SubscribeFromEvent` with monotonic-`event_id` cursor
    carries the post-incident debugging story; gNMI `ON_CHANGE` v1 for


### PR DESCRIPTION
Corrects eight documentation statements that no longer match the code at
`main`. Each was verified against its source of truth before editing; one
reported finding turned out to be correct as written and was left alone.

## Corrections

| # | Finding | Verified reality | Fix |
|---|---------|------------------|-----|
| 1 | `crates/cli/README.md:1` H1 read `# rustbgpd-cli (rbgp)` | No package by that name exists. `crates/cli/Cargo.toml:3` declares `name = "rustbgpctl"`; `:6` `default-run = "rbgp"`; `:22-23` `[[bin]] name = "rbgp"`. `rustbgpd-cli` appears nowhere else in the repo | H1 is now `# rustbgpctl (rbgp)` — the real package name, with the shipped binary kept in the parenthetical. No rename implied |
| 2 | `crates/api/README.md:16` credited RibService with "and watch stream" | The `service RibService` block in `proto/rustbgpd.proto` has no `stream` on any RPC. An in-block comment states live route deltas go through `EventService.WatchEvents` (`EVENT_CATEGORY_ROUTE`) | Row now ends "…RFC 9552); all unary — live route deltas stream through `EventService.WatchEvents`" |
| 3 | `crates/transport/README.md:49-51` says the reply reports `enabled`, not `retention_enabled` | **Declined — see below** | None |
| 4 | `docs/CONFIGURATION.md:4212-4221` described pre-receipt reload failure, incl. "the neighbor-reconcile step returns `None` on partial failure" | `src/reload.rs:3747` `acknowledge_partial()` returns an `Acknowledged` authority carrying `SighupCompletion::KnownPartial` (`:310-313`); no step returns `None`. `src/reload.rs:8435` asserts "failed neighbor reconcile returns a partial snapshot". `:3767` returns `CleanNoEffect` when `!progress.accepted_effect`; `:3761` returns `RecoveryFenced` on `AcknowledgementLost`. The halt log at `:3757` reads "settling the acknowledged partial runtime authority before another reload may begin" | Paragraph rewritten to the three real outcomes: clean no-effect halt, authoritative known-partial receipt, and recovery fence on a lost acknowledgement |
| 5 | `docs/OPERATIONS.md:474` and `:538` both list "`[global]` ASN/router-id/families" | `pub struct Global` (`src/config/schema.rs:774`) has no `families` field. `docs/reload-matrix.md:242-266` lists every `[global]` key and has no `families` row. `families` is a `[[neighbors]]` / EVPN-instance key | Both lines now read "`[global]` ASN/router-id/cluster-id" — `cluster_id` is restart-required per `docs/reload-matrix.md` |
| 6 | `docs/adr/README.md:59` indexed ADR-0049 as "ASPA Upstream Path Verification" | `docs/adr/0049-aspa-verification.md:1` H1 is "ADR-0049: ASPA Path Verification" | Index row matches the ADR |
| 7 | `docs/gobgp-parity.md:111` said rustbgpd "requires explicit `ebgp_requires_policy = true`" | `Config::rfc8212_posture()` (`src/config/schema.rs:294-320`): `(None, ConfigEpoch::V2) => (true, Rfc8212PolicySource::Epoch2Default)`. Root `config_epoch = 2` with the boolean omitted resolves to effective `true` | Prose now names both activation paths. **"Opt-in" kept** — omitted/`config_epoch = 1` still resolves to effective `false` (`LegacyOmission`), so it is not on by default |
| 8 | `docs/gobgp-parity.md:284-285` listed "Config transaction / diff UX" as an open DC-fabric gap | Shipped. `ConfigService` in `proto/rustbgpd.proto:110-144` has `DiffRuntimeConfig`, `PlanConfigTransaction`, `ApplyConfigTransaction`, `ConfirmConfigTransaction`, `AbortConfigTransaction`. ADR-0076 is Accepted; CHANGELOG `[0.35.0]` ships the model, `[0.22.0]` ships `DiffRuntimeConfig` | Marked shipped using the list's own strikethrough convention (matching item 4's "Durable event replay"), with the version and ADR |
| 9 | `bench/README.md:68-78` presents an unrunnable invocation | `git cat-file -t fbb3789881eb1549354ebb5ecf6869b3ed49573d` fails; the `--base` pin `63159c20…` resolves. `bench/compare-route-paging.sh:295` hard-enforces `expected_head_commit` | Added prose above the block marking it as a record of how a retained receipt was produced, not a runnable recipe. **Script and pins unchanged** |

## Declined

**Finding 3 — `crates/transport/README.md` `enabled` → `retention_enabled`.**
The brief's premise does not hold. The sentence describes the transport
crate's own reply type, not the proto message. `RejectedRoutesReply`
(`crates/transport/src/session/rejected_routes.rs:232-247`) has fields
`enabled`, `capacity`, and `evictions_since_reset` — all three match the
README exactly, and its doc comment on `enabled` carries the same
"empty listing is a configuration fact" wording. The proto's
`retention_enabled` (`proto/rustbgpd.proto:1678`) is the gRPC-side name for
the same flag.

The wording is also pinned by a test:
`transport_readme_pins_rejected_route_retention_completeness`
(`crates/transport/src/session/tests/reject_retention.rs:547-573`) asserts
the README contains "The `ListRejectedRoutes` reply reports `enabled`,
`capacity`, and `evictions_since_reset`" and "`enabled = false` makes an
empty result a configuration fact" verbatim. Renaming would require editing
that `.rs` file, which is outside this change's scope.

The README is correct for a `rustbgpd-transport` embedder. If the intent is
to describe the gRPC surface instead, that is a deliberate contract change
needing the pinned test updated alongside it.

## Gates

All captured to files; exit codes checked directly, nothing piped through
`grep`/`tail`/`/dev/null`.

| Gate | Exit |
|---|---|
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `python3 scripts/check-metric-consumers.py` | 0 |
| `python3 scripts/check_ixp_manager_docs.py` | 0 |
| `python3 scripts/check-v1-stable-surface.py` | 0 |
| `python3 scripts/check_release_checklist_paths.py` | 0 |
| `cargo test --locked -p rustbgpd-api adr_index_reports_fully_shipped_boundary` | 0 |
| `cargo test --locked -p rustbgpctl curated_documentation_commands_parse_with_the_real_cli` | 0 |
| `cargo test --locked -p rustbgpd-mrt emitted_table_dump_v2` | 0 |
| `cargo test --locked -p rustbgpd-transport transport_readme_pins_rejected_route_retention_completeness` | 0 |

`just` is not installed on this machine, so the doc/contract recipes from
the `gate` recipe were run as their individual commands. The last four are
the `.rs` contract tests that read the files this branch changes
(`docs/adr/README.md`, `docs/OPERATIONS.md`, `docs/CONFIGURATION.md`, and
the transport README left unchanged). Pre-commit also ran `cargo fmt
--check` and `cargo clippy` clean.

Documentation only — no `.rs` file is modified.
