### PR TITLE
rib: add bounded dataplane prefix pages

### DIFF
--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -52,3 +52,8 @@ required-features = ["bench-internals"]
 name = "evpn_dataplane_query"
 harness = false
 required-features = ["bench-internals"]
+
+[[bench]]
+name = "dataplane_prefix_paging"
+harness = false
+required-features = ["bench-internals"]

--- a/crates/rib/benches/dataplane_prefix_paging.rs
+++ b/crates/rib/benches/dataplane_prefix_paging.rs
@@ -1,0 +1,347 @@
+//! Large-table receipt harness for bounded internal dataplane prefix pages.
+
+use std::io::{self, BufWriter, Write};
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rustbgpd_rib::{RibManager, Route, RouteOrigin, RouteQueryScope};
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{
+    AsPath, AsPathSegment, Ipv4Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
+};
+use tokio::sync::mpsc;
+
+#[derive(Clone, Copy, Debug)]
+enum IndexMode {
+    Eager,
+    LazyBaseline,
+}
+
+impl IndexMode {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Eager => "eager",
+            Self::LazyBaseline => "lazy_indexed_baseline",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Args {
+    prefixes: usize,
+    announcers: usize,
+    max_paths: u32,
+    repetition: usize,
+    mode: IndexMode,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            prefixes: 100_000,
+            announcers: 1,
+            max_paths: 1,
+            repetition: 1,
+            mode: IndexMode::Eager,
+        }
+    }
+}
+
+fn parse_positive(value: String, flag: &str) -> usize {
+    let value = value
+        .parse::<usize>()
+        .unwrap_or_else(|_| panic!("{flag} expects a positive integer"));
+    assert!(value > 0, "{flag} must be positive");
+    value
+}
+
+fn parse_args() -> Args {
+    let mut args = Args::default();
+    let mut raw = std::env::args().skip(1);
+    while let Some(flag) = raw.next() {
+        match flag.as_str() {
+            "--bench" => {}
+            "--prefixes" => {
+                args.prefixes = parse_positive(
+                    raw.next().expect("--prefixes requires a value"),
+                    "--prefixes",
+                );
+            }
+            "--announcers" => {
+                args.announcers = parse_positive(
+                    raw.next().expect("--announcers requires a value"),
+                    "--announcers",
+                );
+            }
+            "--max-paths" => {
+                args.max_paths = u32::try_from(parse_positive(
+                    raw.next().expect("--max-paths requires a value"),
+                    "--max-paths",
+                ))
+                .expect("--max-paths fits u32");
+            }
+            "--repetition" => {
+                args.repetition = parse_positive(
+                    raw.next().expect("--repetition requires a value"),
+                    "--repetition",
+                );
+            }
+            "--mode" => {
+                args.mode = match raw.next().expect("--mode requires a value").as_str() {
+                    "eager" => IndexMode::Eager,
+                    "lazy" | "lazy-baseline" => IndexMode::LazyBaseline,
+                    other => panic!("--mode expects eager or lazy-baseline, got {other}"),
+                };
+            }
+            "--help" | "-h" => {
+                println!(
+                    "dataplane_prefix_paging [--prefixes 100000] [--announcers 1] \
+                     [--max-paths 1] [--repetition 1] [--mode eager|lazy-baseline]"
+                );
+                std::process::exit(0);
+            }
+            other => panic!("unknown argument: {other}"),
+        }
+    }
+    assert!(
+        args.announcers >= usize::try_from(args.max_paths.min(256)).unwrap(),
+        "announcers must cover the normalized max-paths fixture"
+    );
+    args
+}
+
+fn peer(index: usize) -> Ipv4Addr {
+    Ipv4Addr::from(
+        0xc633_6401u32
+            .checked_add(u32::try_from(index).expect("announcer index fits IPv4"))
+            .expect("announcer fixture stays in IPv4 space"),
+    )
+}
+
+fn prefix(index: usize) -> Prefix {
+    let host = 0x0a00_0000u32
+        .checked_add(u32::try_from(index).expect("prefix count fits IPv4"))
+        .expect("prefix fixture stays in IPv4 space");
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(host), 32))
+}
+
+fn make_routes(prefixes: usize, announcers: usize) -> Vec<Route> {
+    let attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65001])],
+        }),
+        PathAttribute::LocalPref(100),
+    ]);
+    let mut routes = Vec::with_capacity(prefixes.saturating_mul(announcers));
+    for announcer in 0..announcers {
+        let peer = peer(announcer);
+        for index in 0..prefixes {
+            routes.push(Route {
+                prefix: prefix(index),
+                next_hop: IpAddr::V4(peer),
+                link_local_next_hop: None,
+                next_hop_scope: None,
+                peer: IpAddr::V4(peer),
+                attributes: Arc::clone(&attributes),
+                received_at: Instant::now(),
+                origin_type: RouteOrigin::Ebgp,
+                peer_router_id: peer,
+                is_stale: false,
+                is_llgr_stale: false,
+                path_id: 0,
+                validation_state: RpkiValidation::NotFound,
+                aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+            });
+        }
+    }
+    routes
+}
+
+fn resident_bytes() -> io::Result<u64> {
+    let status = std::fs::read_to_string("/proc/self/status")?;
+    status
+        .lines()
+        .find_map(|line| {
+            let kib = line.strip_prefix("VmRSS:")?.split_whitespace().next()?;
+            kib.parse::<u64>().ok()?.checked_mul(1_024)
+        })
+        .filter(|bytes| *bytes > 0)
+        .ok_or_else(|| io::Error::other("/proc/self/status has no positive VmRSS"))
+}
+
+fn percentile(sorted: &[Duration], numerator: usize, denominator: usize) -> Duration {
+    let rank = sorted
+        .len()
+        .saturating_mul(numerator)
+        .div_ceil(denominator)
+        .saturating_sub(1)
+        .min(sorted.len().saturating_sub(1));
+    sorted[rank]
+}
+
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn checksum_bytes(checksum: &mut u64, bytes: &[u8]) {
+    for byte in bytes {
+        *checksum ^= u64::from(*byte);
+        *checksum = checksum.wrapping_mul(FNV_PRIME);
+    }
+}
+
+#[derive(Debug)]
+struct Traversal {
+    pages: usize,
+    rows: usize,
+    next_hops: usize,
+    checksum: u64,
+    complete: Duration,
+    page_p50: Duration,
+    page_p99: Duration,
+    page_max: Duration,
+}
+
+fn traverse(manager: &mut RibManager, prefixes: usize, max_paths: u32) -> Traversal {
+    let started = Instant::now();
+    let mut timings = Vec::new();
+    let mut cursor = None;
+    let mut previous = None;
+    let mut rows = 0usize;
+    let mut next_hops = 0usize;
+    let mut checksum = FNV_OFFSET_BASIS;
+    loop {
+        let page_started = Instant::now();
+        let page = manager
+            .bench_query_fib_install_candidates_page(cursor, max_paths)
+            .expect("eager dataplane index enabled");
+        timings.push(page_started.elapsed());
+        for candidate in &page.candidates {
+            assert!(previous.is_none_or(|prior| prior < candidate.best.prefix));
+            previous = Some(candidate.best.prefix);
+            match candidate.best.prefix {
+                Prefix::V4(prefix) => {
+                    checksum_bytes(&mut checksum, &[4, prefix.len]);
+                    checksum_bytes(&mut checksum, &prefix.addr.octets());
+                }
+                Prefix::V6(prefix) => {
+                    checksum_bytes(&mut checksum, &[6, prefix.len]);
+                    checksum_bytes(&mut checksum, &prefix.addr.octets());
+                }
+            }
+            for next_hop in &candidate.next_hops {
+                match next_hop.next_hop {
+                    IpAddr::V4(address) => checksum_bytes(&mut checksum, &address.octets()),
+                    IpAddr::V6(address) => checksum_bytes(&mut checksum, &address.octets()),
+                }
+            }
+            next_hops = next_hops.saturating_add(candidate.next_hops.len());
+        }
+        rows = rows.saturating_add(page.candidates.len());
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    assert_eq!(rows, prefixes);
+    timings.sort_unstable();
+    let page_max = *timings.last().expect("one or more pages");
+    assert!(
+        page_max < Duration::from_secs(2),
+        "page exceeded the two-second stop threshold: {page_max:?}"
+    );
+    Traversal {
+        pages: timings.len(),
+        rows,
+        next_hops,
+        checksum,
+        complete: started.elapsed(),
+        page_p50: percentile(&timings, 50, 100),
+        page_p99: percentile(&timings, 99, 100),
+        page_max,
+    }
+}
+
+fn main() -> io::Result<()> {
+    let args = parse_args();
+    let (_update_tx, update_rx) = mpsc::channel(1);
+    let (_query_tx, query_rx) = mpsc::channel(1);
+    let manager = RibManager::new(update_rx, query_rx, None, None, BgpMetrics::new());
+    let mut manager = match args.mode {
+        IndexMode::Eager => manager.with_eager_dataplane_prefix_index(),
+        IndexMode::LazyBaseline => manager,
+    };
+    let routes = make_routes(args.prefixes, args.announcers);
+    let churn_rows = make_routes(args.prefixes.min(1_000), 1);
+
+    let ingest_started = Instant::now();
+    manager.bench_seed_loc_rib(routes);
+    let ingest = ingest_started.elapsed();
+    let churn_started = Instant::now();
+    manager.bench_churn_loc_rib(churn_rows);
+    let churn = churn_started.elapsed();
+
+    let index_started = Instant::now();
+    if matches!(args.mode, IndexMode::LazyBaseline) {
+        let page = manager.bench_query_route_page(RouteQueryScope::Best, None, 1);
+        assert_eq!(page.routes.len(), 1);
+    }
+    let index_ready = index_started.elapsed();
+    let index = manager.bench_dataplane_prefix_index_receipt();
+    assert_eq!(index.prefixes, args.prefixes);
+    let rss = resident_bytes()?;
+
+    let traversal = matches!(args.mode, IndexMode::Eager)
+        .then(|| traverse(&mut manager, args.prefixes, args.max_paths));
+    let mut output = BufWriter::new(io::stdout().lock());
+    writeln!(
+        output,
+        "mode,prefixes,announcers,max_paths,repetition,ingest_ns,churn_rows,churn_ns,index_ready_ns,index_prefixes,index_bytes,resident_bytes,pages,rows,next_hops,checksum,complete_ns,page_p50_ns,page_p99_ns,page_max_ns"
+    )?;
+    if let Some(sample) = traversal {
+        writeln!(
+            output,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{:016x},{},{},{},{}",
+            args.mode.label(),
+            args.prefixes,
+            args.announcers,
+            args.max_paths,
+            args.repetition,
+            ingest.as_nanos(),
+            args.prefixes.min(1_000),
+            churn.as_nanos(),
+            index_ready.as_nanos(),
+            index.prefixes,
+            index.index_bytes,
+            rss,
+            sample.pages,
+            sample.rows,
+            sample.next_hops,
+            sample.checksum,
+            sample.complete.as_nanos(),
+            sample.page_p50.as_nanos(),
+            sample.page_p99.as_nanos(),
+            sample.page_max.as_nanos(),
+        )?;
+    } else {
+        writeln!(
+            output,
+            "{},{},{},{},{},{},{},{},{},{},{},{},0,0,0,0000000000000000,0,0,0,0",
+            args.mode.label(),
+            args.prefixes,
+            args.announcers,
+            args.max_paths,
+            args.repetition,
+            ingest.as_nanos(),
+            args.prefixes.min(1_000),
+            churn.as_nanos(),
+            index_ready.as_nanos(),
+            index.prefixes,
+            index.index_bytes,
+            rss,
+        )?;
+    }
+    output.flush()
+}

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -59,8 +59,9 @@ pub use loc_rib::LocRib;
 pub use manager::RibManager;
 #[cfg(feature = "bench-internals")]
 pub use manager::{
-    EvpnDataplaneQueryBenchReceipt, bench_evpn_dataplane_generation_query,
-    bench_evpn_dataplane_generation_snapshot, bench_evpn_dataplane_legacy_snapshot,
+    DataplanePrefixIndexBenchReceipt, EvpnDataplaneQueryBenchReceipt,
+    bench_evpn_dataplane_generation_query, bench_evpn_dataplane_generation_snapshot,
+    bench_evpn_dataplane_legacy_snapshot,
 };
 pub use manager::{SelectionDeferralConfig, SelectionDeferralWaiterConfig};
 pub use orr::{
@@ -74,22 +75,22 @@ pub use route::{
     VpnRibRouteKey,
 };
 pub use update::{
-    AdjRibOutCounts, BestPathCandidate, EffectiveDistributionMode, EvpnDataplaneRoutesResponse,
-    ExactExportCandidate, ExactExportEncoder, ExactExportError, ExactExportErrorCode,
-    ExactExportKey, ExactExportResult, ExactExportSnapshot, ExplainAdvertisedRoute,
-    ExplainAdvertisedRouteError, ExplainBestPath, ExplainDecision, ExplainReason, ExportGateStep,
-    ExportGateVerdict, ExportPolicyCohortOutcome, MrtPeerEntry, MrtSnapshotData,
-    NeighborPolicyStats, NeighborRibSnapshot, NeighborRibSnapshotResponse,
-    OUTBOUND_PREFIX_LIMIT_REACHED, OrrExplainCandidate, OutboundPrefixLimitConfig,
-    OutboundPrefixLimitFamilyState, OutboundPrefixLimitPair, OutboundPrefixLimitViolation,
-    OutboundRouteUpdate, PeerExportPolicyReplacement, PeerExportPolicyRestoreReceipt,
-    PeerOutboundState, PlannedGroupability, RibCommandError, RibReadinessError, RibReadinessQuery,
-    RibRowFilter, RibUpdate, RoutePage, RoutePageError, RoutePageVersion, RouteQueryFilter,
-    RouteQueryKey, RouteQueryScope, RouteSourceIdentity, SelectionDeferralPeerFamilyState,
-    SharedGroupEncode, UpdateGroupClassification, UpdateGroupClassifierInput,
-    UpdateGroupComparisonDifference, UpdateGroupComparisonMembership, UpdateGroupComparisonVerdict,
-    UpdateGroupFamilyImpact, UpdateGroupFingerprint, UpdateGroupImpactPlan,
-    UpdateGroupImpactRollup, UpdateGroupPeerComparison, UpdateGroupPeerSnapshot,
-    UpdateGroupSnapshot, WarmMrtSnapshotBudget, WarmMrtSnapshotView, classify_update_group,
-    route_query_key,
+    AdjRibOutCounts, BestPathCandidate, BestRoutesPage, DataplanePageError,
+    EffectiveDistributionMode, EvpnDataplaneRoutesResponse, ExactExportCandidate,
+    ExactExportEncoder, ExactExportError, ExactExportErrorCode, ExactExportKey, ExactExportResult,
+    ExactExportSnapshot, ExplainAdvertisedRoute, ExplainAdvertisedRouteError, ExplainBestPath,
+    ExplainDecision, ExplainReason, ExportGateStep, ExportGateVerdict, ExportPolicyCohortOutcome,
+    FibInstallCandidatesPage, MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats,
+    NeighborRibSnapshot, NeighborRibSnapshotResponse, OUTBOUND_PREFIX_LIMIT_REACHED,
+    OrrExplainCandidate, OutboundPrefixLimitConfig, OutboundPrefixLimitFamilyState,
+    OutboundPrefixLimitPair, OutboundPrefixLimitViolation, OutboundRouteUpdate,
+    PeerExportPolicyReplacement, PeerExportPolicyRestoreReceipt, PeerOutboundState,
+    PlannedGroupability, RibCommandError, RibReadinessError, RibReadinessQuery, RibRowFilter,
+    RibUpdate, RoutePage, RoutePageError, RoutePageVersion, RouteQueryFilter, RouteQueryKey,
+    RouteQueryScope, RouteSourceIdentity, SelectionDeferralPeerFamilyState, SharedGroupEncode,
+    UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupComparisonDifference,
+    UpdateGroupComparisonMembership, UpdateGroupComparisonVerdict, UpdateGroupFamilyImpact,
+    UpdateGroupFingerprint, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
+    UpdateGroupPeerComparison, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, WarmMrtSnapshotBudget,
+    WarmMrtSnapshotView, classify_update_group, route_query_key,
 };

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -65,6 +65,10 @@ pub struct LocRib {
     /// rebuilding, and an unqueried flapping table must not grow the journal
     /// without bound). The next listing rebuilds the index from scratch.
     ordered_rebuild: bool,
+    /// Whether the ordered prefix index is maintained eagerly for bounded
+    /// internal dataplane walks. This mode is opt-in on an empty manager;
+    /// ordinary route listings retain the lazy journal/rebuild path above.
+    dataplane_index_eager: bool,
     /// `FlowSpec` Loc-RIB: best route per `FlowSpec` rule.
     flowspec_routes: HashMap<FlowSpecKey, FlowSpecRoute>,
     /// EVPN Loc-RIB: best route per RFC 7432 route identity.
@@ -103,6 +107,7 @@ impl LocRib {
             // never allocates on the hot path.
             ordered_journal: Vec::with_capacity(ORDERED_JOURNAL_MIN_CAP),
             ordered_rebuild: false,
+            dataplane_index_eager: false,
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
@@ -166,6 +171,14 @@ impl LocRib {
     /// also bounds journal memory when no listing ever runs.
     #[inline]
     fn note_membership_change(&mut self, prefix: Prefix) {
+        if self.dataplane_index_eager {
+            if self.routes.contains_key(&prefix) {
+                self.ordered_prefixes.entry_or_default(prefix);
+            } else {
+                self.ordered_prefixes.remove(&prefix);
+            }
+            return;
+        }
         if self.ordered_rebuild {
             return;
         }
@@ -232,6 +245,42 @@ impl LocRib {
             .filter(move |route| after.is_none_or(|cursor| route_query_key(route) > cursor))
     }
 
+    /// Enable eager ordered-prefix maintenance for internal dataplane pages.
+    ///
+    /// The caller must select this mode before any unicast best route exists;
+    /// switching a populated lazy table would otherwise require an unbounded
+    /// synchronous rebuild.
+    pub(crate) fn enable_dataplane_prefix_index(&mut self) -> bool {
+        if !self.routes.is_empty()
+            || self.ordered_prefixes.iter_from(None).next().is_some()
+            || !self.ordered_journal.is_empty()
+            || self.ordered_rebuild
+        {
+            return false;
+        }
+        self.dataplane_index_eager = true;
+        true
+    }
+
+    /// Whether bounded dataplane pages may read the eager index.
+    pub(crate) const fn dataplane_prefix_index_enabled(&self) -> bool {
+        self.dataplane_index_eager
+    }
+
+    /// Iterate live best routes strictly after a prefix cursor without
+    /// synchronizing or rebuilding the ordered index.
+    ///
+    /// Callers must first check [`Self::dataplane_prefix_index_enabled`].
+    pub(crate) fn iter_dataplane_ordered_after(
+        &self,
+        after: Option<Prefix>,
+    ) -> impl Iterator<Item = &Route> {
+        debug_assert!(self.dataplane_index_eager);
+        self.ordered_prefixes
+            .iter_after(after)
+            .filter_map(|(prefix, ())| self.routes.get(&prefix).map(|(route, _)| route))
+    }
+
     /// Return the number of best routes.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -259,6 +308,26 @@ impl LocRib {
         (
             self.ordered_prefixes.iter_from(None).count(),
             self.ordered_journal.len(),
+        )
+    }
+
+    /// Eager-index state probe for deterministic dataplane paging tests.
+    #[cfg(test)]
+    pub(crate) fn dataplane_index_probe(&self) -> (bool, usize, usize, bool) {
+        (
+            self.dataplane_index_eager,
+            self.ordered_prefixes.iter_from(None).count(),
+            self.ordered_journal.len(),
+            self.ordered_rebuild,
+        )
+    }
+
+    /// Compact ordered-index memory receipt for the dataplane benchmark.
+    #[cfg(feature = "bench-internals")]
+    pub(crate) fn bench_ordered_index_receipt(&self) -> (usize, usize) {
+        (
+            self.ordered_prefixes.len(),
+            self.ordered_prefixes.mem_size(),
         )
     }
 
@@ -2233,6 +2302,42 @@ mod tests {
         // The next listing resolves both journal entries (-1 +1 = n rows).
         assert_eq!(loc.iter_ordered_from(None).count(), n);
         assert_eq!(loc.ordered_index_probe(), (n, 0));
+    }
+
+    #[test]
+    fn eager_dataplane_index_tracks_membership_without_journal_or_rebuild() {
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 10, 0, 0), 16);
+        let mut route = make_route(1, prefix, 100);
+        let mut loc = LocRib::new();
+        assert!(loc.enable_dataplane_prefix_index());
+
+        assert!(loc.recompute(route.prefix, std::iter::once(&route)));
+        assert_eq!(loc.dataplane_index_probe(), (true, 1, 0, false));
+
+        route.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 44));
+        assert!(loc.recompute(route.prefix, std::iter::once(&route)));
+        assert_eq!(
+            loc.dataplane_index_probe(),
+            (true, 1, 0, false),
+            "best-peer/path/payload churn must not mutate prefix membership"
+        );
+
+        assert!(loc.recompute(route.prefix, std::iter::empty()));
+        assert_eq!(loc.dataplane_index_probe(), (true, 0, 0, false));
+    }
+
+    #[test]
+    fn eager_dataplane_index_rejects_populated_then_emptied_lazy_state() {
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 20, 0, 0), 16);
+        let route = make_route(1, prefix, 100);
+        let mut loc = LocRib::new();
+
+        assert!(loc.recompute(route.prefix, std::iter::once(&route)));
+        assert!(loc.recompute(route.prefix, std::iter::empty()));
+        let before = loc.dataplane_index_probe();
+        assert!(!loc.enable_dataplane_prefix_index());
+        assert_eq!(loc.dataplane_index_probe(), before);
+        assert!(!loc.dataplane_prefix_index_enabled());
     }
 
     #[test]

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -26,8 +26,9 @@ use super::RibManager;
 use crate::event::{EvpnRouteEvent, RouteEvent};
 use crate::route::Route;
 use crate::update::{
-    ExactExportEncoder, OutboundRouteUpdate, PeerExportPolicyReplacement, RibUpdate, RoutePage,
-    RouteQueryKey, RouteQueryScope,
+    BestRoutesPage, DataplanePageError, ExactExportEncoder, FibInstallCandidatesPage,
+    OutboundRouteUpdate, PeerExportPolicyReplacement, RibUpdate, RoutePage, RouteQueryKey,
+    RouteQueryScope,
 };
 
 /// Structural receipt for the production prefix-to-announcing-peers index.
