### PR TITLE
ci: enforce release source-to-proof mappings

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -391,6 +391,26 @@ for that review.
 
 ### Interop smoke (requires Docker + containerlab)
 
+The following source-to-proof map is a release contract, not a summary of the
+hosted workflow. `scripts/check_release_checklist_paths.py` validates both the
+owner-to-proof assignments and the proof source paths. These owners cross
+module boundaries: changing the shared drain primitive requires both drain
+proofs, while changing the segment actor requires the DF-election proof and
+both drain proofs. The hosted `Kernel Dataplane` workflow's unfiltered manual
+dispatch remains the defense-in-depth full sweep.
+
+| Source owner | Required release proofs |
+| --- | --- |
+| `src/evpn_es_drain.rs` | M66, M67 |
+| `src/evpn_es_link_drain.rs` | M67 |
+| `src/evpn_segment.rs` | M38, M66, M67 |
+
+| Release proof | Topology | Assertion script |
+| --- | --- | --- |
+| `M38` | `tests/interop/m38-evpn-df-election.clab.yml` | `tests/interop/scripts/test-m38-evpn-df-election.sh` |
+| `M66` | `tests/interop/m66-evpn-es-drain-handover.clab.yml` | `tests/interop/scripts/test-m66-evpn-es-drain-handover.sh` |
+| `M67` | `tests/interop/m67-evpn-link-drain-failover.clab.yml` | `tests/interop/scripts/test-m67-evpn-link-drain-failover.sh` |
+
 Run at least one from each category:
 
 ```bash
@@ -417,7 +437,12 @@ bash tests/interop/scripts/test-m18-extnexthop-frr.sh
 containerlab destroy -t tests/interop/m18-extnexthop-frr.clab.yml
 ```
 
