### PR TITLE
fix(bench): read COMMUNITIES independent of the Partial bit

### DIFF
--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -522,6 +522,17 @@ fn base_prefix_index(prefix: Ipv4Prefix, total_prefixes: u32) -> Option<usize> {
     (index < total_prefixes).then(|| usize::try_from(index).unwrap())
 }
 
+/// COMMUNITIES values as received, whichever Partial flavour the sender used.
+/// Peers that set the RFC 4271 Partial bit on transitive attributes decode to
+/// `CommunitiesPartial`; matching the bare variant alone read an empty slice
+/// and stalled generation tracking against them.
+fn observed_communities(attributes: &[PathAttribute]) -> &[u32] {
+    attributes
+        .iter()
+        .find_map(PathAttribute::communities)
+        .unwrap_or(&[])
+}
+
 fn observe_generation(
     progress: &mut GenerationProgress,
     expected_community: u32,
@@ -924,14 +935,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<Stub, String> {
                         if !parsed.announced.is_empty() {
                             // Borrow the communities out of the single parse;
                             // clone once only to store the last-seen sample.
-                            let communities: &[u32] = parsed
-                                .attributes
-                                .iter()
-                                .find_map(|attribute| match attribute {
-                                    PathAttribute::Communities(c) => Some(c.as_slice()),
-                                    _ => None,
-                                })
-                                .unwrap_or(&[]);
+                            let communities = observed_communities(&parsed.attributes);
                             *ob.last_comms.lock().unwrap() = communities.to_vec();
                             if communities.contains(&COMMUNITY_STABLE) {
                                 ob.stable_marker_seen_at_us.store(t_us, Ordering::Release);
@@ -2938,6 +2942,47 @@ mod tests {
         assert_eq!(
             progress.first_marker_base_at_us, None,
             "a new generation must not inherit first-output evidence"
+        );
+    }
+
+    #[test]
+    fn generation_progress_reads_partial_flagged_communities() {
+        // BIRD sets the RFC 4271 Partial bit on transit routes (flags 0xe0),
+        // so COMMUNITIES decodes to `CommunitiesPartial`. Both flavours must
+        // drive generation progress identically or the harness reports a
+        // false reload stall against a daemon that re-advertised correctly.
+        let announced = [base_prefix(7)];
+        let mut observed = Vec::new();
+
+        for attribute in [
+            PathAttribute::Communities(vec![COMMUNITY_GEN_B]),
+            PathAttribute::CommunitiesPartial(vec![COMMUNITY_GEN_B]),
+        ] {
+            let attributes = vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath { segments: vec![] }),
+                attribute,
+            ];
+            let communities = observed_communities(&attributes);
+            assert_eq!(communities, [COMMUNITY_GEN_B]);
+
+            let mut progress = GenerationProgress::default();
+            progress.reset(128, 1, 100, 27);
+            observe_generation(
+                &mut progress,
+                COMMUNITY_GEN_B,
+                communities,
+                announced.iter().copied(),
+                128,
+                20,
+            );
+            observed.push((progress.unique, progress.first_marker_base_at_us));
+        }
+
+        assert_eq!(observed[0], (1, Some(20)));
+        assert_eq!(
+            observed[0], observed[1],
+            "Partial-flagged COMMUNITIES must be observed like the bare variant"
         );
     }
 

--- a/bench/scale/rrtransport/src/rr1000.rs
+++ b/bench/scale/rrtransport/src/rr1000.rs
@@ -534,14 +534,11 @@ mod tests {
 
     fn assert_exact_communities(routes: &[Route], expected: u32) {
         for route in routes {
-            let mut communities = route.attributes.iter().filter_map(|attribute| {
-                if let PathAttribute::Communities(values) = attribute {
-                    Some(values)
-                } else {
-                    None
-                }
-            });
-            assert_eq!(communities.next().unwrap().as_slice(), [expected]);
+            let mut communities = route
+                .attributes
+                .iter()
+                .filter_map(PathAttribute::communities);
+            assert_eq!(communities.next().unwrap(), [expected]);
             assert!(communities.next().is_none());
         }
     }


### PR DESCRIPTION
## Problem

`e1163f89 fix(wire): preserve Partial on typed transitive attributes (#1990)` (v0.67.0) split five transitive path attributes by the RFC 4271 Partial flag: `Communities`/`CommunitiesPartial`, and likewise for `ExtendedCommunities`, `LargeCommunities`, `OnlyToCustomer`, and `PmsiTunnel`. Two bench readers still matched only the bare variant, so a Partial-flagged attribute fell through to the catch-all arm.

BIRD 3.3.1 sets Partial on transit routes — `flags=0xe0` on the wire, where rustbgpd and OpenBGPD 9.1 send `0xc0`. Against BIRD the reload-stall harness therefore read an empty community slice, `observe_generation` returned early because the expected generation community was never found, and the reload-completion bitmap never advanced. The BIRD cell of the IXP matrix reported `reload 1 STALLED: no re-advertisement progress for 600s` with `observers_complete 0/700` against a daemon that had in fact reconfigured and re-exported correctly.

Startup convergence still passed, because it is driven by a separate flap bitmap that never inspects communities. That asymmetry is what made an instrument defect present as a reload-specific daemon defect.

## Fix

Both reads now go through `PathAttribute::communities()`, the accessor documented as returning the RFC 1997 values independent of the received Partial bit:

- `bench/scale/reloadstall/src/main.rs` — the per-UPDATE read moves into a named `observed_communities` helper so it is reachable from tests.
- `bench/scale/rrtransport/src/rr1000.rs` — `assert_exact_communities`.

A sweep of `bench/` for the other four variant families found no further read sites; the remaining `PathAttribute` uses there construct attributes to send, which the split does not affect.

## Coverage

`generation_progress_rejects_stale_policy_markers` passed a hand-built `&[u32]` straight to `observe_generation` and never constructed a `PathAttribute`, so it could not observe the decode split. The new `generation_progress_reads_partial_flagged_communities` builds real attribute lists and asserts that a Partial-flagged COMMUNITIES carrying the expected generation drives identical progress to the non-Partial variant. It fails against the bare-variant match and passes with the accessor.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked` green on both the `reloadstall` and `rrtransport` manifests (`bench/scale` is a separate workspace from the root one), plus root-workspace `cargo fmt --all -- --check`.