### PR TITLE
ci: fix fuzz corpus staging context

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,7 +18,6 @@ jobs:
     timeout-minutes: 90
     env:
       WIRE_CORPUS_WRITER: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      WIRE_CACHE_BUNDLE: ${{ runner.temp }}/wire-corpus-cache
     steps:
       - uses: actions/checkout@v7
       # fuzz/rust-nightly.txt holds the single reviewed nightly, shared with
@@ -49,12 +48,13 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@v6
         with:
-          path: ${{ env.WIRE_CACHE_BUNDLE }}
+          path: ${{ runner.temp }}/wire-corpus-cache
           key: wire-fuzz-corpus-v1-main-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             wire-fuzz-corpus-v1-main-
       - name: Validate and install wire corpus
         env:
+          WIRE_CACHE_BUNDLE: ${{ runner.temp }}/wire-corpus-cache
           RESTORE_MATCHED_KEY: ${{ steps.wire-corpus-restore.outputs.cache-matched-key }}
           RESTORE_OUTCOME: ${{ steps.wire-corpus-restore.outcome }}
         run: |
@@ -218,6 +218,8 @@ jobs:
       - name: Seal bounded wire corpus cache
         id: wire-corpus-seal
         if: success() && env.WIRE_CORPUS_WRITER == 'true'
+        env:
+          WIRE_CACHE_BUNDLE: ${{ runner.temp }}/wire-corpus-cache
         run: |
           set +e
           python3 scripts/fuzz_corpus_cache.py seal \
@@ -236,5 +238,5 @@ jobs:
         continue-on-error: true
         uses: actions/cache/save@v6
         with:
-          path: ${{ env.WIRE_CACHE_BUNDLE }}
+          path: ${{ runner.temp }}/wire-corpus-cache
           key: wire-fuzz-corpus-v1-main-${{ github.run_id }}-${{ github.run_attempt }}