-If the release includes recent LLGR changes, also run:
+If the release touches LLGR capability, negotiation, retained-route lifecycle,
+or outbound rewriting (`crates/wire/src/capability.rs`,
+`crates/fsm/src/config.rs`, `crates/fsm/src/negotiation.rs`,
+`crates/rib/src/manager/graceful_restart.rs`,
+`crates/rib/src/manager/peer_lifecycle.rs`, or
+`crates/transport/src/session/export.rs`), also run:
 
 ```bash
 containerlab deploy -t tests/interop/m16-llgr-frr.clab.yml
@@ -486,11 +511,18 @@ M37+IP. If the release touches **Gate 8 / 8b** (Type 1/4 origination
 in `crates/evpn/src/origination_es.rs`, DF election in
 `crates/evpn/src/df_election.rs`, ESI Label / ES-Import RT extcomms,
 aliasing in `crates/evpn/src/aliasing.rs`, mass-withdraw in
-`crates/evpn/src/mass_withdraw.rs`, or BUM-port enforcement), run M38
+`crates/evpn/src/mass_withdraw.rs`, or BUM-port intent/enforcement in
+`crates/evpn/src/dataplane.rs`, `src/evpn_dataplane.rs`,
+`src/evpn_segment.rs`,
+`crates/evpn-linux/src/bum_filter.rs`,
+`crates/evpn-linux/src/enforcement.rs`, or
+`crates/evpn-linux/src/reconcile.rs`), run M38
 to validate DF election + Type 1/4 origination against a peer running
-the same code. If the release touches **Gate 9 / ADR-0059 / ADR-0087 /
-ADR-0090** (IP-VRF, Type 5, L3 FIB programming, overlay-index
-recursion/origination, aliasing ECMP, or FDB nexthop groups), run the hosted
+the same code; the source-to-proof map above adds M66/M67 where the daemon
+owner also crosses a drain boundary. If the release touches **Gate 9 /
+ADR-0059 / ADR-0087 / ADR-0090** (IP-VRF, Type 5, L3 FIB programming,
+overlay-index recursion/origination, aliasing ECMP, or FDB nexthop groups),
+run the hosted
 `Kernel Dataplane` workflow for M39, M40, M68, M71, and future M72 as
 appropriate. If it touches
 **ADR-0089 VLAN-aware bridge or SVD programming**, also require M70 plus

--- a/scripts/check_release_checklist_paths.py
+++ b/scripts/check_release_checklist_paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Assert every repo path named in docs/RELEASE_CHECKLIST.md exists in the tree.
+"""Validate release-checklist paths and source-to-proof trigger ownership.
 
 A trigger list that names a path which no longer exists never fires: the
 release gate it guards silently passes. This extracts every path-shaped
@@ -7,6 +7,11 @@ token from the document -- backticked prose paths in the trigger lists, and
 bare paths inside the fenced reproduction blocks -- and checks each against
 the working tree. Bare tokens are read only inside fenced code blocks, so
 prose such as "docs/test improvements" is not mistaken for a path.
+
+Path existence alone cannot catch an owner that is absent from the trigger
+list or points at the wrong proof. The two release-proof tables therefore
+carry a small, machine-checked semantic contract for the cross-module EVPN
+Ethernet Segment owners whose regressions require M38, M66, and/or M67.
 """
 
 from __future__ import annotations
@@ -24,8 +29,37 @@ GENERATED_PATH_PREFIX_SOURCES = {"share/systemd/": "examples/systemd/"}
 BACKTICKED = re.compile(r"`([^`\s]+)`")
 BARE = re.compile(rf"(?<![\w/`.-])({ROOTS}/[\w./-]*[\w/])")
 IS_PATH = re.compile(rf"^{ROOTS}/")
+REPOSITORY_PATH = re.compile(rf"^{ROOTS}/[\w./-]*[\w/]$")
 
 DOCUMENT = Path("docs") / "RELEASE_CHECKLIST.md"
+OWNER_PROOF_HEADER = "| Source owner | Required release proofs |"
+PROOF_SOURCE_HEADER = "| Release proof | Topology | Assertion script |"
+
+# Keep this deliberately narrow: these daemon owners cross the DF-election,
+# operator-drain, and link-drain proof boundaries. Adding a new owner or proof
+# is a reviewable change to both the checklist and this contract, rather than a
+# heuristic inferred from prose.
+REQUIRED_OWNER_PROOFS = {
+    "src/evpn_es_drain.rs": frozenset({"M66", "M67"}),
+    "src/evpn_es_link_drain.rs": frozenset({"M67"}),
+    "src/evpn_segment.rs": frozenset({"M38", "M66", "M67"}),
+}
+REQUIRED_PROOF_SOURCES = {
+    "M38": (
+        "tests/interop/m38-evpn-df-election.clab.yml",
+        "tests/interop/scripts/test-m38-evpn-df-election.sh",
+    ),
+    "M66": (
+        "tests/interop/m66-evpn-es-drain-handover.clab.yml",
+        "tests/interop/scripts/test-m66-evpn-es-drain-handover.sh",
+    ),
+    "M67": (
+        "tests/interop/m67-evpn-link-drain-failover.clab.yml",
+        "tests/interop/scripts/test-m67-evpn-link-drain-failover.sh",
+    ),
+}
+PROOF_ID = re.compile(r"\bM\d+\b")
+PROOF_LIST = re.compile(r"M\d+(?:,\s*M\d+)*")
 
 
 def named_paths(document: str) -> dict[str, list[int]]:
@@ -53,6 +87,152 @@ def named_paths(document: str) -> dict[str, list[int]]:
     return found
 
 
+def table_rows(
+    document: str, header: str, columns: int
+) -> tuple[list[tuple[int, list[str]]], list[str]]:
+    """Return rows from the one Markdown table introduced by `header`."""
+    lines = document.splitlines()
+    matches = [index for index, line in enumerate(lines) if line.strip() == header]
+    if len(matches) != 1:
+        return [], [
+            f"{DOCUMENT.as_posix()} must contain exactly one `{header}` table "
+            f"header; found {len(matches)}"
+        ]
+
+    header_index = matches[0]
+    if header_index + 1 >= len(lines) or not re.fullmatch(
+        rf"\|(?:\s*:?-+:?\s*\|){{{columns}}}", lines[header_index + 1].strip()
+    ):
+        return [], [
+            f"{DOCUMENT.as_posix()}:{header_index + 2} has a malformed separator "
+            f"for the `{header}` table"
+        ]
+
+    rows = []
+    for index in range(header_index + 2, len(lines)):
+        line = lines[index].strip()
+        if not line.startswith("|"):
+            break
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) != columns:
+            return [], [
+                f"{DOCUMENT.as_posix()}:{index + 1} has {len(cells)} columns in "
+                f"the `{header}` table; expected {columns}"
+            ]
+        rows.append((index + 1, cells))
+    if not rows:
+        return [], [
+            f"{DOCUMENT.as_posix()}:{header_index + 1} has no rows under "
+            f"the `{header}` table"
+        ]
+    return rows, []
+
+
+def release_proof_errors(document: str) -> list[str]:
+    """Validate the checklist's semantic owner-to-proof contract."""
+    owner_rows, errors = table_rows(document, OWNER_PROOF_HEADER, 2)
+    proof_rows, proof_errors = table_rows(document, PROOF_SOURCE_HEADER, 3)
+    errors.extend(proof_errors)
+    if errors:
+        return errors
+
+    owner_proofs: dict[str, tuple[int, frozenset[str]]] = {}
+    for line, cells in owner_rows:
+        owner_match = re.fullmatch(r"`([^`]+)`", cells[0])
+        proofs = frozenset(PROOF_ID.findall(cells[1]))
+        if owner_match is None or not REPOSITORY_PATH.fullmatch(
+            owner_match.group(1)
+        ):
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{line} release-proof owner must be one "
+                "backticked repository-source path"
+            )
+            continue
+        owner = owner_match.group(1)
+        if not PROOF_LIST.fullmatch(cells[1]):
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{line} release-proof owner `{owner}` "
+                "must use a comma-separated M-number proof list"
+            )
+        if owner in owner_proofs:
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{line} duplicates release-proof owner `{owner}`"
+            )
+            continue
+        owner_proofs[owner] = (line, proofs)
+
+    proof_sources: dict[str, tuple[int, tuple[str, str]]] = {}
+    for line, cells in proof_rows:
+        proof_match = re.fullmatch(r"`(M\d+)`", cells[0])
+        topology_match = re.fullmatch(r"`([^`]+)`", cells[1])
+        script_match = re.fullmatch(r"`([^`]+)`", cells[2])
+        if (
+            proof_match is None
+            or topology_match is None
+            or script_match is None
+            or not REPOSITORY_PATH.fullmatch(topology_match.group(1))
+            or not REPOSITORY_PATH.fullmatch(script_match.group(1))
+        ):
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{line} proof-source rows require a "
+                "backticked M-number, topology path, and assertion-script path"
+            )
+            continue
+        proof = proof_match.group(1)
+        if proof in proof_sources:
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{line} duplicates release proof `{proof}`"
+            )
+            continue
+        proof_sources[proof] = (
+            line,
+            (topology_match.group(1), script_match.group(1)),
+        )
+
+    for owner, required in REQUIRED_OWNER_PROOFS.items():
+        mapping = owner_proofs.get(owner)
+        if mapping is None:
+            errors.append(
+                f"{DOCUMENT.as_posix()} is missing required release-proof owner "
+                f"mapping for `{owner}`"
+            )
+            continue
+        line, actual = mapping
+        missing = sorted(required - actual)
+        if missing:
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{line} release-proof owner `{owner}` is "
+                f"missing required proofs: {', '.join(missing)}"
+            )
+
+    referenced_proofs = set().union(
+        *(proofs for _, proofs in owner_proofs.values())
+    )
+    for proof in sorted(referenced_proofs):
+        if proof not in proof_sources:
+            errors.append(
+                f"{DOCUMENT.as_posix()} release-proof owner mapping references "
+                f"`{proof}` without a proof-source row"
+            )
+
+    for proof, required_sources in REQUIRED_PROOF_SOURCES.items():
+        source_mapping = proof_sources.get(proof)
+        if source_mapping is None:
+            errors.append(
+                f"{DOCUMENT.as_posix()} is missing required proof-source mapping "
+                f"for `{proof}`"
+            )
+            continue
+        line, actual_sources = source_mapping
+        if actual_sources != required_sources:
+            errors.append(
+                f"{DOCUMENT.as_posix()}:{line} proof-source mapping for `{proof}` "
+                f"must be `{required_sources[0]}` and `{required_sources[1]}`"
+            )
+
+    return errors
+
+
 def check(root: Path) -> tuple[int, list[str]]:
     """Return (paths checked, errors) for the checklist under `root`."""
     document = (root / DOCUMENT).read_text(encoding="utf-8")
