### PR TITLE
Distinguish fully compensated runtime mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Neighbor, peer-group, and policy gRPC mutations now mark a failed runtime
+  change whose effects were fully compensated, distinguishing it from a
+  rejection that made no change while preserving the original status code and
+  error details. The response trailer and message warn that retrying can repeat
+  transient runtime changes even though the staged persistent candidate was
+  discarded.
+
 - Tunnel Encapsulation and ATTR_SET attributes now receive bounded structural
   validation before opaque re-advertisement. Tunnel TLV/sub-TLV boundaries and
   ATTR_SET's Origin AS/embedded-attribute stream must be complete; embedded MP

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -24,7 +24,8 @@ use crate::runtime_config_settlement::{
 };
 use crate::server::{
     AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, check_config_mutation_gate,
-    peer_manager_request, read_only_rejection, stage_runtime_config_event_typed,
+    fully_compensated_status, peer_manager_request, read_only_rejection,
+    stage_runtime_config_event_typed,
 };
 use rustbgpd_rib::{
     EffectiveDistributionMode, NeighborRibSnapshot, NeighborRibSnapshotResponse, RibUpdate,
@@ -334,12 +335,15 @@ where
             error,
             reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::AcknowledgementLost,
         },
-        OwnedNeighborDispatch::Replied(
-            OwnedNeighborMutationOutcome::RejectedNoEffect(error)
-            | OwnedNeighborMutationOutcome::FullyCompensated(error),
-        ) => {
+        OwnedNeighborDispatch::Replied(OwnedNeighborMutationOutcome::RejectedNoEffect(error)) => {
             drop(staged);
             OwnedRuntimeConfigOutcome::CleanNoEffect(Err(owned_neighbor_error_status(error)))
+        }
+        OwnedNeighborDispatch::Replied(OwnedNeighborMutationOutcome::FullyCompensated(error)) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(fully_compensated_status(
+                &owned_neighbor_error_status(error),
+            )))
         }
         OwnedNeighborDispatch::Replied(OwnedNeighborMutationOutcome::CompensationAmbiguous(
             error,
@@ -2534,11 +2538,23 @@ mod tests {
                 )),
             ))
             .unwrap();
+        let error = call.await.unwrap().unwrap_err();
+        assert_eq!(error.code(), tonic::Code::NotFound);
         assert_eq!(
-            call.await.unwrap().unwrap_err().code(),
-            tonic::Code::NotFound
+            error
+                .metadata()
+                .get("rustbgpd-runtime-config-outcome")
+                .unwrap(),
+            "fully-compensated"
         );
