### PR TITLE
telemetry: expose session lifecycle source drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   deployment guide now distinguishes Docker bridge low-port behavior from host
   networking and explains the uid 999 capability and state-owner traps.
 
+- `bgp_session_lifecycle_source_dropped_total{reason}` exposes session state
+  changes dropped before process-local, live, and durable event history. Its
+  preinitialized `channel_full` and `channel_closed` series feed the shipped
+  warning alert, which directs operators to resnapshot current neighbor state.
+
 - Periodic BMP peer statistics now include RFC 9972 type 22 for exact counts of
   current pre-policy IPv4/IPv6-unicast Adj-RIB-In routes rejected by inbound
   policy. Rows are emitted only for negotiated families while rejected-route

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -327,6 +327,7 @@ struct BgpMetricsInner {
     // ── Event streams ───────────────────────────────────────────
     event_stream_lagged: IntCounterVec,
     event_stream_subscribers: IntGaugeVec,
+    session_lifecycle_source_dropped: IntCounterVec,
     grpc_authz_decisions: IntCounterVec,
     grpc_credential_reloads: IntCounterVec,
     config_transaction_lifecycle: IntCounterVec,
@@ -929,6 +930,20 @@ impl BgpMetrics {
             &["service", "source"],
         )
         .expect("valid metric definition");
+
+        let session_lifecycle_source_dropped = IntCounterVec::new(
+            Opts::new(
+                "bgp_session_lifecycle_source_dropped_total",
+                "Session lifecycle events dropped before process-local, live, and durable event history, by bounded reason.",
+            ),
+            &["reason"],
+        )
+        .expect("valid metric definition");
+        for reason in ["channel_full", "channel_closed"] {
+            session_lifecycle_source_dropped
+                .with_label_values(&[reason])
+                .inc_by(0);
+        }
 
         let grpc_authz_decisions = IntCounterVec::new(
             Opts::new(
@@ -2329,6 +2344,9 @@ impl BgpMetrics {
             .register(Box::new(event_stream_subscribers.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(session_lifecycle_source_dropped.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(grpc_authz_decisions.clone()))
             .expect("metric not already registered");
         registry
@@ -2808,6 +2826,7 @@ impl BgpMetrics {
             orr_input_objects,
             event_stream_lagged,
             event_stream_subscribers,
+            session_lifecycle_source_dropped,
             grpc_authz_decisions,
             grpc_credential_reloads,
             config_transaction_lifecycle,
@@ -3571,6 +3590,22 @@ impl BgpMetrics {
             .event_stream_lagged
             .with_label_values(&[service, source])
             .inc_by(missed);
+    }
+
+    /// Record one session lifecycle event dropped because its source channel was full.
+    pub fn record_session_lifecycle_source_channel_full(&self) {
+        self.0
+            .session_lifecycle_source_dropped
+            .with_label_values(&["channel_full"])
+            .inc();
+    }
+
+    /// Record one session lifecycle event dropped because its source channel was closed.
+    pub fn record_session_lifecycle_source_channel_closed(&self) {
+        self.0
+            .session_lifecycle_source_dropped
+            .with_label_values(&["channel_closed"])
+            .inc();
     }
 
     /// Increment the current live event-stream subscriber gauge.
@@ -6085,6 +6120,51 @@ mod tests {
                 .with_label_values(&["watch_events", "session"])
                 .get(),
             0
+        );
+    }
+
+    #[test]
+    fn session_lifecycle_source_drop_series_are_bounded_and_accumulate_independently() {
+        let m = BgpMetrics::new();
+
+        let samples = m
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_session_lifecycle_source_dropped_total")
+            .expect("session lifecycle source-drop metric registered")
+            .metric
+            .into_iter()
+            .map(|metric| {
+                assert_eq!(metric.get_label().len(), 1, "only reason label");
+                (
+                    metric.get_label()[0].value().to_owned(),
+                    metric.get_counter().value(),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(
+            samples,
+            std::collections::BTreeMap::from([
+                ("channel_closed".to_string(), 0.0),
+                ("channel_full".to_string(), 0.0),
+            ])
+        );
+
+        m.record_session_lifecycle_source_channel_full();
+        m.record_session_lifecycle_source_channel_full();
+        m.record_session_lifecycle_source_channel_closed();
+        assert_eq!(
+            m.0.session_lifecycle_source_dropped
+                .with_label_values(&["channel_full"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.0.session_lifecycle_source_dropped
+                .with_label_values(&["channel_closed"])
+                .get(),
+            1
         );
     }
 

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -857,7 +857,7 @@ impl PeerSession {
         follow_up
     }
 
-    fn try_send_lifecycle_state_changed(&self, old: SessionState, new: SessionState) {
+    pub(super) fn try_send_lifecycle_state_changed(&self, old: SessionState, new: SessionState) {
         if let Some(ref lifecycle_tx) = self.session_lifecycle_tx {
             let negotiated = self.fsm.negotiated().or(self.negotiated.as_deref());
             match lifecycle_tx.try_send(SessionLifecycleNotification::StateChanged {
@@ -870,12 +870,15 @@ impl PeerSession {
             }) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {
+                    self.metrics.record_session_lifecycle_source_channel_full();
                     debug!(
                         peer = %self.peer_label,
                         "dropped StateChanged lifecycle event because channel is full"
                     );
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {
+                    self.metrics
+                        .record_session_lifecycle_source_channel_closed();
                     debug!(
                         peer = %self.peer_label,
                         "dropped StateChanged lifecycle event because channel is closed"

--- a/crates/transport/src/session/tests/mod.rs
+++ b/crates/transport/src/session/tests/mod.rs
@@ -213,6 +213,121 @@ fn make_test_session_with_metrics_and_identity(
     )
 }
 
+fn make_test_session_with_lifecycle(
+    metrics: BgpMetrics,
+    lifecycle_tx: Option<mpsc::Sender<SessionLifecycleNotification>>,
+) -> PeerSession {
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    PeerSession::new_with_identity_and_lifecycle(
+        config,
+        metrics,
+        cmd_rx,
+        rib_tx,
+        None,
+        None,
+        None,
+        None,
+        lifecycle_tx,
+        None,
+        None,
+        false,
+        SessionIdentity::default(),
+    )
+}
+
+fn lifecycle_source_drop_value(metrics: &BgpMetrics, reason: &str) -> f64 {
+    counter_samples(metrics, "bgp_session_lifecycle_source_dropped_total")
+        .into_iter()
+        .find_map(|(labels, value)| {
+            (labels.get("reason").map(String::as_str) == Some(reason)).then_some(value)
+        })
+        .expect("preinitialized lifecycle source-drop series")
+}
+
+fn assert_lifecycle_source_drop_value(metrics: &BgpMetrics, reason: &str, expected: f64) {
+    let actual = lifecycle_source_drop_value(metrics, reason);
+    assert!(
+        (actual - expected).abs() < f64::EPSILON,
+        "expected lifecycle source-drop reason {reason} to equal {expected}, got {actual}"
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_source_channel_full_records_one_drop() {
+    let metrics = BgpMetrics::new();
+    let (tx, _rx) = mpsc::channel(1);
+    tx.try_send(SessionLifecycleNotification::StateChanged {
+        session_id: 1,
+        role: SessionRole::Primary,
+        peer_addr: "192.0.2.1".parse().unwrap(),
+        peer_asn: None,
+        old: SessionState::Idle,
+        new: SessionState::Connect,
+    })
+    .unwrap();
+    let session = make_test_session_with_lifecycle(metrics.clone(), Some(tx));
+
+    session.try_send_lifecycle_state_changed(SessionState::Idle, SessionState::Connect);
+
+    assert_lifecycle_source_drop_value(&metrics, "channel_full", 1.0);
+    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 0.0);
+}
+
+#[tokio::test]
+async fn lifecycle_source_channel_closed_records_one_drop() {
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(1);
+    drop(rx);
+    let session = make_test_session_with_lifecycle(metrics.clone(), Some(tx));
+
+    session.try_send_lifecycle_state_changed(SessionState::Idle, SessionState::Connect);
+
+    assert_lifecycle_source_drop_value(&metrics, "channel_full", 0.0);
+    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 1.0);
+}
+
+#[tokio::test]
+async fn lifecycle_source_success_delivers_exact_event_without_drop() {
+    let metrics = BgpMetrics::new();
+    let (tx, mut rx) = mpsc::channel(1);
+    let session = make_test_session_with_lifecycle(metrics.clone(), Some(tx));
+
+    session.try_send_lifecycle_state_changed(SessionState::Idle, SessionState::Connect);
+
+    let event = rx.recv().await.expect("StateChanged delivered");
+    let SessionLifecycleNotification::StateChanged {
+        session_id,
+        role,
+        peer_addr,
+        peer_asn,
+        old,
+        new,
+    } = event;
+    assert_eq!(session_id, 0);
+    assert_eq!(role, SessionRole::Primary);
+    assert_eq!(peer_addr, "10.0.0.2".parse::<IpAddr>().unwrap());
+    assert_eq!(peer_asn, None);
+    assert_eq!(old, SessionState::Idle);
+    assert_eq!(new, SessionState::Connect);
+    assert_lifecycle_source_drop_value(&metrics, "channel_full", 0.0);
+    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 0.0);
+}
+
+#[test]
+fn absent_lifecycle_source_records_no_drop() {
+    let metrics = BgpMetrics::new();
+    let session = make_test_session_with_lifecycle(metrics.clone(), None);
+
+    session.try_send_lifecycle_state_changed(SessionState::Idle, SessionState::Connect);
+
+    assert_lifecycle_source_drop_value(&metrics, "channel_full", 0.0);
+    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 0.0);
+}
+
 fn make_test_session_with_channels(
     local_asn: u32,
     remote_asn: u32,

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -94,7 +94,8 @@ peer, RFC 8212 missing import/export policy, sustained outbound-prefix blocking,
 dynamic-neighbor admission near-limit and rejection,
 actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
 selection-deferral timeout and ledger overflow, outbound route loss, RFC 9687
-send-hold teardown, live event-stream lag/desynchronization, BMP feed loss,
+send-hold teardown, session lifecycle source loss, live event-stream
+lag/desynchronization, BMP feed loss,
 stale MRT dumps, and daemon down)
 ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
@@ -120,6 +121,12 @@ the last increment ages out:
   incremental events. Treat that consumer's local view as desynchronized:
   take a fresh authoritative snapshot for the named service and source, then
   restart the live watch. Use a durable cursor only when that API supports one.
+- `BgpSessionLifecycleSourceDrops` is warning severity because a session state
+  change was lost before process-local, live, and durable event history. The
+  `reason` label distinguishes a full source channel from a closed receiver.
+  Treat all incremental session history as potentially incomplete and
+  resnapshot current neighbor state. The alert clears after the last source
+  drop ages out of its 10-minute window; a flat historical counter stays quiet.
 - `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` are
   warning severity because routing is unaffected, but the BMP mirror is now
   lossy: a dropped per-peer event forces a synthetic PeerDown/PeerUp so

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1136,14 +1136,21 @@ signal.
 
 | Metric | What it tells you |
 |--------|-------------------|
+| `bgp_session_lifecycle_source_dropped_total{reason}` | Session state changes dropped before process-local, live, or durable event history because the bounded source channel was `channel_full` or `channel_closed`. Both reason series exist at zero from startup. |
 | `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`; `source` is `route`, `session`, `policy`, `evpn`, `dataplane`, `dataplane_route`, or `bfd` where applicable |
 | `bgp_event_stream_subscribers{service,source}` | Current live stream subscriber count by service/source |
 | `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rbgp events` history queries |
 | `bgp_route_event_history_capacity` | Fixed capacity of the bounded unicast route-event history ring |
 
-`WatchEvents` is a live tail, not a durable queue. Non-zero `bgp_event_stream_lagged_total` means at least one
-client missed events and should combine a fresh snapshot or `ListRouteEvents`
-query with a new live watch.
+These counters identify distinct loss boundaries. A non-zero
+`bgp_session_lifecycle_source_dropped_total` means the peer manager never
+received a state change, so process-local event history, live delivery, and
+durable history may all be incomplete; resnapshot current neighbor state.
+`WatchEvents` is a live tail, not a durable queue. Non-zero
+`bgp_event_stream_lagged_total` means at least one live subscriber fell behind
+after the event reached the peer manager; combine a fresh snapshot or `ListRouteEvents`
+query with a new live watch. `bgp_event_outbox_dropped_total` instead reports
+loss at the later durable-outbox or durable-cursor boundary.
 
 ### gNMI dial-out
 

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -464,6 +464,23 @@ groups:
             socket, so rustbgpd tore down the session without a NOTIFICATION;
             inspect the writer and peer before allowing the session to recover.
 
+      - alert: BgpSessionLifecycleSourceDrops
+        # Source loss happens before process-local, live, and durable session-event history.
+        expr: increase(bgp_session_lifecycle_source_dropped_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Session lifecycle source dropped events ({{ $labels.reason }})
+          description: >-
+            bgp_session_lifecycle_source_dropped_total for reason
+            {{ $labels.reason }} on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 10 minutes. Session event
+            history, live delivery, and durable history may be incomplete;
+            resnapshot current neighbor state before consuming further
+            incremental session events.
+
       - alert: BgpEventStreamLagged
         # A live subscriber that falls behind misses events and can no longer
         # treat its incremental view as synchronized with daemon state.

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -1447,6 +1447,52 @@ tests:
         alertname: BgpSendHoldExpired
         exp_alerts: []
 
+  # ── BgpSessionLifecycleSourceDrops ────────────────────────
+  - interval: 1m
+    input_series:
+      - series: 'bgp_session_lifecycle_source_dropped_total{reason="channel_full", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_session_lifecycle_source_dropped_total{reason="channel_closed", instance="edge2:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_session_lifecycle_source_dropped_total{reason="channel_full", instance="edge3:9179"}'
+        values: "7x22"
+      - series: 'bgp_event_stream_lagged_total{service="watch_events", source="session", instance="edge4:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpSessionLifecycleSourceDrops
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpSessionLifecycleSourceDrops
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              reason: channel_full
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Session lifecycle source dropped events (channel_full)"
+              description: >-
+                bgp_session_lifecycle_source_dropped_total for reason
+                channel_full on edge1:9179 increased by 1 in the last 10
+                minutes. Session event history, live delivery, and durable
+                history may be incomplete; resnapshot current neighbor state
+                before consuming further incremental session events.
+          - exp_labels:
+              severity: warning
+              reason: channel_closed
+              instance: edge2:9179
+            exp_annotations:
+              summary: "Session lifecycle source dropped events (channel_closed)"
+              description: >-
+                bgp_session_lifecycle_source_dropped_total for reason
+                channel_closed on edge2:9179 increased by 1 in the last 10
+                minutes. Session event history, live delivery, and durable
+                history may be incomplete; resnapshot current neighbor state
+                before consuming further incremental session events.
+      - eval_time: 21m
+        alertname: BgpSessionLifecycleSourceDrops
+        exp_alerts: []
+
   # ── BgpEventStreamLagged ──────────────────────────────────
   # Load-bearing: the old increment pins 10m versus 5m, the reset then
   # increment pins reset-safe increase versus delta, and the same-evaluation

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -557,8 +557,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 198:
-        raise ValueError(f"emitted metric roster changed: expected 198, got {len(inventory)}")
+    if len(inventory) != 199:
+        raise ValueError(f"emitted metric roster changed: expected 199, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,21 +47,21 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 198)
+        self.assertEqual(len(self.inventory), 199)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            185,
+            186,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
         )
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 95)
-        self.assertEqual(len(self.rule_refs), 41)
-        self.assertEqual(len(self.public_doc_refs), 187)
-        self.assertEqual(len(self.doc_refs), 187)
+        self.assertEqual(len(self.rule_refs), 42)
+        self.assertEqual(len(self.public_doc_refs), 188)
+        self.assertEqual(len(self.doc_refs), 188)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 192)
+        self.assertEqual(len(consumers), 193)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("198 emitted families", stdout.getvalue())
-        self.assertIn("187 normative-doc families", stdout.getvalue())
-        self.assertIn("192 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("199 emitted families", stdout.getvalue())
+        self.assertIn("188 normative-doc families", stdout.getvalue())
+        self.assertIn("193 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -31,6 +31,7 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
             {
                 "bgp_evpn_nlri_discarded_total",
                 "bgp_path_attribute_discarded_total",
+                "bgp_session_lifecycle_source_dropped_total",
             },
         )
         self.assertEqual(removed, set())


### PR DESCRIPTION
## Summary

- expose bounded `channel_full` and `channel_closed` source-loss counters for session lifecycle notifications
- ship an immediate warning alert with neighbor-resnapshot recovery guidance
- distinguish source loss from downstream subscriber lag and durable-outbox loss in operator docs

## Validation

- metric consumer suite and live inventory checker
- metric release-note suite and live checker
- focused telemetry and transport lifecycle tests
- pre-push formatting, clippy, full tests, and rustdoc

Linear: LAN-1314