### PR TITLE
wire: validate assigned attribute framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Tunnel Encapsulation and ATTR_SET attributes now receive bounded structural
+  validation before opaque re-advertisement. Tunnel TLV/sub-TLV boundaries and
+  ATTR_SET's Origin AS/embedded-attribute stream must be complete; embedded MP
+  reachability attributes are rejected. The change adds no semantic decoding,
+  and malformed input remains treat-as-withdraw.
+
 - Plain eBGP export now removes non-transitive Extended Communities after
   export policy by default, while iBGP and transparent route-server-client
   sessions preserve them. A peer-group-inheritable

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,12 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- Added bounded, allocation-free framing validation for opaque Tunnel
+  Encapsulation and ATTR_SET attributes. Tunnel TLVs and their variable-width
+  sub-TLV lengths must consume their declared values exactly; ATTR_SET must
+  contain its Origin AS and an exactly framed embedded attribute stream without
+  MP_REACH_NLRI or MP_UNREACH_NLRI. Both remain semantically opaque, propagate
+  with Partial, and use treat-as-withdraw for malformed input.
 - Added one canonical address-family label table plus `parse_family` and
   `family_label` helpers for the twelve AFI/SAFI pairs accepted by rustbgpd's
   configuration and control-plane APIs.

--- a/crates/wire/src/assigned_attributes.rs
+++ b/crates/wire/src/assigned_attributes.rs
@@ -1,11 +1,12 @@
 //! Structural framing checks for assigned attributes retained opaquely.
 
-use crate::constants::attr_type;
+use crate::constants::{attr_flags, attr_type};
 
 /// Called unconditionally from attribute decode; type codes without a
 /// framing check here fall through to `Ok(())`.
 pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> {
     match type_code {
+        attr_type::TUNNEL_ENCAPSULATION => tunnel_encapsulation(value),
         attr_type::COMMUNITY_CONTAINER => community_container(value),
         attr_type::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITY => {
             ipv6_address_specific_extended_community(value)
@@ -16,8 +17,90 @@ pub(crate) fn validate(type_code: u8, value: &[u8]) -> Result<(), &'static str> 
         attr_type::NHC => nhc(value),
         attr_type::PREFIX_SID => prefix_sid(value),
         attr_type::BIER => bier(value),
+        attr_type::ATTR_SET => attr_set(value),
         _ => Ok(()),
     }
+}
+
+fn tunnel_encapsulation(mut value: &[u8]) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("Tunnel Encapsulation attribute contains no Tunnel TLVs");
+    }
+    while !value.is_empty() {
+        if value.len() < 4 {
+            return Err("Tunnel TLV header is truncated");
+        }
+        let length = usize::from(u16::from_be_bytes([value[2], value[3]]));
+        if value.len() < 4 + length {
+            return Err("Tunnel TLV overruns attribute");
+        }
+        tunnel_subtlvs(&value[4..4 + length])?;
+        value = &value[4 + length..];
+    }
+    Ok(())
+}
+
+fn tunnel_subtlvs(mut value: &[u8]) -> Result<(), &'static str> {
+    while !value.is_empty() {
+        let extended = value[0] >= 128;
+        let header_length = if extended { 3 } else { 2 };
+        if value.len() < header_length {
+            return Err(if extended {
+                "Tunnel sub-TLV two-octet length is truncated"
+            } else {
+                "Tunnel sub-TLV header is truncated"
+            });
+        }
+        let length = if extended {
+            usize::from(u16::from_be_bytes([value[1], value[2]]))
+        } else {
+            usize::from(value[1])
+        };
+        if value.len() < header_length + length {
+            return Err("Tunnel sub-TLV overruns Tunnel TLV");
+        }
+        value = &value[header_length + length..];
+    }
+    Ok(())
+}
+
+fn attr_set(value: &[u8]) -> Result<(), &'static str> {
+    if value.len() < 4 {
+        return Err("ATTR_SET Origin AS is truncated");
+    }
+    let mut attributes = &value[4..];
+    while !attributes.is_empty() {
+        if attributes.len() < 2 {
+            return Err("ATTR_SET embedded attribute header is truncated");
+        }
+        let flags = attributes[0];
+        let type_code = attributes[1];
+        if matches!(
+            type_code,
+            attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI
+        ) {
+            return Err("ATTR_SET embeds an MP_REACH_NLRI or MP_UNREACH_NLRI attribute");
+        }
+        let extended = flags & attr_flags::EXTENDED_LENGTH != 0;
+        let header_length = if extended { 4 } else { 3 };
+        if attributes.len() < header_length {
+            return Err(if extended {
+                "ATTR_SET embedded extended length is truncated"
+            } else {
+                "ATTR_SET embedded attribute length is truncated"
+            });
+        }
+        let length = if extended {
+            usize::from(u16::from_be_bytes([attributes[2], attributes[3]]))
+        } else {
+            usize::from(attributes[2])
+        };
+        if attributes.len() < header_length + length {
+            return Err("ATTR_SET embedded attribute overruns ATTR_SET");
+        }
+        attributes = &attributes[header_length + length..];
+    }
+    Ok(())
 }
 
 fn community_container(mut value: &[u8]) -> Result<(), &'static str> {

