### PR TITLE
Unify address-family labels across config and gRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   framing boundary, while pre-negotiation OPEN bodies retain their exact
   4,077-byte legacy boundary.
 
+- Neighbor and peer-group gRPC mutations now accept every address family
+  supported by the configuration file, and read responses emit the same
+  canonical vocabulary. BGP-LS remains `linkstate` / `linkstate_vpn` on
+  configuration and operator surfaces while existing `bgpls` metric labels
+  remain unchanged.
+
 - Policy mutation preflight failures now preserve `NOT_FOUND`, `INVALID_ARGUMENT`, and
   `FAILED_PRECONDITION` while retaining the closed `policy_preflight_rejected` diagnostic.
 

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -526,7 +526,10 @@ fn outbound_refresh_error_status(error: OutboundRefreshError) -> Status {
 }
 
 pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
-    family_label(afi, safi).unwrap_or("unsupported").to_string()
+    family_label(afi, safi).map_or_else(
+        || format!("afi_{}_safi_{}", afi as u16, safi as u8),
+        str::to_string,
+    )
 }
 
 pub(crate) fn parse_remove_private_as_proto(mode: &str) -> Result<RemovePrivateAs, Status> {
@@ -2792,6 +2795,20 @@ mod tests {
             assert_eq!(error.code(), tonic::Code::InvalidArgument);
             assert!(error.message().contains("linkstate"));
         }
+    }
+
+    #[test]
+    fn family_projection_preserves_out_of_vocabulary_pair_identity() {
+        let evpn_on_ipv4 = family_to_string(Afi::Ipv4, Safi::Evpn);
+        let multicast_on_ipv4 = family_to_string(Afi::Ipv4, Safi::Multicast);
+
+        assert_eq!(evpn_on_ipv4, "afi_1_safi_70");
+        assert_eq!(multicast_on_ipv4, "afi_1_safi_2");
+        assert_ne!(evpn_on_ipv4, multicast_on_ipv4);
+        assert_eq!(
+            parse_families_proto(&[evpn_on_ipv4]).unwrap_err().code(),
+            tonic::Code::InvalidArgument
+        );
     }
 
     #[tokio::test]

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -5,7 +5,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use rustbgpd_transport::RemovePrivateAs;
-use rustbgpd_wire::{Afi, BgpRole, Safi};
+use rustbgpd_wire::{Afi, BgpRole, CONFIGURED_FAMILIES, Safi, family_label, parse_family};
 use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
