### PR TITLE
docs: bind four receipts to provenance tags

### DIFF
--- a/docs/perf/config-persistence-2026-07.md
+++ b/docs/perf/config-persistence-2026-07.md
@@ -41,6 +41,15 @@ record agree at every boundary.
 
 **Measured commit:** `6a49f0963c9d30a7866ebf5a413090a5fb4090b5`
 
+**Measured on:** 2026-07-25 UTC
+
+**Receipt tag:** `receipt/config-persistence-2026-07`
+
+**Source-equivalent landed squash:**
+`6ff4fb03e6f3c12fb5086ffd6e57310a6f300aef`. The measurement-relevant
+source and harness landed unchanged; the measurement occurred at the measured
+commit above, not at the landed squash.
+
 **Result:** 109 of 109 precommitted checks pass (105 harness checks, 0 failed;
 4 driver log gates, 0 failed). Zero stub decode errors on daemon UPDATEs. Wall
 clock 27 s.

--- a/docs/perf/outbound-prefix-limits-2026-07.md
+++ b/docs/perf/outbound-prefix-limits-2026-07.md
@@ -33,6 +33,15 @@ edit, including the one made on the peer group.
 
 **Measured commit:** `e2e66fb75e0565c6b3282bef0020744f05b160dc`
 
+**Measured on:** 2026-07-24 UTC
+
+**Receipt tag:** `receipt/outbound-prefix-limits-2026-07`
+
+**Source-equivalent landed squash:**
+`4eb75aa045467fb0676293888ea404f3bbbca1d6`. The measurement-relevant
+source and harness landed unchanged; the measurement occurred at the measured
+commit above, not at the landed squash.
+
 **Result:** 96 of 96 precommitted checks pass (91 harness checks, 0 failed;
 5 driver log gates, 0 failed). Zero stub decode errors on daemon UPDATEs.
 

--- a/docs/perf/reload-stall-2026-07.md
+++ b/docs/perf/reload-stall-2026-07.md
@@ -12,7 +12,18 @@ the receiver, under churn, against a pre-committed gate:
 > **Gate: UPDATE-delivery stall < 1 s during a full import+export
 > policy swap at 700 clients × 400k routes, with live churn.**
 
-**Commit measured:** `61efe075`
+**Commit measured:** `1f519a5bcfb11503d65d23fc9480f821acce1838`
+
+**Measured on:** 2026-07-11 UTC
+
+**Receipt tag:** `receipt/reload-stall-2026-07`
+
+**Source-equivalent landed squash:**
+`cd03ca61a84291d3f6fe4c3e7f5084488cf690a0`. The measurement-relevant
+source and harness landed unchanged; the measurement occurred at the measured
+commit above, not at the landed squash.
+
+The measured tree contains daemon-change commit `61efe075`
 (`fix/outbound-oversized-group-truncation`; main `25979227` plus the
 outbound size-chunking fix described in
 [Why this supersedes the earlier run](#why-this-supersedes-the-earlier-run),
@@ -46,8 +57,9 @@ over-count was not.
 ## Current numbers — 2026-07-16 campaign
 
 **Commit measured:** `a25ad76b`. The section below replaces the
-`61efe075` headline as the current receipt; the historical numbers and
-the interim regression are kept further down for the record.
+`1f519a5b` receipt headline (whose daemon-change commit was `61efe075`) as the
+current receipt; the historical numbers and the interim regression are kept
+further down for the record.
 
 The same 700-client x 400,400-route campaign now runs in BOTH reload
 shapes — the historical full import+export swap, and the export-only

--- a/docs/perf/route-server-1000-2026-07.md
+++ b/docs/perf/route-server-1000-2026-07.md
@@ -11,6 +11,15 @@ describe this disclosed fleet rather than a universal deployment forecast.
 
 **Measured commit:** `cb2c924f117fe264991f12b24ea44c2b15b132e2`
 
+**Measured on:** 2026-07-20 UTC
+
+**Receipt tag:** `receipt/route-server-1000-2026-07`
+
+**Source-equivalent landed squash:**
+`651923720925f85c9000a8e6907fb1b599767803`. The measurement-relevant
+source and harness landed unchanged; the measurement occurred at the measured
+commit above, not at the landed squash.
+
 > **Default drift since this run.** The scenario config declares a bare
 > `[policy]` with no `[policy.explain]` override, so this campaign ran
 > with the import-decision explain cache **enabled** — the default at the


### PR DESCRIPTION
## Summary

- bind four July scale receipts to their permanent receipt tags and exact measured commits
- record UTC measurement dates and source-equivalent landed squashes
- distinguish the reload receipt tree, its daemon-change commit, and the later current campaign

## Validation

- verified all four remote tag mappings and commit objects
- verified landed-squash ancestry and measurement-relevant source/harness equivalence
- `python3 -m unittest -v scripts/test_check_public_tracker_ids.py`
- `python3 scripts/check_public_tracker_ids.py`
- `git diff --check origin/main...HEAD`

Linear: [LAN-1352](https://linear.app/lance0/issue/LAN-1352)