### PR TITLE
fix(policy): preserve preflight error classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Policy mutation preflight failures now preserve `NOT_FOUND`, `INVALID_ARGUMENT`, and
+  `FAILED_PRECONDITION` while retaining the closed `policy_preflight_rejected` diagnostic.
+
 - Canonical and Partial community and Only-to-Customer attributes now receive
   the same value-based treatment in consumers and interoperability fixtures.
 

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -340,6 +340,9 @@ pub enum CatalogMutationError {
     /// Operator supplied invalid catalog data (maps to gRPC
     /// `INVALID_ARGUMENT`).
     Invalid(String),
+    /// A valid mutation cannot be applied in the current runtime state
+    /// (maps to gRPC `FAILED_PRECONDITION`).
+    FailedPrecondition(String),
     /// Applying the mutation would reconfigure something only a daemon
     /// restart can change, e.g. a TCP-AO delta on a reshaped peer-group
     /// member (maps to gRPC `FAILED_PRECONDITION`).
@@ -361,6 +364,11 @@ impl CatalogMutationError {
     }
 
     #[must_use]
+    pub fn failed_precondition(message: impl Into<String>) -> Self {
+        Self::FailedPrecondition(message.into())
+    }
+
+    #[must_use]
     pub fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
     }
@@ -371,6 +379,7 @@ impl std::fmt::Display for CatalogMutationError {
         match self {
             Self::NotFound(message)
             | Self::Invalid(message)
+            | Self::FailedPrecondition(message)
             | Self::RestartRequired(message)
             | Self::Internal(message) => f.write_str(message),
             Self::StillReferenced {

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -290,11 +290,12 @@ pub fn validate_config_transaction_apply_metadata(
 pub(crate) fn catalog_mutation_error_to_status(error: &CatalogMutationError) -> Status {
     match error {
         CatalogMutationError::NotFound(_) => Status::not_found(error.to_string()),
-        CatalogMutationError::StillReferenced { .. } => {
+        CatalogMutationError::StillReferenced { .. }
+        | CatalogMutationError::FailedPrecondition(_)
+        | CatalogMutationError::RestartRequired(_) => {
             Status::failed_precondition(error.to_string())
         }
         CatalogMutationError::Invalid(_) => Status::invalid_argument(error.to_string()),
-        CatalogMutationError::RestartRequired(_) => Status::failed_precondition(error.to_string()),
         CatalogMutationError::Internal(_) => Status::internal(error.to_string()),
     }
 }
@@ -2396,6 +2397,10 @@ mod tests {
             (
                 CatalogMutationError::invalid("bad policy"),
                 tonic::Code::InvalidArgument,
+            ),
+            (
+                CatalogMutationError::failed_precondition("session cannot converge"),
+                tonic::Code::FailedPrecondition,
             ),
             (
                 CatalogMutationError::RestartRequired("tcp_ao delta".into()),

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -334,6 +334,7 @@ fn config_persist_error(error: ConfigPersistError) -> FibTableControlError {
                 FibTableControlError::InvalidArgument(message)
             }
             CatalogMutationError::StillReferenced { .. }
+            | CatalogMutationError::FailedPrecondition(_)
             | CatalogMutationError::RestartRequired(_) => {
                 FibTableControlError::FailedPrecondition(error.to_string())
             }
@@ -1126,6 +1127,12 @@ mod tests {
 
     #[tokio::test]
     async fn persistence_stage_rejection_and_ack_loss_are_typed_clean_failures() {
+        assert!(matches!(
+            config_persist_error(ConfigPersistError::Rejected(
+                CatalogMutationError::failed_precondition("runtime state blocks persistence")
+            )),
+            FibTableControlError::FailedPrecondition(_)
+        ));
         for drop_ack in [false, true] {
             let (tx, mut rx) = mpsc::channel(1);
             let permit = tx.clone().reserve_owned().await.unwrap();

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -150,25 +150,58 @@ enum PolicySnapshotFailureKind {
     CompensationAmbiguous,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PolicySnapshotRejectionClass {
+    NotFound,
+    InvalidArgument,
+    FailedPrecondition,
+    Internal,
+}
+
+impl PolicySnapshotRejectionClass {
+    fn from_error(error: &CatalogMutationError) -> Self {
+        match error {
+            CatalogMutationError::NotFound(_) => Self::NotFound,
+            CatalogMutationError::Invalid(_) => Self::InvalidArgument,
+            CatalogMutationError::StillReferenced { .. }
+            | CatalogMutationError::FailedPrecondition(_)
+            | CatalogMutationError::RestartRequired(_) => Self::FailedPrecondition,
+            CatalogMutationError::Internal(_) => Self::Internal,
+        }
+    }
+
+    fn closed_error(self, code: RuntimeConfigPolicyFailureCode) -> CatalogMutationError {
+        match self {
+            Self::NotFound => CatalogMutationError::not_found(code.as_str()),
+            Self::InvalidArgument => CatalogMutationError::invalid(code.as_str()),
+            Self::FailedPrecondition => CatalogMutationError::failed_precondition(code.as_str()),
+            Self::Internal => CatalogMutationError::internal(code.as_str()),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct PolicySnapshotFailure {
     kind: PolicySnapshotFailureKind,
+    rejection_class: PolicySnapshotRejectionClass,
     pub(super) code: RuntimeConfigPolicyFailureCode,
     message: String,
 }
 
 impl PolicySnapshotFailure {
-    fn rejected(message: impl Into<String>) -> Self {
+    fn rejected(error: &CatalogMutationError) -> Self {
         Self {
             kind: PolicySnapshotFailureKind::RejectedNoEffect,
+            rejection_class: PolicySnapshotRejectionClass::from_error(error),
             code: RuntimeConfigPolicyFailureCode::PreflightRejected,
-            message: message.into(),
+            message: error.to_string(),
         }
     }
 
     fn compensated(message: impl Into<String>) -> Self {
         Self {
             kind: PolicySnapshotFailureKind::FullyCompensated,
+            rejection_class: PolicySnapshotRejectionClass::Internal,
             code: RuntimeConfigPolicyFailureCode::SessionApplyRejected,
             message: message.into(),
         }
@@ -177,6 +210,7 @@ impl PolicySnapshotFailure {
     fn compensated_code(code: RuntimeConfigPolicyFailureCode, message: impl Into<String>) -> Self {
         Self {
             kind: PolicySnapshotFailureKind::FullyCompensated,
+            rejection_class: PolicySnapshotRejectionClass::Internal,
             code,
             message: message.into(),
         }
@@ -185,8 +219,21 @@ impl PolicySnapshotFailure {
     fn ambiguous_code(code: RuntimeConfigPolicyFailureCode, message: impl Into<String>) -> Self {
         Self {
             kind: PolicySnapshotFailureKind::CompensationAmbiguous,
+            rejection_class: PolicySnapshotRejectionClass::Internal,
             code,
             message: message.into(),
+        }
+    }
+
+    fn closed_catalog_error(&self) -> CatalogMutationError {
+        match self.kind {
+            PolicySnapshotFailureKind::RejectedNoEffect => {
+                self.rejection_class.closed_error(self.code)
+            }
+            PolicySnapshotFailureKind::FullyCompensated
+            | PolicySnapshotFailureKind::CompensationAmbiguous => {
+                CatalogMutationError::internal(self.code.as_str())
+            }
         }
     }
 }
@@ -625,7 +672,9 @@ impl PeerManager {
         let preflight_started = Instant::now();
         let preflight = self.preflight_rfc8212_import_transitions(&targets).await;
         phases.preflight_us = elapsed_us(preflight_started);
-        preflight.map_err(PolicySnapshotFailure::rejected)?;
+        preflight.map_err(|error| {
+            PolicySnapshotFailure::rejected(&CatalogMutationError::failed_precondition(error))
+        })?;
         let mut rollback_rib_budget = PolicyRollbackRibBudget::default();
         let total_targets = targets.len();
         let cohort_selection_started = Instant::now();
@@ -3076,27 +3125,19 @@ impl PeerManager {
                 self.publish_policy_config_event(&event, applied);
                 OwnedCatalogMutationOutcome::Success
             }
-            Err(PolicySnapshotFailure {
-                kind: PolicySnapshotFailureKind::RejectedNoEffect,
-                code,
-                ..
-            }) => OwnedCatalogMutationOutcome::RejectedNoEffect(CatalogMutationError::internal(
-                code.as_str(),
-            )),
-            Err(PolicySnapshotFailure {
-                kind: PolicySnapshotFailureKind::FullyCompensated,
-                code,
-                ..
-            }) => OwnedCatalogMutationOutcome::FullyCompensated(CatalogMutationError::internal(
-                code.as_str(),
-            )),
-            Err(PolicySnapshotFailure {
-                kind: PolicySnapshotFailureKind::CompensationAmbiguous,
-                code,
-                ..
-            }) => OwnedCatalogMutationOutcome::CompensationAmbiguous(
-                CatalogMutationError::internal(code.as_str()),
-            ),
+            Err(failure) => match failure.kind {
+                PolicySnapshotFailureKind::RejectedNoEffect => {
+                    OwnedCatalogMutationOutcome::RejectedNoEffect(failure.closed_catalog_error())
+                }
+                PolicySnapshotFailureKind::FullyCompensated => {
+                    OwnedCatalogMutationOutcome::FullyCompensated(failure.closed_catalog_error())
+                }
+                PolicySnapshotFailureKind::CompensationAmbiguous => {
+                    OwnedCatalogMutationOutcome::CompensationAmbiguous(
+                        failure.closed_catalog_error(),
+                    )
+                }
+            },
         }
     }
 
@@ -3150,27 +3191,19 @@ impl PeerManager {
             .await
         {
             Ok(_) => OwnedCatalogMutationOutcome::Success,
-            Err(PolicySnapshotFailure {
-                kind: PolicySnapshotFailureKind::RejectedNoEffect,
-                code,
-                ..
-            }) => OwnedCatalogMutationOutcome::RejectedNoEffect(CatalogMutationError::internal(
-                code.as_str(),
-            )),
-            Err(PolicySnapshotFailure {
-                kind: PolicySnapshotFailureKind::FullyCompensated,
-                code,
-                ..
-            }) => OwnedCatalogMutationOutcome::FullyCompensated(CatalogMutationError::internal(
-                code.as_str(),
-            )),
-            Err(PolicySnapshotFailure {
-                kind: PolicySnapshotFailureKind::CompensationAmbiguous,
-                code,
-                ..
-            }) => OwnedCatalogMutationOutcome::CompensationAmbiguous(
-                CatalogMutationError::internal(code.as_str()),
-            ),
+            Err(failure) => match failure.kind {
+                PolicySnapshotFailureKind::RejectedNoEffect => {
+                    OwnedCatalogMutationOutcome::RejectedNoEffect(failure.closed_catalog_error())
+                }
+                PolicySnapshotFailureKind::FullyCompensated => {
+                    OwnedCatalogMutationOutcome::FullyCompensated(failure.closed_catalog_error())
+                }
+                PolicySnapshotFailureKind::CompensationAmbiguous => {
+                    OwnedCatalogMutationOutcome::CompensationAmbiguous(
+                        failure.closed_catalog_error(),
+                    )
+                }
+            },
         }
     }
 
@@ -3259,9 +3292,9 @@ impl PeerManager {
                     continue;
                 }
                 Err(error) => {
-                    return Err(PolicySnapshotFailure::rejected(
-                        catalog_config_error(error).to_string(),
-                    ));
+                    return Err(PolicySnapshotFailure::rejected(&catalog_config_error(
+                        error,
+                    )));
                 }
             };
             targets.push(ResolvedPeerPolicy {

--- a/src/peer_manager/tests/policy.rs
+++ b/src/peer_manager/tests/policy.rs
@@ -399,9 +399,15 @@ async fn sync_rpol_policies_rejection_keeps_old_registry_for_live_and_new_sessio
             rustbgpd_policy::datasets::DatasetBindings::default(),
         )
         .await;
+    let rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::RejectedNoEffect(error) = outcome
+    else {
+        panic!("unresolvable static rpol chain must be rejected before mutation")
+    };
     assert!(matches!(
-        outcome,
-        rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::RejectedNoEffect(_)
+        error,
+        CatalogMutationError::NotFound(ref message)
+            if message == RuntimeConfigPolicyFailureCode::PreflightRejected.as_str()
+                && !message.contains("edge-in")
     ));
 
     // Existing session: the live chain still evaluates the OLD decision.

--- a/src/peer_manager/tests/rfc8212.rs
+++ b/src/peer_manager/tests/rfc8212.rs
@@ -397,6 +397,71 @@ fn install_rfc8212_peer(
     managed.export_policy = Some(rfc8212_missing_export());
 }
 
+#[tokio::test]
+async fn owned_rfc8212_preflight_rejection_is_failed_precondition_without_mutation() {
+    use rustbgpd_api::peer_types::{
+        CatalogMutationError, ConfigEvent, NamedPolicyDefinition, OwnedCatalogMutationOutcome,
+        PolicyStatementDefinition,
+    };
+    use rustbgpd_api::runtime_config_settlement::RuntimeConfigPolicyFailureCode;
+
+    let (mut mgr, _rib_rx) = rfc8212_status_manager();
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+    mgr.current_config.global.ebgp_requires_policy = Some(true);
+    mgr.current_config.policy.import_chain.clear();
+    mgr.current_config.policy.export_chain.clear();
+    mgr.current_config.neighbors = vec![config_neighbor(addr, 65002)];
+    let setup = mgr
+        .apply_policy_change_owned(
+            ConfigEvent::SetPolicy {
+                name: "edge-in".to_string(),
+                definition: NamedPolicyDefinition {
+                    default_action: "deny".to_string(),
+                    statements: Vec::<PolicyStatementDefinition>::new(),
+                },
+                ack: None,
+            },
+            None,
+        )
+        .await;
+    assert!(
+        matches!(setup, OwnedCatalogMutationOutcome::Success),
+        "policy setup failed: {setup:?}"
+    );
+
+    let refreshes = Arc::new(AtomicUsize::new(0));
+    install_rfc8212_peer(
+        &mut mgr,
+        addr,
+        scripted_policy_handle(addr, false, usize::MAX, Arc::clone(&refreshes)),
+        Some(rfc8212_missing_import()),
+    );
+    let outcome = mgr
+        .apply_policy_change_owned(
+            ConfigEvent::SetGlobalImportChain {
+                policy_names: vec!["edge-in".to_string()],
+                ack: None,
+            },
+            None,
+        )
+        .await;
+    let OwnedCatalogMutationOutcome::RejectedNoEffect(error) = outcome else {
+        panic!("incapable live peer must reject the owned policy mutation")
+    };
+    assert!(matches!(
+        error,
+        CatalogMutationError::FailedPrecondition(ref message)
+            if message == RuntimeConfigPolicyFailureCode::PreflightRejected.as_str()
+                && !message.contains(&addr.to_string())
+    ));
+    assert!(mgr.current_config.policy.import_chain.is_empty());
+    assert_eq!(
+        mgr.peers[&key(addr)].import_policy,
+        Some(rfc8212_missing_import())
+    );
+    assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+}
+
 /// ADR-0112 step 4: an Established peer that never negotiated Route Refresh
 /// cannot converge an import policy-presence change, so the edit is rejected
 /// with clear/reconnect guidance and its chains stay exactly where they were.


### PR DESCRIPTION
## Summary

Preserve the intended client-visible status class when an owned policy change is rejected during preflight, while keeping the public diagnostic closed as `policy_preflight_rejected`.

## Changes

- retain `NotFound` and `InvalidArgument` for static policy-chain resolution failures
- classify RFC 8212 live-state preflight refusals as `FailedPrecondition`
- keep compensated and ambiguous settlement outcomes classified as `Internal`
- cover tonic and FIB translations plus no-mutation, no-refresh, and diagnostic-redaction behavior

## Testing

- [x] `cargo test --locked --workspace --all-features` passes
- [x] `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Relevant interop test intentionally not applicable; no protocol or transport behavior changes
- [x] Performance receipt intentionally not applicable; no performance-affecting path changes

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed
- [x] User/operator docs intentionally not needed
- [x] No hot tracking document changed

## Related issues

Tracked in Linear; the issue will carry the merge receipt.
