### PR TITLE
feat(rpki): prepare independent 0.1.0 publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # Need history so the wire-readme freshness gate can diff
+          # Need history so the published-crate README freshness gate can diff
           # against the previous commit / PR base.
           fetch-depth: 0
       - name: Check CI trigger contract
@@ -268,16 +268,11 @@ jobs:
             docs/perf/event-history-host-fence.sh \
             docs/perf/test-event-history-host-fence.sh \
             docs/perf/test-event-history-naming.sh
-      - name: Wire crate README freshness gate
-        # Catches the common omission where someone bumps
-        # `crates/wire/Cargo.toml` version without revisiting
-        # `crates/wire/README.md`. The README is what crates.io and
-        # docs.rs render, so a stale RFC table or stale "Key types"
-        # list ships to every consumer of the published crate.
-        # If wire's version line moved in this diff, require any
-        # touch to its README. A whitespace-only edit is acceptable
-        # if the README really is current — the gate's purpose is to
-        # force a deliberate review, not to enforce content shape.
+      - name: Published crate README freshness gate
+        # A published crate's README is its crates.io landing page and the
+        # repository usage guide. If an independently versioned library moves,
+        # require a deliberate review of its RFC table, key-type roster, and
+        # examples.
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -290,15 +285,17 @@ jobs:
             echo "no diff base; skipping"
             exit 0
           fi
-          if git diff "$base"...HEAD -- crates/wire/Cargo.toml \
-              | grep -qE '^\+version\s*='; then
-            if ! git diff "$base"...HEAD -- crates/wire/README.md \
-                | grep -qE '^[+-]'; then
-              echo "::error file=crates/wire/Cargo.toml::wire crate version was bumped but crates/wire/README.md was not touched. Update the RFC table / Key types / examples to reflect what's actually published, then re-push. (A whitespace-only edit is fine if the README really is current.)"
-              exit 1
+          for crate in wire fsm rpki; do
+            if git diff "$base"...HEAD -- "crates/$crate/Cargo.toml" \
+                | grep -qE '^\+version\s*='; then
+              if ! git diff "$base"...HEAD -- "crates/$crate/README.md" \
+                  | grep -qE '^[+-]'; then
+                echo "::error file=crates/$crate/Cargo.toml::$crate crate version was bumped but crates/$crate/README.md was not touched. Update its RFC / key-type / example contract to reflect what is actually published, then re-push."
+                exit 1
+              fi
+              echo "$crate bump + README touched — gate passed"
             fi
-            echo "wire bump + README touched — gate passed"
-          fi
+          done
 
   core_tests:
     name: core tests / rustdoc

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -2,9 +2,11 @@ name: semver-checks
 
 # Guards the crates.io-published library crates against an accidental API
 # break. The crate set is re-derived on every run from the workspace: every
-# member whose manifest does NOT carry `publish = false` (today
-# `rustbgpd-wire` and `rustbgpd-fsm`) is checked with cargo-semver-checks
-# against its latest published version.
+# member whose manifest does NOT carry `publish = false` is checked with
+# cargo-semver-checks against its latest published version. The one exact
+# first-publish boundary (`rustbgpd-rpki 0.1.0`) is omitted only while crates.io
+# returns 404 for that name; the checked set picks it up automatically as soon
+# as the normal release is registry-visible.
 #
 # Baseline: no `baseline-version` / `baseline-rev` / `baseline-root` input is
 # passed on purpose. cargo-semver-checks then uses its default baseline — the
@@ -31,7 +33,10 @@ on:
     paths:
       - "crates/wire/**"
       - "crates/fsm/**"
+      - "crates/rpki/**"
       - ".github/workflows/semver-checks.yml"
+      - "scripts/check_semver_publishable_crates.py"
+      - "scripts/test_check_semver_publishable_crates.py"
   workflow_dispatch:
 
 jobs:
@@ -40,31 +45,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+      - name: Test publishable-crate derivation
+        run: python3 -m unittest -v scripts/test_check_semver_publishable_crates.py
       - name: Derive the publishable crate set
         id: publishable
         shell: bash
         run: |
           set -euo pipefail
           cargo metadata --locked --no-deps --format-version 1 > "$RUNNER_TEMP/metadata.json"
-          python3 - "$RUNNER_TEMP/metadata.json" .github/workflows/semver-checks.yml <<'PY' \
+          python3 scripts/check_semver_publishable_crates.py \
+            "$RUNNER_TEMP/metadata.json" .github/workflows/semver-checks.yml \
             | tee -a "$GITHUB_OUTPUT"