@@ -67,15 +67,16 @@ pub(crate) fn parse_families_proto(families: &[String]) -> Result<Vec<(Afi, Safi
     }
     let mut result = Vec::with_capacity(families.len());
     for f in families {
-        let family = match f.as_str() {
-            "ipv4_unicast" => (Afi::Ipv4, Safi::Unicast),
-            "ipv6_unicast" => (Afi::Ipv6, Safi::Unicast),
-            other => {
-                return Err(Status::invalid_argument(format!(
-                    "unknown address family {other:?}, expected \"ipv4_unicast\" or \"ipv6_unicast\""
-                )));
-            }
-        };
+        let family = parse_family(f).ok_or_else(|| {
+            Status::invalid_argument(format!(
+                "unknown address family {f:?}, expected one of: {}",
+                CONFIGURED_FAMILIES
+                    .iter()
+                    .map(|(label, _, _)| format!("{label:?}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })?;
         if !result.contains(&family) {
             result.push(family);
         }
@@ -525,11 +526,7 @@ fn outbound_refresh_error_status(error: OutboundRefreshError) -> Status {
 }
 
 pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
-    match (afi, safi) {
-        (Afi::Ipv4, Safi::Unicast) => "ipv4_unicast".to_string(),
-        (Afi::Ipv6, Safi::Unicast) => "ipv6_unicast".to_string(),
-        _ => format!("{afi:?}_{safi:?}"),
-    }
+    family_label(afi, safi).unwrap_or("unsupported").to_string()
 }
 
 pub(crate) fn parse_remove_private_as_proto(mode: &str) -> Result<RemovePrivateAs, Status> {
@@ -2766,6 +2763,37 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parse_families_proto_accepts_and_emits_the_configured_vocabulary() {
+        let labels = CONFIGURED_FAMILIES
+            .iter()
+            .map(|(label, _, _)| (*label).to_string())
+            .collect::<Vec<_>>();
+        let parsed = parse_families_proto(&labels).unwrap();
+        let expected = CONFIGURED_FAMILIES
+            .iter()
+            .map(|(_, afi, safi)| (*afi, *safi))
+            .collect::<Vec<_>>();
+
+        assert_eq!(parsed, expected);
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|(afi, safi)| family_to_string(*afi, *safi))
+                .collect::<Vec<_>>(),
+            labels
+        );
+    }
+
+    #[test]
+    fn parse_families_proto_rejects_noncanonical_metric_labels() {
+        for label in ["bgpls", "bgpls_vpn"] {
+            let error = parse_families_proto(&[label.to_string()]).unwrap_err();
+            assert_eq!(error.code(), tonic::Code::InvalidArgument);
+            assert!(error.message().contains("linkstate"));
+        }
+    }
+
     #[tokio::test]
     async fn soft_reset_in_deduplicates_requested_families() {
         let (peer_tx, mut peer_rx) = mpsc::channel(16);
@@ -3766,7 +3794,7 @@ mod tests {
                 .iter()
                 .map(|row| row.family.as_str())
                 .collect::<Vec<_>>(),
-            vec!["ipv4_unicast", "ipv6_unicast", "L2Vpn_Evpn"]
+            vec!["ipv4_unicast", "ipv6_unicast", "l2vpn_evpn"]
         );
         // Load-bearing: changing the projection's inactive/unlimited/finite
         // mapping makes one of these three presence-aware assertions red.

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,9 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- Added one canonical address-family label table plus `parse_family` and
+  `family_label` helpers for the twelve AFI/SAFI pairs accepted by rustbgpd's
+  configuration and control-plane APIs.
 - Added `PathAttribute::only_to_customer()` for reading either typed OTC
   representation without discarding the Partial flag.
 

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -406,7 +406,7 @@ cargo run -p rustbgpd-wire --features tokio-codec --example tokio_codec
   arm and later registry additions are not breaking. `CONFIGURED_FAMILIES`,
   `parse_family`, and `family_label` provide the canonical configuration and
   control-plane vocabulary for the twelve AFI/SAFI pairs rustbgpd supports;
-  BGP-LS uses `linkstate` / `linkstate_vpn` there
+  BGP-LS uses `linkstate` / `linkstate_vpn` there.
 - **Well-known community constants** — `u32` values for matching and setting
   standard communities: `COMMUNITY_NO_EXPORT` / `COMMUNITY_NO_ADVERTISE` /
   `COMMUNITY_NO_EXPORT_SUBCONFED` (RFC 1997), `COMMUNITY_BLACKHOLE` (RFC 7999),

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -403,7 +403,10 @@ cargo run -p rustbgpd-wire --features tokio-codec --example tokio_codec
   adds `Afi::BgpLs` (16388) plus `Safi::BgpLs` (71) and `Safi::BgpLsVpn` (72)
   (0.13.0). Both are `#[non_exhaustive]` as of 0.15.0 (see [Enum
   exhaustiveness](#enum-exhaustiveness)), so downstream matches need a wildcard
-  arm and later registry additions are not breaking
+  arm and later registry additions are not breaking. `CONFIGURED_FAMILIES`,
+  `parse_family`, and `family_label` provide the canonical configuration and
+  control-plane vocabulary for the twelve AFI/SAFI pairs rustbgpd supports;
+  BGP-LS uses `linkstate` / `linkstate_vpn` there
 - **Well-known community constants** — `u32` values for matching and setting
   standard communities: `COMMUNITY_NO_EXPORT` / `COMMUNITY_NO_ADVERTISE` /
   `COMMUNITY_NO_EXPORT_SUBCONFED` (RFC 1997), `COMMUNITY_BLACKHOLE` (RFC 7999),

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -84,7 +84,7 @@ impl Safi {
 /// BGP-LS deliberately uses the operator-facing `linkstate` spelling here.
 /// Metrics retain their existing `bgpls` labels independently so dashboards
 /// and alerts do not acquire a label-cardinality fork.
-pub const CONFIGURED_FAMILIES: [(&str, Afi, Safi); 12] = [
+pub const CONFIGURED_FAMILIES: &[(&str, Afi, Safi)] = &[
     ("ipv4_unicast", Afi::Ipv4, Safi::Unicast),
     ("ipv6_unicast", Afi::Ipv6, Safi::Unicast),
     ("ipv4_flowspec", Afi::Ipv4, Safi::FlowSpec),
@@ -102,7 +102,7 @@ pub const CONFIGURED_FAMILIES: [(&str, Afi, Safi); 12] = [
 /// Parse a canonical configuration or control-plane family label.
 #[must_use]
 pub fn parse_family(label: &str) -> Option<(Afi, Safi)> {
-    for &(candidate, afi, safi) in &CONFIGURED_FAMILIES {
+    for &(candidate, afi, safi) in CONFIGURED_FAMILIES {
         if candidate == label {
             return Some((afi, safi));
         }
@@ -114,7 +114,7 @@ pub fn parse_family(label: &str) -> Option<(Afi, Safi)> {
 /// pair supported by rustbgpd.
 #[must_use]
 pub fn family_label(afi: Afi, safi: Safi) -> Option<&'static str> {
-    for &(label, candidate_afi, candidate_safi) in &CONFIGURED_FAMILIES {
+    for &(label, candidate_afi, candidate_safi) in CONFIGURED_FAMILIES {
         if candidate_afi == afi && candidate_safi == safi {
             return Some(label);
         }
@@ -1032,7 +1032,7 @@ mod tests {
 
     #[test]
     fn configured_family_labels_round_trip_canonically() {
-        for &(label, afi, safi) in &CONFIGURED_FAMILIES {
+        for &(label, afi, safi) in CONFIGURED_FAMILIES {
             assert_eq!(parse_family(label), Some((afi, safi)), "label {label}");
             assert_eq!(family_label(afi, safi), Some(label), "label {label}");
         }

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -78,6 +78,50 @@ impl Safi {
     }
 }
 
+/// Canonical configuration and control-plane labels for the AFI/SAFI pairs
+/// supported by rustbgpd.
+///
+/// BGP-LS deliberately uses the operator-facing `linkstate` spelling here.
+/// Metrics retain their existing `bgpls` labels independently so dashboards
+/// and alerts do not acquire a label-cardinality fork.
+pub const CONFIGURED_FAMILIES: [(&str, Afi, Safi); 12] = [
+    ("ipv4_unicast", Afi::Ipv4, Safi::Unicast),
+    ("ipv6_unicast", Afi::Ipv6, Safi::Unicast),
+    ("ipv4_flowspec", Afi::Ipv4, Safi::FlowSpec),
+    ("ipv6_flowspec", Afi::Ipv6, Safi::FlowSpec),
+    ("l2vpn_evpn", Afi::L2Vpn, Safi::Evpn),
+    ("linkstate", Afi::BgpLs, Safi::BgpLs),
+    ("linkstate_vpn", Afi::BgpLs, Safi::BgpLsVpn),
+    ("l3vpn_ipv4_unicast", Afi::Ipv4, Safi::MplsVpn),
+    ("l3vpn_ipv6_unicast", Afi::Ipv6, Safi::MplsVpn),
+    ("ipv4_labeled_unicast", Afi::Ipv4, Safi::LabeledUnicast),
+    ("ipv6_labeled_unicast", Afi::Ipv6, Safi::LabeledUnicast),
+    ("rtc", Afi::Ipv4, Safi::RtConstrain),
+];
+
+/// Parse a canonical configuration or control-plane family label.
+#[must_use]
+pub fn parse_family(label: &str) -> Option<(Afi, Safi)> {
+    for &(candidate, afi, safi) in &CONFIGURED_FAMILIES {
+        if candidate == label {
+            return Some((afi, safi));
+        }
+    }
+    None
+}
+
+/// Return the canonical configuration and control-plane label for an AFI/SAFI
+/// pair supported by rustbgpd.
+#[must_use]
+pub fn family_label(afi: Afi, safi: Safi) -> Option<&'static str> {
+    for &(label, candidate_afi, candidate_safi) in &CONFIGURED_FAMILIES {
+        if candidate_afi == afi && candidate_safi == safi {
+            return Some(label);
+        }
+    }
+    None
+}
+
 /// Per-AFI/SAFI entry in the Graceful Restart capability (RFC 4724 §3).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GracefulRestartFamily {
@@ -985,6 +1029,27 @@ pub(crate) fn encode_extended_optional_parameters(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn configured_family_labels_round_trip_canonically() {
+        for &(label, afi, safi) in &CONFIGURED_FAMILIES {
+            assert_eq!(parse_family(label), Some((afi, safi)), "label {label}");
+            assert_eq!(family_label(afi, safi), Some(label), "label {label}");
+        }
+    }
+
+    #[test]
+    fn configured_family_labels_keep_metric_aliases_out_of_the_parser() {
+        assert_eq!(parse_family("bgpls"), None);
+        assert_eq!(parse_family("bgpls_vpn"), None);
+        assert_eq!(family_label(Afi::BgpLs, Safi::BgpLs), Some("linkstate"));
+        assert_eq!(
+            family_label(Afi::BgpLs, Safi::BgpLsVpn),
+            Some("linkstate_vpn")
+        );
+        assert_eq!(family_label(Afi::Ipv4, Safi::Evpn), None);
+        assert_eq!(family_label(Afi::Ipv4, Safi::Multicast), None);
+    }
 
     #[test]
     fn decode_multi_protocol_ipv4_unicast() {

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -110,8 +110,9 @@ pub mod vpn;
 
 // Re-export primary public API
 pub use capability::{
-    AddPathFamily, AddPathMode, Afi, BgpRole, Capability, ExtendedNextHopFamily,
-    GracefulRestartFamily, LlgrFamily, PathsLimitFamily, Safi,
+    AddPathFamily, AddPathMode, Afi, BgpRole, CONFIGURED_FAMILIES, Capability,
+    ExtendedNextHopFamily, GracefulRestartFamily, LlgrFamily, PathsLimitFamily, Safi, family_label,
+    parse_family,
 };
 pub use constants::{EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN};
 pub use error::{DecodeError, EncodeError};

--- a/docs/API.md
+++ b/docs/API.md
@@ -872,6 +872,12 @@ IPv6 unicast.
 `AddNeighbor` returns `INVALID_ARGUMENT`. Empty inherits a non-empty peer-group
 list; when both are empty, partial negotiation is preserved.
 `NeighborState.config.required_families` reports the effective inherited list.
+Both fields accept the same twelve canonical labels as the configuration file:
+`ipv4_unicast`, `ipv6_unicast`, `ipv4_flowspec`, `ipv6_flowspec`,
+`l2vpn_evpn`, `linkstate`, `linkstate_vpn`, `l3vpn_ipv4_unicast`,
+`l3vpn_ipv6_unicast`, `ipv4_labeled_unicast`, `ipv6_labeled_unicast`, and
+`rtc`. Read responses return those same labels; the `bgpls` spellings remain
+metric labels rather than configuration aliases.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -85,7 +85,10 @@ Public surface (re-exported at crate root — `crates/wire/src/lib.rs`):
   `Aggregator`, `AtomicAggregate`, `NextHop`, `Communities`, `MpReachNlri`, `LargeCommunities`,
   `PmsiTunnel`, `OnlyToCustomer`, ...).
 - **`Prefix`** (`V4(Ipv4Prefix)` / `V6(Ipv6Prefix)`), `NlriEntry`, Add-Path IDs.
-- **`Afi` / `Safi`** — IANA address-family identifiers.
+- **`Afi` / `Safi`** — IANA address-family identifiers. The
+  `CONFIGURED_FAMILIES`, `parse_family`, and `family_label` helpers expose the
+  canonical configuration/control-plane labels for the supported pairs;
+  BGP-LS is `linkstate` / `linkstate_vpn` on that surface.
 - **EVPN** (`EvpnRoute`/`EvpnRouteKey`, Types 1–5; route keys implement `Ord`),
   **FlowSpec** (`FlowSpecRule`),
   **VPNv4/v6** (`vpn` module), **BGP-LS** (`bgpls` module), **ORF** (`orf` module),

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -486,7 +486,10 @@ message NeighborConfig {
   string description = 3;
   uint32 hold_time = 4;
   uint32 max_prefixes = 5;
-  // Address families (e.g., "ipv4_unicast", "ipv6_unicast").
+  // Canonical address-family labels: ipv4_unicast, ipv6_unicast,
+  // ipv4_flowspec, ipv6_flowspec, l2vpn_evpn, linkstate, linkstate_vpn,
+  // l3vpn_ipv4_unicast, l3vpn_ipv6_unicast, ipv4_labeled_unicast,
+  // ipv6_labeled_unicast, or rtc.
   // If empty, defaults to ["ipv4_unicast"].
   repeated string families = 6;
   // Private AS removal mode: "", "remove", "all", or "replace".
@@ -1138,6 +1141,7 @@ message PeerGroupDefinition {
   // 1..255. Requires ttl_security = true; omission preserves the historical
   // one-hop policy (inbound TTL/Hop-Limit exactly 255).
   optional uint32 ttl_security_hops = 30;
+  // Uses the same canonical family labels as NeighborConfig.families.
   repeated string families = 5;
   optional bool graceful_restart = 6;
   optional uint32 gr_restart_time = 7;

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -8,6 +8,7 @@ use rustbgpd_policy::{
     NeighborSetMatch, RouteExtendedCommunityAdmin, RouteExtendedCommunityKind, RouteType,
     encode_route_extended_community,
 };
+use rustbgpd_wire::{CONFIGURED_FAMILIES, parse_family};
 
 /// Parse and validate a single CIDR prefix string with optional ge/le bounds.
 fn parse_prefix_entry(
@@ -699,32 +700,16 @@ fn encode_config_route_community(
 pub(super) fn parse_families(families: &[String]) -> Result<Vec<(Afi, Safi)>, ConfigError> {
     let mut result = Vec::with_capacity(families.len());
     for f in families {
-        let family = match f.as_str() {
-            "ipv4_unicast" => (Afi::Ipv4, Safi::Unicast),
-            "ipv6_unicast" => (Afi::Ipv6, Safi::Unicast),
-            "ipv4_flowspec" => (Afi::Ipv4, Safi::FlowSpec),
-            "ipv6_flowspec" => (Afi::Ipv6, Safi::FlowSpec),
-            "l2vpn_evpn" => (Afi::L2Vpn, Safi::Evpn),
-            "linkstate" => (Afi::BgpLs, Safi::BgpLs),
-            "linkstate_vpn" => (Afi::BgpLs, Safi::BgpLsVpn),
-            "l3vpn_ipv4_unicast" => (Afi::Ipv4, Safi::MplsVpn),
-            "l3vpn_ipv6_unicast" => (Afi::Ipv6, Safi::MplsVpn),
-            "ipv4_labeled_unicast" => (Afi::Ipv4, Safi::LabeledUnicast),
-            "ipv6_labeled_unicast" => (Afi::Ipv6, Safi::LabeledUnicast),
-            "rtc" => (Afi::Ipv4, Safi::RtConstrain),
-            other => {
-                return Err(ConfigError::InvalidPolicyEntry {
-                    reason: format!(
-                        "unknown address family {other:?}, expected one of: \
-                         \"ipv4_unicast\", \"ipv6_unicast\", \"ipv4_flowspec\", \
-                         \"ipv6_flowspec\", \"l2vpn_evpn\", \"linkstate\", \
-                         \"linkstate_vpn\", \"l3vpn_ipv4_unicast\", \
-                         \"l3vpn_ipv6_unicast\", \"ipv4_labeled_unicast\", \
-                         \"ipv6_labeled_unicast\", \"rtc\""
-                    ),
-                });
-            }
-        };
+        let family = parse_family(f).ok_or_else(|| ConfigError::InvalidPolicyEntry {
+            reason: format!(
+                "unknown address family {f:?}, expected one of: {}",
+                CONFIGURED_FAMILIES
+                    .iter()
+                    .map(|(label, _, _)| format!("{label:?}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        })?;
         if !result.contains(&family) {
             result.push(family);
         }

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -446,10 +446,10 @@ pub(crate) fn catalog_config_error(error: ConfigError) -> CatalogMutationError {
 }
 
 fn raw_neighbor(raw: &PresenceAwareNeighborCreate) -> Neighbor {
-    let family_name = |(afi, safi): &(rustbgpd_wire::Afi, rustbgpd_wire::Safi)| match (afi, safi) {
-        (rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast) => "ipv4_unicast".to_string(),
-        (rustbgpd_wire::Afi::Ipv6, rustbgpd_wire::Safi::Unicast) => "ipv6_unicast".to_string(),
-        _ => format!("{afi:?}_{safi:?}"),
+    let family_name = |(afi, safi): &(rustbgpd_wire::Afi, rustbgpd_wire::Safi)| {
+        rustbgpd_wire::family_label(*afi, *safi)
+            .unwrap_or("unsupported")
+            .to_string()
     };
     Neighbor {
         address: raw.address.to_string(),
@@ -941,6 +941,42 @@ remote_asn = 65002
         let config = toml::from_str(&tier_authorized_uds_test_config(toml)).unwrap();
         assert_tier_authorized_test_config(&config);
         config
+    }
+
+    #[test]
+    fn raw_neighbor_persists_canonical_family_labels() {
+        let families = rustbgpd_wire::CONFIGURED_FAMILIES
+            .iter()
+            .map(|(_, afi, safi)| (*afi, *safi))
+            .collect::<Vec<_>>();
+        let raw = PresenceAwareNeighborCreate {
+            address: "192.0.2.1".parse().unwrap(),
+            interface: None,
+            remote_asn: 65_001,
+            description: None,
+            peer_group: None,
+            hold_time: None,
+            min_hold_time: None,
+            send_hold_time: None,
+            max_prefixes: None,
+            max_prefix_restart_seconds: None,
+            remove_private_as: None,
+            local_role: None,
+            families: Some(families.clone()),
+            required_families: Some(families),
+            route_server_client: None,
+            per_client_best: None,
+            strict_role: None,
+            add_path: None,
+        };
+        let expected = rustbgpd_wire::CONFIGURED_FAMILIES
+            .iter()
+            .map(|(label, _, _)| (*label).to_string())
+            .collect::<Vec<_>>();
+
+        let neighbor = raw_neighbor(&raw);
+        assert_eq!(neighbor.families, expected);
+        assert_eq!(neighbor.required_families, expected);
     }
 
     #[test]

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -445,13 +445,27 @@ pub(crate) fn catalog_config_error(error: ConfigError) -> CatalogMutationError {
     }
 }
 
-fn raw_neighbor(raw: &PresenceAwareNeighborCreate) -> Neighbor {
-    let family_name = |(afi, safi): &(rustbgpd_wire::Afi, rustbgpd_wire::Safi)| {
-        rustbgpd_wire::family_label(*afi, *safi)
-            .unwrap_or("unsupported")
-            .to_string()
-    };
-    Neighbor {
+fn configured_family_labels(
+    address: IpAddr,
+    field: &str,
+    families: &[(rustbgpd_wire::Afi, rustbgpd_wire::Safi)],
+) -> Result<Vec<String>, ConfigError> {
+    families
+        .iter()
+        .map(|(afi, safi)| {
+            rustbgpd_wire::family_label(*afi, *safi)
+                .map(str::to_string)
+                .ok_or_else(|| ConfigError::InvalidNeighborConfig {
+                    address: address.to_string(),
+                    field: field.to_string(),
+                    reason: format!("unsupported AFI/SAFI pair {afi:?}/{safi:?}"),
+                })
+        })
+        .collect()
+}
+
+fn raw_neighbor(raw: &PresenceAwareNeighborCreate) -> Result<Neighbor, ConfigError> {
+    Ok(Neighbor {
         address: raw.address.to_string(),
         interface: raw.interface.clone(),
         remote_asn: raw.remote_asn,
@@ -479,12 +493,14 @@ fn raw_neighbor(raw: &PresenceAwareNeighborCreate) -> Neighbor {
         families: raw
             .families
             .as_ref()
-            .map(|families| families.iter().map(family_name).collect())
+            .map(|families| configured_family_labels(raw.address, "families", families))
+            .transpose()?
             .unwrap_or_default(),
         required_families: raw
             .required_families
             .as_ref()
-            .map(|families| families.iter().map(family_name).collect())
+            .map(|families| configured_family_labels(raw.address, "required_families", families))
+            .transpose()?
             .unwrap_or_default(),
         graceful_restart: None,
         gr_restart_time: None,
@@ -515,7 +531,7 @@ fn raw_neighbor(raw: &PresenceAwareNeighborCreate) -> Neighbor {
         export_policy: Vec::new(),
         import_policy_chain: Vec::new(),
         export_policy_chain: Vec::new(),
-    }
+    })
 }
 
 /// Apply a config event to a config snapshot and validate the result.
@@ -529,6 +545,12 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
             if !config.neighbors.iter().any(|neighbor| {
                 neighbor.address == cfg.address.to_string() && neighbor.interface == cfg.interface
             }) {
+                let families = configured_family_labels(cfg.address, "families", &cfg.families)?;
+                let required_families = configured_family_labels(
+                    cfg.address,
+                    "required_families",
+                    &cfg.required_families,
+                )?;
                 config.neighbors.push(Neighbor {
                     address: cfg.address.to_string(),
                     interface: cfg.interface.clone(),
@@ -563,38 +585,8 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                     bfd: None,
                     ttl_security: Some(cfg.ttl_security_hops.is_some()),
                     ttl_security_hops: cfg.ttl_security_hops,
-                    families: cfg
-                        .families
-                        .iter()
-                        .map(|(afi, safi)| match (afi, safi) {
-                            (rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast) => {
-                                "ipv4_unicast".to_string()
-                            }
-                            (rustbgpd_wire::Afi::Ipv6, rustbgpd_wire::Safi::Unicast) => {
-                                "ipv6_unicast".to_string()
-                            }
-                            (rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::FlowSpec) => {
-                                "ipv4_flowspec".to_string()
-                            }
-                            (rustbgpd_wire::Afi::Ipv6, rustbgpd_wire::Safi::FlowSpec) => {
-                                "ipv6_flowspec".to_string()
-                            }
-                            _ => format!("{afi:?}_{safi:?}"),
-                        })
-                        .collect(),
-                    required_families: cfg
-                        .required_families
-                        .iter()
-                        .map(|(afi, safi)| match (afi, safi) {
-                            (rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast) => {
-                                "ipv4_unicast".to_string()
-                            }
-                            (rustbgpd_wire::Afi::Ipv6, rustbgpd_wire::Safi::Unicast) => {
-                                "ipv6_unicast".to_string()
-                            }
-                            _ => format!("{afi:?}_{safi:?}"),
-                        })
-                        .collect(),
+                    families,
+                    required_families,
                     graceful_restart: Some(cfg.graceful_restart),
                     gr_restart_time: Some(cfg.gr_restart_time),
                     gr_peer_restart_time_max: Some(cfg.gr_peer_restart_time_max),
@@ -653,7 +645,7 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
             }
         }
         ConfigEvent::PresenceAwareNeighborAdded { spec, .. } => {
-            let neighbor = raw_neighbor(spec);
+            let neighbor = raw_neighbor(spec)?;
             if !config.neighbors.iter().any(|configured| {
                 configured.address == neighbor.address && configured.interface == neighbor.interface
             }) {
@@ -974,7 +966,7 @@ remote_asn = 65002
             .map(|(label, _, _)| (*label).to_string())
             .collect::<Vec<_>>();
 
-        let neighbor = raw_neighbor(&raw);
+        let neighbor = raw_neighbor(&raw).unwrap();
         assert_eq!(neighbor.families, expected);
         assert_eq!(neighbor.required_families, expected);
     }
@@ -1113,6 +1105,138 @@ peer_group = "fabric"
         assert!(neighbor_policy_chains_from_config(&config, address).is_some());
     }
 
+    fn test_neighbor_config(
+        address: IpAddr,
+    ) -> rustbgpd_api::peer_types::PeerManagerNeighborConfig {
+        rustbgpd_api::peer_types::PeerManagerNeighborConfig {
+            min_hold_time: Some(30),
+            address,
+            interface: None,
+            scope_id: None,
+            remote_asn: 65003,
+            description: "protected".to_string(),
+            peer_group: None,
+            hold_time: None,
+            send_hold_time: None,
+            max_prefixes: None,
+            max_prefixes_ipv4: None,
+            max_prefixes_ipv6: None,
+            max_prefix_restart_seconds: None,
+            md5_password: None,
+            tcp_ao: Some(
+                rustbgpd_transport::TcpAoConfig {
+                    key: "ao-secret".into(),
+                    send_id: 7,
+                    recv_id: 9,
+                    algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
+                    preferred: true,
+                    deprecated: false,
+                }
+                .into(),
+            ),
+            ttl_security_hops: None,
+            families: vec![(rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast)],
+            required_families: Vec::new(),
+            graceful_restart: true,
+            gr_restart_time: 120,
+            gr_peer_restart_time_max: 4095,
+            gr_stale_routes_time: 360,
+            llgr_stale_time: 0,
+            gr_restart_eligible: false,
+            local_ipv6_nexthop: None,
+            route_reflector_client: false,
+            orr_vantage: None,
+            route_server_client: false,
+            per_client_best: false,
+            next_hop_ownership_strict_peer: false,
+            slow_peer_threshold_pct: rustbgpd_transport::DEFAULT_SLOW_PEER_THRESHOLD_PCT,
+            slow_peer_duration: rustbgpd_transport::DEFAULT_SLOW_PEER_DURATION_SECS,
+            slow_peer_isolation: false,
+            interpret_rfc1997: true,
+            rs_control_communities: false,
+            remove_private_as: rustbgpd_transport::RemovePrivateAs::Disabled,
+            add_path_receive: false,
+            add_path_send: false,
+            add_path_send_max: 0,
+            paths_limit_receive_max: 0,
+            local_role: None,
+            strict_role: false,
+            prefix_orf_receive: false,
+            disable_ipv4_unicast: false,
+            import_policy: None,
+            export_policy: None,
+        }
+    }
+
+    #[test]
+    fn neighbor_added_event_persists_canonical_family_labels_that_parse_back() {
+        let mut config = minimal_config();
+        let families = rustbgpd_wire::CONFIGURED_FAMILIES
+            .iter()
+            .map(|(_, afi, safi)| (*afi, *safi))
+            .collect::<Vec<_>>();
+        let expected_labels = rustbgpd_wire::CONFIGURED_FAMILIES
+            .iter()
+            .map(|(label, _, _)| (*label).to_string())
+            .collect::<Vec<_>>();
+        let mut neighbor_config = test_neighbor_config("10.0.0.3".parse().unwrap());
+        neighbor_config.families.clone_from(&families);
+        neighbor_config.required_families.clone_from(&families);
+
+        apply_config_event(
+            &mut config,
+            &ConfigEvent::NeighborAdded {
+                config: neighbor_config,
+                ack: None,
+            },
+        )
+        .unwrap();
+
+        let persisted = config
+            .neighbors
+            .iter()
+            .find(|neighbor| neighbor.address == "10.0.0.3")
+            .unwrap();
+        assert_eq!(persisted.families, expected_labels);
+        assert_eq!(persisted.required_families, expected_labels);
+        for labels in [&persisted.families, &persisted.required_families] {
+            assert_eq!(
+                labels
+                    .iter()
+                    .map(|label| rustbgpd_wire::parse_family(label).unwrap())
+                    .collect::<Vec<_>>(),
+                families
+            );
+        }
+    }
+
+    #[test]
+    fn neighbor_added_event_rejects_an_unconfigured_family_without_mutating() {
+        let mut config = minimal_config();
+        let mut neighbor_config = test_neighbor_config("10.0.0.3".parse().unwrap());
+        neighbor_config.families = vec![(rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Evpn)];
+
+        let error = apply_config_event(
+            &mut config,
+            &ConfigEvent::NeighborAdded {
+                config: neighbor_config,
+                ack: None,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ConfigError::InvalidNeighborConfig { ref field, .. } if field == "families"
+        ));
+        assert!(
+            !config
+                .neighbors
+                .iter()
+                .any(|neighbor| neighbor.address == "10.0.0.3")
+        );
+    }
+
     #[test]
     fn neighbor_added_event_preserves_session_fields() {
         // Mutation-red for min_hold_time: deleting persistence projection
@@ -1122,64 +1246,7 @@ peer_group = "fabric"
         apply_config_event(
             &mut config,
             &ConfigEvent::NeighborAdded {
-                config: rustbgpd_api::peer_types::PeerManagerNeighborConfig {
-                    min_hold_time: Some(30),
-                    address: "10.0.0.3".parse().unwrap(),
-                    interface: None,
-                    scope_id: None,
-                    remote_asn: 65003,
-                    description: "protected".to_string(),
-                    peer_group: None,
-                    hold_time: None,
-                    send_hold_time: None,
-                    max_prefixes: None,
-                    max_prefixes_ipv4: None,
-                    max_prefixes_ipv6: None,
-                    max_prefix_restart_seconds: None,
-                    md5_password: None,
-                    tcp_ao: Some(
-                        rustbgpd_transport::TcpAoConfig {
-                            key: "ao-secret".into(),
-                            send_id: 7,
-                            recv_id: 9,
-                            algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
-                            preferred: true,
-                            deprecated: false,
-                        }
-                        .into(),
-                    ),
-                    ttl_security_hops: None,
-                    families: vec![(rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast)],
-                    required_families: Vec::new(),
-                    graceful_restart: true,
-                    gr_restart_time: 120,
-                    gr_peer_restart_time_max: 4095,
-                    gr_stale_routes_time: 360,
-                    llgr_stale_time: 0,
-                    gr_restart_eligible: false,
-                    local_ipv6_nexthop: None,
-                    route_reflector_client: false,
-                    orr_vantage: None,
-                    route_server_client: false,
-                    per_client_best: false,
-                    next_hop_ownership_strict_peer: false,
-                    slow_peer_threshold_pct: rustbgpd_transport::DEFAULT_SLOW_PEER_THRESHOLD_PCT,
-                    slow_peer_duration: rustbgpd_transport::DEFAULT_SLOW_PEER_DURATION_SECS,
-                    slow_peer_isolation: false,
-                    interpret_rfc1997: true,
-                    rs_control_communities: false,
-                    remove_private_as: rustbgpd_transport::RemovePrivateAs::Disabled,
-                    add_path_receive: false,
-                    add_path_send: false,
-                    add_path_send_max: 0,
-                    paths_limit_receive_max: 0,
-                    local_role: None,
-                    strict_role: false,
-                    prefix_orf_receive: false,
-                    disable_ipv4_unicast: false,
-                    import_policy: None,
-                    export_policy: None,
-                },
+                config: test_neighbor_config("10.0.0.3".parse().unwrap()),
                 ack: None,
             },
         )


### PR DESCRIPTION
## Summary

- centralize the twelve configured AFI/SAFI labels in `rustbgpd-wire`
- accept and emit every configured family through neighbor and peer-group gRPC paths
- keep BGP-LS configuration labels canonical without changing existing metric labels

## Validation

- `cargo test --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p rustbgpd-wire --features tokio-codec --no-deps`
- `python3 scripts/check_embedding_versions.py`
- `python3 scripts/check_embedding_crate_map.py`
- `python3 scripts/check_public_tracker_ids.py`
- `python3 scripts/check_release_checklist_paths.py`
- `python3 scripts/check-v1-stable-surface.py`
