### PR TITLE
ci: harden developer and benchmark tooling gates

### DIFF
--- a/.github/scripts/install-developer-linters.sh
+++ b/.github/scripts/install-developer-linters.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTIONLINT_VERSION="1.7.12"
+ACTIONLINT_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+ACTIONLINT_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+RUFF_VERSION="0.16.0"
+RUFF_SHA256="98001c995a134d95f9bc83106a7f94b552971b583f1c0ab75fb656a881e13865"
+RUFF_URL="https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz"
+
+usage() {
+    echo "usage: $0 INSTALL_DIR" >&2
+    echo "Installs the exact Linux amd64 developer linters into a new directory." >&2
+}
+
+fail() {
+    echo "install-developer-linters: $*" >&2
+    exit 1
+}
+
+download() {
+    local url=$1
+    local output=$2
+
+    curl --fail --location --silent --show-error \
+        --proto '=https' --tlsv1.2 \
+        --connect-timeout 15 --max-time 120 \
+        --retry 3 --retry-delay 1 --retry-max-time 300 --retry-all-errors \
+        --output "$output" "$url"
+}
+
+verify_sha256() {
+    local archive=$1
+    local expected=$2
+
+    printf '%s  %s\n' "$expected" "$archive" | sha256sum --check --status - \
+        || fail "checksum mismatch for $(basename "$archive")"
+}
+
+extract_binary() {
+    local archive=$1
+    local member=$2
+    local output=$3
+    local count
+
+    count=$(tar -tzf "$archive" | grep -Fxc -- "$member" || true)
+    [[ "$count" == 1 ]] || fail "archive does not contain exactly one $member"
+    tar -xOzf "$archive" "$member" > "$output"
+    chmod 0755 "$output"
+}
+
+[[ $# == 1 ]] || {
+    usage
+    exit 2
+}
+
+destination=$1
+[[ -n "$destination" && "$destination" != "/" ]] || fail "INSTALL_DIR must name a directory"
+[[ ! -e "$destination" ]] || fail "INSTALL_DIR already exists: $destination"
+
+parent=$(dirname "$destination")
+name=$(basename "$destination")
+mkdir -p "$parent"
+staging=$(mktemp -d "$parent/.${name}.tmp.XXXXXX")
+
+cleanup() {
+    if [[ -n "${staging:-}" && -d "$staging" ]]; then
+        find "$staging" -mindepth 1 -delete
+        rmdir "$staging"
+    fi
+}
+trap cleanup EXIT
+
+actionlint_archive="$staging/actionlint.tar.gz"
+ruff_archive="$staging/ruff.tar.gz"
+
+download "$ACTIONLINT_URL" "$actionlint_archive"
+verify_sha256 "$actionlint_archive" "$ACTIONLINT_SHA256"
+extract_binary "$actionlint_archive" actionlint "$staging/actionlint"
+
+download "$RUFF_URL" "$ruff_archive"
+verify_sha256 "$ruff_archive" "$RUFF_SHA256"
+extract_binary "$ruff_archive" \
+    ruff-x86_64-unknown-linux-gnu/ruff "$staging/ruff"
+
+actionlint_version=$("$staging/actionlint" -version)
+[[ "${actionlint_version%%$'\n'*}" == "$ACTIONLINT_VERSION" ]] \
+    || fail "actionlint version check failed"
+[[ "$("$staging/ruff" --version)" == "ruff $RUFF_VERSION" ]] \
+    || fail "Ruff version check failed"
+
+find "$staging" -type f ! -name actionlint ! -name ruff -delete
+mv --no-target-directory "$staging" "$destination"
+staging=
+trap - EXIT
+
+printf 'installed actionlint %s and Ruff %s in %s\n' \
+    "$ACTIONLINT_VERSION" "$RUFF_VERSION" "$destination"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,7 @@ jobs:
             --artifact-dir docs/perf/artifacts/reload-authoritative-batch-discriminator-2026-08
           bash -n bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh
           shellcheck bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh
+          shellcheck bench/compare-route-paging.sh bench/compare-rib-memory.sh
           shellcheck bench/smoke-benches.sh
           bash -n bench/scale/route-server-1000/run-receipt.sh
           bash -n bench/scale/enhanced-route-refresh/run-receipt.sh
@@ -414,6 +415,8 @@ jobs:
           bash bench/tests/test-vpn-query-receipt.sh
           bash bench/tests/test-vpn-query-campaign.sh
           bash bench/tests/test-compare-criterion-harness.sh
+          bash bench/tests/test-route-paging-driver.sh
+          python3 bench/tests/test_verify_mrt_attribute_scratch_campaign.py
           bash -n bench/scale/compare-rrharness.sh
           bash bench/tests/test-rrharness-driver.sh
           python3 -m unittest discover \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,18 @@ jobs:
             echo "CI triggers must keep main-only pushes, all PRs, and Markdown ignores" >&2
             exit 1
           fi
+      - name: Install exact developer linters
+        shell: bash
+        run: |
+          bash -n .github/scripts/install-developer-linters.sh
+          shellcheck .github/scripts/install-developer-linters.sh
+          .github/scripts/install-developer-linters.sh \
+            "$RUNNER_TEMP/developer-linters"
+          echo "$RUNNER_TEMP/developer-linters" >> "$GITHUB_PATH"
+      - name: Prove developer-tooling lint failures are enforced
+        run: python3 scripts/check_developer_tooling.py --self-test
+      - name: Check Python and GitHub Actions developer tooling
+        run: python3 scripts/check_developer_tooling.py
       # The chooser's security link once pointed at a posture doc and a
       # nonexistent security email; keep it pinned to the private
       # vulnerability-reporting intake so it cannot silently drift again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,33 @@ workspace benchmark packages. Any `#[allow(clippy::...)]` or
 the escape hatch is intentional. New workspace packages are covered without
 maintaining a second crate list.
 
+### Developer lint gate
+
+The developer-tooling gate uses actionlint 1.7.12 and Ruff 0.16.0. On Linux
+amd64, install those exact binaries once into a new local directory, prove the
+negative fixtures, and run the live checks with:
+
+```bash
+tools="${XDG_DATA_HOME:-$HOME/.local/share}/rustbgpd/developer-linters-1.7.12-ruff-0.16.0"
+.github/scripts/install-developer-linters.sh "$tools"
+PATH="$tools:$PATH" python3 scripts/check_developer_tooling.py --self-test
+PATH="$tools:$PATH" python3 scripts/check_developer_tooling.py
+```
+
+The installer rejects an existing destination instead of partially updating
+it. After the first install, reuse the final two commands. The checker rejects
+any other tool versions, runs Ruff from the repository root, and lets
+actionlint discover every workflow under `.github/workflows/`.
+
+The initial Ruff boundary targets Python 3.11, keeps the 100-character line
+length setting, and enables only `E9`, `F`, and `B`. `B904` and `B905` are
+temporarily ignored so enabling lint does not bundle exception-chaining or
+`zip(strict=...)` behavior changes. The two exact per-file migration exceptions
+are recorded in `pyproject.toml`; new blanket or directory-wide exceptions are
+not part of this boundary. actionlint runs with its ShellCheck and Pyflakes
+integrations disabled; the existing explicitly scoped ShellCheck commands
+remain responsible for shell scripts.
+
 ### Pre-commit hooks
 
 We ship a `.pre-commit-config.yaml` that runs `cargo fmt` and

--- a/bench/run-fib-kernel-dump.py
+++ b/bench/run-fib-kernel-dump.py
@@ -227,13 +227,13 @@ def main():
         for table_count in table_counts:
             expected_global, expected_filtered = fixed_count + foreign_size, table_count * 2
 
-            def global_dump():
+            def global_dump(expected_global=expected_global):
                 count, _, _ = strict.dump()
                 if count != expected_global:
                     raise RuntimeError(f"global route count {count} != {expected_global}")
                 return count
 
-            def filtered_dump():
+            def filtered_dump(table_count=table_count, expected_filtered=expected_filtered):
                 count = 0
                 for table in range(1000, 1000 + table_count):
                     got, tables, flags = strict.dump(table)

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -2145,7 +2145,7 @@ def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> Non
         if cell in ("rustbgpd-sighup", GROUPED_CELL):
             topology_mode = "private" if cell == "rustbgpd-sighup" else "grouped"
             (cdir / "topology.json").write_text(json.dumps({"status": "pass", "mode": topology_mode, "peers": 320, "scrape_epoch_ns": [1_000_000_000, 2_000_000_000, 3_000_000_000], "group_id": 7, "first_reload_wall_us": 4_000_000, "overlap_fraction": 0.0, "overlap_pairs": 0}))
-            received_rows = [f"received_view_v1\ttotal=183040\tpeers=320"]
+            received_rows = ["received_view_v1\ttotal=183040\tpeers=320"]
             for observer in range(320):
                 own = ",".join(str(index) for index in range(observer * 572, (observer + 1) * 572))
                 received_rows.append(f"{observer}\t572\t{own}")

--- a/bench/scale/rebaseline/parse_rrharness.py
+++ b/bench/scale/rebaseline/parse_rrharness.py
@@ -15,7 +15,6 @@ import hashlib
 import math
 from pathlib import Path
 import re
-import sys
 
 from classify_cpu import OUTPUT_PHASES
 

--- a/bench/scale/reloadstall/gen-irr-scenario.py
+++ b/bench/scale/reloadstall/gen-irr-scenario.py
@@ -680,7 +680,7 @@ def emit_rustbgpd(args, members: list[Member], out: pathlib.Path) -> list[str]:
             )
         policy_manifest, policy_manifest_digest = write_policy_manifest(out, a_roster)
         changed_by_kind = {"asn-set": 0, "prefix-set": 0}