@@ -62,7 +242,7 @@ def check(root: Path) -> tuple[int, list[str]]:
             f"no paths were extracted from {DOCUMENT.as_posix()}, "
             "so the parse is broken"
         ]
-    errors = []
+    errors = release_proof_errors(document)
     for token, lines in sorted(found.items()):
         if not (root / token.rstrip("/")).exists():
             where = ",".join(str(number) for number in lines)

--- a/scripts/test_check_release_checklist_paths.py
+++ b/scripts/test_check_release_checklist_paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Mutation proofs for the release-checklist path-existence gate."""
+"""Mutation proofs for release-checklist path and proof-mapping gates."""
 
 import subprocess
 import sys
@@ -12,6 +12,18 @@ CHECKER = ROOT / "scripts" / "check_release_checklist_paths.py"
 
 CHECKLIST = """\
 # Release checklist
+
+| Source owner | Required release proofs |
+| --- | --- |
+| `src/evpn_es_drain.rs` | M66, M67 |
+| `src/evpn_es_link_drain.rs` | M67 |
+| `src/evpn_segment.rs` | M38, M66, M67 |
+
+| Release proof | Topology | Assertion script |
+| --- | --- | --- |
+| `M38` | `tests/interop/m38-evpn-df-election.clab.yml` | `tests/interop/scripts/test-m38-evpn-df-election.sh` |
+| `M66` | `tests/interop/m66-evpn-es-drain-handover.clab.yml` | `tests/interop/scripts/test-m66-evpn-es-drain-handover.sh` |
+| `M67` | `tests/interop/m67-evpn-link-drain-failover.clab.yml` | `tests/interop/scripts/test-m67-evpn-link-drain-failover.sh` |
 
 If the release touches the parser (`src/parser.rs`) or the
 originator (`src/evpn_originator/`), run M-01:
