### PR TITLE
bench: gate retained VPN query classifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   LLGR_STALE community, and withdrawn exactly at LLGR expiry; the RR keeps its
   MPLS and IPv6 dataplanes untouched.
 
+- The retained VPN RIB query campaign now gates all three full-run completion
+  paths on its unchanged classifier while preserving advisory direct verifier
+  use. Gated runs write the classification before returning a follow-up status
+  and always recheck source, toolchain, affinity, and binary provenance first.
+
 - Nightly wire campaigns now seed all 12 targets, apply one reviewed BGP byte
   dictionary to the 11 binary targets, and carry a validated corpus forward on
   the `main` lineage. Restore happens in runner-temporary staging and accepts

--- a/bench/README.md
+++ b/bench/README.md
@@ -264,7 +264,12 @@ invocation; `--retry` allows a second attempt. Its paired verifier,
 `verify-vpn-query-campaign.py`, is a fail-closed classifier for the
 retained receipts: it pins the expected sizes, case matrix, and
 workload checksums, and rejects any missing, malformed, or
-inconsistent row. Guard tests live in
+inconsistent row. Direct verifier use remains advisory for every valid
+classification; `--fail-on-regression` emits the same JSON first, then exits
+zero only for `no_redesign` and exits 2 for every retained follow-up or
+unusable classification. The full runner enables that gate at each of its
+three completion paths and rechecks provenance before returning the captured
+status. Guard tests live in
 `bench/tests/test-vpn-query-campaign.sh`,
 `bench/tests/test-vpn-query-receipt.sh`, and
 `bench/tests/test_verify_vpn_query_campaign.py`.

--- a/bench/run-vpn-query-campaign.sh
+++ b/bench/run-vpn-query-campaign.sh
@@ -151,10 +151,14 @@ for attempt in $(seq 1 "$attempts"); do
                         "$ordinal" "$repetition" 120 "$attempt"
                     rm "$raw"
                     check_provenance
+                    set +e
                     python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
-                        --output "$output/classification.json"
+                        --output "$output/classification.json" \
+                        --fail-on-regression
+                    verifier_status=$?
+                    set -e
                     check_provenance
-                    exit
+                    exit "$verifier_status"
                 elif ((rc != 0)); then
                     exit "$rc"
                 fi
@@ -177,16 +181,25 @@ if ((rc == 75)); then
         "$allocation_hash" 49 1 120 "$attempts"
     rm "$output/allocation-raw.json"
     check_provenance
+    set +e
     python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
-        --output "$output/classification.json"
+        --output "$output/classification.json" \
+        --fail-on-regression
+    verifier_status=$?
+    set -e
     check_provenance
-    exit
+    exit "$verifier_status"
 elif ((rc != 0)); then
     exit "$rc"
 fi
 decorate "$output/allocation-raw.json" "$output/allocation.json" \
     "$allocation_hash" 49 1 120 "$attempts"
 rm "$output/allocation-raw.json"
+set +e
 python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
-    --output "$output/classification.json"
+    --output "$output/classification.json" \
+    --fail-on-regression
+verifier_status=$?
+set -e
 check_provenance
+exit "$verifier_status"

--- a/bench/tests/test-vpn-query-campaign.sh
+++ b/bench/tests/test-vpn-query-campaign.sh
@@ -6,9 +6,36 @@ root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 runner=$root/bench/run-vpn-query-campaign.sh
 verifier=$root/bench/verify-vpn-query-campaign.py
 
+check_verifier_gates() {
+    python3 - "$1" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+invocation = 'python3 "$root/bench/verify-vpn-query-campaign.py" "$output"'
+pattern = re.compile(
+    r'''set \+e\n[ \t]*python3 "\$root/bench/verify-vpn-query-campaign\.py" "\$output" \\\n'''
+    r'''[ \t]*--output "\$output/classification\.json" \\\n'''
+    r'''[ \t]*--fail-on-regression\n'''
+    r'''[ \t]*verifier_status=\$\?\n'''
+    r'''[ \t]*set -e\n'''
+    r'''[ \t]*check_provenance\n'''
+    r'''[ \t]*exit "\$verifier_status"'''
+)
+if text.count(invocation) != 3:
+    raise SystemExit("expected exactly three retained verifier invocations")
+if text.count("--fail-on-regression") != 3 or len(pattern.findall(text)) != 3:
+    raise SystemExit("every retained verifier must gate, re-enable errexit, check provenance, and return its status")
+PY
+}
+
 bash -n "$runner"
 python3 -m unittest -v "$root/bench/tests/test_verify_vpn_query_campaign.py"
