### PR TITLE
refactor: deduplicate attribute and EVPN dataplane guards

### DIFF
--- a/bench/scale/route-server-1000/run-receipt.sh
+++ b/bench/scale/route-server-1000/run-receipt.sh
@@ -339,7 +339,7 @@ with open(sys.argv[1], encoding="utf-8") as stream:
     value = json.load(stream)
 assert value["decision"] == "advertise", value
 assert value.get("update_group_id") is not None, value
-assert any(g["verdict"] == "pass" for g in value["gates"]), value
+assert all(g["verdict"] != "stop" for g in value["gates"]), value
 assert any(g["gate"] == "export_policy" and g["verdict"] == "pass" for g in value["gates"]), value
 PY
 [[ $(git -C "$REPO" rev-parse HEAD) == "$COMMIT" ]] || { echo "HEAD changed during run" >&2; exit 1; }

--- a/crates/rib/benches/evpn_dataplane_query.rs
+++ b/crates/rib/benches/evpn_dataplane_query.rs
@@ -107,7 +107,7 @@ fn bench(c: &mut Criterion) {
             let routes = fixture(rows, mixed);
             let relevant_rows = routes
                 .iter()
-                .filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+                .filter(|route| rustbgpd_wire::is_dataplane_route_type(route.route_type()))
                 .count();
             let changed = bench_evpn_dataplane_generation_snapshot(
                 &routes,

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -99,7 +99,7 @@ pub fn bench_evpn_dataplane_generation_snapshot(
 ) -> EvpnDataplaneQueryBenchReceipt {
     let relevant_rows = rows
         .iter()
-        .filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+        .filter(|route| rustbgpd_wire::is_dataplane_route_type(route.route_type()))
         .count();
     let visits = Cell::new(0usize);
     let routes = super::collect_evpn_dataplane_routes(

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -444,7 +444,7 @@ impl RibManager {
                 };
                 let previous_peer = previous_best.as_ref().map(|r| r.peer);
                 let peer = new_best.as_ref().map(|r| r.peer);
-                if matches!(key.route_type(), 1 | 2 | 5) {
+                if rustbgpd_wire::is_dataplane_route_type(key.route_type()) {
                     match (previous_best.is_some(), new_best.is_some()) {
                         (false, true) => {
                             self.evpn_dataplane_route_count = self
@@ -480,7 +480,7 @@ impl RibManager {
         // projection and therefore do not invalidate its snapshot.
         if changed_keys
             .iter()
-            .any(|key| matches!(key.route_type(), 1 | 2 | 5))
+            .any(|key| rustbgpd_wire::is_dataplane_route_type(key.route_type()))
         {
             self.evpn_dataplane_generation = self.evpn_dataplane_generation.wrapping_add(1);
         }
@@ -489,7 +489,7 @@ impl RibManager {
             self.evpn_dataplane_route_count,
             self.loc_rib
                 .iter_evpn()
-                .filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+                .filter(|route| rustbgpd_wire::is_dataplane_route_type(route.route_type()))
                 .count(),
             "EVPN dataplane relevant-row cardinality drifted from the Loc-RIB"
         );

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -903,7 +903,7 @@ fn collect_evpn_dataplane_routes<'a>(
     }
     let mut routes = Vec::with_capacity(relevant_rows);
     routes.extend(
-        rows.filter(|route| matches!(route.route_type(), 1 | 2 | 5))
+        rows.filter(|route| rustbgpd_wire::is_dataplane_route_type(route.route_type()))
             .cloned(),
     );
     Some(routes)

--- a/crates/wire/src/assigned_attributes.rs
+++ b/crates/wire/src/assigned_attributes.rs
@@ -2,6 +2,8 @@
 
 use crate::constants::attr_type;
 
+/// Called unconditionally from attribute decode; type codes without a
+/// framing check here fall through to `Ok(())`.
 pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> {
     match type_code {
         attr_type::COMMUNITY_CONTAINER => community_container(value),

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1671,25 +1671,13 @@ fn decode_attribute_value(
             ),
         });
     }
-    if matches!(
-        type_code,
-        attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY
-            | attr_type::COMMUNITY_CONTAINER
-            | attr_type::DOMAIN_PATH
-            | attr_type::SFP
-            | attr_type::BFD_DISCRIMINATOR
-            | attr_type::NHC
-            | attr_type::PREFIX_SID
-            | attr_type::BIER
-    ) {
-        crate::assigned_attributes::validate(type_code, value).map_err(|detail| {
-            DecodeError::UpdateAttributeError {
-                subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
-                data: attr_error_data(flags, type_code, value),
-                detail: format!("attribute type {type_code}: {detail}"),
-            }
-        })?;
-    }
+    crate::assigned_attributes::validate(type_code, value).map_err(|detail| {
+        DecodeError::UpdateAttributeError {
+            subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+            data: attr_error_data(flags, type_code, value),
+            detail: format!("attribute type {type_code}: {detail}"),
+        }
+    })?;
     match type_code {
         attr_type::ORIGIN => {
             if value.len() != 1 {

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -649,6 +649,19 @@ impl EvpnRouteKey {
     }
 }
 
+/// Whether an EVPN route-type byte names a route the kernel dataplane
+/// consumes.
+///
+/// Types 1 (Ethernet A-D per-ES/per-EVI), 2 (MAC/IP Advertisement), and 5
+/// (IP Prefix) carry forwarding state — MAC/IP bindings, per-ES mass
+/// withdraw and local bias, and IP prefixes — and may reach the FDB/VXLAN
+/// programmer. Types 3 (IMET) and 4 (Ethernet Segment) drive BGP-side
+/// flooding and DF election only and must never reach it.
+#[must_use]
+pub const fn is_dataplane_route_type(route_type: u8) -> bool {
+    matches!(route_type, 1 | 2 | 5)
+}
+
 // ---------------------------------------------------------------------------
 // Decode helpers
 // ---------------------------------------------------------------------------
@@ -1260,6 +1273,16 @@ pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) -> Result<(), E
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dataplane_route_type_truth_table() {
+        for route_type in [1u8, 2, 5] {
+            assert!(is_dataplane_route_type(route_type), "type {route_type}");
+        }
+        for route_type in [0u8, 3, 4, 6, 255] {
+            assert!(!is_dataplane_route_type(route_type), "type {route_type}");
+        }
+    }
 
     fn sample_rd() -> RouteDistinguisher {
         // Type 0: 2-byte ASN 65000 + 4-byte assigned 100

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -289,7 +289,7 @@ pub use evpn::{
     EthernetSegmentIdentifier, EthernetTagId, EvpnEadPerEs, EvpnEadPerEvi, EvpnEs, EvpnImet,
     EvpnIpPrefixRoute, EvpnIpPrefixValue, EvpnMacIp, EvpnRoute, EvpnRouteKey, MacAddress,
     MplsLabel, RouteDistinguisher, RouteDistinguisherParseError, decode_evpn_nlri,
-    encode_evpn_nlri,
+    encode_evpn_nlri, is_dataplane_route_type,
 };
 
 // Well-known communities (RFC 1997 + RFC 7999 + RFC 8326 + RFC 9494)


### PR DESCRIPTION
Three deletion-shaped cleanups of duplicated or vacuous guards (LAN-1339). No behavior change.

- **Assigned-attribute validation gate**: `decode_attribute_value` gated the call to `assigned_attributes::validate` behind a `matches!` over the same eight type codes the callee itself dispatches on, with `_ => Ok(())` covering everything else. The wrapper is deleted; `validate` is called unconditionally and now carries a comment stating that contract.
- **EVPN dataplane route-type literal**: `matches!(.., 1 | 2 | 5)` appeared at six sites across the RIB manager, distribution, bench support, and the dataplane-query bench. They now share one wire predicate, `rustbgpd_wire::is_dataplane_route_type(u8)`, whose doc comment records why types 1/2/5 (EAD, MAC/IP, IP Prefix) are the kernel-dataplane-relevant set and types 3/4 (IMET, ES) must never reach the FDB/VXLAN programmer. Additive `pub const fn` on the published wire crate; no existing public item changed. A small truth-table test pins the set.
- **route-server-1000 receipt**: the `assert any(verdict == "pass")` line was fully subsumed by the export_policy-specific assertion immediately after it and could never fail independently. It now asserts that no gate verdict is `stop` (admitting `pass` and `not_applicable`), which checks something the next line does not.

Gates run: fmt, clippy (workspace, all targets, -D warnings), wire tests, full workspace tests, cargo doc, bash -n + shellcheck on the receipt script, and `bench/tests/test-route-server-1000-receipt.sh` — all green. No CHANGELOG entry, matching precedent for internal refactors.