### PR TITLE
bench: unify receipt host locking and smoke inventory

### DIFF
--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 root=$(git rev-parse --show-toplevel)
+# shellcheck disable=SC1091 # root is resolved dynamically above
+source "$root/tests/soak/host-lock.sh"
 verifier="$root/bench/scale/rrtransport/verify_receipt.py"
 manifest="$root/bench/scale/rrtransport/Cargo.toml"
 binary="$root/bench/scale/target/release/rrtransport"
@@ -599,7 +601,7 @@ stop_reap_fixture() {
 
 check_seam() {
   local script=$1 outer verify_call completion
-  local direct_rss_call direct_rss_exit direct_rss_resolver
+  local direct_rss_call direct_rss_exit direct_rss_resolver host_lock_source
   outer="timeout -k 10 1200 \"\$scr"
   outer+="ipt\" --campaign-inner \"\$output\""
   verify_call="full_ver"
@@ -609,12 +611,15 @@ check_seam() {
   direct_rss_exit="[[ \$direct_rss_action != exited ]] || break"
   direct_rss_resolver='resolve_direct_'
   direct_rss_resolver+="rss \"\$process\" \"\$expected_start\""
+  host_lock_source="source \"\$root/tests/soak/host-lock.sh\""
   if ! grep -Fq "$outer" "$script" || ! grep -Fq "$verify_call" "$script" ||
     ! grep -Fq "$completion" "$script" ||
     ! grep -Fq "$direct_rss_call" "$script" ||
     ! grep -Fq "$direct_rss_exit" "$script" ||
-    ! grep -Fq "$direct_rss_resolver" "$script"; then
-    echo "runner lacks production verifier/completion/RSS seam" >&2
+    ! grep -Fq "$direct_rss_resolver" "$script" ||
+    ! grep -Fxq "$host_lock_source" "$script" ||
+    ! grep -Fxq 'acquire_rustbgpd_host_lock' "$script"; then
+    echo "runner lacks production verifier/completion/RSS/host-lock seam" >&2
     return 1
   fi
 }
@@ -813,8 +818,7 @@ if [[ -z ${campaign_inner:-} ]]; then
 fi
 [[ $output = /* && $output != "$root"/* ]] || { echo "output must be absolute and outside repo" >&2; exit 1; }
 [[ ! -e $output ]] || { echo "output must not already exist" >&2; exit 1; }
-exec 9>/tmp/rustbgpd-rrtransport-rr1000.lock
-flock -n 9 || { echo "rr1000 host lock busy" >&2; exit 1; }
+acquire_rustbgpd_host_lock
 [[ $(ulimit -n) -ge 4096 ]] || { echo "need at least 4096 FDs" >&2; exit 1; }
 available=$(awk '/MemAvailable:/ {print $2}' /proc/meminfo)
 (( available >= 16 * 1024 * 1024 )) || { echo "need 16 GiB available" >&2; exit 1; }

--- a/bench/smoke-benches.sh
+++ b/bench/smoke-benches.sh
@@ -13,7 +13,7 @@
 # timing it happens to produce is meaningless and is not reported.
 #
 # The target list comes from `cargo metadata`, so a bench target is covered the
-# day it lands rather than when someone remembers to register it here. The three
+# day it lands rather than when someone remembers to register it here. The five
 # non-criterion harnesses are excluded by name; renaming one drops its
 # exclusion and this script then fails loudly instead of skipping it silently.
 
@@ -47,9 +47,12 @@ done
 #                        harness's own `--smoke` bound.
 #   route_paging         CSV receipt harness; one complete traversal per
 #                        process, driven by --route-count/--output.
+#   dataplane_prefix_paging
+#                        CSV-to-stdout receipt harness; one complete traversal
+#                        per process, driven by prefix/path/index-mode flags.
 #   vpn_query_*          are one-cell timing/allocation executables. CI runs
 #                        their exact 256-route smoke separately.
-EXCLUDED=(snapshot_allocation route_paging vpn_query_timing vpn_query_allocation)
+EXCLUDED=(snapshot_allocation route_paging dataplane_prefix_paging vpn_query_timing vpn_query_allocation)
 
 mapfile -t targets < <(
   cargo metadata "${locked_args[@]}" --no-deps --format-version 1 | python3 -c '

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -173,6 +173,39 @@ if "$runner" --classify-rss 2097153 "$tmp/rss-over"; then echo "false green: rss
 grep -q '"root_failure":"rss_ceiling"' "$tmp/rss-over/failure.json"
 expect_red malformed-commit mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());d["commit"]="main";p.write_text(json.dumps(d))'
 "$runner" --check-seam "$runner"
+cp "$runner" "$tmp/no-host-lock-call"
+# shellcheck disable=SC2016 # Exact production source text for destructive proof.
+mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1]);s=p.read_text();seam="acquire_rustbgpd_host_lock\n";assert s.count(seam)==1;p.write_text(s.replace(seam,"",1))' \
+  "$tmp/no-host-lock-call"
+if "$runner" --check-seam "$tmp/no-host-lock-call" \
+  >"$tmp/no-host-lock-call.stdout" 2>"$tmp/no-host-lock-call.stderr"; then
+  echo "false green: production host-lock call removed" >&2
+  exit 1
+fi
+grep -Fxq "runner lacks production verifier/completion/RSS/host-lock seam" \
+  "$tmp/no-host-lock-call.stderr"
+
+shared_host_lock="$tmp/rustbgpd-host.lock"
+exec {held_host_lock_fd}>"$shared_host_lock"
+flock -n "$held_host_lock_fd"
+lock_status=0
+(
+  # If the contention guard regresses, stop at the next production preflight
+  # instead of entering a campaign on a test host.
+  ulimit -n 1024
+  RUSTBGPD_HOST_LOCK="$shared_host_lock" \
+    "$runner" "$tmp/held-host-lock-output" \
+    >"$tmp/held-host-lock.stdout" 2>"$tmp/held-host-lock.stderr"
+) || lock_status=$?
+exec {held_host_lock_fd}>&-
+if [[ $lock_status != 75 ]]; then
+  echo "production runner did not propagate EX_TEMPFAIL for host contention" >&2
+  cat "$tmp/held-host-lock.stdout" "$tmp/held-host-lock.stderr" >&2
+  exit 1
+fi
+grep -Fq "$shared_host_lock is held by another process (soak or bench)" \
+  "$tmp/held-host-lock.stderr"
+[[ ! -e $tmp/held-host-lock-output ]]
 [[ $("$runner" --classify-child-exe /expected /expected R) == sample ]]
 [[ $("$runner" --classify-child-exe /expected /foreign R) == reject ]]
 [[ $("$runner" --classify-child-exe /expected /foreign X) == reject ]]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -142,13 +142,13 @@ not a merge gate.
 
 ### Host coexistence: bench vs. soak
 
-Bench and soak workloads share the primary host. That coexistence is now
-the normal case rather than a plan: the 24h flagship soak receipts record
-the primary host, and benchmarking moved there when the VPS was retired.
-Both workloads acquire an exclusive `flock` on
+Criterion comparisons, the rrtransport production receipt, and soak workloads
+share the primary host. That coexistence is now the normal case rather than a
+plan: the 24h flagship soak receipts record the primary host, and benchmarking
+moved there when the VPS was retired. All three acquire an exclusive `flock` on
 `${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` before doing
-real work — the bench script via `bench/compare-criterion.sh` directly, the soak
-runners via the shared `tests/soak/host-lock.sh` helper. A bench
+real work — `bench/compare-criterion.sh` directly, and the rrtransport receipt
+runner and soak runners via the shared `tests/soak/host-lock.sh` helper. A bench
 dispatch refuses to start while a soak is active and a soak refuses to
 start while a bench is mid-attempt; either workload fails fast with a
 clear error rather than producing useless numbers next to a busy host.
@@ -168,25 +168,26 @@ workspace (`[package] rustbgpd` alongside `[workspace]`) with no
 `[[bench]]` target, `fib_projection`, is `bench-internals`-gated, which
 leaves the auto-discovered `src/lib.rs` libtest harness as the one thing that
 runs — and it declares no benchmarks. `cargo bench` at the root therefore
-measures nothing. `cargo bench --workspace` is not a substitute either: four
+measures nothing. `cargo bench --workspace` is not a substitute either: five
 targets are standalone CLIs rather than criterion harnesses and reject
 criterion's flags.
 
-Run each target explicitly with `-p <crate> --bench <name>`. Fourteen exist.
+Run each target explicitly with `-p <crate> --bench <name>`. Fifteen exist.
 Six build with default features (wire/`codec`, rib/`rib_ops`,
 policy/`policy_eval`, policy/`explain_snapshot`, rpki/`validate`,
-mrt/`snapshot_allocation`); eight are `bench-internals`-gated
+mrt/`snapshot_allocation`); nine are `bench-internals`-gated
 (transport/`fanout`, transport/`inbound_attrs`, rustbgpd/`fib_projection`,
-rib/`route_paging`, rib/`evpn_dataplane_query`, api/`event_history_producer`,
+rib/`route_paging`, rib/`evpn_dataplane_query`,
+rib/`dataplane_prefix_paging`, api/`event_history_producer`,
 api/`vpn_query_timing`, api/`vpn_query_allocation` — the last also requires
-the api crate's `vpn-query-allocation` feature). Four of the fourteen —
-`snapshot_allocation`, `route_paging`, `vpn_query_timing`, and
-`vpn_query_allocation` — are standalone measurement CLIs with their own
-argument contracts (`snapshot_allocation` hard-errors without a
+the api crate's `vpn-query-allocation` feature). Five of the fifteen —
+`snapshot_allocation`, `route_paging`, `dataplane_prefix_paging`,
+`vpn_query_timing`, and `vpn_query_allocation` — are standalone measurement
+CLIs with their own argument contracts (`snapshot_allocation` hard-errors without a
 `timing|diagnostic` mode), not criterion harnesses.
 
 `bench/smoke-benches.sh` enumerates the target list from `cargo metadata`,
-excludes those four by name, and runs every remaining criterion target once
+excludes those five by name, and runs every remaining criterion target once
 in `--test` mode — the cheapest proof that each still executes.
 
 ```bash

--- a/tests/soak/host-lock.sh
+++ b/tests/soak/host-lock.sh
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
-# Host mutex shared with bench/compare-criterion.sh.
+# Canonical host mutex for soak and production benchmark receipt runners.
 #
-# When the soak runner and the Criterion bench runner share a host,
-# letting them both touch CPU / memory / FIB at the same time would
-# corrupt every reading from both. Both workloads acquire an exclusive
-# `flock` on the same path before doing real work.
+# When soak and benchmark runners share a host, letting them touch CPU / memory
+# / FIB at the same time would corrupt every reading. Each workload acquires an
+# exclusive `flock` on the same path before doing real work.
 #
-# Source this file from a soak entrypoint and call
-# `acquire_rustbgpd_host_lock` after log redirection is set up
-# (so the success/failure line lands in soak.log) but before any
-# container, daemon, or churn driver starts.
+# Source this file from a production benchmark or soak entrypoint and call
+# `acquire_rustbgpd_host_lock` after log redirection is set up (so the
+# success/failure line is retained) but before any container, daemon, or churn
+# driver starts.
 #
-# Semantics (must stay byte-equivalent to the bench-side block in
-# bench/compare-criterion.sh):
+# The Criterion comparison runner inlines equivalent semantics; keep its block
+# behaviorally aligned with this helper.
 #
 #   - Path: ${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}.
 #   - Always lock; create the lock dir if missing. (An earlier


### PR DESCRIPTION
## Summary

- move the rrtransport production receipt onto the canonical soak/benchmark host mutex and preserve retryable exit 75 on contention
- add destructive coverage for the production lock seam and a real held shared lock
- exclude the standalone dataplane prefix paging receipt from Criterion smoke execution and correct the documented 15-target inventory

## Validation

- `bash bench/tests/test-rrtransport-receipt.sh`
- Bash syntax and ShellCheck for the touched scripts
- full `bench/smoke-benches.sh`
- Cargo metadata proof that `dataplane_prefix_paging` is `harness = false`
- public docs contract
- pre-push hooks and `git diff --check`

Linear: [LAN-1355](https://linear.app/lance0/issue/LAN-1355) and [LAN-1356](https://linear.app/lance0/issue/LAN-1356)