### PR TITLE
docs: add host-network container service

### DIFF
--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -21,6 +21,7 @@ on:
       - examples/docker-compose/README.md
       - examples/systemd/rustbgpd.service
       - examples/systemd/rustbgpd@.service
+      - examples/systemd/rustbgpd-container.service
       - examples/prometheus/rustbgpd-alerts.yml
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
@@ -52,6 +53,7 @@ on:
       - examples/docker-compose/README.md
       - examples/systemd/rustbgpd.service
       - examples/systemd/rustbgpd@.service
+      - examples/systemd/rustbgpd-container.service
       - examples/prometheus/rustbgpd-alerts.yml
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
@@ -79,6 +81,8 @@ jobs:
         run: python3 scripts/test_check_release_install_contract.py
       - name: Check repository release install contract
         run: python3 scripts/check_release_install_contract.py
+      - name: Verify container systemd unit
+        run: systemd-analyze verify examples/systemd/rustbgpd-container.service
       - name: Test Birdwatcher endpoint parser
         run: cargo test --locked -p birdwatcher-adapter
       - name: Test Birdwatcher UDS startup and recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sums remain unchanged, preventing cumulative averages from masking one slow
   operation.
 
+- A runnable `rustbgpd-container.service` example now supervises the production
+  image with Docker host networking, a fail-closed image selection, a
+  root-owned state bind, and a read-only config bind. The root container drops
+  all capabilities except `NET_BIND_SERVICE`; Docker gets the full 32-minute
+  stop grace inside a 33-minute systemd margin, and reload maps to SIGHUP. The
+  deployment guide now distinguishes Docker bridge low-port behavior from host
+  networking and explains the uid 999 capability and state-owner traps.
+
 - Periodic BMP peer statistics now include RFC 9972 type 22 for exact counts of
   current pre-policy IPv4/IPv6-unicast Adj-RIB-In routes rejected by inbound
   policy. Rows are emitted only for negotiated families while rejected-route

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -610,7 +610,16 @@ docker compose down
 
 For your own deployment:
 
-- **State**: mount a volume at the daemon's `runtime_state_dir` so the
+- **Image name and command**: published GHCR version tags have **no leading
+  `v`**: use `ghcr.io/lance0/rustbgpd:0.67.0`, not
+  `ghcr.io/lance0/rustbgpd:v0.67.0`. The production image runs as uid/gid 999
+  and its default command is exactly
+  `rustbgpd /etc/rustbgpd/config.toml`. If the config is mounted under another
+  container filename, pass that filename explicitly after the image, for
+  example `rustbgpd /etc/rustbgpd/router.toml`.
+
+- **Bridge networking and state**: mount a volume at the daemon's
+  `runtime_state_dir` so the
   GR restart marker and FIB and BLACKHOLE ownership receipts survive container
   restarts. The daemon runs as uid/gid 999 and rewrites its config in
   place, so both host directories must be owned by that uid and the
@@ -627,21 +636,162 @@ For your own deployment:
 
   docker run --rm -d \
     --name rustbgpd \
+    --network=bridge \
     --stop-timeout=1920 \
     -v /etc/rustbgpd:/etc/rustbgpd \
     -v /var/lib/rustbgpd:/var/lib/rustbgpd \
     -p 179:179 \
     -p 9179:9179 \
     --ulimit nofile=65536:524288 \
