### PR TITLE
docs: correct allocator unsafe posture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,8 @@ jobs:
       - name: Gate eager policy-set sharing allocation shape
         run: cargo test --locked -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation shared_set_batch_allocations_do_not_scale_per_peer -- --exact
       # jemalloc became the default feature; keep the stock-glibc build
-      # compiling (debug/fallback builds use it) and keep the
-      # deny(unsafe_code) lint posture — it is only armed when neither
-      # allocator feature is on, so the default build no longer checks it.
+      # compiling (debug/fallback builds use it) while independently exercising
+      # the daemon's unconditional deny(unsafe_code) with no allocator feature.
       - run: cargo check --locked -p rustbgpd --no-default-features --all-targets
       - name: Verify committed RIB rebaseline receipt
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -96,12 +96,11 @@ input from the network. It runs under continuous fuzzing in CI.
     needs the received TTL delivered as ancillary data to enforce the RFC 5881
     exact-255 receive check.
 
-  The daemon binary's own crate-root deny is additionally `cfg_attr`-gated off
-  when the `jemalloc` (the default) or `dhat-heap` feature is on, because
-  registering a `#[global_allocator]` is itself an `unsafe` construct. Building
-  with `--no-default-features` re-arms that deny; the `bfd_runtime` block above
-  carries its own `#[allow]`, so it stays a visible, reviewed opt-out under
-  either configuration.
+  The daemon binary carries the same unconditional crate-root deny with its
+  default `jemalloc`, opt-in `dhat-heap`, and no-default-feature configurations.
+  Registering either dependency-provided allocator introduces no `unsafe` block
+  or `unsafe impl` in this crate. The three shipped boundaries above remain
+  visible, reviewed opt-outs with recorded reasons.
 
   Test and benchmark targets are separate compilation units and are not covered
   by a crate root's deny. Several carry justified `unsafe`: allocation-tracking


### PR DESCRIPTION
## Summary

- replace the false claim that `#[global_allocator]` requires disabling `unsafe_code`
- state that the daemon crate denies unsafe code in the jemalloc, dhat, and allocator-free configurations
- correct the matching stale CI comment while retaining the three reviewed production opt-outs

Follow-up to #2028 and the compiler enforcement merged in #2031.

## Validation

- `cargo clippy --locked -p rustbgpd --bin rustbgpd -- -D warnings`
- `cargo clippy --locked -p rustbgpd --bin rustbgpd --no-default-features --features dhat-heap -- -D warnings`
- `cargo clippy --locked -p rustbgpd --bin rustbgpd --no-default-features -- -D warnings`
- `python3 scripts/check-clippy-reasons.py`
- `python3 scripts/check_release_checklist_paths.py`
- `python3 scripts/check_public_tracker_ids.py`
- `git diff --check`