-        for name, (kind, relative) in a_shape.items():
+        for _name, (kind, relative) in a_shape.items():
             if (a_dir / relative).read_bytes() != (b_dir / relative).read_bytes():
                 changed_by_kind[kind] += 1
         expected_changed = sum(member.changed for member in members)

--- a/justfile
+++ b/justfile
@@ -6,6 +6,8 @@ default:
 
 # Run the broad local correctness baseline in diagnostic order.
 gate:
+    python3 scripts/check_developer_tooling.py --self-test
+    python3 scripts/check_developer_tooling.py
     cargo fmt --all -- --check
     python3 -m unittest -v scripts/test_check_clippy_reasons.py
     python3 scripts/check-clippy-reasons.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E9", "F", "B"]
+# Temporary migration boundary: existing raise chaining and zip strictness are
+# unchanged while the initial lint gate lands. Remove these by semantic cleanup.
+ignore = ["B904", "B905"]
+
+[tool.ruff.lint.per-file-ignores]
+"docs/perf/artifacts/v0.61.0-final-performance-2026-07/verify.py" = ["F401"]
+"scripts/test_check_fuzz_target_inventory.py" = ["B023"]

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -455,7 +455,7 @@ def check(root: Path) -> list[str]:
             "needs: v064_validator",
             "uses: actions/download-artifact@v8",
             f"name: {V064_ARTIFACT}",