@@ -41,6 +42,13 @@ pub struct UnicastPrefixPeersMemoryReceipt {
     pub primary_value_size: usize,
     pub epoch_size: usize,
     pub spill_slots: usize,
+}
+
+/// Compact eager/lazy ordered-index receipt for dataplane paging benchmarks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DataplanePrefixIndexBenchReceipt {
+    pub prefixes: usize,
+    pub index_bytes: usize,
 }
 
 static POLICY_TRANSITION_RECEIPT_PRINTED: AtomicBool = AtomicBool::new(false);
@@ -1069,6 +1077,68 @@ impl RibManager {
         response
             .try_recv()
             .expect("route page handler replies synchronously")
+    }
+
+    /// Return the populated ordered-prefix index's entry and allocator size.
+    #[must_use]
+    pub fn bench_dataplane_prefix_index_receipt(&self) -> DataplanePrefixIndexBenchReceipt {
+        let (prefixes, index_bytes) = self.loc_rib.bench_ordered_index_receipt();
+        DataplanePrefixIndexBenchReceipt {
+            prefixes,
+            index_bytes,
+        }
+    }
+
+    /// Drive the internal best-route dataplane page handler synchronously.
+    ///
+    /// # Errors
+    ///
+    /// Returns the production handler's index/generation error.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the production handler stops replying synchronously.
+    pub fn bench_query_best_routes_page(
+        &mut self,
+        after: Option<Prefix>,
+    ) -> Result<BestRoutesPage, DataplanePageError> {
+        let (reply, mut response) = oneshot::channel();
+        self.handle_query_best_routes_page(
+            after,
+            tokio::time::Instant::now() + std::time::Duration::from_secs(60),
+            reply,
+        );
+        response
+            .try_recv()
+            .expect("best dataplane page handler replies synchronously")
+    }
+
+    /// Drive the internal FIB-candidate dataplane page handler synchronously.
+    ///
+    /// # Errors
+    ///
+    /// Returns the production handler's index/generation error.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the production handler stops replying synchronously.
+    pub fn bench_query_fib_install_candidates_page(
+        &mut self,
+        after: Option<Prefix>,
+        max_paths: u32,
+    ) -> Result<FibInstallCandidatesPage, DataplanePageError> {
+        let (reply, mut response) = oneshot::channel();
+        self.handle_query_fib_install_candidates_page(
+            after,
+            max_paths,
+            false,
+            false,
+            tokio::time::Instant::now() + std::time::Duration::from_secs(60),
+            reply,
+        );
+        response
+            .try_recv()
+            .expect("FIB dataplane page handler replies synchronously")
     }
 
     /// Publish an owned batch through the production route-event helper.

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2,9 +2,10 @@
 mod bench_support;
 #[cfg(feature = "bench-internals")]
 pub use bench_support::{
-    AdjRibOutFanoutBenchReceipt, EvpnDataplaneQueryBenchReceipt, PolicyTransitionBenchReceipt,
-    UnicastPrefixPeersMemoryReceipt, bench_evpn_dataplane_generation_query,
-    bench_evpn_dataplane_generation_snapshot, bench_evpn_dataplane_legacy_snapshot,
+    AdjRibOutFanoutBenchReceipt, DataplanePrefixIndexBenchReceipt, EvpnDataplaneQueryBenchReceipt,
+    PolicyTransitionBenchReceipt, UnicastPrefixPeersMemoryReceipt,
+    bench_evpn_dataplane_generation_query, bench_evpn_dataplane_generation_snapshot,
+    bench_evpn_dataplane_legacy_snapshot,
 };
 mod distribution;
 mod graceful_restart;
