### PR TITLE
fix: add SIGHUP fence context diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- SIGHUP settlement fail-stop diagnostics now name the static reload step
+  that fenced and whether an earlier effect was accepted. Non-SIGHUP owners
+  report an explicit non-applicable step, while
+  targets, configuration contents, and raw error text remain excluded.
+
 - The July bgperf2 receipt and its documentation mirrors now preserve the raw
   historical rows without cross-daemon rankings. A fixed target order,
   sampler threads that continued polling across later cells, incomplete

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -793,6 +793,8 @@ const FENCE_REASON_DIVERGENCE: u8 = 3;
 const FENCE_REASON_PUBLICATION: u8 = 4;
 const FENCE_REASON_ACKNOWLEDGEMENT: u8 = 5;
 const RECOVERY_NOT_READY: &str = "runtime config settlement requires supervised recovery";
+const SIGHUP_RELOAD_STEP_NOT_RECORDED: &str = "not_recorded";
+const SIGHUP_RELOAD_STEP_NOT_APPLICABLE: &str = "not_applicable";
 const WARNING_HALF_BUDGET: Duration = Duration::from_mins(15);
 const WARNING_FIVE_MINUTES_REMAINING: Duration = Duration::from_mins(25);
 const WARNING_ONE_MINUTE_REMAINING: Duration = Duration::from_mins(29);
