### PR TITLE
Distinguish BMP stats snapshot timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or non-Established session from a timed-out state query. Ambiguous queries
   fail the refresh and retain the pending import or export work for a later
   policy replay; RFC 8212 preflight and clean-convergence cohort selection use
-  the same closed three-way outcome model.
+  the same closed three-way outcome model. Periodic BMP statistics use that
+  distinction too: a timed-out snapshot is counted and logged as
+  `state_query_timeout`, not silently treated as a departed peer.
 
 - Policy mutation preflight failures now preserve `NOT_FOUND`, `INVALID_ARGUMENT`, and
   `FAILED_PRECONDITION` while retaining the closed `policy_preflight_rejected` diagnostic.

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -2016,7 +2016,7 @@ impl BgpMetrics {
         let bmp_source_drops = IntCounterVec::new(
             Opts::new(
                 "bmp_source_drops_total",
-                "BMP events dropped at the PeerSession→BmpManager channel by reason (channel_full, channel_closed)",
+                "Per-peer BMP events or periodic reports dropped before BmpManager by reason (channel_full, channel_closed, state_query_timeout)",
             ),
             &["peer", "reason"],
         )
@@ -4977,7 +4977,8 @@ impl BgpMetrics {
         self.0.mrt_dump_failures.with_label_values(&[stage]).inc();
     }
 
-    /// Record a BMP event dropped at the PeerSession→BmpManager channel.
+    /// Record a per-peer BMP event or periodic report dropped before it reaches
+    /// `BmpManager`.
     pub fn record_bmp_source_drop(&self, peer: &str, reason: &str) {
         self.0
             .bmp_source_drops
@@ -7173,6 +7174,7 @@ mod tests {
         m.record_bmp_source_drop("10.0.0.1", "channel_full");
         m.record_bmp_source_drop("10.0.0.1", "channel_full");
         m.record_bmp_source_drop("10.0.0.2", "channel_closed");
+        m.record_bmp_source_drop("10.0.0.3", "state_query_timeout");
 
         let full =
             m.0.bmp_source_drops
@@ -7185,6 +7187,12 @@ mod tests {
                 .with_label_values(&["10.0.0.2", "channel_closed"])
                 .get();
         assert_eq!(closed, 1);
+
+        let state_unknown =
+            m.0.bmp_source_drops
+                .with_label_values(&["10.0.0.3", "state_query_timeout"])
+                .get();
+        assert_eq!(state_unknown, 1);
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1156,9 +1156,12 @@ query with a new live watch.
 | `bmp_loc_rib_source_drops_total{event,reason}` | RFC 9069 Loc-RIB events dropped before they reached the BMP manager, at the internal RIB/PeerManager→BmpManager channel. `event` is `route_monitoring` (a Loc-RIB route install/withdraw that will never reach any collector's Loc-RIB view) or `stats` (one periodic Loc-RIB statistics report skipped; the next tick reports current totals). `reason` is `channel_full` (the BMP manager is not draining as fast as RIB churn produces events) or `channel_closed` (BMP teardown). Both label sets are bounded; the series is process-global, not per-collector. A dropped `route_monitoring` event silently diverges every connected Loc-RIB collector until its next reconnect-triggered table dump, so alert on any sustained `channel_full` increase and correlate with the per-collector `bmp_collector_drops_total` and the `bmp_loc_rib_dump_live_buffer_*` gauges to find the slow consumer; each increment also emits a warn log line |
 | `bmp_control_event_drops_total{collector,kind,reason}` | Collector lifecycle transitions that failed to reach the BMP manager. `kind` identifies connected, bootstrap-complete, or disconnected; `reason` is the bounded channel failure. Any increase means manager state may not match the collector connection lifecycle |
 
-The sibling `bmp_source_drops_total{peer,reason}` counts the same kind of
-loss on the per-peer PeerSession→BmpManager path (RFC 7854 Adj-RIB
-monitoring) with the same `reason` vocabulary.
+The sibling `bmp_source_drops_total{peer,reason}` counts per-peer loss before
+the BMP manager. `channel_full` / `channel_closed` cover the
+PeerSession/PeerManager→BmpManager path. `state_query_timeout` means the
+periodic statistics tick could not obtain a current session snapshot within
+its bounded deadline; the session may still be Established, so this is not a
+Peer Down signal and the report is retried on the next tick.
 The shipped alert pack
 ([`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml))
 fires `BmpSourceDrops`, `BmpLocRibSourceDrops`, `BmpCollectorDrops`, and

--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -166,7 +166,7 @@ configured. Key series:
 |--------|---------|
 | `bgp_event_outbox_degraded` | 1 = latched durability-impacting loss, committed-event delivery skip, or DB open/recovery/quarantine failure; expected shutdown `reason=closed` drops are excluded. Inspect the drop reason and daemon log: replay can remain available |
 | `bmp_collector_drops_total` | messages dropped toward a slow/disconnected collector |
-| `bmp_source_drops_total` | route-monitoring events dropped at the source tap under backpressure |
+| `bmp_source_drops_total` | per-peer BMP events dropped at the source tap, including a periodic stats report whose session-state query timed out |
 | `bmp_replay_attempts_total` | PeerUp-cache replays on collector reconnect |
 | `bgp_rib_outbound_registered_peers` | feed coverage: peers whose routes the views carry |
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -1878,7 +1878,7 @@
       "id": 29,
       "type": "timeseries",
       "title": "BMP drops",
-      "description": "bmp_source_drops_total (session\u2192manager), bmp_collector_drops_total (manager\u2192collector, by phase), bmp_control_event_drops_total. Any non-zero rate means the BMP feed is lossy.",
+      "description": "bmp_source_drops_total (peer source\u2192manager, including periodic state-query timeouts), bmp_collector_drops_total (manager\u2192collector, by phase), bmp_control_event_drops_total. Any non-zero rate means the BMP feed is lossy.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -8,7 +8,7 @@ use rustbgpd_api::peer_types::{
 use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
-use rustbgpd_transport::{PeerHandle, PeerSessionState};
+use rustbgpd_transport::{PeerHandle, PeerSessionState, StateQueryOutcome};
 use tokio_util::task::AbortOnDropHandle;
 use tracing::warn;
 
@@ -210,31 +210,32 @@ fn effective_remote_asn(managed: &ManagedPeer, session_state: Option<&PeerSessio
         .unwrap_or(managed.remote_asn)
 }
 
-/// Run a bounded `query_state` against every peer concurrently.
+/// Run a bounded state query against every peer concurrently.
 ///
 /// Each query is bounded by [`PEER_QUERY_TIMEOUT`]; a peer whose session
-/// task is parked on TCP write (or whose command channel is full) lands
-/// in the result map as `Some(addr) -> None`. A peer whose task spawn
-/// failed entirely is absent from the map. Both cases are treated as
-/// `stale = true` by [`build_peer_info`].
+/// task is parked on TCP write (or whose command channel is full) lands as
+/// [`StateQueryOutcome::TimedOut`], while a closed session task lands as
+/// [`StateQueryOutcome::SessionGone`]. A peer whose query task fails to join
+/// is absent from the map. Every non-state outcome is treated as `stale =
+/// true` by [`build_peer_info`].
 async fn collect_session_states(
     peers: &HashMap<PeerKey, ManagedPeer>,
-) -> HashMap<PeerKey, Option<PeerSessionState>> {
+) -> HashMap<PeerKey, StateQueryOutcome> {
     let mut tasks = Vec::with_capacity(peers.len());
     for (peer, managed) in peers {
         let peer = peer.clone();
         let commands = managed.handle.commands_sender();
         tasks.push(AbortOnDropHandle::new(tokio::spawn(async move {
-            let state = PeerHandle::query_state_with(commands, PEER_QUERY_TIMEOUT).await;
-            (peer, state)
+            let outcome = PeerHandle::query_state_outcome_with(commands, PEER_QUERY_TIMEOUT).await;
+            (peer, outcome)
         })));
     }
 
     let mut out = HashMap::with_capacity(tasks.len());
     for task in tasks {
         match task.await {
-            Ok((addr, state)) => {
-                out.insert(addr, state);
+            Ok((addr, outcome)) => {
+                out.insert(addr, outcome);
             }
             Err(e) => {
                 warn!(error = %e, "query_state task join failed");
@@ -450,7 +451,10 @@ impl PeerManager {
 
         let mut infos = Vec::with_capacity(self.peers.len());
         for (peer, managed) in &self.peers {
-            let session_state = states.get(peer).and_then(Option::as_ref);
+            let session_state = states.get(peer).and_then(|outcome| match outcome {
+                StateQueryOutcome::State(state) => Some(state),
+                StateQueryOutcome::TimedOut | StateQueryOutcome::SessionGone => None,
+            });
             let mut info = build_peer_info(
                 peer,
                 managed,
@@ -605,8 +609,19 @@ impl PeerManager {
         self.emit_loc_rib_bmp_stats(bmp_tx).await;
         for (peer, managed) in &self.peers {
             let peer_addr = peer.address;
-            let Some(Some(state)) = states.get(peer) else {
-                continue;
+            let state = match states.get(peer) {
+                Some(StateQueryOutcome::State(state)) => state,
+                Some(StateQueryOutcome::TimedOut) => {
+                    let peer_label = rustbgpd_telemetry::peer_label(peer_addr);
+                    self.metrics
+                        .record_bmp_source_drop(&peer_label, "state_query_timeout");
+                    warn!(
+                        peer = %peer_addr,
+                        "peer state query timed out, omitting periodic BMP stats report"
+                    );
+                    continue;
+                }
+                Some(StateQueryOutcome::SessionGone) | None => continue,
             };
             if state.fsm_state != SessionState::Established {
                 continue;
@@ -640,6 +655,12 @@ impl PeerManager {
             };
 
             if let Err(e) = bmp_tx.try_send(event) {
+                let reason = match &e {
+                    tokio::sync::mpsc::error::TrySendError::Full(_) => "channel_full",
+                    tokio::sync::mpsc::error::TrySendError::Closed(_) => "channel_closed",
+                };
+                self.metrics
+                    .record_bmp_source_drop(&rustbgpd_telemetry::peer_label(peer_addr), reason);
                 warn!(
                     peer = %peer_addr,
                     error = %e,

--- a/src/peer_manager/tests/metrics.rs
+++ b/src/peer_manager/tests/metrics.rs
@@ -17,6 +17,27 @@ fn peer_metric_series_count(metrics: &BgpMetrics, peer: &str) -> usize {
         .count()
 }
 
+fn bmp_source_drop_metric(metrics: &BgpMetrics, peer: &str, reason: &str) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == "bmp_source_drops_total")
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                let has_peer = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer);
+                let has_reason = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "reason" && label.value() == reason);
+                (has_peer && has_reason).then(|| metric.get_counter().value())
+            })
+        })
+}
+
 fn blocked_truth_observing_start_handle(
     metrics: BgpMetrics,
     peer: PeerKey,
@@ -644,4 +665,118 @@ async fn periodic_bmp_stats_carry_adj_rib_out_counts() {
         }
         other => panic!("expected StatsReport, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn periodic_bmp_stats_distinguish_state_timeout_from_departed_session() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let (bmp_tx, mut bmp_rx) = mpsc::channel(16);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics.clone(),
+        rib_tx,
+        Some(bmp_tx),
+    );
+    let timed_out: IpAddr = "192.0.2.10".parse().unwrap();
+    let departed: IpAddr = "192.0.2.11".parse().unwrap();
+    insert_test_managed_peer(&mut mgr, timed_out, stalled_policy_query_handle(), false);
+    insert_test_managed_peer(&mut mgr, departed, closed_peer_handle(), false);
+
+    let rib_task = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::QueryAdjRibOutCounts { reply } = update {
+                let _ = reply.send(std::collections::HashMap::new());
+                return;
+            }
+        }
+        panic!("QueryAdjRibOutCounts never arrived");
+    });
+
+    mgr.emit_periodic_bmp_stats().await;
+    rib_task.await.unwrap();
+
+    assert!(matches!(
+        bmp_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
+    assert_eq!(
+        bmp_source_drop_metric(&metrics, "192.0.2.10", "state_query_timeout"),
+        Some(1.0)
+    );
+    assert_eq!(
+        bmp_source_drop_metric(&metrics, "192.0.2.11", "state_query_timeout"),
+        None,
+        "a closed session is definitive and must not be counted as a slow live peer"
+    );
+}
+
+#[tokio::test]
+async fn periodic_bmp_stats_channel_full_records_the_source_drop() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let (bmp_tx, _bmp_rx) = mpsc::channel(1);
+    let addr: IpAddr = "192.0.2.20".parse().unwrap();
+    bmp_tx
+        .try_send(BmpEvent::StatsReport {
+            peer_info: rustbgpd_bmp::BmpPeerInfo {
+                peer_addr: addr,
+                peer_asn: 65002,
+                peer_bgp_id: Ipv4Addr::UNSPECIFIED,
+                peer_type: rustbgpd_bmp::BmpPeerType::Global,
+                is_ipv6: false,
+                is_post_policy: false,
+                is_rib_out: false,
+                is_as4: true,
+                timestamp: std::time::SystemTime::now(),
+            },
+            adj_rib_in_routes: 0,
+            adj_rib_out_post: None,
+        })
+        .unwrap();
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics.clone(),
+        rib_tx,
+        Some(bmp_tx),
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        addr,
+        fake_peer_handle(
+            addr,
+            SessionState::Established,
+            Some(Ipv4Addr::new(192, 0, 2, 20)),
+            Arc::new(FakePeerCounters::default()),
+        ),
+        false,
+    );
+
+    let rib_task = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::QueryAdjRibOutCounts { reply } = update {
+                let _ = reply.send(std::collections::HashMap::new());
+                return;
+            }
+        }
+        panic!("QueryAdjRibOutCounts never arrived");
+    });
+
+    mgr.emit_periodic_bmp_stats().await;
+    rib_task.await.unwrap();
+
+    assert_eq!(
+        bmp_source_drop_metric(&metrics, "192.0.2.20", "channel_full"),
+        Some(1.0)
+    );
 }


### PR DESCRIPTION
## Summary

- preserve the closed three-way peer-state outcome in periodic BMP statistics
- count and log a timed-out snapshot without treating the session as departed
- account for periodic BMP channel backpressure in the existing bounded drop metric
- update the operator docs and dashboard description for the expanded reason vocabulary

## Validation

- `cargo test -p rustbgpd periodic_bmp_stats -- --nocapture`
- `cargo test -p rustbgpd-telemetry bmp_source_drop_counter`
- `python3 scripts/check-metric-consumers.py`
- `python3 scripts/check-grafana-dashboard.py`
- `python3 scripts/check_metric_release_notes.py`
- metric/dashboard/release-note checker unit tests
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- pre-push `cargo test` and `cargo doc`

Linear: LAN-1315