@@ -458,6 +459,12 @@ pub struct RibManager {
     /// the Loc-RIB. Counts rows visited only by full internal snapshots.
     #[cfg(test)]
     evpn_dataplane_query_row_visits: usize,
+    /// Deterministic proof that paged FIB queries use the prefix-announcer
+    /// reverse index rather than walking unrelated peer RIBs.
+    #[cfg(test)]
+    dataplane_page_announcer_visits: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
+    dataplane_page_sibling_visits: std::sync::atomic::AtomicUsize,
     adj_ribs_out: HashMap<IpAddr, AdjRibOut>,
     /// Per-peer outbound unicast prefix admission state (ADR-0113). An entry
     /// exists only for a peer whose resolved `max_prefixes_out_ipv4` /
@@ -1392,6 +1399,10 @@ impl RibManager {
             evpn_dataplane_route_count: 0,
             #[cfg(test)]
             evpn_dataplane_query_row_visits: 0,
+            #[cfg(test)]
+            dataplane_page_announcer_visits: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            dataplane_page_sibling_visits: std::sync::atomic::AtomicUsize::new(0),
             adj_ribs_out: HashMap::new(),
             outbound_prefix_limits: HashMap::new(),
             outbound_limit_control: outbound_prefix_limits::OutboundLimitControl::default(),
@@ -1511,6 +1522,26 @@ impl RibManager {
             test_ingest_stall,
             test_panic_on_peer_up: test_panic_on_peer_up.then_some(()),
         }
+    }
+
+    /// Select eager Loc-RIB prefix indexing for bounded internal dataplane
+    /// pages. The mode must be chosen before the manager contains any unicast
+    /// route; this avoids a synchronous index rebuild at cutover time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any Adj-RIB-In or Loc-RIB unicast route is already present.
+    #[must_use]
+    pub fn with_eager_dataplane_prefix_index(mut self) -> Self {
+        assert!(
+            self.loc_rib.is_empty() && self.ribs.is_empty(),
+            "eager dataplane prefix indexing must be selected on an empty RIB manager"
+        );
+        assert!(
+            self.loc_rib.enable_dataplane_prefix_index(),
+            "eager dataplane prefix indexing requires pristine index state"
+        );
+        self
     }
 
     /// Arm bounded benchmark receipts for the real VPN snapshot query arm.
@@ -2412,6 +2443,11 @@ impl RibManager {
             RibUpdate::QueryBestRoutes { deadline, reply } => {
                 self.handle_query_best_routes(deadline, reply);
             }
+            RibUpdate::QueryBestRoutesPage {
+                after,
+                deadline,
+                reply,
+            } => self.handle_query_best_routes_page(after, deadline, reply),
             RibUpdate::QueryFibInstallCandidates {
                 max_paths,
                 relax,
@@ -2423,6 +2459,16 @@ impl RibManager {
                     max_paths, relax, weighted, deadline, reply,
                 );
             }
+            RibUpdate::QueryFibInstallCandidatesPage {
+                after,
+                max_paths,
+                relax,
+                weighted,
+                deadline,
+                reply,
+            } => self.handle_query_fib_install_candidates_page(
+                after, max_paths, relax, weighted, deadline, reply,
+            ),
             RibUpdate::QueryPeerGroups { reply } => self.handle_query_peer_groups(reply),
             RibUpdate::ExplainBestPath {
                 prefix,

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -18,19 +18,28 @@ use crate::adj_rib_in::AdjRibIn;
 use crate::adj_rib_out::AdjRibOut;
 use crate::event::{RouteEvent, RouteEventType};
 use crate::update::{
-    BestPathCandidate, ExactExportKey, ExplainAdvertisedRoute, ExplainAdvertisedRouteError,
-    ExplainBestPath, MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, NeighborRibSnapshot,
-    NeighborRibSnapshotResponse, RibRowFilter, RoutePage, RoutePageError, RoutePageVersion,
-    RouteQueryFilter, RouteQueryKey, RouteQueryScope, UpdateGroupPeerComparison,
-    WarmMrtSnapshotBudget, WarmMrtSnapshotView, ordered_route_query, route_query_key,
+    BestPathCandidate, BestRoutesPage, DataplanePageError, ExactExportKey, ExplainAdvertisedRoute,
+    ExplainAdvertisedRouteError, ExplainBestPath, FibInstallCandidatesPage, MrtPeerEntry,
+    MrtSnapshotData, NeighborPolicyStats, NeighborRibSnapshot, NeighborRibSnapshotResponse,
+    RibRowFilter, RoutePage, RoutePageError, RoutePageVersion, RouteQueryFilter, RouteQueryKey,
+    RouteQueryScope, UpdateGroupPeerComparison, WarmMrtSnapshotBudget, WarmMrtSnapshotView,
+    ordered_route_query, route_query_key,
 };
 
 /// Full-snapshot queries check cancellation at bounded work intervals instead
 /// of adding a branch and clock read to every route on the normal path.
 const FULL_SNAPSHOT_CANCELLATION_STRIDE: usize = 256;
+pub(super) const DATAPLANE_PAGE_MAX_PREFIXES: usize = 1_000;
+pub(super) const DATAPLANE_PAGE_MAX_NEXT_HOPS: usize = 8_192;
+const DATAPLANE_PAGE_MAX_PATHS: u32 = 256;
 
 fn canceled_at_stride(completed: usize, canceled: &mut impl FnMut() -> bool) -> bool {
     completed.is_multiple_of(FULL_SNAPSHOT_CANCELLATION_STRIDE) && canceled()
+}
+
+fn dataplane_visit(completed: &mut usize, canceled: &mut impl FnMut() -> bool) -> bool {
+    *completed = completed.saturating_add(1);
+    (*completed).is_multiple_of(FULL_SNAPSHOT_CANCELLATION_STRIDE) && canceled()
 }
 
 fn collect_full_snapshot<'a, T: Clone + 'a>(
@@ -714,6 +723,135 @@ impl RibManager {
             warn!("query caller dropped before receiving response");
         }
     }
+
+    pub(super) fn materialize_best_routes_page(
+        &self,
+        after: Option<Prefix>,
+        observed_version: Option<RoutePageVersion>,
+        canceled: &mut impl FnMut() -> bool,
+    ) -> Option<Result<BestRoutesPage, DataplanePageError>> {
+        if canceled() {
+            return None;
+        }
+        let Some(observed_version) = observed_version else {
+            return Some(Err(DataplanePageError::GenerationExhausted));
+        };
+        if !self.loc_rib.dataplane_prefix_index_enabled() {
+            return Some(Err(DataplanePageError::IndexDisabled));
+        }
+
+        let mut routes = Vec::with_capacity(DATAPLANE_PAGE_MAX_PREFIXES);
+        let mut prefix_visits = 0;
+        let mut has_more = false;
+        for route in self.loc_rib.iter_dataplane_ordered_after(after) {
+            if dataplane_visit(&mut prefix_visits, &mut *canceled) {
+                return None;
+            }
+            if routes.len() == DATAPLANE_PAGE_MAX_PREFIXES {
+                has_more = true;
+                break;
+            }
+            routes.push(route.clone());
+        }
+        if canceled() {
+            return None;
+        }
+        let next_cursor = has_more.then(|| {
+            routes
+                .last()
+                .expect("a full dataplane page has a last route")
+                .prefix
+        });
+        Some(Ok(BestRoutesPage {
+            routes,
+            next_cursor,
+            observed_version,
+        }))
+    }
+
+    pub(super) fn handle_query_best_routes_page(
+        &mut self,
+        after: Option<Prefix>,
+        deadline: tokio::time::Instant,
+        reply: tokio::sync::oneshot::Sender<Result<BestRoutesPage, DataplanePageError>>,
+    ) {
+        // Capture the signal at handler entry. It deliberately does not fence
+        // continuation: prefix cursors have live-walk churn semantics.
+        let observed_version = self.route_page_table_version;
+        let page = self.materialize_best_routes_page(after, observed_version, &mut || {
+            reply.is_closed() || tokio::time::Instant::now() >= deadline
+        });
+        let Some(page) = page else {
+            debug!("best-route page query canceled during materialization");
+            return;
+        };
+        if reply.send(page).is_err() {
+            warn!("query caller dropped before receiving response");
+        }
+    }
+
+    fn finish_fib_install_candidate(
+        best: &crate::route::Route,
+        mut siblings: Vec<&crate::route::Route>,
+        cap: usize,
+        weighted: bool,
+    ) -> crate::route::FibInstallCandidate {
+        use crate::best_path::link_bandwidth_weights;
+        use crate::route::{FibInstallCandidate, FibInstallNextHop};
+
+        if cap == 1 {
+            return FibInstallCandidate {
+                best: best.clone(),
+                next_hops: vec![FibInstallNextHop {
+                    next_hop: best.next_hop,
+                    link_local_next_hop: best.link_local_next_hop,
+                    next_hop_scope: best.next_hop_scope.as_deref().cloned(),
+                    peer: best.peer,
+                    path_id: best.path_id,
+                    weight: 1,
+                }],
+            };
+        }
+
+        siblings.sort_by(|a, b| {
+            a.next_hop
+                .cmp(&b.next_hop)
+                .then(a.peer.cmp(&b.peer))
+                .then(a.path_id.cmp(&b.path_id))
+        });
+        let mut next_hops = Vec::new();
+        let mut seen: std::collections::BTreeSet<(IpAddr, Option<u32>)> =
+            std::collections::BTreeSet::new();
+        let mut bandwidths = Vec::new();
+        for route in std::iter::once(best).chain(siblings) {
+            if next_hops.len() >= cap {
+                break;
+            }
+            let scope_ifindex = route.next_hop_scope.as_ref().map(|scope| scope.ifindex);
+            if seen.insert((route.next_hop, scope_ifindex)) {
+                next_hops.push(FibInstallNextHop {
+                    next_hop: route.next_hop,
+                    link_local_next_hop: route.link_local_next_hop,
+                    next_hop_scope: route.next_hop_scope.as_deref().cloned(),
+                    peer: route.peer,
+                    path_id: route.path_id,
+                    weight: 1,
+                });
+                bandwidths.push(route.link_bandwidth());
+            }
+        }
+        for (next_hop, weight) in next_hops
+            .iter_mut()
+            .zip(link_bandwidth_weights(weighted, &bandwidths))
+        {
+            next_hop.weight = weight;
+        }
+        FibInstallCandidate {
+            best: best.clone(),
+            next_hops,
+        }
+    }
+
     /// Build the per-prefix FIB install-candidate view: each Loc-RIB best plus
     /// the equal-cost (ECMP) next-hop set, bounded by `max_paths`. Loc-RIB holds
     /// only the single best per prefix, so the equal-cost siblings are gathered
@@ -729,8 +867,7 @@ impl RibManager {
         weighted: bool,
         canceled: &mut impl FnMut() -> bool,
     ) -> Option<Vec<crate::route::FibInstallCandidate>> {
-        use crate::best_path::{link_bandwidth_weights, multipath_equal};
-        use crate::route::{FibInstallCandidate, FibInstallNextHop};
+        use crate::best_path::multipath_equal;
 
         if canceled() {
             debug!("FIB install-candidate query canceled before materialization");
@@ -746,22 +883,8 @@ impl RibManager {
                 debug!("FIB install-candidate query canceled during Loc-RIB materialization");
                 return None;
             }
-            let mut next_hops: Vec<FibInstallNextHop> = Vec::new();
-            if cap <= 1 {
-                // ECMP off (the default `maximum_paths` of 1): skip the
-                // equal-cost sibling scan + sort entirely and program just the
-                // best next-hop. This keeps default FIB deployments off the new
-                // multipath query cost — they pay nothing for sibling gathering.
-                next_hops.push(FibInstallNextHop {
-                    next_hop: best.next_hop,
-                    link_local_next_hop: best.link_local_next_hop,
-                    next_hop_scope: best.next_hop_scope.as_deref().cloned(),
-                    peer: best.peer,
-                    path_id: best.path_id,
-                    weight: 1,
-                });
-            } else {
-                let mut siblings: Vec<&crate::route::Route> = Vec::new();
+            let mut siblings = Vec::new();
+            if cap > 1 {
                 for rib in self.ribs.values() {
                     peer_rib_work += 1;
                     if canceled_at_stride(peer_rib_work, &mut *canceled) {
@@ -781,58 +904,110 @@ impl RibManager {
                         }
                     }
                 }
-                siblings.sort_by(|a, b| {
-                    a.next_hop
-                        .cmp(&b.next_hop)
-                        .then(a.peer.cmp(&b.peer))
-                        .then(a.path_id.cmp(&b.path_id))
-                });
-
-                let mut seen: std::collections::BTreeSet<(IpAddr, Option<u32>)> =
-                    std::collections::BTreeSet::new();
-                // Gather (next-hop, link-bandwidth) best-first, deduped by
-                // (next-hop, egress ifindex), capped. The ifindex is part of the
-                // key so two equal `fe80::/10` gateways reached over different
-                // interfaces stay distinct and both install as ECMP (ADR-0069);
-                // a same-family next-hop carries no scope, so this collapses to
-                // plain next-hop dedup for the common case. Bandwidth is held
-                // alongside so weights can be normalized over exactly the
-                // installed set below.
-                let mut bandwidths: Vec<Option<f32>> = Vec::new();
-                for r in std::iter::once(best).chain(siblings.iter().copied()) {
-                    if next_hops.len() >= cap {
-                        break;
-                    }
-                    let scope_ifindex = r.next_hop_scope.as_ref().map(|scope| scope.ifindex);
-                    if seen.insert((r.next_hop, scope_ifindex)) {
-                        next_hops.push(FibInstallNextHop {
-                            next_hop: r.next_hop,
-                            link_local_next_hop: r.link_local_next_hop,
-                            next_hop_scope: r.next_hop_scope.as_deref().cloned(),
-                            peer: r.peer,
-                            path_id: r.path_id,
-                            weight: 1,
-                        });
-                        bandwidths.push(r.link_bandwidth());
-                    }
-                }
-                for (next_hop, weight) in next_hops
-                    .iter_mut()
-                    .zip(link_bandwidth_weights(weighted, &bandwidths))
-                {
-                    next_hop.weight = weight;
-                }
             }
-            out.push(FibInstallCandidate {
-                best: best.clone(),
-                next_hops,
-            });
+            out.push(Self::finish_fib_install_candidate(
+                best, siblings, cap, weighted,
+            ));
         }
         if canceled() {
             debug!("FIB install-candidate query canceled after materialization");
             return None;
         }
         Some(out)
+    }
+
+    pub(super) fn materialize_fib_install_candidates_page(
+        &self,
+        after: Option<Prefix>,
+        max_paths: u32,
+        relax: bool,
+        weighted: bool,
+        observed_version: Option<RoutePageVersion>,
+        canceled: &mut impl FnMut() -> bool,
+    ) -> Option<Result<FibInstallCandidatesPage, DataplanePageError>> {
+        use crate::best_path::multipath_equal;
+
+        if canceled() {
+            return None;
+        }
+        let Some(observed_version) = observed_version else {
+            return Some(Err(DataplanePageError::GenerationExhausted));
+        };
+        if !self.loc_rib.dataplane_prefix_index_enabled() {
+            return Some(Err(DataplanePageError::IndexDisabled));
+        }
+
+        let cap = max_paths.clamp(1, DATAPLANE_PAGE_MAX_PATHS) as usize;
+        let mut candidates = Vec::with_capacity(DATAPLANE_PAGE_MAX_PREFIXES);
+        let mut next_hop_rows = 0usize;
+        let mut prefix_visits = 0usize;
+        let mut announcer_visits = 0usize;
+        let mut sibling_visits = 0usize;
+        let mut has_more = false;
+        for best in self.loc_rib.iter_dataplane_ordered_after(after) {
+            if dataplane_visit(&mut prefix_visits, &mut *canceled) {
+                return None;
+            }
+            if candidates.len() == DATAPLANE_PAGE_MAX_PREFIXES
+                || next_hop_rows == DATAPLANE_PAGE_MAX_NEXT_HOPS
+            {
+                has_more = true;
+                break;
+            }
+
+            let mut siblings = Vec::new();
+            if cap > 1 {
+                // Count the announcing-peer index walk independently from the
+                // routes it yields. This keeps cancellation bounded even when
+                // many stale announcer entries produce no sibling rows.
+                for _ in self.unicast_prefix_peers.peers(&best.prefix) {
+                    #[cfg(test)]
+                    self.dataplane_page_announcer_visits
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if dataplane_visit(&mut announcer_visits, &mut *canceled) {
+                        return None;
+                    }
+                }
+                for route in
+                    Self::unicast_candidates(&self.ribs, &self.unicast_prefix_peers, &best.prefix)
+                {
+                    #[cfg(test)]
+                    self.dataplane_page_sibling_visits
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if dataplane_visit(&mut sibling_visits, &mut *canceled) {
+                        return None;
+                    }
+                    if multipath_equal(best, route, relax) {
+                        siblings.push(route);
+                    }
+                }
+            }
+            let candidate = Self::finish_fib_install_candidate(best, siblings, cap, weighted);
+            if !candidates.is_empty()
+                && next_hop_rows.saturating_add(candidate.next_hops.len())
+                    > DATAPLANE_PAGE_MAX_NEXT_HOPS
+            {
+                has_more = true;
+                break;
+            }
+            next_hop_rows = next_hop_rows.saturating_add(candidate.next_hops.len());
+            candidates.push(candidate);
+        }
+        if canceled() {
+            return None;
+        }
+        let next_cursor = has_more.then(|| {
+            candidates
+                .last()
+                .expect("a non-terminal dataplane page has a last candidate")
+                .best
+                .prefix
+        });
+        Some(Ok(FibInstallCandidatesPage {
+            candidates,
+            next_cursor,
+            observed_version,
+        }))
     }
     pub(super) fn handle_query_fib_install_candidates(
         &mut self,
@@ -850,6 +1025,33 @@ impl RibManager {
             return;
         };
         if reply.send(candidates).is_err() {
+            warn!("query caller dropped before receiving response");
+        }
+    }
+
+    pub(super) fn handle_query_fib_install_candidates_page(
+        &mut self,
+        after: Option<Prefix>,
+        max_paths: u32,
+        relax: bool,
+        weighted: bool,
+        deadline: tokio::time::Instant,
+        reply: tokio::sync::oneshot::Sender<Result<FibInstallCandidatesPage, DataplanePageError>>,
+    ) {
+        let observed_version = self.route_page_table_version;
+        let page = self.materialize_fib_install_candidates_page(
+            after,
+            max_paths,
+            relax,
+            weighted,
+            observed_version,
+            &mut || reply.is_closed() || tokio::time::Instant::now() >= deadline,
+        );
+        let Some(page) = page else {
+            debug!("FIB install-candidate page query canceled during materialization");
+            return;
+        };
+        if reply.send(page).is_err() {
             warn!("query caller dropped before receiving response");
         }
     }

--- a/crates/rib/src/manager/tests/dataplane_paging.rs
+++ b/crates/rib/src/manager/tests/dataplane_paging.rs
@@ -1,0 +1,698 @@
+//! Internal bounded dataplane prefix pages.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use rustbgpd_wire::{
+    AsPath, AsPathSegment, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Prefix,
+};
+use tokio::sync::{mpsc, oneshot};
+
+use super::*;
+use crate::adj_rib_in::AdjRibIn;
+use crate::manager::queries::{DATAPLANE_PAGE_MAX_NEXT_HOPS, DATAPLANE_PAGE_MAX_PREFIXES};
+use crate::route::{FibInstallCandidate, NextHopScope, Route};
+use crate::update::{
+    BestRoutesPage, DataplanePageError, FibInstallCandidatesPage, RoutePageVersion,
+};
+
+fn manager(eager: bool) -> RibManager {
+    let (_tx, rx) = mpsc::channel(1);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    if eager {
+        manager.with_eager_dataplane_prefix_index()
+    } else {
+        manager
+    }
+}
+
+fn prefix(index: usize) -> Prefix {
+    let host = 0x0a00_0000u32
+        .checked_add(u32::try_from(index).expect("fixture index fits IPv4"))
+        .expect("fixture stays in IPv4 space");
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(host), 32))
+}
+
+fn peer(index: usize) -> Ipv4Addr {
+    Ipv4Addr::from(
+        0xc633_6401u32
+            .checked_add(u32::try_from(index).expect("fixture peer index fits IPv4"))
+            .expect("fixture peers stay in IPv4 space"),
+    )
+}
+
+fn route(prefix: Prefix, peer: Ipv4Addr, next_hop: IpAddr, as_path: &[u32]) -> Route {
+    let mut route = match prefix {
+        Prefix::V4(prefix) => crate::test_support::make_route_with_lp(prefix, peer, 100),
+        Prefix::V6(prefix) => crate::test_support::make_v6_route(
+            prefix,
+            match next_hop {
+                IpAddr::V6(next_hop) => next_hop,
+                IpAddr::V4(_) => Ipv6Addr::LOCALHOST,
+            },
+        ),
+    };
+    route.peer = IpAddr::V4(peer);
+    route.peer_router_id = peer;
+    route.next_hop = next_hop;
+    route.attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(as_path.to_vec())],
+        }),
+        PathAttribute::LocalPref(100),
+    ]);
+    route
+}
+
+fn apply_routes(manager: &mut RibManager, peer: Ipv4Addr, announced: Vec<Route>) {
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(peer),
+        announced,
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    });
+    while manager.process_next_route_chunk() {}
+}
+
+fn withdraw(manager: &mut RibManager, peer: Ipv4Addr, prefixes: &[Prefix]) {
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(peer),
+        announced: Vec::new(),
+        withdrawn: prefixes.iter().copied().map(|prefix| (prefix, 0)).collect(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    });
+    while manager.process_next_route_chunk() {}
+}
+
+fn best_page(
+    manager: &mut RibManager,
+    after: Option<Prefix>,
+) -> Result<BestRoutesPage, DataplanePageError> {
+    let (reply, mut response) = oneshot::channel();
+    manager.handle_query_best_routes_page(
+        after,
+        tokio::time::Instant::now() + Duration::from_secs(60),
+        reply,
+    );
+    response
+        .try_recv()
+        .expect("best page handler replies synchronously")
+}
+
+fn fib_page(
+    manager: &mut RibManager,
+    after: Option<Prefix>,
+    max_paths: u32,
+    relax: bool,
+    weighted: bool,
+) -> Result<FibInstallCandidatesPage, DataplanePageError> {
+    let (reply, mut response) = oneshot::channel();
+    manager.handle_query_fib_install_candidates_page(
+        after,
+        max_paths,
+        relax,
+        weighted,
+        tokio::time::Instant::now() + Duration::from_secs(60),
+        reply,
+    );
+    response
+        .try_recv()
+        .expect("FIB page handler replies synchronously")
+}
+
+fn full_fib(
+    manager: &mut RibManager,
+    max_paths: u32,
+    relax: bool,
+    weighted: bool,
+) -> Vec<FibInstallCandidate> {
+    let (reply, mut response) = oneshot::channel();
+    manager.handle_query_fib_install_candidates(
+        max_paths,
+        relax,
+        weighted,
+        tokio::time::Instant::now() + Duration::from_secs(60),
+        reply,
+    );
+    response
+        .try_recv()
+        .expect("full FIB handler replies synchronously")
+}
+
+fn assert_route_field_equivalent(actual: &Route, expected: &Route) {
+    assert_eq!(actual.prefix, expected.prefix);
+    assert_eq!(actual.next_hop, expected.next_hop);
+    assert_eq!(actual.link_local_next_hop, expected.link_local_next_hop);
+    assert_eq!(actual.next_hop_scope, expected.next_hop_scope);
+    assert_eq!(actual.peer, expected.peer);
+    assert_eq!(actual.attributes, expected.attributes);
+    assert_eq!(actual.received_at, expected.received_at);
+    assert_eq!(actual.origin_type, expected.origin_type);
+    assert_eq!(actual.peer_router_id, expected.peer_router_id);
+    assert_eq!(actual.is_stale, expected.is_stale);
+    assert_eq!(actual.is_llgr_stale, expected.is_llgr_stale);
+    assert_eq!(actual.path_id, expected.path_id);
+    assert_eq!(actual.validation_state, expected.validation_state);
+    assert_eq!(actual.aspa_state, expected.aspa_state);
+    assert_eq!(actual.aspa_context, expected.aspa_context);
+}
+
+#[test]
+fn eager_index_is_ready_and_default_lazy_mode_never_rebuilds_for_dataplane() {
+    let source = peer(0);
+    let routes = (0..3)
+        .map(|index| route(prefix(index), source, IpAddr::V4(source), &[65001]))
+        .collect();
+    let mut eager = manager(true);
+    apply_routes(&mut eager, source, routes);
+    assert_eq!(eager.loc_rib.dataplane_index_probe(), (true, 3, 0, false));
+    assert_eq!(best_page(&mut eager, None).unwrap().routes.len(), 3);
+    assert_eq!(eager.loc_rib.dataplane_index_probe(), (true, 3, 0, false));
+
+    let mut lazy = manager(false);
+    apply_routes(
+        &mut lazy,
+        source,
+        vec![route(prefix(0), source, IpAddr::V4(source), &[65001])],
+    );
+    let before = lazy.loc_rib.dataplane_index_probe();
+    assert_eq!(
+        best_page(&mut lazy, None).unwrap_err(),
+        DataplanePageError::IndexDisabled
+    );
+    assert_eq!(lazy.loc_rib.dataplane_index_probe(), before);
+}
+
+#[test]
+fn best_pages_order_ipv4_before_ipv6_and_match_the_full_snapshot() {
+    let source = peer(0);
+    let mut manager = manager(true);
+    let routes = vec![
+        route(
+            Prefix::V6(Ipv6Prefix::new("2001:db8:2::".parse().unwrap(), 48)),
+            source,
+            "2001:db8::2".parse().unwrap(),
+            &[65001],
+        ),
+        route(prefix(2), source, IpAddr::V4(source), &[65001]),
+        route(
+            Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32)),
+            source,
+            "2001:db8::1".parse().unwrap(),
+            &[65001],
+        ),
+        route(prefix(1), source, IpAddr::V4(source), &[65001]),
+    ];
+    apply_routes(&mut manager, source, routes);
+
+    let page = best_page(&mut manager, None).unwrap();
+    let prefixes = page
+        .routes
+        .iter()
+        .map(|route| route.prefix)
+        .collect::<Vec<_>>();
+    assert!(prefixes.windows(2).all(|pair| pair[0] < pair[1]));
+    assert_eq!(page.next_cursor, None);
+
+    let (reply, mut response) = oneshot::channel();
+    manager.handle_query_best_routes(tokio::time::Instant::now() + Duration::from_secs(60), reply);
+    let mut full = response.try_recv().unwrap();
+    full.sort_by_key(|route| route.prefix);
+    for (actual, expected) in page.routes.iter().zip(&full) {
+        assert_route_field_equivalent(actual, expected);
+    }
+}
+
+#[test]
+fn prefix_cursor_has_live_churn_semantics() {
+    let source = peer(0);
+    let mut manager = manager(true);
+    apply_routes(
+        &mut manager,
+        source,
+        [10usize, 20, 30]
+            .into_iter()
+            .map(|index| route(prefix(index), source, IpAddr::V4(source), &[65001]))
+            .collect(),
+    );
+    let cursor = prefix(20);
+    let before = best_page(&mut manager, Some(cursor)).unwrap();
+    assert_eq!(before.routes[0].prefix, prefix(30));
+
+    // A behind-cursor insertion is not revisited; an ahead insertion may
+    // appear; a withdrawn ahead row disappears.
+    apply_routes(
+        &mut manager,
+        source,
+        vec![
+            route(prefix(15), source, IpAddr::V4(source), &[65001]),
+            route(prefix(25), source, IpAddr::V4(source), &[65001]),
+        ],
+    );
+    withdraw(&mut manager, source, &[prefix(30)]);
+    let page = best_page(&mut manager, Some(cursor)).unwrap();
+    assert_ne!(page.observed_version, before.observed_version);
+    assert_eq!(
+        page.routes
+            .iter()
+            .map(|route| route.prefix)
+            .collect::<Vec<_>>(),
+        vec![prefix(25)]
+    );
+
+    // Payload and best-peer churn changes the row but never its cursor key.
+    let replacement_peer = peer(1);
+    let mut replacement = route(
+        prefix(25),
+        replacement_peer,
+        IpAddr::V4(replacement_peer),
+        &[65001],
+    );
+    replacement.attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65001])],
+        }),
+        PathAttribute::LocalPref(200),
+    ]);
+    apply_routes(&mut manager, replacement_peer, vec![replacement]);
+    let again = best_page(&mut manager, Some(cursor)).unwrap();
+    assert_ne!(again.observed_version, page.observed_version);
+    assert_eq!(again.routes.len(), 1);
+    assert_eq!(again.routes[0].prefix, prefix(25));
+    assert_eq!(again.routes[0].peer, IpAddr::V4(replacement_peer));
+}
+
+#[test]
+fn exact_thousand_prefix_boundary_never_revisits_or_splits() {
+    let source = peer(0);
+    let mut manager = manager(true);
+    let final_v6 = Prefix::V6(Ipv6Prefix::new("2001:db8:ffff::".parse().unwrap(), 48));
+    let mut routes = (0..=DATAPLANE_PAGE_MAX_PREFIXES)
+        .map(|index| route(prefix(index), source, IpAddr::V4(source), &[65001]))
+        .collect::<Vec<_>>();
+    routes.push(route(
+        final_v6,
+        source,
+        "2001:db8::ffff".parse().unwrap(),
+        &[65001],
+    ));
+    apply_routes(&mut manager, source, routes);
+
+    let first = best_page(&mut manager, None).unwrap();
+    assert_eq!(first.routes.len(), DATAPLANE_PAGE_MAX_PREFIXES);
+    assert_eq!(first.next_cursor, Some(prefix(999)));
+    let second = best_page(&mut manager, first.next_cursor).unwrap();
+    assert_eq!(second.routes.len(), 2);
+    assert_eq!(second.routes[0].prefix, prefix(1_000));
+    assert_eq!(second.routes[1].prefix, final_v6);
+    assert_eq!(second.next_cursor, None);
+
+    let first = fib_page(&mut manager, None, 1, false, false).unwrap();
+    assert_eq!(first.candidates.len(), DATAPLANE_PAGE_MAX_PREFIXES);
+    assert_eq!(first.next_cursor, Some(prefix(999)));
+    let second = fib_page(&mut manager, first.next_cursor, 1, false, false).unwrap();
+    assert_eq!(second.candidates.len(), 2);
+    assert_eq!(second.candidates[0].best.prefix, prefix(1_000));
+    assert_eq!(second.candidates[1].best.prefix, final_v6);
+    assert_eq!(second.next_cursor, None);
+}
+
+#[test]
+fn paged_fib_matches_full_single_strict_relaxed_and_weighted_views() {
+    let mut manager = manager(true);
+    let strict_prefix = prefix(10);
+    let weighted_prefix = prefix(20);
+    for (index, source) in [peer(0), peer(1)].into_iter().enumerate() {
+        let mut strict = route(
+            strict_prefix,
+            source,
+            IpAddr::V4(source),
+            &[65001 + u32::try_from(index).unwrap()],
+        );
+        strict.path_id = u32::try_from(index).unwrap();
+        let mut weighted = route(weighted_prefix, source, IpAddr::V4(source), &[65100]);
+        Arc::make_mut(&mut weighted.attributes).push(PathAttribute::ExtendedCommunities(vec![
+            ExtendedCommunity::link_bandwidth(65001, if index == 0 { 40e9 } else { 10e9 }),
+        ]));
+        apply_routes(&mut manager, source, vec![strict, weighted]);
+    }
+
+    for (max_paths, relax, weighted) in [
+        (1, false, false),
+        (2, false, false),
+        (2, true, false),
+        (2, false, true),
+    ] {
+        let page = fib_page(&mut manager, None, max_paths, relax, weighted).unwrap();
+        let mut full = full_fib(&mut manager, max_paths, relax, weighted);
+        full.sort_by_key(|candidate| candidate.best.prefix);
+        assert_eq!(page.candidates.len(), full.len());
+        for (actual, expected) in page.candidates.iter().zip(&full) {
+            assert_route_field_equivalent(&actual.best, &expected.best);
+            assert_eq!(actual.next_hops, expected.next_hops);
+        }
+    }
+
+    let strict = fib_page(&mut manager, None, 2, false, false).unwrap();
+    assert_eq!(strict.candidates[0].next_hops.len(), 1);
+    let relaxed = fib_page(&mut manager, None, 2, true, false).unwrap();
+    assert_eq!(relaxed.candidates[0].next_hops.len(), 2);
+    let weighted = fib_page(&mut manager, None, 2, false, true).unwrap();
+    let weighted = weighted
+        .candidates
+        .iter()
+        .find(|candidate| candidate.best.prefix == weighted_prefix)
+        .unwrap();
+    assert_eq!(weighted.next_hops[0].weight, 256);
+    assert_eq!(weighted.next_hops[1].weight, 64);
+}
+
+#[test]
+fn fib_dedup_preserves_link_local_scope_and_normalizes_max_paths() {
+    let mut manager = manager(true);
+    let dedup_prefix = prefix(40);
+    let scoped_prefix = Prefix::V6(Ipv6Prefix::new("2001:db8:40::".parse().unwrap(), 48));
+    for index in 0..300usize {
+        let source = peer(index);
+        let mut dedup = route(
+            dedup_prefix,
+            source,
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            &[65001],
+        );
+        dedup.path_id = u32::try_from(index).unwrap();
+        let mut rows = vec![dedup];
+        if index < 2 {
+            let mut scoped = route(scoped_prefix, source, "fe80::1".parse().unwrap(), &[65001]);
+            scoped.next_hop_scope = Some(Box::new(NextHopScope {
+                interface: Arc::from(format!("eth{index}")),
+                ifindex: u32::try_from(index + 1).unwrap(),
+            }));
+            rows.push(scoped);
+        }
+        apply_routes(&mut manager, source, rows);
+    }
+
+    let page = fib_page(&mut manager, None, u32::MAX, false, false).unwrap();
+    let dedup = page
+        .candidates
+        .iter()
+        .find(|candidate| candidate.best.prefix == dedup_prefix)
+        .unwrap();
+    assert_eq!(dedup.next_hops.len(), 1, "same egress must dedupe");
+    let scoped = page
+        .candidates
+        .iter()
+        .find(|candidate| candidate.best.prefix == scoped_prefix)
+        .unwrap();
+    assert_eq!(scoped.next_hops.len(), 2);
+    assert_ne!(
+        scoped.next_hops[0].next_hop_scope,
+        scoped.next_hops[1].next_hop_scope
+    );
+
+    // Give one prefix 300 distinct egresses; the page-specific normalization
+    // caps it at 256 without splitting the prefix.
+    let capped_prefix = prefix(50);
+    for index in 0..300usize {
+        let source = peer(index);
+        apply_routes(
+            &mut manager,
+            source,
+            vec![route(capped_prefix, source, IpAddr::V4(source), &[65001])],
+        );
+    }
+    let capped = fib_page(&mut manager, Some(prefix(40)), u32::MAX, false, false).unwrap();
+    let capped = capped
+        .candidates
+        .iter()
+        .find(|candidate| candidate.best.prefix == capped_prefix)
+        .unwrap();
+    assert_eq!(capped.next_hops.len(), 256);
+}
+
+#[test]
+fn exact_next_hop_budget_stops_before_a_complete_prefix() {
+    let mut manager = manager(true);
+    let prefix_count = DATAPLANE_PAGE_MAX_NEXT_HOPS / 256 + 1;
+    for peer_index in 0..256usize {
+        let source = peer(peer_index);
+        apply_routes(
+            &mut manager,
+            source,
+            (0..prefix_count)
+                .map(|prefix_index| {
+                    route(prefix(prefix_index), source, IpAddr::V4(source), &[65001])
+                })
+                .collect(),
+        );
+    }
+
+    let first = fib_page(&mut manager, None, 256, false, false).unwrap();
+    assert_eq!(first.candidates.len(), 32);
+    assert_eq!(
+        first
+            .candidates
+            .iter()
+            .map(|candidate| candidate.next_hops.len())
+            .sum::<usize>(),
+        DATAPLANE_PAGE_MAX_NEXT_HOPS
+    );
+    assert_eq!(first.next_cursor, Some(prefix(31)));
+    let second = fib_page(&mut manager, first.next_cursor, 256, false, false).unwrap();
+    assert_eq!(second.candidates.len(), 1);
+    assert_eq!(second.candidates[0].next_hops.len(), 256);
+    assert_eq!(second.candidates[0].best.prefix, prefix(32));
+    assert_eq!(second.next_cursor, None);
+}
+
+#[test]
+fn fib_page_probes_only_indexed_announcers_for_each_prefix() {
+    let source = peer(0);
+    let mut manager = manager(true);
+    apply_routes(
+        &mut manager,
+        source,
+        vec![route(prefix(0), source, IpAddr::V4(source), &[65001])],
+    );
+    for index in 1..=300usize {
+        let unrelated_peer = peer(index);
+        let mut rib = AdjRibIn::new(IpAddr::V4(unrelated_peer));
+        rib.insert(route(
+            prefix(10_000 + index),
+            unrelated_peer,
+            IpAddr::V4(unrelated_peer),
+            &[65001],
+        ));
+        manager.ribs.insert(IpAddr::V4(unrelated_peer), rib);
+    }
+
+    manager
+        .dataplane_page_announcer_visits
+        .store(0, Ordering::Relaxed);
+    manager
+        .dataplane_page_sibling_visits
+        .store(0, Ordering::Relaxed);
+    let page = fib_page(&mut manager, None, 2, false, false).unwrap();
+    assert_eq!(page.candidates.len(), 1);
+    assert_eq!(
+        manager
+            .dataplane_page_announcer_visits
+            .load(Ordering::Relaxed),
+        1
+    );
+    assert_eq!(
+        manager
+            .dataplane_page_sibling_visits
+            .load(Ordering::Relaxed),
+        1
+    );
+}
+
+#[test]
+fn mid_page_and_mid_sibling_cancellation_publish_nothing() {
+    let source = peer(0);
+    let mut best_manager = manager(true);
+    apply_routes(
+        &mut best_manager,
+        source,
+        (0..300)
+            .map(|index| route(prefix(index), source, IpAddr::V4(source), &[65001]))
+            .collect(),
+    );
+    let observed = best_manager.route_page_table_version;
+    let mut checks = 0usize;
+    let result = best_manager.materialize_best_routes_page(None, observed, &mut || {
+        checks += 1;
+        checks == 2
+    });
+    assert!(result.is_none(), "partial best page must be dropped");
+
+    let sibling_prefix = prefix(1_000);
+    let mut sibling_manager = manager(true);
+    for index in 0..300usize {
+        let source = peer(index);
+        apply_routes(
+            &mut sibling_manager,
+            source,
+            vec![route(sibling_prefix, source, IpAddr::V4(source), &[65001])],
+        );
+    }
+    let observed = sibling_manager.route_page_table_version;
+    let mut checks = 0usize;
+    let result = sibling_manager.materialize_fib_install_candidates_page(
+        None,
+        256,
+        false,
+        false,
+        observed,
+        &mut || {
+            checks += 1;
+            checks == 2
+        },
+    );
+    assert!(
+        result.is_none(),
+        "announcer-walk cancellation drops the page"
+    );
+    assert_eq!(
+        sibling_manager
+            .dataplane_page_announcer_visits
+            .load(Ordering::Relaxed),
+        256
+    );
+    assert_eq!(
+        sibling_manager
+            .dataplane_page_sibling_visits
+            .load(Ordering::Relaxed),
+        0
+    );
+
+    sibling_manager
+        .dataplane_page_announcer_visits
+        .store(0, Ordering::Relaxed);
+    sibling_manager
+        .dataplane_page_sibling_visits
+        .store(0, Ordering::Relaxed);
+    let mut checks = 0usize;
+    let result = sibling_manager.materialize_fib_install_candidates_page(
+        None,
+        256,
+        false,
+        false,
+        observed,
+        &mut || {
+            checks += 1;
+            checks == 3
+        },
+    );
+    assert!(result.is_none(), "partial FIB page must be dropped");
+    assert_eq!(
+        sibling_manager
+            .dataplane_page_announcer_visits
+            .load(Ordering::Relaxed),
+        300
+    );
+    assert_eq!(
+        sibling_manager
+            .dataplane_page_sibling_visits
+            .load(Ordering::Relaxed),
+        256
+    );
+}
+
+#[tokio::test]
+async fn expired_and_preclosed_pages_publish_nothing_then_light_query_runs() {
+    let (tx, rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_eager_dataplane_prefix_index();
+    let handle = tokio::spawn(manager.run());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryBestRoutesPage {
+        after: None,
+        deadline: tokio::time::Instant::now(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(response.await.is_err());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryFibInstallCandidatesPage {
+        after: None,
+        max_paths: 2,
+        relax: false,
+        weighted: false,
+        deadline: tokio::time::Instant::now(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(response.await.is_err());
+
+    let (reply, response) = oneshot::channel::<Result<BestRoutesPage, DataplanePageError>>();
+    drop(response);
+    tx.send(RibUpdate::QueryBestRoutesPage {
+        after: None,
+        deadline: full_snapshot_query_deadline(),
+        reply,
+    })
+    .await
+    .unwrap();
+    let (reply, response) =
+        oneshot::channel::<Result<FibInstallCandidatesPage, DataplanePageError>>();
+    drop(response);
+    tx.send(RibUpdate::QueryFibInstallCandidatesPage {
+        after: None,
+        max_paths: 2,
+        relax: false,
+        weighted: false,
+        deadline: full_snapshot_query_deadline(),
+        reply,
+    })
+    .await
+    .unwrap();
+
+    assert_lightweight_query_is_serviced(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[test]
+fn generation_exhaustion_fails_closed_for_both_page_types() {
+    let mut manager = manager(true);
+    manager.route_page_table_version = None;
+    assert_eq!(
+        best_page(&mut manager, None).unwrap_err(),
+        DataplanePageError::GenerationExhausted
+    );
+    assert_eq!(
+        fib_page(&mut manager, None, 1, false, false).unwrap_err(),
+        DataplanePageError::GenerationExhausted
+    );
+
+    manager.route_page_table_version = Some(RoutePageVersion {
+        epoch: 7,
+        generation: 11,
+    });
+    assert_eq!(
+        best_page(&mut manager, None).unwrap().observed_version,
+        RoutePageVersion {
+            epoch: 7,
+            generation: 11
+        }
+    );
+}

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -1257,6 +1257,7 @@ async fn llgr_gate_peer_up(
 mod attr_intern;
 mod bgpls;
 mod bmp;
+mod dataplane_paging;
 mod events_metrics;
 mod evpn;
 mod evpn_dataplane_query;

--- a/crates/rib/src/prefix_map.rs
+++ b/crates/rib/src/prefix_map.rs
@@ -137,6 +137,16 @@ impl<V> FamilyPrefixMap<V> {
             )
         }))
     }
+
+    /// Iterate strictly after `prefix` in [`Prefix`]'s derived order.
+    ///
+    /// Dataplane continuation cursors identify a complete prefix rather than
+    /// a route identity, so unlike [`Self::iter_from`] they must never revisit
+    /// the cursor prefix.
+    pub(crate) fn iter_after(&self, prefix: Option<Prefix>) -> impl Iterator<Item = (Prefix, &V)> {
+        self.iter_from(prefix)
+            .filter(move |(candidate, _)| prefix.is_none_or(|cursor| *candidate > cursor))
+    }
 }
 
 impl<V> FamilyPrefixMap<V> {
@@ -216,5 +226,29 @@ mod tests {
                 .collect();
             assert_eq!(actual, authoritative, "cursor {cursor}");
         }
+    }
+
+    #[test]
+    fn exclusive_continuation_never_revisits_cursor_prefix() {
+        let mut map = FamilyPrefixMap::<()>::default();
+        let prefixes = [
+            Prefix::V4(Ipv4Prefix::new("10.0.0.0".parse().unwrap(), 8)),
+            Prefix::V4(Ipv4Prefix::new("10.0.0.0".parse().unwrap(), 16)),
+            Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32)),
+        ];
+        for prefix in prefixes {
+            map.entry_or_default(prefix);
+        }
+
+        assert_eq!(
+            map.iter_after(Some(prefixes[0]))
+                .map(|(prefix, ())| prefix)
+                .collect::<Vec<_>>(),
+            prefixes[1..]
+        );
+        assert!(
+            map.iter_after(Some(prefixes[2])).next().is_none(),
+            "the last prefix has no continuation"
+        );
     }
 }

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1421,6 +1421,39 @@ pub struct RoutePage {
     pub version: RoutePageVersion,
 }
 
