### PR TITLE
docs: document eBGP multihop behavior and the GTSM conflict

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -159,7 +159,8 @@ IPv4/IPv6 `Prefix` routes.
 |---|:---:|:---:|:---:|:---:|:---:|
 | TCP MD5 (RFC 2385) | Yes | Yes | Yes | Yes | Yes |
 | TCP-AO (RFC 5925) | Static + dynamic-prefix keyrings; observation-gated live rotation; deprecated/unselected-key deletion on SIGHUP | No | Yes | No | No |
-| GTSM / TTL Security | Yes | Yes | Yes | Yes | Yes |
+| GTSM / TTL Security | Strict 255 only[^gtsm-strict] | Yes | Yes | Yes | Yes |
+| eBGP multihop enablement | None needed[^multihop-rustbgpd] | Required[^multihop-frr] | Required[^multihop-bird] | Configurable[^multihop-gobgp] | Required[^multihop-openbgpd] |
 | RPKI origin validation | Yes | Yes | Yes | Yes | Yes |
 | ASPA path verification | Yes[^aspa] | No | Yes | No | Yes |
 | Private AS removal | Yes | Yes | Yes | Yes | Yes |
@@ -170,6 +171,59 @@ CVE-2026-49943, a stack-based buffer overflow in BIRD's AS-path filter
 matching reachable when RFC 8654 extended messages are enabled (affected
 through 2.19.0), is a recent example of the vulnerability class the
 memory-safe-language row refers to.
