### PR TITLE
perf(transport): restore exact-result reuse throughput

### DIFF
--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -1941,28 +1941,25 @@ impl ExactExportSnapshot for SessionExportProfile {
         }
 
         let max_len = self.max_message_len();
-        Some(
-            encoded_lengths
-                .iter()
-                .copied()
-                .map(|encoded_len| {
-                    if encoded_len > max_len {
-                        Err(ExactExportError::new(
-                            ExactExportErrorCode::MessageTooLong,
-                            format_args!(
-                                "encoded UPDATE is {encoded_len} bytes; negotiated maximum is {max_len} bytes"
-                            ),
-                        ))
-                    } else {
-                        Ok(ExactExportResult {
-                            encoded_len,
-                            max_len,
-                            generation: self.generation,
-                        })
-                    }
+        let mut results = Vec::with_capacity(encoded_lengths.len());
+        for &encoded_len in encoded_lengths {
+            let result = if encoded_len > max_len {
+                Err(ExactExportError::new(
+                    ExactExportErrorCode::MessageTooLong,
+                    format_args!(
+                        "encoded UPDATE is {encoded_len} bytes; negotiated maximum is {max_len} bytes"
+                    ),
+                ))
+            } else {
+                Ok(ExactExportResult {
+                    encoded_len,
+                    max_len,
+                    generation: self.generation,
                 })
-                .collect(),
-        )
+            };
+            results.push(result);
+        }
+        Some(results)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -2575,6 +2572,44 @@ mod tests {
         assert_eq!(error.code(), ExactExportErrorCode::MessageTooLong);
         assert!(error.detail().contains(&(max_len + 1).to_string()));
         assert!(error.detail().contains(&max_len.to_string()));
+    }
+
+    #[test]
+    fn successful_probe_reuse_preserves_empty_and_interleaved_results() {
+        let config = config_with_auth_secret("not-retained");
+        let source = SessionExportProfile::initial(&config, None, false);
+        let mut target = source.clone();
+        target.generation = 17;
+        let max_len = target.max_message_len();
+
+        assert_eq!(
+            target.reuse_successful_probes(&source, &[]),
+            Some(Vec::new())
+        );
+
+        let encoded_lengths = [max_len + 1, max_len - 1, max_len + 2, max_len];
+        let results = target
+            .reuse_successful_probes(&source, &encoded_lengths)
+            .expect("compatible profiles reuse each result independently");
+
+        assert_eq!(results.len(), encoded_lengths.len());
+        for (index, (encoded_len, result)) in encoded_lengths.into_iter().zip(results).enumerate() {
+            if encoded_len > max_len {
+                let error = result.expect_err("above-ceiling entries remain errors in place");
+                assert_eq!(error.code(), ExactExportErrorCode::MessageTooLong);
+                assert!(error.detail().contains(&encoded_len.to_string()));
+            } else {
+                assert_eq!(
+                    result,
+                    Ok(ExactExportResult {
+                        encoded_len,
+                        max_len,
+                        generation: 17,
+                    }),
+                    "successful entry {index} retains its exact position"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace iterator collection in exact-result reuse with one preallocated local fill loop
- preserve result cardinality, ordering, ceiling errors, generation metadata, and incompatible-profile behavior
- add focused coverage for empty and interleaved success/error results

## Validation

- workspace all-feature tests and all-target/all-feature Clippy passed
- Rust 1.98 release assembly keeps allocation and fill local, removes the reuse-path `Vec::from_iter` and outlined fold, and adds 128 bytes of `.text`
- protected MP comparison passed 6/6 alternating attempts across all four shapes, with 5.02% maximum standard deviation and no confident regression at or above 3%
- the parent/current loss reproduced on all four retained rrharness shapes (12.431–20.884%)
- the candidate improved current by 17.254–38.818%, recovered 121.062–144.412% of the measured gap, and finished 2.435–8.446% faster than the parent

The full local artifact bundle is preserved at `/home/lance/artifacts/lan-1305-explicit-reuse-loop-2026-08-27/`.

Tracks [LAN-1305](https://linear.app/lance0/issue/LAN-1305/ribmanager-flood-path-regressed-between-v0640-and-v0670-rr1000-staged).