+/// A bounded internal dataplane page could not be served.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataplanePageError {
+    /// The manager was not started with eager dataplane prefix indexing.
+    IndexDisabled,
+    /// The process-local route-page version space was exhausted.
+    GenerationExhausted,
+}
+
+/// One bounded page of Loc-RIB best routes for internal dataplane consumers.
+#[derive(Debug, Clone)]
+pub struct BestRoutesPage {
+    /// Live best routes, strictly ascending by prefix.
+    pub routes: Vec<Route>,
+    /// Exclusive continuation cursor, present only when another prefix remains.
+    pub next_cursor: Option<Prefix>,
+    /// Conservative table version observed when the actor entered the handler.
+    /// This is a churn signal, not a continuation fence.
+    pub observed_version: RoutePageVersion,
+}
+
+/// One bounded page of per-prefix FIB install candidates.
+#[derive(Debug, Clone)]
+pub struct FibInstallCandidatesPage {
+    /// Complete candidates, strictly ascending by their best route's prefix.
+    pub candidates: Vec<FibInstallCandidate>,
+    /// Exclusive continuation cursor, present only when another prefix remains.
+    pub next_cursor: Option<Prefix>,
+    /// Conservative table version observed when the actor entered the handler.
+    /// This is a churn signal, not a continuation fence.
+    pub observed_version: RoutePageVersion,
+}
+
 /// Effective live unicast distribution mode for a registered peer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EffectiveDistributionMode {
