### PR TITLE
bench: gate enhanced refresh actor timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The Enhanced Route Refresh 100k real-session receipt now applies always-on
+  adjacent-operation ceilings to its actor-duration histogram: 25 ms for each
+  accepted BoRR begin and 250 ms for EoRR or timeout completion. Every phase
+  revalidates the exact accepted predecessor and baseline-relative actor counts;
+  timed transitions advance exactly one operation while all other counts and
+  sums remain unchanged, preventing cumulative averages from masking one slow
+  operation.
+
 - Periodic BMP peer statistics now include RFC 9972 type 22 for exact counts of
   current pre-policy IPv4/IPv6-unicast Adj-RIB-In routes rejected by inbound
   policy. Rows are emitted only for negotiated families while rejected-route

--- a/bench/scale/enhanced-route-refresh/README.md
+++ b/bench/scale/enhanced-route-refresh/README.md
@@ -50,7 +50,23 @@ boundary to reset the daemon's kernel high-water mark and capture the
 pre-action allocator/RSS state. It continuously samples RSS and jemalloc
 gauges, then captures the exact post-action state before acknowledging the
 driver. The actor-duration histogram must advance on every accepted begin,
-EoRR, and timeout operation.
+EoRR, and timeout operation. Timing is checked only between exact adjacent
+accepted phases, in this order:
+
+```text
+baseline -> first-borr -> replay-one -> duplicate-borr -> eorr
+         -> restored -> timeout-borr -> timeout-complete
+```
+
+Before validating a transition, the validator rechecks the predecessor's
+absolute actor counts against the settled baseline and its complete production
+state. A timed transition must add exactly one operation, leave every other
+operation's count and sum unchanged, and have a positive adjacent sum delta no
+greater than the always-on ceiling: begin **0.025 s**, EoRR **0.250 s**, and
+timeout completion **0.250 s**. Replay-one and restored are untimed boundaries,
+so every actor count and sum must remain unchanged. These are per-operation
+deltas, not cumulative histogram averages; older fast observations cannot mask
+one slow operation.
 
 The fleet shape is deliberately one ERR-capable peer × 100,000 unique IPv4
 /24s. It isolates per-peer inventory cost; it does not claim synchronized
@@ -78,10 +94,12 @@ approximately six-minute session; and leaves private raw output under
   local run from being mislabeled as the durable 100k receipt. Removing the
   fixed-shape guard makes it proceed to connection and changes the asserted
   error.
-- `test_validate_phase.py` feeds every exact phase through the same validator
-  the runner invokes, then injects an unswept RIB and a missing actor
-  observation. Removing either production obligation makes its mutation
-  test red.
+- `test_validate_phase.py` feeds every exact adjacent phase pair through the
+  same validator the runner invokes. It pins equality at all three timing
+  ceilings, rejects each over-cap operation, proves a low cumulative average
+  cannot mask one slow transition, rejects untimed sum movement, and rejects
+  missing or wrong predecessors. It also retains the unswept-RIB, missing-actor,
+  and uninterrupted-session mutation proofs.
 - The receipt gate itself checks all route, stale, max-prefix, histogram,
   API-sentinel, session-establishment, and flap values at every boundary.
   Removing the RIB BoRR snapshot makes the first-BoRR assertion red; removing

--- a/bench/scale/enhanced-route-refresh/run-receipt.sh
+++ b/bench/scale/enhanced-route-refresh/run-receipt.sh
@@ -246,19 +246,46 @@ ack() {
     touch "$RUN/evidence/${phase}.ack"
 }
 