--- a/crates/wire/tests/path_attribute_registry.rs
+++ b/crates/wire/tests/path_attribute_registry.rs
@@ -82,8 +82,65 @@ fn community_type_one(subtypes: &[u8]) -> Vec<u8> {
     community_container(1, &body)
 }
 
+fn tunnel_sub_tlv(kind: u8, value: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![kind];
+    if kind < 128 {
+        bytes.push(u8::try_from(value.len()).unwrap());
+    } else {
+        bytes.extend_from_slice(&u16::try_from(value.len()).unwrap().to_be_bytes());
+    }
+    bytes.extend_from_slice(value);
+    bytes
+}
+
+fn tunnel_tlv(kind: u16, value: &[u8]) -> Vec<u8> {
+    let mut bytes = kind.to_be_bytes().to_vec();
+    bytes.extend_from_slice(&u16::try_from(value.len()).unwrap().to_be_bytes());
+    bytes.extend_from_slice(value);
+    bytes
+}
+
+fn attr_set(origin_as: u32, embedded: &[u8]) -> Vec<u8> {
+    let mut bytes = origin_as.to_be_bytes().to_vec();
+    bytes.extend_from_slice(embedded);
+    bytes
+}
+
+fn assert_opaque_round_trip(code: u8, value: &[u8]) {
+    let input = attribute(0xe0, code, value);
+    let strict = decode_path_attributes(&input, true, &[]).unwrap();
+    let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+    assert!(revised.malformed.is_empty());
+    assert!(matches!(
+        strict.as_slice(),
+        [PathAttribute::Unknown(raw)]
+            if raw.type_code == code && raw.data.as_ref() == value
+    ));
+    let mut emitted = Vec::new();
+    encode_path_attributes(&revised.attributes, &mut emitted, true, false).unwrap();
+    assert_eq!(emitted, input);
+}
+
+fn assert_length_error_treat_as_withdraw(code: u8, value: &[u8]) {
+    let input = attribute(0xc0, code, value);
+    assert!(matches!(
+        decode_path_attributes(&input, true, &[]),
+        Err(DecodeError::UpdateAttributeError { subcode, data, .. })
+            if subcode == update_subcode::ATTRIBUTE_LENGTH_ERROR && data == input
+    ));
+    let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+    assert!(revised.attributes.is_empty());
+    assert_eq!(revised.malformed.len(), 1);
+    assert_eq!(revised.malformed[0].type_code, code);
+    assert_eq!(
+        revised.malformed[0].disposition,
+        ErrorDisposition::TreatAsWithdraw
+    );
+}
+
 fn assigned_value(code: u8) -> Vec<u8> {
     match code {
+        23 => tunnel_tlv(1, &[]),
         25 => (0_u8..20).collect(),
         34 => community_container(2, &[]),
         36 => vec![1, 0, 0, 0, 0, 0, 0, 0],
@@ -99,6 +156,7 @@ fn assigned_value(code: u8) -> Vec<u8> {
 
 fn assigned_malformed(code: u8) -> Option<(Vec<u8>, ErrorDisposition)> {
     match code {
+        23 => Some((Vec::new(), ErrorDisposition::TreatAsWithdraw)),
         36 => Some((vec![0; 8], ErrorDisposition::TreatAsWithdraw)),
         37 => Some((vec![2, 0, 1, 1], ErrorDisposition::TreatAsWithdraw)),
         38 => Some((vec![1, 0, 0, 0, 1], ErrorDisposition::AttributeDiscard)),
@@ -111,12 +169,16 @@ fn assigned_malformed(code: u8) -> Option<(Vec<u8>, ErrorDisposition)> {
             vec![0, 1, 0, 8, 0, 0, 0, 0, 0, 2, 0, 1],
             ErrorDisposition::AttributeDiscard,
         )),
+        128 => Some((vec![0; 3], ErrorDisposition::TreatAsWithdraw)),
         _ => None,
     }
 }
 
 fn assigned_payload_contract(code: u8) -> &'static str {
     match code {
+        23 => {
+            "one or more exact two-octet-type/two-octet-length Tunnel TLVs; each body is an exact sub-TLV stream with one-octet lengths for types 0-127 and two-octet lengths for types 128-255; values remain opaque"
+        }
         36 => "non-empty sequence of nonzero-count domain segments, each exactly `1 + 7*n` octets",
         37 => {
             "exact one-octet-type/two-octet-length TLVs, at least one Hop TLV, and at least one exactly framed sub-TLV after every Hop service index"
@@ -134,6 +196,9 @@ fn assigned_payload_contract(code: u8) -> &'static str {
             "non-empty exact two-octet-type/length TLV stream; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque"
         }
         42 => "no payload validation; exact registered class is dropped before value decoding",
+        128 => {
+            "four-octet Origin AS followed by an exact embedded path-attribute stream using each inner Extended Length bit; embedded MP_REACH_NLRI and MP_UNREACH_NLRI are rejected; inner values remain opaque"
+        }
         _ => panic!("no assigned framing contract for code {code}"),
     }
 }
@@ -403,6 +468,105 @@ fn assigned_and_unknown_behavior_fences_are_explicit() {
         decode_path_attributes_revised(&attribute(0x40, 200, &[0xaa]), true, false, &[]).unwrap();
     let error = validate_update_attributes(&unknown.attributes, false, false, true).unwrap_err();
     assert_eq!(error.disposition, ErrorDisposition::TreatAsWithdraw);
+}
+
+#[test]
+fn tunnel_encapsulation_enforces_tlv_and_sub_tlv_framing_only() {
+    let one_tlv = tunnel_tlv(65_000, &tunnel_sub_tlv(127, &[0xaa, 0xbb]));
+    let two_tlvs = [
+        tunnel_tlv(1, &tunnel_sub_tlv(128, &[0xcc])),
+        tunnel_tlv(65_001, &[]),
+    ]
+    .concat();
+    let width_boundary = tunnel_tlv(
+        2,
+        &[tunnel_sub_tlv(127, &[0x7f]), tunnel_sub_tlv(128, &[0x80])].concat(),
+    );
+    for value in [one_tlv, two_tlvs, width_boundary, tunnel_tlv(3, &[])] {
+        assert_opaque_round_trip(23, &value);
+    }
+
+    let malformed = [
+        Vec::new(),
+        vec![0],
+        vec![0, 1],
+        vec![0, 1, 0],
+        vec![0, 1, 0, 1],
+        tunnel_tlv(1, &[127]),
+        tunnel_tlv(1, &[128]),
+        tunnel_tlv(1, &[128, 0]),
+        tunnel_tlv(1, &[127, 1]),
+        tunnel_tlv(1, &[128, 0, 1]),
+    ];
+    for value in malformed {
+        assert_length_error_treat_as_withdraw(23, &value);
+    }
+}
+
+#[test]
+fn attr_set_enforces_embedded_attribute_framing_without_recursive_decode() {
+    let origin_only = attr_set(65_000, &[]);
+    assert_opaque_round_trip(128, &origin_only);
+
+    let embedded = [
+        attribute(0x40, 1, &[0xff]),
+        extended_attribute(0x80, 200, &[0xde, 0xad, 0xbe, 0xef]),
+    ]
+    .concat();
+    assert_opaque_round_trip(128, &attr_set(65_001, &embedded));
+
+    // The nested value would fail if interpreted as another ATTR_SET because
+    // it is shorter than an Origin AS. This tranche treats it as opaque.
+    let nested = attribute(0xc0, 128, &[0xc0, 14, 0]);
+    assert_opaque_round_trip(128, &attr_set(65_002, &nested));
+
+    let origin = 65_003_u32.to_be_bytes();
+    let malformed = [
+        Vec::new(),
+        vec![0],
+        vec![0, 0],
+        vec![0, 0, 0],
+        [origin.as_slice(), &[0x40]].concat(),
+        [origin.as_slice(), &[0x40, 1]].concat(),
+        [origin.as_slice(), &[0x50, 1]].concat(),
+        [origin.as_slice(), &[0x50, 1, 0]].concat(),
+        [origin.as_slice(), &[0x40, 1, 1]].concat(),
+        [origin.as_slice(), &[0x50, 1, 0, 1]].concat(),
+        [origin.as_slice(), &[0x80, 14, 0]].concat(),
+        [origin.as_slice(), &[0x80, 15, 0]].concat(),
+    ];
+    for value in malformed {
+        assert_length_error_treat_as_withdraw(128, &value);
+    }
+}
+
+#[test]
+fn bgpsec_path_remains_ignored_without_payload_parsing_or_egress() {
+    for value in [&[][..], &[0xff][..], &[0x80, 0, 1][..]] {
+        let input = attribute(0x80, 33, value);
+        assert!(
+            decode_path_attributes(&input, true, &[])
+                .unwrap()
+                .is_empty()
+        );
+        let revised = decode_path_attributes_revised(&input, true, false, &[]).unwrap();
+        assert!(revised.attributes.is_empty());
+        assert!(revised.malformed.is_empty());
+    }
+
+    let mut emitted = Vec::new();
+    encode_path_attributes(
+        &[PathAttribute::Unknown(rustbgpd_wire::RawAttribute {
+            flags: 0x80,
+            type_code: 33,
+            data: bytes::Bytes::from_static(&[0xde, 0xad]),
+        })],
+        &mut emitted,
+        true,
+        false,
+    )
+    .unwrap();
+    assert!(emitted.is_empty());
 }
 
 #[test]
@@ -966,9 +1130,9 @@ fn assigned_framing_documentation_matches_executable_cases() {
         ),
         4,
     );
