### PR TITLE
fix(ops): ship and validate EVPN dashboard

### DIFF
--- a/.github/workflows/alert-rules.yml
+++ b/.github/workflows/alert-rules.yml
@@ -1,6 +1,6 @@
 name: Observability assets
 
-# Validates the shipped Grafana dashboard structurally, then checks the
+# Validates the shipped Grafana dashboards structurally, then checks the
 # Prometheus alert-rule pack with promtool (`check rules` for syntax/shape,
 # `test rules` for per-rule behavior). Path-scoped to those assets so it
 # costs nothing on unrelated changes.
@@ -9,7 +9,7 @@ on:
   push:
     paths:
       - "examples/prometheus/**"
-      - "docs/grafana/rustbgpd-overview.json"
+      - "docs/grafana/**"
       - "crates/telemetry/src/metrics.rs"
       - "scripts/check-grafana-dashboard.py"
       - "scripts/test_check_grafana_dashboard.py"
@@ -17,7 +17,7 @@ on:
   pull_request:
     paths:
       - "examples/prometheus/**"
-      - "docs/grafana/rustbgpd-overview.json"
+      - "docs/grafana/**"
       - "crates/telemetry/src/metrics.rs"
       - "scripts/check-grafana-dashboard.py"
       - "scripts/test_check_grafana_dashboard.py"

--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -11,7 +11,7 @@ on:
       - docs/QUICKSTART.md
       - docs/OPERATIONS.md
       - docs/adr/0127-config-transaction-settlement-watchdog.md