-python3 "$verifier" --help >/dev/null
+help=$(COLUMNS=200 python3 "$verifier" --help)
+[[ $help == *"Classification is advisory unless --fail-on-regression is selected."* ]]
+[[ $help == *"default: advisory exit 0"* ]]
+check_verifier_gates "$runner"
 [[ $(grep -Fc '.checked_mul(' "$root/crates/api/benches/vpn_query/mod.rs") -eq 2 && $(grep -Fc '.checked_add(' "$root/crates/api/benches/vpn_query/mod.rs") -eq 1 ]]
 [[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_$target"' "$runner") -eq 1 ]]
 [[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_timing"' "$runner") -eq 1 ]]
@@ -17,6 +44,13 @@ python3 "$verifier" --help >/dev/null
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
+missing_gate_runner=$tmp_dir/run-vpn-query-campaign-missing-gate.sh
+cp "$runner" "$missing_gate_runner"
+sed -i '0,/--fail-on-regression/{/--fail-on-regression/d;}' "$missing_gate_runner"
+if check_verifier_gates "$missing_gate_runner" >/dev/null 2>&1; then
+    echo "structural guard accepted a retained verifier without the gate" >&2
+    exit 1
+fi
 set +e
 env RUSTBGPD_VPN_QUERY_FORCE_CENSOR= "$runner" "$tmp_dir/output" >/dev/null 2>&1
 status=$?

--- a/bench/tests/test_verify_vpn_query_campaign.py
+++ b/bench/tests/test_verify_vpn_query_campaign.py
@@ -1,10 +1,13 @@
+import contextlib
 import hashlib
 import importlib.util
+import io
 import json
 import pathlib
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 SCRIPT = pathlib.Path(__file__).parents[1] / "verify-vpn-query-campaign.py"
 SPEC = importlib.util.spec_from_file_location("vpn_verify", SCRIPT)
@@ -104,6 +107,63 @@ class VerifyCampaign(unittest.TestCase):
         result = VERIFY.verify(self.root)
         self.assertEqual(result["classification"], "no_redesign")
 
+    def test_cli_default_and_gated_exit_matrix_preserve_json(self):
+        classifications = (
+            "capacity_censored",
+            "inconclusive",
+            "instrumentation_suspect",
+            "urgent",
+            "design_followup",
+            "no_redesign",
+        )
+        for classification in classifications:
+            with self.subTest(classification=classification):
+                result = {"classification": classification, "sentinel": 7}
+                expected = json.dumps(result, indent=2, sort_keys=True) + "\n"
+                advisory_stdout = io.StringIO()
+                gated_stdout = io.StringIO()
+                with mock.patch.object(VERIFY, "verify", return_value=result):
+                    with contextlib.redirect_stdout(advisory_stdout):
+                        advisory_status = VERIFY.main([str(self.root)])
+                    with contextlib.redirect_stdout(gated_stdout):
+                        gated_status = VERIFY.main([
+                            "--fail-on-regression", str(self.root)
+                        ])
+                self.assertEqual(advisory_status, 0)
+                self.assertEqual(
+                    gated_status, 0 if classification == "no_redesign" else 2
+                )
+                self.assertEqual(advisory_stdout.getvalue(), expected)
+                self.assertEqual(gated_stdout.getvalue(), expected)
+
+    def test_gated_output_is_written_before_exit_two(self):
+        result = {"classification": "urgent", "sentinel": 7}
+        expected = json.dumps(result, indent=2, sort_keys=True) + "\n"
+        output = self.root / "classification.json"
+        with mock.patch.object(VERIFY, "verify", return_value=result):
+            status = VERIFY.main([
+                str(self.root), "--output", str(output), "--fail-on-regression"
+            ])
+        self.assertEqual(status, 2)
+        self.assertEqual(output.read_text(encoding="utf-8"), expected)
+
+    def test_cli_invalid_evidence_exits_one_without_result(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        output = self.root / "classification.json"
+        with mock.patch.object(
+            VERIFY, "verify", side_effect=VERIFY.Invalid("broken fixture")
+        ):
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                status = VERIFY.main([str(self.root), "--output", str(output)])
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(
+            stderr.getvalue(),
+            "invalid VPN query campaign: broken fixture\n",
+        )
+        self.assertFalse(output.exists())
+
     def test_rejects_affinity_allocation_and_lower_bound_drift(self):
         mutations = [
             ("manifest.json", self.mutate_all_affinity),
@@ -199,6 +259,45 @@ class VerifyCampaign(unittest.TestCase):
         allocation["peak_live_requested_bytes"] = VERIFY.CAPACITY + 1
         self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
                          "capacity_censored")
+
+    def test_classifier_exact_boundaries_remain_unchanged(self):
+        allocation = {"peak_live_requested_bytes": VERIFY.CAPACITY}
+        timings = {
+            (size, case): [value] * 8
+            for size, unfiltered in zip(VERIFY.SIZES, (5_000_000, 10_000_000, 25_000_000))
+            for case, value in (("U", unfiltered), ("F", unfiltered // 2))
+        }
+        self.assertEqual(
+            VERIFY.classify({}, timings, allocation)["classification"],
+            "no_redesign",
+        )
+        timings[(1_000_000, "U")] = [25_000_001] * 8
+        self.assertEqual(
+            VERIFY.classify({}, timings, allocation)["classification"],
+            "design_followup",
+        )
+
+        timings = {
+            (size, case): [value] * 8
+            for size, unfiltered in zip(
+                VERIFY.SIZES, (50_000_000, 100_000_000, 200_000_000)
+            )
+            for case, value in (("U", unfiltered), ("F", unfiltered // 2))
+        }
+        self.assertEqual(
+            VERIFY.classify({}, timings, allocation)["classification"],
+            "design_followup",
+        )
+        timings[(1_000_000, "U")] = [200_000_001] * 8
+        self.assertEqual(
+            VERIFY.classify({}, timings, allocation)["classification"],
+            "urgent",
+        )
+        allocation["peak_live_requested_bytes"] = VERIFY.CAPACITY + 1
+        self.assertEqual(
+            VERIFY.classify({}, timings, allocation)["classification"],
+            "capacity_censored",
+        )
 
     def test_filtered_actor_must_cost_less_than_unfiltered(self):
         """The pushdown gate: a campaign where filtering saves the actor

--- a/bench/verify-vpn-query-campaign.py
+++ b/bench/verify-vpn-query-campaign.py
@@ -345,11 +345,24 @@ def verify(directory):
     return classify(manifest, selected_timings, allocation)
 
 
-def main():
-    parser = argparse.ArgumentParser()
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a VPN query campaign. Classification is advisory unless "
+            "--fail-on-regression is selected."
+        )
+    )
     parser.add_argument("campaign", type=pathlib.Path)
     parser.add_argument("--output", type=pathlib.Path)
-    args = parser.parse_args()
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help=(
+            "exit 2 after emitting a valid classification other than "
+            "no_redesign (default: advisory exit 0)"
+        ),
+    )
+    args = parser.parse_args(argv)
     try:
         result = verify(args.campaign)
     except Invalid as error:
@@ -360,6 +373,8 @@ def main():
         args.output.write_text(encoded, encoding="utf-8")
     else:
         print(encoded, end="")
+    if args.fail_on_regression and result["classification"] != "no_redesign":
+        return 2
     return 0
 
 

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -63,6 +63,11 @@ missing evidence fails closed. A zero post-actor duration is valid.
 Every setup/query timeout produces the typed `capacity_censored` process
 outcome. The driver catches only its exit status 75, stops all remaining cells,
 and verifies the censor receipt; every other nonzero exit is a hard failure.
+At every retained completion path the driver invokes the verifier with
+`--fail-on-regression`, captures its status with `errexit` disabled, restores
+`errexit`, and rechecks provenance before returning that status. This ensures a
+valid gated classification cannot hide source, toolchain, affinity, or binary
+drift discovered after verification.
 
 Peak delta must cover `actor_capacity * size_of::<VpnRibRoute>() + actor_rows *
 size_of::<MplsLabelEntry>()`; the label term is one-label deep clone and values agree.
@@ -105,9 +110,19 @@ with:
 python3 bench/verify-vpn-query-campaign.py /uncommitted/output-directory
 ```
 
+Direct verification is advisory: every valid classification is emitted and
+exits 0. Add `--fail-on-regression` to emit or write the identical JSON and then
+exit 0 only for `no_redesign`; `capacity_censored`, `inconclusive`,
+`instrumentation_suspect`, `urgent`, and `design_followup` exit 2. Invalid
+evidence remains a diagnostic on stderr with exit 1 and no classification.
+
 ## Load-bearing gates
 
 The tests demonstrate red outcomes for fixed-order mutation, receipt
 count/order/pair drift, a dual-case receipt, timing underflow, binary corruption,
 row/checksum corruption, and removal of the allocator seam. These are executable
-mutation proofs, not prose-only claims.
+mutation proofs, not prose-only claims. They also pin every default and gated
+classification exit, exact threshold and precedence boundaries, JSON identity
+before a gated exit, and the runner's three provenance-checked gate sites. A
+temporary mutated runner with one gate removed proves that structural guard can
+fail without editing the retained runner.


### PR DESCRIPTION
## Summary

- keep VPN query campaign classifications advisory by default
- add an explicit `--fail-on-regression` mode for retained regressions
- preserve verifier JSON and provenance receipts before returning a gated exit
- exercise the exit matrix, malformed evidence, and shell runner propagation

## Validation

- `python3 -m unittest -v bench/tests/test_verify_vpn_query_campaign.py` (14 passed)
- `bash bench/tests/test-vpn-query-campaign.sh`
- `COLUMNS=20 bash bench/tests/test-vpn-query-campaign.sh`
- `bash -n bench/run-vpn-query-campaign.sh bench/tests/test-vpn-query-campaign.sh`
- `shellcheck -x bench/run-vpn-query-campaign.sh bench/tests/test-vpn-query-campaign.sh`
- `git diff --check`

Linear: LAN-1353