-    assert_eq!(framing.len(), 7);
-    for (index, row) in framing.iter().enumerate() {
-        let code = u8::try_from(index + 36).unwrap();
+    let codes = [23_u8, 36, 37, 38, 39, 40, 41, 42, 128];
+    assert_eq!(framing.len(), codes.len());
+    for (row, code) in framing.iter().zip(codes) {
         assert_eq!(row[0], code.to_string());
         let canonical = if code == 42 { 0x80 } else { 0xc0 };
         assert!(row[1].contains(&format!("flags `{canonical:#04x}`")));

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -11,7 +11,7 @@ codec claim.
 - CSV: `https://www.iana.org/assignments/bgp-parameters/bgp-parameters-2.csv`
 - Registry snapshot: 2026-08-18 (live-verified 2026-08-23)
 - SHA-256: `691f147f5c9ef9dbde82febe339f5691a1bfc4d83f63e3ed0d224676ebe68886`
-- Normative anchors: [RFC 4271 §§4.3, 5](https://www.rfc-editor.org/rfc/rfc4271), [RFC 7606 §§2, 3, 5.2, 7.1-7.10](https://www.rfc-editor.org/rfc/rfc7606), [RFC 9234 §§5](https://www.rfc-editor.org/rfc/rfc9234), [RFC 7311](https://www.rfc-editor.org/rfc/rfc7311), [RFC 9552](https://www.rfc-editor.org/rfc/rfc9552), and [RFC 8669 §3](https://www.rfc-editor.org/rfc/rfc8669).
+- Normative anchors: [RFC 4271 §§4.3, 5](https://www.rfc-editor.org/rfc/rfc4271), [RFC 7606 §§2, 3, 5.2, 7.1-7.10, 7.16](https://www.rfc-editor.org/rfc/rfc7606), [RFC 9012 §§2, 13](https://www.rfc-editor.org/rfc/rfc9012), [RFC 6368 §5](https://www.rfc-editor.org/rfc/rfc6368), [RFC 9234 §§5](https://www.rfc-editor.org/rfc/rfc9234), [RFC 7311](https://www.rfc-editor.org/rfc/rfc7311), [RFC 9552](https://www.rfc-editor.org/rfc/rfc9552), and [RFC 8669 §3](https://www.rfc-editor.org/rfc/rfc8669).
 
 Manual live comparison (never run by normal CI): download the CSV with
 `curl -fsSL https://www.iana.org/assignments/bgp-parameters/bgp-parameters-2.csv -o /tmp/bgp-parameters-2.csv`, run
@@ -51,7 +51,7 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 20 | Connector Attribute (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 21 | AS_PATHLIMIT (deprecated) | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 22 | PMSI_TUNNEL | optional transitive; flags `0xc0`; RFC 6514 §5 / RFC 7385 | typed canonical + Partial round-trip; Extended Length and reserved low bits canonicalize; malformed tunnel type or identifier is treat-as-withdraw | typed-Partial and PMSI tunnel-type matrices |
-| 23 | Tunnel Encapsulation | optional transitive; flags `0xc0`; RFC 9012 | payload semantics unsupported; correct class retained opaque and emitted with Partial; wrong class is treat-as-withdraw | assigned-class matrix below |
+| 23 | Tunnel Encapsulation | optional transitive; flags `0xc0`; RFC 9012 | opaque retention with exact Tunnel TLV and variable-width sub-TLV framing; malformed framing or class is treat-as-withdraw | assigned class and framing matrices below |
 | 24 | Traffic Engineering | optional non-transitive; flags `0x80`; RFC 5543 §3 / RFC 7606 §7.13 | payload semantics unsupported; correct class ignored and never emitted; class or Partial conflict is treat-as-withdraw | assigned-class matrix below |
 | 25 | IPv6 Address Specific Extended Community | optional transitive; flags `0xc0`; values are non-empty multiples of 20 octets; RFC 5701 §2 / RFC 7606 §7.15 | opaque retention with Partial on egress; zero or non-multiple-of-20 length and class conflicts are treat-as-withdraw | assigned-class and IPv6-community length matrices below |
 | 26 | AIGP | optional non-transitive; flags `0x80`; RFC 7311 §3 | payload semantics unsupported; correct class ignored; Transitive-set conflicts are attribute-discard, other class conflicts are treat-as-withdraw | assigned-class matrix below |
@@ -72,7 +72,7 @@ octet from 0 through 255 to appear exactly once with no blank cell.
 | 41 | BIER | optional transitive; flags `0xc0`; RFC 9793 §§3-4 | opaque retention with exact TLV/sub-TLV length-boundary framing; boundary failure is attribute-discard | assigned framing matrix below |
 | 42 | Edge Metadata Path Attribute (TEMPORARY - registered 2025-04-23, extension registered 2026-04-03, expires 2027-04-23) | optional non-transitive; flags `0x80`; draft-ietf-idr-5g-edge-service-metadata-27 | payload unsupported; correct class ignored and never emitted; every class or Partial conflict is treat-as-withdraw | assigned framing matrix below |
 | 43-127 | Unassigned | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
-| 128 | ATTR_SET | optional transitive; flags `0xc0`; RFC 6368 | payload semantics unsupported; correct class retained opaque and emitted with Partial; wrong class is treat-as-withdraw | assigned-class matrix below |
+| 128 | ATTR_SET | optional transitive; flags `0xc0`; RFC 6368 / RFC 7606 §7.16 | opaque retention with Origin AS and embedded attribute framing; embedded MP attributes, malformed framing, or wrong class are treat-as-withdraw | assigned class and framing matrices below |
 | 129 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 130-240 | Unassigned | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
 | 241 | Deprecated | pending follow-up audit | pending follow-up audit | IANA CSV digest above |
@@ -107,10 +107,11 @@ disposition shown.
 
 ## Assigned class fence
 
-This matrix audits only the registered Optional/Transitive class. It does not
-claim payload parsing, semantic validation, policy support, or feature
-negotiation. "Wrong O" toggles Optional, "wrong T" toggles Transitive, and
-"both" toggles both bits from the canonical class.
+This matrix audits only the registered Optional/Transitive class; bounded
+payload framing is documented separately below. It does not claim semantic
+validation, policy support, or feature negotiation. "Wrong O" toggles
+Optional, "wrong T" toggles Transitive, and "both" toggles both bits from the
+canonical class.
 
 | Codes | Class | Correct-class retention and egress | Wrong O | Wrong T | Both wrong | Legacy decoder |
 |---|---|---|---|---|---|---|
@@ -142,14 +143,16 @@ framing; they do not expose a typed model or claim stable standards support.
 | Known subtypes 1-3 | empty or an exact atom stream; unknown subtypes opaque | atom framing error or reserved atom type 0/255 |
 | Atom values | types 1/4/5/6/7: positive multiples of four; types 2/3: complete IPv4/IPv6 prefix sequences; type 8 and types 9-254 opaque | fixed-width mismatch, prefix length above 32/128, or truncated prefix octets |
 
-## Assigned framing matrix (36-42)
+## Assigned framing matrix (23, 36-42, 128)
 
 These checks are syntax-only. They do not implement route-family applicability,
-stateful lookup, policy, or attribute semantics. Unknown TLVs remain opaque.
+stateful lookup, policy, or attribute semantics. Unknown types and their values
+remain opaque.
 
 <!-- assigned-framing:start -->
 | Code | Registered class | Bounded structural fence | Revised malformed action |
 |---|---|---|---|
+| 23 | optional transitive; flags `0xc0` | one or more exact two-octet-type/two-octet-length Tunnel TLVs; each body is an exact sub-TLV stream with one-octet lengths for types 0-127 and two-octet lengths for types 128-255; values remain opaque | treat-as-withdraw |
 | 36 | optional transitive; flags `0xc0` | non-empty sequence of nonzero-count domain segments, each exactly `1 + 7*n` octets | treat-as-withdraw |
 | 37 | optional transitive; flags `0xc0` | exact one-octet-type/two-octet-length TLVs, at least one Hop TLV, and at least one exactly framed sub-TLV after every Hop service index | treat-as-withdraw |
 | 38 | optional transitive; flags `0xc0` | five-octet base, exact one-octet-type/length optional TLVs, and a Source IP TLV of length 4 or 16 | attribute-discard |
@@ -157,6 +160,7 @@ stateful lookup, policy, or attribute semantics. Unknown TLVs remain opaque.
 | 40 | optional transitive; flags `0xc0` | exact one-octet-type/two-octet-length TLVs; Label-Index length 7; Originator SRGB length `2 + nonzero*6` | attribute-discard |
 | 41 | optional transitive; flags `0xc0` | non-empty exact two-octet-type/length TLV stream; known containers consume nested length framing only when their four-octet fixed prefix is present; semantic field shapes remain opaque | attribute-discard |
 | 42 | optional non-transitive; flags `0x80` | no payload validation; exact registered class is dropped before value decoding | class conflict is treat-as-withdraw |
+| 128 | optional transitive; flags `0xc0` | four-octet Origin AS followed by an exact embedded path-attribute stream using each inner Extended Length bit; embedded MP_REACH_NLRI and MP_UNREACH_NLRI are rejected; inner values remain opaque | treat-as-withdraw |
 <!-- assigned-framing:end -->
 
 ## PMSI tunnel-type matrix


### PR DESCRIPTION
## Summary

Validate the framing of opaque Tunnel Encapsulation and ATTR_SET attributes before retaining and re-advertising them. The validators are allocation-free and intentionally stop at structural boundaries; they do not add semantic decoding.

## Changes

- walk every type-23 Tunnel TLV and its one- or two-octet-length sub-TLV stream exactly
- require type-128 ATTR_SET to contain an Origin AS and a complete embedded path-attribute stream without MP_REACH_NLRI or MP_UNREACH_NLRI
- preserve treat-as-withdraw for malformed type 23/128 input and pin BGPsec_PATH's existing ignore/no-egress behavior
- document the bounded registry behavior and release impact

## Testing

- [x] `cargo test -p rustbgpd-wire --test path_attribute_registry`
- [x] `cargo test -p rustbgpd-wire --all-targets --features tokio-codec`
- [x] `cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p rustbgpd-wire --features tokio-codec --no-deps`
- [x] `cargo fmt --all -- --check`
- [x] normal hooks: workspace all-target clippy, workspace library tests, and workspace rustdoc
- [x] embedding-version and public-tracker-ID checks
- [x] Interop not applicable: this is a syntax-only wire decoder boundary with exhaustive compact fixtures
- [x] Performance receipt not applicable: both validators are bounded single-pass slice walkers with no allocations

Self-review covered the complete one-commit stack and full diff, error disposition precedence, every requested truncation/overrun boundary, opaque round trips, documentation claims, and accidental scope expansion.

## Docs / release notes

- [x] Root and wire changelogs updated
- [x] Path-attribute registry updated and executable claims pinned
- [x] ROADMAP update intentionally not needed

## Related issues

[LAN-1326](https://linear.app/lance0/issue/LAN-1326/validate-tunnel-encapsulation-and-attr-set-framing-before-re)
