### PR TITLE
fix(bench): gate rrharness comparisons on a maximum regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `per_client_best` when two shared-staging group keys differ on the RFC 7947
   per-client-best axis; CLI human and JSON output use the same stable label.
 
+- `bench/scale/compare-rrharness.sh --max-regression PCT` turns an unpinned
+  rrharness comparison into a gated run: every rung — 1000-client rungs
+  included — fails when head regresses by more than PCT percent
+  (`parse_rrharness.py compare --max-regression`), and the receipt reports
+  `regression-gate-passed` / `max-regression` instead of the advisory or
+  pinned statuses it did not run under. (LAN-1316)
+
 ### Fixed
 
 - Policy mutation preflight failures now preserve `NOT_FOUND`, `INVALID_ARGUMENT`, and

--- a/bench/scale/compare-rrharness.sh
+++ b/bench/scale/compare-rrharness.sh
@@ -17,6 +17,9 @@ Usage: bench/scale/compare-rrharness.sh [options]
                           pinned throughput gates are then applied
   --diff-path PATH        Repository-relative path hashed against --pin;
                           repeatable; required with --pin
+  --max-regression PCT    Gate every rung on one uniform maximum regression
+                          of PCT percent (a positive number); applies with or
+                          without --pin and replaces the pinned gate set
   --core N                CPU pinned with taskset (default: 5)
   --output-dir DIR        New, empty receipt directory
   --preflight-wait N      Per-cell idle wait in seconds (default: 120)
@@ -33,10 +36,13 @@ refs, the shared host lock, a performance-governor pinned CPU, load below
 cell. Both sides are built with `cargo build --release --locked` into
 separate target directories and launched as prebuilt binaries.
 
-Without --pin the receipt is advisory: comparison.csv (per cell) and
-summary.csv (per rung) report head-vs-base throughput with no pass/fail
-gate. With --pin the receipt is marked complete only if every pinned
-throughput gate passes.
+Without --pin or --max-regression the receipt is advisory: comparison.csv
+(per cell) and summary.csv (per rung) report head-vs-base throughput with no
+pass/fail gate. With --pin the receipt is marked complete only if every
+pinned throughput gate passes. With --max-regression the receipt is marked
+complete only if every rung holds its regression within PCT percent; when
+--pin and --max-regression are both given the uniform regression gate is the
+one applied and the receipt says so.
 EOF
 }
 
@@ -46,6 +52,7 @@ readonly required_governor=performance
 base_ref=
 head_ref=
 pin_path=
+max_regression=
 diff_paths=()
 core=5
 output_dir=
@@ -59,6 +66,10 @@ while (($#)); do
     --head) head_ref=${2:?--head requires a ref}; shift 2 ;;
     --pin) pin_path=${2:?--pin requires a path}; shift 2 ;;
     --diff-path) diff_paths+=("${2:?--diff-path requires a path}"); shift 2 ;;
+    --max-regression)
+      max_regression=${2:?--max-regression requires a value}
+      shift 2
+      ;;
     --core) core=${2:?--core requires a value}; shift 2 ;;
     --output-dir) output_dir=${2:?--output-dir requires a path}; shift 2 ;;
     --preflight-wait)
@@ -82,6 +93,12 @@ for value_name in preflight_wait_seconds cell_timeout_seconds; do
     exit 2
   }
 done