-            f"path: ${{{{ runner.temp }}}}/rustbgpd-v064-artifact",
+            "path: ${{ runner.temp }}/rustbgpd-v064-artifact",
             "--install-archive",
             f'"$RUNNER_TEMP/rustbgpd-v064-artifact/{V064_ARCHIVE}"',
             '"$RUNNER_TEMP/rustbgpd-v064"',

--- a/scripts/check_developer_tooling.py
+++ b/scripts/check_developer_tooling.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Run the repository's exact developer-tooling lint contract."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_VERSIONS = {
+    "actionlint": "1.7.12",
+    "ruff": "ruff 0.16.0",
+}
+ACTIONLINT_FLAGS = ("-no-color", "-shellcheck=", "-pyflakes=")
+
+
+class CheckFailed(Exception):
+    """The developer-tooling contract did not hold."""
+
+
+def binary(name: str) -> str:
+    path = shutil.which(name)
+    if path is None:
+        raise CheckFailed(f"{name} is not installed or is absent from PATH")
+    return path
+
+
+def exact_version(command: list[str], expected: str) -> None:
+    result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+    lines = result.stdout.splitlines()
+    actual = lines[0].strip() if lines else ""
+    if result.returncode != 0 or actual != expected:
+        detail = actual or result.stderr.strip() or f"exit {result.returncode}"
+        raise CheckFailed(f"expected {expected!r} from {' '.join(command)}, got {detail!r}")
+
+
+def tools() -> tuple[str, str]:
+    actionlint = binary("actionlint")
+    ruff = binary("ruff")
+    exact_version([actionlint, "-version"], EXPECTED_VERSIONS["actionlint"])
+    exact_version([ruff, "--version"], EXPECTED_VERSIONS["ruff"])
+    return actionlint, ruff
+
+
+def expected_failure(command: list[str], needle: str) -> str:
+    result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+    output = result.stdout + result.stderr
+    if result.returncode == 0:
+        raise CheckFailed(f"negative fixture unexpectedly passed: {' '.join(command)}")
+    if needle not in output:
+        raise CheckFailed(
+            f"negative fixture did not report {needle!r}: {' '.join(command)}\n{output}"
+        )
+    return output
+
+
+def self_test(actionlint: str, ruff: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="rustbgpd-developer-lint-") as temporary:
+        fixture = Path(temporary)
+        undefined_name = fixture / "undefined_name.py"
+        undefined_name.write_text("print(missing_name)\n", encoding="utf-8")
+        expected_failure(
+            [
+                ruff,
+                "check",
+                "--config",
+                str(ROOT / "pyproject.toml"),
+                str(undefined_name),
+            ],
+            "F821",
+        )
+
+        runner_temp = fixture / "runner-temp.yml"
+        runner_temp.write_text(
+            """name: invalid runner context
+on: push
+jobs:
+  invalid:
+    runs-on: ubuntu-latest
+    env:
+      TOOL_DIR: ${{ runner.temp }}
+    steps:
+      - run: 'true'
+""",
+            encoding="utf-8",
+        )
+        output = expected_failure(
+            [actionlint, *ACTIONLINT_FLAGS, str(runner_temp)],
+            "runner",
+        )
+        if "context" not in output:
+            raise CheckFailed("actionlint runner.temp fixture did not report a context error")
+
+
+def live_check(actionlint: str, ruff: str) -> None:
+    subprocess.run([ruff, "check", "."], cwd=ROOT, check=True)
+    subprocess.run([actionlint, *ACTIONLINT_FLAGS], cwd=ROOT, check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="prove the lint gate rejects representative Python and workflow errors",
+    )
+    args = parser.parse_args()
+
+    try:
+        actionlint, ruff = tools()
+        if args.self_test:
+            self_test(actionlint, ruff)
+        else:
+            live_check(actionlint, ruff)
+    except (CheckFailed, subprocess.CalledProcessError) as error:
+        print(f"developer-tooling check failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- install checksum-pinned Ruff and actionlint binaries through one developer-tooling bootstrap
- run a narrow Ruff correctness profile and actionlint across every workflow in the existing core CI and just gate
- add negative self-tests for undefined Python names and invalid GitHub Actions contexts, with the nine existing Ruff findings corrected mechanically
- ShellCheck both comparison drivers and run the previously unwired route-paging destructive red proof and MRT attribute-scratch self-test in the existing scale/receipt job

The VPN verifier was already exercised transitively by its shell campaign test, so this does not add a duplicate invocation.

## Validation

- pinned installer, exact versions, Bash syntax, ShellCheck, and live Ruff/actionlint across all 14 workflows
- developer-tooling negative self-tests
- route-paging driver destructive self-test and MRT attribute-scratch 9-test suite
- CI scale-split contract tests and live checker
- image primer 39 tests, rrharness 12 tests, IRR checks, reload scenario, and FIB help/import checks
- full pre-push fmt, clippy, workspace tests, rustdoc, and documentation gates
- independent exact-head review passed for the original tooling tranche; a fresh Copilot review and full hosted labs are required for this bundled head

Linear: LAN-1343, LAN-1361, LAN-1354