### PR TITLE
feat: expose reload and policy transition outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Process-global `bgp_sighup_reload_outcomes_total{outcome}` and
+  `bgp_rib_policy_transition_total{outcome}` counters expose bounded terminal
+  results without peer, path, configuration, or error-text labels. The
+  overview dashboard groups SIGHUP results with config lifecycle activity and
+  pins policy-transition outcomes beside the existing transition state and
+  actor-duration panels.
+
 - Active-primary session telemetry now exports the exact one-hot
   `bgp_peer_session_state{peer,interface,state}` FSM vector and
   `bgp_session_down_total{peer,interface,reason}`. The down counter records

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rpki::VrpTable;
 use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_telemetry::metrics::RibPolicyTransitionOutcome;
 use rustbgpd_telemetry::metrics::StaleSessionMessageKind as Kind;
 use rustbgpd_telemetry::metrics::StaleSessionMessageKind::{
     BgpLs, Eor, Labeled, Orf, PolicyContext, Refresh, Routes, Rtc, Vpn,
@@ -2067,16 +2068,17 @@ impl RibManager {
 
     fn finish_policy_transition_observability(
         &self,
-        outcome: &'static str,
+        outcome: RibPolicyTransitionOutcome,
         member_count: usize,
         elapsed: std::time::Duration,
     ) {
         self.metrics.set_rib_policy_transition_in_progress(false);
         self.metrics
             .set_rib_policy_transition_last_duration(elapsed);
+        self.metrics.record_rib_policy_transition_outcome(outcome);
         let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
         info!(
-            outcome,
+            outcome = outcome.as_str(),
             member_count, elapsed_ms, "RIB export-policy transition completed"
         );
     }
@@ -3718,7 +3720,7 @@ impl RibManager {
                         let member_count = done.member_count();
                         Self::warn_if_policy_transition_slow(&mut done, member_count);
                         self.finish_policy_transition_observability(
-                            "committed",
+                            RibPolicyTransitionOutcome::Committed,
                             done.member_count(),
                             done.elapsed(),
                         );
@@ -3731,9 +3733,9 @@ impl RibManager {
                         let member_count = failed.member_count();
                         Self::warn_if_policy_transition_slow(&mut failed, member_count);
                         let outcome = if cleanup.is_ok() {
-                            "fallback_handoff"
+                            RibPolicyTransitionOutcome::FallbackHandoff
                         } else {
-                            "fallback_cleanup_error"
+                            RibPolicyTransitionOutcome::FallbackCleanupError
                         };
                         self.finish_policy_transition_observability(
                             outcome,

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -1403,6 +1403,23 @@ fn regroups_total(metrics: &BgpMetrics) -> f64 {
         .map_or(0.0, |family| family.metric[0].get_counter().value())
 }
 
+fn policy_transition_outcome_total(metrics: &BgpMetrics, outcome: &str) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .iter()
+        .find(|family| family.name() == "bgp_rib_policy_transition_total")
+        .and_then(|family| {
+            family.metric.iter().find(|metric| {
+                metric
+                    .label
+                    .iter()
+                    .any(|label| label.name() == "outcome" && label.value() == outcome)
+            })
+        })
+        .map_or(0.0, |metric| metric.get_counter().value())
+}
+
 /// Epsilon-compare a gauge/counter reading (clippy `float_cmp`).
 fn assert_metric(observed: f64, expected: f64, what: &str) {
     assert!(
@@ -2010,6 +2027,11 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
     assert_eq!(
         response.await.unwrap(),
         Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+    assert_metric(
+        policy_transition_outcome_total(&metrics, "committed"),
+        1.0,
+        "committed transition records exactly one terminal outcome",
     );
     let transition_hits = (ROUTE_COUNT as u64, ROUTE_COUNT as u64);
     for &peer in &peers {
@@ -2721,6 +2743,47 @@ async fn rejected_policy_transition_batches_leave_observability_idle() {
         0.0,
         "non-started batches do not create a terminal duration",
     );
+    for outcome in ["committed", "fallback_handoff", "fallback_cleanup_error"] {
+        assert_metric(
+            policy_transition_outcome_total(&metrics, outcome),
+            0.0,
+            "non-started batches do not record a transition outcome",
+        );
+    }
+}
+
+#[test]
+fn cleanup_error_transition_outcome_records_once_and_resets_gauges() {
+    let (_tx, rx) = mpsc::channel(1);
+    let metrics = BgpMetrics::new();
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    metrics.set_rib_policy_transition_in_progress(true);
+
+    manager.finish_policy_transition_observability(
+        rustbgpd_telemetry::metrics::RibPolicyTransitionOutcome::FallbackCleanupError,
+        2,
+        std::time::Duration::from_millis(7),
+    );
+
+    assert_metric(
+        policy_transition_outcome_total(&metrics, "fallback_cleanup_error"),
+        1.0,
+        "cleanup error records exactly one terminal outcome",
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_rib_policy_transition_in_progress", &[]),
+        0.0,
+        "cleanup error clears transition ownership",
+    );
+    assert_metric(
+        gauge_metric_value(
+            &metrics,
+            "bgp_rib_policy_transition_last_duration_milliseconds",
+            &[],
+        ),
+        7.0,
+        "cleanup error retains terminal duration",
+    );
 }
 
 /// An authoritative replacement batch whose caller already abandoned
@@ -3108,6 +3171,11 @@ async fn clean_policy_transition_falls_back_wholesale_on_member_ceiling_rejectio
             &[],
         ) < 987_000.0,
         "fallback must replace the retained terminal-duration sample"
+    );
+    assert_metric(
+        policy_transition_outcome_total(&metrics, "fallback_handoff"),
+        1.0,
+        "fallback handoff records exactly one terminal outcome",
     );
     apply_authoritative_policy_handoff(&tx, &peers, Some(next_policy.clone()), outcome).await;
 

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -170,6 +170,62 @@ const RIB_ACTOR_DURATION_BUCKETS: [f64; 13] = [
 /// Closed operation labels for outbound prefix-limit actor work.
 const OUTBOUND_PREFIX_LIMIT_ACTOR_OPERATIONS: [&str; 2] = ["apply", "recovery"];
 
+/// Closed outcome vocabulary for retained and dropped SIGHUP reload work.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SighupReloadOutcome {
+    Complete,
+    KnownPartial,
+    RejectedNoEffect,
+    IgnoredInFlight,
+    TaskFailed,
+}
+
+impl SighupReloadOutcome {
+    const ALL: [Self; 5] = [
+        Self::Complete,
+        Self::KnownPartial,
+        Self::RejectedNoEffect,
+        Self::IgnoredInFlight,
+        Self::TaskFailed,
+    ];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::KnownPartial => "known_partial",
+            Self::RejectedNoEffect => "rejected_no_effect",
+            Self::IgnoredInFlight => "ignored_in_flight",
+            Self::TaskFailed => "task_failed",
+        }
+    }
+}
+
+/// Closed outcome vocabulary for actor-owned RIB policy transitions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RibPolicyTransitionOutcome {
+    Committed,
+    FallbackHandoff,
+    FallbackCleanupError,
+}
+
+impl RibPolicyTransitionOutcome {
+    const ALL: [Self; 3] = [
+        Self::Committed,
+        Self::FallbackHandoff,
+        Self::FallbackCleanupError,
+    ];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Committed => "committed",
+            Self::FallbackHandoff => "fallback_handoff",
+            Self::FallbackCleanupError => "fallback_cleanup_error",
+        }
+    }
+}
+
 /// Closed subscriber vocabulary for `NETLINK_ROUTE` receive-buffer overruns.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NetlinkSubscriber {