@@ -835,6 +837,25 @@ struct OwnedResources {
     stream_admission: Option<Arc<Semaphore>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SighupRecoveryContext {
+    reload_step: &'static str,
+    accepted_effect: bool,
+}
+
+impl SighupRecoveryContext {
+    const fn for_kind(kind: RuntimeConfigOperationKind) -> Self {
+        Self {
+            reload_step: if matches!(kind, RuntimeConfigOperationKind::Sighup) {
+                SIGHUP_RELOAD_STEP_NOT_RECORDED
+            } else {
+                SIGHUP_RELOAD_STEP_NOT_APPLICABLE
+            },
+            accepted_effect: false,
+        }
+    }
+}
+
 struct OperationInner {
     id: u64,
     kind: RuntimeConfigOperationKind,
@@ -844,6 +865,7 @@ struct OperationInner {
     response_attached: Arc<AtomicBool>,
     fatal_at_nanos: AtomicU64,
     warning_bits: AtomicU8,
+    sighup_recovery: Mutex<SighupRecoveryContext>,
     propagation_claimed: AtomicBool,
     #[cfg(test)]
     propagation_completed: AtomicBool,
@@ -1245,6 +1267,7 @@ impl RuntimeConfigSettlementWatchdog {
                 self.registry.instant_nanos(deadline + self.registry.grace),
             ),
             warning_bits: AtomicU8::new(0),
+            sighup_recovery: Mutex::new(SighupRecoveryContext::for_kind(kind)),
             propagation_claimed: AtomicBool::new(false),
             #[cfg(test)]
             propagation_completed: AtomicBool::new(false),
@@ -1555,6 +1578,38 @@ impl OwnedRuntimeConfigOperation {
         self.inner.fence_reason()
     }
 
+    /// Record that an earlier SIGHUP effect was accepted. The bit is monotonic
+    /// and freezes when recovery fencing wins.
+    pub fn mark_sighup_accepted_effect(&self) {
+        if self.inner.kind != RuntimeConfigOperationKind::Sighup {
+            return;
+        }
+        let mut context = self
+            .inner
+            .sighup_recovery
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.inner.terminal() == RuntimeConfigSettlementTerminal::Owned {
+            context.accepted_effect = true;
+        }
+    }
+
+    /// Record the compile-time SIGHUP bucket that produced a typed recovery
+    /// fence. Runtime targets and raw error text must never enter this field.
+    pub fn record_sighup_recovery_step(&self, reload_step: &'static str) {
+        if self.inner.kind != RuntimeConfigOperationKind::Sighup {
+            return;
+        }
+        let mut context = self
+            .inner
+            .sighup_recovery
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.inner.terminal() == RuntimeConfigSettlementTerminal::Owned {
+            context.reload_step = reload_step;
+        }
+    }
+
     /// Fence a typed recovery result before any response can be published.
     #[must_use]
     pub fn fence_recovery(&self, reason: RuntimeConfigFenceReason) -> bool {
@@ -1632,6 +1687,12 @@ fn transition_to_fenced(operation: &OperationInner, reason: RuntimeConfigFenceRe
         RuntimeConfigFenceReason::PublicationAmbiguous => FENCE_REASON_PUBLICATION,
         RuntimeConfigFenceReason::AcknowledgementLost => FENCE_REASON_ACKNOWLEDGEMENT,
     };
+    // Serialize the winning terminal transition with SIGHUP diagnostic writes
+    // so the fail-stop line cannot observe a post-fence bucket or effect bit.
+    let _sighup_recovery = operation
+        .sighup_recovery
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut observed = operation.state.load(Ordering::Acquire);
     loop {
         if observed & TERMINAL_MASK != TERMINAL_OWNED {
@@ -1685,6 +1746,10 @@ fn propagate_fence(operation: &OperationInner) {
     {
         admission.close();
     }
+    let sighup_recovery = *operation
+        .sighup_recovery
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     tracing::error!(
         operation_id = operation.id,
         kind = operation.kind.as_str(),
@@ -1700,6 +1765,8 @@ fn propagate_fence(operation: &OperationInner) {
         fence_reason = operation
             .fence_reason()
             .map_or("none", RuntimeConfigFenceReason::as_str),
+        reload_step = sighup_recovery.reload_step,
+        accepted_effect = sighup_recovery.accepted_effect,
         exit_status = AMBIGUOUS_CONFIG_EXIT_STATUS,
         "runtime config settlement fail-stop armed"
     );
@@ -1934,6 +2001,19 @@ mod tests {
         RuntimeConfigCoordinator,
         Option<Arc<Semaphore>>,
     ) {
+        operation_with_kind(watchdog, stream, RuntimeConfigOperationKind::Apply).await
+    }
+
+    async fn operation_with_kind(
+        watchdog: &RuntimeConfigSettlementWatchdog,
+        stream: bool,
+        kind: RuntimeConfigOperationKind,
+    ) -> (
+        OwnedRuntimeConfigOperation,
+        RuntimeConfigExecutorGuard,
+        RuntimeConfigCoordinator,
+        Option<Arc<Semaphore>>,
+    ) {
         let coordinator = RuntimeConfigCoordinator::new();
         let permit = coordinator.acquire().await.unwrap();
         let admission = stream.then(|| Arc::new(Semaphore::new(1)));
@@ -1942,7 +2022,7 @@ mod tests {
             None => None,
         };
         let (operation, guard) = watchdog.register_owned(
-            RuntimeConfigOperationKind::Apply,
+            kind,
             coordinator.clone(),
             permit,
             DaemonGate::new(),
@@ -2435,6 +2515,78 @@ mod tests {
         operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
         assert_eq!(operation.phase(), RuntimeConfigSettlementPhase::Mutating);
         assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn sighup_recovery_context_is_monotonic_and_freezes_with_fence() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, _, _) =
+            operation_with_kind(&watchdog, false, RuntimeConfigOperationKind::Sighup).await;
+        assert_eq!(
+            *operation.inner.sighup_recovery.lock().unwrap(),
+            SighupRecoveryContext {
+                reload_step: SIGHUP_RELOAD_STEP_NOT_RECORDED,
+                accepted_effect: false,
+            }
+        );
+        operation.mark_sighup_accepted_effect();
+        operation.record_sighup_recovery_step("neighbors.reconcile");
+        assert!(operation.fence_recovery(RuntimeConfigFenceReason::AcknowledgementLost));
+        operation.record_sighup_recovery_step("config_bridge");
+        operation.mark_sighup_accepted_effect();
+        assert_eq!(
+            *operation.inner.sighup_recovery.lock().unwrap(),
+            SighupRecoveryContext {
+                reload_step: "neighbors.reconcile",
+                accepted_effect: true,
+            }
+        );
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn sighup_recovery_context_freezes_false_before_any_accepted_effect() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, _, _) =
+            operation_with_kind(&watchdog, false, RuntimeConfigOperationKind::Sighup).await;
+        assert_eq!(
+            *operation.inner.sighup_recovery.lock().unwrap(),
+            SighupRecoveryContext {
+                reload_step: SIGHUP_RELOAD_STEP_NOT_RECORDED,
+                accepted_effect: false,
+            }
+        );
+        operation.record_sighup_recovery_step("neighbors.reconcile");
+        assert!(operation.fence_recovery(RuntimeConfigFenceReason::AcknowledgementLost));
+        operation.record_sighup_recovery_step("config_bridge");
+        operation.mark_sighup_accepted_effect();
+        assert_eq!(
+            *operation.inner.sighup_recovery.lock().unwrap(),
+            SighupRecoveryContext {
+                reload_step: "neighbors.reconcile",
+                accepted_effect: false,
+            }
+        );
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn non_sighup_recovery_context_remains_not_applicable() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        operation.mark_sighup_accepted_effect();
+        operation.record_sighup_recovery_step("neighbors.reconcile");
+        assert_eq!(
+            *operation.inner.sighup_recovery.lock().unwrap(),
+            SighupRecoveryContext {
+                reload_step: SIGHUP_RELOAD_STEP_NOT_APPLICABLE,
+                accepted_effect: false,
+            }
+        );
+        assert!(operation.try_settle());
         drop(guard);
     }
 

--- a/docs/settlement-watchdog.md
+++ b/docs/settlement-watchdog.md
@@ -226,7 +226,8 @@ runtime config settlement fail-stop armed
 
 with fields `operation_id`, `kind`, `phase`, `elapsed_seconds`,
 `budget_seconds`, `response_attached`, `terminal="recovery_fenced"`,
-`fence_reason`, and `exit_status=70`. In daemon mode no other path
+`fence_reason`, `reload_step`, `accepted_effect`, and `exit_status=70`.
+In daemon mode no other path
 exits 70, and no fail-stop happens without this line. Reading it:
 
 - `kind` names the owner family (`sighup`, `apply`, `confirm`,
@@ -244,10 +245,21 @@ exits 70, and no fail-stop happens without this line. Reading it:
   anything; it explains why no client saw an error.
 - `operation_id` is a daemon-generated correlation ID, meaningful only
   for matching this process's own log lines.
+- For `kind=sighup`, `reload_step` names the compile-time reload bucket
+  that returned the typed fenced outcome, and `accepted_effect=true`
+  means at least one earlier SIGHUP effect was accepted, including the
+  credential-generation refresh that begins a daemon SIGHUP. `false`
+  means no earlier accepted effect was observed; it does **not** prove
+  that the fenced step had no effect, because an acknowledgement-lost
+  step remains ambiguous by definition.
+  `reload_step=not_recorded` means the budget or executor-loss fence won
+  before a typed SIGHUP bucket was recorded. Other operation kinds report
+  `reload_step=not_applicable` and `accepted_effect=false`; the bit is not
+  meaningful for those kinds.
 
 The diagnostic deliberately carries no config contents, paths, tokens,
-confirm IDs, or raw error text; `kind` + `phase` + `fence_reason` are
-the complete classification.
+confirm IDs, targets, or raw error text. The SIGHUP bucket is a static
+classification, never an operator-supplied value.
 
 The Prometheus `RustbgpdRestarted` alert can reveal a sampled change in
 `process_start_time_seconds` for the stable rustbgpd scrape target. It covers

--- a/src/main.rs
+++ b/src/main.rs
@@ -5391,6 +5391,7 @@ async fn run<T>(
                         SighupReloadOutcome::RecoveryFenced { error, reason } => OwnedRuntimeConfigOutcome::Fenced { error, reason },
                         SighupReloadOutcome::Acknowledged(authority) => {
                             let Some(bridge_replace) = bridge_replace.as_ref() else {
+                                operation.record_sighup_recovery_step("config_bridge");
                                 return OwnedRuntimeConfigOutcome::Fenced {
                                     error: SighupReloadError::preflight("config_bridge", "bridge authority unavailable after runtime effects"),
                                     reason: rustbgpd_api::runtime_config_settlement::RuntimeConfigFenceReason::KnownDivergence,

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -370,10 +370,14 @@ struct SighupMutationProgress<'a> {
 
 impl<'a> SighupMutationProgress<'a> {
     fn new(operation: Option<&'a OwnedRuntimeConfigOperation>, accepted_effect: bool) -> Self {
-        Self {
+        let progress = Self {
             operation,
             accepted_effect,
+        };
+        if accepted_effect && let Some(operation) = operation {
+            operation.mark_sighup_accepted_effect();
         }
+        progress
     }
 
     fn begin_mutation(&self) {
@@ -384,6 +388,15 @@ impl<'a> SighupMutationProgress<'a> {
 
     fn mark_accepted_effect(&mut self) {
         self.accepted_effect = true;
+        if let Some(operation) = self.operation {
+            operation.mark_sighup_accepted_effect();
+        }
+    }
+
+    fn record_recovery_step(&self, reload_step: &'static str) {
+        if let Some(operation) = self.operation {
+            operation.record_sighup_recovery_step(reload_step);
+        }
     }
 }
 
@@ -443,10 +456,12 @@ fn clean_reload_failure(bucket: &'static str, error: impl Into<String>) -> Sighu
 }
 
 fn fenced_reload_failure(
+    progress: &SighupMutationProgress<'_>,
     bucket: &'static str,
     error: ReloadStepError,
     reason: RuntimeConfigFenceReason,
 ) -> SighupReloadOutcome {
+    progress.record_recovery_step(bucket);
     SighupReloadOutcome::RecoveryFenced {
         error: sighup_error(bucket, String::new(), error),
         reason,
@@ -480,16 +495,19 @@ fn tcp_ao_awaiting_peer_outcome(
             )
         }
         ReloadDispatch::AcknowledgementLost => fenced_reload_failure(
+            progress,
             "tcp_ao.awaiting_peer_marker",
             ReloadStepError::AcknowledgementLost,
             RuntimeConfigFenceReason::AcknowledgementLost,
         ),
         ReloadDispatch::NotAccepted(error) => fenced_reload_failure(
+            progress,
             "tcp_ao.awaiting_peer_marker",
             ReloadStepError::NotAccepted(error.to_string()),
             RuntimeConfigFenceReason::KnownDivergence,
         ),
         ReloadDispatch::Replied(Err(error)) => fenced_reload_failure(
+            progress,
             "tcp_ao.awaiting_peer_marker",
             ReloadStepError::Rejected(error.to_string()),
             RuntimeConfigFenceReason::KnownDivergence,
@@ -1118,7 +1136,9 @@ fn owned_step_failure(
                 error,
             },
         ),
-        OwnedStepFailure::Fenced { error, reason } => fenced_reload_failure(bucket, error, reason),
+        OwnedStepFailure::Fenced { error, reason } => {
+            fenced_reload_failure(progress, bucket, error, reason)
+        }
     }
 }
 
@@ -1653,13 +1673,16 @@ pub(crate) async fn finalize_sighup_authority(
     dialout_manager: &Arc<tokio::sync::Mutex<rustbgpd_api::gnmi_dialout::DialoutManager>>,
 ) -> OwnedRuntimeConfigOutcome<SighupAuthority, SighupReloadError> {
     operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
-    let fenced = |bucket, reason, fence_reason| OwnedRuntimeConfigOutcome::Fenced {
-        error: SighupReloadError::Failed(ReloadStepFailure {
-            bucket,
-            target: String::new(),
-            error: reason,
-        }),
-        reason: fence_reason,
+    let fenced = |bucket, reason, fence_reason| {
+        operation.record_sighup_recovery_step(bucket);
+        OwnedRuntimeConfigOutcome::Fenced {
+            error: SighupReloadError::Failed(ReloadStepFailure {
+                bucket,
+                target: String::new(),
+                error: reason,
+            }),
+            reason: fence_reason,
+        }
     };
     // Acknowledge the snapshot so the caller (holding the FIB coordinator lock)
     // doesn't release the lock until the peer manager has actually assigned
@@ -1688,6 +1711,7 @@ pub(crate) async fn finalize_sighup_authority(
             RuntimeConfigFenceReason::AcknowledgementLost,
         );
     }
+    operation.mark_sighup_accepted_effect();
     let (adopted, adopted_rx) = oneshot::channel();
     if bridge_replace_tx
         .send(AcceptedBridgeReplacement {
@@ -1704,7 +1728,7 @@ pub(crate) async fn finalize_sighup_authority(
         );
     }
     match adopted_rx.await {
-        Ok(ReloadDispatch::Replied(())) => {}
+        Ok(ReloadDispatch::Replied(())) => operation.mark_sighup_accepted_effect(),
         Ok(ReloadDispatch::NotAccepted(error)) => {
             return fenced(
                 "config_persister",
@@ -2129,7 +2153,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             } else {
                 RuntimeConfigFenceReason::KnownDivergence
             };
-            return fenced_reload_failure("tcp_ao.listener_apply", error, reason);
+            return fenced_reload_failure(&progress, "tcp_ao.listener_apply", error, reason);
         }
         if let Err(error) = send_tcp_ao_apply(peer_mgr_tx, plan, &mut progress).await {
             if plan.operation == TcpAoRotationOperation::Selection
@@ -2174,7 +2198,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             } else {
                 RuntimeConfigFenceReason::KnownDivergence
             };
-            return fenced_reload_failure("tcp_ao.peer_apply", error, reason);
+            return fenced_reload_failure(&progress, "tcp_ao.peer_apply", error, reason);
         }
         if plan.operation == TcpAoRotationOperation::Selection
             && let Err(error) = listener_step(
@@ -2197,7 +2221,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             } else {
                 RuntimeConfigFenceReason::KnownDivergence
             };
-            return fenced_reload_failure("tcp_ao.listener_finalize", error, reason);
+            return fenced_reload_failure(&progress, "tcp_ao.listener_finalize", error, reason);
         }
         if let Err(error) = listener_step(
             listener
@@ -2218,7 +2242,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             } else {
                 RuntimeConfigFenceReason::KnownDivergence
             };
-            return fenced_reload_failure("tcp_ao.listener_commit", error, reason);
+            return fenced_reload_failure(&progress, "tcp_ao.listener_commit", error, reason);
         }
         tcp_ao_rotation_applied = true;
         info!(
@@ -2267,7 +2291,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 } else {
                     RuntimeConfigFenceReason::KnownDivergence
                 };
-                return fenced_reload_failure("listener_auth.apply", error, reason);
+                return fenced_reload_failure(&progress, "listener_auth.apply", error, reason);
             }
             info!("listener inbound MD5/GTSM inventory replaced");
         }
@@ -2315,6 +2339,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                      fencing before later reload mutations"
                 );
                 return fenced_reload_failure(
+                    &progress,
                     "evpn_runtime.apply",
                     ReloadStepError::Rejected(format!("{error:?}")),
                     RuntimeConfigFenceReason::KnownDivergence,
@@ -2327,6 +2352,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                      fencing before later reload mutations"
                 );
                 return fenced_reload_failure(
+                    &progress,
                     "evpn_runtime.apply",
                     ReloadStepError::Rejected(format!("{error:?}")),
                     RuntimeConfigFenceReason::PublicationAmbiguous,
@@ -3314,6 +3340,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             if sighup_ack_fault("reconcile") {
                 drop(reply_rx);
                 return fenced_reload_failure(
+                    &progress,
                     "neighbors.reconcile",
                     ReloadStepError::AcknowledgementLost,
                     RuntimeConfigFenceReason::AcknowledgementLost,
@@ -3323,6 +3350,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 Ok(reconcile) => {
                     if reconcile.authority == PeerReconcileAuthority::Diverged {
                         return fenced_reload_failure(
+                            &progress,
                             "neighbors.reconcile",
                             ReloadStepError::Rejected(
                                 "peer reconcile returned non-authoritative state".into(),
@@ -3386,6 +3414,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 }
                 Err(_) => {
                     return fenced_reload_failure(
+                        &progress,
                         "neighbors.reconcile",
                         ReloadStepError::AcknowledgementLost,
                         RuntimeConfigFenceReason::AcknowledgementLost,
@@ -3415,6 +3444,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             }
             Err(error @ ReloadStepError::AcknowledgementLost) => {
                 return fenced_reload_failure(
+                    &progress,
                     "honor_graceful_shutdown.apply",
                     error,
                     RuntimeConfigFenceReason::AcknowledgementLost,
@@ -3460,6 +3490,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             }
             Err(error @ ReloadStepError::AcknowledgementLost) => {
                 return fenced_reload_failure(
+                    &progress,
                     "honor_blackhole.apply",
                     error,
                     RuntimeConfigFenceReason::AcknowledgementLost,
@@ -3558,6 +3589,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                     }
                     Ok(OwnedFibReplaceOutcome::CompensationAmbiguous(error)) => {
                         return fenced_reload_failure(
+                            &progress,
                             "fib_tables.apply",
                             ReloadStepError::Rejected(error),
                             RuntimeConfigFenceReason::KnownDivergence,
@@ -3565,6 +3597,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                     }
                     Err(_) => {
                         return fenced_reload_failure(
+                            &progress,
                             "fib_tables.apply",
                             ReloadStepError::AcknowledgementLost,
                             RuntimeConfigFenceReason::AcknowledgementLost,
@@ -3759,6 +3792,7 @@ fn acknowledge_partial(
         "config reload stopped at this step; settling the acknowledged partial runtime authority before another reload may begin"
     );
     if matches!(failure.error, ReloadStepError::AcknowledgementLost) {
+        progress.record_recovery_step(failure.bucket);
         return SighupReloadOutcome::RecoveryFenced {
             error: SighupReloadError::Failed(failure),
             reason: RuntimeConfigFenceReason::AcknowledgementLost,
@@ -6456,8 +6490,10 @@ hold_time = 90
                 SighupReloadOutcome::CleanNoEffect(_)
             ));
         }
+        let progress = SighupMutationProgress::new(None, false);
         assert!(matches!(
             fenced_reload_failure(
+                &progress,
                 "tcp_ao.peer_apply",
                 ReloadStepError::AcknowledgementLost,
                 RuntimeConfigFenceReason::AcknowledgementLost,

--- a/tests/runtime_config_persistence_failstop.rs
+++ b/tests/runtime_config_persistence_failstop.rs
@@ -190,7 +190,11 @@ fn assert_settlement_metrics(text: &str, kind: &str, phase: &str, attachment: &s
     }
 }
 
-fn assert_one_redacted_diagnostic(daemon: &Daemon) {
+fn assert_one_redacted_diagnostic(
+    daemon: &Daemon,
+    expected_reload_step: &str,
+    expected_accepted_effect: bool,
+) {
     let matching = daemon
         .log()
         .lines()
@@ -198,6 +202,14 @@ fn assert_one_redacted_diagnostic(daemon: &Daemon) {
         .map(str::to_string)
         .collect::<Vec<_>>();
     assert_eq!(matching.len(), 1, "log:\n{}", daemon.log());
+    let diagnostic: serde_json::Value =
+        serde_json::from_str(&matching[0]).expect("fail-stop diagnostic is JSON");
+    let fields = &diagnostic["fields"];
+    assert_eq!(fields["reload_step"], expected_reload_step);
+    assert_eq!(
+        fields["accepted_effect"],
+        serde_json::Value::Bool(expected_accepted_effect)
+    );
     for forbidden in ["injected", "rustbgpd.toml", "grpc.sock", FIRST_NEIGHBOR] {
         assert!(
             !matching[0].contains(forbidden),
@@ -329,7 +341,7 @@ fn exercise(fault: &str, published: bool) {
         .expect("daemon exceeded the five-second fail-stop grace plus test jitter before wait");
     let status = daemon.wait_for_exit(remaining_grace);
     assert_eq!(status.code(), Some(70), "log:\n{}", daemon.log());
-    assert_one_redacted_diagnostic(&daemon);
+    assert_one_redacted_diagnostic(&daemon, "not_applicable", false);
     assert!(
         recovery_fenced_at.elapsed() <= FAILSTOP_GRACE_WITH_JITTER,
         "exit 70 exceeded the five-second grace plus test jitter"
@@ -421,7 +433,28 @@ fn exercise_sighup_ack_loss(fault: &str) {
         .expect("daemon exceeded the five-second fail-stop grace plus test jitter before wait");
     let status = daemon.wait_for_exit(remaining_grace);
     assert_eq!(status.code(), Some(70), "log:\n{}", daemon.log());
-    assert_one_redacted_diagnostic(&daemon);
+    assert_one_redacted_diagnostic(
+        &daemon,
+        if fault == "reconcile" {
+            "neighbors.reconcile"
+        } else {
+            "config_bridge"
+        },
+        true,
+    );
+    if fault == "reconcile" {
+        let log = daemon.log();
+        let credential_reload = log
+            .find("gRPC credential generation reloaded")
+            .expect("SIGHUP credential generation refresh precedes reconciliation");
+        let fail_stop = log
+            .find("runtime config settlement fail-stop armed")
+            .expect("fail-stop diagnostic exists");
+        assert!(
+            credential_reload < fail_stop,
+            "credential refresh must precede the reconciler fence:\n{log}"
+        );
+    }
 
     let bytes = std::fs::read(&config_path).expect("read operator config");
     assert_eq!(bytes, operator_candidate.as_bytes());


### PR DESCRIPTION
## Summary

- carry a fixed, redacted reload-step and accepted-effect context into settlement fail-stop diagnostics
- freeze the context with the winning fence and keep non-SIGHUP operations explicitly `not_applicable`
- cover pre-effect, monotonic-effect, reconcile, bridge, and non-SIGHUP fail-stop cases

## Validation

- focused API context and unchanged clean/partial reload tests
- real-process persistence fail-stop suite: 4/4 serially
- workspace all-target/all-feature clippy with warnings denied
- public tracker contract and live check
- pre-push formatting, clippy, tests, and rustdoc

Linear: [LAN-1321](https://linear.app/lance0/issue/LAN-1321)