-          import json, os, sys
-          meta = json.load(open(sys.argv[1]))
-          root = meta["workspace_root"]
-          publishable = sorted(
-              (p["name"], os.path.relpath(os.path.dirname(p["manifest_path"]), root))
-              for p in meta["packages"]
-              if p["publish"] is None
-          )
-          if not publishable:
-              sys.exit("no publishable crate found; did every manifest gain publish = false?")
-          filter_text = open(sys.argv[2]).read()
-          missing = [d for _, d in publishable if f'- "{d}/**"' not in filter_text]
-          if missing:
-              sys.exit(f"publishable crate dirs missing from the pull_request paths filter: {missing}")
-          print("publishable:", ", ".join(f"{n} ({d})" for n, d in publishable), file=sys.stderr)
-          print("packages=" + ",".join(n for n, _ in publishable))
-          PY
       - uses: obi1kenobi/cargo-semver-checks-action@v2.9
         with:
           package: ${{ steps.publishable.outputs.packages }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Prepare `rustbgpd-rpki 0.1.0` as the third independently published library
+  crate, with its current root and module API documented as the complete
+  `0.1.x` compatibility boundary. The package includes a compiled origin
+  validation example, an explicit Tokio/plain-TCP RTR boundary, and a
+  registry-aware CI bootstrap that begins semver checking automatically once
+  the first normal crates.io release is visible.
+
 ### Fixed
 
 - Settlement-owned live policy changes no longer treat one missed 100 ms

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.67.0"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "rustbgpd-wire",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rustbgpd-rib = { path = "crates/rib", version = "0.67.0" }
 rustbgpd-policy = { path = "crates/policy", version = "0.67.0" }
 rustbgpd-api = { path = "crates/api", version = "0.67.0" }
 rustbgpd-telemetry = { path = "crates/telemetry", version = "0.67.0" }
-rustbgpd-rpki = { path = "crates/rpki", version = "0.67.0" }
+rustbgpd-rpki = { path = "crates/rpki", version = "0.1.0" }
 rustbgpd-bmp = { path = "crates/bmp", version = "0.67.0" }
 rustbgpd-mrt = { path = "crates/mrt", version = "0.67.0" }
 rustbgpd-evpn = { path = "crates/evpn", version = "0.67.0" }

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.67.0"
+version = "0.1.0"
 dependencies = [
  "rustbgpd-wire",
  "rustc-hash",

--- a/crates/rpki/CHANGELOG.md
+++ b/crates/rpki/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+This changelog covers the independently published `rustbgpd-rpki` crate.
+Daemon and workspace changes remain in the repository-level `CHANGELOG.md`.
+
+## Unreleased
+
+## 0.1.0 - 2026-08-27
+
+- Initial independent crate release with immutable VRP and ASPA tables, RFC
+  6811 origin validation, role-aware ASPA path verification, a bounded RTR
+  client, and multi-cache snapshot management.
+- Established the `0.1.x` public boundary across both the crate-root facade and
+  the public module paths, including the raw RTR PDU codec. Breaking Rust API
+  or incompatible public wire-type changes require `0.2.0`.
+- Documented the Tokio runtime boundary, direct dependency set, plain-TCP RTR
+  transport, supported RFC/draft scope, and the separation between standalone
+  validation capabilities and rustbgpd daemon integration.

--- a/crates/rpki/Cargo.toml
+++ b/crates/rpki/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-publish = false
 name = "rustbgpd-rpki"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -1,39 +1,115 @@
 # rustbgpd-rpki
 
-RPKI origin validation and ASPA path verification for rustbgpd — VRP
-table, ASPA table, RTR protocol client, and multi-cache management.
+RPKI origin validation, ASPA path verification, an RTR protocol client, and
+multi-cache table management for Rust applications.
 
-Part of [rustbgpd](https://github.com/lance0/rustbgpd).
+Part of [rustbgpd](https://github.com/lance0/rustbgpd). Requires Rust 1.95 or
+newer. Release-by-release crate changes are recorded in the
+[changelog](CHANGELOG.md).
 
-## Features
+## What this crate provides
 
-- **VRP table** with a family-split, prefix-length-bucketed index (one binary
-  search per ancestor length over masked networks) for ~constant-time RFC 6811
-  origin validation; `Arc<VrpTable>` snapshot pattern for lock-free reads
-- **RTR client** (RFC 8210 / draft-ietf-sidrops-8210bis) — prefers RTR
-  protocol v2 for ASPA, falls back to v1 on server rejection; persistent TCP
-  sessions, Serial Query / Reset Query, Serial Notify handling,
-  `expire_interval` enforcement. `RtrClientConfig::max_expire_interval` adds an
+- **VRP table** — a synchronous, immutable `VrpTable` for RFC 6811 origin
+  validation.
+- **RTR client** — an asynchronous client that prefers the ASPA-capable
+  protocol v2 shape and falls back to RFC 8210 version 1 when the cache
+  explicitly rejects v2. `RtrClientConfig::max_expire_interval` adds an
   optional operator freshness ceiling: it clamps both the configured
   `expire_interval` and a cache-advertised End of Data expire down, never raises
   a lower value, and when unset leaves the configured interval unchanged while
   cache-advertised values retain the protocol ceiling. The crate exports the
   RFC 8210 two-day ceiling as `RTR_EXPIRE_MAX_SECS` (`172800` seconds).
-- **ASPA path verification** — ASPA table + AS_PATH verification per
-  draft-ietf-sidrops-aspa-verification (§6.2), fed over RTR v2
-- **Multi-cache merge** — `VrpManager` combines VRPs from multiple cache
-  servers into a single authoritative table
-- **Best-path integration** — Valid > NotFound > Invalid at step 0.5
-  (between stale demotion and LOCAL_PREF)
-- **Policy matching** — `match_rpki_validation` in policy statements
+- **ASPA path verification** — a synchronous `AspaTable` plus role-aware path
+  verification.
+- **Multi-cache merge** — a `VrpManager` that merges retained contributions
+  from multiple RTR caches and publishes immutable VRP and ASPA snapshots.
 
-## Key types
+The standalone crate does not select BGP best paths or evaluate rustbgpd policy
+statements. In the daemon, `rustbgpd-rib` consumes these validation results in
+best-path selection and `rustbgpd-policy` exposes validation match conditions;
+those are workspace integrations, not capabilities supplied by this package.
 
-- **`VrpEntry`** — prefix, max_length, origin ASN
-- **`VrpTable`** — prefix-length-indexed VRP store with `validate(prefix, origin_asn)` lookup
-- **`AspaTable`** / **`AspaRecord`** — ASPA lookup table and a single ASPA record (customer → providers)
-- **`RtrClient`** — async per-cache RTR session
-- **`VrpManager`** — multi-cache merge and distribution to RIB
+The crate's direct dependency set is `rustbgpd-wire`, `smallvec`, `thiserror`,
+`tokio`, `tracing`, and `rustc-hash`. Table construction and validation are
+synchronous. `RtrClient` and `VrpManager` require a Tokio runtime.
+
+## Usage
+
+Origin validation uses prefix and validation-state types from the independently
+published wire crate:
+
+```toml
+[dependencies]
+rustbgpd-rpki = "0.1.0"
+rustbgpd-wire = "0.18.0"
+```
+
+```rust
+use std::net::{IpAddr, Ipv4Addr};
+
+use rustbgpd_rpki::{VrpEntry, VrpTable};
+use rustbgpd_wire::{Ipv4Prefix, Prefix, RpkiValidation};
+
+let table = VrpTable::new(vec![VrpEntry {
+    prefix: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)),
+    prefix_len: 24,
+    max_len: 24,
+    origin_asn: 64_496,
+}]);
+let route = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+
+assert_eq!(table.validate(&route, 64_496), RpkiValidation::Valid);
+```
+
+The same public-API walkthrough is kept compiling as an in-tree example:
+
+```sh
+cargo run -p rustbgpd-rpki --example origin_validation
+```
+
+Applications that run `RtrClient` or `VrpManager` also need Tokio features for
+their chosen runtime and for `tokio::sync::mpsc`. The client owns no runtime; it
+runs inside the task the application supplies.
+
+## Protocol support
+
+| Specification | Implemented scope |
+|---|---|
+| RFC 1982 | Serial-number ordering for incremental RTR epochs. |
+| RFC 6482 | Validated ROA Payload prefix, maximum-length, and origin-AS semantics. |
+| RFC 6811 | `Valid`, `Invalid`, and `NotFound` origin validation over every covering VRP. |
+| RFC 8210 | RTR version 1 client and PDU codec, including serial/reset synchronization and expiry. |
+| `draft-ietf-sidrops-8210bis` | Scoped RTR version 2 support for ASPA records, with v1 fallback. Router Key PDUs are not implemented. |
+| `draft-ietf-sidrops-aspa-verification-27` | Role-aware upstream/downstream ASPA path verification for IPv4 and IPv6 unicast. |
+
+RTR cache connections use plain TCP. TLS and SSH transports are not implemented.
+Transactions are bounded by time, record count, and byte count; validated data
+is retained across reconnects until replacement or expiry.
+
+## Public API boundary
+
+The crate-root facade exports the primary application surface:
+
+- `VrpEntry`, `VrpTable`, `AspaRecord`, and `AspaTable`
+- `AspaInvalidHop`, `AspaVerificationResult`, and `ValidationSnapshot`
+- `RtrClient`, `RtrClientConfig`, `VrpUpdate`, and `RTR_EXPIRE_MAX_SECS`
+- `VrpManager`, `RpkiTableUpdate`, and `AspaTableUpdate`
+
+The public modules are also part of the `0.1.x` API. They expose the advanced
+ASPA helpers (`ProviderAuth`, `verify`, `verify_detailed`, `verify_upstream`),
+the raw RTR PDU codec (`RtrPdu`, its version constants, `RtrDecodeError`, and
+`RtrEncodeError`), the client-side `RtrError`, and the module-qualified forms
+of the facade types. Publishing `0.1.0` freezes all of those public paths for
+the `0.1.x` compatibility line; they are not merely internal implementation
+details.
+
+## Compatibility
+
+This is an alpha `0.x` crate. Backward-compatible fixes and additions remain on
+the `0.1.x` line. Removing or changing public items requires `0.2.0`. Public
+method signatures use types from `rustbgpd-wire 0.18`; moving that dependency
+to an incompatible wire line also requires an RPKI minor-version bump so the
+shared types do not silently split in one dependency graph.
 
 ## License
 

--- a/crates/rpki/examples/origin_validation.rs
+++ b/crates/rpki/examples/origin_validation.rs
@@ -1,0 +1,17 @@
+use std::net::{IpAddr, Ipv4Addr};
+
+use rustbgpd_rpki::{VrpEntry, VrpTable};
+use rustbgpd_wire::{Ipv4Prefix, Prefix, RpkiValidation};
+
+fn main() {
+    let table = VrpTable::new(vec![VrpEntry {
+        prefix: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)),
+        prefix_len: 24,
+        max_len: 24,
+        origin_asn: 64_496,
+    }]);
+    let route = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+
+    assert_eq!(table.validate(&route, 64_496), RpkiValidation::Valid);
+    println!("{route} is valid for AS64496");
+}

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -2,9 +2,10 @@
 
 rustbgpd is not one crate; it is a layered workspace. The bottom layers are
 published as daemon-independent crates: a pure BGP message codec
-(`rustbgpd-wire`) and a pure RFC 4271 state machine (`rustbgpd-fsm`). They are
-consumable by Rust projects — monitors, analyzers, test harnesses, MRT readers,
-k8s sidecars, SDN controllers — without linking the daemon.
+(`rustbgpd-wire`), a pure RFC 4271 state machine (`rustbgpd-fsm`), and RPKI/RTR
+validation components (`rustbgpd-rpki`). They are consumable by Rust projects —
+monitors, analyzers, test harnesses, MRT readers, RPKI validators, k8s sidecars,
+and SDN controllers — without linking the daemon.
 
 This document is the contract for embedders: which crate to depend on, what the
 `pub use` boundary is, and what a minimal consumer looks like.
@@ -32,7 +33,7 @@ This document is the contract for embedders: which crate to depend on, what the
 | `rustbgpd-mrt` | Disabled | `rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-wire` | RFC 6396 MRT dump export. |
 | `rustbgpd-policy` | Disabled | `rustbgpd-wire` | Import/export policy engine. |
 | `rustbgpd-rib` | Disabled | `rustbgpd-bmp`, `rustbgpd-policy`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-wire` | Adj-RIB and Loc-RIB best-path data structures. |
-| `rustbgpd-rpki` | Disabled | `rustbgpd-wire` | VRP table, RTR client, and origin validation. |
+| `rustbgpd-rpki` | Enabled | `rustbgpd-wire` | VRP/ASPA tables, RTR client, and validation. |
 | `rustbgpd-telemetry` | Disabled | None | Prometheus metrics and structured tracing. |
 | `rustbgpd-transport` | Disabled | `rustbgpd-bmp`, `rustbgpd-fsm`, `rustbgpd-policy`, `rustbgpd-rib`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-wire` | Async TCP session runtime. |
 | `rustbgpd-wire` | Enabled | None | Pure BGP message encode/decode. |
@@ -40,13 +41,13 @@ This document is the contract for embedders: which crate to depend on, what the
 
 All Cargo workspace packages are listed. Internal dependencies include normal and build dependencies, including target-specific dependencies; dev dependencies are excluded.
 
-Only `rustbgpd-wire` and `rustbgpd-fsm` are registry-published releases from
-this workspace. `Disabled` means this repository's package manifest sets
-`publish = false`; it makes no claim about unrelated registry packages with a
-similar name. These workspace packages can still be consumed through git or
-path dependencies, including from outside this repository. A consumer that
-needs the daemon's gRPC surface can instead generate a client from the proto
-(§3.4).
+`rustbgpd-wire`, `rustbgpd-fsm`, and `rustbgpd-rpki` are registry-published
+releases from this workspace. `Disabled` means this repository's package
+manifest sets `publish = false`; it makes no claim about unrelated registry
+packages with a similar name. These workspace packages can still be consumed
+through git or path dependencies, including from outside this repository. A
+consumer that needs the daemon's gRPC surface can instead generate a client
+from the proto (§3.5).
 
 This map records the current workspace topology, not a publication sequence.
 Notably, `rustbgpd-rib` depends on `rustbgpd-bmp`; §4 discusses future
@@ -265,7 +266,42 @@ The FSM does not touch the network. It is `(State, Event) -> (State, Vec<Action>
 This makes it trivially testable and lets a sidecar plug in any transport
 (TCP, TLS, a Unix socket for tests, a virtual link in a simulator).
 
-### 3.4 What a "prefixd-class" consumer links
+### 3.4 Validate an origin (RPKI table — the synchronous consumer)
+
+An analyzer or policy controller that already has validated ROA payloads can
+construct an immutable table and classify a route without starting Tokio or an
+RTR session. The prefix and validation-state types are part of the published
+wire boundary, so consumers name both compatible crate lines directly.
+
+```toml
+# Cargo.toml
+[dependencies]
+rustbgpd-rpki = "0.1.0"
+rustbgpd-wire = "0.18.0"
+```
+
+```rust
+use std::net::{IpAddr, Ipv4Addr};
+
+use rustbgpd_rpki::{VrpEntry, VrpTable};
+use rustbgpd_wire::{Ipv4Prefix, Prefix, RpkiValidation};
+
+let table = VrpTable::new(vec![VrpEntry {
+    prefix: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)),
+    prefix_len: 24,
+    max_len: 24,
+    origin_asn: 64_496,
+}]);
+let route = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+assert_eq!(table.validate(&route, 64_496), RpkiValidation::Valid);
+```
+
+`RtrClient` and `VrpManager` are the asynchronous layer. They require a Tokio
+runtime and channels supplied by the application; RTR transport is plain TCP,
+not TLS or SSH. The crate README carries the complete runtime, protocol, and
+public-module boundary.
+
+### 3.5 What a "prefixd-class" consumer links
 
 A route-injection controller (the rustbgpd beachhead — an automation controller
 that originates and withdraws prefixes) has two viable shapes:
@@ -307,15 +343,16 @@ not want a full daemon in the loop (e.g. a minimal speaker in a constrained
 k8s pod) links `rustbgpd-wire` + `rustbgpd-fsm` and owns one or a few sessions.
 It does *not* get a RIB or best-path — it is a speaker, not a router. This is
 the gap Cilium fills by embedding GoBGP today. Links: `rustbgpd-wire` +
-`rustbgpd-fsm` + `tokio`. If it needs origin validation, add `rustbgpd-rpki`
-once that crate is published.
+`rustbgpd-fsm` + `tokio`. If it needs origin validation, add the published
+`rustbgpd-rpki 0.1` line with its compatible direct `rustbgpd-wire 0.18`
+dependency.
 
 ---
 
 ## 4. Which crate to publish next, and why
 
-**Status: `wire` → `fsm` are published; `rpki` is next; `rib`, `bmp`, `mrt`,
-and `policy` are later.**
+**Status: `wire`, `fsm`, and `rpki` are published; `rib`, `bmp`, `mrt`, and
+`policy` remain demand-gated.**
 
 1. **`rustbgpd-wire` (published as `0.18.0`).** This is the
    foundation — dependent crate versions cannot publish before their wire
@@ -432,15 +469,15 @@ and `policy` are later.**
      crate already has the forward-compat boundary: `PeerConfig`,
      `NegotiatedSession`, `Event`, and `Action` are `#[non_exhaustive]`.
 