@@ -343,6 +399,7 @@ struct BgpMetricsInner {
     session_lifecycle_source_dropped: IntCounterVec,
     grpc_authz_decisions: IntCounterVec,
     grpc_credential_reloads: IntCounterVec,
+    sighup_reload_outcomes: IntCounterVec,
     config_transaction_lifecycle: IntCounterVec,
 
     // ── Policy ──────────────────────────────────────────────────
@@ -373,6 +430,7 @@ struct BgpMetricsInner {
     rib_policy_transition_in_progress: IntGauge,
     rib_policy_transition_last_duration_milliseconds: IntGauge,
     rib_policy_transition_actor_poll_duration_seconds: HistogramVec,
+    rib_policy_transition_outcomes: IntCounterVec,
     rib_outbound_prefix_limit_actor_duration_seconds: HistogramVec,
     rib_route_refresh_actor_duration_seconds: HistogramVec,
 
@@ -992,6 +1050,17 @@ impl BgpMetrics {
             &["outcome"],
         )
         .expect("valid metric definition");
+        let sighup_reload_outcomes = IntCounterVec::new(
+            Opts::new(
+                "bgp_sighup_reload_outcomes_total",
+                "SIGHUP reload signals and retained tasks by bounded terminal outcome.",
+            ),
+            &["outcome"],
+        )
+        .expect("valid metric definition");
+        for outcome in SighupReloadOutcome::ALL {
+            sighup_reload_outcomes.with_label_values(&[outcome.as_str()]);
+        }
 
         let config_transaction_lifecycle = IntCounterVec::new(
             Opts::new(
@@ -1244,6 +1313,17 @@ impl BgpMetrics {
             &["poll_kind"],
         )
         .expect("valid metric definition");
+        let rib_policy_transition_outcomes = IntCounterVec::new(
+            Opts::new(
+                "bgp_rib_policy_transition_total",
+                "Actor-owned RIB export-policy transitions by bounded terminal outcome.",
+            ),
+            &["outcome"],
+        )
+        .expect("valid metric definition");
+        for outcome in RibPolicyTransitionOutcome::ALL {
+            rib_policy_transition_outcomes.with_label_values(&[outcome.as_str()]);
+        }
 
         let rib_outbound_prefix_limit_actor_duration_seconds = HistogramVec::new(
             HistogramOpts::new(
@@ -2390,6 +2470,9 @@ impl BgpMetrics {
             .register(Box::new(grpc_credential_reloads.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(sighup_reload_outcomes.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(config_transaction_lifecycle.clone()))
             .expect("metric not already registered");
         registry
@@ -2464,6 +2547,9 @@ impl BgpMetrics {
             .register(Box::new(
                 rib_policy_transition_actor_poll_duration_seconds.clone(),
             ))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(rib_policy_transition_outcomes.clone()))
             .expect("metric not already registered");
         registry
             .register(Box::new(
@@ -2868,6 +2954,7 @@ impl BgpMetrics {
             session_lifecycle_source_dropped,
             grpc_authz_decisions,
             grpc_credential_reloads,
+            sighup_reload_outcomes,
             config_transaction_lifecycle,
             max_prefix_usage,
             max_prefix_limit,
@@ -2892,6 +2979,7 @@ impl BgpMetrics {
             rib_policy_transition_in_progress,
             rib_policy_transition_last_duration_milliseconds,
             rib_policy_transition_actor_poll_duration_seconds,
+            rib_policy_transition_outcomes,
             rib_outbound_prefix_limit_actor_duration_seconds,
             rib_route_refresh_actor_duration_seconds,
             update_groups,
@@ -3769,6 +3857,14 @@ impl BgpMetrics {
             .inc();
     }
 
+    /// Record one SIGHUP signal disposition or retained task outcome.
+    pub fn record_sighup_reload_outcome(&self, outcome: SighupReloadOutcome) {
+        self.0
+            .sighup_reload_outcomes
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+    }
+
     /// Record a confirmed config transaction lifecycle transition.
     ///
     /// Labels are deliberately bounded:
@@ -4141,6 +4237,14 @@ impl BgpMetrics {
             "unbounded dirty-resync outcome label: {outcome:?}"
         );
         self.0.rib_dirty_resync.with_label_values(&[outcome]).inc();
+    }
+
+    /// Record one terminal actor-owned RIB export-policy transition.
+    pub fn record_rib_policy_transition_outcome(&self, outcome: RibPolicyTransitionOutcome) {
+        self.0
+            .rib_policy_transition_outcomes
+            .with_label_values(&[outcome.as_str()])
+            .inc();
     }
 
     /// Set the sampled depth of the RIB manager ingest channel.
@@ -6333,6 +6437,26 @@ mod tests {
     }
 
     #[test]
+    fn sighup_reload_outcomes_preinitialize_and_increment_exact_rows() {
+        let m = BgpMetrics::new();
+        let initial = gather_text(&m);
+        for outcome in SighupReloadOutcome::ALL {
+            assert!(initial.contains(&format!(
+                "bgp_sighup_reload_outcomes_total{{outcome=\"{}\"}} 0",
+                outcome.as_str()
+            )));
+            m.record_sighup_reload_outcome(outcome);
+        }
+        let incremented = gather_text(&m);
+        for outcome in SighupReloadOutcome::ALL {
+            assert!(incremented.contains(&format!(
+                "bgp_sighup_reload_outcomes_total{{outcome=\"{}\"}} 1",
+                outcome.as_str()
+            )));
+        }
+    }
+
+    #[test]
     fn config_transaction_lifecycle_counter_uses_bounded_labels() {
         let m = BgpMetrics::new();
         m.record_config_transaction_lifecycle("confirm", "success");
@@ -6662,6 +6786,26 @@ mod tests {
         let text = gather_text(&m);
         assert!(text.contains("bgp_rib_policy_transition_in_progress 0"));
         assert!(text.contains("bgp_rib_policy_transition_last_duration_milliseconds 1234"));
+    }
+
+    #[test]
+    fn policy_transition_outcomes_preinitialize_and_increment_exact_rows() {
+        let m = BgpMetrics::new();
+        let initial = gather_text(&m);
+        for outcome in RibPolicyTransitionOutcome::ALL {
+            assert!(initial.contains(&format!(
+                "bgp_rib_policy_transition_total{{outcome=\"{}\"}} 0",
+                outcome.as_str()
+            )));
+            m.record_rib_policy_transition_outcome(outcome);
+        }
+        let incremented = gather_text(&m);
+        for outcome in RibPolicyTransitionOutcome::ALL {
+            assert!(incremented.contains(&format!(
+                "bgp_rib_policy_transition_total{{outcome=\"{}\"}} 1",
+                outcome.as_str()
+            )));
+        }
     }
 
     #[test]

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -211,6 +211,13 @@ inside the bounded window does.
   during transitions, p99 is sparse and legitimately shows no data/NaN outside
   those windows. The >200ms view is an `increase` estimate above the exact
   `le="0.2"` histogram boundary.
+- **Policy transition outcomes** shows terminal committed, authoritative
+  fallback-handoff, and cleanup-error rates by instance. It excludes work that
+  never acquired transition ownership and non-terminal actor polls.
+- **Config lifecycle outcomes** combines config-transaction activity with the
+  bounded SIGHUP signal/task outcome rate. A recovery-fenced reload remains
+  owned rather than terminal; use the `bgp_runtime_config_settlement_*` series
+  for that state.
 - Accepted-policy age is informational and clamped at zero to tolerate clock
   correction. A static-policy deployment legitimately lets this age grow from
   boot; rejected reloads also leave the last accepted timestamp unchanged.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -546,6 +546,18 @@ the daemon, makes `/readyz` fail, rejects another persisted mutation, and exits
 error text. Per-step operational detail remains in structured
 `bucket` / `target` / `error` logs.
 
+`bgp_sighup_reload_outcomes_total{outcome}` is process-global and
+preinitializes five bounded outcomes: `complete` includes a clean no-op;
+`known_partial` means the retained task settled with an authoritative partial
+receipt; `rejected_no_effect` means it rejected before any runtime effect;
+`ignored_in_flight` counts each concurrent signal dropped while another reload
+owns the lane; and `task_failed` means the retained Tokio task itself failed.
+Recovery-fenced ownership deliberately has no outcome row because it remains
+parked. Diagnose that state with `bgp_runtime_config_settlement_active`,
+`bgp_runtime_config_settlement_elapsed_seconds`,
+`bgp_runtime_config_settlement_budget_seconds`, and
+`bgp_runtime_config_settlement_fail_stops_total`.
+
 Coordinated shutdown closes new SIGHUP and runtime-mutation admission first.
 It does not abort an already-owned reload: the daemon waits for its typed
 settlement before taking the warm checkpoint or tearing down required actors.
@@ -1035,6 +1047,7 @@ exactly under the floods these drops account for.
 | `bgp_rib_policy_transition_in_progress` | Whether the RIB actor owns an atomic export-policy transition (`1` = in progress). General RIB queries and mutations remain fenced while the dedicated core-readiness lane remains responsive |
 | `bgp_rib_policy_transition_last_duration_milliseconds` | Monotonic elapsed duration of the most recently completed atomic export-policy transition; retained across idle periods for post-event diagnosis |
 | `bgp_rib_policy_transition_actor_poll_duration_seconds{poll_kind}` | Duration of each real RIB actor transition poll. Bounded `poll_kind` values are `bounded` (chunked phase work), `prefix_snapshot` (the two complete O(table) snapshot polls), `finalize` (atomic membership/emission commit plus the global dirty/forced retry opportunity), and `commit` (bounded `CommitMembers` batches — at most eight members flushed per poll) |
+| `bgp_rib_policy_transition_total{outcome}` | Terminal actor-owned policy transitions. `committed` means the atomic cohort transition committed; `fallback_handoff` means uncommitted cleanup succeeded and authoritative per-peer apply is required; `fallback_cleanup_error` means that cleanup failed. Empty, rejected, missing, in-progress, abandoned, continued, pre-ownership, and synthetic actor-exit paths do not increment it |
 | `bgp_rib_outbound_prefix_limit_actor_duration_seconds{operation}` | Duration of complete synchronous outbound prefix-limit work on the RIB actor. The closed `operation` set is `apply` (one active transaction after its identity/epoch gates, including the live-peer precondition recheck and any successful installation) and `recovery` (one non-empty scheduled batch that replays at least one live peer/family). An apply whose live precondition recheck rejects still contributes its real scan time; discarded, missing, superseded, idempotent, and empty paths do not contribute samples |
 | `bgp_orr_input_objects{classification}` | Inputs considered by the ORR default-topology builder before NLRI deduplication. Exactly five classifications exist: `included_default`, `excluded_nondefault`, `malformed_topology`, `malformed_attribute_29`, and `default_with_ignored_flex_algo`. The Flex series is a subset of included default objects: its base object and classic metric remain usable. All series reset to zero when no vantage is configured |
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2291,8 +2291,8 @@
     {
       "id": 43,
       "type": "timeseries",
-      "title": "Config transactions",
-      "description": "bgp_config_transaction_lifecycle_total by operation/outcome as a rate: prepare/commit/confirm/rollback activity from gRPC and gNMI config sessions.",
+      "title": "Config lifecycle outcomes",
+      "description": "Config transaction lifecycle and bounded SIGHUP signal/task outcomes as rates.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -2335,6 +2335,15 @@
           "expr": "sum by (operation, outcome) (rate(bgp_config_transaction_lifecycle_total{instance=~\"$instance\"}[$__rate_interval]))",
           "legendFormat": "{{operation}}/{{outcome}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (outcome) (rate(bgp_sighup_reload_outcomes_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "sighup/{{outcome}}",
+          "refId": "B"
         }
       ]
     },
@@ -2534,7 +2543,7 @@
       "title": "Policy transition in progress",
       "description": "Current ownership state only: 1 while the RIB actor owns an export-policy transition, otherwise 0.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 132 },
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 132 },
       "fieldConfig": { "defaults": { "unit": "short", "min": 0, "max": 1 }, "overrides": [] },
       "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
       "targets": [
@@ -2551,7 +2560,7 @@
       "title": "Last completed policy transition",
       "description": "Terminal duration of the most recently completed transition. This retained sample is not the live elapsed time of an in-progress transition.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 132 },
+      "gridPos": { "h": 6, "w": 4, "x": 4, "y": 132 },
       "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
       "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
       "targets": [
@@ -2568,7 +2577,7 @@
       "title": "Policy-transition actor poll p99",
       "description": "Fifteen-minute p99 by instance, scrape job, and bounded poll kind. This is actor occupancy per poll, not total transition duration.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 132 },
+      "gridPos": { "h": 6, "w": 4, "x": 8, "y": 132 },
       "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2586,7 +2595,7 @@
       "title": "Policy-transition actor polls over 200ms",
       "description": "Fifteen-minute increase estimate for actor polls above the exact 200ms bucket boundary, preserving instance, scrape job, and poll kind.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 132 },
+      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 132 },
       "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2594,6 +2603,24 @@
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "increase(bgp_rib_policy_transition_actor_poll_duration_seconds_count{instance=~\"$instance\"}[15m]) - ignoring(le) increase(bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance=~\"$instance\",le=\"0.2\"}[15m])",
           "legendFormat": "{{instance}} {{job}} {{poll_kind}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 74,
+      "type": "timeseries",
+      "title": "Policy transition outcomes",
+      "description": "Terminal actor-owned policy transitions by instance and bounded outcome.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 132 },
+      "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (instance, outcome) (rate(bgp_rib_policy_transition_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} {{outcome}}",
           "refId": "A"
         }
       ]

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -326,6 +326,10 @@ TARGETS = {
     ("Peer administrative / session truth", "A"): (
         'bgp_peer_admin_enabled{instance=~"$instance",peer=~"$peer"}'
     ),
+    ("Config lifecycle outcomes", "B"): (
+        "sum by (outcome) (rate(bgp_sighup_reload_outcomes_total"
+        '{instance=~"$instance"}[$__rate_interval]))'
+    ),
     ("Peer administrative / session truth", "B"): (
         'bgp_peer_session_established{instance=~"$instance",peer=~"$peer"}'
     ),
@@ -365,6 +369,10 @@ TARGETS = {
         '{instance=~"$instance"}[15m]) - ignoring(le) '
         "increase(bgp_rib_policy_transition_actor_poll_duration_seconds_bucket"
         '{instance=~"$instance",le="0.2"}[15m])'
+    ),
+    ("Policy transition outcomes", "A"): (
+        "sum by (instance, outcome) (rate(bgp_rib_policy_transition_total"
+        '{instance=~"$instance"}[$__rate_interval]))'
     ),
     ("Accepted policy generation age", "A"): (
         "clamp_min(time() - bgp_policy_generation_loaded_timestamp_seconds"

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -557,8 +557,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 201:
-        raise ValueError(f"emitted metric roster changed: expected 201, got {len(inventory)}")
+    if len(inventory) != 203:
+        raise ValueError(f"emitted metric roster changed: expected 203, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,21 +47,21 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 201)
+        self.assertEqual(len(self.inventory), 203)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            188,
+            190,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
         )
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
-        self.assertEqual(len(self.dashboard_refs), 95)
+        self.assertEqual(len(self.dashboard_refs), 97)
         self.assertEqual(len(self.rule_refs), 42)
-        self.assertEqual(len(self.public_doc_refs), 190)
-        self.assertEqual(len(self.doc_refs), 190)
+        self.assertEqual(len(self.public_doc_refs), 192)
+        self.assertEqual(len(self.doc_refs), 192)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 195)
+        self.assertEqual(len(consumers), 197)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("201 emitted families", stdout.getvalue())
-        self.assertIn("190 normative-doc families", stdout.getvalue())
-        self.assertIn("195 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("203 emitted families", stdout.getvalue())
+        self.assertIn("192 normative-doc families", stdout.getvalue())
+        self.assertIn("197 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -32,8 +32,10 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
                 "bgp_evpn_nlri_discarded_total",
                 "bgp_path_attribute_discarded_total",
                 "bgp_peer_session_state",
+                "bgp_rib_policy_transition_total",
                 "bgp_session_down_total",
                 "bgp_session_lifecycle_source_dropped_total",
+                "bgp_sighup_reload_outcomes_total",
             },
         )
         self.assertEqual(removed, set())

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ use rustbgpd_mrt::{
     resolved_import_policy_digest_v1, write_warm_bundle_bounded,
 };
 use rustbgpd_rib::{RibManager, RibUpdate, WarmMrtSnapshotBudget, WarmMrtSnapshotView};
+use rustbgpd_telemetry::metrics::SighupReloadOutcome as SighupReloadMetricOutcome;
 use rustbgpd_telemetry::{BgpMetrics, init_logging};
 use rustbgpd_transport::{
     BgpListener, ListenerSocketOptions, Md5ListenerKey, TcpAoAlgorithm,
@@ -3102,6 +3103,21 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
     RIB_CHANNEL_CAPACITY
 }
 
+fn sighup_reload_metric_outcome(
+    outcome: &Result<Result<SighupAuthority, SighupReloadError>, tokio::task::JoinError>,
+) -> SighupReloadMetricOutcome {
+    match outcome {
+        Ok(Ok(authority)) => match authority.completion {
+            reload::SighupCompletion::Complete => SighupReloadMetricOutcome::Complete,
+            reload::SighupCompletion::KnownPartial { .. } => {
+                SighupReloadMetricOutcome::KnownPartial
+            }
+        },
+        Ok(Err(_)) => SighupReloadMetricOutcome::RejectedNoEffect,
+        Err(_) => SighupReloadMetricOutcome::TaskFailed,
+    }
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "runtime startup keeps listener, API, and shutdown wiring in one owner"
@@ -5270,6 +5286,7 @@ async fn run<T>(
             }
             _ = sighup.recv() => {
                 if reload_in_flight.is_some() {
+                    metrics.record_sighup_reload_outcome(SighupReloadMetricOutcome::IgnoredInFlight);
                     warn!("SIGHUP received while previous reload still in flight; ignoring");
                     continue;
                 }
@@ -5423,6 +5440,7 @@ async fn run<T>(
                 }
             } => {
                 reload_in_flight = None;
+                metrics.record_sighup_reload_outcome(sighup_reload_metric_outcome(&outcome));
                 match outcome {
                     Ok(Ok(authority)) => {
                         match &authority.completion {
@@ -5452,7 +5470,9 @@ async fn run<T>(
         .expect("runtime-config settlement wait task must not panic");
     runtime_config_lock.wait_until_drained().await;
     if let Some(handle) = reload_in_flight.take() {
-        match handle.await {
+        let outcome = handle.await;
+        metrics.record_sighup_reload_outcome(sighup_reload_metric_outcome(&outcome));
+        match outcome {
             Ok(Ok(authority)) => config = authority.runtime,
             Ok(Err(error)) => warn!(error = %error, "SIGHUP rejected during shutdown drain"),
             Err(error) => error!(error = %error, "SIGHUP task failed during shutdown drain"),
@@ -6124,6 +6144,41 @@ mod tests {
         }
         assert!(run.contains("_ = sigint.recv() => {"));
         assert!(!run.contains("tokio::signal::ctrl_c()"));
+    }
+
+    #[test]
+    fn sighup_outcome_metric_covers_every_terminal_and_drop_path_once() {
+        let source = include_str!("main.rs");
+        let production = source.split_once("\n#[cfg(test)]\nmod tests").unwrap().0;
+        let classifier = production
+            .split_once("fn sighup_reload_metric_outcome(")
+            .unwrap()
+            .1
+            .split_once("\n}\n")
+            .unwrap()
+            .0;
+        for outcome in ["Complete", "KnownPartial", "RejectedNoEffect", "TaskFailed"] {
+            assert_eq!(
+                classifier
+                    .matches(&format!("SighupReloadMetricOutcome::{outcome}"))
+                    .count(),
+                1
+            );
+        }
+        assert_eq!(
+            production
+                .matches("record_sighup_reload_outcome(sighup_reload_metric_outcome(&outcome))")
+                .count(),
+            2,
+            "normal completion and shutdown drain must each classify before consumption",
+        );
+        assert_eq!(
+            production
+                .matches("record_sighup_reload_outcome(SighupReloadMetricOutcome::IgnoredInFlight)")
+                .count(),
+            1,
+            "each dropped concurrent signal is counted at the drop site",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add bounded, preinitialized SIGHUP reload outcomes at the signal-drop and retained-task completion boundaries
- add bounded RIB policy-transition outcomes at the existing actor-owned terminal funnel
- ship exact dashboard panels, operator guidance, release notes, and consumer/inventory contracts for both families

## Validation

- telemetry 113/113 and RIB 1,241 passed with 2 intentional ignores
- focused normal, shutdown-drain, ignored-signal, committed, fallback, cleanup-error, and non-started proofs
- workspace clippy, rustdoc, metric consumer/release-note, Grafana, commit, and pre-push gates
- independent exact-head semantic and once-only review

Linear: LAN-1365, LAN-1366