-        assert!(coordinator.acquire().await.is_ok());
+        assert_eq!(
+            error.message(),
+            "runtime effects were fully compensated; retry may repeat transient runtime changes: range disappeared before mutation"
+        );
+        let _released = tokio::time::timeout(Duration::from_secs(1), coordinator.acquire())
+            .await
+            .expect("compensated neighbor mutation must release the coordinator")
+            .expect("coordinator must remain open");
     }
 
     #[tokio::test]

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -24,8 +24,8 @@ use crate::runtime_config_settlement::{
 use crate::server::{
     AccessMode, ConfigMutationGateFn, OwnedCatalogDispatch, RuntimeConfigCoordinator,
     catalog_mutation_error_to_status, check_config_mutation_gate, dispatch_owned_catalog_mutation,
-    peer_manager_request, read_only_rejection, stage_runtime_config_event_typed,
-    with_catalog_persist_ack,
+    fully_compensated_status, peer_manager_request, read_only_rejection,
+    stage_runtime_config_event_typed, with_catalog_persist_ack,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -547,12 +547,15 @@ async fn owned_peer_group_mutation_body(
             error,
             reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::AcknowledgementLost,
         },
-        OwnedCatalogDispatch::Replied(
-            OwnedCatalogMutationOutcome::RejectedNoEffect(error)
-            | OwnedCatalogMutationOutcome::FullyCompensated(error),
-        ) => {
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::RejectedNoEffect(error)) => {
             drop(staged);
             OwnedRuntimeConfigOutcome::CleanNoEffect(Err(catalog_mutation_error_to_status(&error)))
+        }
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::FullyCompensated(error)) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(fully_compensated_status(
+                &catalog_mutation_error_to_status(&error),
+            )))
         }
         OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(
             error,
@@ -1732,7 +1735,14 @@ mod tests {
     async fn owned_rejected_no_effect_discards_stage_and_returns() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let coordinator = RuntimeConfigCoordinator::new();
+        let svc = PeerGroupService::with_runtime_config_coordinator(
+            AccessMode::ReadWrite,
+            peer_tx,
+            Some(config_tx),
+            None,
+            coordinator.clone(),
+        );
         let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
         let staged = tokio::spawn(ack.accept());
         match peer_rx.recv().await.expect("expected owned delete") {
@@ -1753,17 +1763,43 @@ mod tests {
             !staged.await.unwrap(),
             "rejected mutation must discard stage"
         );
-        assert_eq!(
-            call.await.unwrap().unwrap_err().code(),
-            tonic::Code::NotFound
+        let error = call.await.unwrap().unwrap_err();
+        let expected = catalog_mutation_error_to_status(
+            &crate::peer_types::CatalogMutationError::not_found("missing group"),
         );
+        assert_eq!(error.code(), expected.code());
+        assert_eq!(error.message(), expected.message());
+        assert_eq!(error.details(), expected.details());
+        assert_eq!(error.metadata().len(), expected.metadata().len());
+        assert!(
+            !error
+                .message()
+                .starts_with("runtime effects were fully compensated")
+        );
+        assert!(
+            error
+                .metadata()
+                .get("rustbgpd-runtime-config-outcome")
+                .is_none()
+        );
+        let _released = tokio::time::timeout(Duration::from_secs(1), coordinator.acquire())
+            .await
+            .expect("rejected peer-group mutation must release the coordinator")
+            .expect("coordinator must remain open");
     }
 
     #[tokio::test]
     async fn owned_fully_compensated_discards_stage_and_returns() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let coordinator = RuntimeConfigCoordinator::new();
+        let svc = PeerGroupService::with_runtime_config_coordinator(
+            AccessMode::ReadWrite,
+            peer_tx,
+            Some(config_tx),
+            None,
+            coordinator.clone(),
+        );
         let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
         let staged = tokio::spawn(ack.accept());
         match peer_rx.recv().await.expect("expected owned delete") {
@@ -1782,10 +1818,23 @@ mod tests {
             !staged.await.unwrap(),
             "compensated mutation must discard stage"
         );
+        let error = call.await.unwrap().unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Internal);
         assert_eq!(
-            call.await.unwrap().unwrap_err().code(),
-            tonic::Code::Internal
+            error
+                .metadata()
+                .get("rustbgpd-runtime-config-outcome")
+                .unwrap(),
+            "fully-compensated"
         );
+        assert_eq!(
+            error.message(),
+            "runtime effects were fully compensated; retry may repeat transient runtime changes: apply failed; prior runtime restored"
+        );
+        let _released = tokio::time::timeout(Duration::from_secs(1), coordinator.acquire())
+            .await
+            .expect("compensated peer-group mutation must release the coordinator")
+            .expect("coordinator must remain open");
     }
 
     #[tokio::test]

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -27,7 +27,8 @@ use crate::runtime_config_settlement::{
 use crate::server::{
     AccessMode, ConfigMutationGateFn, OwnedCatalogDispatch, RuntimeConfigCoordinator,
     catalog_mutation_error_to_status, check_config_mutation_gate, dispatch_owned_catalog_mutation,
-    read_only_rejection, stage_runtime_config_event_typed, with_catalog_persist_ack,
+    fully_compensated_status, read_only_rejection, stage_runtime_config_event_typed,
+    with_catalog_persist_ack,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -483,12 +484,15 @@ async fn owned_policy_mutation_body(
             error,
             reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::AcknowledgementLost,
         },
-        OwnedCatalogDispatch::Replied(
-            OwnedCatalogMutationOutcome::RejectedNoEffect(error)
-            | OwnedCatalogMutationOutcome::FullyCompensated(error),
-        ) => {
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::RejectedNoEffect(error)) => {
             drop(staged);
             OwnedRuntimeConfigOutcome::CleanNoEffect(Err(catalog_mutation_error_to_status(&error)))
+        }
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::FullyCompensated(error)) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(fully_compensated_status(
+                &catalog_mutation_error_to_status(&error),
+            )))
         }
         OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(
             error,
@@ -4179,6 +4183,59 @@ policy customer-in(peer_lp: u32) {
             _ => panic!("expected DeletePolicy"),
         };
         (call, ack)
+    }
+
+    #[tokio::test]
+    async fn owned_policy_fully_compensated_discards_stage_and_returns_marker() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let coordinator = RuntimeConfigCoordinator::new();
+        let svc = PolicyService::with_runtime_config_coordinator(
+            AccessMode::ReadWrite,
+            peer_tx,
+            Some(config_tx),
+            None,
+            coordinator.clone(),
+        );
+        let (call, ack) = staged_policy_delete(svc, &mut config_rx).await;
+        let staged = tokio::spawn(ack.accept());
+        match peer_rx.recv().await.expect("expected owned policy delete") {
+            PeerManagerCommand::OwnedCatalogMutation {
+                mutation: OwnedCatalogMutation::DeletePolicy { name },
+                reply,
+            } => {
+                assert_eq!(name, "edge-policy");
+                reply
+                    .send(OwnedCatalogMutationOutcome::FullyCompensated(
+                        CatalogMutationError::failed_precondition(
+                            "policy fan-out failed; prior runtime restored",
+                        ),
+                    ))
+                    .unwrap();
+            }
+            _ => panic!("expected owned policy delete"),
+        }
+        assert!(
+            !staged.await.unwrap(),
+            "compensation must discard the stage"
+        );
+        let error = call.await.unwrap().unwrap_err();
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(
+            error
+                .metadata()
+                .get("rustbgpd-runtime-config-outcome")
+                .unwrap(),
+            "fully-compensated"
+        );
+        assert_eq!(
+            error.message(),
+            "runtime effects were fully compensated; retry may repeat transient runtime changes: policy fan-out failed; prior runtime restored"
+        );
+        let _released = tokio::time::timeout(Duration::from_secs(1), coordinator.acquire())
+            .await
+            .expect("compensated policy mutation must release the coordinator")
+            .expect("coordinator must remain open");
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -67,6 +67,26 @@ use rustbgpd_telemetry::BgpMetrics;
 
 const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
 const GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+const FULLY_COMPENSATED_STATUS_PREFIX: &str =
+    "runtime effects were fully compensated; retry may repeat transient runtime changes: ";
+const RUNTIME_CONFIG_OUTCOME_METADATA: &str = "rustbgpd-runtime-config-outcome";
+
+/// Mark a runtime-config error whose forward effects were fully compensated.
+///
+/// The original status code, details, metadata, and message remain available
+/// to clients. The added trailer distinguishes this retry-sensitive outcome
+/// from a rejection that produced no runtime effect.
+pub(crate) fn fully_compensated_status(status: &Status) -> Status {
+    let code = status.code();
+    let message = format!("{FULLY_COMPENSATED_STATUS_PREFIX}{}", status.message());
+    let details = bytes::Bytes::copy_from_slice(status.details());
+    let mut metadata = status.metadata().clone();
+    metadata.insert(
+        RUNTIME_CONFIG_OUTCOME_METADATA,
+        tonic::metadata::MetadataValue::from_static("fully-compensated"),
+    );
+    Status::with_details_and_metadata(code, message, details, metadata)
+}
 
 /// Closeable, one-permit serializer for persisted runtime-config mutations.
 #[derive(Debug)]
@@ -2415,6 +2435,36 @@ mod tests {
         for (error, code) in cases {
             assert_eq!(catalog_mutation_error_to_status(&error).code(), code);
         }
+    }
+
+    #[test]
+    fn fully_compensated_status_preserves_original_status_and_adds_marker() {
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("existing-trailer", "kept".parse().unwrap());
+        let original = Status::with_details_and_metadata(
+            tonic::Code::FailedPrecondition,
+            "candidate could not settle",
+            bytes::Bytes::from_static(b"\0opaque-details\xff"),
+            metadata,
+        );
+
+        let marked = fully_compensated_status(&original);
+
+        assert_eq!(marked.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(
+            marked.message(),
+            "runtime effects were fully compensated; retry may repeat transient runtime changes: candidate could not settle"
+        );
+        assert!(marked.message().ends_with("candidate could not settle"));
+        assert_eq!(marked.details(), b"\0opaque-details\xff");
+        assert_eq!(marked.metadata().get("existing-trailer").unwrap(), "kept");
+        assert_eq!(
+            marked
+                .metadata()
+                .get("rustbgpd-runtime-config-outcome")
+                .unwrap(),
+            "fully-compensated"
+        );
     }
 
     #[test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -78,7 +78,11 @@ const RUNTIME_CONFIG_OUTCOME_METADATA: &str = "rustbgpd-runtime-config-outcome";
 /// from a rejection that produced no runtime effect.
 pub(crate) fn fully_compensated_status(status: &Status) -> Status {
     let code = status.code();
-    let message = format!("{FULLY_COMPENSATED_STATUS_PREFIX} {}", status.message());
+    let message = if status.message().is_empty() {
+        FULLY_COMPENSATED_STATUS_PREFIX.to_string()
+    } else {
+        format!("{FULLY_COMPENSATED_STATUS_PREFIX} {}", status.message())
+    };
     let details = bytes::Bytes::copy_from_slice(status.details());
     let mut metadata = status.metadata().clone();
     metadata.insert(
@@ -2458,6 +2462,27 @@ mod tests {
         assert!(marked.message().ends_with("candidate could not settle"));
         assert_eq!(marked.details(), b"\0opaque-details\xff");
         assert_eq!(marked.metadata().get("existing-trailer").unwrap(), "kept");
+        assert_eq!(
+            marked
+                .metadata()
+                .get("rustbgpd-runtime-config-outcome")
+                .unwrap(),
+            "fully-compensated"
+        );
+    }
+
+    #[test]
+    fn fully_compensated_status_has_no_trailing_space_for_empty_message() {
+        let original = Status::internal("");
+
+        let marked = fully_compensated_status(&original);
+
+        assert_eq!(marked.code(), tonic::Code::Internal);
+        assert_eq!(
+            marked.message(),
+            "runtime effects were fully compensated; retry may repeat transient runtime changes:"
+        );
+        assert!(!marked.message().ends_with(' '));
         assert_eq!(
             marked
                 .metadata()

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -68,7 +68,7 @@ use rustbgpd_telemetry::BgpMetrics;
 const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
 const GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 const FULLY_COMPENSATED_STATUS_PREFIX: &str =
-    "runtime effects were fully compensated; retry may repeat transient runtime changes: ";
+    "runtime effects were fully compensated; retry may repeat transient runtime changes:";
 const RUNTIME_CONFIG_OUTCOME_METADATA: &str = "rustbgpd-runtime-config-outcome";
 
 /// Mark a runtime-config error whose forward effects were fully compensated.
@@ -78,7 +78,7 @@ const RUNTIME_CONFIG_OUTCOME_METADATA: &str = "rustbgpd-runtime-config-outcome";
 /// from a rejection that produced no runtime effect.
 pub(crate) fn fully_compensated_status(status: &Status) -> Status {
     let code = status.code();
-    let message = format!("{FULLY_COMPENSATED_STATUS_PREFIX}{}", status.message());
+    let message = format!("{FULLY_COMPENSATED_STATUS_PREFIX} {}", status.message());
     let details = bytes::Bytes::copy_from_slice(status.details());
     let mut metadata = status.metadata().clone();
     metadata.insert(

--- a/docs/API.md
+++ b/docs/API.md
@@ -232,6 +232,16 @@ The API uses gRPC status codes consistently across services:
 | `UNIMPLEMENTED` | The RPC is reserved in the protobuf but runtime support has not shipped yet |
 | `INTERNAL` | An internal daemon actor, metrics encoder, or RIB boundary failed unexpectedly after the request passed validation |
 
+Runtime-config mutations that fail after transient runtime changes, but whose
+forward effects are then fully compensated, preserve the original gRPC status
+code and append the original message after this exact prefix:
+`runtime effects were fully compensated; retry may repeat transient runtime changes: `.
+Their trailing metadata also includes
+`rustbgpd-runtime-config-outcome: fully-compensated`. The staged persistent
+candidate is discarded, so the runtime and TOML remain at their prior state.
+The marker is a retry warning: repeating the request can repeat those transient
+runtime changes even though the reported attempt left no final-state change.
+
 ---
 
 ## gnmi.gNMI

--- a/docs/API.md
+++ b/docs/API.md
@@ -236,7 +236,8 @@ Runtime-config mutations that fail after transient runtime changes, but whose
 forward effects are then fully compensated, preserve the original gRPC status
 code and append the original message after this exact prefix:
 `runtime effects were fully compensated; retry may repeat transient runtime changes:`.
-Exactly one ASCII space separates that prefix from the original message.
+When an original message is present, exactly one ASCII space separates it from
+that prefix; an empty original message adds no trailing space.
 Their trailing metadata also includes
 `rustbgpd-runtime-config-outcome: fully-compensated`. The staged persistent
 candidate is discarded, so the runtime and TOML remain at their prior state.

--- a/docs/API.md
+++ b/docs/API.md
@@ -235,7 +235,8 @@ The API uses gRPC status codes consistently across services:
 Runtime-config mutations that fail after transient runtime changes, but whose
 forward effects are then fully compensated, preserve the original gRPC status
 code and append the original message after this exact prefix:
-`runtime effects were fully compensated; retry may repeat transient runtime changes: `.
+`runtime effects were fully compensated; retry may repeat transient runtime changes:`.
+Exactly one ASCII space separates that prefix from the original message.
 Their trailing metadata also includes
 `rustbgpd-runtime-config-outcome: fully-compensated`. The staged persistent
 candidate is discarded, so the runtime and TOML remain at their prior state.


### PR DESCRIPTION
## Summary

- preserve no-effect gRPC errors byte-for-byte while marking only fully compensated runtime-config outcomes
- retain the original status code, details, metadata, and message while adding an exact retry-warning prefix and `rustbgpd-runtime-config-outcome: fully-compensated` trailer
- keep staged-candidate discard, final-state settlement, coordinator release, and persistent TOML behavior unchanged across neighbor, peer-group, and policy mutations
- document the operator-visible error contract without changing protobufs or the stable method surface

## Validation

- five exact focused helper and service-boundary tests
- `cargo test --locked -p rustbgpd-api` (689 unit tests plus settlement exit integration)
- `cargo clippy --locked -p rustbgpd-api --all-targets -- -D warnings`
- `cargo doc --locked -p rustbgpd-api --lib --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- stable protobuf and inventory files unchanged from `origin/main`
- normal pre-commit and pre-push hooks (workspace fmt, clippy, tests, and docs)

Linear: LAN-1331