-3. **`rustbgpd-rpki` (publish next).** Why:
-   - It depends only on `rustbgpd-wire` + `tokio` + `tracing` + `smallvec`.
-     No `rib`/`policy` edge.
-   - It is the natural third publish because a route-injecting sidecar that
-     wants origin validation needs exactly `wire + fsm + rpki` — nothing else.
-   - API stability required: `VrpTable`, `VrpEntry`, `RtrClient`,
-     `VrpManager`, `validate(prefix, asn)`. The `Arc<VrpTable>` snapshot pattern
-     is already lock-free and stable. The RTR client API (`RtrClient`) is
-     async and tokio-coupled — document the runtime requirement.
+3. **`rustbgpd-rpki` (published as `0.1.0`).** Why it is independent:
+   - Its direct dependencies are `rustbgpd-wire`, `tokio`, `tracing`,
+     `smallvec`, `thiserror`, and `rustc-hash`; it has no `rib`/`policy` edge.
+   - Synchronous `VrpTable` / `AspaTable` validation can be embedded without a
+     runtime. `RtrClient` and `VrpManager` are the explicitly Tokio-coupled
+     acquisition layer.
+   - The `0.1.x` compatibility boundary covers the crate-root facade and every
+     public module path, including the raw RTR PDU codec. Breaking Rust API or
+     an incompatible public wire-type move requires `0.2.0`.
 
 4. **Later: `rib`, `bmp`, `mrt`, `policy`.** These pull in heavier deps
    (`prefix-trie`, `ipnet`, `flate2`, `chrono`) and have more churn. Publish