+
+[^gtsm-strict]: rustbgpd implements GTSM as strict RFC 5082 §3.2 — TTL /
+    Hop Limit exactly 255 in both directions, with no hop-count form — so it
+    cannot be combined with a multihop peer. The others document a
+    distance-aware variant: FRR
+    [`neighbor PEER ttl-security hops NUMBER`](https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-PEER-ttl-security-hops-NUMBER)
+    (documented as mutually exclusive with `ebgp-multihop`), BIRD
+    [3.3.1](https://bird.nic.cz/doc/bird-3.3.1.html) `ttl security`, where "if
+    both ttl security and multihop options are enabled, multihop option should
+    specify proper hop value to compute expected TTL", and the
+    [OpenBSD-current `bgpd.conf(5)` ttl-security documentation](https://man.openbsd.org/bgpd.conf#ttl-security),
+    where "for multihop peers, incoming packets are required to have a TTL of
+    256 minus multihop distance". GoBGP
+    [v4.8.0](https://github.com/osrg/gobgp/blob/v4.8.0/docs/sources/configuration.md#L166-L171)
+    exposes a configurable `ttl-min` but documents TTL security as mutually
+    exclusive with `neighbors.ebgp-multihop.config`.
+
+[^multihop-rustbgpd]: rustbgpd has no multihop knob because there is nothing
+    to enable: it never lowers the outbound TTL / Hop Limit on a BGP socket and
+    has no check refusing an eBGP peer for not being directly connected, so a
+    non-adjacent peer is dialed with the kernel default TTL. The same property
+    means it has no way to *bound* how far away a peer may be, so it does not
+    get the misconfiguration guard the other implementations' hop count
+    provides. This describes the mechanism, not an interoperability receipt.
+    See [CONFIGURATION.md](CONFIGURATION.md) and
+    [LIMITATIONS.md](LIMITATIONS.md).
+
+[^multihop-frr]: [FRR latest](https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-PEER-ebgp-multihop)
+    documents `neighbor PEER ebgp-multihop` and states that "when the neighbor
+    is not directly connected and this knob is not enabled, the session will
+    not establish".
+
+[^multihop-bird]: BIRD [3.3.1](https://bird.nic.cz/doc/bird-3.3.1.html)
+    documents `direct` — the neighbor address "must be from a directly
+    reachable IP range ... otherwise the BGP session wouldn't start" — as
+    "Default: enabled for eBGP", and `multihop [number]` as its alternative
+    for "a neighbor that isn't directly connected", where the "optional number
+    argument can be used to specify the number of hops (used for TTL)". This
+    claim is limited to that release line.
+
+[^multihop-gobgp]: GoBGP
+    [v4.8.0 configuration documentation](https://github.com/osrg/gobgp/blob/v4.8.0/docs/sources/configuration.md#L83-L85)
+    documents `[neighbors.ebgp-multihop.config]` with `enabled` and
+    `multihop-ttl`. The pinned document does not state what happens to a
+    non-adjacent peer when the section is omitted, so this cell records the
+    knob's existence rather than a requirement.
+
+[^multihop-openbgpd]: The
+    [OpenBSD-current `bgpd.conf(5)` multihop documentation](https://man.openbsd.org/bgpd.conf#multihop)
+    says neighbors not in the same AS as the local `bgpd(8)` "normally have to
+    be directly connected to the local machine", and that when this is not the
+    case the `multihop` statement "defines the maximum hops the neighbor may be
+    away".
 
 [^aspa]: rustbgpd ships RTR v2 ASPA input, role-aware upstream/downstream path
     verification selected by BGP Roles, best-path preference, policy matching

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -895,7 +895,7 @@ complete atomic block. There is no probe or automatic legacy fallback.
 | `md5_password`         | string   | no       | --      | TCP MD5 authentication password (RFC 2385, Linux only) |
 | `tcp_ao`               | table or array | no | -- | Ordered TCP-AO keyring for static neighbors (RFC 5925; Linux; append a non-preferred successor, then select it in a later observation-gated SIGHUP generation) |
 | `bfd`                  | table    | no       | --      | Single-hop BFD attachment referencing a `[[bfd_profiles]]` entry (RFC 5880/5881/5882; static neighbors only, restart-required edits) |
-| `ttl_security`         | bool     | no       | false   | Enable GTSM / TTL security (RFC 5082, Linux only). Strict: inbound packets must arrive with TTL/Hop-Limit exactly 255 (`IP_MINTTL` / `IPV6_MINHOPCOUNT`, RFC 5082 §3.2) and outbound packets are sent with 255. Earlier releases accepted 254; a peer that depended on that leniency will not establish |
+| `ttl_security`         | bool     | no       | false   | Enable GTSM / TTL security (RFC 5082, Linux only). Strict: inbound packets must arrive with TTL/Hop-Limit exactly 255 (`IP_MINTTL` / `IPV6_MINHOPCOUNT`, RFC 5082 §3.2) and outbound packets are sent with 255. Earlier releases accepted 254; a peer that depended on that leniency will not establish. Mutually exclusive with a multihop peer — see below |
 | `families`             | [string] | no       | (auto)  | Address families to negotiate (see below)        |
 | `required_families`    | [string] | no       | `[]`    | Families that must appear in the final negotiated intersection; must be a subset of effective `families` |
 | `graceful_restart`     | bool     | no       | true    | Enable Graceful Restart receiving speaker (RFC 4724) |
@@ -1150,6 +1150,37 @@ configuration change. Appending a non-preferred successor can be installed
 live on SIGHUP; a later SIGHUP can select that installed successor and
 observation-gate predecessor deprecation in the same immutable generation.
 Deleting an MKT remains restart-coordinated.
+
+### eBGP multihop and `ttl_security`
+
+There is no `ebgp_multihop` key, because there is nothing to enable. rustbgpd
+never lowers the outbound TTL / Hop Limit on a BGP socket, and it has no check
+that refuses an eBGP peer for not being directly connected. A neighbor several
+hops away is configured exactly like an adjacent one — an address, a
+`remote_asn`, and whatever policy the session needs — and the outgoing
+connection carries the kernel default TTL like any other TCP connection. The
+same is true in the inbound direction: nothing inspects the arriving TTL unless
+`ttl_security` is set.
+
+The corollary is that rustbgpd has no way to *bound* how far away a peer may
+be. Elsewhere a multihop peer needs an explicit statement, and where that
+statement carries a hop count the count doubles as a misconfiguration guard: a
+mistyped neighbor address that happens to be a reachable host far away fails to
+establish instead of quietly coming up. rustbgpd gives that up by default.
+Treat the neighbor address itself as the control, and keep `local_address`
+pinned on multihop sessions so the source address is stable. The
+per-implementation comparison and its sourcing live in
+[COMPARISON.md](COMPARISON.md).
+
+> **`ttl_security` makes a multihop session impossible.** GTSM (RFC 5082 §3.2)
+> is an exact-255 check in both directions: rustbgpd sends with TTL / Hop Limit
+> 255 and installs `IP_MINTTL` / `IPV6_MINHOPCOUNT` at 255, so any packet that
+> crossed a router — decremented to 254 or lower — is dropped by the kernel
+> before the handshake completes. A peer that is not directly connected cannot
+> satisfy that, so the session will never establish. The two features are
+> alternatives, not layers: use `ttl_security` on adjacent peers, and leave it
+> off (`false`, the default) on multihop ones. rustbgpd does not implement the
+> "255 minus hop count" variant that would let the two coexist.
 
 ### BFD (RFC 5880 / 5881 / 5882)
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -85,8 +85,24 @@ full gate ladder.
   non-deprecated-key deletion, and protected-owner CRUD require a daemon restart.
 - TCP MD5 and GTSM are supported.
 - BFD supports IPv4/IPv6 global-address single-hop asynchronous sessions for
-  static neighbors. Multihop, echo, demand mode, authentication,
-  dynamic-neighbor BFD, and IPv6 link-local BFD remain follow-up work.
+  static neighbors. Multihop BFD (RFC 5883), echo, demand mode,
+  authentication, dynamic-neighbor BFD, and IPv6 link-local BFD remain
+  follow-up work. This deferral is scoped to BFD sessions only. It says
+  nothing about BGP sessions to non-adjacent peers, which are a separate
+  mechanism with a different answer — see the next entry.
+- Multihop eBGP sessions require no configuration, and there is no knob to
+  bound them. rustbgpd never lowers the outbound TTL / Hop Limit on a BGP
+  socket and has no check that refuses an eBGP peer for not being directly
+  connected, so a session to a non-adjacent peer is attempted with the kernel
+  default TTL like any other outgoing TCP connection. The limitation is the
+  second half: other implementations require an explicit multihop statement,
+  and where that statement carries a hop count the count doubles as a
+  misconfiguration guard — a mistyped neighbor address fails loudly instead of
+  quietly establishing to a distant speaker. rustbgpd does not currently offer
+  that guard, and `ttl_security` is not a substitute for it: GTSM and multihop
+  are mutually exclusive. See [`CONFIGURATION.md`](CONFIGURATION.md) for the
+  configuration consequence and [`COMPARISON.md`](COMPARISON.md) for the
+  per-implementation sourcing.
 - BGP unnumbered supports static IPv6 link-local neighbors for IPv4 unicast.
   Interface-neighbor autodiscovery and capability 77 remain follow-up work.
 


### PR DESCRIPTION
## What the source actually shows

eBGP multihop works today with zero configuration, and that was documented
nowhere. Verified against the tree at `cb314721`:

1. **The only TTL writes on a BGP socket are the GTSM ones.**
   `crates/transport/src/socket_opts.rs:3287-3293` — `set_gtsm_outbound()`
   calls `set_ttl_v4(255)` / `set_unicast_hops_v6(255)`. Nothing else in
   `crates/transport/src` or `src/` sets a TTL on a BGP socket. (The other
   hits for `set_ttl` / `set_unicast_hops` are in `src/bfd_runtime.rs`, which
   is the BFD UDP path, not BGP.)

2. **`set_gtsm_outbound` is reachable only through `ttl_security`.** Three
   callers, all gated:
   - `crates/transport/src/socket_opts.rs:3250` and `:3278` — inside
     `set_gtsm_v4` / `set_gtsm_v6`, which are only reached via
     `set_gtsm()` (`socket_opts.rs:3208`).
   - `crates/transport/src/listener.rs:2702` — inside
     `enable_listener_gtsm_outbound`, guarded by
     `listener_gtsm_outbound_required()` (`listener.rs:2712-2716`), which
     returns `false` when no `TtlSecurityListenerPolicy` is enforcing.

   `set_gtsm()` in turn has exactly two live callers, both conditional:
   - `crates/transport/src/session/io.rs:995-998` — the outbound connect
     path, `if config.ttl_security { ... }`.
   - `crates/transport/src/listener.rs:1033-1034` — the accept path, under
     `resolve_ttl_security(&self.ttl_security, peer_ip)`.

3. **No connected-check exists.** A case-insensitive grep for `multihop`,
   `directly connected`, `ebgp_multihop` across `crates/` and `src/` returns
   three hits: two GTSM doc comments
   (`socket_opts.rs:3195`, `:3223`) and one BFD scope note
   (`crates/bfd/src/lib.rs:11`). Nothing refuses an eBGP peer for not being
   adjacent.

4. **`ttl_security` defaults to false.**
   `crates/transport/src/config.rs:560` in `TransportConfig::default()`, and
   `src/config/resolution.rs:783-786` resolves neighbor -> peer-group ->
   `.unwrap_or(false)`.

Net: with `ttl_security` off (the default), a BGP socket carries the kernel
default TTL, and a non-adjacent eBGP peer is dialed like any other TCP
connection. Turning `ttl_security` on installs a strict-255 check
(`IP_MINTTL` / `IPV6_MINHOPCOUNT` at 255, `socket_opts.rs:3228`, `:3264`),
which a multihop peer's decremented packets can never satisfy.

## What each document now says

**`docs/LIMITATIONS.md`** — the only `Multihop` occurrence in the doc set sat
inside the BFD deferral list, so a reader searching the term found it listed
as deferred and concluded BGP multihop was unsupported. That entry now reads
"Multihop BFD (RFC 5883)" and states explicitly that the deferral is scoped to
BFD sessions and says nothing about BGP sessions to non-adjacent peers. A new
sibling entry covers BGP multihop: no configuration needed, no TTL lowering,
no connected check — and records the actual limitation, that there is no way
to bound how far away a peer may be.

**`docs/CONFIGURATION.md`** — new `### eBGP multihop and ttl_security`
subsection under `[[neighbors]]`, placed next to the other transport-security
material. It states that there is no `ebgp_multihop` key because there is
nothing to enable, explains the mechanism, and carries a callout that enabling
`ttl_security` makes a multihop session impossible: GTSM is an exact-255 check
in both directions, so any packet that crossed a router is dropped by the
kernel before the handshake completes. The two are alternatives, not layers.
The `ttl_security` table row now ends with a pointer to it.

Both files record the design position neutrally: other implementations'
multihop statement carries a hop count that doubles as a misconfiguration
guard, so a mistyped neighbor address fails loudly instead of quietly
establishing to a distant speaker. rustbgpd does not currently offer that
guard. No future knob is promised.

## COMPARISON.md sourcing decision

I added the row rather than omitting it, because every competitor cell could
be sourced from pinned primary documentation in the convention this file
already uses.

New row `eBGP multihop enablement`, placed directly under the GTSM row:

| cell | sourced from |
|---|---|
| FRR `Required` | `docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-PEER-ebgp-multihop` — "when the neighbor is not directly connected and this knob is not enabled, the session will not establish" |
| BIRD `Required` | BIRD 3.3.1 user guide — `direct` is "Default: enabled for eBGP" and requires a directly reachable range; `multihop [number]` is its alternative |
| GoBGP `Configurable` | GoBGP v4.8.0 `docs/sources/configuration.md` L83-L85 |
| OpenBGPd `Required` | OpenBSD-current `bgpd.conf(5)` — neighbors in another AS "normally have to be directly connected" |

The GoBGP cell is deliberately weaker than the other three. The pinned v4.8.0
document shows the `[neighbors.ebgp-multihop.config]` block with `enabled` and
`multihop-ttl`, but never states what happens to a non-adjacent peer when the
section is omitted. Marking it `Required` would have been a guess, so the cell
records the knob's existence and its footnote says exactly that.

I also narrowed the existing `GTSM / TTL Security` row. It read `Yes` across
all five, which is true at the "supports GTSM" level but hides the fact that
rustbgpd's is strict-255-only while the other four document a distance-aware
form — and that difference is the whole reason `ttl_security` and multihop
cannot be combined here. The rustbgpd cell is now `Strict 255 only` with a
footnote sourcing all four: FRR `ttl-security hops NUMBER`, BIRD's note that
`multihop` should specify a proper hop value when both are enabled, OpenBGPd's
"256 minus multihop distance", and GoBGP's configurable `ttl-min` alongside
its documented mutual exclusivity with `ebgp-multihop`.

Every claim is scoped to the mechanism. There is no compatibility or interop
assertion, no hop-count figure, and no "supported"/"validated" language.

## Gates

All run from the branch, output captured to files, exit codes checked. No gate
was piped through `tail`, `grep`, or `/dev/null`.

| command | exit |
|---|---|
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `python3 -m unittest -v scripts/test_check_public_tracker_ids.py` | 0 |
| `python3 scripts/check_ixp_manager_docs.py` | 0 |
| `python3 -m unittest -v scripts/test_check_ixp_manager_docs.py` | 0 |
| `python3 scripts/check_release_checklist_paths.py` | 0 |
| `python3 -m unittest -v scripts/test_check_release_checklist_paths.py` | 0 |
| `python3 scripts/check-metric-consumers.py` | 0 |
| `python3 -m unittest -v scripts/test_check_metric_consumers.py` | 0 |
| `python3 scripts/check_metric_release_notes.py` | 0 |
| `python3 -m unittest -v scripts/test_check_metric_release_notes.py` | 0 |
| `python3 scripts/check_embedding_versions.py` | 0 |
| `python3 scripts/check_embedding_crate_map.py` | 0 |
| `python3 scripts/check-v1-stable-surface.py` | 0 |
| `python3 scripts/reflow-release-notes.py --selftest` | 0 |

That covers every step of the `Public docs contract` workflow (both the
`public` and `embedding` matrix legs) plus the doc-relevant recipes from
`justfile`'s `gate`. The pre-commit and pre-push hooks ran `cargo fmt`,
`cargo clippy`, and `cargo doc` — all passed. The remaining `gate` recipes are
Rust build and test lanes untouched by a docs-only change.

Also validated that every footnote in `docs/COMPARISON.md` is both defined and
referenced, with no duplicate labels.

## Scope

Documentation only. Three files, +105/-4. No `.rs`, `.toml`, or workflow file
touched. No tracker IDs under `docs/`. No addresses, ASNs, or hostnames from
any deployment — the behavior is described as a mechanism throughout.
