### PR TITLE
ci: fail kernel-dataplane lanes that run nothing

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -438,6 +438,11 @@ jobs:
     name: M43 — TCP-AO live rotation and crash recovery (BIRD 3.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Every lab step below is gated on the TCP-AO probe, so a runner kernel
+    # without CONFIG_TCP_AO=y would let this job succeed having run nothing.
+    # Republish the probe result for the check aggregate to require.
+    outputs:
+      tcp_ao_supported: ${{ steps.tcp_ao.outputs.supported }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
@@ -978,6 +983,22 @@ jobs:
                   continue
               if result != expected_result:
                   failed = True
+          # An m43 that succeeded with every TCP-AO step disabled ran no labs
+          # at all: the kernel-support probe republishes its verdict as a job
+          # output, and a lab run must prove the steps were live. The excused
+          # bird3 skip above stays the only tolerated coverage hole.
+          tcp_ao = needs["m43"].get("outputs", {}).get("tcp_ao_supported")
+          if (
+              run_labs == "true"
+              and needs["m43"].get("result") == "success"
+              and tcp_ao != "true"
+          ):
+              print(
+                  "::error::m43 succeeded with tcp_ao_supported="
+                  f"{tcp_ao!r}: every TCP-AO step was disabled, so the "
+                  "TCP-AO lane ran nothing"
+              )
+              failed = True
           if excused:
               print(
                   "::warning::m43=skipped (bird3 archive unavailable upstream): "

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -278,6 +278,30 @@ else
     fi
 fi
 
+# Cargo exits 0 when a test filter matches nothing, so a renamed or
+# removed test would leave every selector green while running zero
+# tests. List what the assembled command would actually run — same
+# image, env, and filters — and require the expected match count
+# before the real invocation.
+if [ -n "$RUSTBGPD_TEST_FILTER" ]; then
+    LIST_ARGS=(sh -c "${TEST_ARGS[2]} --list")
+else
+    LIST_ARGS=("${TEST_ARGS[@]}" --list)
+fi
+echo "[harness] listing: ${LIST_ARGS[*]}"
+LIST_OUT="$(docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" "${LIST_ARGS[@]}")"
+MATCHED="$(grep -c ': test$' <<<"$LIST_OUT" || true)"
+if [ "$EXACT_FILTER" = "1" ] && [ -n "$FILTER" ]; then
+    if [ "$MATCHED" -ne 1 ]; then
+        echo "ERROR: selector '$SELECTOR' (--exact '$FILTER') matched $MATCHED tests in $TEST_BIN, expected exactly 1 — renamed or removed?" >&2
+        exit 1
+    fi
+elif [ "$MATCHED" -lt 1 ]; then
+    echo "ERROR: selector '$SELECTOR' matched 0 tests — renamed, removed, or filter narrowed?" >&2
+    exit 1
+fi
+echo "[harness] selector '$SELECTOR' matches $MATCHED test(s)"
+
 echo "[harness] running: ${TEST_ARGS[*]}"
 docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" "${TEST_ARGS[@]}"
 

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -320,6 +320,10 @@ class PrimerContractTests(unittest.TestCase):
             }
             for job in expected
         }
