### PR TITLE
bench: require quiet hosts for measured receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,22 +399,31 @@ jobs:
             bench/tests/test-rib-memory-comparator.sh
           shellcheck bench/smoke-benches.sh
           bash -n bench/scale/route-server-1000/run-receipt.sh
+          bash -n bench/scale/host-quiet.sh
+          bash -n bench/scale/matrix/run-matrix.sh
+          bash -n bench/scale/irrreload/run-irr-reload.sh
           bash -n bench/scale/enhanced-route-refresh/run-receipt.sh
           bash -n bench/scale/rrtransport/run-receipt.sh
           bash -n bench/tests/test-rrtransport-receipt.sh
           bash -n bench/tests/test-route-server-1000-receipt.sh
+          bash -n bench/tests/test-scale-host-quiet.sh
           bash -n bench/tests/test-vpn-query-receipt.sh
           bash -n bench/tests/test-vpn-query-campaign.sh
           bash -n bench/run-vpn-query-campaign.sh
-          shellcheck bench/scale/route-server-1000/run-receipt.sh \
+          shellcheck bench/scale/host-quiet.sh \
+            bench/scale/matrix/run-matrix.sh \
+            bench/scale/irrreload/run-irr-reload.sh \
+            bench/scale/route-server-1000/run-receipt.sh \
             bench/scale/enhanced-route-refresh/run-receipt.sh \
             bench/scale/rrtransport/run-receipt.sh \
             bench/tests/test-rrtransport-receipt.sh \
-            bench/tests/test-route-server-1000-receipt.sh
+            bench/tests/test-route-server-1000-receipt.sh \
+            bench/tests/test-scale-host-quiet.sh
           shellcheck bench/tests/test-vpn-query-receipt.sh
           shellcheck bench/tests/test-vpn-query-campaign.sh \
             bench/run-vpn-query-campaign.sh
           bash bench/tests/test-route-server-1000-receipt.sh
+          bash bench/tests/test-scale-host-quiet.sh
           bash bench/tests/test-vpn-query-receipt.sh
           bash bench/tests/test-vpn-query-campaign.sh
           bash bench/tests/test-compare-criterion-harness.sh

--- a/bench/scale/README.md
+++ b/bench/scale/README.md
@@ -21,6 +21,8 @@ cargo update --workspace --manifest-path bench/scale/Cargo.toml
 | [`rrharness/`](rrharness/) | RibManager flood/churn CPU + memory profiling (manager task in isolation, folded-stack output) | `docs/perf/rebaseline-2026-07.md`, LAN-348 re-profile |
 | [`rrtransport/`](rrtransport/) | Fixed real-transport RR correctness smoke plus a gated 1,000-peer × 100,000-route measurement instrument with exact staged/wire classification | CI foundation and LAN-694 measurement campaign; no published claim yet |
 | [`reloadstall/`](reloadstall/) | Policy-reload UPDATE-stall at route-server scale (real BGP stub clients vs a running daemon) | `docs/perf/reload-stall-2026-07.md` (LAN-333) |
+| [`matrix/`](matrix/) | Sequential same-host rustbgpd, BIRD, and OpenBGPD reload-stall comparison driver | `docs/perf/ixp-matrix-2026-07.md` |
+| [`enhanced-route-refresh/`](enhanced-route-refresh/) | Real-session one-peer × 100,000-prefix RFC 7313 inventory and memory receipt | `docs/perf/enhanced-route-refresh-2026-07.md` |
 | [`irrreload/`](irrreload/) | Full IRR-policy reload matrix plus a two-run, one-collector RFC 9069 dump/live-buffer boundary receipt | IRR reload evidence and BMP Loc-RIB buffer measurement; no general capacity claim |
 | [`route-server-1000/`](route-server-1000/) | Fixed-shape 1,000-peer rustbgpd route-server retained receipt driver | LAN-508 ([retained receipt](../../docs/perf/route-server-1000-2026-07.md)) |
 