@@ -462,7 +499,7 @@ and `policy` are later.**
 | 1 | **BGP test harness / fuzzer** (à la GoBGP's `internal/testing`, or a Rust peer for FRR interop CI) | Replays PCAPs/MRT, speaks BGP to a device under test, asserts on received UPDATEs | `rustbgpd-wire` (decode/encode), `rustbgpd-fsm` (drive a peer) | `decode_message`, `encode_message`, `Message`/`ParsedUpdate`, `Session::handle_event` | **Highest-leverage, lowest-friction.** Pure codec + pure FSM. No network state, no RIB. This is the crate's natural first friend — we should ship one in-tree as `examples/peer-loop/` to prove the embedding story. |
 | 2 | **MRT route collector / analyzer** (à la BGPKIT-parser use case, but with *encode* too) | Reads RFC 6396 dumps, decodes UPDATEs, builds reports; some also synthesize test traffic | `rustbgpd-wire` for decode; optionally `rustbgpd-mrt` later for the dump container | `decode_message`, `ParsedUpdate`, `PathAttribute`, `Prefix`, EVPN/FlowSpec/BGP-LS NLRI types | **Strong fit.** The wire crate already decodes everything BGPKIT-parser parses *plus* BGP-LS, ORF, PMSI, OTC. The gap is the MRT container — `rustbgpd-mrt` closes it but is not yet published. |
 | 3 | **k8s BGP sidecar / minimal speaker** (the Cilium-embeds-GoBGP niche, in Rust) | Advertises pod/service CIDRs to a top-of-rack router; needs a *speaker*, not a router | `rustbgpd-wire` + `rustbgpd-fsm` (+ `rustbgpd-rpki` for origin validation) | `Session`, `PeerConfig`, `Action`, `encode_message`, `VrpTable` | **Real but hard.** This is GoBGP's library-reach moat: Cilium embeds the full GoBGP library (not just the codec) to get a session runtime + RIB + policy. rustbgpd offers only codec+FSM as a library today; the sidecar would have to own the RIB-less "speaker" path itself. Honest: we are not displacing Cilium's GoBGP embedding in 2026; we are the option for a *Rust-native* sidecar that wants no CGo and a smaller blast radius. |
-| 4 | **RPKI validator / RTR cache client** (à la Routinator consumer, or a VRP-driven policy gate) | Maintains a VRP table from one or more RTR caches; validates origins | `rustbgpd-rpki` (`VrpTable`, `RtrClient`, `VrpManager`), `rustbgpd-wire` (`RpkiValidation`) | `VrpTable::validate`, `RtrClient` async session, `VrpManager` merge | **Good fit once `rpki` publishes.** The `RpkiValidation` enum already lives in `wire` (shared by rib/policy/transport), so the validation-state type is already stable. The RTR client is the novel value. |
+| 4 | **RPKI validator / RTR cache client** (à la Routinator consumer, or a VRP-driven policy gate) | Maintains a VRP table from one or more RTR caches; validates origins | `rustbgpd-rpki` (`VrpTable`, `RtrClient`, `VrpManager`), `rustbgpd-wire` (`RpkiValidation`) | `VrpTable::validate`, `RtrClient` async session, `VrpManager` merge | **Published fit.** Table validation is synchronous; cache acquisition and merging are Tokio-coupled. The validation-state type lives in the compatible wire line. |
 | 5 | **BMP monitor / telemetry sink** (à la OpenBMP, or a Rust BMP collector) | Receives RFC 7854 BMP messages, decodes per-peer UPDATEs, exports metrics | `rustbgpd-wire` (decode embedded UPDATEs), `rustbgpd-bmp` later | `decode_message`, `PathAttribute`, `MpReachNlri` | **Medium.** BMP message framing is small; the value is the embedded UPDATE decode, which `wire` already does. `rustbgpd-bmp` is the container/framing; publish it once a collector asks. |
 
 ---
@@ -508,12 +545,12 @@ To be the de facto Rust BGP codec, the concrete gaps:
 
 ## 7. Published-crate release boundary
 
-`rustbgpd-wire 0.18.0` and `rustbgpd-fsm 0.5.0` are published and are the
-versions the §3 dependency examples name. Both crates moved in the same
-release: the codec took the next 0.x compatibility line for its changed
-decode acceptance, and the FSM's public API re-exports codec types, so it
-took the paired breaking bump. Upgrade the two together. The ordering rules
-that govern every future publish are:
+`rustbgpd-wire 0.18.0`, `rustbgpd-fsm 0.5.0`, and `rustbgpd-rpki 0.1.0` are
+published and are the versions the §3 dependency examples name. The wire/FSM
+pair moved together because the FSM re-exports codec types. RPKI starts its own
+alpha line but also exposes wire types in public method signatures, so an
+incompatible wire move requires the corresponding RPKI compatibility-line
+bump. The ordering rules that govern future publishes are:
 
 - Publish `rustbgpd-wire` first, then verify it is registry-visible. Only then
   run the fully verified package/dry-run gate for `rustbgpd-fsm`. Cargo
@@ -522,8 +559,10 @@ that govern every future publish are:
   is present in the registry.
 - Keep the dependency examples in §3 pinned to the versions actually available
   from crates.io — never to a version not yet published.
-- Both crates keep their package metadata and README; the README is the rendered
-  docs.rs landing page and carries the per-version compatibility notes.
+- Publish a changed wire compatibility line before packaging either FSM or RPKI
+  against it. FSM and RPKI do not depend on each other.
+- All three crates keep their package metadata and README; the README is the
+  rendered crates.io landing page and carries the compatibility boundary.
 - Treat any additional crate publish as separate, demand-gated work.
 
 `docs/RELEASE_CHECKLIST.md` holds the executable form of this, including the
@@ -533,7 +572,7 @@ per-crate semver bump rules.
 
 ## 8. The Shape-A (gRPC) embedder surface — recent additions
 
-Shape A (§3.4) — a separate process driving the daemon over gRPC — is
+Shape A (§3.5) — a separate process driving the daemon over gRPC — is
 the recommended production embedding, and its surface grew. What a
 gRPC consumer gains from the recent proto additions
 (`proto/rustbgpd.proto`; all additive):
@@ -622,7 +661,7 @@ from the public gRPC API, including per-route `age` from
 `ListAdvertisedRoutes` diff with each suppression explained by
 `RibService.ExplainAdvertisedRoute`). Both live in this workspace, so they take
 `rustbgpd-api` as a path dependency; read them for the call shapes and the RPC
-sequencing, but generate your own client from the proto (§3.4) rather than
+sequencing, but generate your own client from the proto (§3.5) rather than
 copying that dependency line. The adapter is the honest template: if the public
 API is missing a field an external tool needs, the fix is an additive proto
 field, not a daemon-internal shortcut — that is how `received_at_epoch_seconds`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -29,9 +29,9 @@ diff actually ran before tagging.
 - [ ] **MSRV gate** — `cargo check --workspace --all-targets` at the
       declared `rust-version` (kept in lockstep with the Dockerfile
       builder version)