+        if workflow == "kernel-dataplane.yml" and needs["m43"]["result"] == "success":
+            # A live m43 republishes its TCP-AO probe verdict; the aggregate
+            # requires it whenever the labs ran.
+            needs["m43"]["outputs"] = {"tcp_ao_supported": "true"}
         return subprocess.run(
             ["python3", "-c", script],
             check=False,

--- a/scripts/test_kernel_dataplane_bird3_tolerance.py
+++ b/scripts/test_kernel_dataplane_bird3_tolerance.py
@@ -52,6 +52,7 @@ def needs_context(
     bird3_status: str | None = "ok",
     bird3_result: str | None = None,
     m43_result: str | None = None,
+    tcp_ao_supported: str | None = "true",
 ) -> dict[str, dict]:
     default = "success" if run_labs == "true" else "skipped"
     needs = {job: {"result": default} for job in EXPECTED_JOBS}
@@ -63,6 +64,8 @@ def needs_context(
     if bird3_status is not None:
         needs["bird3_archive"]["outputs"] = {"bird3_status": bird3_status}
     needs["m43"] = {"result": m43_result or default}
+    if tcp_ao_supported is not None:
+        needs["m43"]["outputs"] = {"tcp_ao_supported": tcp_ao_supported}
     return needs
 
 
@@ -104,6 +107,27 @@ class Bird3ToleranceTests(unittest.TestCase):
         self.assertEqual(1, result.returncode, result.stdout + result.stderr)
         self.assertIn("m43=failure\n", result.stdout)
         self.assertNotIn(EXCUSE, result.stdout)
+
+    def test_m43_success_with_tcp_ao_disabled_fails(self) -> None:
+        # A green m43 on a kernel without CONFIG_TCP_AO=y ran zero lab
+        # steps; the aggregate must treat that success as a coverage hole.
+        for tcp_ao in ("false", None):
+            with self.subTest(tcp_ao_supported=tcp_ao):
+                result = run_aggregate(needs_context(tcp_ao_supported=tcp_ao))
+                self.assertEqual(1, result.returncode, result.stdout)
+                self.assertIn("every TCP-AO step was disabled", result.stdout)
+
+    def test_excused_skip_needs_no_tcp_ao_output(self) -> None:
+        # A skipped job publishes no outputs; the excused bird3 skip must
+        # not additionally be charged with the missing TCP-AO verdict.
+        result = run_aggregate(
+            needs_context(
+                bird3_status="unavailable",
+                m43_result="skipped",
+                tcp_ao_supported=None,
+            )
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
 
     def test_corrupt_archive_stays_red(self) -> None:
         # A checksum/version failure on bytes that DID download is a
@@ -149,6 +173,7 @@ class Bird3ToleranceTests(unittest.TestCase):
             "bird3_status: ${{ steps.prepare.outputs.bird3_status }}",
             "if: needs.bird3_archive.outputs.bird3_status != 'unavailable'",
             "if: steps.prepare.outputs.bird3_status == 'ok'",
+            "tcp_ao_supported: ${{ steps.tcp_ao.outputs.supported }}",
             "3) status=unavailable ;;",
             "4) status=corrupt ;;",
         ):


### PR DESCRIPTION
Two lanes in the kernel-dataplane gate could pass while running nothing. Both now fail loudly when their coverage silently disappears. (LAN-1322, LAN-1337)

## Netns selector zero-match guard

`crates/evpn-linux/tests/docker/run-netns-tests.sh` assembles `cargo test` filters from hardcoded test names, and cargo exits 0 on a filter that matches nothing — so a renamed or removed test left every selector green and the selector receipt still recorded it as executed. Before the real invocation, the harness now runs the identically assembled command with `--list` appended, through the same container image, env, and filters, and counts `: test` lines:

- exact selectors (`EXACT_FILTER=1` with a filter) require exactly 1 match
- substring/module-path selectors and whole-binary runs require at least 1

A mismatch exits 1 with the selector and filter named, before any test runs and before the receipt append.

Demonstrated red/green both ways: the extracted guard logic against local `cargo test --list` (misspelled exact name and misspelled substring prefix both exit 1; real names pass), and the full script end-to-end through Docker (`spike` passes and runs 1 test; a copy with a misspelled `spike` filter exits 1 at the listing step without running anything).

## TCP-AO job success-with-holes

The m43 job gates all nine lab steps on the `CONFIG_TCP_AO=y` probe, so an unsupported runner kernel let the job succeed having run nothing — the opposite of what its own skip-vs-hollow-success comment demands. Mirroring the bird3 pattern, the probe verdict is republished as a job-level output (`tcp_ao_supported`) and the `check` aggregate now requires it to be `true` whenever `run_labs == 'true'` and m43 succeeded, failing with a message naming the hole. The excused bird3-unavailable skip remains the only tolerated coverage gap, and when the guarded steps run is unchanged.

`scripts/test_kernel_dataplane_bird3_tolerance.py` executes the real aggregate body against the new contexts: a green m43 with `tcp_ao_supported` false or absent fails, and the excused skip still passes without the output (skipped jobs publish none). The image-primer truth-table stub carries the output on a live m43.

## Validation

- `bash -n` + `shellcheck` clean on the harness
- `kernel-dataplane.yml` validated by YAML parse only (actionlint not installed locally); the workflow change proves itself on its next scheduled or path-triggered run
- `python3 -m unittest` green on `scripts.test_kernel_dataplane_bird3_tolerance` (11 tests), `scripts.test_check_ci_image_primer_contract` (38), `scripts.test_check_netns_selector_receipt`, `scripts.test_check_ci_scale_split_contract`
- `scripts/check_ci_image_primer_contract.py` and `scripts/check_ci_scale_split_contract.py` green