@@ -1883,6 +1916,15 @@ pub enum RibUpdate {
         /// Response channel.
         reply: oneshot::Sender<Vec<Route>>,
     },
+    /// Query: return one bounded live-prefix page of Loc-RIB best routes.
+    QueryBestRoutesPage {
+        /// Resume strictly after this prefix; `None` starts at the beginning.
+        after: Option<Prefix>,
+        /// Absolute deadline for queued send plus actor materialization.
+        deadline: tokio::time::Instant,
+        /// Response channel; a dropped receiver cancels the query.
+        reply: oneshot::Sender<Result<BestRoutesPage, DataplanePageError>>,
+    },
     /// Query: return per-prefix FIB install candidates — the best route plus
     /// its equal-cost (ECMP) next-hop set, bounded by `max_paths`. The
     /// deliberate install-candidate view ADR-0066 builds multipath on.
@@ -1901,6 +1943,21 @@ pub enum RibUpdate {
         deadline: tokio::time::Instant,
         /// Response channel.
         reply: oneshot::Sender<Vec<FibInstallCandidate>>,
+    },
+    /// Query: return one bounded live-prefix page of FIB install candidates.
+    QueryFibInstallCandidatesPage {
+        /// Resume strictly after this prefix; `None` starts at the beginning.
+        after: Option<Prefix>,
+        /// Max equal-cost next-hops per prefix, normalized to `1..=256`.
+        max_paths: u32,
+        /// ADR-0066 multipath-relax selection rule.
+        relax: bool,
+        /// ADR-0068 weighted multipath selection rule.
+        weighted: bool,
+        /// Absolute deadline for queued send plus actor materialization.
+        deadline: tokio::time::Instant,
+        /// Response channel; a dropped receiver cancels the query.
+        reply: oneshot::Sender<Result<FibInstallCandidatesPage, DataplanePageError>>,
     },
     /// Query: return the current per-peer peer-group map.
     QueryPeerGroups {


### PR DESCRIPTION
## Summary

- add an opt-in eager Loc-RIB prefix index for bounded internal dataplane walks; the default manager remains lazy and page queries fail with `IndexDisabled`
- add live, exclusive-prefix pages for best routes and FIB install candidates with observed churn versions, absolute deadlines, and all-or-nothing cancellation
- preserve full-query FIB output semantics while bounding pages to 1,000 prefixes and 8,192 next-hop rows, using the existing prefix-to-announcer reverse index for ECMP
- add deterministic boundary, churn, equivalence, ECMP, cancellation, and index-mode coverage plus a reproducible large-table benchmark

## Benchmark receipt

Three fresh-process repetitions per shape:

- 1.1M prefixes, max_paths=1: lazy indexed ingest median 1.590s vs eager 1.607s (+1.1%); RSS 661.4 MB vs 687.0 MB (+25.6 MB); eager page p50 0.184 ms, p99 0.251 ms, max 0.556 ms
- 100k prefixes, max_paths=2: 200k next hops; page p50 0.389 ms, p99 0.458 ms, max 0.469 ms
- 100k prefixes, max_paths=8: 800k next hops; page p50 1.386 ms, p99 1.458 ms, max 1.509 ms

Checksums were stable across all repetitions. The measured ingest, memory, and two-second page stop thresholds all passed.

## Validation

- `cargo test --locked -p rustbgpd-rib --all-features` (1,233 passed, 2 ignored)
- `cargo clippy --locked -p rustbgpd-rib --all-targets --all-features -- -D warnings`
- `cargo check --locked --workspace --all-targets`
- `cargo test --locked --workspace`
- installed pre-commit and pre-push hooks, including workspace clippy, library tests, and docs

This is internal substrate only; no daemon caller or reconciler behavior is switched in this PR. LAN-1324 remains open for cutover and deletion revalidation.
