### PR TITLE
bmp: emit RFC 9972 Adj-RIB-In statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Periodic BMP peer statistics now include RFC 9972 post-policy Adj-RIB-In
+  gauges: global type 20 and negotiated IPv4/IPv6-unicast family types 21 and
+  23. These gauges are omitted when effective unicast Add-Path receive is active,
+  because the current prefix counters intentionally deduplicate paths.
+
 - The RIB memory harness now models the opposing costs of interned attribute
   container layouts at live-table-calibrated diversity and route-reflector
   fanout. Its pinned full campaign rejects an `Arc<[PathAttribute]>` migration

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -3760,6 +3760,7 @@ mod tests {
             remote_router_id: "192.0.2.7".parse().unwrap(),
             four_octet_as: false,
             families: vec![(Afi::Ipv6, Safi::Unicast)],
+            add_path_receive_families: Vec::new(),
             peer_route_refresh: false,
             peer_enhanced_route_refresh: false,
             peer_extended_message: false,

--- a/crates/bmp/README.md
+++ b/crates/bmp/README.md
@@ -17,7 +17,9 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 - Periodic Stats Reports for each peer carry the RFC 7854 Adj-RIB-In route
   count (type 7); when available, they also carry the RFC 8671 post-policy
   Adj-RIB-Out total (type 15) and per-(AFI, SAFI) counts (type 17); types 15/17
-  are omitted when unavailable rather than reported as false zero.
+  are omitted when unavailable rather than reported as false zero. RFC 9972
+  post-policy Adj-RIB-In gauges (types 20/21/23) cover negotiated IPv4/IPv6
+  unicast and are omitted when effective unicast Add-Path receive is active.
 - RFC 8671 post-policy Adj-RIB-Out route monitoring (O=1/L=1)
 - RFC 9069 Loc-RIB route monitoring + Loc-RIB Stats Report (peer type 3),
   with a resumable cursor-based Loc-RIB dump

--- a/crates/bmp/src/codec.rs
+++ b/crates/bmp/src/codec.rs
@@ -59,25 +59,25 @@ const PEER_FLAG_O: u8 = 0x10; // Adj-RIB-Out (RFC 8671)
 
 /// Stat counter for Stats Report messages.
 ///
-/// RFC 7854 numeric stat types (4-byte or 8-byte `Stat Data`):
+/// RFC 7854 and RFC 9972 numeric stat types (4-byte or 8-byte `Stat Data`):
 /// - 32-bit: 0-6, 11-13
 /// - 64-bit: 7-8, plus RFC 8671 Adj-RIB-Out gauges 14-15
 ///
-/// AFI/SAFI-qualified stat types 9-10 and 16-17 must use
+/// AFI/SAFI-qualified stat types 9-10, 16-17, and the RFC 9972 family
+/// types must use
 /// [`AfiStatCounter`].
 #[derive(Debug, Clone)]
 pub struct StatCounter {
-    /// RFC 7854 stat type code (0-8, 11-13).
+    /// Numeric stat type code.
     pub stat_type: u16,
     /// Counter or gauge value.
     pub value: u64,
 }
 
-/// AFI/SAFI-qualified stat counter (RFC 7854 stat types 9-10,
-/// RFC 8671 types 16-17). Payload: AFI(2) + SAFI(1) + count(8).
+/// AFI/SAFI-qualified stat counter. Payload: AFI(2) + SAFI(1) + count(8).
 #[derive(Debug, Clone)]
 pub struct AfiStatCounter {
-    /// Stat type code (9, 10, 16, or 17).
+    /// AFI/SAFI-qualified stat type code.
     pub stat_type: u16,
     /// Address Family Identifier.
     pub afi: u16,
@@ -87,14 +87,57 @@ pub struct AfiStatCounter {
     pub value: u64,
 }
 
-/// Returns the value size for RFC 7854 numeric stat types.
+enum EncodedStat<'a> {
+    Numeric(&'a StatCounter),
+    Afi(&'a AfiStatCounter),
+}
+
+impl EncodedStat<'_> {
+    fn sort_key(&self) -> (u16, u16, u8) {
+        match self {
+            Self::Numeric(counter) => (counter.stat_type, 0, 0),
+            Self::Afi(counter) => (counter.stat_type, counter.afi, counter.safi),
+        }
+    }
+}
+
+fn put_encoded_stat(buf: &mut BytesMut, entry: &EncodedStat<'_>) {
+    match entry {
+        EncodedStat::Numeric(counter) => {
+            let Some(sz) = numeric_stat_size(counter.stat_type) else {
+                return;
+            };
+            buf.put_u16(counter.stat_type);
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "BMP 4-octet stat counters are encoded in their declared protocol field width"
+            )]
+            if sz == 4 {
+                buf.put_u16(4);
+                buf.put_u32(counter.value as u32);
+            } else {
+                buf.put_u16(8);
+                buf.put_u64(counter.value);
+            }
+        }
+        EncodedStat::Afi(counter) => {
+            buf.put_u16(counter.stat_type);
+            buf.put_u16(11); // AFI(2) + SAFI(1) + value(8) = 11
+            buf.put_u16(counter.afi);
+            buf.put_u8(counter.safi);
+            buf.put_u64(counter.value);
+        }
+    }
+}
+
+/// Returns the value size for RFC 7854, RFC 8671, and RFC 9972 numeric stat types.
 /// Returns `None` for AFI/SAFI-qualified or unknown types.
 fn numeric_stat_size(stat_type: u16) -> Option<usize> {
     match stat_type {
         // 4-byte counters: types 0-6, 11-13
         0..=6 | 11..=13 => Some(4),
-        // 64-bit gauges: types 7-8, RFC 8671 Adj-RIB-Out types 14-15
-        7 | 8 | 14 | 15 => Some(8),
+        // 64-bit gauges: RFC 7854/8671 plus RFC 9972 global types.
+        7 | 8 | 14 | 15 | 18 | 20 | 29 | 31 | 33 | 39 => Some(8),
         // AFI/SAFI-qualified and unknown type formats are not encoded
         // by this numeric-only helper.
         _ => None,
@@ -102,7 +145,19 @@ fn numeric_stat_size(stat_type: u16) -> Option<usize> {
 }
 
 fn is_afi_stat(stat_type: u16) -> bool {
-    matches!(stat_type, 9 | 10 | 16 | 17)
+    matches!(
+        stat_type,
+        9 | 10
+            | 16
+            | 17
+            | 19
+            | 21..=23
+            | 26..=28
+            | 30
+            | 32
+            | 34..=38
+            | 40..=43
+    )
 }
 
 /// Encode the per-peer header (42 bytes, RFC 7854 §4.2).
@@ -396,8 +451,8 @@ pub fn encode_route_monitoring(
 
 /// Encode BMP Statistics Report (Type 1, RFC 7854 §4.8).
 ///
-/// `counters` are RFC 7854 numeric stat types (0-8, 11-13).
-/// `afi_counters` are AFI/SAFI-qualified stat types (9-10).
+/// `counters` are numeric stat types and `afi_counters` are
+/// AFI/SAFI-qualified stat types defined by RFC 7854, RFC 8671, and RFC 9972.
 /// Stat types placed in the wrong list are silently skipped.
 ///
 /// In v4 the Stats Count and stats data are enclosed in the mandatory
@@ -451,31 +506,32 @@ pub fn encode_stats_report(
     )]
     buf.put_u32(num_valid as u32);
 
-    for counter in counters {
-        if let Some(sz) = numeric_stat_size(counter.stat_type) {
-            buf.put_u16(counter.stat_type);
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "BMP 4-octet stat counters are encoded in their declared protocol field width"
-            )]
-            if sz == 4 {
-                buf.put_u16(4);
-                buf.put_u32(counter.value as u32);
-            } else {
-                buf.put_u16(8);
-                buf.put_u64(counter.value);
-            }
-        }
+    for counter in counters
+        .iter()
+        .filter(|counter| counter.stat_type < 18 && numeric_stat_size(counter.stat_type).is_some())
+    {
+        put_encoded_stat(&mut buf, &EncodedStat::Numeric(counter));
     }
-
-    for counter in afi_counters {
-        if is_afi_stat(counter.stat_type) {
-            buf.put_u16(counter.stat_type);
-            buf.put_u16(11); // AFI(2) + SAFI(1) + value(8) = 11
-            buf.put_u16(counter.afi);
-            buf.put_u8(counter.safi);
-            buf.put_u64(counter.value);
-        }
+    for counter in afi_counters
+        .iter()
+        .filter(|counter| counter.stat_type < 18 && is_afi_stat(counter.stat_type))
+    {
+        put_encoded_stat(&mut buf, &EncodedStat::Afi(counter));
+    }
+    let mut rfc9972_entries = counters
+        .iter()
+        .filter(|counter| counter.stat_type >= 18 && numeric_stat_size(counter.stat_type).is_some())
+        .map(EncodedStat::Numeric)
+        .chain(
+            afi_counters
+                .iter()
+                .filter(|counter| counter.stat_type >= 18 && is_afi_stat(counter.stat_type))
+                .map(EncodedStat::Afi),
+        )
+        .collect::<Vec<_>>();
+    rfc9972_entries.sort_by_key(EncodedStat::sort_key);
+    for entry in rfc9972_entries {
+        put_encoded_stat(&mut buf, &entry);
     }
 
     write_common_header(&mut buf, BMP_MSG_STATS_REPORT, version);
@@ -785,6 +841,135 @@ mod tests {
             stats_body,
             "value = the exact v3 count + stats bytes"
         );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one table-driven proof covers every final RFC 9972 numeric shape and exclusion"
+    )]
+    fn rfc9972_final_stat_shapes_and_order_are_exact() {
+        let numeric_types = [18, 20, 29, 31, 33, 39];
+        let afi_types = [
+            19, 21, 22, 23, 26, 27, 28, 30, 32, 34, 35, 36, 37, 38, 40, 41, 42, 43,
+        ];
+        let counters = numeric_types
+            .into_iter()
+            .rev()
+            .map(|stat_type| StatCounter {
+                stat_type,
+                value: u64::from(stat_type),
+            })
+            .chain([
+                StatCounter {
+                    stat_type: 15,
+                    value: 15,
+                },
+                StatCounter {
+                    stat_type: 7,
+                    value: 7,
+                },
+                StatCounter {
+                    stat_type: 24,
+                    value: 24,
+                },
+                StatCounter {
+                    stat_type: 25,
+                    value: 25,
+                },
+                StatCounter {
+                    stat_type: 21,
+                    value: 21,
+                },
+            ])
+            .collect::<Vec<_>>();
+        let afi_counters = afi_types
+            .into_iter()
+            .rev()
+            .map(|stat_type| AfiStatCounter {
+                stat_type,
+                afi: 2,
+                safi: 1,
+                value: u64::from(stat_type),
+            })
+            .chain([
+                AfiStatCounter {
+                    stat_type: 17,
+                    afi: 2,
+                    safi: 1,
+                    value: 17,
+                },
+                AfiStatCounter {
+                    stat_type: 17,
+                    afi: 1,
+                    safi: 1,
+                    value: 17,
+                },
+                AfiStatCounter {
+                    stat_type: 25,
+                    afi: 1,
+                    safi: 1,
+                    value: 25,
+                },
+                AfiStatCounter {
+                    stat_type: 24,
+                    afi: 1,
+                    safi: 1,
+                    value: 24,
+                },
+                AfiStatCounter {
+                    stat_type: 20,
+                    afi: 1,
+                    safi: 1,
+                    value: 20,
+                },
+            ])
+            .collect::<Vec<_>>();
+
+        let v3 = encode_stats_report(
+            &sample_peer_info(),
+            &counters,
+            &afi_counters,
+            BmpVersion::V3,
+        );
+        let mut cursor = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
+        let count = u32::from_be_bytes(v3[cursor..cursor + 4].try_into().unwrap()) as usize;
+        cursor += 4;
+        let mut seen = Vec::new();
+        for _ in 0..count {
+            let stat_type = u16::from_be_bytes(v3[cursor..cursor + 2].try_into().unwrap());
+            let len = u16::from_be_bytes(v3[cursor + 2..cursor + 4].try_into().unwrap());
+            seen.push((stat_type, len));
+            cursor += 4 + usize::from(len);
+        }
+        let mut expected = vec![(15, 8), (7, 8), (17, 11), (17, 11)];
+        for stat_type in 18..=43 {
+            if numeric_types.contains(&stat_type) {
+                expected.push((stat_type, 8));
+            } else if afi_types.contains(&stat_type) {
+                expected.push((stat_type, 11));
+            }
+        }
+        assert_eq!(
+            seen, expected,
+            "legacy input order, then sorted RFC 9972 block"
+        );
+        assert_eq!(cursor, v3.len());
+        assert!(
+            !seen
+                .iter()
+                .any(|(stat_type, _)| matches!(stat_type, 24 | 25))
+        );
+
+        let v4 = encode_stats_report(
+            &sample_peer_info(),
+            &counters,
+            &afi_counters,
+            BmpVersion::V4,
+        );
+        let v4_body = &v4[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + 4..];
+        let v3_body = &v3[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..];
+        assert_eq!(v4_body, v3_body, "v3/v4 statistics bodies must match");
     }
 
     /// draft-ietf-grow-bmp-tlv-21 §3 + §5.5: message types that already

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -398,6 +398,7 @@ impl BmpManager {
             BmpEvent::StatsReport {
                 peer_info,
                 adj_rib_in_routes,
+                rfc9972_adj_rib_in_post,
                 adj_rib_out_post,
             } => {
                 let mut counters = vec![codec::StatCounter {
@@ -405,6 +406,28 @@ impl BmpManager {
                     value: *adj_rib_in_routes,
                 }];
                 let mut afi_counters = Vec::new();
+                if let Some(per_family) = rfc9972_adj_rib_in_post {
+                    counters.push(codec::StatCounter {
+                        stat_type: 20,
+                        value: per_family.iter().map(|(_, _, count)| count).sum(),
+                    });
+                    let mut sorted = per_family.iter().collect::<Vec<_>>();
+                    sorted.sort_by_key(|(afi, safi, _)| (*afi, *safi));
+                    for &&(afi, safi, value) in &sorted {
+                        afi_counters.push(codec::AfiStatCounter {
+                            stat_type: 21,
+                            afi,
+                            safi,
+                            value,
+                        });
+                        afi_counters.push(codec::AfiStatCounter {
+                            stat_type: 23,
+                            afi,
+                            safi,
+                            value,
+                        });
+                    }
+                }
                 // RFC 8671: type 15 = post-policy Adj-RIB-Out total,
                 // type 17 = its per-AFI/SAFI breakdown. Omitted when
                 // the counts were unavailable this tick.
@@ -413,7 +436,9 @@ impl BmpManager {
                         stat_type: 15,
                         value: per_family.iter().map(|(_, _, count)| count).sum(),
                     });
-                    for &(afi, safi, value) in per_family {
+                    let mut sorted = per_family.iter().collect::<Vec<_>>();
+                    sorted.sort_by_key(|(afi, safi, _)| (*afi, *safi));
+                    for &&(afi, safi, value) in &sorted {
                         afi_counters.push(codec::AfiStatCounter {
                             stat_type: 17,
                             afi,
@@ -1581,6 +1606,7 @@ mod tests {
             .send(BmpEvent::StatsReport {
                 peer_info: sample_peer_info(),
                 adj_rib_in_routes: 42,
+                rfc9972_adj_rib_in_post: None,
                 adj_rib_out_post: None,
             })
             .await
@@ -1821,14 +1847,15 @@ mod tests {
             .send(BmpEvent::StatsReport {
                 peer_info: sample_peer_info(),
                 adj_rib_in_routes: 42,
-                adj_rib_out_post: Some(vec![(1, 1, 10), (2, 1, 5)]),
+                rfc9972_adj_rib_in_post: Some(vec![(2, 1, 7), (1, 1, 11)]),
+                adj_rib_out_post: Some(vec![(2, 1, 5), (1, 1, 10)]),
             })
             .await
             .unwrap();
 
         let msg = c_rx.recv().await.unwrap();
         let stats = decode_stats(&msg);
-        assert_eq!(stats.len(), 4);
+        assert_eq!(stats.len(), 9);
 
         let adj_rib_in_type = stats[0].0;
         let adj_rib_out_total_type = stats[1].0;
@@ -1847,8 +1874,18 @@ mod tests {
                 .iter()
                 .map(|(_, payload)| payload.len())
                 .collect::<Vec<_>>(),
-            vec![8, 8, 11, 11]
+            vec![8, 8, 11, 11, 8, 11, 11, 11, 11]
         );
+        assert_eq!(
+            stats
+                .iter()
+                .map(|(stat_type, _)| *stat_type)
+                .collect::<Vec<_>>(),
+            vec![7, 15, 17, 17, 20, 21, 21, 23, 23]
+        );
+        assert_eq!(u64::from_be_bytes(stats[4].1.try_into().unwrap()), 18);
+        assert_eq!(&stats[5].1[..3], &[0, 1, 1]);
+        assert_eq!(&stats[6].1[..3], &[0, 2, 1]);
 
         assert_eq!(u64::from_be_bytes(stats[0].1.try_into().unwrap()), 42);
         assert_eq!(u64::from_be_bytes(stats[1].1.try_into().unwrap()), 15);
@@ -1860,7 +1897,56 @@ mod tests {
         event_tx
             .send(BmpEvent::StatsReport {
                 peer_info: sample_peer_info(),
+                adj_rib_in_routes: 0,
+                rfc9972_adj_rib_in_post: Some(vec![(1, 1, 0), (2, 1, 0)]),
+                adj_rib_out_post: None,
+            })
+            .await
+            .unwrap();
+        let zero = c_rx.recv().await.unwrap();
+        let zero_stats = decode_stats(&zero);
+        assert_eq!(
+            zero_stats
+                .iter()
+                .map(|(stat_type, _)| *stat_type)
+                .collect::<Vec<_>>(),
+            vec![7, 20, 21, 21, 23, 23],
+            "available zero gauges remain present in legacy-then-RFC order"
+        );
+        assert_eq!(
+            zero_stats
+                .iter()
+                .filter(|(stat_type, payload)| *stat_type == 20 && payload.len() == 8)
+                .count(),
+            1
+        );
+        assert!(
+            zero_stats
+                .iter()
+                .all(|(stat_type, payload)| match stat_type {
+                    7 | 20 => payload.len() == 8 && payload.iter().all(|byte| *byte == 0),
+                    21 | 23 => {
+                        payload.len() == 11
+                            && matches!(&payload[..3], [0, 1 | 2, 1])
+                            && payload[3..].iter().all(|byte| *byte == 0)
+                    }
+                    _ => false,
+                })
+        );
+        for stat_type in [21, 23] {
+            let families = zero_stats
+                .iter()
+                .filter(|(candidate, _)| *candidate == stat_type)
+                .map(|(_, payload)| &payload[..3])
+                .collect::<Vec<_>>();
+            assert_eq!(families, vec![&[0, 1, 1], &[0, 2, 1]]);
+        }
+
+        event_tx
+            .send(BmpEvent::StatsReport {
+                peer_info: sample_peer_info(),
                 adj_rib_in_routes: 43,
+                rfc9972_adj_rib_in_post: None,
                 adj_rib_out_post: None,
             })
             .await
@@ -1915,7 +2001,9 @@ mod tests {
              Adj-RIB-Out total (type {adj_rib_out_total_type}) and per-(AFI, SAFI) counts \
              (type {adj_rib_out_family_type}); types \
              {adj_rib_out_total_type}/{adj_rib_out_family_type} are omitted when unavailable \
-             rather than reported as false zero."
+             rather than reported as false zero. RFC 9972 post-policy Adj-RIB-In gauges \
+             (types 20/21/23) cover negotiated IPv4/IPv6 unicast and are omitted when effective \
+             unicast Add-Path receive is active."
         );
         assert_eq!(
             actual,
@@ -2683,6 +2771,7 @@ mod tests {
             .send(BmpEvent::StatsReport {
                 peer_info: sample_peer_info(),
                 adj_rib_in_routes: 1,
+                rfc9972_adj_rib_in_post: None,
                 adj_rib_out_post: None,
             })
             .await
@@ -3405,6 +3494,7 @@ mod tests {
             .send(BmpEvent::StatsReport {
                 peer_info: sample_peer_info(),
                 adj_rib_in_routes: 7,
+                rfc9972_adj_rib_in_post: None,
                 adj_rib_out_post: None,
             })
             .await
@@ -3476,6 +3566,7 @@ mod tests {
             .send(BmpEvent::StatsReport {
                 peer_info: sample_peer_info(),
                 adj_rib_in_routes: 9,
+                rfc9972_adj_rib_in_post: None,
                 adj_rib_out_post: None,
             })
             .await

--- a/crates/bmp/src/types.rs
+++ b/crates/bmp/src/types.rs
@@ -46,6 +46,10 @@ pub enum BmpEvent {
         peer_info: BmpPeerInfo,
         /// RFC 7854 type 7: routes in Adj-RIB-In.
         adj_rib_in_routes: u64,
+        /// RFC 9972 post-policy Adj-RIB-In counts for negotiated IPv4/IPv6
+        /// unicast families. `None` omits types 20, 21, and 23, including
+        /// when effective Add-Path receive makes unique-prefix gauges inexact.
+        rfc9972_adj_rib_in_post: Option<Vec<(u16, u8, u64)>>,
         /// RFC 8671 post-policy Adj-RIB-Out counts per `(afi, safi)`,
         /// encoded as stat type 17 entries plus their sum as type 15.
         /// `None` means the counts were unavailable this tick — types

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -708,6 +708,8 @@ pub struct NegotiatedSessionState {
     pub four_octet_as: bool,
     /// Address families mutually negotiated in the OPEN exchange.
     pub families: Vec<(Afi, Safi)>,
+    /// Families for which this session negotiated Add-Path receive/both.
+    pub add_path_receive_families: Vec<(Afi, Safi)>,
     /// Whether the peer advertised the RFC 2918 Route Refresh capability, so a
     /// `SendRouteRefresh` command against this session can be delivered rather
     /// than rejected as `RouteRefreshUnsupported`.

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1158,6 +1158,9 @@ impl PeerSession {
                         let negotiated = neg?;
                         let mut families = negotiated.negotiated_families.clone();
                         families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+                        let mut add_path_receive_families = self.add_path_receive_families.clone();
+                        add_path_receive_families
+                            .sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
                         let graceful_restart = negotiated.peer_gr_capable.then(|| {
                             let mut peer_families = negotiated
                                 .peer_gr_families
@@ -1184,6 +1187,7 @@ impl PeerSession {
                             remote_router_id: negotiated.peer_router_id,
                             four_octet_as: negotiated.four_octet_as,
                             families,
+                            add_path_receive_families,
                             peer_route_refresh: negotiated.peer_route_refresh,
                             peer_enhanced_route_refresh: negotiated.peer_enhanced_route_refresh,
                             peer_extended_message: negotiated.peer_extended_message,

--- a/crates/transport/src/session/tests/bmp.rs
+++ b/crates/transport/src/session/tests/bmp.rs
@@ -739,6 +739,7 @@ async fn bmp_repair_timer_retries_until_channel_drains() {
         tx.try_send(BmpEvent::StatsReport {
             peer_info: session.build_bmp_peer_info(),
             adj_rib_in_routes: 0,
+            rfc9972_adj_rib_in_post: None,
             adj_rib_out_post: None,
         })
         .unwrap();
@@ -785,6 +786,7 @@ async fn bmp_peer_down_survives_full_channel() {
         tx.try_send(BmpEvent::StatsReport {
             peer_info: session.build_bmp_peer_info(),
             adj_rib_in_routes: 0,
+            rfc9972_adj_rib_in_post: None,
             adj_rib_out_post: None,
         })
         .unwrap();
@@ -837,6 +839,7 @@ async fn tcp_disconnect_clears_bmp_repair_latch() {
         tx.try_send(BmpEvent::StatsReport {
             peer_info: session.build_bmp_peer_info(),
             adj_rib_in_routes: 0,
+            rfc9972_adj_rib_in_post: None,
             adj_rib_out_post: None,
         })
         .unwrap();
@@ -888,6 +891,7 @@ async fn repair_partial_enqueue_duplicate_peer_down_is_acceptable() {
         tx.try_send(BmpEvent::StatsReport {
             peer_info: session.build_bmp_peer_info(),
             adj_rib_in_routes: 0,
+            rfc9972_adj_rib_in_post: None,
             adj_rib_out_post: None,
         })
         .unwrap();

--- a/crates/transport/src/session/tests/state_query.rs
+++ b/crates/transport/src/session/tests/state_query.rs
@@ -319,6 +319,7 @@ async fn query_state_projects_established_negotiation_and_capped_gr_runtime() {
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv6, Safi::Unicast), (Afi::Ipv4, Safi::Unicast)];
+    peer_config.add_path_receive = true;
     peer_config.graceful_restart = true;
     peer_config.gr_restart_time = 120;
     let mut session = make_test_session_with_peer_config(peer_config);
@@ -341,6 +342,11 @@ async fn query_state_projects_established_negotiation_and_capped_gr_runtime() {
                 Capability::RouteRefresh,
                 Capability::EnhancedRouteRefresh,
                 Capability::ExtendedMessage,
+                Capability::AddPath(vec![rustbgpd_wire::AddPathFamily {
+                    afi: Afi::Ipv4,
+                    safi: Safi::Unicast,
+                    send_receive: rustbgpd_wire::AddPathMode::Send,
+                }]),
                 Capability::GracefulRestart {
                     restart_state: false,
                     notification: false,
@@ -392,6 +398,10 @@ async fn query_state_projects_established_negotiation_and_capped_gr_runtime() {
     assert_eq!(negotiated.remote_router_id, Ipv4Addr::new(192, 0, 2, 7));
     assert!(negotiated.four_octet_as);
     assert_eq!(negotiated.families, vec![(Afi::Ipv4, Safi::Unicast)]);
+    assert_eq!(
+        negotiated.add_path_receive_families,
+        vec![(Afi::Ipv4, Safi::Unicast)]
+    );
     assert!(negotiated.peer_route_refresh);
     assert!(negotiated.peer_enhanced_route_refresh);
     assert!(negotiated.peer_extended_message);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3053,7 +3053,7 @@ BMP messages sent to collectors:
 | **Peer Up** (Type 3) | BGP session reaches Established (includes raw OPEN PDUs) |
 | **Peer Down** (Type 2) | BGP session leaves Established |
 | **Route Monitoring** (Type 0) | Inbound UPDATE received (pre-policy, raw PDU); with `rib_out_post`, also every outbound UPDATE (post-policy Adj-RIB-Out, RFC 8671); with `loc_rib`, every Loc-RIB best-path change plus the connect-time table dump (RFC 9069) |
-| **Stats Report** (Type 1) | Periodic per-peer export every 60s (Adj-RIB-In count type 7; post-policy Adj-RIB-Out gauges type 15 + per-AFI/SAFI type 17; with `loc_rib`, Loc-RIB gauges type 8 + per-AFI/SAFI type 10) |
+| **Stats Report** (Type 1) | Periodic per-peer export every 60s (Adj-RIB-In count type 7; RFC 9972 post-policy Adj-RIB-In gauges type 20 + negotiated IPv4/IPv6-unicast types 21/23, omitted under effective unicast Add-Path receive; post-policy Adj-RIB-Out gauges type 15 + per-AFI/SAFI type 17; with `loc_rib`, Loc-RIB gauges type 8 + per-AFI/SAFI type 10) |
 | **Termination** (Type 5) | On coordinated daemon shutdown (and on client channel shutdown) |
 
 Route Monitoring messages carry the original raw BGP UPDATE PDU bytes

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -9,6 +9,7 @@ use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_transport::{PeerHandle, PeerSessionState, StateQueryOutcome};
+use rustbgpd_wire::{Afi, Safi};
 use tokio_util::task::AbortOnDropHandle;
 use tracing::warn;
 
@@ -38,6 +39,33 @@ fn authentication_snapshot(
     } else {
         "plaintext"
     }
+}
+
+pub(super) fn rfc9972_adj_rib_in_counts(state: &PeerSessionState) -> Option<Vec<(u16, u8, u64)>> {
+    let session = state.negotiated_session.as_ref()?;
+    if session
+        .add_path_receive_families
+        .iter()
+        .any(|family| matches!(family, (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast)))
+    {
+        return None;
+    }
+    let mut counts = Vec::new();
+    if session.families.contains(&(Afi::Ipv4, Safi::Unicast)) {
+        counts.push((
+            Afi::Ipv4 as u16,
+            Safi::Unicast as u8,
+            u64::try_from(state.max_prefix.prefix_count_ipv4).unwrap_or(u64::MAX),
+        ));
+    }
+    if session.families.contains(&(Afi::Ipv6, Safi::Unicast)) {
+        counts.push((
+            Afi::Ipv6 as u16,
+            Safi::Unicast as u8,
+            u64::try_from(state.max_prefix.prefix_count_ipv6).unwrap_or(u64::MAX),
+        ));
+    }
+    (!counts.is_empty()).then_some(counts)
 }
 
 /// Build a `PeerInfo` snapshot from config + an optional fresh
@@ -628,6 +656,7 @@ impl PeerManager {
             }
 
             let prefix_count = u64::try_from(state.prefix_count).unwrap_or(u64::MAX);
+            let rfc9972_adj_rib_in_post = rfc9972_adj_rib_in_counts(state);
             let remote_asn = effective_remote_asn(managed, Some(state));
             // RFC 8671 types 15/17: a peer absent from the RIB's
             // Adj-RIB-Out map simply has nothing advertised — report
@@ -651,6 +680,7 @@ impl PeerManager {
                     state.four_octet_as,
                 ),
                 adj_rib_in_routes: prefix_count,
+                rfc9972_adj_rib_in_post,
                 adj_rib_out_post,
             };
 

--- a/src/peer_manager/tests/metrics.rs
+++ b/src/peer_manager/tests/metrics.rs
@@ -598,6 +598,36 @@ async fn dynamic_peer_auto_removal_reaps_metric_series() {
 /// The 60s BMP stats tick sources RFC 8671 types 15/17 from the RIB's
 /// per-peer Adj-RIB-Out family counts via one `QueryAdjRibOutCounts`
 /// round-trip, converting `(Afi, Safi)` to raw wire codes.
+fn rfc9972_stats_peer_handle(peer_addr: IpAddr) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let task = tokio::spawn(async move {
+        while let Some(command) = session_rx.recv().await {
+            match command {
+                PeerCommand::QueryState { reply } => {
+                    let mut state = policy_test_peer_state(peer_addr, SessionState::Established);
+                    state.peer_asn = Some(65002);
+                    state.remote_router_id = Some(Ipv4Addr::new(10, 0, 0, 2));
+                    state.four_octet_as = Some(true);
+                    state.prefix_count = 22;
+                    state.max_prefix.prefix_count_ipv4 = 12;
+                    state.max_prefix.prefix_count_ipv6 = 7;
+                    let mut negotiated = test_negotiated_session(true);
+                    negotiated.families =
+                        vec![(Afi::Ipv6, Safi::Unicast), (Afi::Ipv4, Safi::Unicast)];
+                    state.negotiated_session = Some(negotiated);
+                    let _ = reply.send(state);
+                }
+                PeerCommand::Shutdown => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
 #[tokio::test]
 async fn periodic_bmp_stats_carry_adj_rib_out_counts() {
     let (_tx, rx) = mpsc::channel(16);
@@ -614,18 +644,7 @@ async fn periodic_bmp_stats_carry_adj_rib_out_counts() {
         Some(bmp_tx),
     );
     let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
-    let counters = Arc::new(FakePeerCounters::default());
-    insert_test_managed_peer(
-        &mut mgr,
-        addr,
-        fake_peer_handle(
-            addr,
-            SessionState::Established,
-            Some(Ipv4Addr::new(10, 0, 0, 2)),
-            counters,
-        ),
-        false,
-    );
+    insert_test_managed_peer(&mut mgr, addr, rfc9972_stats_peer_handle(addr), false);
 
     // Answer the single RIB-wide Adj-RIB-Out counts query.
     let rib_task = tokio::spawn(async move {
@@ -653,10 +672,12 @@ async fn periodic_bmp_stats_carry_adj_rib_out_counts() {
         rustbgpd_bmp::BmpEvent::StatsReport {
             peer_info,
             adj_rib_in_routes,
+            rfc9972_adj_rib_in_post,
             adj_rib_out_post,
         } => {
             assert_eq!(peer_info.peer_addr, addr);
-            assert_eq!(adj_rib_in_routes, 0);
+            assert_eq!(adj_rib_in_routes, 22);
+            assert_eq!(rfc9972_adj_rib_in_post, Some(vec![(1, 1, 12), (2, 1, 7)]));
             assert_eq!(
                 adj_rib_out_post,
                 Some(vec![(1, 1, 12), (1, 128, 3)]),
@@ -665,6 +686,50 @@ async fn periodic_bmp_stats_carry_adj_rib_out_counts() {
         }
         other => panic!("expected StatsReport, got {other:?}"),
     }
+}
+
+#[test]
+fn rfc9972_stats_use_exact_unicast_counts_and_omit_for_effective_add_path() {
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut state = policy_test_peer_state(addr, SessionState::Established);
+    state.prefix_count = 99;
+    state.max_prefix.prefix_count_ipv4 = 12;
+    state.max_prefix.prefix_count_ipv6 = 7;
+    let mut negotiated = test_negotiated_session(true);
+    negotiated.families = vec![
+        (Afi::Ipv6, Safi::Unicast),
+        (Afi::Ipv4, Safi::MplsVpn),
+        (Afi::Ipv4, Safi::Unicast),
+    ];
+    state.negotiated_session = Some(negotiated);
+
+    assert_eq!(
+        super::super::snapshot::rfc9972_adj_rib_in_counts(&state),
+        Some(vec![(1, 1, 12), (2, 1, 7)]),
+        "only exact IPv4/IPv6-unicast gauges are emitted in wire-family order"
+    );
+
+    state
+        .negotiated_session
+        .as_mut()
+        .unwrap()
+        .add_path_receive_families = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    assert_eq!(
+        super::super::snapshot::rfc9972_adj_rib_in_counts(&state),
+        Some(vec![(1, 1, 12), (2, 1, 7)]),
+        "non-unicast Add-Path does not make the unicast gauges inexact"
+    );
+
+    state
+        .negotiated_session
+        .as_mut()
+        .unwrap()
+        .add_path_receive_families = vec![(Afi::Ipv4, Safi::Unicast)];
+    assert_eq!(
+        super::super::snapshot::rfc9972_adj_rib_in_counts(&state),
+        None,
+        "any effective unicast Add-Path receive family suppresses the whole gauge set"
+    );
 }
 
 #[tokio::test]
@@ -736,6 +801,7 @@ async fn periodic_bmp_stats_channel_full_records_the_source_drop() {
                 timestamp: std::time::SystemTime::now(),
             },
             adj_rib_in_routes: 0,
+            rfc9972_adj_rib_in_post: None,
             adj_rib_out_post: None,
         })
         .unwrap();

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -1221,6 +1221,7 @@ fn test_negotiated_session(route_refresh: bool) -> rustbgpd_transport::Negotiate
         remote_router_id: Ipv4Addr::new(192, 0, 2, 1),
         four_octet_as: true,
         families: vec![(Afi::Ipv4, Safi::Unicast)],
+        add_path_receive_families: Vec::new(),
         peer_route_refresh: route_refresh,
         peer_enhanced_route_refresh: false,
         peer_extended_message: false,

--- a/src/peer_manager/tests/snapshots.rs
+++ b/src/peer_manager/tests/snapshots.rs
@@ -534,6 +534,7 @@ async fn negotiated_snapshot_uses_only_fresh_established_actor_state() {
         remote_router_id: Ipv4Addr::new(192, 0, 2, 7),
         four_octet_as: false,
         families: vec![(Afi::Ipv6, Safi::Unicast)],
+        add_path_receive_families: Vec::new(),
         peer_route_refresh: true,
         peer_enhanced_route_refresh: true,
         peer_extended_message: true,

--- a/tests/interop/scripts/m81-bmp-assert.py
+++ b/tests/interop/scripts/m81-bmp-assert.py
@@ -249,13 +249,30 @@ def cmd_stats_v4_wrap():
 
 def _stat_types(body):
     """Stat type codes in an RFC 7854 stats body (count + TLVs)."""
+    return [stat_type for stat_type, _payload in _stats(body)]
+
+
+def _stats(body):
+    """(type, payload) entries in an RFC 7854 stats body."""
+    if len(body) < 4:
+        fail(f"truncated stats count: need 4 bytes, have {len(body)}")
     count = u32(body, 0)
-    off, types = 4, []
-    for _ in range(count):
+    off, entries = 4, []
+    for index in range(count):
+        if off + 4 > len(body):
+            fail(f"truncated stats entry {index} header at offset {off}: "
+                 f"need 4 bytes, have {len(body) - off}")
         t, ln = u16(body, off), u16(body, off + 2)
-        types.append(t)
-        off += 4 + ln
-    return types
+        value_start, value_end = off + 4, off + 4 + ln
+        if value_end > len(body):
+            fail(f"truncated stats entry {index} type {t} value at offset "
+                 f"{value_start}: need {ln} bytes, have {len(body) - value_start}")
+        payload = body[value_start:value_end]
+        entries.append((t, payload))
+        off = value_end
+    if off != len(body):
+        fail(f"stats body has {len(body) - off} trailing bytes")
+    return entries
 
 
 def cmd_stats_locrib_counts():
@@ -272,8 +289,38 @@ def cmd_stats_locrib_counts():
     ptypes = _stat_types(peer[-1]["raw"][6 + PER_PEER_LEN :])
     if 7 not in ptypes:
         fail(f"peer stats types {ptypes} missing 7 (Adj-RIB-In)")
+    for required in (20, 21, 23):
+        if required not in ptypes:
+            fail(f"peer stats types {ptypes} missing RFC 9972 type {required}")
+    legacy_end = max(i for i, t in enumerate(ptypes) if t in (7, 15, 17))
+    rfc_start = min(i for i, t in enumerate(ptypes) if t >= 18)
+    if legacy_end >= rfc_start:
+        fail(f"peer stats types {ptypes}: RFC 9972 block precedes legacy block")
+    rfc_types = ptypes[rfc_start:]
+    if rfc_types != sorted(rfc_types):
+        fail(f"peer RFC 9972 stats block is not sorted by type: {rfc_types}")
+    if ptypes.count(20) != 1 or ptypes.count(21) != 2 or ptypes.count(23) != 2:
+        fail(f"peer stats types {ptypes}: expected one global and two family gauges")
+    entries = _stats(peer[-1]["raw"][6 + PER_PEER_LEN :])
+    global_rows = [payload for stat_type, payload in entries if stat_type == 20]
+    family_21 = [payload for stat_type, payload in entries if stat_type == 21]
+    family_23 = [payload for stat_type, payload in entries if stat_type == 23]
+    if len(global_rows[0]) != 8:
+        fail(f"RFC 9972 type 20 length {len(global_rows[0])} != 8")
+    for stat_type, rows in ((21, family_21), (23, family_23)):
+        if any(len(row) != 11 for row in rows):
+            fail(f"RFC 9972 type {stat_type} rows do not all have length 11")
+        families = [(u16(row, 0), row[2]) for row in rows]
+        if families != [(1, 1), (2, 1)]:
+            fail(f"RFC 9972 type {stat_type} families {families} != v4/v6 unicast")
+    if family_21 != family_23:
+        fail("RFC 9972 accepted-route type 21/23 family payloads differ")
+    total = int.from_bytes(global_rows[0], "big")
+    family_total = sum(int.from_bytes(row[3:], "big") for row in family_21)
+    if total != family_total:
+        fail(f"RFC 9972 type 20 value {total} != family sum {family_total}")
     ok(f"stats: loc-rib peer carries types 8+10 ({types}); regular peer "
-       f"carries type 7 ({ptypes})")
+       f"carries legacy and RFC 9972 Adj-RIB-In gauges ({ptypes})")
 
 
 def cmd_no_path_marking():


### PR DESCRIPTION
## Summary

- support every final RFC 9972 BMP Statistics Report wire shape while excluding temporary predecessor assignments 24 and 25
- emit exact post-policy Adj-RIB-In gauges 20, 21, and 23 from actor-consistent negotiated IPv4/IPv6-unicast state, omitting them whenever effective Add-Path receive makes the unique-prefix counters inexact
- preserve the legacy statistics block, deterministically order family rows, keep BMPv3 and BMPv4 bodies identical, and extend operator docs plus the M81 raw-byte oracle

## Verification

- full rustbgpd-bmp suite: 87 passed plus README contract and doc tests
- full rustbgpd-transport suite: 523 passed, 3 ignored; listener 21 passed; lifecycle 15 passed
- full peer-manager suite: 356 passed
- focused codec, manager wire, periodic source, effective negotiation, available-zero versus unavailable, and malformed-oracle boundary tests
- exact-head local M81 topology: 48 passed, 0 failed, including live RFC 9972 lengths, families, type-21/type-23 equality, type-20 summation, repeated legacy-type boundary coverage, and v3/v4 body parity
- clippy with warnings denied for bmp, transport, and root across all targets and features
- formatting, diff checks, Python oracle syntax, workspace pre-push hooks
- independent final protocol and compatibility review: approved at head 8d4f727d