-      - docs/grafana/rustbgpd-overview.json
+      - docs/grafana/**
       - docs/cookbook/ixp-filter-pipeline.md
       - docs/cookbook/monitoring-feed.md
       - examples/birdwatcher-adapter/Cargo.toml
@@ -42,7 +42,7 @@ on:
       - docs/QUICKSTART.md
       - docs/OPERATIONS.md
       - docs/adr/0127-config-transaction-settlement-watchdog.md
-      - docs/grafana/rustbgpd-overview.json
+      - docs/grafana/**
       - docs/cookbook/ixp-filter-pipeline.md
       - docs/cookbook/monitoring-feed.md
       - examples/birdwatcher-adapter/Cargo.toml
@@ -128,7 +128,11 @@ jobs:
                         lib/systemd/system/rustbgpd@.service \
                         usr/share/man/man1/rbgp.1.gz \
                         usr/share/man/man8/rustbgpd.8.gz \
-                        usr/share/doc/rustbgpd/LICENSES.md; do
+                        usr/share/doc/rustbgpd/LICENSES.md \
+                        usr/share/doc/rustbgpd/monitoring/rustbgpd-overview.json \
+                        usr/share/doc/rustbgpd/monitoring/rustbgpd-evpn.json \
+                        usr/share/doc/rustbgpd/monitoring/rustbgpd-alerts.yml \
+                        usr/share/doc/rustbgpd/monitoring/rustbgpd-alerts_test.yml; do
               test -s "$tree/$file" || { echo "missing or empty: $tree/$file" >&2; exit 1; }
             done
             # The packaged daemon must accept the config its own package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           #   share/completions/rbgp.{bash,zsh,fish}  shell completions
           #   share/systemd/rustbgpd{,@}.service      hardened systemd units
           #   share/systemd/rustbgpd-dataplane.conf   opt-in CAP_NET_ADMIN drop-in
-          #   share/monitoring/rustbgpd-overview.json Grafana dashboard
+          #   share/monitoring/rustbgpd-{overview,evpn}.json Grafana dashboards
           #   share/monitoring/rustbgpd-alerts.yml    Prometheus alert rules
           #   share/monitoring/rustbgpd-alerts_test.yml promtool rule tests
           #
@@ -171,7 +171,8 @@ jobs:
           cp docs/rustbgpd.schema.json staging/
           cp examples/systemd/rustbgpd.service examples/systemd/rustbgpd@.service \
             examples/systemd/rustbgpd-dataplane.conf staging/share/systemd/
-          cp docs/grafana/rustbgpd-overview.json staging/share/monitoring/
+          cp docs/grafana/rustbgpd-overview.json \
+            docs/grafana/rustbgpd-evpn.json staging/share/monitoring/
           cp examples/prometheus/rustbgpd-alerts.yml \
             examples/prometheus/rustbgpd-alerts_test.yml \
             staging/share/monitoring/
@@ -217,6 +218,7 @@ jobs:
                    share/systemd/rustbgpd@.service \
                    share/systemd/rustbgpd-dataplane.conf \
                    share/monitoring/rustbgpd-overview.json \
+                   share/monitoring/rustbgpd-evpn.json \
                    share/monitoring/rustbgpd-alerts.yml \
                    share/monitoring/rustbgpd-alerts_test.yml; do
             if ! grep -qxF "$f" <<<"$entries"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The shipped Grafana overview now pairs the RFC 9107 ORR SPF computation
   rate with current topology node and usable-link counts. (LAN-1205)
 
+- Release archives and native packages now include the Alpha EVPN operations
+  dashboard alongside the Grafana overview, with both dashboards covered by
+  directory-wide validation and release-contract triggers.
+
 - gNMI dial-out now exposes `gnmi_dialout_resync_total{target}`,
   `gnmi_dialout_queue_depth{target}`, and
   `gnmi_dialout_last_publish_timestamp_seconds{target}` so repeated

--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ Four binaries: the daemon, the `rbgp` CLI, `rs-config-render` (the
 harmless if you don't run one), and the optional Alice-LG
 `birdwatcher-adapter`. The tarball also carries man pages and
 bash/zsh/fish completions under `share/`, plus the version-matched Grafana
-dashboard, Prometheus alert rules, and promtool test suite under
+overview and Alpha EVPN dashboards, Prometheus alert rules, and promtool test
+suite under
 `share/monitoring/` (`/usr/share/doc/rustbgpd/monitoring/` after a
 `.deb`/`.rpm` install) — the
 [install walkthrough](docs/deployment.md#install) covers installing those

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -46,7 +46,7 @@ rustbgpd --version && rbgp --version
 nothing below uses it, but it is in the same archive, so install it here
 rather than hunting for it the day you stand up a route server. The
 tarball also ships man pages, shell completions, and version-matched
-monitoring payloads under `share/`. The Grafana dashboard and Prometheus
+monitoring payloads under `share/`. The Grafana dashboards and Prometheus
 rules live in `share/monitoring/`; verify the alert pack without changing
 its relative `rule_files` reference:
 
@@ -55,10 +55,11 @@ its relative `rule_files` reference:
 ```
 
 Native packages install the same monitoring payloads under
-`/usr/share/doc/rustbgpd/monitoring/`. Import
-`rustbgpd-overview.json` in Grafana and load `rustbgpd-alerts.yml` from
-Prometheus. [deployment.md](deployment.md#monitoring-payloads) covers the
-paths, setup, and pinning a specific release instead of `latest`.
+`/usr/share/doc/rustbgpd/monitoring/`. Import `rustbgpd-overview.json` and,
+when operating EVPN, the Alpha `rustbgpd-evpn.json` dashboard in Grafana; load
+`rustbgpd-alerts.yml` from Prometheus.
+[deployment.md](deployment.md#monitoring-payloads) covers the paths, setup, and
+pinning a specific release instead of `latest`.
 
 ### Or build from source
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,7 +59,8 @@ share/completions/rbgp.{bash,zsh,fish}  shell completions
 share/systemd/rustbgpd.service          hardened systemd unit
 share/systemd/rustbgpd@.service         opt-in per-handle systemd unit
 share/systemd/rustbgpd-dataplane.conf   opt-in CAP_NET_ADMIN drop-in
-share/monitoring/rustbgpd-overview.json Grafana dashboard
+share/monitoring/rustbgpd-overview.json Grafana overview dashboard
+share/monitoring/rustbgpd-evpn.json     Alpha EVPN Grafana dashboard
 share/monitoring/rustbgpd-alerts.yml    Prometheus alert rules
 share/monitoring/rustbgpd-alerts_test.yml promtool rule tests
 ```
@@ -316,11 +317,12 @@ terms and warranty disclaimers.
 
 ### Monitoring payloads
 
-Every release archive carries its matching Grafana dashboard, Prometheus alert
-rules, and promtool test suite under `share/monitoring/`. Native packages put
-the same files under `/usr/share/doc/rustbgpd/monitoring/`. Keep
-`rustbgpd-alerts.yml` beside `rustbgpd-alerts_test.yml`: the suite deliberately
-uses the relative `rule_files` entry `rustbgpd-alerts.yml`.
+Every release archive carries its version-matched Grafana dashboards,
+Prometheus alert rules, and promtool test suite under `share/monitoring/`.
+Native packages put the same files under
+`/usr/share/doc/rustbgpd/monitoring/`. Keep `rustbgpd-alerts.yml` beside
+`rustbgpd-alerts_test.yml`: the suite deliberately uses the relative
+`rule_files` entry `rustbgpd-alerts.yml`.
 
 Validate the shipped rules before loading them:
 
@@ -334,10 +336,11 @@ Validate the shipped rules before loading them:
 ```
 
 Copy or reference `rustbgpd-alerts.yml` from Prometheus's `rule_files`
-configuration, then import `rustbgpd-overview.json` in Grafana. The
-[Grafana guide](GRAFANA.md) supplies the matching scrape job and dashboard
-setup; keep the payloads from one rustbgpd release together so rules and
-metrics do not drift across versions.
+configuration, then import `rustbgpd-overview.json` and, when operating EVPN,
+the Alpha `rustbgpd-evpn.json` dashboard in Grafana. The [Grafana
+guide](GRAFANA.md) supplies the matching scrape job and dashboard setup; keep
+the payloads from one rustbgpd release together so rules and metrics do not
+drift across versions.
 
 ### From source
 

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -112,6 +112,10 @@ contents:
     dst: /usr/share/doc/rustbgpd/monitoring/rustbgpd-overview.json
     file_info:
       mode: 0644
+  - src: docs/grafana/rustbgpd-evpn.json
+    dst: /usr/share/doc/rustbgpd/monitoring/rustbgpd-evpn.json
+    file_info:
+      mode: 0644
   - src: examples/prometheus/rustbgpd-alerts.yml
     dst: /usr/share/doc/rustbgpd/monitoring/rustbgpd-alerts.yml
     file_info:

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -22,6 +22,11 @@ MONITORING = (
         "/usr/share/doc/rustbgpd/monitoring/rustbgpd-overview.json",
     ),
     (
+        "docs/grafana/rustbgpd-evpn.json",
+        "share/monitoring/rustbgpd-evpn.json",
+        "/usr/share/doc/rustbgpd/monitoring/rustbgpd-evpn.json",
+    ),
+    (
         "examples/prometheus/rustbgpd-alerts.yml",
         "share/monitoring/rustbgpd-alerts.yml",
         "/usr/share/doc/rustbgpd/monitoring/rustbgpd-alerts.yml",
@@ -295,7 +300,7 @@ def check(root: Path) -> list[str]:
         ) + (
             r"^cp LICENSE-MIT LICENSE-APACHE LICENSES\.md staging/$",
             r"^cp examples/systemd/rustbgpd\.service examples/systemd/rustbgpd@\.service examples/systemd/rustbgpd-dataplane\.conf staging/share/systemd/$",
-            r"^cp docs/grafana/rustbgpd-overview\.json staging/share/monitoring/$",
+            r"^cp docs/grafana/rustbgpd-overview\.json docs/grafana/rustbgpd-evpn\.json staging/share/monitoring/$",
             r"^cp examples/prometheus/rustbgpd-alerts\.yml examples/prometheus/rustbgpd-alerts_test\.yml staging/share/monitoring/$",
             exact(package_tar),
         )
@@ -371,7 +376,7 @@ def check(root: Path) -> list[str]:
                 r"^for tree in extracted/deb extracted/rpm; do$",
                 r"^for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do$",
                 r'^test -x "\$tree/usr/bin/\$exe" ',
-                r"^for file in lib/systemd/system/rustbgpd\.service lib/systemd/system/rustbgpd@\.service usr/share/man/man1/rbgp\.1\.gz usr/share/man/man8/rustbgpd\.8\.gz usr/share/doc/rustbgpd/LICENSES\.md; do$",
+                r"^for file in lib/systemd/system/rustbgpd\.service lib/systemd/system/rustbgpd@\.service usr/share/man/man1/rbgp\.1\.gz usr/share/man/man8/rustbgpd\.8\.gz usr/share/doc/rustbgpd/LICENSES\.md usr/share/doc/rustbgpd/monitoring/rustbgpd-overview\.json usr/share/doc/rustbgpd/monitoring/rustbgpd-evpn\.json usr/share/doc/rustbgpd/monitoring/rustbgpd-alerts\.yml usr/share/doc/rustbgpd/monitoring/rustbgpd-alerts_test\.yml; do$",
                 r'^test -s "\$tree/\$file" ',
                 r'^"\$tree/usr/bin/rustbgpd" --check "\$tree/etc/rustbgpd/config\.toml"$',
                 r'^unit="\$tree/lib/systemd/system/rustbgpd\.service"$',

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -29,6 +29,7 @@ INPUTS = (
     "packaging/nfpm.yaml",
     "scripts/build-packages.sh",
     "docs/grafana/rustbgpd-overview.json",
+    "docs/grafana/rustbgpd-evpn.json",
     "examples/prometheus/rustbgpd-alerts.yml",
     "examples/prometheus/rustbgpd-alerts_test.yml",
     contract.SYSTEMD_UNIT,
@@ -392,11 +393,13 @@ class ReleaseInstallContractTest(unittest.TestCase):
         )
 
     def test_empty_monitoring_source_fails(self) -> None:
-        root = self.fixture()
-        (root / "docs/grafana/rustbgpd-overview.json").write_text("")
-        self.assertTrue(
-            any("missing or empty" in error for error in contract.check(root))
-        )
+        for source, _, _ in contract.MONITORING:
+            with self.subTest(source=source):
+                root = self.fixture()
+                (root / source).write_text("")
+                self.assertTrue(
+                    any("missing or empty" in error for error in contract.check(root))
+                )
 
     def test_presentation_edits_do_not_gate_artifacts(self) -> None:
         root = self.fixture()


### PR DESCRIPTION
## Summary

- make observability and release-contract workflows watch the full Grafana asset directory
- include the Alpha EVPN dashboard in release archives and native packages
- assert both dashboards in tarball and extracted-package inventories
- document the two version-matched dashboards in release and install guidance

## Validation

- `python3 -m unittest -v scripts/test_check_release_install_contract.py`
- `python3 scripts/check_release_install_contract.py`
- `python3 -m unittest -v scripts/test_check_grafana_dashboard.py`
- `python3 scripts/check-grafana-dashboard.py`
- public and embedding documentation contract suites
- `cargo fmt --all -- --check`
- pre-commit workspace Clippy
- workflow YAML syntax check
