### PR TITLE
Bound full RIB snapshot queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Full-table blackhole and FIB RIB queries now share one two-second deadline
+  across channel admission and reply, and cooperatively abandon Loc-RIB and
+  ECMP materialization at bounded strides. An incomplete snapshot is dropped
+  instead of reaching kernel reconciliation.
+
 - Neighbor, peer-group, and policy gRPC mutations now mark a failed runtime
   change whose effects were fully compensated, distinguishing it from a
   rejection that made no change while preserving the original status code and

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2409,14 +2409,19 @@ impl RibManager {
                     reply,
                 );
             }
-            RibUpdate::QueryBestRoutes { reply } => self.handle_query_best_routes(reply),
+            RibUpdate::QueryBestRoutes { deadline, reply } => {
+                self.handle_query_best_routes(deadline, reply);
+            }
             RibUpdate::QueryFibInstallCandidates {
                 max_paths,
                 relax,
                 weighted,
+                deadline,
                 reply,
             } => {
-                self.handle_query_fib_install_candidates(max_paths, relax, weighted, reply);
+                self.handle_query_fib_install_candidates(
+                    max_paths, relax, weighted, deadline, reply,
+                );
             }
             RibUpdate::QueryPeerGroups { reply } => self.handle_query_peer_groups(reply),
             RibUpdate::ExplainBestPath {

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -25,6 +25,34 @@ use crate::update::{
     WarmMrtSnapshotBudget, WarmMrtSnapshotView, ordered_route_query, route_query_key,
 };
 
+/// Full-snapshot queries check cancellation at bounded work intervals instead
+/// of adding a branch and clock read to every route on the normal path.
+const FULL_SNAPSHOT_CANCELLATION_STRIDE: usize = 256;
+
+fn canceled_at_stride(completed: usize, canceled: &mut impl FnMut() -> bool) -> bool {
+    completed.is_multiple_of(FULL_SNAPSHOT_CANCELLATION_STRIDE) && canceled()
+}
+
+fn collect_full_snapshot<'a, T: Clone + 'a>(
+    capacity: usize,
+    rows: impl Iterator<Item = &'a T>,
+    canceled: &mut impl FnMut() -> bool,
+) -> Option<Vec<T>> {
+    if canceled() {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(capacity);
+    for (index, row) in rows.enumerate() {
+        if index != 0 && canceled_at_stride(index, canceled) {
+            return None;
+        }
+        out.push(row.clone());
+    }
+
+    (!canceled()).then_some(out)
+}
+
 /// Copy the rows of one non-unicast Loc-RIB table that match the caller's
 /// pushed-down predicate.
 ///
@@ -44,19 +72,6 @@ pub(super) fn filter_rows<'a, T: Clone + 'a>(
     match filter {
         Some(matches) => rows.filter(|row| matches(row)).cloned().collect(),
         None => rows.cloned().collect(),
-    }
-}
-
-fn send_materialized_rows<T>(
-    reply: tokio::sync::oneshot::Sender<Vec<T>>,
-    materialize: impl FnOnce() -> Vec<T>,
-) {
-    if reply.is_closed() {
-        debug!("route query canceled before materialization");
-        return;
-    }
-    if reply.send(materialize()).is_err() {
-        warn!("query caller dropped before receiving response");
     }
 }
 
@@ -685,9 +700,19 @@ impl RibManager {
     }
     pub(super) fn handle_query_best_routes(
         &mut self,
+        deadline: tokio::time::Instant,
         reply: tokio::sync::oneshot::Sender<Vec<crate::route::Route>>,
     ) {
-        send_materialized_rows(reply, || self.loc_rib.iter().cloned().collect());
+        let routes = collect_full_snapshot(self.loc_rib.len(), self.loc_rib.iter(), &mut || {
+            reply.is_closed() || tokio::time::Instant::now() >= deadline
+        });
+        let Some(routes) = routes else {
+            debug!("best-route query canceled during materialization");
+            return;
+        };
+        if reply.send(routes).is_err() {
+            warn!("query caller dropped before receiving response");
+        }
     }
     /// Build the per-prefix FIB install-candidate view: each Loc-RIB best plus
     /// the equal-cost (ECMP) next-hop set, bounded by `max_paths`. Loc-RIB holds
@@ -697,19 +722,30 @@ impl RibManager {
     /// best route's next-hop is always index 0; the remaining equal-cost siblings
     /// follow ordered by `(next_hop, peer, path_id)`. Deduped by next-hop *before*
     /// the `max_paths` cap.
-    pub(super) fn handle_query_fib_install_candidates(
-        &mut self,
+    fn materialize_fib_install_candidates(
+        &self,
         max_paths: u32,
         relax: bool,
         weighted: bool,
-        reply: tokio::sync::oneshot::Sender<Vec<crate::route::FibInstallCandidate>>,
-    ) {
+        canceled: &mut impl FnMut() -> bool,
+    ) -> Option<Vec<crate::route::FibInstallCandidate>> {
         use crate::best_path::{link_bandwidth_weights, multipath_equal};
         use crate::route::{FibInstallCandidate, FibInstallNextHop};
 
+        if canceled() {
+            debug!("FIB install-candidate query canceled before materialization");
+            return None;
+        }
+
         let cap = max_paths.max(1) as usize;
         let mut out = Vec::with_capacity(self.loc_rib.len());
-        for best in self.loc_rib.iter() {
+        let mut peer_rib_work = 0;
+        let mut sibling_work = 0;
+        for (best_index, best) in self.loc_rib.iter().enumerate() {
+            if best_index != 0 && canceled_at_stride(best_index, &mut *canceled) {
+                debug!("FIB install-candidate query canceled during Loc-RIB materialization");
+                return None;
+            }
             let mut next_hops: Vec<FibInstallNextHop> = Vec::new();
             if cap <= 1 {
                 // ECMP off (the default `maximum_paths` of 1): skip the
@@ -725,12 +761,26 @@ impl RibManager {
                     weight: 1,
                 });
             } else {
-                let mut siblings: Vec<&crate::route::Route> = self
-                    .ribs
-                    .values()
-                    .flat_map(|rib| rib.iter_prefix(&best.prefix))
-                    .filter(|r| multipath_equal(best, r, relax))
-                    .collect();
+                let mut siblings: Vec<&crate::route::Route> = Vec::new();
+                for rib in self.ribs.values() {
+                    peer_rib_work += 1;
+                    if canceled_at_stride(peer_rib_work, &mut *canceled) {
+                        debug!("FIB install-candidate query canceled during ECMP peer-RIB walk");
+                        return None;
+                    }
+                    for route in rib.iter_prefix(&best.prefix) {
+                        sibling_work += 1;
+                        if canceled_at_stride(sibling_work, &mut *canceled) {
+                            debug!(
+                                "FIB install-candidate query canceled during ECMP sibling gathering"
+                            );
+                            return None;
+                        }
+                        if multipath_equal(best, route, relax) {
+                            siblings.push(route);
+                        }
+                    }
+                }
                 siblings.sort_by(|a, b| {
                     a.next_hop
                         .cmp(&b.next_hop)
@@ -778,7 +828,28 @@ impl RibManager {
                 next_hops,
             });
         }
-        if reply.send(out).is_err() {
+        if canceled() {
+            debug!("FIB install-candidate query canceled after materialization");
+            return None;
+        }
+        Some(out)
+    }
+    pub(super) fn handle_query_fib_install_candidates(
+        &mut self,
+        max_paths: u32,
+        relax: bool,
+        weighted: bool,
+        deadline: tokio::time::Instant,
+        reply: tokio::sync::oneshot::Sender<Vec<crate::route::FibInstallCandidate>>,
+    ) {
+        let candidates =
+            self.materialize_fib_install_candidates(max_paths, relax, weighted, &mut || {
+                reply.is_closed() || tokio::time::Instant::now() >= deadline
+            });
+        let Some(candidates) = candidates else {
+            return;
+        };
+        if reply.send(candidates).is_err() {
             warn!("query caller dropped before receiving response");
         }
     }
@@ -2282,6 +2353,24 @@ impl RibManager {
 mod cancellation_tests {
     use super::*;
 
+    fn manager_with_best(best: &crate::route::Route) -> RibManager {
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let (_query_tx, query_rx) = tokio::sync::mpsc::channel(1);
+        let mut manager = RibManager::new(
+            rx,
+            query_rx,
+            None,
+            None,
+            rustbgpd_telemetry::BgpMetrics::new(),
+        );
+        assert!(
+            manager
+                .loc_rib
+                .recompute(best.prefix, std::iter::once(best))
+        );
+        manager
+    }
+
     #[test]
     fn family_continuation_starts_at_cursor_and_reads_one_lookahead() {
         let peer = Ipv4Addr::new(192, 0, 2, 1);
@@ -2363,10 +2452,93 @@ mod cancellation_tests {
     }
 
     #[test]
-    fn canceled_materialized_rows_does_not_invoke_builder() {
-        let (reply, receiver) = tokio::sync::oneshot::channel::<Vec<crate::route::Route>>();
+    fn preclosed_full_snapshot_does_not_advance_iterator() {
+        let (reply, receiver) = tokio::sync::oneshot::channel::<Vec<usize>>();
         drop(receiver);
-        send_materialized_rows(reply, || panic!("canceled query materialized"));
+        let rows =
+            std::iter::once_with(|| -> &'static usize { panic!("canceled query materialized") });
+        assert!(collect_full_snapshot(1, rows, &mut || reply.is_closed()).is_none());
+    }
+
+    #[test]
+    fn full_snapshot_cancels_at_fixed_stride_without_returning_partial_rows() {
+        let visited = std::cell::Cell::new(0);
+        let checks = std::cell::Cell::new(0);
+        let source = (0..FULL_SNAPSHOT_CANCELLATION_STRIDE * 3).collect::<Vec<_>>();
+        let rows = source.iter().inspect(|_| {
+            visited.set(visited.get() + 1);
+        });
+        let result =
+            collect_full_snapshot(FULL_SNAPSHOT_CANCELLATION_STRIDE * 3, rows, &mut || {
+                checks.set(checks.get() + 1);
+                checks.get() == 2
+            });
+
+        assert!(result.is_none(), "partial full snapshot must not escape");
+        assert_eq!(checks.get(), 2, "start plus one stride boundary");
+        assert_eq!(
+            visited.get(),
+            FULL_SNAPSHOT_CANCELLATION_STRIDE + 1,
+            "materialization stops at the chosen stride"
+        );
+    }
+
+    #[test]
+    fn fib_snapshot_cancels_inside_peer_rib_walk() {
+        let prefix = rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+        let best = crate::test_support::make_route(prefix, Ipv4Addr::new(192, 0, 2, 1));
+        let mut manager = manager_with_best(&best);
+        for index in 0..=FULL_SNAPSHOT_CANCELLATION_STRIDE {
+            let peer = IpAddr::V4(Ipv4Addr::new(
+                198,
+                18,
+                u8::try_from(index / 256).unwrap(),
+                u8::try_from(index % 256).unwrap(),
+            ));
+            manager.ribs.insert(peer, AdjRibIn::new(peer));
+        }
+
+        let checks = std::cell::Cell::new(0);
+        let result = manager.materialize_fib_install_candidates(2, false, false, &mut || {
+            checks.set(checks.get() + 1);
+            checks.get() == 2
+        });
+
+        assert!(result.is_none(), "partial FIB snapshot must not escape");
+        assert_eq!(checks.get(), 2, "start plus one peer-RIB stride");
+    }
+
+    #[test]
+    fn fib_snapshot_cancels_inside_high_fanout_sibling_gathering() {
+        let prefix = rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+        let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let best = crate::test_support::make_route(prefix, Ipv4Addr::new(192, 0, 2, 1));
+        let mut manager = manager_with_best(&best);
+        let mut rib = AdjRibIn::new(peer);
+        for index in 0..=FULL_SNAPSHOT_CANCELLATION_STRIDE {
+            let mut route = crate::test_support::make_route(
+                prefix,
+                Ipv4Addr::new(
+                    203,
+                    0,
+                    u8::try_from(index / 256).unwrap(),
+                    u8::try_from(index % 256).unwrap(),
+                ),
+            );
+            route.peer = peer;
+            route.path_id = u32::try_from(index + 1).unwrap();
+            rib.insert(route);
+        }
+        manager.ribs.insert(peer, rib);
+
+        let checks = std::cell::Cell::new(0);
+        let result = manager.materialize_fib_install_candidates(2, false, false, &mut || {
+            checks.set(checks.get() + 1);
+            checks.get() == 2
+        });
+
+        assert!(result.is_none(), "partial FIB snapshot must not escape");
+        assert_eq!(checks.get(), 2, "start plus one sibling stride");
     }
 
     #[test]

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -1323,9 +1323,12 @@ async fn rib_prefixes_gauge_tracks_adjribin() {
 
     // Serialize
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     let families = metrics.registry().gather();
@@ -1344,9 +1347,12 @@ async fn rib_prefixes_gauge_tracks_adjribin() {
     .await
     .unwrap();
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     let families = metrics.registry().gather();
@@ -1388,9 +1394,12 @@ async fn loc_rib_gauge_tracks_best() {
     .unwrap();
 
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     let families = metrics.registry().gather();
@@ -1456,9 +1465,12 @@ async fn adj_rib_out_gauge_tracks_advertised() {
     .unwrap();
 
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     let families = metrics.registry().gather();
@@ -1558,9 +1570,12 @@ async fn query_advertised_count() {
 
     // Serialize
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     let (reply_tx, reply_rx) = oneshot::channel();

--- a/crates/rib/src/manager/tests/gr_llgr.rs
+++ b/crates/rib/src/manager/tests/gr_llgr.rs
@@ -67,11 +67,7 @@ async fn gr_marks_stale_and_demotes_routes() {
     .unwrap();
 
     // Route should still be in Loc-RIB (stale but present)
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
+    let best = query_best_routes(&tx).await;
     assert_eq!(best.len(), 1);
     assert!(best[0].is_stale, "route should be marked stale");
 
@@ -310,11 +306,7 @@ async fn gr_timer_sweeps_stale_routes() {
     .unwrap();
 
     // Route is stale but still in Loc-RIB
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
+    let best = query_best_routes(&tx).await;
     assert_eq!(best.len(), 1);
     assert!(best[0].is_stale);
 
@@ -324,11 +316,7 @@ async fn gr_timer_sweeps_stale_routes() {
     tokio::task::yield_now().await;
 
     // Route should have been swept
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
+    let best = query_best_routes(&tx).await;
     assert!(best.is_empty(), "stale routes should be swept after timer");
 
     drop(tx);
@@ -371,11 +359,7 @@ async fn gr_peer_up_defers_stale_to_eor() {
     .unwrap();
 
     // Verify route is stale
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
+    let best = query_best_routes(&tx).await;
     assert!(best[0].is_stale);
 
     // Source re-establishes — route should STILL be stale
@@ -402,11 +386,7 @@ async fn gr_peer_up_defers_stale_to_eor() {
     .unwrap();
     drain_eor(&mut out_rx).await;
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
+    let best = query_best_routes(&tx).await;
     assert_eq!(best.len(), 1);
     assert!(best[0].is_stale, "route should still be stale after PeerUp");
 
@@ -436,11 +416,7 @@ async fn gr_peer_up_defers_stale_to_eor() {
     .await
     .unwrap();
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
+    let best = query_best_routes(&tx).await;
     assert_eq!(best.len(), 1);
     assert!(
         !best[0].is_stale,
@@ -516,9 +492,12 @@ async fn gr_peer_up_timer_expires_sweeps_stale() {
 
     // Route still stale (no EoR yet)
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
     assert!(best[0].is_stale);
@@ -528,9 +507,12 @@ async fn gr_peer_up_timer_expires_sweeps_stale() {
     tokio::task::yield_now().await;
 
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert!(best.is_empty(), "stale routes should be swept after timer");
 
@@ -583,9 +565,12 @@ async fn gr_peer_down_aborts_gr() {
 
     // Routes should be gone
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert!(best.is_empty(), "routes cleared after PeerDown aborts GR");
 
@@ -636,9 +621,12 @@ async fn gr_withdraws_non_gr_family_routes() {
 
     // Verify both routes present
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 2);
 
@@ -658,9 +646,12 @@ async fn gr_withdraws_non_gr_family_routes() {
 
     // IPv4 route should be stale, IPv6 route should be gone
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1, "only IPv4 route should remain");
     assert!(

--- a/crates/rib/src/manager/tests/lifecycle.rs
+++ b/crates/rib/src/manager/tests/lifecycle.rs
@@ -99,9 +99,12 @@ async fn channel_full_marks_dirty_and_resyncs() {
 
     // Force serialization
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     // After channel-full failure, AdjRibOut preserves last successfully
@@ -248,9 +251,12 @@ async fn dirty_resync_not_starved_by_query_traffic() {
 
     // Force serialization
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     // Drain the outbound channel to allow resync
@@ -264,9 +270,12 @@ async fn dirty_resync_not_starved_by_query_traffic() {
     // would reset the 1s countdown, starving the timer.
     for _ in 0..5 {
         let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-            .await
-            .unwrap();
+        tx.send(RibUpdate::QueryBestRoutes {
+            deadline: full_snapshot_query_deadline(),
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
         let _ = reply_rx.await;
     }
 

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -277,9 +277,12 @@ async fn drain_eor(out_rx: &mut mpsc::Receiver<OutboundRouteUpdate>) {
 
 async fn query_best_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<Route> {
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     reply_rx.await.unwrap()
 }
 
@@ -317,11 +320,118 @@ async fn query_fib_install_candidates_opts(
         max_paths,
         relax,
         weighted,
+        deadline: full_snapshot_query_deadline(),
         reply: reply_tx,
     })
     .await
     .unwrap();
     reply_rx.await.unwrap()
+}
+
+fn full_snapshot_query_deadline() -> tokio::time::Instant {
+    tokio::time::Instant::now() + Duration::from_secs(60)
+}
+
+async fn assert_lightweight_query_is_serviced(tx: &mpsc::Sender<RibUpdate>) {
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryPeerGroups { reply }).await.unwrap();
+    let groups = tokio::time::timeout(Duration::from_secs(1), response)
+        .await
+        .expect("lightweight query was serviced")
+        .unwrap();
+    assert!(groups.is_empty());
+}
+
+#[tokio::test]
+async fn expired_best_routes_query_publishes_nothing_and_releases_actor() {
+    let (tx, rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: tokio::time::Instant::now(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(
+        response.await.is_err(),
+        "expired query must publish no vector"
+    );
+    assert_lightweight_query_is_serviced(&tx).await;
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn preclosed_best_routes_query_skips_snapshot_and_releases_actor() {
+    let (tx, rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let (reply, response) = oneshot::channel();
+    drop(response);
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_lightweight_query_is_serviced(&tx).await;
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn expired_fib_candidates_query_publishes_nothing_and_releases_actor() {
+    let (tx, rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryFibInstallCandidates {
+        max_paths: 2,
+        relax: false,
+        weighted: false,
+        deadline: tokio::time::Instant::now(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(
+        response.await.is_err(),
+        "expired query must publish no vector"
+    );
+    assert_lightweight_query_is_serviced(&tx).await;
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn preclosed_fib_candidates_query_skips_snapshot_and_releases_actor() {
+    let (tx, rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let (reply, response) = oneshot::channel();
+    drop(response);
+    tx.send(RibUpdate::QueryFibInstallCandidates {
+        max_paths: 2,
+        relax: false,
+        weighted: false,
+        deadline: full_snapshot_query_deadline(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_lightweight_query_is_serviced(&tx).await;
+
+    drop(tx);
+    handle.await.unwrap();
 }
 
 async fn query_received_routes(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Vec<Route> {

--- a/crates/rib/src/manager/tests/multipath_fib.rs
+++ b/crates/rib/src/manager/tests/multipath_fib.rs
@@ -1686,9 +1686,12 @@ async fn multipath_policy_filtered_events_for_denied_candidates() {
 
     // Force serialization — query to ensure all RoutesReceived processed
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     // No outbound updates should have been sent (all denied)

--- a/crates/rib/src/manager/tests/policy.rs
+++ b/crates/rib/src/manager/tests/policy.rs
@@ -299,9 +299,12 @@ async fn export_policy_blocks_denied() {
 
     // Force serialization
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     // Should NOT have received the denied route

--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -731,9 +731,12 @@ async fn rpki_cache_update_changes_best_path() {
 
     // Before RPKI: peer1 should be best (lower address)
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
     assert_eq!(best[0].peer, peer1);
@@ -754,9 +757,12 @@ async fn rpki_cache_update_changes_best_path() {
     // peer2's route has origin 65002, covered with matching ASN → Valid.
     // Wait a moment for processing...
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
     // peer2 wins: Valid beats NotFound
@@ -819,9 +825,12 @@ async fn rpki_cache_update_invalid_demotes_best_path() {
 
     // peer1 is now Invalid (VRP covers prefix but wrong origin), peer2 is Valid
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
     assert_eq!(best[0].peer, peer2);

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -2249,9 +2249,12 @@ async fn best_routes_returns_winner() {
     .unwrap();
 
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
 
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
@@ -2306,9 +2309,12 @@ async fn peer_down_promotes_second_best() {
     .unwrap();
 
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
 
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
@@ -2369,9 +2375,12 @@ async fn withdrawal_updates_best() {
     .unwrap();
 
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
 
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
@@ -2426,9 +2435,12 @@ async fn different_best_per_prefix() {
     .unwrap();
 
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
 
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 2);
@@ -2663,9 +2675,12 @@ async fn split_horizon_prevents_echo() {
 
     // Force a query to serialize the event loop
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     // Channel should be empty (no outbound update sent)
@@ -2972,9 +2987,12 @@ async fn ibgp_split_horizon_withdraw_on_best_change() {
 
     // Force serialization
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let _ = reply_rx.await;
 
     // iBGP-learned route should NOT be sent to iBGP peer
@@ -3229,9 +3247,12 @@ async fn inject_route_enters_loc_rib_and_distributes() {
 
     // Should be in Loc-RIB
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
+    tx.send(RibUpdate::QueryBestRoutes {
+        deadline: full_snapshot_query_deadline(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
     assert_eq!(best[0].prefix, Prefix::V4(prefix));

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -3844,11 +3844,7 @@ async fn residue_gauge_tracks_tombstones_and_clears_on_resync() {
 
     let residue = || gauge_metric_value(&metrics, "bgp_update_group_residue_entries", &[]);
     let quiesce = async || {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-            .await
-            .unwrap();
-        let _ = reply_rx.await.unwrap();
+        let _ = query_best_routes(&tx).await;
     };
     let send_routes = async |announced: Vec<crate::route::Route>, withdrawn: Vec<(Prefix, u32)>| {
         tx.send(RibUpdate::RoutesReceived {
@@ -3944,11 +3940,7 @@ async fn residue_gauge_clears_after_dirty_leaver_moves_to_per_peer_path() {
 
     let residue = || gauge_metric_value(&metrics, "bgp_update_group_residue_entries", &[]);
     let quiesce = async || {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-            .await
-            .unwrap();
-        let _ = reply_rx.await.unwrap();
+        let _ = query_best_routes(&tx).await;
     };
     let send_routes = async |announced: Vec<crate::route::Route>, withdrawn: Vec<(Prefix, u32)>| {
         tx.send(RibUpdate::RoutesReceived {

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -916,7 +916,10 @@ impl Oracle {
     pub(super) async fn best_routes(&mut self) -> Vec<Route> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
-            .send(RibUpdate::QueryBestRoutes { reply: reply_tx })
+            .send(RibUpdate::QueryBestRoutes {
+                deadline: full_snapshot_query_deadline(),
+                reply: reply_tx,
+            })
             .await
             .unwrap();
         reply_rx.await.unwrap()

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1877,6 +1877,9 @@ pub enum RibUpdate {
     },
     /// Query: return best routes from the Loc-RIB.
     QueryBestRoutes {
+        /// Absolute deadline shared with the caller's complete send-and-reply
+        /// wait. The RIB actor cooperatively abandons materialization after it.
+        deadline: tokio::time::Instant,
         /// Response channel.
         reply: oneshot::Sender<Vec<Route>>,
     },
@@ -1893,6 +1896,9 @@ pub enum RibUpdate {
         /// Link Bandwidth Extended Community, weight next-hops in proportion to
         /// it; otherwise every next-hop stays weight 1 (equal cost).
         weighted: bool,
+        /// Absolute deadline shared with the caller's complete send-and-reply
+        /// wait. The RIB actor cooperatively abandons materialization after it.
+        deadline: tokio::time::Instant,
         /// Response channel.
         reply: oneshot::Sender<Vec<FibInstallCandidate>>,
     },

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -516,25 +516,37 @@ async fn recv_route_event(
 }
 
 async fn query_best_routes(rib_tx: &mpsc::Sender<RibUpdate>) -> Option<Vec<Route>> {
+    let deadline = tokio::time::Instant::now() + RIB_QUERY_TIMEOUT;
     let (reply, rx) = oneshot::channel();
-    if rib_tx
-        .send(RibUpdate::QueryBestRoutes { reply })
-        .await
-        .is_err()
-    {
-        warn!("BLACKHOLE discard task could not query best routes");
-        return None;
-    }
-    match tokio::time::timeout(RIB_QUERY_TIMEOUT, rx).await {
+    let query = async {
+        rib_tx
+            .send(RibUpdate::QueryBestRoutes { deadline, reply })
+            .await
+            .map_err(|_| "send_failed")?;
+        rx.await.map_err(|_| {
+            if tokio::time::Instant::now() >= deadline {
+                "timeout"
+            } else {
+                "reply_dropped"
+            }
+        })
+    };
+
+    match tokio::time::timeout_at(deadline, query).await {
         Ok(Ok(routes)) => Some(routes),
-        Ok(Err(_)) => {
+        Ok(Err("send_failed")) => {
+            warn!("BLACKHOLE discard task could not query best routes");
+            None
+        }
+        Ok(Err("reply_dropped")) => {
             warn!("BLACKHOLE discard task best-route reply dropped");
             None
         }
-        Err(_) => {
+        Ok(Err("timeout")) | Err(_) => {
             warn!("BLACKHOLE discard task best-route query timed out");
             None
         }
+        Ok(Err(_)) => unreachable!("query uses only static classifications above"),
     }
 }
 
@@ -1492,11 +1504,95 @@ pub(super) mod tests {
             .is_some_and(|content| content.contains(&format!("\"{prefix}\"")))
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn best_route_query_times_out_while_rib_send_is_blocked() {
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let (filler_reply, _filler_response) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryPeerGroups {
+                reply: filler_reply,
+            })
+            .await
+            .unwrap();
+
+        let started = tokio::time::Instant::now();
+        assert!(query_best_routes(&rib_tx).await.is_none());
+        assert_eq!(
+            tokio::time::Instant::now() - started,
+            RIB_QUERY_TIMEOUT,
+            "blocked send consumes the same two-second query budget"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn best_route_query_uses_one_deadline_for_send_and_reply() {
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let (filler_reply, _filler_response) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryPeerGroups {
+                reply: filler_reply,
+            })
+            .await
+            .unwrap();
+
+        let started = tokio::time::Instant::now();
+        let query = tokio::spawn(async move { query_best_routes(&rib_tx).await });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let _filler = rib_rx.recv().await.unwrap();
+        tokio::task::yield_now().await;
+        let RibUpdate::QueryBestRoutes { deadline, reply } = rib_rx.recv().await.unwrap() else {
+            panic!("expected best-route query after freeing channel capacity");
+        };
+        assert_eq!(deadline, started + RIB_QUERY_TIMEOUT);
+
+        tokio::time::advance(Duration::from_millis(999)).await;
+        tokio::task::yield_now().await;
+        assert!(!query.is_finished());
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(query.await.unwrap().is_none());
+        assert_eq!(tokio::time::Instant::now() - started, RIB_QUERY_TIMEOUT);
+        drop(reply);
+    }
+
+    #[tokio::test]
+    async fn failed_best_route_query_performs_no_kernel_work() {
+        let (rib_tx, rib_rx) = mpsc::channel(1);
+        drop(rib_rx);
+        let prefix = v4(32);
+        let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
+        let mut fib = FakeFib::default();
+        fib.installed.insert(prefix);
+        let config = BlackholeConfig::default();
+        let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let mut state = ReconcilerState::new(
+            config,
+            tokio::time::Instant::now() + Duration::from_hours(1),
+            OwnershipState::ephemeral([prefix]),
+        );
+        state.owned.insert(prefix, OwnedBlackhole { peer });
+
+        reconcile_once(
+            config,
+            &rib_tx,
+            &mut fib,
+            &BgpMetrics::with_registry(Registry::new()),
+            &status_tx,
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(fib.dump_calls, 0);
+        assert!(fib.install_calls.is_empty() && fib.remove_calls.is_empty());
+        assert!(fib.installed.contains(&prefix));
+        assert_eq!(state.owned.get(&prefix), Some(&OwnedBlackhole { peer }));
+    }
+
     fn rib_with_routes(routes: Vec<Route>) -> mpsc::Sender<RibUpdate> {
         let (tx, mut rx) = mpsc::channel(8);
         tokio::spawn(async move {
             while let Some(update) = rx.recv().await {
-                if let RibUpdate::QueryBestRoutes { reply } = update {
+                if let RibUpdate::QueryBestRoutes { reply, .. } = update {
                     let _ = reply.send(routes.clone());
                 }
             }
@@ -1519,7 +1615,7 @@ pub(super) mod tests {
         tokio::spawn(async move {
             while let Some(update) = rx.recv().await {
                 match update {
-                    RibUpdate::QueryBestRoutes { reply } => {
+                    RibUpdate::QueryBestRoutes { reply, .. } => {
                         query_count_task.fetch_add(1, Ordering::SeqCst);
                         let _ = reply.send(routes.clone());
                     }

--- a/src/blackhole/limits.rs
+++ b/src/blackhole/limits.rs
@@ -263,7 +263,7 @@ mod tests {
                     RibUpdate::SubscribeRouteEvents { reply } => {
                         let _ = reply.send(events.subscribe());
                     }
-                    RibUpdate::QueryBestRoutes { reply }
+                    RibUpdate::QueryBestRoutes { reply, .. }
                         if seen.fetch_add(1, Ordering::SeqCst) == 0 =>
                     {
                         let _ = reply.send(vec![tagged(66), tagged(68)]);

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -651,30 +651,43 @@ async fn query_fib_install_candidates(
     relax: bool,
     weighted: bool,
 ) -> Result<Vec<FibInstallCandidate>, &'static str> {
+    let deadline = tokio::time::Instant::now() + RIB_QUERY_TIMEOUT;
     let (reply, rx) = oneshot::channel();
-    if rib_tx
-        .send(RibUpdate::QueryFibInstallCandidates {
-            max_paths,
-            relax,
-            weighted,
-            reply,
+    let query = async {
+        rib_tx
+            .send(RibUpdate::QueryFibInstallCandidates {
+                max_paths,
+                relax,
+                weighted,
+                deadline,
+                reply,
+            })
+            .await
+            .map_err(|_| "send_failed")?;
+        rx.await.map_err(|_| {
+            if tokio::time::Instant::now() >= deadline {
+                "timeout"
+            } else {
+                "reply_dropped"
+            }
         })
-        .await
-        .is_err()
-    {
-        warn!("general FIB task could not query install candidates");
-        return Err("send_failed");
-    }
-    match tokio::time::timeout(RIB_QUERY_TIMEOUT, rx).await {
+    };
+
+    match tokio::time::timeout_at(deadline, query).await {
         Ok(Ok(candidates)) => Ok(candidates),
-        Ok(Err(_)) => {
+        Ok(Err("send_failed")) => {
+            warn!("general FIB task could not query install candidates");
+            Err("send_failed")
+        }
+        Ok(Err("reply_dropped")) => {
             warn!("general FIB task install-candidate reply dropped");
             Err("reply_dropped")
         }
-        Err(_) => {
+        Ok(Err("timeout")) | Err(_) => {
             warn!("general FIB task install-candidate query timed out");
             Err("timeout")
         }
+        Ok(Err(_)) => unreachable!("query uses only static classifications above"),
     }
 }
 
@@ -2858,6 +2871,66 @@ mod tests {
             }
         }
         candidates
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn install_candidate_query_times_out_while_rib_send_is_blocked() {
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let (filler_reply, _filler_response) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryPeerGroups {
+                reply: filler_reply,
+            })
+            .await
+            .unwrap();
+
+        let started = tokio::time::Instant::now();
+        assert!(matches!(
+            query_fib_install_candidates(&rib_tx, 1, false, false).await,
+            Err("timeout")
+        ));
+        assert_eq!(
+            tokio::time::Instant::now() - started,
+            RIB_QUERY_TIMEOUT,
+            "blocked send consumes the same two-second query budget"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn install_candidate_query_uses_one_deadline_for_send_and_reply() {
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let (filler_reply, _filler_response) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryPeerGroups {
+                reply: filler_reply,
+            })
+            .await
+            .unwrap();
+
+        let started = tokio::time::Instant::now();
+        let query =
+            tokio::spawn(
+                async move { query_fib_install_candidates(&rib_tx, 1, false, false).await },
+            );
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let _filler = rib_rx.recv().await.unwrap();
+        tokio::task::yield_now().await;
+        let RibUpdate::QueryFibInstallCandidates {
+            deadline, reply, ..
+        } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected install-candidate query after freeing channel capacity");
+        };
+        assert_eq!(deadline, started + RIB_QUERY_TIMEOUT);
+
+        tokio::time::advance(Duration::from_millis(999)).await;
+        tokio::task::yield_now().await;
+        assert!(!query.is_finished());
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(matches!(query.await.unwrap(), Err("timeout")));
+        assert_eq!(tokio::time::Instant::now() - started, RIB_QUERY_TIMEOUT);
+        drop(reply);
     }
 
     fn rib_with_routes(routes: Vec<Route>) -> mpsc::Sender<RibUpdate> {
@@ -5332,8 +5405,9 @@ mod tests {
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
         };
+        let existing_key = existing.key;
         let mut owned = FibOwnedState {
-            routes: BTreeMap::from([(existing.key, existing)]),
+            routes: BTreeMap::from([(existing_key, existing)]),
         };
         let (status_tx, status_rx) = watch::channel(Vec::new());
 
@@ -5352,6 +5426,8 @@ mod tests {
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses[0].state, FibRuntimeState::Failed);
         assert_eq!(statuses[0].reason, "rib_query_failed:send_failed");
+        assert!(fib.applied.is_empty(), "failed query must not reach apply");
+        assert!(owned.routes.contains_key(&existing_key));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- carry one absolute two-second deadline across blackhole and FIB RIB queueing plus reply
- abandon best-route and FIB candidate materialization at fixed Loc-RIB, peer-RIB, and ECMP sibling strides
- drop incomplete snapshots before reconciliation and cover blocked-send, pre-closed, expired, and mid-scan cases

## Validation

- `cargo check --locked --workspace --all-targets`
- `cargo test -p rustbgpd-rib manager::tests` (787 passed, 2 ignored)
- `cargo test -p rustbgpd blackhole::tests` (49 passed)
- `cargo test -p rustbgpd fib_runtime::tests` (96 passed)
- `cargo test --locked --workspace`
- `cargo clippy -p rustbgpd-rib --locked --all-targets --all-features -- -D warnings`
- `cargo clippy -p rustbgpd --locked --all-targets --all-features -- -D warnings`
- normal fmt and clippy hooks

LAN-1324 Phase A. Phase B pagination design remains open.