### PR TITLE
Make readiness peer probe constant-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `/readyz` now checks peer-manager responsiveness with a constant-time actor
+  ping instead of building a full peer inventory and querying every session.
+  The mutation gate, RIB check, and shared 200 ms deadline are unchanged;
+  `GetHealth` continues to return the detailed peer snapshot.
+
 - Full-table blackhole and FIB RIB queries now share one two-second deadline
   across channel admission and reply, and cooperatively abandon Loc-RIB and
   ECMP materialization at bounded strides. An incomplete snapshot is dropped

--- a/crates/api/src/health_probe.rs
+++ b/crates/api/src/health_probe.rs
@@ -148,7 +148,13 @@ impl CoreReadinessProbe {
     /// drops its reply channel, or does not respond before the readiness
     /// deadline, or when the RIB reports a stalled export-policy transition.
     pub async fn check(&self) -> Result<(), CoreReadinessError> {
-        self.snapshot().await.map(|_| ())
+        if let Some(reason) = self.gate.as_ref().and_then(DaemonGate::not_ready_reason) {
+            return Err(CoreReadinessError::DaemonUnavailable(reason));
+        }
+        let deadline = Instant::now() + CORE_READINESS_DEADLINE;
+        self.ping_peer_manager(deadline).await?;
+        self.query_rib(deadline).await?;
+        Ok(())
     }
 
     /// Return the same core actor snapshot used by `GetHealth`.
@@ -185,6 +191,27 @@ impl CoreReadinessProbe {
             } else {
                 self.peer_mgr_tx
                     .send(PeerManagerCommand::ListPeers { reply: reply_tx })
+                    .await
+                    .map_err(|_| CoreReadinessError::PeerManagerUnavailable)?;
+            }
+            reply_rx
+                .await
+                .map_err(|_| CoreReadinessError::PeerManagerDroppedReply)
+        })
+        .await
+    }
+
+    async fn ping_peer_manager(&self, deadline: Instant) -> Result<(), CoreReadinessError> {
+        timeout_until(deadline, CoreReadinessError::PeerManagerTimedOut, async {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if let Some(readiness_tx) = &self.peer_mgr_readiness_tx {
+                readiness_tx
+                    .send(PeerManagerReadinessQuery::Ping { reply: reply_tx })
+                    .await
+                    .map_err(|_| CoreReadinessError::PeerManagerUnavailable)?;
+            } else {
+                self.peer_mgr_tx
+                    .send(PeerManagerCommand::Ping { reply: reply_tx })
                     .await
                     .map_err(|_| CoreReadinessError::PeerManagerUnavailable)?;
             }
@@ -316,6 +343,14 @@ mod tests {
         reply.send(peers).expect("peer reply receiver is alive");
     }
 
+    async fn reply_to_peer_manager_ping(peer_rx: &mut mpsc::Receiver<PeerManagerCommand>) {
+        let command = peer_rx.recv().await.expect("peer manager command");
+        let PeerManagerCommand::Ping { reply } = command else {
+            panic!("expected Ping command");
+        };
+        reply.send(()).expect("peer reply receiver is alive");
+    }
+
     async fn reply_to_rib(rib_rx: &mut mpsc::Receiver<RibUpdate>, total_routes: usize) {
         let command = rib_rx.recv().await.expect("RIB command");
         let RibUpdate::QueryLocRibCount { reply } = command else {
@@ -334,6 +369,17 @@ mod tests {
     ) {
         tokio::join!(
             reply_to_peer_manager(peer_rx, peers),
+            reply_to_rib(rib_rx, total_routes)
+        );
+    }
+
+    async fn reply_to_core_check(
+        peer_rx: &mut mpsc::Receiver<PeerManagerCommand>,
+        rib_rx: &mut mpsc::Receiver<RibUpdate>,
+        total_routes: usize,
+    ) {
+        tokio::join!(
+            reply_to_peer_manager_ping(peer_rx),
             reply_to_rib(rib_rx, total_routes)
         );
     }
@@ -400,20 +446,14 @@ mod tests {
     /// widens the blast radius of a local mistake to the whole node. Adding
     /// any RFC 8212 gate to this probe makes the test red.
     #[tokio::test]
-    async fn readiness_stays_green_for_a_peer_under_the_reserved_deny() {
-        use crate::peer_types::Rfc8212PolicyStatus;
-
+    async fn readiness_does_not_inventory_peers_for_policy_gating() {
         let (peer_tx, mut peer_rx) = mpsc::channel(1);
         let (rib_tx, mut rib_rx) = mpsc::channel(1);
         let probe = CoreReadinessProbe::new(peer_tx, rib_tx);
 
-        let mut peer = crate::test_support::peer_info("10.0.0.2".parse().unwrap());
-        peer.rfc8212_import_policy = Rfc8212PolicyStatus::Missing;
-        peer.rfc8212_export_policy = Rfc8212PolicyStatus::Missing;
-
         let result = tokio::join!(
             probe.check(),
-            reply_to_core_probe(&mut peer_rx, vec![peer], &mut rib_rx, 0)
+            reply_to_core_check(&mut peer_rx, &mut rib_rx, 0)
         )
         .0;
 
@@ -433,7 +473,10 @@ mod tests {
 
         let (result, ()) = tokio::join!(probe.snapshot(), async {
             let PeerManagerReadinessQuery::ListPeers { reply } =
-                readiness_rx.recv().await.expect("readiness query");
+                readiness_rx.recv().await.expect("readiness query")
+            else {
+                panic!("expected ListPeers readiness query");
+            };
             reply.send(Vec::new()).unwrap();
             reply_to_rib(&mut rib_rx, 9).await;
         });
@@ -494,17 +537,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_succeeds_when_snapshot_succeeds() {
+    async fn check_uses_ping_on_the_ordinary_peer_manager_lane() {
         let (peer_tx, mut peer_rx) = mpsc::channel(1);
         let (rib_tx, mut rib_rx) = mpsc::channel(1);
         let probe = CoreReadinessProbe::new(peer_tx, rib_tx);
 
         let (result, ()) = tokio::join!(
             probe.check(),
-            reply_to_core_probe(&mut peer_rx, Vec::new(), &mut rib_rx, 0)
+            reply_to_core_check(&mut peer_rx, &mut rib_rx, 0)
         );
 
         result.expect("check should succeed");
+    }
+
+    #[tokio::test]
+    async fn check_uses_ping_on_the_dedicated_peer_manager_lane() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (readiness_tx, mut readiness_rx) = mpsc::channel(1);
+        let (rib_query_tx, mut rib_query_rx) = mpsc::channel(1);
+        let (rib_readiness_tx, mut rib_readiness_rx) = mpsc::channel(1);
+        let probe = CoreReadinessProbe::new(peer_tx, rib_query_tx)
+            .with_peer_manager_readiness(readiness_tx)
+            .with_rib_readiness(rib_readiness_tx);
+
+        let (result, ()) = tokio::join!(probe.check(), async {
+            let query = readiness_rx.recv().await.expect("readiness query");
+            let PeerManagerReadinessQuery::Ping { reply } = query else {
+                panic!("expected Ping readiness query");
+            };
+            reply.send(()).unwrap();
+            let RibReadinessQuery::LocRibCount { reply } =
+                rib_readiness_rx.recv().await.expect("RIB readiness query");
+            reply.send(Ok(0)).unwrap();
+        });
+
+        result.expect("check should succeed");
+        assert!(
+            peer_rx.try_recv().is_err(),
+            "ordinary peer-manager command lane must remain untouched"
+        );
+        assert!(
+            rib_query_rx.try_recv().is_err(),
+            "ordinary RIB query lane must remain untouched"
+        );
     }
 
     #[tokio::test]
@@ -638,7 +713,7 @@ mod tests {
 
         let (result, ()) = tokio::join!(
             probe.check(),
-            reply_to_core_probe(&mut peer_rx, Vec::new(), &mut rib_rx, 0)
+            reply_to_core_check(&mut peer_rx, &mut rib_rx, 0)
         );
 
         result.expect("untripped gate must not affect readiness");

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -677,6 +677,12 @@ pub struct WarmCheckpointCapture {
 }
 
 pub enum PeerManagerCommand {
+    /// Confirm that the peer-manager actor can service its ordinary command
+    /// lane without collecting per-peer session state.
+    Ping {
+        /// Reply channel acknowledging actor responsiveness.
+        reply: oneshot::Sender<()>,
+    },
     /// Add a new peer with the given configuration.
     AddPeer {
         /// Neighbor configuration.
@@ -1528,6 +1534,12 @@ pub enum OwnedHotUpdatePeerOutcome {
 /// ordered on [`PeerManagerCommand`] and cannot observe or alter a partially
 /// applied transaction.
 pub enum PeerManagerReadinessQuery {
+    /// Confirm that the peer-manager actor can service the dedicated readiness
+    /// lane without collecting per-peer session state.
+    Ping {
+        /// Reply channel acknowledging actor responsiveness.
+        reply: oneshot::Sender<()>,
+    },
     /// Return a live snapshot of all configured peers.
     ListPeers {
         /// Reply channel returning all peer snapshots.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -39,9 +39,12 @@ The daemon exits with code 1 — it never starts with an invalid config.
 
 On success, structured JSON logs go to stdout. If `prometheus_addr` is
 configured, use `GET /readyz` on that listener as the orchestrator readiness
-signal; it returns ready once the PeerManager and RIB actors answer their
-bounded probes. The `starting rustbgpd` log line means process startup reached
-runtime wiring, not that every actor has answered a readiness probe yet.
+signal; it returns ready once the PeerManager answers an O(1) actor ping and
+the RIB actor answers its O(1) Loc-RIB count query within one shared 200 ms
+deadline. The readiness ping does not collect peer inventory or query session
+state; `GetHealth` continues to return that detailed snapshot. The `starting
+rustbgpd` log line means process startup reached runtime wiring, not that every
+actor has answered a readiness probe yet.
 
 ### Runtime-config settlement fail-stop
 
@@ -1026,9 +1029,10 @@ bounded polls from one long O(table) snapshot or finalization poll; the
 retained terminal duration still describes the previous completed transition
 while one is active.
 A readiness request that arrives after general queries have queued can overtake
-them on its dedicated lane. It cannot preempt an O(table) general query that
-was already executing when the request arrived; that actor call must return
-before either the transition or readiness probe can advance.
+them on its dedicated lane. The PeerManager half is a constant-time actor ping
+and does not fan out session-state queries. It cannot preempt an O(table)
+general query that was already executing when the request arrived; that actor
+call must return before either the transition or readiness probe can advance.
 
 ### Policy artifact freshness
 

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -253,8 +253,8 @@ mod tests {
         let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
 
         tokio::spawn(async move {
-            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
-                let _ = reply.send(Vec::new());
+            if let Some(PeerManagerCommand::Ping { reply }) = peer_rx.recv().await {
+                let _ = reply.send(());
             }
         });
         tokio::spawn(async move {
@@ -275,7 +275,7 @@ mod tests {
         let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
 
         tokio::spawn(async move {
-            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
+            if let Some(PeerManagerCommand::Ping { reply }) = peer_rx.recv().await {
                 drop(reply);
             }
         });
@@ -292,8 +292,8 @@ mod tests {
         let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
 
         tokio::spawn(async move {
-            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
-                let _ = reply.send(Vec::new());
+            if let Some(PeerManagerCommand::Ping { reply }) = peer_rx.recv().await {
+                let _ = reply.send(());
             }
         });
         tokio::spawn(async move {
@@ -329,8 +329,8 @@ mod tests {
         let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
 
         tokio::spawn(async move {
-            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
-                let _ = reply.send(Vec::new());
+            if let Some(PeerManagerCommand::Ping { reply }) = peer_rx.recv().await {
+                let _ = reply.send(());
             }
         });
         tokio::spawn(async move {
@@ -397,8 +397,8 @@ mod tests {
         // Answer the peer half, then hold the RIB reply until the wedge is
         // in place so it is already queued when the runtime unparks well
         // past the deadline.
-        if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
-            let _ = reply.send(Vec::new());
+        if let Some(PeerManagerCommand::Ping { reply }) = peer_rx.recv().await {
+            let _ = reply.send(());
         }
         let Some(RibUpdate::QueryLocRibCount { reply }) = rib_rx.recv().await else {
             panic!("expected QueryLocRibCount");

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -580,6 +580,9 @@ impl PeerManager {
 
     async fn handle_readiness_query(&self, query: PeerManagerReadinessQuery) {
         match query {
+            PeerManagerReadinessQuery::Ping { reply } => {
+                let _ = reply.send(());
+            }
             PeerManagerReadinessQuery::ListPeers { reply } => {
                 self.answer_list_peers(reply).await;
             }
@@ -986,6 +989,9 @@ impl PeerManager {
                         return;
                     };
                     match cmd {
+                        PeerManagerCommand::Ping { reply } => {
+                            let _ = reply.send(());
+                        }
                         PeerManagerCommand::AddPeer { config, sync_config_snapshot, reply } => {
                             let result = self.add_peer(config, sync_config_snapshot).await;
                             let _ = reply.send(result);

--- a/src/peer_manager/tests/queries.rs
+++ b/src/peer_manager/tests/queries.rs
@@ -62,6 +62,73 @@ async fn closed_internal_command_lane_keeps_public_actor_live() {
         .unwrap();
 }
 
+/// A readiness ping is an actor-liveness check, not an inventory request. A
+/// session command queue that cannot currently accept `QueryState` must not
+/// delay either the ordinary fallback or the dedicated readiness lane.
+#[tokio::test]
+async fn ping_on_both_manager_lanes_does_not_query_stalled_session_state() {
+    let (tx, rx) = mpsc::channel(4);
+    let (readiness_tx, readiness_rx) = mpsc::channel(4);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    let mut manager = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_readiness_queries(readiness_rx);
+    let peer: IpAddr = "192.0.2.1".parse().unwrap();
+    let (release, release_rx) = oneshot::channel();
+    let (observed, mut observations) = mpsc::unbounded_channel();
+    insert_test_managed_peer(
+        &mut manager,
+        peer,
+        blocked_snapshot_query_handle(peer, release_rx, observed),
+        false,
+    );
+    let actor = tokio::spawn(manager.run());
+
+    let (ordinary_reply, ordinary_response) = oneshot::channel();
+    tx.send(PeerManagerCommand::Ping {
+        reply: ordinary_reply,
+    })
+    .await
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), ordinary_response)
+        .await
+        .expect("ordinary ping must not wait for session state")
+        .expect("ordinary ping reply");
+
+    let (readiness_reply, readiness_response) = oneshot::channel();
+    readiness_tx
+        .send(PeerManagerReadinessQuery::Ping {
+            reply: readiness_reply,
+        })
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), readiness_response)
+        .await
+        .expect("dedicated ping must not wait for session state")
+        .expect("dedicated ping reply");
+
+    assert!(
+        observations.try_recv().is_err(),
+        "neither ping may fan out a session-state query"
+    );
+
+    release.send(()).unwrap();
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    actor.await.unwrap();
+    assert!(
+        observations.try_recv().is_err(),
+        "no delayed session-state query may outlive either ping"
+    );
+}
+
 fn blocked_snapshot_query_handle(
     peer: IpAddr,
     release: oneshot::Receiver<()>,


### PR DESCRIPTION
## Summary

Replace the `/readyz` peer inventory scan with an O(1) PeerManager actor ping while preserving detailed health snapshots.

## Changes

- add a unit-reply `Ping` to the ordinary and dedicated peer-manager lanes
- keep one absolute 200 ms gate, peer, and RIB readiness deadline
- preserve `ListPeers` for `snapshot()` and `GetHealth`
- prove both ping paths avoid stalled per-session state responders
- document the operator-visible readiness boundary

## Testing

- [x] `cargo test --locked -p rustbgpd-api health_probe`
- [x] `cargo test --locked -p rustbgpd --bin rustbgpd peer_manager::tests::queries::ping_on_both_manager_lanes_does_not_query_stalled_session_state`
- [x] `cargo test --locked -p rustbgpd --bin rustbgpd metrics_server::tests::get_readyz`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Interop intentionally not applicable: no BGP protocol or transport behavior changes
- [x] A performance receipt is intentionally not applicable: the regression test proves the removal of per-session fan-out and this PR makes no numeric performance claim

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed; this closes a focused post-release bug
- [x] User/operator docs updated
- [x] Hot tracking docs not touched

## Related issues

- [LAN-1325](https://linear.app/lance0/issue/LAN-1325/take-opeers-off-the-readiness-probe)