-    --cap-add=NET_BIND_SERVICE \
-    --cap-add=NET_ADMIN \
     ghcr.io/lance0/rustbgpd:latest
   ```
+
+  This recipe succeeds because Docker sets
+  `net.ipv4.ip_unprivileged_port_start=0` inside its default bridge network
+  namespace. Port 179 is therefore not privileged there; no capability flag is
+  responsible for the bind. Add `NET_ADMIN` only when the container actually
+  programs its network namespace. The bridge path is the supported choice when
+  the daemon does not need to bind a particular host/peering-LAN address.
 
   The `edge` profile is used because its `runtime_state_dir`,
   `grpc_uds` path, and `0.0.0.0` metrics bind are already the container
   forms; the `lab` profile's `/tmp` state directory and `127.0.0.1`
   metrics bind both need editing first.
+
+### Host networking and privileged BGP ports
+
+Host networking is the second supported container path, and is required when
+`listen_addresses` must name a host/peering-LAN address, a multihop session
+pins its source, or the daemon must program the host network namespace. It does
+not inherit Docker's bridge-netns low-port setting:
+
+| Docker network mode | Effective `net.ipv4.ip_unprivileged_port_start` | Image uid 999 can bind `:179` |
+|---|---:|---|
+| default bridge | `0` in the container namespace | yes |
+| `--network=host` | the host value (commonly `1024`) | no when the host value is above `179` |
+
+`--cap-add=NET_BIND_SERVICE` is **not sufficient** for the image's uid 999 in
+host mode. Docker does not provide that capability as an ambient capability to
+the non-root image process, so it is unavailable after the uid 999 exec. This
+differs from the bare-binary systemd unit above, whose
+`AmbientCapabilities=CAP_NET_BIND_SERVICE` is effective and remains correct.
+
+Use exactly one of these deployment paths:
+
+1. Keep the default bridge network and published ports when address pinning is
+   unnecessary; the image continues to run as uid 999.
+2. Use `--network=host` with `--user=root` and bind a root-owned host state
+   directory at `/var/lib/rustbgpd`:
+
+   ```sh
+   sudo install -d -o root -g root -m 0755 /etc/rustbgpd
+   sudo install -d -o root -g root -m 0700 /var/lib/rustbgpd
+   sudo install -o root -g root -m 0600 config.toml /etc/rustbgpd/config.toml
+
+   docker run --rm -d \
+     --name rustbgpd \
+     --network=host \
+     --user=root \
+     --cap-drop=ALL \
+     --cap-add=NET_BIND_SERVICE \
+     --stop-timeout=1920 \
+     --ulimit nofile=65536:524288 \
+     --mount=type=bind,source=/etc/rustbgpd,target=/etc/rustbgpd,readonly \
+     --mount=type=bind,source=/var/lib/rustbgpd,target=/var/lib/rustbgpd \
+     ghcr.io/lance0/rustbgpd:0.67.0
+   ```
+
+Do not omit the host state bind when overriding the image user. The directory
+baked into the image is owned by uid 999; a root daemon expects uid 0. The
+runtime-state owner guard treats that mismatch as unsafe, logs
+`runtime-state marker/checkpoint storage unavailable`, and continues with the
+graceful-restart marker and warm checkpoint storage disabled. A root-owned,
+non-group/world-writable bind mount makes the authority match the running uid.
+
+Adding `NET_BIND_SERVICE` to uid 999 is not a third supported host-network
+recipe. If changing the host's low-port sysctl is part of a separately managed
+host policy, validate that policy outside this unit; the shipped container
+guidance does not mutate the host sysctl.
+
+The root host-network path drops Docker's entire default capability set, then
+adds back only `NET_BIND_SERVICE` for port 179. Root makes that explicitly
+granted capability usable; applying the same add-cap flag to uid 999 remains
+ineffective because Docker supplies no ambient capability to that non-root
+exec.
+
+The command above and the systemd unit below are control-plane defaults. A
+configuration that programs the host FIB or interfaces also needs
+`--cap-add=NET_ADMIN` on the same root host-network path, as described in
+[kernel dataplane privileges](#kernel-dataplane-opt-in-privilege-drop-in); that
+opt-in does not replace the root-user and root-owned-state requirements.
+
+### systemd-supervised host-network container
+
+[`examples/systemd/rustbgpd-container.service`](../examples/systemd/rustbgpd-container.service)
+generalizes the host-network recipe above. It keeps `docker run` attached so
+the daemon's exit status drives `Restart=on-failure`, maps `systemctl reload`
+to SIGHUP, gives Docker the full 32-minute settlement grace and systemd a
+33-minute outer margin, and makes the registry pull best-effort so an
+explicitly selected cached image remains usable during a registry outage. A
+missing or empty `RUSTBGPD_IMAGE` fails closed before any Docker command runs.
+
+Install the unit and its required image environment file after creating the
+root-owned state directory:
+
+```sh
+sudo install -d -o root -g root -m 0755 /etc/rustbgpd
+sudo install -d -o root -g root -m 0700 /var/lib/rustbgpd
+sudo install -o root -g root -m 0600 config.toml /etc/rustbgpd/config.toml
+sudo install -m 0644 examples/systemd/rustbgpd-container.service \
+  /etc/systemd/system/rustbgpd-container.service
+sudo tee /etc/rustbgpd/rustbgpd-container.env >/dev/null <<'EOF'
+RUSTBGPD_IMAGE=ghcr.io/lance0/rustbgpd:0.67.0
+EOF
+sudo chmod 0644 /etc/rustbgpd/rustbgpd-container.env
+sudo systemctl daemon-reload
+```
+
+The overridable host defaults are `RUSTBGPD_CONFIG_DIR=/etc/rustbgpd` and
+`RUSTBGPD_STATE_DIR=/var/lib/rustbgpd`; both are bind-mounted at their standard
+container paths. `RUSTBGPD_CONFIG_FILE=/etc/rustbgpd/config.toml` selects the
+file inside the read-only config mount. Put any overrides beside
+`RUSTBGPD_IMAGE` in the environment file. An upgrade is one image-tag edit
+followed by `systemctl restart rustbgpd-container`; version tags still omit the
+leading `v`. `RUSTBGPD_IMAGE` is required and must be non-empty; the unit
+checks it before its best-effort pull.
+
+The unit deliberately mounts the config directory read-only. Runtime mutation
+(`rbgp neighbor add`, policy edits, gNMI `Set`, and `rbgp config apply`) is
+therefore excluded: those calls cannot persist and are rejected. Supporting
+them requires an explicit change to the mount and root-owned config-directory
+write contract; the shipped unit is for externally managed config plus SIGHUP.
+
+Before the first start, and before restarting after an image or config change,
+validate the exact externally managed config directory and selected image
+without touching the running container:
+
+```sh
+docker run --rm \
+  --user=root \
+  --cap-drop=ALL \
+  --mount=type=bind,source=/etc/rustbgpd,target=/etc/rustbgpd,readonly \
+  ghcr.io/lance0/rustbgpd:0.67.0 \
+  rustbgpd --check --strict /etc/rustbgpd/config.toml
+```
+
+Only enable the service after that check succeeds:
+
+```sh
+sudo systemctl enable --now rustbgpd-container
+```
+
+The image's declared healthcheck remains active under systemd supervision and
+runs `rbgp --json health` against the default state-directory UDS. An
+`unhealthy` result remains observable with
+`docker inspect --format '{{.State.Health.Status}}' rustbgpd`, but Docker health
+status does not terminate the attached process and therefore does not drive
+systemd's `Restart=on-failure`. If the config moves the socket, set
+`RUSTBGPD_ADDR` for the container by extending the unit's `docker run` command.
 
 - **File descriptors**: `--ulimit nofile` is required, not tuning. The
   Docker default soft limit is 1024, well under the 4096 floor
@@ -656,9 +806,10 @@ For your own deployment:
   RPC is rejected without it. Mount it `:ro` only when the config is
   managed entirely from outside and reloaded with SIGHUP.
 
-- **Settlement fail-stop**: `--stop-timeout=1920` gives an explicit stop the
-  same 32-minute grace as the shipped systemd unit. A failure to create the
-  initial persistence stage rejects cleanly before runtime mutation. After
+- **Settlement fail-stop**: `--stop-timeout=1920` gives the daemon a 32-minute
+  Docker stop grace; the shipped container unit's `TimeoutStopSec=33min` is the
+  supervisor margin around that operation. A failure to create the initial
+  persistence stage rejects cleanly before runtime mutation. After
   runtime mutation begins, a failed rename is `NotPublished`: only complete
   acknowledged compensation returns cleanly; otherwise known divergence fences
   recovery. A post-rename directory-fsync failure is `PublicationAmbiguous`:
@@ -681,11 +832,13 @@ For your own deployment:
 - **Logs**: structured JSON when `[global.telemetry] log_format =
   "json"` is set; pipe to your log aggregator.
 
-- **Networking**: Linux FIB integration and BFD require the container
-  to share the host network namespace (or otherwise have access to
-  the routing table you intend to program). The interop suite runs
-  rustbgpd as a containerlab `kind: linux` node, which is the cleanest
-  reference setup.
+- **Networking**: Linux FIB integration and BFD require access to the network
+  namespace they operate on. For host addresses, use the [root host-network
+  path](#host-networking-and-privileged-bgp-ports) above; if the configuration
+  also programs the host FIB or interfaces, add its documented `NET_ADMIN`
+  opt-in. A bridge container affects only its own namespace. The interop suite
+  runs rustbgpd as a containerlab `kind: linux` node, which is the cleanest
+  reference setup for an isolated lab namespace.
 
 ## Containerlab quick start
 

--- a/examples/systemd/rustbgpd-container.service
+++ b/examples/systemd/rustbgpd-container.service
@@ -1,0 +1,57 @@
+[Unit]
+Description=rustbgpd BGP daemon (Docker container)
+Documentation=https://github.com/lance0/rustbgpd/blob/main/docs/deployment.md
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+# Bound repeated fail-stop recovery: five starts per ten-minute window.
+StartLimitIntervalSec=10min
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=root
+Group=root
+
+# RUSTBGPD_IMAGE is required. The other values below are overridable defaults.
+# Example EnvironmentFile:
+#   RUSTBGPD_IMAGE=ghcr.io/lance0/rustbgpd:0.67.0
+Environment=RUSTBGPD_CONFIG_DIR=/etc/rustbgpd
+Environment=RUSTBGPD_STATE_DIR=/var/lib/rustbgpd
+Environment=RUSTBGPD_CONFIG_FILE=/etc/rustbgpd/config.toml
+EnvironmentFile=/etc/rustbgpd/rustbgpd-container.env
+
+# Fail closed before any Docker action when the required image is missing or
+# empty. The x-prefix keeps both test operands present after systemd expansion.
+ExecStartPre=/usr/bin/test x${RUSTBGPD_IMAGE} != x
+# Pull is best-effort so a registry outage does not hide a locally cached,
+# explicitly selected image. Remove a stale same-name container before start.
+ExecStartPre=-/usr/bin/docker pull ${RUSTBGPD_IMAGE}
+ExecStartPre=-/usr/bin/docker rm --force rustbgpd
+ExecStart=/usr/bin/docker run \
+  --name=rustbgpd \
+  --rm \
+  --network=host \
+  --user=root \
+  --cap-drop=ALL \
+  --cap-add=NET_BIND_SERVICE \
+  --stop-timeout=1920 \
+  --ulimit=nofile=65536:524288 \
+  --mount=type=bind,source=${RUSTBGPD_CONFIG_DIR},target=/etc/rustbgpd,readonly \
+  --mount=type=bind,source=${RUSTBGPD_STATE_DIR},target=/var/lib/rustbgpd \
+  ${RUSTBGPD_IMAGE} \
+  rustbgpd ${RUSTBGPD_CONFIG_FILE}
+ExecReload=/usr/bin/docker kill --signal=HUP rustbgpd
+ExecStop=-/usr/bin/docker stop -t 1920 rustbgpd
+ExecStopPost=-/usr/bin/docker rm --force rustbgpd
+
+# The attached `docker run` exits with the daemon, so component failures and
+# exit 70 remain restartable while a clean SIGTERM/systemctl stop does not.
+Restart=on-failure
+RestartSec=5
+# Docker owns the 32-minute daemon grace; systemd gets a one-minute outer
+# margin to observe docker stop and reap the attached client cleanly.
+TimeoutStopSec=33min
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -39,6 +40,7 @@ MONITORING = (
 )
 SYSTEMD_UNIT = "examples/systemd/rustbgpd.service"
 SYSTEMD_TEMPLATE = "examples/systemd/rustbgpd@.service"
+SYSTEMD_CONTAINER_UNIT = "examples/systemd/rustbgpd-container.service"
 COMPOSE_FILE = "examples/docker-compose/docker-compose.yml"
 LICENSE_MAP = "LICENSES.md"
 SYSTEMD_DIRECTIVES = {
@@ -62,6 +64,51 @@ TEMPLATE_DIRECTIVES = {
     ("Service", "PrivateTmp"): "yes",
     ("Service", "AmbientCapabilities"): "CAP_NET_BIND_SERVICE",
     ("Service", "CapabilityBoundingSet"): "CAP_NET_BIND_SERVICE",
+}
+CONTAINER_EXEC_START = (
+    "/usr/bin/docker run --name=rustbgpd --rm --network=host --user=root "
+    "--cap-drop=ALL --cap-add=NET_BIND_SERVICE "
+    "--stop-timeout=1920 --ulimit=nofile=65536:524288 "
+    "--mount=type=bind,source=${RUSTBGPD_CONFIG_DIR},target=/etc/rustbgpd,readonly "
+    "--mount=type=bind,source=${RUSTBGPD_STATE_DIR},target=/var/lib/rustbgpd "
+    "${RUSTBGPD_IMAGE} rustbgpd ${RUSTBGPD_CONFIG_FILE}"
+)
+CONTAINER_DIRECTIVES = {
+    ("Unit", "After"): ("docker.service network-online.target",),
+    ("Unit", "Requires"): ("docker.service",),
+    ("Unit", "Wants"): ("network-online.target",),
+    ("Unit", "StartLimitIntervalSec"): ("10min",),
+    ("Unit", "StartLimitBurst"): ("5",),
+    ("Service", "Type"): ("simple",),
+    ("Service", "User"): ("root",),
+    ("Service", "Group"): ("root",),
+    ("Service", "Environment"): (
+        "RUSTBGPD_CONFIG_DIR=/etc/rustbgpd",
+        "RUSTBGPD_STATE_DIR=/var/lib/rustbgpd",
+        "RUSTBGPD_CONFIG_FILE=/etc/rustbgpd/config.toml",
+    ),
+    ("Service", "EnvironmentFile"): (
+        "/etc/rustbgpd/rustbgpd-container.env",
+    ),
+    ("Service", "ExecStartPre"): (
+        "/usr/bin/test x${RUSTBGPD_IMAGE} != x",
+        "-/usr/bin/docker pull ${RUSTBGPD_IMAGE}",
+        "-/usr/bin/docker rm --force rustbgpd",
+    ),
+    ("Service", "ExecStart"): (CONTAINER_EXEC_START,),
+    ("Service", "ExecReload"): (
+        "/usr/bin/docker kill --signal=HUP rustbgpd",
+    ),
+    ("Service", "ExecStop"): (
+        "-/usr/bin/docker stop -t 1920 rustbgpd",
+    ),
+    ("Service", "ExecStopPost"): (
+        "-/usr/bin/docker rm --force rustbgpd",
+    ),
+    ("Service", "Restart"): ("on-failure",),
+    ("Service", "RestartSec"): ("5",),
+    ("Service", "TimeoutStopSec"): ("33min",),
+    ("Install", "WantedBy"): ("multi-user.target",),
 }
 
 
@@ -178,6 +225,20 @@ def systemd_status_is_70(token: str) -> bool:
         return False
 
 
+def check_systemd_exit_70(
+    errors: list[str],
+    assignments: tuple[tuple[str | None, str, str], ...],
+    label: str,
+) -> None:
+    for _, key, value in assignments:
+        if key in {"SuccessExitStatus", "RestartPreventExitStatus"} and any(
+            systemd_status_is_70(token) for token in value.split()
+        ):
+            errors.append(
+                f"{label}: {key} must not classify exit 70/SOFTWARE as non-restartable"
+            )
+
+
 def check_systemd_unit(errors: list[str], text: str) -> None:
     assignments = systemd_assignments(text)
     for (section, key), expected in SYSTEMD_DIRECTIVES.items():
@@ -190,13 +251,7 @@ def check_systemd_unit(errors: list[str], text: str) -> None:
             errors.append(
                 f"systemd unit: [{section}] {key} must occur once with value {expected!r}, got {actual!r}"
             )
-    for _, key, value in assignments:
-        if key in {"SuccessExitStatus", "RestartPreventExitStatus"} and any(
-            systemd_status_is_70(token) for token in value.split()
-        ):
-            errors.append(
-                f"systemd unit: {key} must not classify exit 70/SOFTWARE as non-restartable"
-            )
+    check_systemd_exit_70(errors, assignments, "systemd unit")
 
 
 def check_systemd_template(
@@ -223,6 +278,135 @@ def check_systemd_template(
     if "%I" in text:
         errors.append("systemd template: unescaped %I must not replace the exact router handle")
     check_systemd_unit(errors, text)
+
+
+def check_systemd_container(errors: list[str], text: str) -> None:
+    assignments = systemd_assignments(text)
+    for (section, key), expected in CONTAINER_DIRECTIVES.items():
+        actual = tuple(
+            value
+            for found_section, found_key, value in assignments
+            if found_section == section and found_key == key
+        )
+        if actual != expected:
+            errors.append(
+                "systemd container unit: "
+                f"[{section}] {key} must be {expected!r}, got {actual!r}"
+            )
+    check_systemd_exit_70(errors, assignments, "systemd container unit")
+    exec_starts = (
+        value
+        for section, key, value in assignments
+        if section == "Service" and key == "ExecStart"
+    )
+    if any(container_exec_start_publishes(command) for command in exec_starts):
+        errors.append(
+            "systemd container unit: host networking must not carry bridge publish flags"
+        )
+
+
+def container_exec_start_publishes(command: str) -> bool:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    if tokens[:2] != ["/usr/bin/docker", "run"]:
+        return False
+    try:
+        image_index = tokens.index("${RUSTBGPD_IMAGE}", 2)
+    except ValueError:
+        return False
+    for token in tokens[2:image_index]:
+        if token == "-p" or (token.startswith("-p") and not token.startswith("--")):
+            return True
+        if token == "-P" or token.startswith("-P="):
+            return True
+        if token == "--publish" or token.startswith("--publish="):
+            return True
+        if token == "--publish-all" or token.startswith("--publish-all="):
+            return True
+    return False
+
+
+def check_container_deployment_docs(
+    errors: list[str], deployment: str, dockerfile: str
+) -> None:
+    required_docs = (
+        "published GHCR version tags have **no leading",
+        "default command is exactly",
+        "net.ipv4.ip_unprivileged_port_start=0",
+        "`--cap-add=NET_BIND_SERVICE` is **not sufficient**",
+        "Use exactly one of these deployment paths:",
+        "`--network=host` with `--user=root`",
+        "--cap-drop=ALL",
+        "runtime-state marker/checkpoint storage unavailable",
+        "must be non-empty",
+        "Runtime mutation",
+        "status does not terminate the attached process",
+        "`TimeoutStopSec=33min`",
+        "rustbgpd --check --strict /etc/rustbgpd/config.toml",
+        "docker inspect --format '{{.State.Health.Status}}' rustbgpd",
+    )
+    for statement in required_docs:
+        if statement not in deployment:
+            errors.append(
+                f"container deployment docs: missing contract statement {statement!r}"
+            )
+
+    bridge_section = deployment.partition("- **Bridge networking and state**:")[2]
+    bridge_section = bridge_section.partition(
+        "### Host networking and privileged BGP ports"
+    )[0]
+    bridge_recipes = re.findall(r"(?ms)^  ```sh\n(.*?)^  ```$", bridge_section)
+    bridge = next((body for body in bridge_recipes if "--network=bridge" in body), None)
+    if bridge is None:
+        errors.append("container deployment docs: bridge recipe missing")
+    elif "--cap-add" in bridge:
+        errors.append(
+            "container deployment docs: bridge recipe must not credit a capability for port 179"
+        )
+
+    host_section = deployment.partition(
+        "### Host networking and privileged BGP ports"
+    )[2].partition("### systemd-supervised host-network container")[0]
+    host_recipes = re.findall(r"(?ms)^   ```sh\n(.*?)^   ```$", host_section)
+    host = next((body for body in host_recipes if "--network=host" in body), None)
+    if host is None:
+        errors.append("container deployment docs: host-network recipe missing")
+    else:
+        for flag in ("--user=root", "--cap-drop=ALL", "--cap-add=NET_BIND_SERVICE"):
+            if flag not in host:
+                errors.append(
+                    f"container deployment docs: host-network recipe missing {flag!r}"
+                )
+
+    service_section = deployment.partition(
+        "### systemd-supervised host-network container"
+    )[2].partition("- **File descriptors**")[0]
+    preflight = service_section.find(
+        "rustbgpd --check --strict /etc/rustbgpd/config.toml"
+    )
+    enable = service_section.find("sudo systemctl enable --now rustbgpd-container")
+    if preflight < 0 or enable < 0 or preflight > enable:
+        errors.append(
+            "container deployment docs: strict preflight must precede enable --now"
+        )
+
+    try:
+        runtime = dockerfile.split("FROM debian:bookworm-slim AS runtime", 1)[1]
+    except IndexError:
+        errors.append("container image contract: production runtime stage missing")
+        return
+    for statement in (
+        "chown rustbgpd:rustbgpd /var/lib/rustbgpd",
+        "USER rustbgpd",
+        "CMD rbgp --json health | grep -q '\"healthy\": true' || exit 1",
+        'CMD ["rustbgpd", "/etc/rustbgpd/config.toml"]',
+    ):
+        if statement not in runtime:
+            errors.append(
+                f"container image contract: missing production statement {statement!r}"
+            )
 
 
 def compose_service(text: str, name: str) -> tuple[str, ...]:
@@ -268,6 +452,10 @@ def check(root: Path) -> list[str]:
     try:
         check_systemd_unit(errors, read(SYSTEMD_UNIT))
         check_systemd_template(errors, read(SYSTEMD_TEMPLATE))
+        check_systemd_container(errors, read(SYSTEMD_CONTAINER_UNIT))
+        check_container_deployment_docs(
+            errors, read("docs/deployment.md"), read("Dockerfile")
+        )
         check_compose(errors, read(COMPOSE_FILE))
         license_map = read(LICENSE_MAP)
         for clause in (
@@ -358,6 +546,11 @@ def check(root: Path) -> list[str]:
             errors.append(f"native systemd template mapping missing {template_mapping!r}")
 
         contract = read(".github/workflows/release-install-contract.yml")
+        select_script(
+            contract,
+            "container systemd syntax verification",
+            "systemd-analyze verify examples/systemd/rustbgpd-container.service",
+        )
         native = select_script(
             contract,
             "real native package assertions",

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -15,6 +17,7 @@ CHECK = '"$tree/usr/bin/rustbgpd" --check "$tree/etc/rustbgpd/config.toml"'
 RPM_EXTRACT = "cpio --quiet -id --no-absolute-filenames --directory=extracted/rpm"
 EXE_LOOP = "for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do"
 IMAGE_RUN = "run: docker run --rm --entrypoint birdwatcher-adapter"
+SYSTEMD_VERIFY = "systemd-analyze verify examples/systemd/rustbgpd-container.service"
 UNIT_ASSERT = 'grep -qxF "$directive" "$unit"'
 TEMPLATE_EXEC_ASSERT = "grep -qxF 'ExecStart=/usr/bin/rustbgpd /var/lib/rustbgpd/%i/activation/current/config.toml' \"$template\""
 STATUS_GUARD = "from scripts.check_release_install_contract import check_systemd_template, systemd_assignments, systemd_status_is_70"
@@ -32,8 +35,11 @@ INPUTS = (
     "docs/grafana/rustbgpd-evpn.json",
     "examples/prometheus/rustbgpd-alerts.yml",
     "examples/prometheus/rustbgpd-alerts_test.yml",
+    "Dockerfile",
+    "docs/deployment.md",
     contract.SYSTEMD_UNIT,
     contract.SYSTEMD_TEMPLATE,
+    contract.SYSTEMD_CONTAINER_UNIT,
     contract.COMPOSE_FILE,
     contract.LICENSE_MAP,
 )
@@ -244,6 +250,156 @@ MUTATIONS = (
         "systemd unit",
     ),
     (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "After=docker.service network-online.target",
+        "After=network-online.target",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "Requires=docker.service",
+        "Requires=network-online.target",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "Wants=network-online.target",
+        "Wants=docker.service",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "WantedBy=multi-user.target",
+        "WantedBy=default.target",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "--network=host",
+        "--network=bridge",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "--user=root",
+        "--user=rustbgpd",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "target=/etc/rustbgpd,readonly",
+        "target=/etc/rustbgpd",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "target=/var/lib/rustbgpd",
+        "target=/tmp/rustbgpd",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "ExecStartPre=/usr/bin/test x${RUSTBGPD_IMAGE} != x\n",
+        "",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "ExecStartPre=/usr/bin/test x${RUSTBGPD_IMAGE} != x",
+        "ExecStartPre=/usr/bin/test -n ${RUSTBGPD_IMAGE}",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "EnvironmentFile=/etc/rustbgpd/rustbgpd-container.env",
+        "EnvironmentFile=-/etc/rustbgpd/rustbgpd-container.env",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "  --cap-drop=ALL \\\n",
+        "  --cap-drop=NET_RAW \\\n",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "  --cap-add=NET_BIND_SERVICE \\\n",
+        "",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "  ${RUSTBGPD_IMAGE} \\\n",
+        "  ${RUSTBGPD_IMAGE_TAG} \\\n",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "ExecStartPre=-/usr/bin/docker pull",
+        "ExecStartPre=/usr/bin/docker pull",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "ExecReload=/usr/bin/docker kill --signal=HUP rustbgpd",
+        "ExecReload=/usr/bin/docker restart rustbgpd",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "ExecStop=-/usr/bin/docker stop -t 1920 rustbgpd",
+        "ExecStop=-/usr/bin/docker stop --timeout=1920 rustbgpd",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "TimeoutStopSec=33min",
+        "TimeoutStopSec=32min",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "[Service]",
+        "[Service]\nSuccessExitStatus=70",
+        "systemd container unit",
+    ),
+    (
+        contract.SYSTEMD_CONTAINER_UNIT,
+        "[Service]",
+        "[Service]\nRestartPreventExitStatus=SOFTWARE",
+        "systemd container unit",
+    ),
+    (
+        WORKFLOW,
+        SYSTEMD_VERIFY,
+        "true # " + SYSTEMD_VERIFY,
+        "container systemd syntax verification",
+    ),
+    (
+        "docs/deployment.md",
+        "`--cap-add=NET_BIND_SERVICE` is **not sufficient**",
+        "`--cap-add=NET_BIND_SERVICE` is sufficient",
+        "container deployment docs",
+    ),
+    (
+        "docs/deployment.md",
+        "    --network=bridge \\\n",
+        "    --network=bridge \\\n    --cap-add=NET_BIND_SERVICE \\\n",
+        "container deployment docs",
+    ),
+    (
+        "docs/deployment.md",
+        "docker run --rm \\\n  --user=root \\\n  --cap-drop=ALL \\\n",
+        "sudo systemctl enable --now rustbgpd-container\ndocker run --rm \\\n  --user=root \\\n  --cap-drop=ALL \\\n",
+        "container deployment docs",
+    ),
+    (
+        "Dockerfile",
+        "USER rustbgpd",
+        "USER root",
+        "container image contract",
+    ),
+    (
         contract.COMPOSE_FILE,
         "stop_grace_period: 32m",
         "stop_grace_period: 31m",
@@ -278,6 +434,79 @@ class ReleaseInstallContractTest(unittest.TestCase):
 
     def test_repository_contract(self) -> None:
         self.assertEqual(contract.check(ROOT), [])
+
+    def test_required_container_image_guard_is_empty_safe(self) -> None:
+        unit = (ROOT / contract.SYSTEMD_CONTAINER_UNIT).read_text()
+        guards = [
+            value
+            for section, key, value in contract.systemd_assignments(unit)
+            if section == "Service"
+            and key == "ExecStartPre"
+            and value.startswith("/usr/bin/test ")
+        ]
+        self.assertEqual(guards, ["/usr/bin/test x${RUSTBGPD_IMAGE} != x"])
+        for image in (None, ""):
+            with self.subTest(image=image):
+                expanded = guards[0].replace("${RUSTBGPD_IMAGE}", image or "")
+                self.assertNotEqual(
+                    subprocess.run(shlex.split(expanded), check=False).returncode,
+                    0,
+                )
+        expanded = guards[0].replace(
+            "${RUSTBGPD_IMAGE}", "ghcr.io/lance0/rustbgpd:0.67.0"
+        )
+        self.assertEqual(
+            subprocess.run(shlex.split(expanded), check=False).returncode,
+            0,
+        )
+
+    def test_host_network_container_rejects_every_publish_flag(self) -> None:
+        unit = (ROOT / contract.SYSTEMD_CONTAINER_UNIT).read_text()
+        message = (
+            "systemd container unit: host networking must not carry bridge "
+            "publish flags"
+        )
+        for flag in (
+            "-p 179:179",
+            "-p179:179",
+            "-p=179:179",
+            "-P ",
+            "-P=true ",
+            "-P=false ",
+            "--publish 179:179",
+            "--publish=179:179",
+            "--publish-all ",
+            "--publish-all=true ",
+        ):
+            with self.subTest(flag=flag):
+                errors: list[str] = []
+                mutated = unit.replace("--network=host", f"--network=host {flag}", 1)
+                contract.check_systemd_container(errors, mutated)
+                self.assertIn(message, errors)
+
+    def test_container_publish_guard_ignores_non_docker_option_tokens(self) -> None:
+        unit = (ROOT / contract.SYSTEMD_CONTAINER_UNIT).read_text()
+        message = (
+            "systemd container unit: host networking must not carry bridge "
+            "publish flags"
+        )
+        mutations = (
+            unit.replace(
+                "ExecStartPre=/usr/bin/test x${RUSTBGPD_IMAGE} != x",
+                "ExecStartPre=/usr/bin/test -p /run/docker.sock",
+                1,
+            ),
+            unit.replace(
+                "rustbgpd ${RUSTBGPD_CONFIG_FILE}",
+                "rustbgpd ${RUSTBGPD_CONFIG_FILE} -profile",
+                1,
+            ),
+        )
+        for mutated in mutations:
+            with self.subTest(mutated=mutated):
+                errors: list[str] = []
+                contract.check_systemd_container(errors, mutated)
+                self.assertNotIn(message, errors)
 
     def test_destructive_mutations_fail(self) -> None:
         for relative, old, new, label in MUTATIONS:


### PR DESCRIPTION
## Summary

- document the distinct Docker bridge and host-network low-port contracts, including why adding NET_BIND_SERVICE does not make the image's uid 999 path work under host networking
- add a generalized host-network systemd unit with fail-closed image selection, minimized root capabilities, root-owned persistent state, read-only external config, HUP reload, attached restart semantics, and a bounded stop margin
- extend the release install contract with exact service/directive drift checks, destructive tests, and hosted systemd syntax verification

The bridge recipe remains the default uid 999 path. Host networking is the explicit root path for host-address binding or host dataplane integration; it drops all capabilities and adds back only NET_BIND_SERVICE, with NET_ADMIN separately opt-in.

## Validation

- release install contract tests: 14/14
- live release install checker
- systemd-analyze verify
- Docker option/help checks
- ShellCheck for new deployment snippets
- public tracker-ID and release-checklist path checks
- git diff --check
- full push hooks
- two independent documentation/service audits