@@ -34,10 +46,19 @@ These path-shaped tokens are not repository paths: `RibService/SetFibTable`,
 """
 
 FIXTURE_PATHS = (
+    "src/evpn_es_drain.rs",
+    "src/evpn_es_link_drain.rs",
+    "src/evpn_segment.rs",
     "src/parser.rs",
     "src/evpn_originator/",
     "tests/interop/m01.clab.yml",
+    "tests/interop/m38-evpn-df-election.clab.yml",
+    "tests/interop/m66-evpn-es-drain-handover.clab.yml",
+    "tests/interop/m67-evpn-link-drain-failover.clab.yml",
     "tests/interop/scripts/test-m01.sh",
+    "tests/interop/scripts/test-m38-evpn-df-election.sh",
+    "tests/interop/scripts/test-m66-evpn-es-drain-handover.sh",
+    "tests/interop/scripts/test-m67-evpn-link-drain-failover.sh",
     "proto/rustbgpd.proto",
     "tools/rs-config-render/",
     ".cargo/config.toml",
@@ -78,6 +99,43 @@ class ReleaseChecklistPathTests(unittest.TestCase):
         """Passes with recognized paths present; prose tokens are not extracted."""
         result = self.run_checker(CHECKLIST, FIXTURE_PATHS)
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_fails_when_required_owner_mapping_is_removed(self) -> None:
+        """Fails when a source owner disappears while its proof paths remain."""
+        checklist = CHECKLIST.replace(
+            "| `src/evpn_es_link_drain.rs` | M67 |\n", ""
+        )
+        result = self.run_checker(checklist, FIXTURE_PATHS)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "missing required release-proof owner mapping for "
+            "`src/evpn_es_link_drain.rs`",
+            result.stderr,
+        )
+
+    def test_fails_when_required_owner_proof_is_removed(self) -> None:
+        """Fails when an owner silently drops one of its required proofs."""
+        checklist = CHECKLIST.replace(
+            "| `src/evpn_segment.rs` | M38, M66, M67 |",
+            "| `src/evpn_segment.rs` | M38, M66 |",
+        )
+        result = self.run_checker(checklist, FIXTURE_PATHS)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "release-proof owner `src/evpn_segment.rs` is missing required "
+            "proofs: M67",
+            result.stderr,
+        )
+
+    def test_fails_when_proof_source_mapping_is_changed(self) -> None:
+        """Fails when an M-number is repointed at a different existing proof."""
+        checklist = CHECKLIST.replace(
+            "`tests/interop/m67-evpn-link-drain-failover.clab.yml`",
+            "`tests/interop/m66-evpn-es-drain-handover.clab.yml`",
+        )
+        result = self.run_checker(checklist, FIXTURE_PATHS)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("proof-source mapping for `M67` must be", result.stderr)
 
     def test_non_repository_path_tokens_stay_excluded(self) -> None:
         """Path-shaped API, image, action, and download tokens stay out."""


### PR DESCRIPTION
## Summary

- make the EVPN Ethernet Segment source-to-proof mapping explicit in the release checklist
- validate required M38/M66/M67 ownership and proof source paths in the existing checklist checker
- add mutation tests for removed owners, missing proofs, and repointed proof sources

## Validation

- python3 scripts/test_check_release_checklist_paths.py (12 tests)
- python3 scripts/check_release_checklist_paths.py (118 paths)
- git diff --check
- repository pre-commit checks