### PR TITLE
security: enforce daemon unsafe opt-outs

### DIFF
--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -1754,7 +1754,10 @@ fn fatal_clock_loop(registry: &Arc<Registry>) {
 }
 
 #[cfg(not(test))]
-#[allow(unsafe_code)]
+#[allow(
+    unsafe_code,
+    reason = "the settlement fail-stop requires bare libc::_exit without unwinding"
+)]
 fn terminate_process() -> ! {
     unsafe { libc::_exit(AMBIGUOUS_CONFIG_EXIT_STATUS) }
 }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -16,7 +16,10 @@ pub mod framing;
 pub mod handle;
 pub mod listener;
 pub(crate) mod session;
-#[allow(unsafe_code)]
+#[allow(
+    unsafe_code,
+    reason = "Linux BGP socket options require raw libc ABI calls and records"
+)]
 mod socket_opts;
 pub mod timer;
 

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -4,9 +4,9 @@
 //! require raw socket options that are only available on Linux. TCP-AO
 //! (RFC 5925) uses the same boundary for `setsockopt` and `getsockopt`.
 //!
-//! These are the only `unsafe` blocks in any library crate — they exist
-//! because there is no safe Rust API for `TCP_MD5SIG`, `IP_MINTTL`, or
-//! TCP-AO. See SECURITY.md for the full unsafe-code posture.
+//! This crate's `unsafe` blocks are isolated here because there is no safe Rust
+//! API for `TCP_MD5SIG`, `IP_MINTTL`, or TCP-AO. See SECURITY.md for the full
+//! project-wide unsafe-code posture.
 
 use std::io;
 #[cfg(target_os = "linux")]
@@ -3136,7 +3136,10 @@ fn write_alg_name(dst: &mut [u8; 64], name: &str) -> io::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code)]
+#[allow(
+    unsafe_code,
+    reason = "encode an IP address in the Linux sockaddr_storage ABI"
+)]
 fn write_sockaddr(storage: &mut libc::sockaddr_storage, peer: IpAddr, scope_id: u32) {
     match peer {
         IpAddr::V4(addr) => {

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -1216,7 +1216,10 @@ mod linux {
 
     // Raw setsockopt: socket2 / the safe wrappers don't expose IP_RECVTTL /
     // IPV6_RECVHOPLIMIT. The call is a textbook c_int option set on an owned fd.
-    #[allow(unsafe_code)]
+    #[allow(
+        unsafe_code,
+        reason = "BFD receive TTL requires the raw Linux socket-option ABI"
+    )]
     fn enable_recv_ttl(fd: i32, v6: bool) -> std::io::Result<()> {
         let on: libc::c_int = 1;
         let (level, opt) = if v6 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,7 @@
 //!
 //! Binary entry point. Loads config, wires components, starts runtime.
 
-#![cfg_attr(
-    not(any(feature = "jemalloc", feature = "dhat-heap")),
-    deny(unsafe_code)
-)]
+#![deny(unsafe_code)]
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 


### PR DESCRIPTION
## Summary

- enforce `#![deny(unsafe_code)]` in the daemon for every allocator and feature configuration
- attach explicit audit reasons to the BFD, settlement-watchdog, and transport socket-option opt-outs
- scope the transport module comment to its own crate instead of repeating a false project-wide inventory claim

The project-wide SECURITY and DESIGN inventory corrections landed separately in #2028; this PR contains only the compiler-enforced source side of that posture.

## Validation

- `cargo clippy --locked -p rustbgpd --bin rustbgpd -- -D warnings`
- `cargo clippy --locked -p rustbgpd --all-features --bin rustbgpd -- -D warnings`
- `cargo clippy --locked -p rustbgpd --no-default-features --bin rustbgpd -- -D warnings`
- `cargo test --locked -p rustbgpd-api production_terminal_wrapper_is_an_exact_exit_only_boundary`
- `cargo test --locked -p rustbgpd receive_ttl_setsockopt_preserves_errno`
- repository pre-push fmt, clippy, test, and rustdoc hooks
