### PR TITLE
test(docs): enforce performance receipt freshness

### DIFF
--- a/.github/workflows/public-docs-contract.yml
+++ b/.github/workflows/public-docs-contract.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Check published crate boundary
         if: matrix.contract == 'embedding'
         run: |
@@ -61,3 +63,8 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_release_checklist_paths.py
           python3 scripts/check_release_checklist_paths.py
+      - name: Check performance receipt provenance and freshness
+        if: matrix.contract == 'public'
+        run: |
+          python3 -m unittest -v scripts/test_check_perf_receipt_freshness.py
+          python3 scripts/check_perf_receipt_freshness.py

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -465,19 +465,21 @@ it. BIRD still holds the lower RSS peak there (1,375–1,420 MiB vs rustbgpd's
 2.1–2.3 s at reload 1 vs 3.3–3.8 s after) remains the open item the
 per-client receipt recorded.
 
-A separate [1,000-peer retained receipt](perf/route-server-1000-2026-07.md)
-exercises a uniform all-eBGP route-server fleet against the real daemon: 400k
-routes, 399.6 million observer-NLRI cold deliveries, four generation-complete
-export reloads, and continuous readiness/RSS/grouping checks. It is capacity
-acceptance for that disclosed same-host shape, not another competitor result.
+A separate [1,000-peer retained receipt](perf/route-server-1000-2026-07.md),
+measured 2026-07-20, exercises a uniform all-eBGP route-server fleet against
+the real daemon: 400k routes, 399.6 million observer-NLRI cold deliveries, four
+generation-complete export reloads, and continuous readiness/RSS/grouping
+checks. It is capacity acceptance for that disclosed same-host shape, not
+another competitor result.
 
 The exact v0.61.0 release tip also has an