+if [[ -n $max_regression ]]; then
+  [[ $max_regression =~ ^[0-9]+(\.[0-9]+)?$ && $max_regression =~ [1-9] ]] || {
+    printf '%s must be a positive percentage\n' --max-regression >&2
+    exit 2
+  }
+fi
 if [[ -n $pin_path ]]; then
   ((${#diff_paths[@]})) || { printf '%s requires at least one --diff-path\n' --pin >&2; exit 2; }
 elif ((${#diff_paths[@]})); then
@@ -529,7 +546,8 @@ for repetition in 1 2; do
 done
 
 gate_args=()
-[[ -n $pin_path ]] || gate_args=(--no-gates)
+[[ -n $pin_path || -n $max_regression ]] || gate_args=(--no-gates)
+[[ -z $max_regression ]] || gate_args+=(--max-regression "$max_regression")
 python3 "$source_dir/parse_rrharness.py" compare \
   --input "$results" --raw-dir "$raw_dir" --output "$comparison" \
   --summary "$summary" "${gate_args[@]}"
@@ -559,7 +577,10 @@ python3 "$source_dir/parse_rrharness.py" compare \
 
 run_utc_finish=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 cpu_model=$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)
-if [[ -n $pin_path ]]; then
+if [[ -n $max_regression ]]; then
+  receipt_status=regression-gate-passed
+  receipt_gates=max-regression
+elif [[ -n $pin_path ]]; then
   receipt_status=all-throughput-gates-passed
   receipt_gates=pinned
 else

--- a/bench/scale/rebaseline/parse_rrharness.py
+++ b/bench/scale/rebaseline/parse_rrharness.py
@@ -2,7 +2,9 @@
 """Parse, summarise, and optionally gate the rrharness comparison matrix.
 
 `compare` applies the pinned throughput gates by default; `--no-gates` keeps
-every row advisory and `--summary PATH` adds a per-rung table.
+every row advisory, `--max-regression PCT` replaces the pinned gates with one
+uniform regression ceiling on every rung, and `--summary PATH` adds a per-rung
+table.
 """
 
 from __future__ import annotations
@@ -132,6 +134,16 @@ def finite_number(text: str, field: str) -> float:
         raise ValueError(f"{field} is not a number: {text!r}") from error
     if not math.isfinite(value) or value < 0:
         raise ValueError(f"{field} must be finite and nonnegative")
+    return value
+
+
+def positive_percentage(text: str) -> float:
+    try:
+        value = float(text)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"not a number: {text!r}") from error
+    if not math.isfinite(value) or value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive percentage")
     return value
 
 
@@ -421,8 +433,12 @@ def compare_command(args: argparse.Namespace) -> None:
             maximum_regression = 0.0
             verdict = "advisory"
         else:
-            required_improvement = 15.0 if mode == "churn" or clients == 1000 else 0.0
-            maximum_regression = 5.0 if clients == 256 else 0.0
+            if args.max_regression is not None:
+                required_improvement = 0.0
+                maximum_regression = args.max_regression
+            else:
+                required_improvement = 15.0 if mode == "churn" or clients == 1000 else 0.0
+                maximum_regression = 5.0 if clients == 256 else 0.0
             verdict = "pass"
             if required_improvement and improvement + 1e-9 < required_improvement:
                 verdict = "fail-improvement"
@@ -453,7 +469,8 @@ def compare_command(args: argparse.Namespace) -> None:
     if args.summary is not None:
         write_summary(args.summary, comparisons)
     if failed:
-        raise ValueError("one or more LAN-395 throughput gates failed")
+        gate_set = "max-regression" if args.max_regression is not None else "LAN-395"
+        raise ValueError(f"one or more {gate_set} throughput gates failed")
 
 
 def write_summary(path: Path, comparisons: list[dict[str, object]]) -> None:
@@ -534,10 +551,18 @@ def build_parser() -> argparse.ArgumentParser:
     compare.add_argument("--raw-dir", type=Path, required=True)
     compare.add_argument("--output", type=Path, required=True)
     compare.add_argument("--summary", type=Path, help="per-rung summary CSV (also printed)")
-    compare.add_argument(
+    gates = compare.add_mutually_exclusive_group()
+    gates.add_argument(
         "--no-gates",
         action="store_true",
         help="keep every row advisory instead of applying the pinned throughput gates",
+    )
+    gates.add_argument(
+        "--max-regression",
+        type=positive_percentage,
+        metavar="PCT",
+        help="gate every rung on one uniform maximum regression of PCT percent "
+        "instead of the pinned throughput gates",
     )
     compare.set_defaults(run=compare_command)
     return parser

--- a/bench/scale/rebaseline/test_parse_rrharness.py
+++ b/bench/scale/rebaseline/test_parse_rrharness.py
@@ -342,6 +342,88 @@ rss_end_mib 210
             self.assertEqual({row["head_improvement_percent_mean"] for row in rungs}, {"14.000"})
             self.assertIn("head-faster", result.stdout)
 
+    def test_max_regression_passes_flat_matrix_on_every_rung(self) -> None:
+        with tempfile.TemporaryDirectory() as directory_text:
+            directory = Path(directory_text)
+            matrix = directory / "matrix.csv"
+            raw_dir = directory / "raw"
+            comparison = directory / "comparison.csv"
+            # Flat head misses the pinned 15% gates; the uniform regression
+            # gate replaces them, so a flat matrix passes.
+            self.write_matrix(matrix, raw_dir, head_multiplier=1.0)
+            self.run_parser(
+                "compare",
+                "--input",
+                str(matrix),
+                "--raw-dir",
+                str(raw_dir),
+                "--output",
+                str(comparison),
+                "--max-regression",
+                "10",
+            )
+            with comparison.open(newline="", encoding="utf-8") as handle:
+                rows = list(csv.DictReader(handle))
+            self.assertEqual(len(rows), 8)
+            self.assertEqual({row["verdict"] for row in rows}, {"pass"})
+            self.assertEqual({row["maximum_regression_percent"] for row in rows}, {"10.0"})
+            self.assertEqual({row["required_improvement_percent"] for row in rows}, {"0.0"})
+
+    def test_max_regression_fails_regressing_matrix_on_1000_client_rungs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory_text:
+            directory = Path(directory_text)
+            matrix = directory / "matrix.csv"
+            raw_dir = directory / "raw"
+            comparison = directory / "comparison.csv"
+            # A 31% head regression: exactly the shape the pinned gates gave
+            # 1000-client rungs no budget to fail on.
+            self.write_matrix(matrix, raw_dir, head_multiplier=0.69)
+            self.run_parser(
+                "compare",
+                "--input",
+                str(matrix),
+                "--raw-dir",
+                str(raw_dir),
+                "--output",
+                str(comparison),
+                "--max-regression",
+                "10",
+                success=False,
+            )
+            with comparison.open(newline="", encoding="utf-8") as handle:
+                rows = list(csv.DictReader(handle))
+            self.assertEqual({row["verdict"] for row in rows}, {"fail-regression"})
+            self.assertIn("1000", {row["clients"] for row in rows})
+
+    def test_max_regression_rejects_no_gates_combo_and_bad_values(self) -> None:
+        with tempfile.TemporaryDirectory() as directory_text:
+            directory = Path(directory_text)
+            matrix = directory / "matrix.csv"
+            raw_dir = directory / "raw"
+            comparison = directory / "comparison.csv"
+            self.write_matrix(matrix, raw_dir)
+            invalid = (
+                ("--no-gates", "--max-regression", "10"),
+                ("--max-regression", "0"),
+                ("--max-regression", "-5"),
+                ("--max-regression", "NaN"),
+                ("--max-regression", "fast"),
+            )
+            for extra in invalid:
+                with self.subTest(extra=extra):
+                    self.run_parser(
+                        "compare",
+                        "--input",
+                        str(matrix),
+                        "--raw-dir",
+                        str(raw_dir),
+                        "--output",
+                        str(comparison),
+                        *extra,
+                        success=False,
+                    )
+                    self.assertFalse(comparison.exists())
+
     def test_matrix_rejects_tampered_numeric_and_hash_evidence(self) -> None:
         mutations = {
             "nonfinite rate": ("rate", "NaN"),

--- a/bench/tests/test-rrharness-driver.sh
+++ b/bench/tests/test-rrharness-driver.sh
@@ -69,6 +69,24 @@ expect_rc 2 '--diff-path without --pin' "$driver" --validate-only \
 expect_rc 2 'pinned diff drift' "$driver" --validate-only \
   --base "$base" --head "$head" --pin "$pin" --diff-path bench/scale/rrharness/README.md
 
+"$driver" --validate-only --base "$base" --head "$head" --max-regression 10 >/dev/null
+"$driver" --validate-only --base "$base" --head "$head" \
+  --pin "$pin" --diff-path "$diff_path" --max-regression 2.5 >/dev/null
+expect_rc 2 'zero max-regression' "$driver" --validate-only \
+  --base "$base" --head "$head" --max-regression 0
+expect_rc 2 'zero-decimal max-regression' "$driver" --validate-only \
+  --base "$base" --head "$head" --max-regression 0.00
+expect_rc 2 'non-numeric max-regression' "$driver" --validate-only \
+  --base "$base" --head "$head" --max-regression fast
+rg -F -- 'gate_args+=(--max-regression "$max_regression")' "$driver" >/dev/null || {
+  printf 'rrharness driver does not thread --max-regression into the gate arguments\n' >&2
+  exit 1
+}
+rg -F 'receipt_status=regression-gate-passed' "$driver" >/dev/null || {
+  printf 'rrharness driver does not report the regression-gate receipt status\n' >&2
+  exit 1
+}
+
 cp "$driver" "$external_driver"
 chmod +x "$external_driver"
 expect_rc 2 'external driver' "$external_driver" --validate-only --base "$base" --head "$head"


### PR DESCRIPTION
## What

An unpinned `bench/scale/compare-rrharness.sh` run passed `--no-gates` to the parser, so its receipts were always advisory; in gated (pinned) mode the gate table gives 1000-client rungs `maximum_regression = 0.0` (only 256-client rungs get 5.0), so a throughput regression on the 1000-client rungs could never fail a run. A 31% rr1000 regression shipped past a green board this way.

- `bench/scale/rebaseline/parse_rrharness.py`: `compare` gains `--max-regression PCT` (positive finite float, argparse-validated). When given, every rung is gated on the one uniform regression ceiling — `maximum_regression = PCT`, `required_improvement = 0.0` — and verdicts are `pass` / `fail-regression`. The pinned gate path (`required_improvement` 15% on churn/1000-client rungs, 5% regression budget on 256-client rungs) is unchanged, and `--no-gates` is unchanged. `--no-gates --max-regression` is rejected as a mutually exclusive combination.
- `bench/scale/compare-rrharness.sh`: new `--max-regression PCT` driver flag, validated as a positive percentage, threaded into both `compare` invocations independent of the pin branch. Receipt status is now honest about which gate set ran: `regression-gate-passed` / `max-regression` for a max-regression run, `all-throughput-gates-passed` / `pinned` reserved for the pin path, `advisory-no-gates` / `none` only when no gate ran. When `--pin` and `--max-regression` are both given, the uniform regression gate is the one applied and the receipt says so.
- Tests: `test_parse_rrharness.py` covers a flat matrix passing under `--max-regression 10`, a fabricated 31% regression failing every rung (1000-client rungs included), and rejection of `--no-gates --max-regression`, zero, negative, NaN, and non-numeric values. `test-rrharness-driver.sh` covers validate-only acceptance with and without `--pin`, zero/non-numeric rejection, and the gate-argument threading and status seams.
- CHANGELOG entry under Unreleased.

## Scope

The companion half of LAN-1316 — committed `WIRE_MS_LIMIT`/`STAGED_MS_LIMIT` ceilings in `bench/scale/rrtransport/verify_receipt.py` — is deliberately not in this PR. The repository contains no sealed full-shape rr1000 receipt from the rrtransport instrument to seed a ceiling from: `bench/scale/README.md` records the instrument as "no published claim yet", and the only committed full-shape rr1000 timings (`docs/perf/scale-receipt-2026-07.md`, 1.80 s staged / 1.82 s wire) are from the retired scratch harness, which `bench/scale/rrtransport/README.md` declares not comparable to this instrument. Seeding a committed ceiling from those figures would invent a bound; the ceilings should land with the instrument's first sealed receipt.

## Gates

- `python3 -m unittest test_parse_rrharness test_classifiers test_validate_lan395_criterion` (41 tests): pass
- `bash -n` + `shellcheck` on `compare-rrharness.sh` and `test-rrharness-driver.sh`: clean
- `bash bench/tests/test-rrharness-driver.sh`: pass
- `bash bench/tests/test-rrtransport-receipt.sh`: pass
- `python3 scripts/check_ci_scale_split_contract.py`: pass
- Red proofs: a fabricated −31% matrix fails `--max-regression 10` on all 8 rows (`fail-regression`, exit 2); a driver copy with the gate-argument threading removed fails the new seam check; `--max-regression 0` exits 2.

LAN-1316