### PR TITLE
fix: accept live MRT timing timestamps in verifier

### DIFF
--- a/bench/tests/test_verify_mrt_attribute_scratch_campaign.py
+++ b/bench/tests/test_verify_mrt_attribute_scratch_campaign.py
@@ -84,6 +84,20 @@ class CampaignContract(unittest.TestCase):
         tmp=tempfile.TemporaryDirectory(); self.addCleanup(tmp.cleanup); root=pathlib.Path(tmp.name)
         fixture(root,candidate_ns=909999993,control_ns=999999992,same_left=1000000007,same_right=960000007,finalize=False)
         with self.assertRaises(VERIFY.Invalid): VERIFY.derive(root)
+    def test_timing_raw_variation_with_stable_semantics_passes(self):
+        tmp,root=self.make(); self.addCleanup(tmp.cleanup)
+        edit_rows(root/"raw/b1-s1-ixp-700.timing.jsonl",lambda rows:[row.update(raw_sha256=f"{index:064x}") for index,row in enumerate(rows,1)])
+        write_rows(root/"canonical.jsonl",VERIFY.derive(root)); seal(root)
+        self.assertEqual(VERIFY.verify(root,REPO)["classification"],"go")
+    def test_live_time_parity_mutations_fail(self):
+        mutations={
+          "diagnostic-raw":lambda r:edit_rows(r/"raw/b1-s1-ixp-700.diagnostic.jsonl",lambda x:x[0].update(raw_sha256="9"*64)),
+          "timing-semantic":lambda r:edit_rows(r/"raw/b1-s1-ixp-700.timing.jsonl",lambda x:x[0].update(semantic_sha256="9"*64)),
+          "timing-length":lambda r:edit_rows(r/"raw/b1-s1-ixp-700.timing.jsonl",lambda x:x[0].update(output_len_bytes=x[0]["output_len_bytes"]+1)),
+          "timing-cardinality":lambda r:edit_rows(r/"raw/b1-s1-ixp-700.timing.jsonl",lambda x:x[0].update(decoded_entry_count=x[0]["decoded_entry_count"]-1)),
+        }
+        for name,mutate in mutations.items():
+            with self.subTest(name=name): self.rejected(mutate,rederive=True)
     def rejected(self, mutate, rederive=False, exact=False):
         tmp,root=self.make(); self.addCleanup(tmp.cleanup); mutate(root); seal(root)
         if rederive:

--- a/bench/verify-mrt-attribute-scratch-campaign.py
+++ b/bench/verify-mrt-attribute-scratch-campaign.py
@@ -85,7 +85,7 @@ def check_raw(rows, variant, shape, mode):
             need(sum(alloc[k] for k in ("alloc_calls","alloc_zeroed_calls","realloc_calls")) > 0, "allocator signal")
     if mode == "timing": need(cv_within_limit(rows), "timing CV")
 def derive(root):
-    canonical, cells = [], {}; identities={shape:set() for shape in SHAPES}
+    canonical, cells = [], {}; identities={shape:set() for shape in SHAPES}; diagnostic_raw={shape:set() for shape in SHAPES}
     for block in range(1, 5):
         for slot, variant in enumerate(ORDER, 1):
             for shape in SHAPES:
@@ -94,8 +94,9 @@ def derive(root):
                 timing, diagnostic = read_rows(timing_path), read_rows(diagnostic_path)
                 check_raw(timing, variant, shape, "timing"); check_raw(diagnostic, variant, shape, "diagnostic")
                 all_rows, d = timing + diagnostic, diagnostic[0]
-                need(len({(r["raw_sha256"],r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"]) for r in all_rows}) == 1, "raw/semantic/count mismatch")
-                identities[shape].update((r["raw_sha256"],r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"],r["path_count"],r["prefix_count"],r["source_count"]) for r in all_rows)
+                need(len({(r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"],r["path_count"],r["prefix_count"],r["source_count"]) for r in all_rows}) == 1, "semantic/count mismatch")
+                identities[shape].update((r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"],r["path_count"],r["prefix_count"],r["source_count"]) for r in all_rows)
+                diagnostic_raw[shape].add(d["raw_sha256"])
                 alloc = sum(d["allocator"][k] for k in ("alloc_calls","alloc_zeroed_calls","realloc_calls"))
                 row = {"schema":2,"block":block,"slot":slot,"scratch_variant":variant,
                        "shape":shape,"source_commit":d["commit"],"source_tree":TREES[variant],
@@ -115,10 +116,11 @@ def derive(root):
             path=root / "raw" / f"same-{shape}-{side}.timing.jsonl"; rows = read_rows(path)
             same_hashes[shape,side]=sha(path)
             check_raw(rows, "control", shape, "timing"); sides.append(median(rows))
-            identities[shape].update((r["raw_sha256"],r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"],r["path_count"],r["prefix_count"],r["source_count"]) for r in rows)
+            identities[shape].update((r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"],r["path_count"],r["prefix_count"],r["source_count"]) for r in rows)
         favorable=max(0,sides[0]-sides[1]); need(favorable*100 < sides[0]*5, "same-SHA favorable drift")
         same[shape] = favorable,sides[0]
     need(all(len(values)==1 for values in identities.values()), "cross-cell encoded identity drift")
+    need(all(len(values)==1 for values in diagnostic_raw.values()), "diagnostic raw identity drift")
     for row in canonical:
         row["same_sha_left_jsonl_sha256"]=same_hashes[row["shape"],"left"]
         row["same_sha_right_jsonl_sha256"]=same_hashes[row["shape"],"right"]


### PR DESCRIPTION
## Summary

- compare live timing rows by semantic hash, output length, and complete cardinality rather than unstable raw bytes
- keep exact raw-byte equality mandatory for fixed-time diagnostic rows across control and candidate cells
- add mutation tests for allowed timing raw variation and rejected diagnostic/raw semantic/length/cardinality drift

## Validation

- `python3 -m unittest -v bench/tests/test_verify_mrt_attribute_scratch_campaign.py` (9 tests)
- exact two-file scope and direct current-main ancestry
- repository hooks and `git diff --check`

The runner, campaign order, thresholds, source pins, allocation/timing/CV/reuse/capacity checks, production MRT code, and retained LAN-807 artifact are unchanged.

Closes LAN-1308.