### PR TITLE
Fuzz the RFC 8654 extended-message range

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,7 +52,7 @@ jobs:
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
-            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=4096
+            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=65535
           done
       - name: Fuzz rpol policy frontend (2 minutes per target)
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -49,10 +49,28 @@ jobs:
             exit 1
           fi
           for t in $targets; do
+            # Full messages carry their header; body-only decoders must use
+            # the corresponding framed body ceiling. Substrate, constructor,
+            # and text targets retain the reviewed 4096-byte campaign bound.
+            case "$t" in
+              decode_bgpls) max_len=4096 ;;
+              decode_evpn) max_len=4096 ;;
+              decode_flowspec) max_len=4096 ;;
+              decode_labeled) max_len=4096 ;;
+              decode_message) max_len=65535 ;;
+              decode_open) max_len=4077 ;;
+              decode_route_refresh) max_len=65516 ;;
+              decode_rtc) max_len=4096 ;;
+              decode_update) max_len=65516 ;;
+              decode_vpn) max_len=4096 ;;
+              encode_evpn) max_len=4096 ;;
+              parse_rd) max_len=4096 ;;
+              *) echo "wire fuzz target has no reviewed max_len: $t" >&2; exit 1 ;;
+            esac
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
-            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=65535
+            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len="$max_len"
           done
       - name: Fuzz rpol policy frontend (2 minutes per target)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   policy replay; RFC 8212 preflight and clean-convergence cohort selection use
   the same closed three-way outcome model.
 
+- The nightly and hosted wire fuzz campaigns now exercise complete BGP
+  messages through the 65,535-byte RFC 8654 limit and UPDATE bodies through
+  the corresponding 65,516-byte framing boundary instead of stopping at the
+  legacy 4,096-byte ceiling.
+
 - Policy mutation preflight failures now preserve `NOT_FOUND`, `INVALID_ARGUMENT`, and
   `FAILED_PRECONDITION` while retaining the closed `policy_preflight_rejected` diagnostic.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The nightly and hosted wire fuzz campaigns now exercise complete BGP
   messages through the 65,535-byte RFC 8654 limit and UPDATE bodies through
   the corresponding 65,516-byte framing boundary instead of stopping at the
-  legacy 4,096-byte ceiling.
+  legacy 4,096-byte ceiling. ROUTE-REFRESH bodies use that same extended
+  framing boundary, while pre-negotiation OPEN bodies retain their exact
+  4,077-byte legacy boundary.
 
 - Policy mutation preflight failures now preserve `NOT_FOUND`, `INVALID_ARGUMENT`, and
   `FAILED_PRECONDITION` while retaining the closed `policy_preflight_rejected` diagnostic.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -136,8 +136,11 @@ compilation and explain-walk agreement, MRT snapshot and warm-bundle
 readers, EVPN parsing, the BFD control-packet decoder, and the RTR PDU
 decoder. A nightly CI campaign (`.github/workflows/fuzz.yml`) runs every
 target in each crate against tracked seed corpora and fails loudly if
-target enumeration returns nothing. A ClusterFuzzLite workflow builds all
-targets with AddressSanitizer for on-demand campaigns. The target
+target enumeration returns nothing. In both nightly and hosted campaigns,
+the complete-message wire target accepts 65,535-byte RFC 8654 messages and
+the body-only UPDATE target accepts the corresponding 65,516-byte body. A
+ClusterFuzzLite workflow builds all targets with AddressSanitizer for
+on-demand campaigns. The target
 inventory is fail-closed: `scripts/check_fuzz_target_inventory.py` runs
 in CI and fails when the inventory drifts from the reviewed list.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,9 +138,10 @@ decoder. A nightly CI campaign (`.github/workflows/fuzz.yml`) runs every
 target in each crate against tracked seed corpora and fails loudly if
 target enumeration returns nothing. In both nightly and hosted campaigns,
 the complete-message wire target accepts 65,535-byte RFC 8654 messages and
-the body-only UPDATE target accepts the corresponding 65,516-byte body. A
-ClusterFuzzLite workflow builds all targets with AddressSanitizer for
-on-demand campaigns. The target
+the body-only UPDATE and ROUTE-REFRESH targets accept the corresponding
+65,516-byte bodies. Pre-negotiation OPEN bodies remain capped at the legacy
+4,077-byte body boundary. A ClusterFuzzLite workflow builds all targets with
+AddressSanitizer for on-demand campaigns. The target
 inventory is fail-closed: `scripts/check_fuzz_target_inventory.py` runs
 in CI and fails when the inventory drifts from the reviewed list.
 