-- [ ] **Wire crate README freshness gate** — if
-      `crates/wire/Cargo.toml` version changed in the diff,
-      `crates/wire/README.md` must also be touched
+- [ ] **Published-crate README freshness gate** — if the independently
+      versioned manifest for `wire`, `fsm`, or `rpki` changed in the diff, the
+      matching crate README must also be touched
 - [ ] **Gate 8b BUM-filter kernel primitive**
       (`evpn_bum_filter_kernel` job) — runs the netns harness under
       `--cap-add=NET_ADMIN --cap-add=SYS_ADMIN
@@ -49,11 +49,14 @@ diff actually ran before tagging.
       `.github/workflows/public-docs-contract.yml` is green. Its two
       seconds-cheap Python checks now run unfiltered beside the public-docs
       contract on every pull request and main-branch push.
-- [ ] **Published-crate semver contract** — when `crates/wire/` or
-      `crates/fsm/` changed, `.github/workflows/semver-checks.yml` is green for
-      the pull request or a manual dispatch at the release commit. It is
-      path-scoped on pull requests to those crate trees and its own workflow;
-      it has no push trigger.
+- [ ] **Published-crate semver contract** — when `crates/wire/`, `crates/fsm/`,
+      or `crates/rpki/` changed, `.github/workflows/semver-checks.yml` is green
+      for the pull request or a manual dispatch at the release commit. It is
+      path-scoped on pull requests to those crate trees, its tested derivation
+      helper, and its own workflow; it has no push trigger. The exact RPKI
+      `0.1.0` first-publish exception applies only while crates.io returns 404
+      for the name and becomes an ordinary registry baseline automatically
+      once that normal release is visible.
 - [ ] **IXP Manager / Bird's Eye contract** — when the IXP Manager,
       Bird's Eye, renderer, adapter, or interop-doc surface changed,
       `.github/workflows/ixp-compat.yml` ran and is green. It is path-scoped on
@@ -795,3 +798,42 @@ do not force an FSM release for every daemon tag.
 7. Verify the version is visible in the registry, update the declared current
    boundary and dependency snippets in `docs/EMBEDDING.md`, then run
    `python3 scripts/check_embedding_versions.py`.
+
+### rustbgpd-rpki crate release
+
+The RPKI crate has its own version in `crates/rpki/Cargo.toml`, decoupled from
+the daemon workspace version. Its synchronous table API and asynchronous RTR
+client share one published compatibility boundary.
+
+1. **Did `crates/rpki/` or its public examples/docs change since the last
+   `rustbgpd-rpki` publish?**
+   - If no: skip. Do not publish a no-op release.
+   - If yes: continue.
+2. Decide semver bump:
+   - **Patch**: backward-compatible fixes, docs/test improvements, or additive
+     public API within the current `0.x` compatibility line.
+   - **Minor**: removed/changed public items, incompatible enum or struct shape
+     changes, or an incompatible `rustbgpd-wire` dependency move because wire
+     types appear in public RPKI method signatures.
+   The `semver-checks` workflow compares every registry-visible release with
+   its latest normal crates.io baseline.
+3. Update `version` in `crates/rpki/Cargo.toml` and the root workspace
+   dependency pin. Refresh every lockfile that resolves the path crate.
+4. Roll `crates/rpki/CHANGELOG.md`, update the crate README, and add a
+   `rustbgpd-rpki` entry in the repository-level `CHANGELOG.md`.
+5. Run `cargo package --locked -p rustbgpd-rpki --list`; inspect the exact
+   package inventory and normalized manifest. Normal dependencies must resolve
+   from crates.io with no path-only edge.
+6. Run `cargo publish --locked -p rustbgpd-rpki --dry-run`.
+7. Publish `rustbgpd-rpki`, verify the version and ownership are visible in the
+   registry, then manually dispatch `semver-checks.yml` at the publish commit.
+   The checked package set must now include RPKI.
+8. Update the declared current boundary and dependency snippets in
+   `docs/EMBEDDING.md`, then run `python3 scripts/check_embedding_versions.py`.
+
+For the initial `0.1.0` publish only, the semver workflow permits the exact
+`rustbgpd-rpki 0.1.0` package to have no baseline while crates.io returns 404
+for its name. Any other missing package/version, a claimed name without a
+normal release, or an ambiguous registry response fails closed. Recheck the
+name immediately before removing `publish = false` and immediately before the
+real publish.

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -187,19 +187,20 @@ def check(root: Path) -> list[str]:
         if text.count(command) != 1 or command not in job:
             errors.append(f"{command} must exist exactly once in {job_name}")
 
-    wire_step_name = "Wire crate README freshness gate"
-    wire_step = named_step(jobs.get("core", ""), wire_step_name)
-    if text.count(f"- name: {wire_step_name}") != 1 or not wire_step:
-        errors.append("wire README freshness gate must exist exactly once in core")
+    readme_step_name = "Published crate README freshness gate"
+    readme_step = named_step(jobs.get("core", ""), readme_step_name)
+    if text.count(f"- name: {readme_step_name}") != 1 or not readme_step:
+        errors.append("published-crate README freshness gate must exist exactly once in core")
     else:
         for seam in (
-            'git diff "$base"...HEAD -- crates/wire/Cargo.toml \\',
-            'git diff "$base"...HEAD -- crates/wire/README.md \\',
+            "for crate in wire fsm rpki; do",
+            'git diff "$base"...HEAD -- "crates/$crate/Cargo.toml" \\',
+            'git diff "$base"...HEAD -- "crates/$crate/README.md" \\',
             r"'^\+version\s*='",
             "exit 1",
         ):
-            if seam not in wire_step:
-                errors.append(f"wire README freshness gate missing {seam}")
+            if seam not in readme_step:
+                errors.append(f"published-crate README freshness gate missing {seam}")
 
     aggregate = jobs.get("check", "")
     if "if: ${{ always() }}" not in aggregate:

--- a/scripts/check_embedding_versions.py
+++ b/scripts/check_embedding_versions.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 
-PACKAGES = ("wire", "fsm")
+PACKAGES = ("wire", "fsm", "rpki")
 HEADING = re.compile(r"^(#{1,6})\s+(?:\d+(?:\.\d+)*\.?\s+)?(.+?)\s*$", re.MULTILINE)
 SECTION_HEADING = re.compile(r"^(#{2,3})\s+", re.MULTILINE)
 
@@ -29,6 +29,7 @@ def check(document: str) -> list[str]:
         "boundary": (2, "Published-crate release boundary"),
         "decode": (3, "Decode an UPDATE (codec-only — the canonical embedder)"),
         "session": (3, 'Build a session (codec + FSM — the "minimal speaker" consumer)'),
+        "rpki": (3, "Validate an origin (RPKI table — the synchronous consumer)"),
         "publish": (2, "Which crate to publish next, and why"),
     }
     sections = {}
@@ -40,14 +41,16 @@ def check(document: str) -> list[str]:
         return errors
 
     boundary = sections["boundary"].lstrip().split("\n\n", 1)[0]
-    current = re.findall(r"`rustbgpd-(wire|fsm) ([^`]+)`", boundary)
+    package_pattern = "|".join(PACKAGES)
+    current = re.findall(rf"`rustbgpd-({package_pattern}) ([^`]+)`", boundary)
     versions = dict(current)
     if len(current) != len(PACKAGES) or set(versions) != set(PACKAGES):
         return ["current-boundary-version"]
 
     examples = {
-        "wire": (sections["decode"], sections["session"]),
+        "wire": (sections["decode"], sections["session"], sections["rpki"]),
         "fsm": (sections["session"],),
+        "rpki": (sections["rpki"],),
     }
     for package, bodies in examples.items():
         assignment = re.compile(rf'^rustbgpd-{package} = "([^"]+)"$', re.MULTILINE)
@@ -56,7 +59,7 @@ def check(document: str) -> list[str]:
             errors.append(f"{package}-snippet-version")
 
     publish = re.findall(
-        r"^\d+\. \*\*`rustbgpd-(wire|fsm)` \(published as `([^`]+)`\)\.\*\*",
+        rf"^\d+\. \*\*`rustbgpd-({package_pattern})` \(published as `([^`]+)`\)\.\*\*",
         sections["publish"],
         re.MULTILINE,
     )

--- a/scripts/check_semver_publishable_crates.py
+++ b/scripts/check_semver_publishable_crates.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Derive crates.io-backed semver-check inputs from Cargo metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+
+CRATES_IO = "https://crates.io/api/v1/crates"
+USER_AGENT = "rustbgpd-semver-contract/1.0 (https://github.com/lance0/rustbgpd)"
+FIRST_PUBLISH = {("rustbgpd-rpki", "0.1.0")}
+SUPPORT_PATHS = (
+    ".github/workflows/semver-checks.yml",
+    "scripts/check_semver_publishable_crates.py",
+    "scripts/test_check_semver_publishable_crates.py",
+)
+NORMAL_VERSION = re.compile(r"^\d+\.\d+\.\d+(?:\+[0-9A-Za-z.-]+)?$")
+
+
+class ContractError(RuntimeError):
+    """The semver workflow cannot establish a fail-closed package set."""
+
+
+class RegistryState(Enum):
+    ABSENT = "absent"
+    NORMAL_RELEASE = "normal-release"
+    CLAIMED_WITHOUT_NORMAL_RELEASE = "claimed-without-normal-release"
+
+
+@dataclass(frozen=True)
+class Package:
+    name: str
+    version: str
+    directory: str
+
+
+def _normal_release(payload: object, name: str) -> bool:
+    if not isinstance(payload, dict):
+        raise ContractError(f"crates.io returned a non-object for {name}")
+    crate = payload.get("crate")
+    versions = payload.get("versions")
+    if not isinstance(crate, dict) or crate.get("id") != name:
+        raise ContractError(f"crates.io identity mismatch for {name}")
+    if not isinstance(versions, list):
+        raise ContractError(f"crates.io omitted the version inventory for {name}")
+    return any(
+        isinstance(version, dict)
+        and isinstance(version.get("num"), str)
+        and NORMAL_VERSION.fullmatch(version["num"])
+        and version.get("yanked") is False
+        for version in versions
+    )
+
+
+def registry_state(name: str) -> RegistryState:
+    request = urllib.request.Request(
+        f"{CRATES_IO}/{name}",
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            if response.status != 200:
+                raise ContractError(
+                    f"crates.io returned HTTP {response.status} for {name}"
+                )
+            try:
+                payload = json.load(response)
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise ContractError(f"invalid crates.io JSON for {name}") from error
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return RegistryState.ABSENT
+        raise ContractError(f"crates.io returned HTTP {error.code} for {name}") from error
+    except urllib.error.URLError as error:
+        raise ContractError(f"cannot query crates.io for {name}: {error.reason}") from error
+
+    if _normal_release(payload, name):
+        return RegistryState.NORMAL_RELEASE
+    return RegistryState.CLAIMED_WITHOUT_NORMAL_RELEASE
+
+
+def _publishable(metadata: dict[str, object]) -> list[Package]:
+    root = metadata.get("workspace_root")
+    packages = metadata.get("packages")
+    if not isinstance(root, str) or not isinstance(packages, list):
+        raise ContractError("invalid cargo metadata shape")
+    root_path = Path(root)
+    result = []
+    for package in packages:
+        if not isinstance(package, dict) or package.get("publish") is not None:
+            continue
+        name = package.get("name")
+        version = package.get("version")
+        manifest = package.get("manifest_path")
+        if not all(isinstance(value, str) for value in (name, version, manifest)):
+            raise ContractError("publishable package metadata is incomplete")
+        result.append(
+            Package(
+                name=name,
+                version=version,
+                directory=str(Path(manifest).parent.relative_to(root_path)),
+            )
+        )
+    if not result:
+        raise ContractError("no publishable crate found; did every manifest disable publish?")
+    return sorted(result, key=lambda package: package.name)
+
+
+def derive(
+    metadata: dict[str, object],
+    workflow: str,
+    probe: Callable[[str], RegistryState] = registry_state,
+) -> tuple[list[Package], list[Package]]:
+    publishable = _publishable(metadata)
+    required_paths = tuple(package.directory for package in publishable) + SUPPORT_PATHS
+    missing_paths = [
+        path for path in required_paths if f'- "{path}/**"' not in workflow
+        and f'- "{path}"' not in workflow
+    ]
+    if missing_paths:
+        raise ContractError(
+            f"semver pull_request paths filter is missing: {missing_paths}"
+        )
+
+    checked = []
+    first_publish = []
+    for package in publishable:
+        state = probe(package.name)
+        if state is RegistryState.NORMAL_RELEASE:
+            checked.append(package)
+        elif (
+            state is RegistryState.ABSENT
+            and (package.name, package.version) in FIRST_PUBLISH
+        ):
+            first_publish.append(package)
+        elif state is RegistryState.ABSENT:
+            raise ContractError(
+                f"unpublished crate is not an approved first publish: "
+                f"{package.name}@{package.version}"
+            )
+        else:
+            raise ContractError(
+                f"crate name is claimed without a normal semver baseline: {package.name}"
+            )
+    if not checked:
+        raise ContractError("no crates.io-published crate remains for semver checking")
+    return checked, first_publish
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        raise SystemExit(
+            f"usage: {Path(sys.argv[0]).name} METADATA_JSON SEMVER_WORKFLOW"
+        )
+    try:
+        metadata = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+        workflow = Path(sys.argv[2]).read_text(encoding="utf-8")
+        checked, first_publish = derive(metadata, workflow)
+    except (OSError, json.JSONDecodeError, ContractError) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    print(
+        "checked:",
+        ", ".join(f"{p.name}@{p.version}" for p in checked),
+        file=sys.stderr,
+    )
+    if first_publish:
+        print(
+            "first publish (no public semver baseline yet):",
+            ", ".join(f"{p.name}@{p.version}" for p in first_publish),
+            file=sys.stderr,
+        )
+    print("packages=" + ",".join(package.name for package in checked))
+    print("first_publish=" + ",".join(package.name for package in first_publish))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_semver_publishable_crates.py
+++ b/scripts/check_semver_publishable_crates.py
@@ -102,11 +102,17 @@ def _publishable(metadata: dict[str, object]) -> list[Package]:
         manifest = package.get("manifest_path")
         if not all(isinstance(value, str) for value in (name, version, manifest)):
             raise ContractError("publishable package metadata is incomplete")
+        try:
+            directory = Path(manifest).parent.relative_to(root_path)
+        except ValueError as error:
+            raise ContractError(
+                f"publishable package manifest is outside workspace root: {name}"
+            ) from error
         result.append(
             Package(
                 name=name,
                 version=version,
-                directory=str(Path(manifest).parent.relative_to(root_path)),
+                directory=str(directory),
             )
         )
     if not result:

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -159,16 +159,20 @@ class ScaleSplitContractTests(unittest.TestCase):
             ),
             ('RUSTDOCFLAGS: "-D warnings"', 'RUSTDOCFLAGS: ""'),
             (
-                "- name: Wire crate README freshness gate",
-                "- name: Unchecked wire README",
+                "- name: Published crate README freshness gate",
+                "- name: Unchecked published crate README",
             ),
             (
-                'git diff "$base"...HEAD -- crates/wire/Cargo.toml',
-                'git diff "$base"...HEAD -- crates/wire/README.md',
+                "for crate in wire fsm rpki; do",
+                "for crate in wire rpki; do",
             ),
             (
-                'git diff "$base"...HEAD -- crates/wire/README.md',
-                'git diff "$base"...HEAD -- crates/wire/NOTES.md',
+                'git diff "$base"...HEAD -- "crates/$crate/Cargo.toml"',
+                'git diff "$base"...HEAD -- "crates/$crate/NOTES.toml"',
+            ),
+            (
+                'git diff "$base"...HEAD -- "crates/$crate/README.md"',
+                'git diff "$base"...HEAD -- "crates/$crate/NOTES.md"',
             ),
             (r"'^\+version\s*='", r"'^version\s*='"),
             ("              exit 1", "              true"),

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -37,7 +37,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
         return DOCUMENT[:start] + new + DOCUMENT[start + len(old) :]
 
     def test_each_wire_snippet_is_guarded(self) -> None:
-        """Red if either wire dependency example drifts to 0.15.0."""
+        """Fails if any wire dependency example drifts to 0.15.0."""
         old = 'rustbgpd-wire = "0.18.0"'
         for occurrence in (0, 1, 2):
             with self.subTest(occurrence=occurrence):
@@ -47,21 +47,21 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                 )
 
     def test_fsm_snippet_is_guarded(self) -> None:
-        """Red if the FSM dependency example drifts to 0.3.1."""
+        """Fails if the FSM dependency example drifts to 0.3.1."""
         self.assert_fails(
             self.replace_nth('rustbgpd-fsm = "0.5.0"', 'rustbgpd-fsm = "0.3.1"'),
             "fsm-snippet-version",
         )
 
     def test_rpki_snippet_is_guarded(self) -> None:
-        """Red if the RPKI dependency example drifts from its published line."""
+        """Fails if the RPKI dependency example drifts from its published line."""
         self.assert_fails(
             self.replace_nth('rustbgpd-rpki = "0.1.0"', 'rustbgpd-rpki = "0.2.0"'),
             "rpki-snippet-version",
         )
 
     def test_publish_statuses_are_guarded(self) -> None:
-        """Red if either numbered publish heading names an old version."""
+        """Fails if any numbered publish heading names an old version."""
         mutations = (
             ("wire", "0.18.0", "0.17.2"),
             ("fsm", "0.5.0", "0.4.1"),
@@ -77,7 +77,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                 )
 
     def test_current_boundary_is_guarded(self) -> None:
-        """Red if §7 loses either authoritative current-version slot."""
+        """Fails if §7 loses any authoritative current-version slot."""
         for package, version in (("wire", "0.18.0"), ("fsm", "0.5.0"), ("rpki", "0.1.0")):
             with self.subTest(package=package):
                 self.assert_fails(
@@ -89,7 +89,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                 )
 
     def test_status_parser_rejects_prepared_as(self) -> None:
-        """Red if an actual publish status changes from published to prepared."""
+        """Fails if an actual publish status changes from published to prepared."""
         self.assert_fails(
             self.replace_nth(
                 "(published as `0.18.0`)", "(prepared as `0.18.0`)"

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -39,7 +39,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
     def test_each_wire_snippet_is_guarded(self) -> None:
         """Red if either wire dependency example drifts to 0.15.0."""
         old = 'rustbgpd-wire = "0.18.0"'
-        for occurrence in (0, 1):
+        for occurrence in (0, 1, 2):
             with self.subTest(occurrence=occurrence):
                 self.assert_fails(
                     self.replace_nth(old, 'rustbgpd-wire = "0.15.0"', occurrence),
@@ -53,9 +53,20 @@ class EmbeddingVersionContractTests(unittest.TestCase):
             "fsm-snippet-version",
         )
 
+    def test_rpki_snippet_is_guarded(self) -> None:
+        """Red if the RPKI dependency example drifts from its published line."""
+        self.assert_fails(
+            self.replace_nth('rustbgpd-rpki = "0.1.0"', 'rustbgpd-rpki = "0.2.0"'),
+            "rpki-snippet-version",
+        )
+
     def test_publish_statuses_are_guarded(self) -> None:
         """Red if either numbered publish heading names an old version."""
-        mutations = (("wire", "0.18.0", "0.17.2"), ("fsm", "0.5.0", "0.4.1"))
+        mutations = (
+            ("wire", "0.18.0", "0.17.2"),
+            ("fsm", "0.5.0", "0.4.1"),
+            ("rpki", "0.1.0", "0.0.1"),
+        )
         for package, current, old in mutations:
             with self.subTest(package=package):
                 self.assert_fails(
@@ -67,10 +78,15 @@ class EmbeddingVersionContractTests(unittest.TestCase):
 
     def test_current_boundary_is_guarded(self) -> None:
         """Red if §7 loses either authoritative current-version slot."""
-        self.assert_fails(
-            self.replace_nth("`rustbgpd-fsm 0.5.0`", "rustbgpd-fsm 0.5.0"),
-            "current-boundary-version",
-        )
+        for package, version in (("wire", "0.18.0"), ("fsm", "0.5.0"), ("rpki", "0.1.0")):
+            with self.subTest(package=package):
+                self.assert_fails(
+                    self.replace_nth(
+                        f"`rustbgpd-{package} {version}`",
+                        f"rustbgpd-{package} {version}",
+                    ),
+                    "current-boundary-version",
+                )
 
     def test_status_parser_rejects_prepared_as(self) -> None:
         """Red if an actual publish status changes from published to prepared."""
@@ -84,7 +100,8 @@ class EmbeddingVersionContractTests(unittest.TestCase):
     def test_heading_renumbering_and_unrelated_prepared_prose_are_allowed(self) -> None:
         changed = DOCUMENT
         for old, new in (("## 7. ", "## 70. "), ("### 3.1 ", "### 30.1 "),
-                         ("### 3.3 ", "### 30.3 "), ("## 4. ", "## 40. ")):
+                         ("### 3.3 ", "### 30.3 "), ("### 3.4 ", "### 30.4 "),
+                         ("## 4. ", "## 40. ")):
             changed = changed.replace(old, new, 1)
         changed += "\nAn unrelated consumer prepared its own deployment.\n"
         self.assertEqual(self.run_checker(changed).returncode, 0)
@@ -94,6 +111,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
             "Published-crate release boundary",
             "Decode an UPDATE (codec-only — the canonical embedder)",
             'Build a session (codec + FSM — the "minimal speaker" consumer)',
+            "Validate an origin (RPKI table — the synchronous consumer)",
             "Which crate to publish next, and why",
         )
         for title in titles:

--- a/scripts/test_check_semver_publishable_crates.py
+++ b/scripts/test_check_semver_publishable_crates.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Mutation proofs for publishable-crate semver derivation."""
+
+import io
+import json
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+from scripts.check_semver_publishable_crates import (
+    ContractError,
+    RegistryState,
+    derive,
+    registry_state,
+)
+
+
+ROOT = "/repo"
+WORKFLOW = """
+      - "crates/wire/**"
+      - "crates/fsm/**"
+      - "crates/rpki/**"
+      - ".github/workflows/semver-checks.yml"
+      - "scripts/check_semver_publishable_crates.py"
+      - "scripts/test_check_semver_publishable_crates.py"
+"""
+
+
+class FakeResponse:
+    """Minimal context-managed response used by the registry tests."""
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.status = 200
+        self.body = io.BytesIO(json.dumps(payload).encode())
+
+    def read(self, *args: object) -> bytes:
+        return self.body.read(*args)
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+
+def metadata(rpki_version: str = "0.1.0") -> dict[str, object]:
+    return {
+        "workspace_root": ROOT,
+        "packages": [
+            {
+                "name": "rustbgpd-wire",
+                "version": "0.18.0",
+                "manifest_path": f"{ROOT}/crates/wire/Cargo.toml",
+                "publish": None,
+            },
+            {
+                "name": "rustbgpd-fsm",
+                "version": "0.5.0",
+                "manifest_path": f"{ROOT}/crates/fsm/Cargo.toml",
+                "publish": None,
+            },
+            {
+                "name": "rustbgpd-rpki",
+                "version": rpki_version,
+                "manifest_path": f"{ROOT}/crates/rpki/Cargo.toml",
+                "publish": None,
+            },
+            {
+                "name": "rustbgpd",
+                "version": "0.67.0",
+                "manifest_path": f"{ROOT}/Cargo.toml",
+                "publish": [],
+            },
+        ],
+    }
+
+
+class PublishableCrateContractTests(unittest.TestCase):
+    def test_exact_rpki_first_publish_is_excluded_until_registry_visible(self) -> None:
+        states = {
+            "rustbgpd-wire": RegistryState.NORMAL_RELEASE,
+            "rustbgpd-fsm": RegistryState.NORMAL_RELEASE,
+            "rustbgpd-rpki": RegistryState.ABSENT,
+        }
+        checked, first = derive(metadata(), WORKFLOW, states.__getitem__)
+        self.assertEqual(
+            [package.name for package in checked],
+            ["rustbgpd-fsm", "rustbgpd-wire"],
+        )
+        self.assertEqual([package.name for package in first], ["rustbgpd-rpki"])
+
+    def test_rpki_joins_semver_set_automatically_after_publish(self) -> None:
+        checked, first = derive(
+            metadata(), WORKFLOW, lambda _name: RegistryState.NORMAL_RELEASE
+        )
+        self.assertEqual(
+            [package.name for package in checked],
+            ["rustbgpd-fsm", "rustbgpd-rpki", "rustbgpd-wire"],
+        )
+        self.assertEqual([], first)
+
+    def test_unapproved_first_publish_version_fails(self) -> None:
+        with self.assertRaisesRegex(ContractError, "not an approved first publish"):
+            derive(
+                metadata("0.1.1"),
+                WORKFLOW,
+                lambda name: RegistryState.ABSENT
+                if name == "rustbgpd-rpki"
+                else RegistryState.NORMAL_RELEASE,
+            )
+
+    def test_claimed_name_without_normal_release_fails(self) -> None:
+        with self.assertRaisesRegex(ContractError, "claimed without a normal"):
+            derive(
+                metadata(),
+                WORKFLOW,
+                lambda name: RegistryState.CLAIMED_WITHOUT_NORMAL_RELEASE
+                if name == "rustbgpd-rpki"
+                else RegistryState.NORMAL_RELEASE,
+            )
+
+    def test_unexpected_unpublished_crate_fails(self) -> None:
+        changed = metadata()
+        changed["packages"].append(
+            {
+                "name": "rustbgpd-surprise",
+                "version": "0.1.0",
+                "manifest_path": f"{ROOT}/crates/surprise/Cargo.toml",
+                "publish": None,
+            }
+        )
+        workflow = WORKFLOW + '      - "crates/surprise/**"\n'
+        with self.assertRaisesRegex(ContractError, "rustbgpd-surprise@0.1.0"):
+            derive(
+                changed,
+                workflow,
+                lambda name: RegistryState.ABSENT
+                if name in {"rustbgpd-rpki", "rustbgpd-surprise"}
+                else RegistryState.NORMAL_RELEASE,
+            )
+
+    def test_each_publishable_directory_is_required_in_trigger(self) -> None:
+        with self.assertRaisesRegex(ContractError, "crates/rpki"):
+            derive(
+                metadata(),
+                WORKFLOW.replace('      - "crates/rpki/**"\n', ""),
+                lambda _name: RegistryState.NORMAL_RELEASE,
+            )
+
+    def test_helper_and_its_test_are_required_in_trigger(self) -> None:
+        for path in (
+            "scripts/check_semver_publishable_crates.py",
+            "scripts/test_check_semver_publishable_crates.py",
+        ):
+            with self.subTest(path=path), self.assertRaisesRegex(ContractError, path):
+                derive(
+                    metadata(),
+                    WORKFLOW.replace(f'      - "{path}"\n', ""),
+                    lambda _name: RegistryState.NORMAL_RELEASE,
+                )
+
+    @patch("scripts.check_semver_publishable_crates.urllib.request.urlopen")
+    def test_registry_normal_release_is_accepted(self, urlopen) -> None:
+        urlopen.return_value = FakeResponse(
+            {
+                "crate": {"id": "rustbgpd-rpki"},
+                "versions": [{"num": "0.1.0", "yanked": False}],
+            }
+        )
+        self.assertIs(
+            registry_state("rustbgpd-rpki"), RegistryState.NORMAL_RELEASE
+        )
+
+    @patch("scripts.check_semver_publishable_crates.urllib.request.urlopen")
+    def test_registry_404_is_the_only_absent_response(self, urlopen) -> None:
+        urlopen.side_effect = urllib.error.HTTPError(
+            "https://crates.io", 404, "not found", {}, None
+        )
+        self.assertIs(registry_state("rustbgpd-rpki"), RegistryState.ABSENT)
+
+    @patch("scripts.check_semver_publishable_crates.urllib.request.urlopen")
+    def test_registry_network_failure_fails_closed(self, urlopen) -> None:
+        urlopen.side_effect = urllib.error.URLError("offline")
+        with self.assertRaisesRegex(ContractError, "cannot query crates.io"):
+            registry_state("rustbgpd-rpki")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_semver_publishable_crates.py
+++ b/scripts/test_check_semver_publishable_crates.py
@@ -139,6 +139,15 @@ class PublishableCrateContractTests(unittest.TestCase):
                 else RegistryState.NORMAL_RELEASE,
             )
 
+    def test_manifest_outside_workspace_root_fails_with_contract_error(self) -> None:
+        changed = metadata()
+        changed["packages"][2]["manifest_path"] = "/outside/crates/rpki/Cargo.toml"
+        with self.assertRaisesRegex(
+            ContractError,
+            "publishable package manifest is outside workspace root: rustbgpd-rpki",
+        ):
+            derive(changed, WORKFLOW, lambda _name: RegistryState.NORMAL_RELEASE)
+
     def test_each_publishable_directory_is_required_in_trigger(self) -> None:
         with self.assertRaisesRegex(ContractError, "crates/rpki"):
             derive(


### PR DESCRIPTION
## Summary

- decouple `rustbgpd-rpki` at `0.1.0` with package-ready metadata, changelog, README, and a compiling origin-validation example
- document the existing root and module API boundary, runtime requirements, protocol scope, and compatible `rustbgpd-wire 0.18` dependency
- extend embedding/release guidance and derive the semver package set with a tested first-publication transition
- generalize published-crate README freshness coverage across wire, FSM, and RPKI

## Validation

- 163 RPKI tests plus all targets, bench/example targets, and doc tests
- all-feature Clippy and warning-clean rustdoc
- locked metadata and embedding version/map checks
- semver helper, CI contract, and release-checklist tests
- 15-file package inventory with registry `rustbgpd-wire = 0.18.0`
- `cargo publish --locked -p rustbgpd-rpki --dry-run`
- normal commit and pre-push hooks

## After merge

Publish `rustbgpd-rpki 0.1.0`, verify registry visibility and ownership, then manually dispatch semver checks so RPKI joins the ordinary published baseline.