--- a/scripts/check_fuzz_target_inventory.py
+++ b/scripts/check_fuzz_target_inventory.py
@@ -535,6 +535,12 @@ def validate_wire_corpus_cache_contract(
         raise InventoryError("nightly wire corpus cache unique run key count differs")
     if "WIRE_SEALED_BUNDLE" in workflow:
         raise InventoryError("nightly wire corpus cache has distinct seal staging")
+    job_header = workflow[: workflow.index("    steps:\n")]
+    if "runner." in job_header:
+        raise InventoryError("nightly wire corpus cache uses runner context in job env")
+    bundle_env = "WIRE_CACHE_BUNDLE: ${{ runner.temp }}/wire-corpus-cache"
+    if workflow.count(bundle_env) != 2:
+        raise InventoryError("wire corpus cache step staging count differs")
 
     restore_block = re.search(
         r"(?ms)^      - name: Restore bounded wire corpus cache\n(?P<body>.*?)(?=^      - name:)",
@@ -550,7 +556,7 @@ def validate_wire_corpus_cache_contract(
         raise InventoryError("cache restore outage is not an explicit fallback")
     if save_block is None or "continue-on-error: true" not in save_block.group("body"):
         raise InventoryError("cache save outage can fail the completed campaign")
-    cache_path = "path: ${{ env.WIRE_CACHE_BUNDLE }}"
+    cache_path = "path: ${{ runner.temp }}/wire-corpus-cache"
     if (
         cache_path not in restore_block.group("body")
         or cache_path not in save_block.group("body")

--- a/scripts/check_fuzz_target_inventory.py
+++ b/scripts/check_fuzz_target_inventory.py
@@ -535,7 +535,10 @@ def validate_wire_corpus_cache_contract(
         raise InventoryError("nightly wire corpus cache unique run key count differs")
     if "WIRE_SEALED_BUNDLE" in workflow:
         raise InventoryError("nightly wire corpus cache has distinct seal staging")
-    job_header = workflow[: workflow.index("    steps:\n")]
+    steps_index = workflow.find("    steps:\n")
+    if steps_index < 0:
+        raise InventoryError("nightly wire corpus cache lacks steps marker")
+    job_header = workflow[:steps_index]
     if "runner." in job_header:
         raise InventoryError("nightly wire corpus cache uses runner context in job env")
     bundle_env = "WIRE_CACHE_BUNDLE: ${{ runner.temp }}/wire-corpus-cache"

--- a/scripts/test_check_fuzz_target_inventory.py
+++ b/scripts/test_check_fuzz_target_inventory.py
@@ -545,6 +545,12 @@ class FuzzTargetInventoryTests(unittest.TestCase):
                 invalid_job_env, helper, dictionary
             )
 
+        missing_steps = workflow.replace("    steps:\n", "    workflow-steps:\n", 1)
+        with self.assertRaisesRegex(inventory.InventoryError, "lacks steps marker"):
+            inventory.validate_wire_corpus_cache_contract(
+                missing_steps, helper, dictionary
+            )
+
         reordered = workflow.replace(
             "python3 scripts/fuzz_corpus_cache.py seal",
             "python3 scripts/fuzz_corpus_cache.py restore",

--- a/scripts/test_check_fuzz_target_inventory.py
+++ b/scripts/test_check_fuzz_target_inventory.py
@@ -490,7 +490,7 @@ class FuzzTargetInventoryTests(unittest.TestCase):
         )
         for name, old, new in mutations:
             with self.subTest(contract=name), self.assertRaisesRegex(
-                inventory.InventoryError, "nightly wire corpus cache"
+                inventory.InventoryError, "wire corpus cache"
             ):
                 inventory.validate_wire_corpus_cache_contract(
                     workflow.replace(old, new, 1), helper, dictionary
@@ -504,7 +504,8 @@ class FuzzTargetInventoryTests(unittest.TestCase):
         restore_continue = workflow.index("continue-on-error: true", restore_start)
         save_start = workflow.index("- name: Save bounded wire corpus cache")
         save_continue = workflow.index("continue-on-error: true", save_start)
-        save_path = workflow.index("path: ${{ env.WIRE_CACHE_BUNDLE }}", save_start)
+        cache_path = "path: ${{ runner.temp }}/wire-corpus-cache"
+        save_path = workflow.index(cache_path, save_start)
         for name, position in (
             ("restore", restore_continue),
             ("save", save_continue),
@@ -524,11 +525,24 @@ class FuzzTargetInventoryTests(unittest.TestCase):
         distinct_save_path = (
             workflow[:save_path]
             + "path: ${{ runner.temp }}/wire-corpus-save"
-            + workflow[save_path + len("path: ${{ env.WIRE_CACHE_BUNDLE }}") :]
+            + workflow[save_path + len(cache_path) :]
         )
         with self.assertRaisesRegex(inventory.InventoryError, "action paths differ"):
             inventory.validate_wire_corpus_cache_contract(
                 distinct_save_path, helper, dictionary
+            )
+
+        steps = workflow.index("    steps:\n")
+        invalid_job_env = (
+            workflow[:steps]
+            + "      WIRE_CACHE_BUNDLE: ${{ runner.temp }}/wire-corpus-cache\n"
+            + workflow[steps:]
+        )
+        with self.assertRaisesRegex(
+            inventory.InventoryError, "runner context in job env"
+        ):
+            inventory.validate_wire_corpus_cache_contract(
+                invalid_job_env, helper, dictionary
             )
 
         reordered = workflow.replace(


### PR DESCRIPTION
## Summary

- scope fuzz corpus staging to workflow contexts where `runner.temp` is available
- preserve one identical temporary path across restore, install, seal, and save
- reject job-level runner-context use and restore/save path drift in the inventory contract

## Why

The first post-merge commissioning dispatch for the bounded corpus cache was rejected before a run was created because GitHub does not expose the `runner` context in a job-level `env`. Step environments and action inputs do expose it.

## Validation

- actionlint 1.7.12 reproduces the parent workflow failure and accepts this workflow
- 79 combined corpus-cache, inventory, toolchain, and CI-routing tests
- live 21-target inventory and toolchain-pin checks
- full pre-push fmt, clippy, workspace library tests, and rustdoc
- independent exact-head review: GO_PR_FIX

Tracks LAN-1346. The issue remains in progress until two consecutive main commissioning runs prove save and restore.