--- a/crates/wire/fuzz/decode_message.options
+++ b/crates/wire/fuzz/decode_message.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 65535

--- a/crates/wire/fuzz/decode_open.options
+++ b/crates/wire/fuzz/decode_open.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 4077

--- a/crates/wire/fuzz/decode_route_refresh.options
+++ b/crates/wire/fuzz/decode_route_refresh.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 65516

--- a/crates/wire/fuzz/decode_update.options
+++ b/crates/wire/fuzz/decode_update.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 65516

--- a/crates/wire/fuzz/fuzz_targets/decode_message.rs
+++ b/crates/wire/fuzz/fuzz_targets/decode_message.rs
@@ -7,5 +7,5 @@ use rustbgpd_wire::message::decode_message;
 fuzz_target!(|data: &[u8]| {
     let mut buf = Bytes::copy_from_slice(data);
     // Must never panic regardless of input
-    let _ = decode_message(&mut buf, rustbgpd_wire::constants::MAX_MESSAGE_LEN);
+    let _ = decode_message(&mut buf, rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN);
 });

--- a/crates/wire/fuzz/fuzz_targets/decode_open.rs
+++ b/crates/wire/fuzz/fuzz_targets/decode_open.rs
@@ -10,6 +10,14 @@ use libfuzzer_sys::fuzz_target;
 use rustbgpd_wire::{Message, OpenMessage, decode_message};
 
 fuzz_target!(|data: &[u8]| {
+    // OPEN is decoded before Extended Messages can be negotiated. Mirror the
+    // legacy full-message ceiling for this body-only harness.
+    if data.len()
+        > usize::from(rustbgpd_wire::MAX_MESSAGE_LEN)
+            - rustbgpd_wire::constants::HEADER_LEN
+    {
+        return;
+    }
     let mut buf = Bytes::copy_from_slice(data);
     let Ok(open) = OpenMessage::decode(&mut buf, data.len()) else {
         return;

--- a/crates/wire/fuzz/fuzz_targets/decode_route_refresh.rs
+++ b/crates/wire/fuzz/fuzz_targets/decode_route_refresh.rs
@@ -14,7 +14,10 @@ fuzz_target!(|data: &[u8]| {
     // In the real session path the body length comes from a header already
     // bounded by the negotiated maximum message size; mirror that bound so
     // the re-encoded message stays decodable (RFC 8654 extended limit).
-    if data.len() > usize::from(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN) - 19 {
+    if data.len()
+        > usize::from(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)
+            - rustbgpd_wire::constants::HEADER_LEN
+    {
         return;
     }
     let mut buf = Bytes::copy_from_slice(data);

--- a/crates/wire/fuzz/fuzz_targets/decode_update.rs
+++ b/crates/wire/fuzz/fuzz_targets/decode_update.rs
@@ -3,6 +3,15 @@ use bytes::Bytes;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
+    // The session decoder admits an UPDATE body only after framing the full
+    // message under the RFC 8654 limit. Keep this body-only harness on that
+    // same boundary instead of exploring bytes the daemon cannot pass here.
+    if data.len()
+        > usize::from(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)
+            - rustbgpd_wire::constants::HEADER_LEN
+    {
+        return;
+    }
     // Need at least 4 bytes for the minimal UPDATE body
     if data.len() < 4 {
         return;

--- a/scripts/check_fuzz_target_inventory.py
+++ b/scripts/check_fuzz_target_inventory.py
@@ -35,6 +35,17 @@ EXPECTED_TARGETS: dict[str, tuple[str, ...]] = {
     ),
 }
 EXPECTED_COUNT = 21
+WIRE_EXTENDED_TARGETS = {
+    "decode_message": (
+        65_535,
+        "decode_message(&mut buf, rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)",
+    ),
+    "decode_update": (
+        65_516,
+        "usize::from(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)",
+    ),
+}
+WIRE_EXTENDED_MAX_LEN = 65_535
 CAMPAIGN_BOUNDS: dict[str, tuple[str, int]] = {
     "crates/bfd": ("decode_bfd_control", 256),
     "crates/rpki": ("decode_rtr_pdu", 65_535),
@@ -188,6 +199,41 @@ def validate_pipeline_enrollment(builder: str, workflow: str) -> None:
 
     if 'cp "fuzz/$name.options" "$OUT/$name.options"' not in builder:
         raise InventoryError("shared hosted builder does not copy target options")
+
+    wire_block = re.search(
+        r"(?ms)^      - name: [^\n]+\n        run: \|\n(?P<body>.*?cd crates/wire.*?)(?=^      - name:|\Z)",
+        workflow,
+    )
+    if wire_block is None:
+        raise InventoryError("nightly workflow has no crates/wire campaign")
+    if f"-max_len={WIRE_EXTENDED_MAX_LEN}" not in wire_block.group("body"):
+        raise InventoryError(
+            "nightly workflow does not enforce the RFC 8654 wire max_len="
+            f"{WIRE_EXTENDED_MAX_LEN}"
+        )
+    for target, (hosted_max_len, required_source) in WIRE_EXTENDED_TARGETS.items():
+        options = ROOT / "crates/wire/fuzz" / f"{target}.options"
+        expected_options = f"[libfuzzer]\nmax_len = {hosted_max_len}\n"
+        try:
+            actual_options = options.read_text()
+        except OSError as error:
+            raise InventoryError(f"cannot read {options.relative_to(ROOT)}: {error}")
+        if actual_options != expected_options:
+            raise InventoryError(
+                f"{options.relative_to(ROOT)} must set max_len = "
+                f"{hosted_max_len}"
+            )
+
+        harness = ROOT / f"crates/wire/fuzz/fuzz_targets/{target}.rs"
+        try:
+            harness_text = harness.read_text()
+        except OSError as error:
+            raise InventoryError(f"cannot read {harness.relative_to(ROOT)}: {error}")
+        if required_source not in harness_text:
+            raise InventoryError(
+                f"{harness.relative_to(ROOT)} must enforce its "
+                "EXTENDED_MAX_MESSAGE_LEN contract"
+            )
 
     for crate, (target, max_len) in CAMPAIGN_BOUNDS.items():
         crate_block = re.search(

--- a/scripts/check_fuzz_target_inventory.py
+++ b/scripts/check_fuzz_target_inventory.py
@@ -35,17 +35,53 @@ EXPECTED_TARGETS: dict[str, tuple[str, ...]] = {
     ),
 }
 EXPECTED_COUNT = 21
-WIRE_EXTENDED_TARGETS = {
+WIRE_NIGHTLY_MAX_LENS = {
+    "decode_bgpls": 4_096,
+    "decode_evpn": 4_096,
+    "decode_flowspec": 4_096,
+    "decode_labeled": 4_096,
+    "decode_message": 65_535,
+    "decode_open": 4_077,
+    "decode_route_refresh": 65_516,
+    "decode_rtc": 4_096,
+    "decode_update": 65_516,
+    "decode_vpn": 4_096,
+    "encode_evpn": 4_096,
+    "parse_rd": 4_096,
+}
+WIRE_HOSTED_CONTRACTS = {
     "decode_message": (
         65_535,
         "decode_message(&mut buf, rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)",
     ),
+    "decode_open": (
+        4_077,
+        "if data.len()\n"
+        "        > usize::from(rustbgpd_wire::MAX_MESSAGE_LEN)\n"
+        "            - rustbgpd_wire::constants::HEADER_LEN\n"
+        "    {\n"
+        "        return;\n"
+        "    }",
+    ),
+    "decode_route_refresh": (
+        65_516,
+        "if data.len()\n"
+        "        > usize::from(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)\n"
+        "            - rustbgpd_wire::constants::HEADER_LEN\n"
+        "    {\n"
+        "        return;\n"
+        "    }",
+    ),
     "decode_update": (
         65_516,
-        "usize::from(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)",
+        "if data.len()\n"
+        "        > usize::from(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)\n"
+        "            - rustbgpd_wire::constants::HEADER_LEN\n"
+        "    {\n"
+        "        return;\n"
+        "    }",
     ),
 }
-WIRE_EXTENDED_MAX_LEN = 65_535
 CAMPAIGN_BOUNDS: dict[str, tuple[str, int]] = {
     "crates/bfd": ("decode_bfd_control", 256),
     "crates/rpki": ("decode_rtr_pdu", 65_535),
@@ -206,12 +242,34 @@ def validate_pipeline_enrollment(builder: str, workflow: str) -> None:
     )
     if wire_block is None:
         raise InventoryError("nightly workflow has no crates/wire campaign")
-    if f"-max_len={WIRE_EXTENDED_MAX_LEN}" not in wire_block.group("body"):
+    wire_body = wire_block.group("body")
+    bound_rows = re.findall(
+        r"(?m)^\s+(?P<target>[a-z][a-z0-9_]*)\) max_len=(?P<max_len>[0-9]+) ;;$",
+        wire_body,
+    )
+    bound_targets = [target for target, _ in bound_rows]
+    if len(bound_targets) != len(set(bound_targets)):
+        raise InventoryError("nightly wire max_len dispatch has duplicate targets")
+    actual_bounds = {target: int(max_len) for target, max_len in bound_rows}
+    if actual_bounds != WIRE_NIGHTLY_MAX_LENS:
         raise InventoryError(
-            "nightly workflow does not enforce the RFC 8654 wire max_len="
-            f"{WIRE_EXTENDED_MAX_LEN}"
+            "nightly wire target-specific max_len dispatch differs: "
+            f"expected {WIRE_NIGHTLY_MAX_LENS}, got {actual_bounds}"
         )
-    for target, (hosted_max_len, required_source) in WIRE_EXTENDED_TARGETS.items():
+    if 'case "$t" in' not in wire_body:
+        raise InventoryError("nightly wire max_len dispatch has no case statement")
+    if (
+        '*) echo "wire fuzz target has no reviewed max_len: $t" >&2; exit 1 ;;'
+        not in wire_body
+    ):
+        raise InventoryError("nightly wire max_len dispatch has no fail-closed default")
+    if '-max_len="$max_len"' not in wire_body:
+        raise InventoryError("nightly wire campaign does not use its selected max_len")
+
+    if tuple(sorted(WIRE_NIGHTLY_MAX_LENS)) != EXPECTED_TARGETS["crates/wire"]:
+        raise InventoryError("nightly wire max_len map differs from target inventory")
+
+    for target, (hosted_max_len, required_source) in WIRE_HOSTED_CONTRACTS.items():
         options = ROOT / "crates/wire/fuzz" / f"{target}.options"
         expected_options = f"[libfuzzer]\nmax_len = {hosted_max_len}\n"
         try:
@@ -232,7 +290,7 @@ def validate_pipeline_enrollment(builder: str, workflow: str) -> None:
         if required_source not in harness_text:
             raise InventoryError(
                 f"{harness.relative_to(ROOT)} must enforce its "
-                "EXTENDED_MAX_MESSAGE_LEN contract"
+                "reviewed max_len contract"
             )
 
     for crate, (target, max_len) in CAMPAIGN_BOUNDS.items():

--- a/scripts/test_check_fuzz_target_inventory.py
+++ b/scripts/test_check_fuzz_target_inventory.py
@@ -168,21 +168,62 @@ class FuzzTargetInventoryTests(unittest.TestCase):
         with self.assertRaisesRegex(inventory.InventoryError, "target options"):
             inventory.validate_pipeline_enrollment(mutated, workflow)
 
-    def test_wire_extended_message_campaign_bound_drift_is_rejected(self) -> None:
+    def test_wire_nightly_target_specific_bound_drift_is_rejected(self) -> None:
         builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
         workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
-        mutated = workflow.replace(
-            f"-max_len={inventory.WIRE_EXTENDED_MAX_LEN}", "-max_len=4096", 1
+        for target, max_len in inventory.WIRE_NIGHTLY_MAX_LENS.items():
+            with self.subTest(target=target, mutation="changed"):
+                mutated = workflow.replace(
+                    f"{target}) max_len={max_len} ;;",
+                    f"{target}) max_len={max_len + 1} ;;",
+                    1,
+                )
+                with self.assertRaisesRegex(
+                    inventory.InventoryError, "target-specific max_len"
+                ):
+                    inventory.validate_pipeline_enrollment(builder, mutated)
+
+            with self.subTest(target=target, mutation="omitted"):
+                mutated = workflow.replace(
+                    f"              {target}) max_len={max_len} ;;\n", "", 1
+                )
+                with self.assertRaisesRegex(
+                    inventory.InventoryError, "target-specific max_len"
+                ):
+                    inventory.validate_pipeline_enrollment(builder, mutated)
+
+    def test_wire_nightly_bound_dispatch_is_fail_closed(self) -> None:
+        builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
+        workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
+        mutations = (
+            (
+                'case "$t" in',
+                'case "$omitted" in',
+                "case statement",
+            ),
+            (
+                '*) echo "wire fuzz target has no reviewed max_len: $t" >&2; exit 1 ;;',
+                "*) max_len=4096 ;;",
+                "fail-closed default",
+            ),
+            (
+                '-max_len="$max_len"',
+                "-max_len=4096",
+                "selected max_len",
+            ),
         )
-        with self.assertRaisesRegex(inventory.InventoryError, "RFC 8654"):
-            inventory.validate_pipeline_enrollment(builder, mutated)
+        for old, new, error in mutations:
+            with self.subTest(error=error):
+                mutated = workflow.replace(old, new, 1)
+                with self.assertRaisesRegex(inventory.InventoryError, error):
+                    inventory.validate_pipeline_enrollment(builder, mutated)
 
     def test_wire_extended_message_target_options_are_load_bearing(self) -> None:
         builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
         workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
         read_text = Path.read_text
 
-        for target, (hosted_max_len, _) in inventory.WIRE_EXTENDED_TARGETS.items():
+        for target, (hosted_max_len, _) in inventory.WIRE_HOSTED_CONTRACTS.items():
             options = inventory.ROOT / "crates/wire/fuzz" / f"{target}.options"
 
             def changed_options(path, *args, **kwargs):
@@ -195,28 +236,56 @@ class FuzzTargetInventoryTests(unittest.TestCase):
                     with self.assertRaisesRegex(inventory.InventoryError, "must set"):
                         inventory.validate_pipeline_enrollment(builder, workflow)
 
-    def test_wire_extended_message_harness_limits_are_load_bearing(self) -> None:
+    def test_wire_hosted_harness_limits_are_load_bearing(self) -> None:
         builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
         workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
         read_text = Path.read_text
 
-        for target in inventory.WIRE_EXTENDED_TARGETS:
+        for target, (_, required_source) in inventory.WIRE_HOSTED_CONTRACTS.items():
             harness = (
                 inventory.ROOT / f"crates/wire/fuzz/fuzz_targets/{target}.rs"
             )
 
-            def removed_extended_limit(path, *args, **kwargs):
+            def removed_hosted_limit(path, *args, **kwargs):
                 text = read_text(path, *args, **kwargs)
                 if path == harness:
-                    return text.replace("EXTENDED_MAX_MESSAGE_LEN", "MAX_MESSAGE_LEN")
+                    return text.replace(
+                        required_source, "/* reviewed bound omitted */", 1
+                    )
                 return text
 
             with self.subTest(target=target):
-                with mock.patch.object(Path, "read_text", removed_extended_limit):
+                with mock.patch.object(Path, "read_text", removed_hosted_limit):
                     with self.assertRaisesRegex(
-                        inventory.InventoryError, "EXTENDED_MAX_MESSAGE_LEN"
+                        inventory.InventoryError, "reviewed max_len contract"
                     ):
                         inventory.validate_pipeline_enrollment(builder, workflow)
+
+    def test_body_decoder_full_guard_is_load_bearing(self) -> None:
+        builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
+        workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
+        read_text = Path.read_text
+        mutations = (
+            ("            - rustbgpd_wire::constants::HEADER_LEN\n", ""),
+            ("rustbgpd_wire::constants::HEADER_LEN", "19"),
+        )
+
+        for target in ("decode_open", "decode_route_refresh", "decode_update"):
+            harness = inventory.ROOT / f"crates/wire/fuzz/fuzz_targets/{target}.rs"
+            for old, new in mutations:
+
+                def changed_guard(path, *args, **kwargs):
+                    text = read_text(path, *args, **kwargs)
+                    if path == harness:
+                        return text.replace(old, new, 1)
+                    return text
+
+                with self.subTest(target=target, replacement=new or "removed"):
+                    with mock.patch.object(Path, "read_text", changed_guard):
+                        with self.assertRaisesRegex(
+                            inventory.InventoryError, "reviewed max_len contract"
+                        ):
+                            inventory.validate_pipeline_enrollment(builder, workflow)
 
     def test_new_nightly_campaign_omission_is_rejected(self) -> None:
         builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()

--- a/scripts/test_check_fuzz_target_inventory.py
+++ b/scripts/test_check_fuzz_target_inventory.py
@@ -168,6 +168,56 @@ class FuzzTargetInventoryTests(unittest.TestCase):
         with self.assertRaisesRegex(inventory.InventoryError, "target options"):
             inventory.validate_pipeline_enrollment(mutated, workflow)
 
+    def test_wire_extended_message_campaign_bound_drift_is_rejected(self) -> None:
+        builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
+        workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
+        mutated = workflow.replace(
+            f"-max_len={inventory.WIRE_EXTENDED_MAX_LEN}", "-max_len=4096", 1
+        )
+        with self.assertRaisesRegex(inventory.InventoryError, "RFC 8654"):
+            inventory.validate_pipeline_enrollment(builder, mutated)
+
+    def test_wire_extended_message_target_options_are_load_bearing(self) -> None:
+        builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
+        workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
+        read_text = Path.read_text
+
+        for target, (hosted_max_len, _) in inventory.WIRE_EXTENDED_TARGETS.items():
+            options = inventory.ROOT / "crates/wire/fuzz" / f"{target}.options"
+
+            def changed_options(path, *args, **kwargs):
+                if path == options:
+                    return f"[libfuzzer]\nmax_len = {hosted_max_len - 1}\n"
+                return read_text(path, *args, **kwargs)
+
+            with self.subTest(target=target):
+                with mock.patch.object(Path, "read_text", changed_options):
+                    with self.assertRaisesRegex(inventory.InventoryError, "must set"):
+                        inventory.validate_pipeline_enrollment(builder, workflow)
+
+    def test_wire_extended_message_harness_limits_are_load_bearing(self) -> None:
+        builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
+        workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()
+        read_text = Path.read_text
+
+        for target in inventory.WIRE_EXTENDED_TARGETS:
+            harness = (
+                inventory.ROOT / f"crates/wire/fuzz/fuzz_targets/{target}.rs"
+            )
+
+            def removed_extended_limit(path, *args, **kwargs):
+                text = read_text(path, *args, **kwargs)
+                if path == harness:
+                    return text.replace("EXTENDED_MAX_MESSAGE_LEN", "MAX_MESSAGE_LEN")
+                return text
+
+            with self.subTest(target=target):
+                with mock.patch.object(Path, "read_text", removed_extended_limit):
+                    with self.assertRaisesRegex(
+                        inventory.InventoryError, "EXTENDED_MAX_MESSAGE_LEN"
+                    ):
+                        inventory.validate_pipeline_enrollment(builder, workflow)
+
     def test_new_nightly_campaign_omission_is_rejected(self) -> None:
         builder = (inventory.ROOT / "fuzz/build-fuzzers.sh").read_text()
         workflow = (inventory.ROOT / ".github/workflows/fuzz.yml").read_text()


### PR DESCRIPTION
## Summary

Exercise the message-length range rustbgpd accepts after negotiating RFC 8654 instead of ending wire fuzz inputs at the legacy 4,096-byte ceiling.

## Changes

- raise the nightly wire campaign input bound to 65,535 bytes
- pass the extended-message limit into the complete-message harness and cap the body-only UPDATE harness at the corresponding 65,516-byte boundary
- ship matching libFuzzer options for hosted `decode_message` and `decode_update` campaigns
- make the fuzz inventory gate reject workflow, harness, or hosted-option drift from those bounds
- document the effective nightly and hosted coverage; keep corpus persistence and seed expansion in a separate follow-up

## Testing

- [ ] `cargo test --workspace` passes
- [x] pre-push `cargo test --workspace --lib` passes
- [x] `cargo test -p rustbgpd-wire` passes (671 unit tests plus integration and doc tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] pinned-nightly ASan builds and bounded smoke runs pass for `decode_message` and `decode_update` with `-max_len=65535`
- [x] fuzz inventory mutation tests and repository inventory check pass
- [x] release-checklist path and public-document tracker checks pass
- [x] Relevant interop test intentionally not applicable; no protocol behavior changes
- [x] Performance receipt intentionally not applicable; campaign bounds only

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed
- [x] SECURITY.md updated with the complete-message and body-only bounds
- [x] No hot tracking document changed

## Related issues

Tracked in Linear; corpus lifecycle work remains a separate follow-up.
