### PR TITLE
observability: add active-primary session telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Active-primary session telemetry now exports the exact one-hot
+  `bgp_peer_session_state{peer,interface,state}` FSM vector and
+  `bgp_session_down_total{peer,interface,reason}`. The down counter records
+  each Established epoch once under bounded local/remote notification,
+  no-notification, transport-error, or defensive unknown reasons; collision
+  candidates remain silent until promotion.
+
 - The M99 FRR receipt now proves RFC 9072 extended OPEN framing at raw-byte
   level. One pinned FRR 10.3.1 process forces a small extended OPEN on one
   link while a second link stays classic; rustbgpd emits its exact 342-byte,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -151,6 +151,17 @@ const ORR_INPUT_CLASSIFICATIONS: [&str; 5] = [
 const EVENT_OUTBOX_QUEUE_DEPTH_CATEGORIES: [&str; 6] =
     ["route", "evpn", "session", "policy", "bfd", "dataplane"];
 
+/// Exact RFC 4271 FSM state vocabulary exported by
+/// `bgp_peer_session_state`.
+const SESSION_STATES: [&str; 6] = [
+    "idle",
+    "connect",
+    "active",
+    "open_sent",
+    "open_confirm",
+    "established",
+];
+
 /// Shared wall-clock buckets for synchronous work on the single RIB actor.
 const RIB_ACTOR_DURATION_BUCKETS: [f64; 13] = [
     0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.200, 0.500, 1.0, 2.5, 5.0, 10.0, 30.0,
@@ -271,6 +282,8 @@ struct BgpMetricsInner {
     session_established: IntCounterVec,
     peer_admin_enabled: IntGaugeVec,
     peer_session_established: IntGaugeVec,
+    peer_session_state: IntGaugeVec,
+    session_down: IntCounterVec,
     stale_timer_events: IntCounterVec,
     session_notification_outstanding_value: Arc<AtomicI64>,
     session_notification_outstanding_high_watermark_value: Arc<AtomicI64>,
@@ -612,6 +625,24 @@ impl BgpMetrics {
                 "Active-primary BGP session state (1 = Established, 0 = not Established)",
             ),
             &["peer", "interface"],
+        )
+        .expect("valid metric definition");
+
+        let peer_session_state = IntGaugeVec::new(
+            Opts::new(
+                "bgp_peer_session_state",
+                "Active-primary BGP FSM state as an exact six-row one-hot gauge",
+            ),
+            &["peer", "interface", "state"],
+        )
+        .expect("valid metric definition");
+
+        let session_down = IntCounterVec::new(
+            Opts::new(
+                "bgp_session_down_total",
+                "Established active-primary sessions that ended, by bounded teardown reason",
+            ),
+            &["peer", "interface", "reason"],
         )
         .expect("valid metric definition");
 
@@ -2236,6 +2267,12 @@ impl BgpMetrics {
             .register(Box::new(peer_session_established.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(peer_session_state.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(session_down.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(bfd_session_up.clone()))
             .expect("metric not already registered");
         registry
@@ -2790,6 +2827,8 @@ impl BgpMetrics {
             session_established,
             peer_admin_enabled,
             peer_session_established,
+            peer_session_state,
+            session_down,
             stale_timer_events,
             dynamic_neighbor_slots_used,
             dynamic_neighbor_slots_limit,
@@ -3056,6 +3095,8 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.0.session_established, peer);
         Self::reap_peer_series_from_vec(&self.0.peer_admin_enabled, peer);
         Self::reap_peer_series_from_vec(&self.0.peer_session_established, peer);
+        Self::reap_peer_series_from_vec(&self.0.peer_session_state, peer);
+        Self::reap_peer_series_from_vec(&self.0.session_down, peer);
         Self::reap_peer_series_from_vec(&self.0.stale_timer_events, peer);
         Self::reap_peer_series_from_vec(&self.0.bfd_session_up, peer);
         Self::reap_peer_series_from_vec(&self.0.bfd_session_flaps_total, peer);
@@ -3125,6 +3166,18 @@ impl BgpMetrics {
         let labels = &[peer, interface];
         let _ = self.0.peer_admin_enabled.remove_label_values(labels);
         let _ = self.0.peer_session_established.remove_label_values(labels);
+        for state in SESSION_STATES {
+            let _ = self
+                .0
+                .peer_session_state
+                .remove_label_values(&[peer, interface, state]);
+        }
+        for reason in crate::reason_labels::SessionDownReason::ALL {
+            let _ = self
+                .0
+                .session_down
+                .remove_label_values(&[peer, interface, reason.as_str()]);
+        }
     }
 
     fn reap_peer_series_from_vec<T: prometheus::core::MetricVecBuilder>(
@@ -3222,6 +3275,54 @@ impl BgpMetrics {
             .peer_session_established
             .with_label_values(&[peer, interface])
             .set(i64::from(established));
+    }
+
+    /// Materialize the exact six-row active-primary FSM state vector.
+    ///
+    /// Calling this for every transition keeps the vector one-hot; calling it
+    /// before `Start` makes a never-established peer visible as `idle=1`.
+    ///
+    /// An unknown state is rejected without changing the last valid vector;
+    /// accepting it would publish an invalid all-zero vector.
+    pub fn set_peer_session_state(&self, peer: &str, interface: &str, current: &str) {
+        debug_assert!(
+            SESSION_STATES.contains(&current),
+            "session state must use the exact bounded FSM vocabulary"
+        );
+        if !SESSION_STATES.contains(&current) {
+            tracing::warn!(
+                peer,
+                interface,
+                state = current,
+                "unknown BGP session state; one-hot gauge left unchanged"
+            );
+            return;
+        }
+        for state in SESSION_STATES {
+            self.0
+                .peer_session_state
+                .with_label_values(&[peer, interface, state])
+                .set(i64::from(state == current));
+        }
+        for reason in crate::reason_labels::SessionDownReason::ALL {
+            let _counter =
+                self.0
+                    .session_down
+                    .with_label_values(&[peer, interface, reason.as_str()]);
+        }
+    }
+
+    /// Record one classified active-primary Established-session teardown.
+    pub fn record_session_down(
+        &self,
+        peer: &str,
+        interface: &str,
+        reason: crate::reason_labels::SessionDownReason,
+    ) {
+        self.0
+            .session_down
+            .with_label_values(&[peer, interface, reason.as_str()])
+            .inc();
     }
 
     /// Set the gNMI dial-out connection gauge for a configured target.
@@ -5892,10 +5993,13 @@ mod tests {
         let m = BgpMetrics::new();
         m.set_peer_admin_enabled("192.0.2.1", "", true);
         m.set_peer_session_established("192.0.2.1", "", false);
+        m.set_peer_session_state("192.0.2.1", "", "idle");
         m.set_peer_admin_enabled("fe80::1", "eth0", true);
         m.set_peer_session_established("fe80::1", "eth0", true);
+        m.set_peer_session_state("fe80::1", "eth0", "established");
         m.set_peer_admin_enabled("fe80::1", "eth1", false);
         m.set_peer_session_established("fe80::1", "eth1", false);
+        m.set_peer_session_state("fe80::1", "eth1", "idle");
 
         let text = gather_text(&m);
         assert!(text.contains(r#"bgp_peer_admin_enabled{interface="",peer="192.0.2.1"} 1"#));
@@ -5908,6 +6012,16 @@ mod tests {
         let text = gather_text(&m);
         assert!(!text.contains(r#"interface="eth0",peer="fe80::1""#));
         assert!(text.contains(r#"interface="eth1",peer="fe80::1""#));
+        assert_eq!(
+            text.matches(r#"interface="eth1",peer="fe80::1",state="#)
+                .count(),
+            6
+        );
+        assert_eq!(
+            text.matches(r#"interface="eth1",peer="fe80::1",reason="#)
+                .count(),
+            6
+        );
     }
 
     #[test]
@@ -7587,6 +7701,12 @@ mod tests {
         m.record_state_transition(peer, "established", "idle");
         m.set_peer_admin_enabled(peer, "", true);
         m.set_peer_session_established(peer, "", false);
+        m.set_peer_session_state(peer, "", "established");
+        m.record_session_down(
+            peer,
+            "",
+            crate::reason_labels::SessionDownReason::TransportError,
+        );
         m.record_stale_timer_event(peer, "idle", "hold");
         m.record_bfd_state(peer, true, false);
         m.record_bfd_state(peer, false, true); // bfd flap counter
@@ -7672,8 +7792,9 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 56 peer-labeled series; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 56);
+        // 68 peer-labeled series; state transitions hold two, while exact
+        // state and down-reason vocabularies materialize six rows each.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 68);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -7683,7 +7804,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 56);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 68);
     }
 
     /// Load-bearing finite/unlimited proof: removing either finite gauge
@@ -7927,7 +8048,7 @@ mod tests {
     // `gather()`, so no runtime check can catch one that is added and
     // left unpopulated; this list plus the struct doc comment is the
     // practical ceiling.
-    const PEER_LABELED_FAMILIES: [&str; 55] = [
+    const PEER_LABELED_FAMILIES: [&str; 57] = [
         "bfd_session_flaps_total",
         "bfd_session_up",
         "bgp_as_path_loop_detected_total",
@@ -7959,6 +8080,7 @@ mod tests {
         "bgp_peer_admin_enabled",
         "bgp_peer_outbound_queue_depth",
         "bgp_peer_session_established",
+        "bgp_peer_session_state",
         "bgp_peer_slow",
         "bgp_peer_update_group",
         "bgp_policy_routes_total",
@@ -7977,6 +8099,7 @@ mod tests {
         "bgp_route_refresh_stale_entries",
         "bgp_rr_loop_detected_total",
         "bgp_send_hold_expirations_total",
+        "bgp_session_down_total",
         "bgp_session_established_total",
         "bgp_session_flaps_total",
         "bgp_session_state_transitions_total",

--- a/crates/telemetry/src/reason_labels.rs
+++ b/crates/telemetry/src/reason_labels.rs
@@ -1,5 +1,5 @@
-//! Canonical reason-label vocabulary for UPDATE-path route rejection
-//! and inbound connection admission drops.
+//! Canonical reason-label vocabulary for UPDATE-path route rejection,
+//! session teardown, and inbound connection admission drops.
 //!
 //! Single source of truth for the `reason` strings that ingress (and
 //! the OTC egress sibling) route-rejection mechanisms report across
@@ -15,8 +15,9 @@
 //! - One reason string per mechanism, shared by every surface that
 //!   reports that mechanism. The metric label value IS the documented
 //!   string; log lines may add detail but carry the canonical token.
-//! - Reasons are named for what was observed on the wire, not for the
-//!   consumer that reacts to it.
+//! - Reasons are named for the bounded protocol condition or locally selected
+//!   protocol action that initiated the outcome, not for the consumer that
+//!   reacts to it.
 //!
 //! Renaming any string here is a breaking observability change
 //! (operators key alerts on these values) and must be called out in
@@ -29,6 +30,62 @@
 //! `reason` label, but the log line emitted alongside it
 //! distinguishes the two RFC 4456 §8 loop signals via
 //! [`RrLoopReason`].
+
+/// Active-primary Established-session teardown reasons.
+///
+/// This vocabulary is deliberately independent of BMP's raw-PDU-bearing
+/// `PeerDownReason`: Prometheus needs a closed, low-cardinality answer even
+/// when BMP is disabled. One Established epoch contributes at most one sample
+/// to `bgp_session_down_total{peer,interface,reason}`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SessionDownReason {
+    /// The local speaker initiated a NOTIFICATION teardown.
+    ///
+    /// The label describes the selected protocol action even when the
+    /// best-effort enqueue or TCP write cannot deliver the NOTIFICATION.
+    LocalNotification,
+    /// The local speaker closed without a NOTIFICATION.
+    LocalNoNotification,
+    /// The remote speaker sent a BGP NOTIFICATION before teardown.
+    RemoteNotification,
+    /// The remote speaker closed the TCP stream without a NOTIFICATION.
+    RemoteNoNotification,
+    /// The reader, writer, connect task, or enqueue path failed.
+    TransportError,
+    /// Defensive fallback for abrupt actor loss without a classified cause.
+    Unknown,
+}
+
+impl SessionDownReason {
+    /// Every stable Prometheus label value.
+    pub const ALL: [Self; 6] = [
+        Self::LocalNotification,
+        Self::LocalNoNotification,
+        Self::RemoteNotification,
+        Self::RemoteNoNotification,
+        Self::TransportError,
+        Self::Unknown,
+    ];
+
+    /// The canonical bounded label string.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalNotification => "local_notification",
+            Self::LocalNoNotification => "local_no_notification",
+            Self::RemoteNotification => "remote_notification",
+            Self::RemoteNoNotification => "remote_no_notification",
+            Self::TransportError => "transport_error",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionDownReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// RFC 9234 Only-to-Customer route-leak block reasons.
 ///
@@ -395,7 +452,7 @@ impl std::fmt::Display for ExactExportReason {
 mod tests {
     use super::{
         ExactExportReason, ImportRejectReason, MalformedUpdateDisposition,
-        NextHopOwnershipBlockReason, OtcBlockReason, RrLoopReason,
+        NextHopOwnershipBlockReason, OtcBlockReason, RrLoopReason, SessionDownReason,
     };
 
     fn assert_snake_case(label: &str) {
@@ -416,6 +473,15 @@ mod tests {
     fn otc_block_reasons_are_snake_case_and_distinct() {
         let mut seen = std::collections::HashSet::new();
         for reason in OtcBlockReason::ALL {
+            assert_snake_case(reason.as_str());
+            assert!(seen.insert(reason.as_str()), "duplicate label");
+        }
+    }
+
+    #[test]
+    fn session_down_reasons_are_snake_case_and_distinct() {
+        let mut seen = std::collections::HashSet::new();
+        for reason in SessionDownReason::ALL {
             assert_snake_case(reason.as_str());
             assert!(seen.insert(reason.as_str()), "duplicate label");
         }
@@ -473,6 +539,21 @@ mod tests {
     /// old → new pair.
     #[test]
     fn canonical_reason_strings_are_pinned() {
+        let session_down: Vec<&str> = SessionDownReason::ALL
+            .iter()
+            .map(|reason| reason.as_str())
+            .collect();
+        assert_eq!(
+            session_down,
+            [
+                "local_notification",
+                "local_no_notification",
+                "remote_notification",
+                "remote_no_notification",
+                "transport_error",
+                "unknown",
+            ]
+        );
         let otc: Vec<&str> = OtcBlockReason::ALL.iter().map(|r| r.as_str()).collect();
         assert_eq!(
             otc,

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1585,9 +1585,8 @@ impl PeerSession {
                 // Collision promotion activates every metric lease owned only
                 // by the active primary, not just max-prefix capacity.
                 self.max_prefix_metric_lease.active = true;
-                self.session_established_metric_lease.active = true;
-                self.session_established_metric_lease
-                    .set(self.fsm.state() == SessionState::Established);
+                self.session_telemetry_metric_lease
+                    .activate(self.fsm.state());
                 self.sync_max_prefix_capacity_metrics();
                 let _ = reply.send(());
                 ControlFlow::Continue(())
@@ -1602,11 +1601,15 @@ impl PeerSession {
                     cease_subcode::CONNECTION_COLLISION_RESOLUTION,
                     bytes::Bytes::new(),
                 );
+                self.session_telemetry_metric_lease.latch_down_reason(
+                    rustbgpd_telemetry::reason_labels::SessionDownReason::LocalNotification,
+                );
                 self.emit_notification_event(SessionNotificationDirection::Sent, &notif, None);
                 let _ = self.enqueue_priority(&Message::Notification(notif));
                 self.notifications_sent += 1;
                 // Clean up RIB if Established
                 if self.fsm.state() == SessionState::Established {
+                    self.session_telemetry_metric_lease.record_down();
                     let _ = self
                         .rib_tx
                         .send(RibUpdate::PeerDown {

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -214,6 +214,13 @@ impl PeerSession {
             if hard_reset_notification_in_actions(&actions) {
                 self.sent_hard_reset = true;
             }
+            // Classify before executing the batch: some FSM paths publish
+            // SessionDown before their SendNotification action. This observes
+            // the batch without changing protocol action order.
+            if let Some(reason) = session_down_reason_for_batch(&event, &actions) {
+                self.session_telemetry_metric_lease
+                    .latch_down_reason(reason);
+            }
             let follow_up = self.execute_actions(actions).await;
             pending.extend(follow_up);
         }
@@ -282,7 +289,9 @@ impl PeerSession {
                         self.sent_hard_reset = true;
                     }
                     let msg = Message::Notification(notif);
-                    // Cache raw NOTIFICATION PDU for BMP Peer Down (reason 1: local sent NOTIFICATION)
+                    // Cache the attempted raw NOTIFICATION PDU for BMP Peer
+                    // Down reason 1. The locally initiated cause survives a
+                    // best-effort enqueue/write failure.
                     if self.bmp_tx.is_some()
                         && let Ok(encoded) = rustbgpd_wire::encode_message(&msg)
                     {
@@ -354,10 +363,7 @@ impl PeerSession {
                     self.close_tcp();
                 }
                 Action::StateChanged { old, new } => {
-                    if old == SessionState::Established || new == SessionState::Established {
-                        self.session_established_metric_lease
-                            .set(new == SessionState::Established);
-                    }
+                    self.session_telemetry_metric_lease.set_state(new);
                     info!(
                         peer = %self.peer_label,
                         from = old.as_str(),
@@ -731,6 +737,7 @@ impl PeerSession {
                 }
                 Action::SessionDown => {
                     info!(peer = %self.peer_label, "session down");
+                    self.session_telemetry_metric_lease.record_down();
 
                     // Emit BMP Peer Down event before clearing state —
                     // reliable (awaited): PeerDown is the collectors'
@@ -887,6 +894,32 @@ impl PeerSession {
             }
         }
     }
+}
+
+/// Derive the bounded Prometheus teardown reason from one unchanged FSM
+/// event/action batch. A received NOTIFICATION wins, followed by a locally
+/// initiated NOTIFICATION and then a transport failure. The action vector is
+/// inspected without reordering it or requiring best-effort delivery to
+/// succeed.
+pub(super) fn session_down_reason_for_batch(
+    event: &Event,
+    actions: &[Action],
+) -> Option<rustbgpd_telemetry::reason_labels::SessionDownReason> {
+    use rustbgpd_telemetry::reason_labels::SessionDownReason;
+
+    if matches!(event, Event::NotificationReceived(_)) {
+        return Some(SessionDownReason::RemoteNotification);
+    }
+    if actions
+        .iter()
+        .any(|action| matches!(action, Action::SendNotification(_)))
+    {
+        return Some(SessionDownReason::LocalNotification);
+    }
+    if matches!(event, Event::TcpConnectionFails) {
+        return Some(SessionDownReason::TransportError);
+    }
+    None
 }
 
 /// Return true when this event/action batch represents a

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -425,6 +425,9 @@ impl PeerSession {
             return;
         }
         self.pending_outbound_teardown_cause = Some(cause);
+        self.session_telemetry_metric_lease.latch_down_reason(
+            rustbgpd_telemetry::reason_labels::SessionDownReason::LocalNotification,
+        );
         let notif = rustbgpd_wire::NotificationMessage::new(
             NotificationCode::Cease,
             cease_subcode::OUT_OF_RESOURCES,
@@ -432,9 +435,10 @@ impl PeerSession {
         );
         self.record_notification_cause(SessionNotificationDirection::Sent, &notif);
         self.last_error = cause.to_string();
-        // Classify the upcoming BMP Peer Down truthfully: reason 1
-        // (local system sent NOTIFICATION) carrying the Cease/8 PDU,
-        // instead of the reason-4 "remote closed" default.
+        // Classify the upcoming BMP Peer Down as the locally initiated
+        // NOTIFICATION teardown, carrying the attempted Cease/8 PDU instead
+        // of the reason-4 "remote closed" default. The following enqueue is
+        // best-effort and does not change that initiating cause.
         if self.bmp_tx.is_some()
             && let Ok(pdu) = rustbgpd_wire::encode_message(&Message::Notification(notif.clone()))
         {

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -26,7 +26,7 @@ use rustbgpd_rib::{
     LabeledRibRoute, LabeledRibRouteKey, NextHopScope, OutboundRouteUpdate, RibUpdate, Route,
     RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
-use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_telemetry::{BgpMetrics, reason_labels::SessionDownReason};
 use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
 use rustbgpd_wire::{
     AddPathMode, Afi, AsPath, AsPathSegment, BgpRole, Capability, EvpnRoute, EvpnRouteKey,
@@ -93,43 +93,100 @@ impl Drop for MaxPrefixMetricLease {
     }
 }
 
-/// Ownership guard for the current-session truth gauge.
+/// Ownership guard for active-primary session telemetry.
 ///
 /// Collision candidates remain inactive until the manager has quiesced the
-/// retiring primary. Dropping an active owner publishes a final zero but keeps
-/// the configured identity present; peer deletion is reaped by `PeerManager`.
-struct SessionEstablishedMetricLease {
+/// retiring primary. It owns the exact FSM one-hot vector, the Established
+/// compatibility gauge, and one classified down event per Established epoch.
+/// Dropping an active owner publishes Idle; peer deletion is reaped later by
+/// `PeerManager`.
+struct SessionTelemetryMetricLease {
     metrics: BgpMetrics,
     peer: String,
     interface: String,
     active: bool,
-    published: bool,
+    state: SessionState,
+    established_epoch_open: bool,
+    down_reason: Option<SessionDownReason>,
 }
 
-impl SessionEstablishedMetricLease {
+impl SessionTelemetryMetricLease {
     fn new(metrics: BgpMetrics, peer: String, interface: String, active: bool) -> Self {
         Self {
             metrics,
             peer,
             interface,
             active,
-            published: false,
+            state: SessionState::Idle,
+            established_epoch_open: false,
+            down_reason: None,
         }
     }
 
-    fn set(&mut self, established: bool) {
+    fn publish(&self) {
         if self.active {
             self.metrics
-                .set_peer_session_established(&self.peer, &self.interface, established);
-            self.published = true;
+                .set_peer_session_state(&self.peer, &self.interface, self.state.as_str());
+            self.metrics.set_peer_session_established(
+                &self.peer,
+                &self.interface,
+                self.state == SessionState::Established,
+            );
         }
+    }
+
+    fn set_state(&mut self, state: SessionState) {
+        let entering_established =
+            state == SessionState::Established && self.state != SessionState::Established;
+        self.state = state;
+        if entering_established {
+            self.established_epoch_open = true;
+            self.down_reason = None;
+        }
+        self.publish();
+    }
+
+    fn activate(&mut self, state: SessionState) {
+        self.active = true;
+        self.state = state;
+        self.established_epoch_open = state == SessionState::Established;
+        self.down_reason = None;
+        self.publish();
+    }
+
+    /// Latch the first classified cause for the current teardown. Follow-up
+    /// `TcpConnectionFails` events must not overwrite a preceding local or
+    /// remote NOTIFICATION classification.
+    fn latch_down_reason(&mut self, reason: SessionDownReason) {
+        if self.down_reason.is_none() {
+            self.down_reason = Some(reason);
+        }
+    }
+
+    /// Close the current Established epoch. Inactive collision candidates
+    /// consume their latch without emitting shared active-primary telemetry.
+    fn record_down(&mut self) {
+        let reason = self
+            .down_reason
+            .take()
+            .unwrap_or(SessionDownReason::Unknown);
+        if self.active && self.established_epoch_open {
+            self.metrics
+                .record_session_down(&self.peer, &self.interface, reason);
+        }
+        self.established_epoch_open = false;
     }
 }
 
-impl Drop for SessionEstablishedMetricLease {
+impl Drop for SessionTelemetryMetricLease {
     fn drop(&mut self) {
-        if self.published {
-            self.set(false);
+        if self.active {
+            // An Established actor that disappears without its ordinary
+            // SessionDown action is the sole defensive `unknown` path. A
+            // preclassified cause survives here and remains truthful.
+            self.record_down();
+            self.state = SessionState::Idle;
+            self.publish();
         }
     }
 }
@@ -284,8 +341,8 @@ pub(crate) struct PeerSession {
     /// quiesced the old primary, preventing either loser from erasing the
     /// surviving actor's values.
     max_prefix_metric_lease: MaxPrefixMetricLease,
-    /// Active-primary ownership for `bgp_peer_session_established`.
-    session_established_metric_lease: SessionEstablishedMetricLease,
+    /// Active-primary ownership for exact FSM state and classified downs.
+    session_telemetry_metric_lease: SessionTelemetryMetricLease,
     /// Optional BMP event sender (None when BMP not configured).
     bmp_tx: Option<mpsc::Sender<BmpEvent>>,
     /// A `RouteMonitoring` event for this session was dropped on a full
@@ -1072,7 +1129,7 @@ impl PeerSession {
             peer_label.clone(),
             session_identity.role == SessionRole::Primary,
         );
-        let session_established_metric_lease = SessionEstablishedMetricLease::new(
+        let session_telemetry_metric_lease = SessionTelemetryMetricLease::new(
             metrics.clone(),
             peer_label.clone(),
             config.peer_interface.clone().unwrap_or_default(),
@@ -1118,7 +1175,7 @@ impl PeerSession {
             session_event_tx,
             session_identity,
             max_prefix_metric_lease,
-            session_established_metric_lease,
+            session_telemetry_metric_lease,
             bmp_tx,
             bmp_stream_diverged: false,
             bmp_repair_timer: None,
@@ -1228,7 +1285,7 @@ impl PeerSession {
             peer_label.clone(),
             session_identity.role == SessionRole::Primary,
         );
-        let session_established_metric_lease = SessionEstablishedMetricLease::new(
+        let session_telemetry_metric_lease = SessionTelemetryMetricLease::new(
             metrics.clone(),
             peer_label.clone(),
             config.peer_interface.clone().unwrap_or_default(),
@@ -1286,7 +1343,7 @@ impl PeerSession {
             session_event_tx,
             session_identity,
             max_prefix_metric_lease,
-            session_established_metric_lease,
+            session_telemetry_metric_lease,
             bmp_tx,
             bmp_stream_diverged: false,
             bmp_repair_timer: None,
@@ -1627,6 +1684,8 @@ impl PeerSession {
                 self.last_down_reason = Some(PeerDownReason::LocalNoNotification(
                     SEND_HOLD_TIMER_EXPIRES_FSM_EVENT,
                 ));
+                self.session_telemetry_metric_lease
+                    .latch_down_reason(SessionDownReason::LocalNoNotification);
                 if pending_outbound_cause.is_none() {
                     self.last_error = format!(
                         "send hold timer expired after {}s (RFC 9687)",
@@ -1654,6 +1713,8 @@ impl PeerSession {
                 // `TcpConnectionFails` and the RIB gets its
                 // PeerDown/deregistration from this run-loop path.
                 debug!(peer = %self.peer_label, "writer task completed local hard teardown");
+                self.session_telemetry_metric_lease
+                    .latch_down_reason(SessionDownReason::TransportError);
             }
             Ok(Err(writer::WriterExit::Io(e))) => {
                 let cause = crate::handle::SessionFailureCause::WriterIo(e.kind());
@@ -1661,6 +1722,8 @@ impl PeerSession {
                 if pending_outbound_cause.is_none() {
                     self.last_error = cause.to_string();
                 }
+                self.session_telemetry_metric_lease
+                    .latch_down_reason(SessionDownReason::TransportError);
             }
             Err(e) => {
                 let cause = if e.is_cancelled() {
@@ -1672,6 +1735,8 @@ impl PeerSession {
                 if pending_outbound_cause.is_none() {
                     self.last_error = cause.to_string();
                 }
+                self.session_telemetry_metric_lease
+                    .latch_down_reason(SessionDownReason::TransportError);
             }
         }
         self.handle_tcp_disconnect();
@@ -1681,6 +1746,8 @@ impl PeerSession {
     async fn handle_tcp_read_result(&mut self, result: std::io::Result<usize>) {
         match result {
             Ok(0) => {
+                self.session_telemetry_metric_lease
+                    .latch_down_reason(SessionDownReason::RemoteNoNotification);
                 self.handle_tcp_disconnect();
                 self.drive_fsm(Event::TcpConnectionFails).await;
             }
@@ -1691,6 +1758,8 @@ impl PeerSession {
                 if self.pending_outbound_teardown_cause.is_none() {
                     self.last_error = cause.to_string();
                 }
+                self.session_telemetry_metric_lease
+                    .latch_down_reason(SessionDownReason::TransportError);
                 self.handle_tcp_disconnect();
                 self.drive_fsm(Event::TcpConnectionFails).await;
             }

--- a/crates/transport/src/session/tests/metrics.rs
+++ b/crates/transport/src/session/tests/metrics.rs
@@ -1,0 +1,511 @@
+use super::*;
+use rustbgpd_telemetry::reason_labels::SessionDownReason;
+
+const STATES: [SessionState; 6] = [
+    SessionState::Idle,
+    SessionState::Connect,
+    SessionState::Active,
+    SessionState::OpenSent,
+    SessionState::OpenConfirm,
+    SessionState::Established,
+];
+
+fn gauge_rows(metrics: &BgpMetrics, family_name: &str) -> HashMap<String, f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == family_name)
+        .map_or_else(HashMap::new, |family| {
+            family
+                .get_metric()
+                .iter()
+                .filter_map(|metric| {
+                    let labels: HashMap<_, _> = metric
+                        .get_label()
+                        .iter()
+                        .map(|label| (label.name(), label.value()))
+                        .collect();
+                    (labels.get("peer") == Some(&"10.0.0.2")
+                        && labels.get("interface") == Some(&""))
+                    .then(|| {
+                        (
+                            labels.get("state").copied().unwrap_or("").to_string(),
+                            metric.get_gauge().value(),
+                        )
+                    })
+                })
+                .collect()
+        })
+}
+
+fn down_value(metrics: &BgpMetrics, reason: SessionDownReason) -> f64 {
+    counter_samples(metrics, "bgp_session_down_total")
+        .into_iter()
+        .find_map(|(labels, value)| {
+            (labels.get("peer").map(String::as_str) == Some("10.0.0.2")
+                && labels.get("interface").map(String::as_str) == Some("")
+                && labels.get("reason").map(String::as_str) == Some(reason.as_str()))
+            .then_some(value)
+        })
+        .unwrap_or(0.0)
+}
+
+fn assert_sample(actual: f64, expected: f64, context: impl std::fmt::Display) {
+    assert!(
+        (actual - expected).abs() < f64::EPSILON,
+        "{context}: expected {expected}, got {actual}"
+    );
+}
+
+fn assert_only_down_reason(metrics: &BgpMetrics, expected: SessionDownReason) {
+    for reason in SessionDownReason::ALL {
+        assert_sample(
+            down_value(metrics, reason),
+            f64::from(reason == expected),
+            format_args!("only {expected} may advance; inspected {reason}"),
+        );
+    }
+}
+
+fn install_closed_priority_sender(session: &mut PeerSession) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    drop(rx);
+    assert!(tx.is_closed(), "test seam must reject the next enqueue");
+    session.writer_priority_tx = Some(tx);
+}
+
+async fn transition(session: &mut PeerSession, old: SessionState, new: SessionState) {
+    session
+        .execute_actions(vec![Action::StateChanged { old, new }])
+        .await;
+}
+
+#[test]
+fn notification_batches_are_preclassified_without_action_reordering() {
+    let notification = rustbgpd_wire::NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::ADMINISTRATIVE_RESET,
+        Bytes::new(),
+    );
+    let actions = vec![
+        Action::SessionDown,
+        Action::SendNotification(notification.clone()),
+    ];
+    assert_eq!(
+        fsm::session_down_reason_for_batch(&Event::HoldTimerExpires, &actions),
+        Some(SessionDownReason::LocalNotification)
+    );
+    assert!(matches!(actions[0], Action::SessionDown));
+    assert!(matches!(actions[1], Action::SendNotification(_)));
+    assert_eq!(
+        fsm::session_down_reason_for_batch(&Event::NotificationReceived(notification), &actions),
+        Some(SessionDownReason::RemoteNotification),
+        "received NOTIFICATION owns the classification even if the batch also sends one"
+    );
+    assert_eq!(
+        fsm::session_down_reason_for_batch(&Event::TcpConnectionFails, &[Action::SessionDown]),
+        Some(SessionDownReason::TransportError)
+    );
+}
+
+#[tokio::test]
+async fn active_primary_publishes_all_six_states_as_exact_one_hot() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(1));
+
+    let mut old = SessionState::Idle;
+    for new in STATES {
+        transition(&mut session, old, new).await;
+        let rows = gauge_rows(&metrics, "bgp_peer_session_state");
+        assert_eq!(rows.len(), 6, "all bounded state rows must exist");
+        assert_sample(
+            rows.values().sum::<f64>(),
+            1.0,
+            "state vector must be one-hot",
+        );
+        for state in STATES {
+            assert_eq!(
+                rows.get(state.as_str()),
+                Some(&f64::from(state == new)),
+                "wrong one-hot value for {} while current state is {new}",
+                state.as_str()
+            );
+        }
+        old = new;
+    }
+}
+
+#[tokio::test]
+async fn never_established_reset_does_not_count_a_down() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(2));
+    transition(&mut session, SessionState::Idle, SessionState::Connect).await;
+    session
+        .session_telemetry_metric_lease
+        .latch_down_reason(SessionDownReason::TransportError);
+    session.execute_actions(vec![Action::SessionDown]).await;
+
+    for reason in SessionDownReason::ALL {
+        assert_sample(down_value(&metrics, reason), 0.0, reason);
+    }
+}
+
+#[tokio::test]
+async fn every_bounded_down_reason_counts_without_bmp() {
+    for (index, reason) in SessionDownReason::ALL.into_iter().enumerate() {
+        let metrics = BgpMetrics::new();
+        let (mut session, _rib_rx) = make_test_session_with_metrics_and_identity(
+            metrics.clone(),
+            SessionIdentity::primary(index as u64 + 10),
+        );
+        assert!(session.bmp_tx.is_none());
+        transition(
+            &mut session,
+            SessionState::OpenConfirm,
+            SessionState::Established,
+        )
+        .await;
+        session
+            .session_telemetry_metric_lease
+            .latch_down_reason(reason);
+        session.execute_actions(vec![Action::SessionDown]).await;
+
+        for candidate in SessionDownReason::ALL {
+            assert_sample(
+                down_value(&metrics, candidate),
+                f64::from(candidate == reason),
+                format_args!("only {reason} may advance; inspected {candidate}"),
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn real_fsm_batches_classify_local_remote_and_transport_teardown() {
+    for (index, reason) in [
+        SessionDownReason::LocalNotification,
+        SessionDownReason::RemoteNotification,
+        SessionDownReason::TransportError,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let metrics = BgpMetrics::new();
+        let (mut session, _rib_rx) = make_test_session_with_metrics_and_identity(
+            metrics.clone(),
+            SessionIdentity::primary(index as u64 + 30),
+        );
+        let (client, _server) = connected_stream_pair().await;
+        session.test_install_stream(client);
+        establish_test_session(&mut session, 65002).await;
+        assert!(session.bmp_tx.is_none());
+
+        match reason {
+            SessionDownReason::LocalNotification => {
+                session.drive_fsm(Event::ManualStop { reason: None }).await;
+            }
+            SessionDownReason::RemoteNotification => {
+                session
+                    .drive_fsm(Event::NotificationReceived(
+                        rustbgpd_wire::NotificationMessage::new(
+                            NotificationCode::Cease,
+                            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+                            Bytes::new(),
+                        ),
+                    ))
+                    .await;
+            }
+            SessionDownReason::TransportError => {
+                session.drive_fsm(Event::TcpConnectionFails).await;
+            }
+            _ => unreachable!("loop contains only directly driven FSM reasons"),
+        }
+        drop(session);
+
+        assert_sample(down_value(&metrics, reason), 1.0, reason);
+        assert_sample(
+            down_value(&metrics, SessionDownReason::Unknown),
+            0.0,
+            "known teardown must not advance unknown",
+        );
+    }
+}
+
+#[tokio::test]
+async fn established_tcp_eof_counts_remote_no_notification_exactly_once() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(33));
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    assert!(matches!(
+        read_single_bgp_message(&mut server).await,
+        Message::Open(_)
+    ));
+    assert!(matches!(
+        read_single_bgp_message(&mut server).await,
+        Message::Keepalive
+    ));
+    drop(server);
+
+    let mut byte = [0_u8; 1];
+    let read = session
+        .read_half
+        .as_mut()
+        .expect("established session has a reader")
+        .read(&mut byte)
+        .await;
+    assert!(
+        matches!(&read, Ok(0)),
+        "peer close must reach EOF: {read:?}"
+    );
+    session.handle_tcp_read_result(read).await;
+    drop(session);
+
+    assert_only_down_reason(&metrics, SessionDownReason::RemoteNoNotification);
+}
+
+#[tokio::test]
+async fn send_hold_writer_exit_counts_local_no_notification_exactly_once() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(34));
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    session
+        .handle_writer_exit(Ok(Err(super::writer::WriterExit::SendHoldExpired {
+            limit: Duration::from_secs(2),
+        })))
+        .await;
+    drop(session);
+
+    assert_only_down_reason(&metrics, SessionDownReason::LocalNoNotification);
+}
+
+#[tokio::test]
+async fn established_keepalive_enqueue_failure_counts_transport_error() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(35));
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    install_closed_priority_sender(&mut session);
+
+    session.drive_fsm(Event::KeepaliveTimerExpires).await;
+    drop(session);
+
+    assert_only_down_reason(&metrics, SessionDownReason::TransportError);
+}
+
+#[tokio::test]
+async fn failed_notification_enqueue_retains_local_notification_cause() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(36));
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    install_closed_priority_sender(&mut session);
+
+    session.drive_fsm(Event::ManualStop { reason: None }).await;
+    drop(session);
+
+    assert_only_down_reason(&metrics, SessionDownReason::LocalNotification);
+}
+
+#[tokio::test]
+async fn duplicate_established_and_session_down_actions_keep_one_epoch_sample() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(37));
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    session
+        .execute_actions(vec![
+            Action::StateChanged {
+                old: SessionState::Established,
+                new: SessionState::Established,
+            },
+            Action::StateChanged {
+                old: SessionState::Established,
+                new: SessionState::Established,
+            },
+        ])
+        .await;
+    session.handle_tcp_read_result(Ok(0)).await;
+    session
+        .execute_actions(vec![Action::SessionDown, Action::SessionDown])
+        .await;
+    drop(session);
+
+    assert_only_down_reason(&metrics, SessionDownReason::RemoteNoNotification);
+}
+
+#[tokio::test]
+async fn collision_candidate_is_silent_until_exact_promotion() {
+    let metrics = BgpMetrics::new();
+    let (mut candidate, _rib_rx) = make_test_session_with_metrics_and_identity(
+        metrics.clone(),
+        SessionIdentity::inbound_candidate(40),
+    );
+    let (client, _server) = connected_stream_pair().await;
+    candidate.test_install_stream(client);
+    establish_test_session(&mut candidate, 65002).await;
+    assert!(gauge_rows(&metrics, "bgp_peer_session_state").is_empty());
+    assert_sample(
+        down_value(&metrics, SessionDownReason::Unknown),
+        0.0,
+        "inactive candidate unknown count",
+    );
+
+    let (reply, done) = oneshot::channel();
+    assert_eq!(
+        candidate
+            .handle_command(PeerCommand::ActivateMaxPrefixMetrics { reply })
+            .await,
+        ControlFlow::Continue(())
+    );
+    done.await.unwrap();
+    let rows = gauge_rows(&metrics, "bgp_peer_session_state");
+    assert_eq!(rows.len(), 6);
+    assert_eq!(rows.get("established"), Some(&1.0));
+    assert_sample(rows.values().sum::<f64>(), 1.0, "promoted one-hot sum");
+
+    candidate
+        .session_telemetry_metric_lease
+        .latch_down_reason(SessionDownReason::TransportError);
+    candidate.execute_actions(vec![Action::SessionDown]).await;
+    assert_sample(
+        down_value(&metrics, SessionDownReason::TransportError),
+        1.0,
+        "promoted candidate transport down",
+    );
+}
+
+#[tokio::test]
+async fn unpromoted_candidate_establishment_and_drop_remain_silent() {
+    let metrics = BgpMetrics::new();
+    let (mut candidate, _rib_rx) = make_test_session_with_metrics_and_identity(
+        metrics.clone(),
+        SessionIdentity::inbound_candidate(41),
+    );
+    transition(
+        &mut candidate,
+        SessionState::OpenConfirm,
+        SessionState::Established,
+    )
+    .await;
+    drop(candidate);
+    assert!(gauge_rows(&metrics, "bgp_peer_session_state").is_empty());
+    for reason in SessionDownReason::ALL {
+        assert_sample(down_value(&metrics, reason), 0.0, reason);
+    }
+}
+
+#[tokio::test]
+async fn collision_dump_and_abrupt_drop_each_count_once() {
+    let collision_metrics = BgpMetrics::new();
+    let (mut collision, _rib_rx) = make_test_session_with_metrics_and_identity(
+        collision_metrics.clone(),
+        SessionIdentity::primary(50),
+    );
+    transition(
+        &mut collision,
+        SessionState::OpenConfirm,
+        SessionState::Established,
+    )
+    .await;
+    assert_eq!(
+        collision.handle_command(PeerCommand::CollisionDump).await,
+        ControlFlow::Break(())
+    );
+    drop(collision);
+    assert_sample(
+        down_value(&collision_metrics, SessionDownReason::LocalNotification),
+        1.0,
+        "collision dump local notification",
+    );
+    let collision_rows = gauge_rows(&collision_metrics, "bgp_peer_session_state");
+    assert_eq!(collision_rows.get("idle"), Some(&1.0));
+    assert_sample(
+        collision_rows.values().sum::<f64>(),
+        1.0,
+        "collision one-hot sum",
+    );
+
+    let abrupt_metrics = BgpMetrics::new();
+    let (mut abrupt, _rib_rx) = make_test_session_with_metrics_and_identity(
+        abrupt_metrics.clone(),
+        SessionIdentity::primary(51),
+    );
+    transition(
+        &mut abrupt,
+        SessionState::OpenConfirm,
+        SessionState::Established,
+    )
+    .await;
+    drop(abrupt);
+    assert_sample(
+        down_value(&abrupt_metrics, SessionDownReason::Unknown),
+        1.0,
+        "abrupt drop unknown",
+    );
+    let abrupt_rows = gauge_rows(&abrupt_metrics, "bgp_peer_session_state");
+    assert_eq!(abrupt_rows.get("idle"), Some(&1.0));
+    assert_sample(abrupt_rows.values().sum::<f64>(), 1.0, "abrupt one-hot sum");
+}
+
+#[tokio::test]
+async fn reconnect_opens_a_fresh_exactly_once_down_epoch() {
+    let metrics = BgpMetrics::new();
+    let (mut session, _rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(60));
+    transition(
+        &mut session,
+        SessionState::OpenConfirm,
+        SessionState::Established,
+    )
+    .await;
+    session
+        .session_telemetry_metric_lease
+        .latch_down_reason(SessionDownReason::TransportError);
+    session.execute_actions(vec![Action::SessionDown]).await;
+    transition(&mut session, SessionState::Established, SessionState::Idle).await;
+    transition(
+        &mut session,
+        SessionState::OpenConfirm,
+        SessionState::Established,
+    )
+    .await;
+    session
+        .session_telemetry_metric_lease
+        .latch_down_reason(SessionDownReason::RemoteNoNotification);
+    session.execute_actions(vec![Action::SessionDown]).await;
+    drop(session);
+
+    assert_sample(
+        down_value(&metrics, SessionDownReason::TransportError),
+        1.0,
+        "first reconnect epoch",
+    );
+    assert_sample(
+        down_value(&metrics, SessionDownReason::RemoteNoNotification),
+        1.0,
+        "second reconnect epoch",
+    );
+    assert_sample(
+        down_value(&metrics, SessionDownReason::Unknown),
+        0.0,
+        "reconnect epochs remain classified",
+    );
+}

--- a/crates/transport/src/session/tests/mod.rs
+++ b/crates/transport/src/session/tests/mod.rs
@@ -1962,6 +1962,7 @@ mod inbound_update;
 mod labeled;
 mod loop_detection;
 mod max_prefix;
+mod metrics;
 mod next_hop;
 mod notification;
 mod orf;

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -152,6 +152,18 @@ inside the bounded window does.
   empty `interface`. The shipped session-down alert joins these exact labels,
   so enabled peers that never Established are visible while disabled peers do
   not page.
+- **Exact session state** uses the one-hot vector directly; preserving
+  `interface` keeps scoped siblings distinct and summing the six rows provides
+  a built-in integrity check:
+  `sum by (instance,peer,interface) (bgp_peer_session_state) == 1`.
+  Recent Established losses can be grouped without log parsing via
+  `sum by (instance,peer,interface,reason)
+  (increase(bgp_session_down_total[$__rate_interval]))`. The fixed `reason`
+  vocabulary separates locally initiated and remotely received NOTIFICATION
+  teardown, local/remote close without NOTIFICATION, transport failure, and
+  defensive `unknown`. Local initiation remains the cause when best-effort
+  NOTIFICATION delivery fails; neither query adds an alert or overview-dashboard
+  panel.
 - Exact-export rejection and malformed-UPDATE disposition rates share the
   `$peer` selector, like every other per-peer panel.
   Outbound route-drop and RFC 9687 send-hold alerts preserve that same `peer`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -937,11 +937,13 @@ dashboards see no negative-rate artifacts. Process-global counters and
 families keyed by other identities (AFI/SAFI, VRF, VNI, BMP collector) are
 never removed.
 
-The exact `bgp_peer_admin_enabled{peer,interface}` and
-`bgp_peer_session_established{peer,interface}` identity is removed after its
-session actor terminates, including abort-on-timeout teardown. If a scoped
-sibling shares the bare address, its exact gauge rows and the shared
-bare-address history remain.
+The exact `bgp_peer_admin_enabled{peer,interface}`,
+`bgp_peer_session_established{peer,interface}`, and
+`bgp_peer_session_state{peer,interface,state}` identity is removed after its
+session actor terminates, including abort-on-timeout teardown. Its matching
+`bgp_session_down_total{peer,interface,reason}` history is reaped at the same
+identity boundary. If a scoped sibling shares the bare address, its exact rows
+and the shared bare-address history remain.
 
 ### Health
 
@@ -949,8 +951,10 @@ bare-address history remain.
 |--------|-------------------|
 | `bgp_peer_admin_enabled{peer,interface}` | Authoritative configured administrative intent: 1 enabled, 0 disabled |
 | `bgp_peer_session_established{peer,interface}` | Current active-primary session truth: 1 Established, 0 otherwise |
+| `bgp_peer_session_state{peer,interface,state}` | Exact active-primary one-hot FSM state; `state` is `idle`, `connect`, `active`, `open_sent`, `open_confirm`, or `established` |
 | `bgp_session_established_total` | Cumulative sessions that reached Established (per-process counter; resets on restart) |
 | `bgp_session_flaps_total` | Cumulative session flaps |
+| `bgp_session_down_total{peer,interface,reason}` | Established active-primary sessions that ended. `local_notification` means a locally initiated NOTIFICATION teardown even if best-effort delivery failed; `remote_notification` means a received NOTIFICATION; `local_no_notification` includes forced local close such as send-hold expiry; `remote_no_notification` means remote TCP close without a NOTIFICATION; the remaining bounded values are `transport_error` and defensive `unknown`. |
 | `bgp_session_state_transitions_total` | FSM state transitions |
 
 The shipped `BgpSessionNotEstablished` alert requires administrative intent 1
@@ -960,6 +964,20 @@ without paging on disabled peers. Flap-rate alerting remains based on
 `bgp_session_flaps_total`. Aggregate Established counts and daemon uptime are
 also available via `ControlService.GetHealth` / `rbgp health`; that RPC uses
 the same 200 ms core-actor deadline as `/readyz`.
+
+For a current state view that also catches a broken one-hot invariant:
+
+```promql
+sum by (instance, peer, interface) (bgp_peer_session_state) == 1
+```
+
+To break recent Established-session losses down by their bounded cause:
+
+```promql
+sum by (instance, peer, interface, reason) (
+  increase(bgp_session_down_total[5m])
+)
+```
 
 ### Routing
 

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -557,8 +557,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 199:
-        raise ValueError(f"emitted metric roster changed: expected 199, got {len(inventory)}")
+    if len(inventory) != 201:
+        raise ValueError(f"emitted metric roster changed: expected 201, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,10 +47,10 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 199)
+        self.assertEqual(len(self.inventory), 201)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            186,
+            188,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
@@ -58,10 +58,10 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 95)
         self.assertEqual(len(self.rule_refs), 42)
-        self.assertEqual(len(self.public_doc_refs), 188)
-        self.assertEqual(len(self.doc_refs), 188)
+        self.assertEqual(len(self.public_doc_refs), 190)
+        self.assertEqual(len(self.doc_refs), 190)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 193)
+        self.assertEqual(len(consumers), 195)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("199 emitted families", stdout.getvalue())
-        self.assertIn("188 normative-doc families", stdout.getvalue())
-        self.assertIn("193 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("201 emitted families", stdout.getvalue())
+        self.assertIn("190 normative-doc families", stdout.getvalue())
+        self.assertIn("195 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -31,6 +31,8 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
             {
                 "bgp_evpn_nlri_discarded_total",
                 "bgp_path_attribute_discarded_total",
+                "bgp_peer_session_state",
+                "bgp_session_down_total",
                 "bgp_session_lifecycle_source_dropped_total",
             },
         )

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -69,6 +69,8 @@ impl PeerManager {
             .set_peer_admin_enabled(&peer_label, interface, enabled);
         self.metrics
             .set_peer_session_established(&peer_label, interface, false);
+        self.metrics
+            .set_peer_session_state(&peer_label, interface, "idle");
     }
 
     pub(super) async fn provision_new_peer_session(

--- a/src/peer_manager/tests/metrics.rs
+++ b/src/peer_manager/tests/metrics.rs
@@ -38,6 +38,57 @@ fn bmp_source_drop_metric(metrics: &BgpMetrics, peer: &str, reason: &str) -> Opt
         })
 }
 
+fn peer_identity_series_count(
+    metrics: &BgpMetrics,
+    family_name: &str,
+    peer: &str,
+    interface: &str,
+) -> usize {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == family_name)
+        .map_or(0, |family| {
+            family
+                .get_metric()
+                .iter()
+                .filter(|metric| {
+                    let labels = metric.get_label();
+                    labels
+                        .iter()
+                        .any(|label| label.name() == "peer" && label.value() == peer)
+                        && labels
+                            .iter()
+                            .any(|label| label.name() == "interface" && label.value() == interface)
+                })
+                .count()
+        })
+}
+
+fn peer_state_gauge(metrics: &BgpMetrics, peer: &str, interface: &str, state: &str) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == "bgp_peer_session_state")
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                let labels = metric.get_label();
+                (labels
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer)
+                    && labels
+                        .iter()
+                        .any(|label| label.name() == "interface" && label.value() == interface)
+                    && labels
+                        .iter()
+                        .any(|label| label.name() == "state" && label.value() == state))
+                .then(|| metric.get_gauge().value())
+            })
+        })
+}
+
 fn blocked_truth_observing_start_handle(
     metrics: BgpMetrics,
     peer: PeerKey,
@@ -61,7 +112,16 @@ fn blocked_truth_observing_start_handle(
             peer_identity_gauge(&metrics, "bgp_peer_session_established", &label, interface),
             Some(0.0)
         );
+        assert_eq!(
+            peer_state_gauge(&metrics, &label, interface, "idle"),
+            Some(1.0)
+        );
+        assert_eq!(
+            peer_identity_series_count(&metrics, "bgp_peer_session_state", &label, interface),
+            6
+        );
         metrics.set_peer_session_established(&label, interface, true);
+        metrics.set_peer_session_state(&label, interface, "established");
         let _ = observed_tx.send(());
         while let Some(command) = command_rx.recv().await {
             if matches!(command, PeerCommand::Shutdown) {
@@ -95,6 +155,14 @@ async fn assert_new_peer_start_truth_is_seeded(peer: PeerKey) {
         peer_identity_gauge(&metrics, "bgp_peer_session_established", &label, interface),
         Some(0.0)
     );
+    assert_eq!(
+        peer_state_gauge(&metrics, &label, interface, "idle"),
+        Some(1.0)
+    );
+    assert_eq!(
+        peer_identity_series_count(&metrics, "bgp_session_down_total", &label, interface),
+        6
+    );
     gate.notify_one();
     let handle = provision.await.unwrap();
     observed.await.unwrap();
@@ -102,6 +170,10 @@ async fn assert_new_peer_start_truth_is_seeded(peer: PeerKey) {
         peer_identity_gauge(&metrics, "bgp_peer_session_established", &label, interface),
         Some(1.0),
         "ownership preparation must never overwrite a post-Start state"
+    );
+    assert_eq!(
+        peer_state_gauge(&metrics, &label, interface, "established"),
+        Some(1.0)
     );
     handle.shutdown().await.unwrap().unwrap();
 }
@@ -182,6 +254,16 @@ async fn failed_start_exact_reaps_provisional_truth_and_preserves_scoped_sibling
             Some(0.0)
         );
     }
+    for family in ["bgp_peer_session_state", "bgp_session_down_total"] {
+        assert_eq!(
+            peer_identity_series_count(&metrics, family, "fe80::1", "eth0"),
+            0
+        );
+        assert_eq!(
+            peer_identity_series_count(&metrics, family, "fe80::1", "eth1"),
+            6
+        );
+    }
 
     let source = include_str!("../lifecycle.rs");
     let body = source
@@ -209,6 +291,7 @@ fn seed_peer_metric_series(metrics: &BgpMetrics, peer_label: &str) {
     metrics.record_state_transition(peer_label, "open_confirm", "established");
     metrics.set_peer_admin_enabled(peer_label, "", true);
     metrics.set_peer_session_established(peer_label, "", true);
+    metrics.set_peer_session_state(peer_label, "", "established");
     metrics.record_message_sent(peer_label, "keepalive");
     metrics.set_rib_prefixes(peer_label, "ipv4_unicast", 42);
     metrics.record_bfd_state(peer_label, true, false);
@@ -359,11 +442,31 @@ async fn peer_presence_scoped_siblings_remove_exactly_and_reap_bare_address_last
     }
 
     mgr.delete_peer(first, false).await.unwrap();
+    assert_eq!(
+        peer_identity_series_count(&mgr.metrics, "bgp_peer_session_state", "fe80::1", "eth0"),
+        0
+    );
+    assert_eq!(
+        peer_identity_series_count(&mgr.metrics, "bgp_peer_session_state", "fe80::1", "eth1"),
+        6
+    );
+    assert_eq!(
+        peer_identity_series_count(&mgr.metrics, "bgp_session_down_total", "fe80::1", "eth1"),
+        6
+    );
     assert!(
         rib_rx.try_recv().is_err(),
         "surviving sibling owns bare address"
     );
     mgr.delete_peer(last, false).await.unwrap();
+    assert_eq!(
+        peer_identity_series_count(&mgr.metrics, "bgp_peer_session_state", "fe80::1", "eth1"),
+        0
+    );
+    assert_eq!(
+        peer_identity_series_count(&mgr.metrics, "bgp_session_down_total", "fe80::1", "eth1"),
+        0
+    );
     assert!(matches!(
         rib_rx.try_recv(),
         Ok(RibUpdate::PeerDeleted { peer }) if peer == address


### PR DESCRIPTION
## Summary

- publish an active-primary one-hot BGP session-state gauge across all six FSM states
- count each Established-session teardown exactly once with a bounded first-cause reason vocabulary
- document the new operator contract and make both metric families load-bearing in the consumer and release-note checks

## Semantics

- candidate sessions remain silent until promotion; only the active primary owns telemetry
- teardown reasons distinguish local/remote notification intent, no-notification closures, transport failures, and the bounded unknown fallback
- duplicate state actions, teardown events, and Drop cannot double-count an Established epoch
- existing session, BMP, API, configuration, dashboard, and alert behavior is unchanged

## Validation

- transport metrics and real lifecycle seam tests: 14/14 focused, 365/365 full transport
- telemetry: 111/111
- peer-manager metrics: 17/17
- metric consumer inventory: 201 emitted, 195 consumed, 6 justified
- metric release-note contract: five additions, zero removals, all documented
- workspace formatting, clippy, rustdoc, commit hooks, push hooks, and `git diff --check`
- independent final review on the exact patch-equivalent head

Linear: [LAN-1364](https://linear.app/lance0/issue/LAN-1364)