-[absolute baseline](perf/v0.61.0-final-performance-2026-07.md): three
-1,000-peer × 400-BASE-route real-daemon runs measured steady process-tree RSS
-medians of 441.760/441.215/441.131 MiB while all settled grouping,
-registration, rejection, and writer gates held. Its 71-row Criterion archive
-is likewise single-revision. Neither set is a competitor comparison or a
-causal delta, and neither rewrites the pinned `515659b1` campaign above.
+[absolute baseline](perf/v0.61.0-final-performance-2026-07.md),
+measured 2026-07-26: three 1,000-peer × 400-BASE-route real-daemon runs
+measured steady process-tree RSS medians of 441.760/441.215/441.131 MiB while
+all settled grouping, registration, rejection, and writer gates held. Its
+71-row Criterion archive is likewise single-revision. Neither set is a
+competitor comparison or a causal delta, and neither rewrites the pinned
+`515659b1` campaign above.
 
 ## Positioning
 

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -16,6 +16,15 @@ contract](INTEROP.md#m-series-proof-quality-contract): target-scoped
 assertions, kernel evidence for kernel claims, rerunnable cleanup-safe
 drivers, and a non-vacuity sentinel.
 
+Front-door performance citations and their measured/release revisions are
+declared in the structured
+[`perf/receipt-provenance.json`](perf/receipt-provenance.json) manifest. The
+public-docs [`receipt integrity checker`](../scripts/check_perf_receipt_freshness.py)
+requires every receipt link in those curated headline blocks to match the
+manifest, resolves its provenance against Git tags, and enforces dates on stale
+claims. The manifest is not a whole-corpus catalog: the checker separately
+reports top-level receipts with no inbound Markdown link as a sorted advisory.
+
 Numbering note: M0–M4 and M10 onward are interop labs. M5–M9 were
 development-phase build milestones (wire/RIB/API hardening) and are documented
 in [`milestones.md`](milestones.md), not here.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -83,10 +83,18 @@ convention in `CONTRIBUTING.md`:
       docs, and tests all move together.
 - [ ] Process-only documentation changes intentionally omit CHANGELOG entries
       unless they affect users or operators.
-- [ ] Every README front-matter performance claim cites a receipt measured
-      within the last three releases, or carries an explicit measured-on date
-      in the claim text (e.g. "measured 2026-07-03"). Older numbers stay
-      quotable with their date; undated stale numbers do not ship.
+- [ ] Every front-door performance claim inventoried in
+      [`docs/perf/receipt-provenance.json`](perf/receipt-provenance.json) — in
+      `README.md`, `docs/BENCHMARKS.md`, `docs/COMPARISON.md`, or
+      `docs/ixp-evaluation.md` — cites a receipt measured within the last three
+      releases, or carries an explicit measured-on date in the claim text
+      (e.g. "measured 2026-07-03"). Older numbers stay quotable with their
+      date; undated stale numbers do not ship. The public-docs contract checks
+      every receipt link in those curated headline blocks against the manifest,
+      plus commit/tag provenance and this freshness rule. The manifest does not
+      catalog the whole performance corpus; the checker's sorted
+      zero-inbound-link inventory covers all top-level receipts as an advisory
+      so discoverability is not conflated with measurement validity.
 
 ## Narrow v1 RS/RR compatibility gate
 

--- a/docs/perf/attr-intern-hashing-2026-08.md
+++ b/docs/perf/attr-intern-hashing-2026-08.md
@@ -16,6 +16,11 @@ values remain in the artifact for audit, but are explicitly marked
 This is a measurement receipt, not a performance claim. It changes no
 production code and measures no production speedup.
 
+*Post-publication note:* the same-source
+[noise-floor recheck](attr-intern-hashing-recheck-2026-08.md) left attribution
+not evaluated rather than renewing this measured NO-GO. This document's raw
+rows and original verdict remain unchanged.
+
 ## Question and decision rule
 
 The roadmap asks whether repeatedly hashing an already-shared

--- a/docs/perf/irr-reload-comparison-2026-08.md
+++ b/docs/perf/irr-reload-comparison-2026-08.md
@@ -13,6 +13,12 @@ A/B/B/A order, all green, cross-checked by the campaign's independent
 verifier. A standalone grouped-export control cell (never a comparison
 row) prices rustbgpd's per-client path-hiding fan-out.
 
+*Post-publication note:* the
+[realistic-mix receipt](irr-reload-realistic-mix-2026-08.md) extends this
+comparison with controlled announcement overlap and carries the forward link
+to the later grouped per-client-best acceptance receipt. This document's rows
+and verdict remain unchanged.
+
 ## Headline
 
 | Cell (320 members × 183,040 routes, 3.2M filter entries, 4 reloads × 2 roots) | Completion p50 (reload 1; reloads 2–4) | Completion p95 (reloads 2–4) | Reload stall p50 (reload 1; reloads 2–4) | First new-generation route p50 | Process-tree RSS peak (root A / B) |

--- a/docs/perf/receipt-provenance.json
+++ b/docs/perf/receipt-provenance.json
@@ -1,0 +1,108 @@
+{
+  "schema": 1,
+  "release_window": 3,
+  "front_doors": [
+    "README.md",
+    "docs/BENCHMARKS.md",
+    "docs/COMPARISON.md",
+    "docs/ixp-evaluation.md"
+  ],
+  "receipts": [
+    {
+      "path": "docs/perf/fib-kernel-dump-2026-08.md",
+      "measured_commit": "8f1c920e0f0b9d0adefdc1874ef867c3454a21f9",
+      "measured_on": "2026-08-25"
+    },
+    {
+      "path": "docs/perf/irr-reload-comparison-2026-08.md",
+      "measured_commit": "f2a8b0275d22d431ec0b031cb8f58fcf28a95029"
+    },
+    {
+      "path": "docs/perf/irr-reload-grouped-per-client-best-2026-08.md",
+      "measured_commit": "aa022e18c14fc8e2cf6ec23f9ba88d9e0c090042"
+    },
+    {
+      "path": "docs/perf/ixp-matrix-2026-07.md",
+      "measured_commit": "295d1f375451d4a58d605006c87770e4743f3011",
+      "measured_on": "2026-08-08"
+    },
+    {
+      "path": "docs/perf/route-server-1000-2026-07.md",
+      "measured_commit": "cb2c924f117fe264991f12b24ea44c2b15b132e2",
+      "release_commit": "651923720925f85c9000a8e6907fb1b599767803",
+      "measured_on": "2026-07-20"
+    },
+    {
+      "path": "docs/perf/scale-receipt-2026-07.md",
+      "measured_commit": "b26ff11c91e01fc506552267e197c3acd75bd970",
+      "measured_on": "2026-07-03"
+    },
+    {
+      "path": "docs/perf/v0.61.0-final-performance-2026-07.md",
+      "measured_commit": "99ee74ba67ec24ce8e09c0c18a83b652da35712b",
+      "measured_on": "2026-07-26"
+    }
+  ],
+  "claims": [
+    {
+      "source": "README.md",
+      "anchor": "- **IRR-scale filter reload**",
+      "receipt": "docs/perf/irr-reload-comparison-2026-08.md"
+    },
+    {
+      "source": "README.md",
+      "anchor": "- **IRR-scale filter reload**",
+      "receipt": "docs/perf/irr-reload-grouped-per-client-best-2026-08.md"
+    },
+    {
+      "source": "README.md",
+      "anchor": "- **Policy reload at IXP scale**",
+      "receipt": "docs/perf/ixp-matrix-2026-07.md"
+    },
+    {
+      "source": "README.md",
+      "anchor": "- **Route-reflector scale**",
+      "receipt": "docs/perf/scale-receipt-2026-07.md"
+    },
+    {
+      "source": "docs/BENCHMARKS.md",
+      "anchor": "`bench/run-fib-kernel-dump.py` is the privileged",
+      "receipt": "docs/perf/fib-kernel-dump-2026-08.md"
+    },
+    {
+      "source": "docs/COMPARISON.md",
+      "anchor": "A separate [1,000-peer retained receipt]",
+      "receipt": "docs/perf/route-server-1000-2026-07.md"
+    },
+    {
+      "source": "docs/COMPARISON.md",
+      "anchor": "At IRR scale, the [grouped per-client-best IRR reload",
+      "receipt": "docs/perf/irr-reload-comparison-2026-08.md"
+    },
+    {
+      "source": "docs/COMPARISON.md",
+      "anchor": "At IRR scale, the [grouped per-client-best IRR reload",
+      "receipt": "docs/perf/irr-reload-grouped-per-client-best-2026-08.md"
+    },
+    {
+      "source": "docs/COMPARISON.md",
+      "anchor": "At route-server scale, the [IXP receipt",
+      "receipt": "docs/perf/ixp-matrix-2026-07.md"
+    },
+    {
+      "source": "docs/COMPARISON.md",
+      "anchor": "The exact v0.61.0 release tip also has an",
+      "receipt": "docs/perf/v0.61.0-final-performance-2026-07.md"
+    },
+    {
+      "source": "docs/ixp-evaluation.md",
+      "anchor": "| 7 | Reload at IRR scale |",
+      "receipt": "docs/perf/irr-reload-comparison-2026-08.md"
+    },
+    {
+      "source": "docs/ixp-evaluation.md",
+      "anchor": "| 7 | Reload at IRR scale |",
+      "receipt": "docs/perf/irr-reload-grouped-per-client-best-2026-08.md"
+    }
+  ]
+}

--- a/scripts/check_perf_receipt_freshness.py
+++ b/scripts/check_perf_receipt_freshness.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Validate front-door performance claims and receipt provenance.
+
+The structured manifest names the performance claims that function as project
+front doors.  Git proves when each measured revision first entered a release;
+old evidence remains publishable only when its claim carries an exact
+``measured YYYY-MM-DD`` label.  Receipt files outside the front-door manifest
+are still inventoried for inbound links, but an orphan is advisory rather than
+a release failure.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote, urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "docs" / "perf" / "receipt-provenance.json"
+WORKFLOW = ROOT / ".github" / "workflows" / "public-docs-contract.yml"
+CHECKLIST = ROOT / "docs" / "RELEASE_CHECKLIST.md"
+RECEIPTS_INDEX = ROOT / "docs" / "RECEIPTS.md"
+
+FRONT_DOORS = (
+    "README.md",
+    "docs/BENCHMARKS.md",
+    "docs/COMPARISON.md",
+    "docs/ixp-evaluation.md",
+)
+RELEASE_WINDOW = 3
+COMMIT = re.compile(r"[0-9a-f]{40}")
+SEMVER_TAG = re.compile(r"v(\d+)\.(\d+)\.(\d+)")
+MARKDOWN_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+class ContractError(ValueError):
+    """A malformed manifest cannot be checked safely."""
+
+
+def safe_repo_path(value: object, *, suffix: str | None = None) -> str:
+    if not isinstance(value, str) or not value:
+        raise ContractError(f"repository path must be a nonempty string, got {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or value != path.as_posix():
+        raise ContractError(f"repository path is not normalized and relative: {value!r}")
+    if suffix is not None and not value.endswith(suffix):
+        raise ContractError(f"repository path must end in {suffix!r}: {value!r}")
+    return value
+
+
+def parse_manifest(text: str) -> dict[str, object]:
+    try:
+        manifest = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ContractError(f"invalid JSON at line {error.lineno}: {error.msg}") from error
+    if not isinstance(manifest, dict) or set(manifest) != {
+        "schema",
+        "release_window",
+        "front_doors",
+        "receipts",
+        "claims",
+    }:
+        raise ContractError(
+            "manifest must contain only schema, release_window, front_doors, receipts, and claims"
+        )
+    if manifest["schema"] != 1:
+        raise ContractError(f"manifest schema must be 1, got {manifest['schema']!r}")
+    if manifest["release_window"] != RELEASE_WINDOW:
+        raise ContractError(
+            f"manifest release_window must be {RELEASE_WINDOW}, got {manifest['release_window']!r}"
+        )
+    if manifest["front_doors"] != list(FRONT_DOORS):
+        raise ContractError(
+            "manifest front_doors must be the exact ordered four-file contract: "
+            + ", ".join(FRONT_DOORS)
+        )
+
+    raw_receipts = manifest["receipts"]
+    if not isinstance(raw_receipts, list) or not raw_receipts:
+        raise ContractError("manifest receipts must be a nonempty list")
+    receipt_paths: list[str] = []
+    for item in raw_receipts:
+        if (
+            not isinstance(item, dict)
+            or not set(item).issubset({"path", "measured_commit", "release_commit", "measured_on"})
+            or not {"path", "measured_commit"}.issubset(item)
+        ):
+            raise ContractError(
+                "each receipt must contain path and measured_commit plus only "
+                "optional release_commit and measured_on"
+            )
+        path = safe_repo_path(item["path"], suffix=".md")
+        if not path.startswith("docs/perf/") or "/artifacts/" in path:
+            raise ContractError(f"manifest receipt is outside docs/perf receipts: {path}")
+        receipt_paths.append(path)
+        for key in ("measured_commit", "release_commit"):
+            if key in item and (
+                not isinstance(item[key], str) or COMMIT.fullmatch(item[key]) is None
+            ):
+                raise ContractError(f"{path} {key} must be a full lowercase commit SHA")
+        if "measured_on" in item:
+            try:
+                measured = date.fromisoformat(item["measured_on"])
+            except (TypeError, ValueError) as error:
+                raise ContractError(f"{path} measured_on must be an ISO date") from error
+            if measured.isoformat() != item["measured_on"]:
+                raise ContractError(f"{path} measured_on must be a canonical ISO date")
+    if receipt_paths != sorted(set(receipt_paths)):
+        raise ContractError("manifest receipts must be sorted by path and unique")
+
+    raw_claims = manifest["claims"]
+    if not isinstance(raw_claims, list) or not raw_claims:
+        raise ContractError("manifest claims must be a nonempty list")
+    claim_keys: list[tuple[str, str, str]] = []
+    for item in raw_claims:
+        if not isinstance(item, dict) or set(item) != {"source", "anchor", "receipt"}:
+            raise ContractError("each claim must contain only source, anchor, and receipt")
+        source = safe_repo_path(item["source"], suffix=".md")
+        receipt = safe_repo_path(item["receipt"], suffix=".md")
+        anchor = item["anchor"]
+        if source not in FRONT_DOORS:
+            raise ContractError(f"claim source is not a front door: {source}")
+        if receipt not in receipt_paths:
+            raise ContractError(f"claim references unmanifested receipt: {receipt}")
+        if not isinstance(anchor, str) or len(anchor.strip()) < 12:
+            raise ContractError(f"claim anchor must be a specific nonempty string: {anchor!r}")
+        claim_keys.append((source, anchor, receipt))
+    if claim_keys != sorted(set(claim_keys)):
+        raise ContractError("manifest claims must be sorted by source/anchor/receipt and unique")
+    sources = {source for source, _, _ in claim_keys}
+    if sources != set(FRONT_DOORS):
+        raise ContractError(
+            "manifest claims must exercise every front door; missing "
+            + ", ".join(sorted(set(FRONT_DOORS) - sources))
+        )
+    claimed_receipts = {receipt for _, _, receipt in claim_keys}
+    if claimed_receipts != set(receipt_paths):
+        raise ContractError(
+            "manifest receipts and claimed receipts differ: "
+            f"unclaimed={sorted(set(receipt_paths) - claimed_receipts)}"
+        )
+    return manifest
+
+
+def git_lines(root: Path, *arguments: str) -> list[str]:
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise ContractError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout.splitlines()
+
+
+def stable_release_tags(root: Path) -> list[tuple[tuple[int, int, int], str]]:
+    tags = []
+    for tag in git_lines(root, "tag", "--list"):
+        match = SEMVER_TAG.fullmatch(tag)
+        if match is not None:
+            tags.append((tuple(int(part) for part in match.groups()), tag))
+    tags.sort()
+    if not tags:
+        raise ContractError("repository has no stable vMAJOR.MINOR.PATCH release tags")
+    return tags
+
+
+def commit_tags(root: Path, commit: str) -> list[str]:
+    resolved = git_lines(root, "rev-parse", "--verify", f"{commit}^{{commit}}")
+    if resolved != [commit]:
+        raise ContractError(f"commit {commit} did not resolve exactly")
+    return git_lines(root, "tag", "--contains", commit)
+
+
+def claim_block(document: str, anchor: str) -> str:
+    starts = [match.start() for match in re.finditer(re.escape(anchor), document)]
+    if len(starts) != 1:
+        raise ContractError(f"claim anchor {anchor!r} occurs {len(starts)} times")
+    position = starts[0]
+    line_start = document.rfind("\n", 0, position) + 1
+    line_end = document.find("\n", position)
+    line_end = len(document) if line_end < 0 else line_end
+    line = document[line_start:line_end]
+    if line.startswith("|"):
+        return line
+    if line.startswith("- "):
+        next_item = re.search(r"(?m)^- ", document[line_end + 1 :])
+        end = len(document) if next_item is None else line_end + 1 + next_item.start()
+        return document[line_start:end]
+    paragraph_end = re.search(r"\n\s*\n", document[line_start:])
+    end = len(document) if paragraph_end is None else line_start + paragraph_end.start()
+    return document[line_start:end]
+
+
+def resolved_receipt_links(root: Path, source: str, block: str) -> set[str]:
+    resolved: set[str] = set()
+    source_dir = (root / source).parent
+    for raw_target in MARKDOWN_LINK.findall(block):
+        target = unquote(urlsplit(raw_target.strip().split()[0]).path)
+        if not target or target.startswith("/"):
+            continue
+        try:
+            path = (source_dir / target).resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            continue
+        if path.startswith("docs/perf/") and path.endswith(".md"):
+            resolved.add(path)
+    return resolved
+
+
+def contract_text(root: Path, relative: str, overrides: dict[str, str] | None = None) -> str:
+    if overrides is not None and relative in overrides:
+        return overrides[relative]
+    return (root / relative).read_text(encoding="utf-8")
+
+
+def check_house_contract(
+    root: Path, errors: list[str], overrides: dict[str, str] | None = None
+) -> None:
+    expected = {
+        root / WORKFLOW.relative_to(ROOT): (
+            "fetch-depth: 0",
+            "python3 -m unittest -v scripts/test_check_perf_receipt_freshness.py",
+            "python3 scripts/check_perf_receipt_freshness.py",
+        ),
+        root / CHECKLIST.relative_to(ROOT): (
+            "docs/perf/receipt-provenance.json",
+            *FRONT_DOORS,
+        ),
+        root / RECEIPTS_INDEX.relative_to(ROOT): (
+            "perf/receipt-provenance.json",
+            "../scripts/check_perf_receipt_freshness.py",
+        ),
+    }
+    for path, fragments in expected.items():
+        relative = path.relative_to(root).as_posix()
+        try:
+            text = contract_text(root, relative, overrides)
+        except OSError as error:
+            errors.append(f"cannot read house-contract file {relative}: {error}")
+            continue
+        for fragment in fragments:
+            count = text.count(fragment)
+            if path == root / WORKFLOW.relative_to(ROOT) and count != 1:
+                errors.append(
+                    f"{path.relative_to(root)} must contain {fragment!r} exactly once, "
+                    f"found {count}"
+                )
+            elif path != root / WORKFLOW.relative_to(ROOT) and count == 0:
+                errors.append(
+                    f"{path.relative_to(root)} must contain required fragment {fragment!r}"
+                )
+
+
+def check_contract(
+    root: Path,
+    manifest: dict[str, object],
+    overrides: dict[str, str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    check_house_contract(root, errors, overrides)
+    try:
+        releases = stable_release_tags(root)
+    except ContractError as error:
+        return errors + [str(error)]
+    release_names = [name for _, name in releases]
+    current_release = release_names[-1]
+
+    receipt_by_path = {item["path"]: item for item in manifest["receipts"]}
+    release_ages: dict[str, int] = {}
+    for path, item in receipt_by_path.items():
+        try:
+            receipt = contract_text(root, path, overrides)
+        except OSError as error:
+            errors.append(f"cannot read manifested receipt {path}: {error}")
+            continue
+        measured_commit = item["measured_commit"]
+        for key in ("measured_commit", "release_commit"):
+            commit = item.get(key)
+            if commit is not None and commit not in receipt and commit[:8] not in receipt:
+                errors.append(f"{path} does not record its manifested {key} {commit}")
+        try:
+            measured_tags = commit_tags(root, measured_commit)
+        except ContractError as error:
+            errors.append(f"{path}: {error}")
+            continue
+        if not measured_tags:
+            errors.append(f"{path} measured commit {measured_commit} is contained by no git tag")
+        release_commit = item.get("release_commit", measured_commit)
+        try:
+            release_tags = set(commit_tags(root, release_commit))
+        except ContractError as error:
+            errors.append(f"{path}: {error}")
+            continue
+        containing = [tag for tag in release_names if tag in release_tags]
+        if not containing:
+            errors.append(
+                f"{path} release commit {release_commit} is contained by no stable release tag"
+            )
+            continue
+        first_release = containing[0]
+        release_ages[path] = release_names.index(current_release) - release_names.index(
+            first_release
+        )
+
+    documents: dict[str, str] = {}
+    for source in FRONT_DOORS:
+        try:
+            documents[source] = contract_text(root, source, overrides)
+        except OSError as error:
+            errors.append(f"cannot read front door {source}: {error}")
+
+    claims_by_block: dict[tuple[str, str], set[str]] = {}
+    for claim in manifest["claims"]:
+        claims_by_block.setdefault((claim["source"], claim["anchor"]), set()).add(claim["receipt"])
+    for (source, anchor), expected_receipts in claims_by_block.items():
+        if source not in documents:
+            continue
+        try:
+            block = claim_block(documents[source], anchor)
+        except ContractError as error:
+            errors.append(f"{source}: {error}")
+            continue
+        actual_receipts = resolved_receipt_links(root, source, block)
+        if actual_receipts != expected_receipts:
+            errors.append(
+                f"{source} claim {anchor!r} receipt links differ from its manifest: "
+                f"actual={sorted(actual_receipts)} expected={sorted(expected_receipts)}"
+            )
+        for receipt in expected_receipts:
+            age = release_ages.get(receipt)
+            # Age counts stable-release transitions after first containment:
+            # the containing release plus three later lines remains current,
+            # and the fourth transition requires an exact measured-on date.
+            if age is None or age <= RELEASE_WINDOW:
+                continue
+            measured_on = receipt_by_path[receipt].get("measured_on")
+            if measured_on is None:
+                errors.append(
+                    f"{source} stale claim for {receipt} has no manifested measured_on date"
+                )
+                continue
+            phrase = f"measured {measured_on}"
+            if phrase not in block:
+                errors.append(
+                    f"{source} stale claim for {receipt} must carry exact phrase {phrase!r}"
+                )
+    return errors
+
+
+def tracked_markdown(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ("git", "ls-files", "-z", "--", "*.md"),
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stderr.decode(errors="replace").strip() or f"exit {result.returncode}"
+        raise ContractError(f"git ls-files for Markdown failed: {detail}")
+    return [root / value.decode() for value in result.stdout.split(b"\0") if value]
+
+
+def unlinked_receipts(root: Path) -> list[str]:
+    receipts = {
+        path.resolve(): path.relative_to(root).as_posix()
+        for path in (root / "docs" / "perf").glob("*.md")
+    }
+    inbound = {path: 0 for path in receipts}
+    for source in tracked_markdown(root):
+        try:
+            text = source.read_text(encoding="utf-8")
+        except OSError as error:
+            raise ContractError(f"cannot read tracked Markdown {source.relative_to(root)}: {error}")
+        for raw_target in MARKDOWN_LINK.findall(text):
+            target = unquote(urlsplit(raw_target.strip().split()[0]).path)
+            if not target or target.startswith("/"):
+                continue
+            resolved = (source.parent / target).resolve()
+            if resolved in inbound and resolved != source.resolve():
+                inbound[resolved] += 1
+    return sorted(receipts[path] for path, count in inbound.items() if count == 0)
+
+
+def main() -> int:
+    try:
+        manifest = parse_manifest(MANIFEST.read_text(encoding="utf-8"))
+        errors = check_contract(ROOT, manifest)
+        orphans = unlinked_receipts(ROOT)
+    except (OSError, ContractError) as error:
+        errors = [str(error)]
+        orphans = []
+    for error in errors:
+        print(f"performance receipt integrity check failed: {error}", file=sys.stderr)
+    for path in orphans:
+        print(f"performance receipt advisory: no inbound Markdown link to {path}")
+    if not errors:
+        print(
+            "performance receipt integrity check passed: "
+            f"{len(orphans)} unlinked receipt(s) reported"
+        )
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_perf_receipt_freshness.py
+++ b/scripts/test_check_perf_receipt_freshness.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Destructive proofs for the performance-receipt integrity contract."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_perf_receipt_freshness as checker
+
+
+ROOT = checker.ROOT
+MANIFEST_TEXT = checker.MANIFEST.read_text(encoding="utf-8")
+MANIFEST = checker.parse_manifest(MANIFEST_TEXT)
+
+
+def receipt_item(manifest: dict[str, object], path: str) -> dict[str, str]:
+    return next(item for item in manifest["receipts"] if item["path"] == path)
+
+
+def text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class TemporaryReceiptRepository:
+    """A deterministic release graph independent of the developer checkout."""
+
+    receipt = "docs/perf/fixture-receipt.md"
+    measured_on = "2026-01-02"
+
+    def __enter__(self) -> TemporaryReceiptRepository:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.commit_number = 0
+        self.run("init", "-q", "-b", "main")
+        self.run("config", "user.name", "Receipt Contract Test")
+        self.run("config", "user.email", "receipt-contract@example.invalid")
+        self.run("config", "commit.gpgsign", "false")
+
+        (self.root / "graph.txt").write_text("common base\n", encoding="utf-8")
+        self.common_commit = self.commit("common base")
+
+        self.run("checkout", "-q", "-b", "measurement")
+        (self.root / "measurement.txt").write_text("off-main measurement\n", encoding="utf-8")
+        self.measured_commit = self.commit("measure receipt")
+        self.receipt_tag = "receipt/fixture-2026-01"
+        self.run("tag", self.receipt_tag, self.measured_commit)
+
+        self.run("checkout", "-q", "main")
+        (self.root / "landed.txt").write_text("landed implementation\n", encoding="utf-8")
+        self.release_commit = self.commit("land implementation")
+        self.run("tag", "v0.1.0", self.release_commit)
+
+        self.write_contract_files()
+        self.commit("add front-door receipt contract")
+        self.run("tag", "v0.2.0")
+        self.commit("release 0.3.0", allow_empty=True)
+        self.run("tag", "v0.3.0")
+        self.commit("release 0.4.0", allow_empty=True)
+        self.run("tag", "v0.4.0")
+        self.manifest = checker.parse_manifest(
+            (self.root / "docs/perf/receipt-provenance.json").read_text(encoding="utf-8")
+        )
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.temporary.cleanup()
+
+    def git_environment(self, **overrides: str) -> dict[str, str]:
+        environment = {
+            **os.environ,
+            "LC_ALL": "C",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "core.hooksPath",
+            "GIT_CONFIG_VALUE_0": str(self.root / ".disabled-hooks"),
+        }
+        environment.update(overrides)
+        return environment
+
+    def run(
+        self,
+        *arguments: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ("git", *arguments),
+            cwd=self.root,
+            env=self.git_environment(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if check and result.returncode:
+            self.fail(
+                f"git {' '.join(arguments)} failed ({result.returncode}): "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        return result
+
+    def fail(self, detail: str) -> None:
+        raise AssertionError(detail)
+
+    def commit(self, message: str, *, allow_empty: bool = False) -> str:
+        self.run("add", "-A")
+        self.commit_number += 1
+        timestamp = f"2026-01-{self.commit_number:02d}T00:00:00+00:00"
+        environment = self.git_environment(
+            GIT_AUTHOR_NAME="Receipt Contract Test",
+            GIT_AUTHOR_EMAIL="receipt-contract@example.invalid",
+            GIT_AUTHOR_DATE=timestamp,
+            GIT_COMMITTER_NAME="Receipt Contract Test",
+            GIT_COMMITTER_EMAIL="receipt-contract@example.invalid",
+            GIT_COMMITTER_DATE=timestamp,
+        )
+        arguments = ["git", "commit", "-q", "-m", message]
+        if allow_empty:
+            arguments.append("--allow-empty")
+        result = subprocess.run(
+            arguments,
+            cwd=self.root,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode:
+            self.fail(
+                f"git commit failed ({result.returncode}): "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        return self.run("rev-parse", "HEAD").stdout.strip()
+
+    def write(self, relative: str, contents: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+    def write_contract_files(self) -> None:
+        claims = (
+            ("README.md", "Fixture README claim"),
+            ("docs/BENCHMARKS.md", "Fixture benchmark claim"),
+            ("docs/COMPARISON.md", "Fixture comparison claim"),
+            ("docs/ixp-evaluation.md", "Fixture evaluation claim"),
+        )
+        manifest = {
+            "schema": 1,
+            "release_window": 3,
+            "front_doors": list(checker.FRONT_DOORS),
+            "receipts": [
+                {
+                    "path": self.receipt,
+                    "measured_commit": self.measured_commit,
+                    "release_commit": self.release_commit,
+                    "measured_on": self.measured_on,
+                }
+            ],
+            "claims": [
+                {"source": source, "anchor": anchor, "receipt": self.receipt}
+                for source, anchor in claims
+            ],
+        }
+        self.write(
+            "docs/perf/receipt-provenance.json",
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        )
+        self.write(
+            self.receipt,
+            "# Fixture receipt\n\n"
+            f"Measured commit: `{self.measured_commit}`\n\n"
+            f"Release commit: `{self.release_commit}`\n",
+        )
+        self.write(
+            "README.md",
+            f"- **Fixture README claim** [receipt]({self.receipt})\n",
+        )
+        self.write(
+            "docs/BENCHMARKS.md",
+            "Fixture benchmark claim uses the [receipt](perf/fixture-receipt.md).\n",
+        )
+        self.write(
+            "docs/COMPARISON.md",
+            "Fixture comparison claim uses the [receipt](perf/fixture-receipt.md).\n",
+        )
+        self.write(
+            "docs/ixp-evaluation.md",
+            "| Claim | Evidence |\n"
+            "| --- | --- |\n"
+            "| Fixture evaluation claim | [receipt](perf/fixture-receipt.md) |\n",
+        )
+        self.write(
+            ".github/workflows/public-docs-contract.yml",
+            "steps:\n"
+            "  - uses: actions/checkout@v7\n"
+            "    with:\n"
+            "      fetch-depth: 0\n"
+            "  - run: |\n"
+            "      python3 -m unittest -v scripts/test_check_perf_receipt_freshness.py\n"
+            "      python3 scripts/check_perf_receipt_freshness.py\n",
+        )
+        self.write(
+            "docs/RELEASE_CHECKLIST.md",
+            "Validate docs/perf/receipt-provenance.json against:\n"
+            + "".join(f"- {source}\n" for source in checker.FRONT_DOORS),
+        )
+        self.write(
+            "docs/RECEIPTS.md",
+            "See [the manifest](perf/receipt-provenance.json) and "
+            "[checker](../scripts/check_perf_receipt_freshness.py).\n",
+        )
+
+    def add_next_stable_release(self) -> None:
+        self.commit("release 0.5.0", allow_empty=True)
+        self.run("tag", "v0.5.0")
+
+    def add_measured_date_to_claims(self) -> None:
+        for relative, anchor in (
+            ("README.md", "Fixture README claim"),
+            ("docs/BENCHMARKS.md", "Fixture benchmark claim"),
+            ("docs/COMPARISON.md", "Fixture comparison claim"),
+            ("docs/ixp-evaluation.md", "Fixture evaluation claim"),
+        ):
+            path = self.root / relative
+            contents = path.read_text(encoding="utf-8")
+            path.write_text(
+                contents.replace(anchor, f"{anchor}, measured {self.measured_on}", 1),
+                encoding="utf-8",
+            )
+
+
+class PerfReceiptFreshnessTests(unittest.TestCase):
+    maxDiff = None
+
+    def errors(
+        self,
+        manifest: dict[str, object] | None = None,
+        overrides: dict[str, str] | None = None,
+    ) -> list[str]:
+        return checker.check_contract(ROOT, MANIFEST if manifest is None else manifest, overrides)
+
+    def assert_red(
+        self,
+        needle: str,
+        manifest: dict[str, object] | None = None,
+        overrides: dict[str, str] | None = None,
+    ) -> None:
+        errors = self.errors(manifest, overrides)
+        self.assertTrue(any(needle in error for error in errors), errors)
+
+    def test_live_contract_is_green(self) -> None:
+        self.assertEqual(self.errors(), [])
+
+    def test_manifest_is_canonical_json(self) -> None:
+        self.assertEqual(
+            MANIFEST_TEXT,
+            json.dumps(json.loads(MANIFEST_TEXT), indent=2, ensure_ascii=False) + "\n",
+        )
+
+    def test_manifest_shape_fails_closed(self) -> None:
+        with self.assertRaisesRegex(checker.ContractError, "invalid JSON"):
+            checker.parse_manifest("{")
+        document = json.loads(MANIFEST_TEXT)
+        document["unexpected"] = True
+        with self.assertRaisesRegex(checker.ContractError, "contain only"):
+            checker.parse_manifest(json.dumps(document))
+        document = json.loads(MANIFEST_TEXT)
+        document["release_window"] = 4
+        with self.assertRaisesRegex(checker.ContractError, "release_window must be 3"):
+            checker.parse_manifest(json.dumps(document))
+
+    def test_manifest_requires_all_four_front_doors(self) -> None:
+        document = json.loads(MANIFEST_TEXT)
+        document["front_doors"].pop()
+        with self.assertRaisesRegex(checker.ContractError, "exact ordered four-file"):
+            checker.parse_manifest(json.dumps(document))
+
+        document = json.loads(MANIFEST_TEXT)
+        document["claims"] = [
+            claim for claim in document["claims"] if claim["source"] != "docs/ixp-evaluation.md"
+        ]
+        with self.assertRaisesRegex(checker.ContractError, "exercise every front door"):
+            checker.parse_manifest(json.dumps(document))
+
+    def test_manifest_order_and_references_fail_closed(self) -> None:
+        document = json.loads(MANIFEST_TEXT)
+        document["receipts"].reverse()
+        with self.assertRaisesRegex(checker.ContractError, "sorted by path"):
+            checker.parse_manifest(json.dumps(document))
+
+        document = json.loads(MANIFEST_TEXT)
+        document["claims"][0]["receipt"] = "docs/perf/not-manifested.md"
+        with self.assertRaisesRegex(checker.ContractError, "unmanifested receipt"):
+            checker.parse_manifest(json.dumps(document))
+
+    def test_manifest_rejects_bad_commit_and_date_fields(self) -> None:
+        document = json.loads(MANIFEST_TEXT)
+        document["receipts"][0]["measured_commit"] = "8f1c920e"
+        with self.assertRaisesRegex(checker.ContractError, "full lowercase commit SHA"):
+            checker.parse_manifest(json.dumps(document))
+
+        document = json.loads(MANIFEST_TEXT)
+        document["receipts"][0]["measured_on"] = "2026-08-99"
+        with self.assertRaisesRegex(checker.ContractError, "ISO date"):
+            checker.parse_manifest(json.dumps(document))
+
+    def test_missing_or_duplicate_claim_anchor_is_red(self) -> None:
+        readme = text("README.md")
+        self.assert_red(
+            "occurs 0 times",
+            overrides={
+                "README.md": readme.replace("- **IRR-scale filter reload**", "- **IRR reload**", 1)
+            },
+        )
+        self.assert_red(
+            "occurs 2 times",
+            overrides={"README.md": readme + "\n- **IRR-scale filter reload** duplicate\n"},
+        )
+
+    def test_claim_must_link_the_manifested_receipt(self) -> None:
+        comparison = text("docs/COMPARISON.md")
+        self.assert_red(
+            "receipt links differ from its manifest",
+            overrides={
+                "docs/COMPARISON.md": comparison.replace(
+                    "perf/route-server-1000-2026-07.md",
+                    "perf/not-the-receipt.md",
+                    1,
+                )
+            },
+        )
+
+    def test_unmanifested_receipt_link_in_an_enforced_block_is_red(self) -> None:
+        readme = text("README.md")
+        mutated = readme.replace(
+            "[1000-peer scale receipt](docs/perf/scale-receipt-2026-07.md)",
+            "[1000-peer scale receipt](docs/perf/scale-receipt-2026-07.md) and "
+            "[another receipt](docs/perf/route-server-1000-2026-07.md)",
+            1,
+        )
+        self.assert_red("receipt links differ from its manifest", overrides={"README.md": mutated})
+
+    def test_each_stale_claim_requires_its_exact_date(self) -> None:
+        comparison = text("docs/COMPARISON.md")
+        for old, expected in (
+            ("measured 2026-07-20", "measured 2026-07-20"),
+            ("measured 2026-07-26", "measured 2026-07-26"),
+        ):
+            with self.subTest(old=old):
+                self.assert_red(
+                    f"must carry exact phrase '{expected}'",
+                    overrides={"docs/COMPARISON.md": comparison.replace(old, "measured later", 1)},
+                )
+
+    def test_stale_claim_cannot_hide_behind_a_manifest_exception(self) -> None:
+        manifest = copy.deepcopy(MANIFEST)
+        receipt_item(manifest, "docs/perf/route-server-1000-2026-07.md").pop("measured_on")
+        self.assert_red("has no manifested measured_on date", manifest)
+
+    def test_fresh_claim_does_not_require_a_date(self) -> None:
+        readme = text("README.md").replace("  measured 2026-08-08,\n", "", 1)
+        self.assertEqual(self.errors(overrides={"README.md": readme}), [])
+
+    def test_receipt_must_record_manifested_provenance(self) -> None:
+        path = "docs/perf/ixp-matrix-2026-07.md"
+        self.assert_red(
+            "does not record its manifested measured_commit",
+            overrides={path: text(path).replace("295d1f37", "not-a-commit")},
+        )
+
+    def test_temporary_git_unknown_commit_is_red(self) -> None:
+        with TemporaryReceiptRepository() as fixture:
+            unknown = "0" * 40
+            manifest = copy.deepcopy(fixture.manifest)
+            item = receipt_item(manifest, fixture.receipt)
+            item["measured_commit"] = unknown
+            receipt = (fixture.root / fixture.receipt).read_text(encoding="utf-8")
+            errors = checker.check_contract(
+                fixture.root,
+                manifest,
+                {fixture.receipt: receipt + f"\nMeasured commit: `{unknown}`\n"},
+            )
+            self.assertTrue(any("rev-parse --verify" in error for error in errors), errors)
+
+    def test_temporary_git_release_without_stable_tag_is_red(self) -> None:
+        with TemporaryReceiptRepository() as fixture:
+            untagged = fixture.commit("valid but unreleased", allow_empty=True)
+            self.assertEqual(fixture.run("rev-parse", "--verify", untagged).returncode, 0)
+            self.assertIn(
+                fixture.receipt_tag,
+                checker.commit_tags(fixture.root, fixture.measured_commit),
+            )
+            manifest = copy.deepcopy(fixture.manifest)
+            item = receipt_item(manifest, fixture.receipt)
+            item["release_commit"] = untagged
+            receipt = (fixture.root / fixture.receipt).read_text(encoding="utf-8")
+            errors = checker.check_contract(
+                fixture.root,
+                manifest,
+                {fixture.receipt: receipt + f"\nRelease commit: `{untagged}`\n"},
+            )
+            expected = f"release commit {untagged} is contained by no stable release tag"
+            self.assertTrue(any(expected in error for error in errors), errors)
+
+    def test_temporary_git_off_main_measurement_and_landed_sibling_are_green(self) -> None:
+        with TemporaryReceiptRepository() as fixture:
+            self.assertEqual(
+                fixture.run(
+                    "merge-base", fixture.measured_commit, fixture.release_commit
+                ).stdout.strip(),
+                fixture.common_commit,
+            )
+            self.assertNotEqual(
+                fixture.run(
+                    "merge-base",
+                    "--is-ancestor",
+                    fixture.measured_commit,
+                    fixture.release_commit,
+                    check=False,
+                ).returncode,
+                0,
+            )
+            self.assertNotEqual(
+                fixture.run(
+                    "merge-base",
+                    "--is-ancestor",
+                    fixture.release_commit,
+                    fixture.measured_commit,
+                    check=False,
+                ).returncode,
+                0,
+            )
+            self.assertIn(
+                fixture.receipt_tag,
+                checker.commit_tags(fixture.root, fixture.measured_commit),
+            )
+            self.assertIn("v0.1.0", checker.commit_tags(fixture.root, fixture.release_commit))
+            self.assertEqual(checker.check_contract(fixture.root, fixture.manifest), [])
+
+    def test_temporary_git_next_release_requires_exact_measured_date(self) -> None:
+        with TemporaryReceiptRepository() as fixture:
+            self.assertEqual(checker.check_contract(fixture.root, fixture.manifest), [])
+            fixture.add_next_stable_release()
+            errors = checker.check_contract(fixture.root, fixture.manifest)
+            expected = f"must carry exact phrase 'measured {fixture.measured_on}'"
+            self.assertEqual(sum(expected in error for error in errors), 4, errors)
+            fixture.add_measured_date_to_claims()
+            self.assertEqual(checker.check_contract(fixture.root, fixture.manifest), [])
+
+    def test_workflow_checklist_and_index_wiring_fail_closed(self) -> None:
+        cases = (
+            (
+                ".github/workflows/public-docs-contract.yml",
+                "fetch-depth: 0",
+                "must contain 'fetch-depth: 0' exactly once",
+            ),
+            (
+                ".github/workflows/public-docs-contract.yml",
+                "python3 scripts/check_perf_receipt_freshness.py",
+                "must contain 'python3 scripts/check_perf_receipt_freshness.py' exactly once",
+            ),
+            (
+                "docs/RELEASE_CHECKLIST.md",
+                "docs/perf/receipt-provenance.json",
+                "must contain required fragment 'docs/perf/receipt-provenance.json'",
+            ),
+            (
+                "docs/RECEIPTS.md",
+                "../scripts/check_perf_receipt_freshness.py",
+                "must contain required fragment '../scripts/check_perf_receipt_freshness.py'",
+            ),
+        )
+        for path, fragment, error in cases:
+            with self.subTest(path=path, fragment=fragment):
+                self.assert_red(error, overrides={path: text(path).replace(fragment, "removed", 1)})
+
+    def test_zero_inbound_links_are_advisory_inventory(self) -> None:
+        self.assertEqual(
+            checker.unlinked_receipts(ROOT),
+            [
+                "docs/perf/event-history-producer-2026-07.md",
+                "docs/perf/persisted-config-serialization-2026-08.md",
+                "docs/perf/private-single-best-fanout-2026-07.md",
+                "docs/perf/shared-source-ordering-2026-07.md",
+                "docs/perf/vpn-rib-query-occupancy-method.md",
+            ],
+        )
+        self.assertEqual(self.errors(), [])
+
+    def test_supersession_links_are_direct_and_non_destructive(self) -> None:
+        self.assertIn(
+            "[realistic-mix receipt](irr-reload-realistic-mix-2026-08.md)",
+            text("docs/perf/irr-reload-comparison-2026-08.md"),
+        )
+        self.assertIn(
+            "[noise-floor recheck](attr-intern-hashing-recheck-2026-08.md)",
+            text("docs/perf/attr-intern-hashing-2026-08.md"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate front-door performance-receipt links against a curated, full-SHA provenance manifest
- enforce stable-release ancestry and the latest-three-release freshness window, with exact measured-date fallback
- add deterministic real-Git destructive fixtures and run the gate in the full-history public-docs workflow

## Validation

- receipt freshness tests: 20/20 plus live checker
- public tracker, IXP docs, and release-checklist suites plus live checks
- Ruff check/format, canonical JSON, diff check
- pre-push formatting, clippy, tests, and rustdoc

Linear: [LAN-1357](https://linear.app/lance0/issue/LAN-1357)