--- a/bench/scale/enhanced-route-refresh/run-receipt.sh
+++ b/bench/scale/enhanced-route-refresh/run-receipt.sh
@@ -42,7 +42,7 @@ cleanup() {
 
 [[ ${BASH_SOURCE[0]} == "$0" ]] || return 0
 [[ $# -eq 0 ]] || { echo "usage: $0" >&2; exit 2; }
-for command in awk cargo curl date find flock git grep mktemp nproc python3 \
+for command in awk cargo curl date find flock git grep mktemp nproc ps python3 \
     rustc sha256sum sort ss timeout uname xargs; do
     command -v "$command" >/dev/null || {
         echo "missing required command: $command" >&2
@@ -52,19 +52,19 @@ done
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 readonly REPO
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/tests/soak/host-lock.sh"
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/bench/scale/host-quiet.sh"
 readonly RECEIPT_DIR="$REPO/bench/scale/enhanced-route-refresh"
 readonly PORT=1793 METRICS_PORT=9183 PREFIXES=100000
 readonly PEER=127.1.0.1 FAMILY=ipv4_unicast
-readonly LOCK="${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}"
 readonly OVERALL_TIMEOUT=480
 [[ -z $(git -C "$REPO" status --porcelain --untracked-files=normal) ]] || {
     echo "refusing dirty worktree (tracked or untracked files present)" >&2
     exit 2
 }
-mkdir -p "$(dirname "$LOCK")"
-touch "$LOCK"
-exec {LOCK_FD}>"$LOCK"
-flock -n "$LOCK_FD" || { echo "host lock busy: $LOCK" >&2; exit 75; }
+acquire_rustbgpd_host_lock || exit $?
 
 COMMIT="$(git -C "$REPO" rev-parse HEAD)"
 TREE="$(git -C "$REPO" rev-parse 'HEAD^{tree}')"
@@ -135,6 +135,7 @@ python3 "$RECEIPT_DIR/gen-scenario.py" "$RUN" "$PORT" "$METRICS_PORT" \
     >"$OUT/scenario/generator.log"
 cp "$RUN/config.toml" "$OUT/scenario/config.toml"
 "$DAEMON" --check "$RUN/config.toml" >"$OUT/scenario/daemon-check.log" 2>&1
+wait_for_rustbgpd_quiet_host "$OUT/quiet.tsv" || exit $?
 "$DAEMON" "$RUN/config.toml" >"$OUT/daemon.log" 2>&1 &
 DAEMON_PID=$!
 for _ in {1..200}; do

--- a/bench/scale/host-quiet.sh
+++ b/bench/scale/host-quiet.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Canonical quiet-host gate for measured scale and performance receipts.
+#
+# Source this file and call `wait_for_rustbgpd_quiet_host QUIET_TSV` after the
+# shared host lock is held, but before starting a measured cell.  A successful
+# call retains two consecutive samples that prove:
+#
+#   - one-minute load average is below 2.0;
+#   - at least one CPU frequency governor exists and every governor is
+#     `performance`;
+#   - no compiler, benchmark, rustbgpd, or other BGP daemon is running; and
+#   - pswpin / pswpout did not move between the two accepted samples.
+#
+# The gate retries until RUSTBGPD_HOST_QUIET_TIMEOUT_SECS (default 300) and
+# returns EX_TEMPFAIL (75) with the last failed dimensions when the host does
+# not settle.  RUSTBGPD_HOST_QUIET_SAMPLE_INTERVAL_SECS defaults to 30.
+
+rustbgpd_host_quiet_competitors() {
+    local processes
+    processes=$(ps -eo pid=,comm= --no-headers) || return 1
+    awk -v self="$$" '
+        function competing(name) {
+            return name == "cargo" || name == "rustc" || name == "rustdoc" ||
+                name == "cc" || name == "c++" || name == "gcc" ||
+                name == "g++" || name == "clang" || name == "clang++" ||
+                name == "cc1" || name == "cc1plus" || name == "ld" ||
+                name == "ld.lld" || name == "mold" ||
+                name == "perf" || name == "rustbgpd" || name == "rrtransport" ||
+                name == "reloadstall" || name ~ /^rrharness/ ||
+                name ~ /^route_paging/ || name ~ /^rib_nlri_build/ ||
+                name ~ /^nlri_build/ || name ~ /^event_history_/ ||
+                name ~ /^codec/ || name ~ /^fanout/ || name ~ /^inbound_attrs/ ||
+                name ~ /^rib_ops/ || name ~ /^policy_eval/ ||
+                name ~ /^explain_snapsho/ || name ~ /^bgperf/ ||
+                name ~ /^enhanced-route-/ ||
+                name == "bird" || name == "bird6" || name == "bgpd" ||
+                name == "openbgpd" || name == "gobgpd" || name == "zebra" ||
+                name == "frr" || name == "ospfd" || name == "staticd"
+        }
+        BEGIN {separator = ""}
+        $1 != self && competing($2) {
+            printf "%s%s:%s", separator, $1, $2
+            separator = ","
+        }
+        END {print ""}
+    ' <<<"$processes"
+}
+
+rustbgpd_host_quiet_snapshot() {
+    local proc_root=${RUSTBGPD_HOST_QUIET_PROC_ROOT:-/proc}
+    local cpu_root=${RUSTBGPD_HOST_QUIET_CPU_ROOT:-/sys/devices/system/cpu}
+    local path value
+    local -a paths=() governors=()
+
+    RUSTBGPD_HOST_QUIET_LOAD=$(awk '{print $1; exit}' "$proc_root/loadavg") || return 1
+    read -r RUSTBGPD_HOST_QUIET_PSWPIN RUSTBGPD_HOST_QUIET_PSWPOUT < <(
+        awk '$1 == "pswpin" {pin=$2} $1 == "pswpout" {pout=$2}
+             END {print pin+0, pout+0}' "$proc_root/vmstat"
+    ) || return 1
+    RUSTBGPD_HOST_QUIET_COMPETITORS=$(rustbgpd_host_quiet_competitors) || return 1
+
+    shopt -s nullglob
+    paths=("$cpu_root"/cpu[0-9]*/cpufreq/scaling_governor)
+    shopt -u nullglob
+    for path in "${paths[@]}"; do
+        value=''
+        if ! IFS= read -r value <"$path" || [ -z "$value" ]; then
+            return 1
+        fi
+        governors+=("$value")
+    done
+    RUSTBGPD_HOST_QUIET_GOVERNORS=$(IFS=,; printf '%s' "${governors[*]}")
+    RUSTBGPD_HOST_QUIET_GOVERNOR_COUNT=${#governors[@]}
+    RUSTBGPD_HOST_QUIET_PERFORMANCE_COUNT=0
+    for value in "${governors[@]}"; do
+        if [ "$value" = performance ]; then
+            RUSTBGPD_HOST_QUIET_PERFORMANCE_COUNT=$((RUSTBGPD_HOST_QUIET_PERFORMANCE_COUNT + 1))
+        fi
+    done
+}
+
+rustbgpd_host_quiet_dimensions() {
+    local -a failed=()
+
+    awk -v load1="$RUSTBGPD_HOST_QUIET_LOAD" \
+        'BEGIN {exit !(load1 ~ /^[0-9]+([.][0-9]+)?$/ && load1 < 2.0)}' ||
+        failed+=(load1)
+    if [ "$RUSTBGPD_HOST_QUIET_GOVERNOR_COUNT" -eq 0 ]; then
+        failed+=(governors_missing)
+    elif [ "$RUSTBGPD_HOST_QUIET_PERFORMANCE_COUNT" -ne \
+        "$RUSTBGPD_HOST_QUIET_GOVERNOR_COUNT" ]; then
+        failed+=(governors_not_performance)
+    fi
+    [ -z "$RUSTBGPD_HOST_QUIET_COMPETITORS" ] || failed+=(competitors)
+
+    RUSTBGPD_HOST_QUIET_FAILED=$(IFS=,; printf '%s' "${failed[*]}")
+    [ ${#failed[@]} -eq 0 ]
+}
+
+wait_for_rustbgpd_quiet_host() {
+    if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+        echo "usage: wait_for_rustbgpd_quiet_host QUIET_TSV [EXTRA_SAMPLE_FUNCTION [EXTRA_HEADER]]" >&2
+        return 2
+    fi
+    local output=$1
+    local extra_sample=${2:-} extra_header=${3:-}
+    local timeout=${RUSTBGPD_HOST_QUIET_TIMEOUT_SECS:-300}
+    local interval=${RUSTBGPD_HOST_QUIET_SAMPLE_INTERVAL_SECS:-30}
+    local min_spacing=${RUSTBGPD_HOST_QUIET_MIN_SPACING_SECS:-30}
+    local deadline
+    local attempt=0 accepted=0 first_epoch='' first_pswpin='' first_pswpout=''
+    local epoch failed generic_ok extra_ok last_failed=second_sample
+
+    if [ -n "$extra_sample" ] && ! declare -F "$extra_sample" >/dev/null; then
+        echo "unknown host-quiet extra sample function: $extra_sample" >&2
+        return 2
+    fi
+
+    case $timeout in '' | *[!0-9]*)
+        echo "RUSTBGPD_HOST_QUIET_TIMEOUT_SECS must be a non-negative integer" >&2
+        return 2
+        ;;
+    esac
+    case $min_spacing in '' | *[!0-9]*)
+        echo "RUSTBGPD_HOST_QUIET_MIN_SPACING_SECS must be a non-negative integer" >&2
+        return 2
+        ;;
+    esac
+    if ! awk -v interval="$interval" \
+        'BEGIN {exit !(interval ~ /^[0-9]+([.][0-9]+)?$/)}'; then
+        echo "RUSTBGPD_HOST_QUIET_SAMPLE_INTERVAL_SECS must be non-negative" >&2
+        return 2
+    fi
+    deadline=$((SECONDS + timeout))
+    mkdir -p "$(dirname "$output")" || return 1
+
+    rustbgpd_host_quiet_header() {
+        printf 'sample\tepoch_s\tload1\tpswpin\tpswpout'
+        [ -z "$extra_header" ] || printf '\t%s' "$extra_header"
+        printf '\tgovernors\tperformance_governors\tgovernor_count\tcompetitors\tquiet\tfailed_dimensions\toriginal_attempt\n'
+    }
+    rustbgpd_host_quiet_row() {
+        local sample=$1 row_failed=${2:-none}
+        printf '%s\t%s\t%s\t%s\t%s' "$sample" "$epoch" \
+            "$RUSTBGPD_HOST_QUIET_LOAD" "$RUSTBGPD_HOST_QUIET_PSWPIN" \
+            "$RUSTBGPD_HOST_QUIET_PSWPOUT"
+        [ -z "$extra_header" ] || printf '\t%s' "$RUSTBGPD_HOST_QUIET_EXTRA_FIELDS"
+        printf '\t%s\t%s\t%s\t%s\ttrue\t%s\t%s\n' \
+            "${RUSTBGPD_HOST_QUIET_GOVERNORS:-none}" \
+            "$RUSTBGPD_HOST_QUIET_PERFORMANCE_COUNT" \
+            "$RUSTBGPD_HOST_QUIET_GOVERNOR_COUNT" \
+            "${RUSTBGPD_HOST_QUIET_COMPETITORS:-none}" "$row_failed" "$attempt"
+    }
+    rustbgpd_host_quiet_header >"$output" || return 1
+
+    while :; do
+        attempt=$((attempt + 1))
+        generic_ok=true
+        if ! rustbgpd_host_quiet_snapshot; then
+            RUSTBGPD_HOST_QUIET_LOAD=unreadable
+            RUSTBGPD_HOST_QUIET_GOVERNORS=unreadable
+            RUSTBGPD_HOST_QUIET_PERFORMANCE_COUNT=0
+            RUSTBGPD_HOST_QUIET_GOVERNOR_COUNT=0
+            RUSTBGPD_HOST_QUIET_COMPETITORS=unreadable
+            RUSTBGPD_HOST_QUIET_PSWPIN=unreadable
+            RUSTBGPD_HOST_QUIET_PSWPOUT=unreadable
+            RUSTBGPD_HOST_QUIET_FAILED=snapshot
+            generic_ok=false
+        elif ! rustbgpd_host_quiet_dimensions; then
+            generic_ok=false
+        fi
+
+        RUSTBGPD_HOST_QUIET_EXTRA_FIELDS=''
+        RUSTBGPD_HOST_QUIET_EXTRA_FAILED=''
+        extra_ok=true
+        if [ -n "$extra_sample" ] && ! "$extra_sample"; then
+            extra_ok=false
+            [ -n "$RUSTBGPD_HOST_QUIET_EXTRA_FAILED" ] ||
+                RUSTBGPD_HOST_QUIET_EXTRA_FAILED=extra_snapshot
+        fi
+        [ -z "$RUSTBGPD_HOST_QUIET_EXTRA_FAILED" ] || extra_ok=false
+        failed=$RUSTBGPD_HOST_QUIET_FAILED
+        if [ -n "$RUSTBGPD_HOST_QUIET_EXTRA_FAILED" ]; then
+            [ -z "$failed" ] || failed+=,
+            failed+=$RUSTBGPD_HOST_QUIET_EXTRA_FAILED
+        fi
+        epoch=$(date +%s)
+
+        if [ "$generic_ok" != true ] || [ "$extra_ok" != true ]; then
+            last_failed=${failed:-snapshot}
+            accepted=0
+            first_epoch=''
+            first_pswpin=''
+            first_pswpout=''
+            rustbgpd_host_quiet_header >"$output" || return 1
+        elif [ "$accepted" -eq 0 ]; then
+            first_epoch=$epoch
+            first_pswpin=$RUSTBGPD_HOST_QUIET_PSWPIN
+            first_pswpout=$RUSTBGPD_HOST_QUIET_PSWPOUT
+            accepted=1
+            rustbgpd_host_quiet_header >"$output" || return 1
+            rustbgpd_host_quiet_row 1 >>"$output" || return 1
+            last_failed=second_sample
+        elif [ "$RUSTBGPD_HOST_QUIET_PSWPIN" != "$first_pswpin" ] ||
+            [ "$RUSTBGPD_HOST_QUIET_PSWPOUT" != "$first_pswpout" ]; then
+            first_epoch=$epoch
+            first_pswpin=$RUSTBGPD_HOST_QUIET_PSWPIN
+            first_pswpout=$RUSTBGPD_HOST_QUIET_PSWPOUT
+            accepted=1
+            rustbgpd_host_quiet_header >"$output" || return 1
+            rustbgpd_host_quiet_row 1 >>"$output" || return 1
+            last_failed=swap_activity
+        elif [ $((epoch - first_epoch)) -lt "$min_spacing" ]; then
+            last_failed=sample_spacing
+        else
+            rustbgpd_host_quiet_row 2 >>"$output" || return 1
+            echo "host quiet: retained two accepted samples in $output"
+            return 0
+        fi
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "host quiet timeout: failed dimensions: $last_failed" >&2
+            return 75
+        fi
+        sleep "$interval"
+    done
+}

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -37,6 +37,10 @@ set -u
 set -o pipefail
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/tests/soak/host-lock.sh"
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/bench/scale/host-quiet.sh"
 RSTALL="$REPO/bench/scale/reloadstall"
 HARNESS="$REPO/bench/scale/target/release/reloadstall"
 GEN="$RSTALL/gen-irr-scenario.py"
@@ -127,6 +131,52 @@ PORT="${PORT:-1790}"
 START_TIMEOUT="${START_TIMEOUT:-600}"
 BIRD_THREADS="${BIRD_THREADS:-8}"
 ART="${ARTIFACTS_DIR:-/tmp/irrreload-artifacts}"
+
+# shellcheck disable=SC2317 # invoked indirectly by the shared host-quiet sampler
+irrreload_host_quiet_extra_sample() {
+    local disk_kib port1790 port9179
+    local port1790_free=true port9179_free=true
+    local -a failed=()
+
+    disk_kib=$(df -Pk "$ART" | awk 'NR == 2 {print $4}') || {
+        RUSTBGPD_HOST_QUIET_EXTRA_FIELDS=$'unreadable\tunreadable\tunreadable'
+        RUSTBGPD_HOST_QUIET_EXTRA_FAILED=extra_snapshot
+        return 1
+    }
+    port1790=$(ss -ltnH 'sport = :1790') || {
+        RUSTBGPD_HOST_QUIET_EXTRA_FIELDS=$'unreadable\tunreadable\tunreadable'
+        RUSTBGPD_HOST_QUIET_EXTRA_FAILED=extra_snapshot
+        return 1
+    }
+    port9179=$(ss -ltnH 'sport = :9179') || {
+        RUSTBGPD_HOST_QUIET_EXTRA_FIELDS=$'unreadable\tunreadable\tunreadable'
+        RUSTBGPD_HOST_QUIET_EXTRA_FAILED=extra_snapshot
+        return 1
+    }
+    if [ -n "$port1790" ]; then
+        port1790_free=false
+        failed+=(port1790)
+    fi
+    if [ -n "$port9179" ]; then
+        port9179_free=false
+        failed+=(port9179)
+    fi
+    [ "$disk_kib" -ge $((40 * 1024 * 1024)) ] || failed+=(disk_available)
+    printf -v RUSTBGPD_HOST_QUIET_EXTRA_FIELDS '%s\t%s\t%s' \
+        "$port1790_free" "$port9179_free" "$disk_kib"
+    RUSTBGPD_HOST_QUIET_EXTRA_FAILED=$(IFS=,; printf '%s' "${failed[*]}")
+    [ ${#failed[@]} -eq 0 ]
+}
+
+if [ "${1:-}" = --self-test-host-quiet ]; then
+    [ "$#" -eq 2 ] || { echo "usage: $0 --self-test-host-quiet OUTPUT" >&2; exit 2; }
+    ART=$(dirname "$2")
+    mkdir -p "$ART"
+    wait_for_rustbgpd_quiet_host "$2" irrreload_host_quiet_extra_sample \
+        $'port1790_free\tport9179_free\tdisk_available_kib'
+    exit $?
+fi
+
 PREFLIGHT_LOG=""
 cleanup_preflight_log() { [ -z "$PREFLIGHT_LOG" ] || rm -f "$PREFLIGHT_LOG"; }
 trap cleanup_preflight_log EXIT
@@ -186,7 +236,7 @@ if [ -e "$ART" ] || [ -L "$ART" ]; then
     exit 2
 fi
 
-for tool in docker jq python3 cargo curl flock ss sha256sum git awk timeout find sort setsid stdbuf cmp mktemp stat df env; do
+for tool in docker jq python3 cargo curl flock ss sha256sum git awk timeout find sort setsid stdbuf cmp mktemp stat df env ps; do
     command -v "$tool" >/dev/null || {
         echo "missing required tool: $tool" >&2
         exit 1
@@ -272,13 +322,7 @@ if [ -z "$SMOKE" ]; then
     }
 fi
 
-HOST_LOCK="${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}"
-mkdir -p "$(dirname "$HOST_LOCK")"
-exec {HOST_LOCK_FD}>"$HOST_LOCK"
-flock -n "$HOST_LOCK_FD" || {
-    echo "host benchmark lock is held: $HOST_LOCK" >&2
-    exit 75
-}
+acquire_rustbgpd_host_lock || exit $?
 
 echo "=== builds ==="
 (cd "$REPO" && cargo build --release -q -p rustbgpd -p rustbgpctl -p rs-config-render) || exit 1
@@ -410,39 +454,12 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 load_gate() {
-    local cell=$1 load sample=1 quiet pswpin pswpout disk_kib first_pswpin first_pswpout port1790 port9179
+    local cell=$1 quiet
     quiet="$ART/$cell/quiet.tsv"
     [ -n "$SMOKE" ] && return 0
     mkdir -p "$ART/$cell"
-    printf 'sample\tepoch_s\tload1\tpswpin\tpswpout\tport1790_free\tport9179_free\tdisk_available_kib\n' >"$quiet"
-    while [ "$sample" -le 2 ]; do
-        load=$(cut -d' ' -f1 /proc/loadavg)
-        pswpin=$(awk '$1 == "pswpin" {print $2}' /proc/vmstat)
-        pswpout=$(awk '$1 == "pswpout" {print $2}' /proc/vmstat)
-        disk_kib=$(df -Pk "$ART" | awk 'NR == 2 {print $4}')
-        port1790=$(ss -ltnH 'sport = :1790') || { echo "load_gate: cannot inspect port 1790" >&2; exit 1; }
-        port9179=$(ss -ltnH 'sport = :9179') || { echo "load_gate: cannot inspect port 9179" >&2; exit 1; }
-        if awk -v l="$load" 'BEGIN { exit !(l < 2.0) }' &&
-            [ -z "$port1790" ] && [ -z "$port9179" ] &&
-            [ "$disk_kib" -ge $((40 * 1024 * 1024)) ]; then
-            printf '%s\t%s\t%s\t%s\t%s\ttrue\ttrue\t%s\n' \
-                "$sample" "$(date +%s)" "$load" "$pswpin" "$pswpout" "$disk_kib" >>"$quiet"
-            if [ "$sample" -eq 1 ]; then
-                first_pswpin=$pswpin
-                first_pswpout=$pswpout
-            elif [ "$pswpin" != "$first_pswpin" ] || [ "$pswpout" != "$first_pswpout" ]; then
-                echo "load_gate: swap activity observed; restarting quiet samples"
-                printf 'sample\tepoch_s\tload1\tpswpin\tpswpout\tport1790_free\tport9179_free\tdisk_available_kib\n' >"$quiet"
-                sample=1
-                sleep 30
-                continue
-            fi
-            sample=$((sample + 1))
-        else
-            echo "load_gate: waiting for load <2, free ports 1790/9179, and 40 GiB free on ART"
-        fi
-        [ "$sample" -gt 2 ] || sleep 30
-    done
+    wait_for_rustbgpd_quiet_host "$quiet" irrreload_host_quiet_extra_sample \
+        $'port1790_free\tport9179_free\tdisk_available_kib'
 }
 
 capture_topology() {
@@ -869,7 +886,7 @@ run_cell() {
 overall=0
 for cell in "${CELLS[@]}"; do
     status_file="$ART/$cell/status"
-    load_gate "$cell"
+    load_gate "$cell" || exit $?
     echo "=== cell $cell start $(date -Is) ==="
     if run_cell "$cell"; then
         printf 'pass\n' >"$status_file"

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -1119,7 +1119,10 @@ def generation_marker(path: Path) -> str:
 
 
 def validate_quiet(path: Path) -> None:
-    data = list(csv.DictReader(path.open(), delimiter="\t"))
+    with path.open() as stream:
+        reader = csv.DictReader(stream, delimiter="\t")
+        fields = set(reader.fieldnames or ())
+        data = list(reader)
     if [row.get("sample") for row in data] != ["1", "2"]:
         fail(f"{path}: quiet gate needs exactly two samples")
     epochs = [int(row["epoch_s"]) for row in data]
@@ -1133,6 +1136,37 @@ def validate_quiet(path: Path) -> None:
         or any(not row.get("pswpin", "").isdigit() or not row.get("pswpout", "").isdigit() for row in data)
     ):
         fail(f"{path}: quiet samples fail spacing, load, port, disk, or swap gates")
+    canonical = {
+        "governors", "performance_governors", "governor_count", "competitors",
+        "quiet", "failed_dimensions", "original_attempt",
+    }
+    present = fields & canonical
+    if present and present != canonical:
+        fail(f"{path}: canonical quiet-host fields are incomplete")
+    if present:
+        attempts = []
+        for row in data:
+            try:
+                performance = int(row["performance_governors"])
+                count = int(row["governor_count"])
+                attempt = int(row["original_attempt"])
+            except (KeyError, TypeError, ValueError, OverflowError):
+                fail(f"{path}: canonical quiet-host counts are malformed")
+            governors = row["governors"].split(",")
+            if (
+                count <= 0
+                or performance != count
+                or len(governors) != count
+                or any(governor != "performance" for governor in governors)
+                or row["competitors"] != "none"
+                or row["quiet"] != "true"
+                or row["failed_dimensions"] != "none"
+                or attempt <= 0
+            ):
+                fail(f"{path}: canonical governor or competitor quiet gate failed")
+            attempts.append(attempt)
+        if attempts[0] >= attempts[1]:
+            fail(f"{path}: canonical quiet-host attempts are not ordered")
 
 
 def validate_process(path: Path) -> tuple[int, int]:

--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -21,6 +21,10 @@
 set -u
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/tests/soak/host-lock.sh"
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/bench/scale/host-quiet.sh"
 RSTALL="$REPO/bench/scale/reloadstall"
 HARNESS="$REPO/bench/scale/target/release/reloadstall"
 SAMPLER="$REPO/bench/scale/matrix/rss-sampler.sh"
@@ -35,6 +39,8 @@ FLAPSTORM="${FLAPSTORM:-}"
 ART="${ARTIFACTS_DIR:-$REPO/bench/scale/matrix/artifacts}"
 RSS_LIMIT_KIB=$((100 * 1024 * 1024)) # abort a cell past 100 GiB
 
+acquire_rustbgpd_host_lock || exit $?
+
 CELLS=("$@")
 [ ${#CELLS[@]} -eq 0 ] && CELLS=(rustbgpd bird openbgpd)
 
@@ -43,16 +49,6 @@ CELLS=("$@")
     exit 1
 }
 mkdir -p "$ART"
-
-load_gate() {
-    local load
-    while :; do
-        load=$(cut -d' ' -f1 /proc/loadavg)
-        if awk -v l="$load" 'BEGIN { exit !(l < 2.0) }'; then return 0; fi
-        echo "load_gate: 1-min loadavg $load >= 2.0, waiting 30s"
-        sleep 30
-    done
-}
 
 # run_cell <cell>: everything for one matrix cell. Nonzero return = cell
 # failed; the campaign moves on.
@@ -171,7 +167,7 @@ for cell in "${CELLS[@]}"; do
         echo "cell $cell: already pass, skipping (rm $status_file to rerun)"
         continue
     fi
-    load_gate
+    wait_for_rustbgpd_quiet_host "$ART/$cell/quiet.tsv" || exit $?
     echo "=== cell $cell start $(date -Is) ==="
     if run_cell "$cell"; then
         echo pass >"$status_file"

--- a/bench/tests/test-scale-host-quiet.sh
+++ b/bench/tests/test-scale-host-quiet.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # single-quoted strings below are literal production seams
+set -euo pipefail
+
+repo=$(cd "$(dirname "$0")/../.." && pwd)
+helper="$repo/bench/scale/host-quiet.sh"
+matrix="$repo/bench/scale/matrix/run-matrix.sh"
+irrreload="$repo/bench/scale/irrreload/run-irr-reload.sh"
+enhanced="$repo/bench/scale/enhanced-route-refresh/run-receipt.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/scale-host-quiet.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+make_fixture() {
+    local root=$1 load=${2:-0.50}
+    mkdir -p "$root/proc" "$root/sys/cpu0/cpufreq" "$root/bin"
+    printf '%s 0.40 0.30 1/100 1\n' "$load" >"$root/proc/loadavg"
+    printf 'pswpin 10\npswpout 20\n' >"$root/proc/vmstat"
+    printf 'performance\n' >"$root/sys/cpu0/cpufreq/scaling_governor"
+    cat >"$root/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$root/bin/ps"
+}
+
+run_gate() {
+    local root=$1 output=$2 timeout=${3:-2} interval=${4:-0}
+    PATH="$root/bin:$PATH" \
+        RUSTBGPD_HOST_QUIET_PROC_ROOT="$root/proc" \
+        RUSTBGPD_HOST_QUIET_CPU_ROOT="$root/sys" \
+        RUSTBGPD_HOST_QUIET_TIMEOUT_SECS="$timeout" \
+        RUSTBGPD_HOST_QUIET_SAMPLE_INTERVAL_SECS="$interval" \
+        RUSTBGPD_HOST_QUIET_MIN_SPACING_SECS=0 \
+        bash -c 'source "$1"; wait_for_rustbgpd_quiet_host "$2"' \
+        bash "$helper" "$output"
+}
+
+success="$tmp/success"
+make_fixture "$success"
+run_gate "$success" "$success/quiet.tsv"
+[[ $(wc -l <"$success/quiet.tsv") -eq 3 ]] || fail 'success did not retain exactly two samples'
+awk -F '\t' '
+    NR == 1 {
+        expected="sample\tepoch_s\tload1\tpswpin\tpswpout\tgovernors\tperformance_governors\tgovernor_count\tcompetitors\tquiet\tfailed_dimensions\toriginal_attempt"
+        if ($0 != expected) exit 1
+        next
+    }
+    $1 != NR - 1 || $3 >= 2.0 || $4 != 10 || $5 != 20 ||
+        $6 != "performance" || $7 != 1 || $8 != 1 || $9 != "none" ||
+        $10 != "true" || $11 != "none" || $12 != NR - 1 {exit 1}
+    END {if (NR != 3) exit 1}
+' "$success/quiet.tsv" || fail 'success quiet.tsv does not prove every dimension'
+
+assert_rejected() {
+    local name=$1 expected=$2
+    shift 2
+    local root="$tmp/$name" status=0
+    make_fixture "$root"
+    "$@" "$root"
+    run_gate "$root" "$root/quiet.tsv" 0 0 >"$root/stdout" 2>"$root/stderr" || status=$?
+    [[ $status -eq 75 ]] || fail "$name returned $status instead of 75"
+    grep -Fq "host quiet timeout: failed dimensions: $expected" "$root/stderr" ||
+        fail "$name missing $expected timeout diagnostic"
+}
+
+remove_governors() { rm -rf "$1/sys/cpu0"; }
+mix_governors() {
+    mkdir -p "$1/sys/cpu1/cpufreq"
+    printf 'powersave\n' >"$1/sys/cpu1/cpufreq/scaling_governor"
+}
+break_later_governor_read() {
+    mkdir -p "$1/sys/cpu1/cpufreq/scaling_governor"
+}
+raise_load() { printf '2.00 0.40 0.30 1/100 1\n' >"$1/proc/loadavg"; }
+write_competitor() {
+    local root=$1 process=$2
+    cat >"$root/bin/ps" <<EOF
+#!/usr/bin/env bash
+printf '4242 $process\n'
+EOF
+    chmod +x "$root/bin/ps"
+}
+add_compiler() { write_competitor "$1" rustc; }
+add_benchmark() { write_competitor "$1" rrharness-fixt; }
+add_rustbgpd() { write_competitor "$1" rustbgpd; }
+add_bgp_daemon() { write_competitor "$1" bird; }
+
+assert_rejected missing-governor governors_missing remove_governors
+assert_rejected mixed-governor governors_not_performance mix_governors
+assert_rejected unreadable-governor snapshot break_later_governor_read
+assert_rejected high-load load1 raise_load
+assert_rejected compiler competitors add_compiler
+assert_rejected benchmark competitors add_benchmark
+assert_rejected rustbgpd competitors add_rustbgpd
+assert_rejected bgp-daemon competitors add_bgp_daemon
+
+swap="$tmp/swap"
+make_fixture "$swap"
+cat >"$swap/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+read -r _ pin <"$FAKE_VMSTAT"
+read -r _ pout < <(sed -n '2p' "$FAKE_VMSTAT")
+printf 'pswpin %s\npswpout %s\n' "$((pin + 1))" "$((pout + 1))" >"$FAKE_VMSTAT"
+EOF
+chmod +x "$swap/bin/ps"
+swap_status=0
+FAKE_VMSTAT="$swap/proc/vmstat" PATH="$swap/bin:$PATH" \
+    RUSTBGPD_HOST_QUIET_PROC_ROOT="$swap/proc" \
+    RUSTBGPD_HOST_QUIET_CPU_ROOT="$swap/sys" \
+    RUSTBGPD_HOST_QUIET_TIMEOUT_SECS=2 \
+    RUSTBGPD_HOST_QUIET_SAMPLE_INTERVAL_SECS=0.05 \
+    RUSTBGPD_HOST_QUIET_MIN_SPACING_SECS=0 \
+    bash -c 'source "$1"; wait_for_rustbgpd_quiet_host "$2"' \
+    bash "$helper" "$swap/quiet.tsv" >"$swap/stdout" 2>"$swap/stderr" || swap_status=$?
+[[ $swap_status -eq 75 ]] || fail "swap activity returned $swap_status instead of 75"
+grep -Fq 'failed dimensions: swap_activity' "$swap/stderr" || fail 'swap timeout omitted failed dimension'
+
+irr="$tmp/irr-compatibility"
+make_fixture "$irr"
+cat >"$irr/bin/ss" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat >"$irr/bin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted\n'
+printf 'fixture 100000000 1 50000000 1%% /fixture\n'
+EOF
+cat >"$irr/bin/date" <<'EOF'
+#!/usr/bin/env bash
+count=$(cat "$FAKE_DATE_COUNTER" 2>/dev/null || printf '0')
+printf '%s\n' "$((1 + 30 * count))"
+printf '%s\n' "$((count + 1))" >"$FAKE_DATE_COUNTER"
+EOF
+chmod +x "$irr/bin/ss" "$irr/bin/df" "$irr/bin/date"
+FAKE_DATE_COUNTER="$irr/date-counter" PATH="$irr/bin:$PATH" \
+    RUSTBGPD_HOST_QUIET_PROC_ROOT="$irr/proc" \
+    RUSTBGPD_HOST_QUIET_CPU_ROOT="$irr/sys" \
+    RUSTBGPD_HOST_QUIET_TIMEOUT_SECS=2 \
+    RUSTBGPD_HOST_QUIET_SAMPLE_INTERVAL_SECS=0 \
+    bash "$irrreload" --self-test-host-quiet "$irr/quiet.tsv"
+python3 - "$repo/bench/scale/irrreload/verify-receipt.py" "$irr/quiet.tsv" <<'PY'
+import csv
+import importlib.util
+import pathlib
+import sys
+
+verifier_path, quiet_path = map(pathlib.Path, sys.argv[1:])
+spec = importlib.util.spec_from_file_location("irr_verify_receipt", verifier_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+module.validate_quiet(quiet_path)
+
+with quiet_path.open(newline="") as stream:
+    reader = csv.DictReader(stream, delimiter="\t")
+    fieldnames = reader.fieldnames
+    rows = list(reader)
+assert fieldnames is not None
+
+def rejected(name, mutate):
+    candidate = quiet_path.with_name(f"quiet-{name}.tsv")
+    changed = [dict(row) for row in rows]
+    mutate(changed)
+    with candidate.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(changed)
+    try:
+        module.validate_quiet(candidate)
+    except module.InvalidReceipt:
+        return
+    raise SystemExit(f"{name} mutation stayed green")
+
+rejected("port", lambda data: data[0].update(port1790_free="false"))
+rejected("disk", lambda data: data[0].update(disk_available_kib="41943039"))
+rejected("swap", lambda data: data[1].update(pswpin="11"))
+rejected("governor", lambda data: data[0].update(governors="powersave"))
+rejected("competitor", lambda data: data[0].update(competitors="4242:rustc"))
+PY
+
+check_driver_seam() {
+    local driver=$1 name=$2 acquire_line quiet_line quiet_call workload workload_line
+    grep -Fxq 'source "$REPO/tests/soak/host-lock.sh"' "$driver" || return 1
+    grep -Fxq 'source "$REPO/bench/scale/host-quiet.sh"' "$driver" || return 1
+    grep -Fxq 'acquire_rustbgpd_host_lock || exit $?' "$driver" || return 1
+    case $name in
+        matrix)
+            quiet_call='wait_for_rustbgpd_quiet_host "$ART/$cell/quiet.tsv" || exit $?'
+            workload_line='if run_cell "$cell"; then'
+            ;;
+        irrreload)
+            grep -Fq 'wait_for_rustbgpd_quiet_host "$quiet"' "$driver" || return 1
+            quiet_call='load_gate "$cell" || exit $?'
+            workload_line='if run_cell "$cell"; then'
+            ;;
+        enhanced)
+            quiet_call='wait_for_rustbgpd_quiet_host "$OUT/quiet.tsv" || exit $?'
+            workload_line='"$DAEMON" "$RUN/config.toml" >"$OUT/daemon.log" 2>&1 &'
+            ;;
+        *) return 1 ;;
+    esac
+    grep -Fq "$quiet_call" "$driver" || return 1
+    acquire_line=$(grep -nF 'acquire_rustbgpd_host_lock || exit $?' "$driver" | cut -d: -f1)
+    quiet_line=$(grep -nF "$quiet_call" "$driver" | cut -d: -f1)
+    workload=$(grep -nF "$workload_line" "$driver" | head -n1 | cut -d: -f1)
+    [[ -n $acquire_line && -n $quiet_line && -n $workload ]] || return 1
+    ((acquire_line < workload && quiet_line < workload))
+}
+
+for spec in "$matrix:matrix" "$irrreload:irrreload" "$enhanced:enhanced"; do
+    driver=${spec%:*}
+    name=${spec##*:}
+    check_driver_seam "$driver" "$name" || fail "$name production seam rejected"
+    for mutation in host-source quiet-source acquire quiet-call; do
+        candidate="$tmp/${name}-${mutation}"
+        cp "$driver" "$candidate"
+        case $mutation in
+            host-source) sed -i '\|source "$REPO/tests/soak/host-lock.sh"|d' "$candidate" ;;
+            quiet-source) sed -i '\|source "$REPO/bench/scale/host-quiet.sh"|d' "$candidate" ;;
+            acquire) sed -i '/acquire_rustbgpd_host_lock || exit \$?/d' "$candidate" ;;
+            quiet-call)
+                if [[ $name == irrreload ]]; then
+                    sed -i '/load_gate "$cell" || exit \$?/d' "$candidate"
+                else
+                    sed -i '/wait_for_rustbgpd_quiet_host .* || exit \$?/d' "$candidate"
+                fi
+                ;;
+        esac
+        ! check_driver_seam "$candidate" "$name" ||
+            fail "$name $mutation mutation stayed green"
+    done
+done
+
+lock="$tmp/matrix.lock"
+artifacts="$tmp/matrix-artifacts"
+exec {lock_fd}>"$lock"
+flock -n "$lock_fd"
+matrix_status=0
+RUSTBGPD_HOST_LOCK="$lock" ARTIFACTS_DIR="$artifacts" \
+    bash "$matrix" rustbgpd >"$tmp/matrix.stdout" 2>"$tmp/matrix.stderr" || matrix_status=$?
+[[ $matrix_status -eq 75 ]] || fail "held matrix lock returned $matrix_status instead of 75"
+grep -Fq 'is held by another process (soak or bench)' "$tmp/matrix.stderr" ||
+    fail 'held matrix lock omitted canonical diagnostic'
+[[ ! -e $artifacts ]] || fail 'matrix created artifacts before rejecting held host lock'
+
+printf 'PASS: shared scale host-quiet gate and destructive production seams\n'


### PR DESCRIPTION
## Summary

- add one canonical two-sample host-quiet gate for measured scale receipts, including load, swap, CPU governor, and competing-process evidence
- apply it to the IXP matrix, IRR reload, and Enhanced Route Refresh drivers, and give the matrix the shared host lock
- preserve IRR quiet.tsv compatibility while appending fail-closed governor and competitor evidence verified by destructive tests
- wire the production scripts and tests into CI and complete the scale-harness index

## Validation

- Bash syntax and CI-equivalent ShellCheck
- host-quiet fixture, mutation, and held-lock tests
- helper-produced IRR receipt accepted by validate_quiet; port, disk, swap, governor, and competitor mutations rejected
- full IRR verifier self-test and published receipt compatibility
- route-server-1000 and rrtransport destructive receipt suites
- scale-split and reloadstall emitted-contract suites
- full pre-commit and pre-push hooks
- independent exact-head review

This is the host-discipline tranche of LAN-1355; provenance and driver-consolidation follow-ups remain separate.

Linear: https://linear.app/lance0/issue/LAN-1355