### PR TITLE
fix(fib): remove the unsupervised FIB-table fence path

### DIFF
--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4504,7 +4504,7 @@ remote_asn = 65002
             (transaction, ".execute_owned_operation(", 5),
             (settlement, "let coordinator_permit = coordinator.acquire().await?;", 1),
             (settlement, "watchdog.register_owned(", 1),
-            (fib, ".acquire()", 2),
+            (fib, ".acquire()", 1),
             (neighbor, "self.execute_owned_neighbor_mutation(", 4),
             (neighbor, "reserve_config_event_slot(self.config_tx.clone()).await?", 4),
             (server, "runtime_config_lock.acquire()", 0),

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -110,13 +110,6 @@ impl From<FibTableControlError> for OwnedFibControlError {
     }
 }
 
-/// Build the `FibTableControlFn` the RIB service calls for FIB-table CRUD.
-#[must_use]
-#[cfg(test)]
-pub fn make_fib_table_control_fn(deps: FibTableControlDeps) -> FibTableControlFn {
-    make_fib_table_control_fn_inner(deps, None)
-}
-
 /// Build the daemon's fail-stop-owned FIB-table CRUD hook.
 #[must_use]
 pub fn make_owned_fib_table_control_fn(
@@ -124,14 +117,8 @@ pub fn make_owned_fib_table_control_fn(
     watchdog: RuntimeConfigSettlementWatchdog,
     daemon_gate: DaemonGate,
 ) -> FibTableControlFn {
-    make_fib_table_control_fn_inner(deps, Some((watchdog, daemon_gate)))
-}
-
-fn make_fib_table_control_fn_inner(
-    deps: FibTableControlDeps,
-    settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
-) -> FibTableControlFn {
     let deps = Arc::new(deps);
+    let settlement = (watchdog, daemon_gate);
     Arc::new(move |request| {
         let deps = deps.clone();
         let settlement = settlement.clone();
@@ -141,7 +128,7 @@ fn make_fib_table_control_fn_inner(
 
 async fn handle(
     deps: Arc<FibTableControlDeps>,
-    settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
+    settlement: (RuntimeConfigSettlementWatchdog, DaemonGate),
     request: FibTableControlRequest,
 ) -> Result<proto::ListFibTablesResponse, FibTableControlError> {
     match request {
@@ -200,7 +187,7 @@ impl Mutation {
 
 async fn mutate(
     deps: Arc<FibTableControlDeps>,
-    settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
+    settlement: (RuntimeConfigSettlementWatchdog, DaemonGate),
     mutation: Mutation,
 ) -> Result<proto::ListFibTablesResponse, FibTableControlError> {
     // A mutation needs a running reconciler and a persistence sink. Resolve
@@ -236,38 +223,16 @@ async fn mutate(
         .await
     };
     let (context, attachment) = OwnedRuntimeConfigRequestContext::unary();
-    let result: Result<_, OwnedFibControlError> = if let Some((watchdog, daemon_gate)) = settlement
-    {
-        watchdog
-            .execute_owned(
-                kind,
-                deps.lock.clone(),
-                daemon_gate,
-                context.response_attached(),
-                move |operation| body(Some(operation)),
-            )
-            .await
-    } else {
-        let coordinator = deps.lock.clone();
-        let join = tokio::spawn(async move {
-            let _guard = coordinator.acquire().await?;
-            match body(None).await {
-                OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
-                OwnedRuntimeConfigOutcome::PublishedDurable(value)
-                | OwnedRuntimeConfigOutcome::AcknowledgedAuthority(value) => Ok(value),
-                OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
-                    let _ = error;
-                    std::future::pending().await
-                }
-            }
-        });
-        match join.await {
-            Ok(result) => result,
-            Err(_) => Err(OwnedFibControlError(FibTableControlError::Internal(
-                "FIB-table mutation task did not complete".to_string(),
-            ))),
-        }
-    };
+    let (watchdog, daemon_gate) = settlement;
+    let result: Result<_, OwnedFibControlError> = watchdog
+        .execute_owned(
+            kind,
+            deps.lock.clone(),
+            daemon_gate,
+            context.response_attached(),
+            move |operation| body(Some(operation)),
+        )
+        .await;
     drop(attachment);
     result.map_err(|error| error.0)
 }
@@ -912,17 +877,21 @@ mod tests {
                 "actor-read test unexpectedly reached persistence"
             );
         });
-        let control = make_fib_table_control_fn(FibTableControlDeps {
-            fib_cmd_tx,
-            peer_mgr_tx,
-            rib_tx: None,
-            config_tx: Some(config_tx),
-            lock: RuntimeConfigCoordinator::new(),
-            config_mutation_gate: None,
-            startup_tables,
-            confirm_journal_path: None,
-            config_history_dir: None,
-        });
+        let control = make_owned_fib_table_control_fn(
+            FibTableControlDeps {
+                fib_cmd_tx,
+                peer_mgr_tx,
+                rib_tx: None,
+                config_tx: Some(config_tx),
+                lock: RuntimeConfigCoordinator::new(),
+                config_mutation_gate: None,
+                startup_tables,
+                confirm_journal_path: None,
+                config_history_dir: None,
+            },
+            RuntimeConfigSettlementWatchdog::new(),
+            DaemonGate::new(),
+        );
         let (rib_tx, _rib_rx) = mpsc::channel(1);
         RibService::with_status_snapshots(rib_tx, Arc::new(Vec::new), Arc::new(Vec::new))
             .with_fib_table_control(AccessMode::ReadWrite, Some(control))
@@ -947,13 +916,18 @@ mod tests {
             config_history_dir: None,
         });
 
-        let list_error = handle(deps.clone(), None, FibTableControlRequest::List)
+        let settlement = || (RuntimeConfigSettlementWatchdog::new(), DaemonGate::new());
+        let list_error = handle(deps.clone(), settlement(), FibTableControlRequest::List)
             .await
             .unwrap_err();
         assert!(matches!(list_error, FibTableControlError::Unavailable(_)));
-        let set_error = mutate(deps.clone(), None, Mutation::Upsert(table("core", 1001)))
-            .await
-            .unwrap_err();
+        let set_error = mutate(
+            deps.clone(),
+            settlement(),
+            Mutation::Upsert(table("core", 1001)),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(set_error, FibTableControlError::Unavailable(_)));
         assert!(matches!(
             fib_rx.try_recv(),
@@ -1094,9 +1068,13 @@ mod tests {
             confirm_journal_path: None,
             config_history_dir: None,
         });
-        let err = mutate(deps, None, Mutation::Upsert(table("core", 1001)))
-            .await
-            .expect_err("persistence rejection must fail the mutation");
+        let err = mutate(
+            deps,
+            (RuntimeConfigSettlementWatchdog::new(), DaemonGate::new()),
+            Mutation::Upsert(table("core", 1001)),
+        )
+        .await
+        .expect_err("persistence rejection must fail the mutation");
         assert!(
             matches!(err, FibTableControlError::FailedPrecondition(ref message) if message == "desired config validation failed"),
             "{err:?}"


### PR DESCRIPTION
## What

Deletes the test-only `make_fib_table_control_fn` constructor and the `settlement: None` code path it fed in `src/fib_table_control.rs`. `make_owned_fib_table_control_fn` now builds the hook directly, and `handle`/`mutate` take the `(RuntimeConfigSettlementWatchdog, DaemonGate)` pair as a plain tuple instead of an `Option`.

## Why the `Option` was a hazard

The `None` arm handled a fenced FIB mutation by parking the spawned task on `std::future::pending()` while still holding the `RuntimeConfigCoordinator` permit, with no `fence_recovery(reason)` escalation to fail-stop — unlike the supervised twin in `crates/api/src/runtime_config_settlement.rs`. One fence on that path would silently deadlock every subsequent runtime-config mutation behind `coordinator.acquire()` instead of exiting the daemon. Production was never exposed: `main.rs` wires only the owned constructor, and the unsupervised constructor was `#[cfg(test)]` with a single test caller. The `Option` nevertheless kept the hazard representable and one refactor away from reachable; this change makes it structurally unrepresentable.

## Test coverage

The tests that rode the unsupervised path now exercise the owned, watchdog-supervised path at the same seams, with assertions unchanged:

- The `rpc_service` fixture builds its control hook with `make_owned_fib_table_control_fn` plus a real `RuntimeConfigSettlementWatchdog::new()` and `DaemonGate::new()`, so the actor-read outage tests (`Unavailable`/`Internal` mapping) now run under supervision.
- `closed_coordinator_rejects_fib_before_actor_or_persistence` passes a real settlement pair; a closed coordinator still rejects as `Unavailable` before any actor, peer-manager, or persistence effect — now via the watchdog's coordinator acquisition.
- The persistence-rejection test (`fail_write` -> `FAILED_PRECONDITION`, runtime and peer-manager snapshots restored) likewise runs supervised.

The direct `owned_fib_mutation_body` outcome-classification tests are untouched; the body's `Option<OwnedRuntimeConfigOperation>` phase-reporting parameter remains for them.

The runtime-config coordinator inventory in `src/config_transaction_control.rs` drops the fib `.acquire()` census from 2 to 1 for the deleted acquisition site.

No operator-visible behavior change. (LAN-1329)