+phase_predecessor() {
+    case "$1" in
+        first-borr) printf '%s\n' baseline ;;
+        replay-one) printf '%s\n' first-borr ;;
+        duplicate-borr) printf '%s\n' replay-one ;;
+        eorr) printf '%s\n' duplicate-borr ;;
+        restored) printf '%s\n' eorr ;;
+        timeout-borr) printf '%s\n' restored ;;
+        timeout-complete) printf '%s\n' timeout-borr ;;
+        *) echo "phase $1 has no receipt predecessor" >&2; return 1 ;;
+    esac
+}
+
 validate_phase() {
     local phase=$1 timeout_seconds=$2
     local deadline=$((SECONDS + timeout_seconds))
     local candidate="$RUN/${phase}.candidate.prom"
     local error="$RUN/${phase}.error"
     local baseline="$OUT/metrics/baseline.prom"
+    local predecessor_phase='' predecessor=''
+    local -a validator
+    if [[ $phase != baseline ]]; then
+        predecessor_phase=$(phase_predecessor "$phase")
+        predecessor="$OUT/metrics/${predecessor_phase}.prom"
+        [[ -f $predecessor ]] || {
+            echo "phase $phase predecessor is missing: $predecessor" >&2
+            exit 1
+        }
+    fi
     until ((SECONDS >= deadline)); do
         if [[ $phase == baseline ]]; then
             baseline=$candidate
         fi
+        validator=(
+            python3 "$RECEIPT_DIR/validate_phase.py" "$phase" "$candidate" "$baseline"
+        )
+        [[ -z $predecessor ]] || validator+=("$predecessor")
+        validator+=(--output "$OUT/phase/${phase}.json")
         if scrape "$candidate" &&
-            python3 "$RECEIPT_DIR/validate_phase.py" "$phase" "$candidate" \
-                "$baseline" --output "$OUT/phase/${phase}.json" \
+            "${validator[@]}" \
                 >"$OUT/phase/${phase}.validation.log" 2>"$error"; then
             mv "$candidate" "$OUT/metrics/${phase}.prom"
             validate_route_sentinels "$phase"

--- a/bench/scale/enhanced-route-refresh/test_validate_phase.py
+++ b/bench/scale/enhanced-route-refresh/test_validate_phase.py
@@ -8,13 +8,35 @@ import unittest
 import validate_phase
 
 
+VALID_SUM_DELTAS = {
+    "baseline": {"begin": 0.0, "eorr": 0.0, "timeout": 0.0},
+    "first-borr": {"begin": 0.010, "eorr": 0.0, "timeout": 0.0},
+    "replay-one": {"begin": 0.010, "eorr": 0.0, "timeout": 0.0},
+    "duplicate-borr": {"begin": 0.020, "eorr": 0.0, "timeout": 0.0},
+    "eorr": {"begin": 0.020, "eorr": 0.100, "timeout": 0.0},
+    "restored": {"begin": 0.020, "eorr": 0.100, "timeout": 0.0},
+    "timeout-borr": {"begin": 0.030, "eorr": 0.100, "timeout": 0.0},
+    "timeout-complete": {"begin": 0.030, "eorr": 0.100, "timeout": 0.100},
+}
+
+
 def line(name, value, **labels):
     encoded = ",".join(f'{key}="{labels[key]}"' for key in sorted(labels))
     suffix = f"{{{encoded}}}" if labels else ""
     return f"{name}{suffix} {value}\n"
 
 
-def metrics(rib, active, stale, begin, eorr, timeout, *, current=1, established=1, flaps=0):
+def metrics(
+    rib,
+    active,
+    stale,
+    actor_counts,
+    actor_sums,
+    *,
+    current=1,
+    established=1,
+    flaps=0,
+):
     text = ""
     text += line(
         "bgp_rib_prefixes",
@@ -54,80 +76,260 @@ def metrics(rib, active, stale, begin, eorr, timeout, *, current=1, established=
     )
     if flaps is not None:
         text += line("bgp_session_flaps_total", flaps, peer=validate_phase.PEER)
-    for operation, count in (
-        ("begin", begin),
-        ("eorr", eorr),
-        ("timeout", timeout),
-    ):
+    for operation in validate_phase.OPERATIONS:
         text += line(
             "bgp_rib_route_refresh_actor_duration_seconds_count",
-            count,
+            actor_counts[operation],
             operation=operation,
         )
         text += line(
             "bgp_rib_route_refresh_actor_duration_seconds_sum",
-            count * 0.001,
+            actor_sums[operation],
             operation=operation,
         )
     return text
 
 
+def metric_key(name, **labels):
+    return name, tuple(sorted(labels.items()))
+
+
 class PhaseValidatorTests(unittest.TestCase):
+    BASE_COUNTS = {"begin": 7, "eorr": 11, "timeout": 13}
+    BASE_SUMS = {"begin": 0.700, "eorr": 1.100, "timeout": 1.300}
+
     def parse(self, text):
         with tempfile.TemporaryDirectory() as directory:
             path = pathlib.Path(directory) / "metrics.prom"
             path.write_text(text, encoding="utf-8")
             return validate_phase.parse_metrics(path)
 
-    def test_every_phase_accepts_only_its_exact_production_state(self):
-        baseline = self.parse(metrics(100_000, 0, 0, 7, 11, 13))
+    def make_chain(self, base_counts=None, base_sums=None):
+        base_counts = dict(base_counts or self.BASE_COUNTS)
+        base_sums = dict(base_sums or self.BASE_SUMS)
+        chain = {}
         for phase, expected in validate_phase.EXPECTED.items():
-            rib, active, stale, begin, eorr, timeout = expected
-            candidate = self.parse(
-                metrics(
-                    rib,
-                    active,
-                    stale,
-                    7 + begin,
-                    11 + eorr,
-                    13 + timeout,
-                )
-            )
-            summary = validate_phase.validate(phase, candidate, baseline)
-            self.assertEqual(summary["phase"], phase)
+            rib, active, stale, *count_deltas = expected
+            counts = {
+                operation: base_counts[operation] + delta
+                for operation, delta in zip(validate_phase.OPERATIONS, count_deltas, strict=True)
+            }
+            sums = {
+                operation: base_sums[operation] + VALID_SUM_DELTAS[phase][operation]
+                for operation in validate_phase.OPERATIONS
+            }
+            chain[phase] = self.parse(metrics(rib, active, stale, counts, sums))
+        return chain
+
+    def validate_chain_phase(self, chain, phase, candidate=None, predecessor=None):
+        previous_phase = validate_phase.PREDECESSOR.get(phase)
+        if predecessor is None and previous_phase is not None:
+            predecessor = chain[previous_phase]
+        return validate_phase.validate(
+            phase,
+            chain[phase] if candidate is None else candidate,
+            chain["baseline"],
+            predecessor,
+        )
+
+    @staticmethod
+    def changed(source, name, value, **labels):
+        changed = dict(source)
+        changed[metric_key(name, **labels)] = value
+        return changed
+
+    def test_every_phase_accepts_only_its_exact_adjacent_transition(self):
+        chain = self.make_chain()
+        for phase in validate_phase.EXPECTED:
+            with self.subTest(phase=phase):
+                summary = self.validate_chain_phase(chain, phase)
+                self.assertEqual(summary["phase"], phase)
 
     def test_later_phase_requires_current_uninterrupted_session(self):
-        baseline = self.parse(metrics(100_000, 0, 0, 7, 11, 13))
-        candidate = dict(rib=100_000, active=0, stale=0, begin=9, eorr=12, timeout=13)
-        summary = validate_phase.validate(
-            "restored", self.parse(metrics(**candidate, flaps=None)), baseline
-        )
-        self.assertEqual(summary["session_established"], 1)
-        for name, change, metric in (
-            ("current-down", {"current": 0}, "bgp_peer_session_established"),
-            ("reestablished", {"established": 2}, "bgp_session_established_total"),
-            ("flapped", {"flaps": 1}, "bgp_session_flaps_total"),
+        chain = self.make_chain()
+        for name, metric, labels, value in (
+            (
+                "current-down",
+                "bgp_peer_session_established",
+                {"interface": "", "peer": validate_phase.PEER},
+                0,
+            ),
+            (
+                "reestablished",
+                "bgp_session_established_total",
+                {"peer": validate_phase.PEER},
+                2,
+            ),
+            (
+                "flapped",
+                "bgp_session_flaps_total",
+                {"peer": validate_phase.PEER},
+                1,
+            ),
         ):
             with self.subTest(name=name):
+                candidate = self.changed(chain["restored"], metric, value, **labels)
                 with self.assertRaisesRegex(AssertionError, metric):
-                    validate_phase.validate(
-                        "restored", self.parse(metrics(**candidate, **change)), baseline
-                    )
+                    self.validate_chain_phase(chain, "restored", candidate=candidate)
 
     def test_missing_eorr_sweep_is_red(self):
-        baseline = self.parse(metrics(100_000, 0, 0, 0, 0, 0))
-        unswept = self.parse(metrics(100_000, 0, 0, 2, 1, 0))
+        chain = self.make_chain()
+        unswept = self.changed(
+            chain["eorr"],
+            "bgp_rib_prefixes",
+            validate_phase.PREFIXES,
+            afi_safi="all",
+            peer=validate_phase.PEER,
+        )
         with self.assertRaisesRegex(AssertionError, "bgp_rib_prefixes"):
-            validate_phase.validate("eorr", unswept, baseline)
+            self.validate_chain_phase(chain, "eorr", candidate=unswept)
 
     def test_missing_actor_observation_is_red(self):
-        baseline = self.parse(metrics(100_000, 0, 0, 0, 0, 0))
-        unobserved = self.parse(metrics(100_000, 1, 100_000, 0, 0, 0))
+        chain = self.make_chain()
+        unobserved = self.changed(
+            chain["first-borr"],
+            "bgp_rib_route_refresh_actor_duration_seconds_count",
+            self.BASE_COUNTS["begin"],
+            operation="begin",
+        )
         with self.assertRaisesRegex(
             AssertionError,
             "bgp_rib_route_refresh_actor_duration_seconds_count",
         ):
-            validate_phase.validate("first-borr", unobserved, baseline)
+            self.validate_chain_phase(chain, "first-borr", candidate=unobserved)
+
+    def test_each_operation_accepts_ceiling_equality_and_rejects_over_cap(self):
+        chain = self.make_chain()
+        for phase, operation in (
+            ("first-borr", "begin"),
+            ("eorr", "eorr"),
+            ("timeout-complete", "timeout"),
+        ):
+            previous = chain[validate_phase.PREDECESSOR[phase]]
+            previous_sum = validate_phase.actor_sum(previous, operation)
+            ceiling = validate_phase.TIMING_CEILINGS_SECONDS[operation]
+            labels = {"operation": operation}
+            at_ceiling = self.changed(
+                chain[phase],
+                "bgp_rib_route_refresh_actor_duration_seconds_sum",
+                previous_sum + ceiling,
+                **labels,
+            )
+            with self.subTest(phase=phase, operation=operation, boundary="equality"):
+                summary = self.validate_chain_phase(chain, phase, candidate=at_ceiling)
+                self.assertAlmostEqual(summary["actor_timed_delta_seconds"], ceiling)
+
+            over_cap = self.changed(
+                at_ceiling,
+                "bgp_rib_route_refresh_actor_duration_seconds_sum",
+                previous_sum + ceiling + 0.001,
+                **labels,
+            )
+            message = rf"phase={phase} op={operation} observed=.* ceiling={ceiling:g}s"
+            with self.subTest(phase=phase, operation=operation, boundary="over-cap"):
+                with self.assertRaisesRegex(AssertionError, message):
+                    self.validate_chain_phase(chain, phase, candidate=over_cap)
+
+    def test_adjacent_delta_cannot_be_masked_by_a_low_cumulative_average(self):
+        chain = self.make_chain(
+            base_counts={"begin": 1_000, "eorr": 11, "timeout": 13},
+            base_sums={"begin": 1.0, "eorr": 1.1, "timeout": 1.3},
+        )
+        previous = chain["replay-one"]
+        operation = "begin"
+        candidate = self.changed(
+            chain["duplicate-borr"],
+            "bgp_rib_route_refresh_actor_duration_seconds_sum",
+            validate_phase.actor_sum(previous, operation) + 0.030,
+            operation=operation,
+        )
+        cumulative_average = validate_phase.actor_sum(
+            candidate, operation
+        ) / validate_phase.actor_count(candidate, operation)
+        self.assertLess(
+            cumulative_average,
+            validate_phase.TIMING_CEILINGS_SECONDS[operation],
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"phase=duplicate-borr op=begin observed=.* ceiling=0.025s",
+        ):
+            self.validate_chain_phase(chain, "duplicate-borr", candidate=candidate)
+
+    def test_untimed_operation_sum_movement_is_rejected(self):
+        chain = self.make_chain()
+        candidate = self.changed(
+            chain["first-borr"],
+            "bgp_rib_route_refresh_actor_duration_seconds_sum",
+            validate_phase.actor_sum(chain["baseline"], "eorr") + 0.001,
+            operation="eorr",
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"phase=first-borr op=eorr observed=.* ceiling=0s",
+        ):
+            self.validate_chain_phase(chain, "first-borr", candidate=candidate)
+
+    def test_count_delta_failure_reports_count_semantics(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"phase=first-borr timed_op=begin op=begin "
+            r"observed_count_delta=0 expected_count_delta=1",
+        ):
+            validate_phase.validate_transition(
+                "first-borr",
+                self.BASE_COUNTS,
+                self.BASE_SUMS,
+                self.BASE_COUNTS,
+                self.BASE_SUMS,
+            )
+
+    def test_missing_and_wrong_predecessors_are_rejected(self):
+        chain = self.make_chain()
+        with self.assertRaisesRegex(
+            AssertionError,
+            "phase=replay-one: missing predecessor metrics for first-borr",
+        ):
+            validate_phase.validate(
+                "replay-one",
+                chain["replay-one"],
+                chain["baseline"],
+            )
+
+        with self.assertRaisesRegex(AssertionError, "bgp_rib_prefixes"):
+            validate_phase.validate(
+                "restored",
+                chain["restored"],
+                chain["baseline"],
+                chain["restored"],
+            )
+
+        with self.assertRaisesRegex(AssertionError, "must not have predecessor"):
+            validate_phase.validate(
+                "baseline",
+                chain["baseline"],
+                chain["baseline"],
+                chain["baseline"],
+            )
+
+    def test_predecessor_absolute_counts_are_checked_before_its_state(self):
+        chain = self.make_chain()
+        wrong = self.changed(
+            chain["restored"],
+            "bgp_rib_route_refresh_actor_duration_seconds_count",
+            self.BASE_COUNTS["eorr"],
+            operation="eorr",
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            "bgp_rib_route_refresh_actor_duration_seconds_count",
+        ):
+            validate_phase.validate(
+                "restored",
+                chain["restored"],
+                chain["baseline"],
+                wrong,
+            )
 
 
 if __name__ == "__main__":

--- a/bench/scale/enhanced-route-refresh/validate_phase.py
+++ b/bench/scale/enhanced-route-refresh/validate_phase.py
@@ -22,6 +22,30 @@ EXPECTED = {
     "timeout-complete": (0, 0, 0, 3, 1, 1),
 }
 
+PREDECESSOR = {
+    "first-borr": "baseline",
+    "replay-one": "first-borr",
+    "duplicate-borr": "replay-one",
+    "eorr": "duplicate-borr",
+    "restored": "eorr",
+    "timeout-borr": "restored",
+    "timeout-complete": "timeout-borr",
+}
+
+OPERATIONS = ("begin", "eorr", "timeout")
+TIMED_OPERATION = {
+    "first-borr": "begin",
+    "duplicate-borr": "begin",
+    "eorr": "eorr",
+    "timeout-borr": "begin",
+    "timeout-complete": "timeout",
+}
+TIMING_CEILINGS_SECONDS = {
+    "begin": 0.025,
+    "eorr": 0.250,
+    "timeout": 0.250,
+}
+
 LINE = re.compile(
     r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)"
     r"(?:\{(?P<labels>[^}]*)\})?\s+(?P<value>[-+0-9.eE]+)$"
@@ -62,9 +86,7 @@ def get(metrics, name, labels=None, *, absent_zero=False):
 def require(metrics, name, labels, expected, *, absent_zero=False):
     value = get(metrics, name, labels, absent_zero=absent_zero)
     if value != expected:
-        raise AssertionError(
-            f"{name}{labels}: expected {expected}, got {value:g}"
-        )
+        raise AssertionError(f"{name}{labels}: expected {expected}, got {value:g}")
     return value
 
 
@@ -84,8 +106,8 @@ def actor_sum(metrics, operation):
     )
 
 
-def validate(phase, metrics, baseline):
-    rib, active, stale, begin_delta, eorr_delta, timeout_delta = EXPECTED[phase]
+def require_phase_state(phase, metrics):
+    rib, active, stale, _, _, _ = EXPECTED[phase]
     require(metrics, "bgp_rib_prefixes", {"afi_safi": "all", "peer": PEER}, rib)
     for scope in ("aggregate", "ipv4_unicast"):
         require(metrics, "bgp_max_prefix_usage", {"peer": PEER, "scope": scope}, rib)
@@ -118,17 +140,12 @@ def validate(phase, metrics, baseline):
         absent_zero=True,
     )
 
+
+def require_actor_absolute_counts(phase, metrics, baseline):
+    deltas = dict(zip(OPERATIONS, EXPECTED[phase][3:], strict=True))
     expected_counts = {
-        "begin": actor_count(baseline, "begin") + begin_delta,
-        "eorr": actor_count(baseline, "eorr") + eorr_delta,
-        "timeout": actor_count(baseline, "timeout") + timeout_delta,
+        operation: actor_count(baseline, operation) + deltas[operation] for operation in OPERATIONS
     }
-    count_deltas = {
-        "begin": begin_delta,
-        "eorr": eorr_delta,
-        "timeout": timeout_delta,
-    }
-    actor_sums = {}
     for operation, expected in expected_counts.items():
         require(
             metrics,
@@ -136,20 +153,82 @@ def validate(phase, metrics, baseline):
             {"operation": operation},
             expected,
         )
-        baseline_sum = actor_sum(baseline, operation)
-        current_sum = actor_sum(metrics, operation)
-        if count_deltas[operation] == 0 and current_sum != baseline_sum:
+    return expected_counts
+
+
+def require_actor_sums(metrics):
+    return {operation: actor_sum(metrics, operation) for operation in OPERATIONS}
+
+
+def validate_transition(phase, current_counts, current_sums, previous_counts, previous_sums):
+    timed_operation = TIMED_OPERATION.get(phase)
+    for operation in OPERATIONS:
+        expected_count_delta = int(operation == timed_operation)
+        observed_count_delta = current_counts[operation] - previous_counts[operation]
+        if observed_count_delta != expected_count_delta:
             raise AssertionError(
-                f"{operation} actor sum advanced without an accepted operation: "
-                f"{baseline_sum:g} -> {current_sum:g}"
+                f"phase={phase} timed_op={timed_operation} op={operation} "
+                f"observed_count_delta={observed_count_delta:g} "
+                f"expected_count_delta={expected_count_delta}: actor count delta mismatch"
             )
-        if count_deltas[operation] > 0 and current_sum <= baseline_sum:
+
+    timed_delta = None
+    for operation in OPERATIONS:
+        observed = current_sums[operation] - previous_sums[operation]
+        if operation != timed_operation:
+            if observed != 0:
+                raise AssertionError(
+                    f"phase={phase} op={operation} observed={observed:g}s ceiling=0s: "
+                    "actor sum advanced without an accepted operation"
+                )
+            continue
+
+        ceiling = TIMING_CEILINGS_SECONDS[operation]
+        over_ceiling = observed > ceiling and not math.isclose(
+            observed, ceiling, rel_tol=0.0, abs_tol=1e-12
+        )
+        if observed <= 0 or over_ceiling:
             raise AssertionError(
-                f"{operation} actor sum did not advance with "
-                f"{count_deltas[operation]} accepted operation(s): "
-                f"{baseline_sum:g} -> {current_sum:g}"
+                f"phase={phase} op={operation} observed={observed:g}s "
+                f"ceiling={ceiling:g}s: timed actor delta must be positive and "
+                "within the adjacent-phase ceiling"
             )
-        actor_sums[operation] = current_sum
+        timed_delta = observed
+    return timed_operation, timed_delta
+
+
+def validate(phase, metrics, baseline, predecessor=None):
+    previous_phase = PREDECESSOR.get(phase)
+    if previous_phase is None:
+        if predecessor is not None:
+            raise AssertionError("phase=baseline must not have predecessor metrics")
+        previous_counts = None
+        previous_sums = None
+    else:
+        if predecessor is None:
+            raise AssertionError(f"phase={phase}: missing predecessor metrics for {previous_phase}")
+        # The predecessor's absolute actor counts are checked against the
+        # settled baseline before either its phase state or the new candidate.
+        previous_counts = require_actor_absolute_counts(previous_phase, predecessor, baseline)
+        require_phase_state(previous_phase, predecessor)
+        previous_sums = require_actor_sums(predecessor)
+
+    require_phase_state(phase, metrics)
+    expected_counts = require_actor_absolute_counts(phase, metrics, baseline)
+    actor_sums = require_actor_sums(metrics)
+
+    timed_operation = None
+    timed_delta = None
+    if previous_phase is not None:
+        timed_operation, timed_delta = validate_transition(
+            phase,
+            expected_counts,
+            actor_sums,
+            previous_counts,
+            previous_sums,
+        )
+
+    rib, active, stale, _, _, _ = EXPECTED[phase]
 
     return {
         "phase": phase,
@@ -166,6 +245,11 @@ def validate(phase, metrics, baseline):
         "actor_begin_sum_seconds": actor_sums["begin"],
         "actor_eorr_sum_seconds": actor_sums["eorr"],
         "actor_timeout_sum_seconds": actor_sums["timeout"],
+        "actor_timed_operation": timed_operation,
+        "actor_timed_delta_seconds": timed_delta,
+        "actor_timed_ceiling_seconds": (
+            TIMING_CEILINGS_SECONDS[timed_operation] if timed_operation else None
+        ),
     }
 
 
@@ -174,6 +258,7 @@ def main():
     parser.add_argument("phase", choices=EXPECTED)
     parser.add_argument("metrics", type=pathlib.Path)
     parser.add_argument("baseline", type=pathlib.Path)
+    parser.add_argument("predecessor", nargs="?", type=pathlib.Path)
     parser.add_argument("--output", type=pathlib.Path)
     arguments = parser.parse_args()
 
@@ -181,6 +266,7 @@ def main():
         arguments.phase,
         parse_metrics(arguments.metrics),
         parse_metrics(arguments.baseline),
+        (parse_metrics(arguments.predecessor) if arguments.predecessor is not None else None),
     )
     encoded = json.dumps(summary, sort_keys=True)
     if arguments.output:


### PR DESCRIPTION
## Summary

- gate enhanced-route-refresh phases on adjacent per-operation actor timing rather than cumulative averages
- enforce fixed 25 ms BoRR, 250 ms EoRR, and 250 ms timeout-completion ceilings
- require exact predecessor evidence and unchanged untimed actor counts/sums
- record timed operation, adjacent delta, and ceiling in the phase summary

## Validation

- 9/9 validator tests, including equality/over-cap boundaries and cumulative-masking proof
- CI-exact unittest discovery
- Bash syntax and ShellCheck
- pinned Ruff lint/format and developer-tooling checks
- scale contract checks and repository hooks

No live campaign was run; the retained published receipt seeds the fixed ceilings with reviewed headroom.

Linear: LAN-1353