### PR TITLE
bench: bind measured receipts to exact workload bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,7 @@ jobs:
           rrtransport_receipt=$(mktemp -d)
           bench/scale/rrtransport/run-receipt.sh --real-smoke "$rrtransport_receipt"
           bash bench/tests/test-rrtransport-receipt.sh
+          bash bench/tests/test-scale-provenance.sh
           cargo clippy --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml \
             --locked --all-targets -- -D warnings
           # The IRR manifest contract exercises the production rustbgpd
@@ -400,23 +401,27 @@ jobs:
           shellcheck bench/smoke-benches.sh
           bash -n bench/scale/route-server-1000/run-receipt.sh
           bash -n bench/scale/host-quiet.sh
+          bash -n bench/scale/provenance.sh
           bash -n bench/scale/matrix/run-matrix.sh
           bash -n bench/scale/irrreload/run-irr-reload.sh
           bash -n bench/scale/enhanced-route-refresh/run-receipt.sh
           bash -n bench/scale/rrtransport/run-receipt.sh
           bash -n bench/tests/test-rrtransport-receipt.sh
+          bash -n bench/tests/test-scale-provenance.sh
           bash -n bench/tests/test-route-server-1000-receipt.sh
           bash -n bench/tests/test-scale-host-quiet.sh
           bash -n bench/tests/test-vpn-query-receipt.sh
           bash -n bench/tests/test-vpn-query-campaign.sh
           bash -n bench/run-vpn-query-campaign.sh
           shellcheck bench/scale/host-quiet.sh \
+            bench/scale/provenance.sh \
             bench/scale/matrix/run-matrix.sh \
             bench/scale/irrreload/run-irr-reload.sh \
             bench/scale/route-server-1000/run-receipt.sh \
             bench/scale/enhanced-route-refresh/run-receipt.sh \
             bench/scale/rrtransport/run-receipt.sh \
             bench/tests/test-rrtransport-receipt.sh \
+            bench/tests/test-scale-provenance.sh \
             bench/tests/test-route-server-1000-receipt.sh \
             bench/tests/test-scale-host-quiet.sh
           shellcheck bench/tests/test-vpn-query-receipt.sh

--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -326,9 +326,13 @@ exit, daemon process-tree RSS > 100 GiB (cell aborted), or cell timeout
 failed or interrupted root is preserved for inspection; reruns always choose a
 fresh directory and never resume, repair, or overwrite prior evidence.
 
-The root `provenance.json` is a compact context record: exact commit and tree,
+The root schema-2 `provenance.json` is a compact context record: exact commit and tree,
 the clean-worktree result, selected workload knobs, container image IDs, and
-plain tool/platform versions. Every cell retains its generator `manifest.json`,
+plain tool/platform versions. Its exact `binaries` map binds the rustbgpd,
+reloadstall, rbgp, and rs-config-render bytes used by the campaign; the runner
+rechecks those bytes before every selected cell and before `COMPLETED`. Older
+schema-1 roots have no binary-byte identity and must be attributed only to the
+originating commit, never treated as evidence for rebuilt binaries. Every cell retains its generator `manifest.json`,
 raw rows, RSS samples, daemon and harness logs, process identity, and semantic
 summaries. The common canonical dataset digest remains explicit at the root.
 

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -41,6 +41,8 @@ REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 source "$REPO/tests/soak/host-lock.sh"
 # shellcheck disable=SC1091 # REPO is resolved dynamically above
 source "$REPO/bench/scale/host-quiet.sh"
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/bench/scale/provenance.sh"
 RSTALL="$REPO/bench/scale/reloadstall"
 HARNESS="$REPO/bench/scale/target/release/reloadstall"
 GEN="$RSTALL/gen-irr-scenario.py"
@@ -333,6 +335,24 @@ for bin in "$HARNESS" "$RBGP" "$RENDER" "$DAEMON"; do
         exit 1
     }
 done
+declare -A CAMPAIGN_BINARY_HASHES
+for relative in bench/scale/target/release/reloadstall target/release/rbgp \
+    target/release/rs-config-render target/release/rustbgpd; do
+    CAMPAIGN_BINARY_HASHES[$relative]=$(provenance_sha256_file "$REPO/$relative") || exit 1
+done
+recheck_campaign_binaries() {
+    local relative
+    for relative in "${!CAMPAIGN_BINARY_HASHES[@]}"; do
+        provenance_require_sha256 "$REPO/$relative" "${CAMPAIGN_BINARY_HASHES[$relative]}" || {
+            echo "campaign binary changed: $relative" >&2
+            return 1
+        }
+    done
+}
+COMMIT=$(git -C "$REPO" rev-parse HEAD) || exit 1
+COMMIT_TREE=$(git -C "$REPO" rev-parse 'HEAD^{tree}') || exit 1
+DIRTY=false
+[ -z "$(git -C "$REPO" status --porcelain=v1)" ] || DIRTY=true
 mkdir "$ART" || exit 1
 
 BIRD_IMAGE="bird:3.3.1"
@@ -352,11 +372,7 @@ BIRD_IMAGE_ID=$(image_id_for_cells bird "$BIRD_IMAGE") || exit 1
 OPENBGPD_IMAGE_ID=$(image_id_for_cells openbgpd "$OPENBGPD_IMAGE") || exit 1
 DOCKER_VERSION=$(docker --version)
 
-COMMIT=$(git -C "$REPO" rev-parse HEAD) || exit 1
-COMMIT_TREE=$(git -C "$REPO" rev-parse 'HEAD^{tree}') || exit 1
 CAMPAIGN_STARTED_EPOCH_NS=$(date +%s%N)
-DIRTY=false
-[ -z "$(git -C "$REPO" status --porcelain=v1)" ] || DIRTY=true
 CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg commit "$COMMIT" --arg tree "$COMMIT_TREE" --argjson dirty "$DIRTY" \
     --argjson started_at_epoch_ns "$CAMPAIGN_STARTED_EPOCH_NS" \
@@ -378,7 +394,11 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg cpu_model "$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)" \
     --arg bird_image "$BIRD_IMAGE" --arg bird_image_id "$BIRD_IMAGE_ID" \
     --arg openbgpd_image "$OPENBGPD_IMAGE" --arg openbgpd_image_id "$OPENBGPD_IMAGE_ID" \
-    '{schema:1,started_at_epoch_ns:$started_at_epoch_ns,git:{commit:$commit,tree:$tree,dirty:$dirty},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,overlap_fraction:$overlap_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
+    --arg reloadstall_sha "${CAMPAIGN_BINARY_HASHES[bench/scale/target/release/reloadstall]}" \
+    --arg rbgp_sha "${CAMPAIGN_BINARY_HASHES[target/release/rbgp]}" \
+    --arg render_sha "${CAMPAIGN_BINARY_HASHES[target/release/rs-config-render]}" \
+    --arg rustbgpd_sha "${CAMPAIGN_BINARY_HASHES[target/release/rustbgpd]}" \
+    '{schema:2,started_at_epoch_ns:$started_at_epoch_ns,git:{commit:$commit,tree:$tree,dirty:$dirty},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},binaries:{"bench/scale/target/release/reloadstall":$reloadstall_sha,"target/release/rbgp":$rbgp_sha,"target/release/rs-config-render":$render_sha,"target/release/rustbgpd":$rustbgpd_sha},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,overlap_fraction:$overlap_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
 printf '%s\n' "$CAMPAIGN_PROVENANCE" | jq -cS . >"$ART/provenance.json" || exit 1
 if [ -n "$PREFLIGHT_LOG" ]; then
     mv "$PREFLIGHT_LOG" "$ART/preflight.log" || exit 1
@@ -615,6 +635,7 @@ run_cell() {
         gen_scenario rustbgpd "$run" --render-bin "$RENDER" \
             --path-hiding true --admit-churn true || return 1
         record_dataset "$run" || return 1
+        recheck_campaign_binaries || return 1
         setsid "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
         ACTIVE_DAEMON_PID=$daemon_pid
@@ -631,6 +652,7 @@ run_cell() {
         gen_scenario "$generator_cell" "$run" --render-bin "$RENDER" \
             --path-hiding false --admit-churn true || return 1
         record_dataset "$run" || return 1
+        recheck_campaign_binaries || return 1
         setsid "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
         ACTIVE_DAEMON_PID=$daemon_pid
@@ -659,6 +681,7 @@ run_cell() {
             fi
         done
         record_dataset "$run" || return 1
+        recheck_campaign_binaries || return 1
         setsid "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
         ACTIVE_DAEMON_PID=$daemon_pid
@@ -681,6 +704,7 @@ run_cell() {
         gen_scenario bird "$run" --threads "$BIRD_THREADS" \
             --path-hiding true --admit-churn true || return 1
         record_dataset "$run" || return 1
+        recheck_campaign_binaries || return 1
         container="irr-bird"
         docker rm -f "$container" >/dev/null 2>&1
         docker run -d --name "$container" --network=host -v "$run":/etc/bird \
@@ -692,6 +716,7 @@ run_cell() {
     openbgpd)
         gen_scenario openbgpd "$run" --path-hiding true --admit-churn true || return 1
         record_dataset "$run" || return 1
+        recheck_campaign_binaries || return 1
         container="irr-obgpd"
         docker rm -f "$container" >/dev/null 2>&1
         docker run -d --name "$container" --network=host -v "$run":/etc/bgpd \
@@ -886,7 +911,9 @@ run_cell() {
 overall=0
 for cell in "${CELLS[@]}"; do
     status_file="$ART/$cell/status"
+    recheck_campaign_binaries || exit 1
     load_gate "$cell" || exit $?
+    recheck_campaign_binaries || exit 1
     echo "=== cell $cell start $(date -Is) ==="
     if run_cell "$cell"; then
         printf 'pass\n' >"$status_file"
@@ -914,6 +941,7 @@ for cell in "${CELLS[@]}"; do
 done
 echo "measurement rows: $ART/rows.csv"
 if [ "$overall" -eq 0 ]; then
+    recheck_campaign_binaries || exit 1
     jq -n --argjson completed_at_epoch_ns "$(date +%s%N)" \
         --arg cells "$(IFS=,; echo "${CELLS[*]}")" \
         '{status:"pass",completed_at_epoch_ns:$completed_at_epoch_ns,cells:$cells}' \

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -1659,6 +1659,13 @@ def validate_root(root: Path, kind: str):
     validate_preflight(root / "preflight.log")
     provenance = read_json(root / "provenance.json")
     inputs, git = provenance.get("inputs", {}), provenance.get("git", {})
+    binaries = provenance.get("binaries")
+    expected_binaries = {
+        "bench/scale/target/release/reloadstall",
+        "target/release/rbgp",
+        "target/release/rs-config-render",
+        "target/release/rustbgpd",
+    }
     expected_cells = {
         "comparison": COMPARISON_CELLS,
         "grouped": (GROUPED_CELL,),
@@ -1683,15 +1690,19 @@ def validate_root(root: Path, kind: str):
             "started_at_epoch_ns",
             "git",
             "environment",
+            "binaries",
             "inputs",
         }
-        or provenance.get("schema") != 1
+        or provenance.get("schema") != 2
         or not isinstance(provenance.get("started_at_epoch_ns"), int)
         or provenance.get("started_at_epoch_ns", -1) <= 0
         or not isinstance(environment, dict)
         or set(environment)
         != {"rustc", "cargo", "python", "jq", "docker", "kernel", "cpu_model"}
         or not all(isinstance(value, str) and value for value in environment.values())
+        or not isinstance(binaries, dict)
+        or set(binaries) != expected_binaries
+        or not all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) for value in binaries.values())
     ):
         fail(f"{root}: receipt context is incomplete")
     expected_input_keys = {
@@ -1868,6 +1879,7 @@ def validate_root(root: Path, kind: str):
         "completed": int(completed.get("completed_at_epoch_ns", -1)),
         "git": git,
         "environment": environment,
+        "binaries": binaries,
         "inputs": inputs,
         "identities": identities,
         "rows": rows_data,
@@ -1932,14 +1944,14 @@ def validate_campaigns(roots: list[Path], output_dir: Path) -> None:
         for index in range(3)
     ):
         fail("campaign roots overlap or do not finish before the next root starts")
-    source_identity = ("git", "environment")
+    source_identity = ("git", "environment", "binaries")
     if any(
         tuple(campaign[key] for key in source_identity)
         != tuple(campaigns[0][key] for key in source_identity)
         for campaign in campaigns[1:]
     ):
         fail("four roots do not share exact source and environment context")
-    repeat_identity = ("git", "environment", "inputs")
+    repeat_identity = ("git", "environment", "binaries", "inputs")
     for left, right in ((campaigns[0], campaigns[3]), (campaigns[1], campaigns[2])):
         if tuple(left[key] for key in repeat_identity) != tuple(
             right[key] for key in repeat_identity
@@ -2113,10 +2125,11 @@ def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> Non
     (root / "dataset.sha256").write_text(dataset + "\n")
     image_id = "sha256:" + "a" * 64
     provenance = {
-        "schema": 1,
+        "schema": 2,
         "started_at_epoch_ns": started,
         "git": {"commit": "c" * 40, "tree": "b" * 40, "dirty": False},
         "environment": {key: "fixture" for key in ("rustc", "cargo", "python", "jq", "docker", "kernel", "cpu_model")},
+        "binaries": {key: "d" * 64 for key in ("bench/scale/target/release/reloadstall", "target/release/rbgp", "target/release/rs-config-render", "target/release/rustbgpd")},
         "inputs": {
             **CANONICAL_FULL_INPUTS,
             "overlap_fraction": "0",
@@ -2401,7 +2414,7 @@ def self_test() -> None:
                 fail(f"pair fixture did not publish negative {name}")
             print(f"red-proof authoritative-pair-negative-{name}=pass")
         for name, mutate in (
-            ("schema", lambda value: value.update(schema=2)),
+            ("schema", lambda value: value.update(schema=1)),
             ("input", lambda value: value["inputs"].update(overlap_fraction="0.1"))):
             copied = root / f"pair-{name}"; shutil.copytree(roots[1], copied)
             value = read_json(copied / "provenance.json"); mutate(value); copied.joinpath("provenance.json").write_text(json.dumps(value))
@@ -2919,6 +2932,9 @@ def self_test() -> None:
         rejected("dirty-commit", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"dirty": True})))
         rejected("mismatched-commit", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"commit": "d" * 40})))
         rejected("commit-malformed", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"commit": "C" * 40})))
+        rejected("provenance-downgrade", lambda root: alter_json(root / "provenance.json", lambda data: data.update({"schema": 1})))
+        rejected("binary-roster", lambda root: alter_json(root / "provenance.json", lambda data: data["binaries"].pop("target/release/rbgp")))
+        rejected("binary-malformed", lambda root: alter_json(root / "provenance.json", lambda data: data["binaries"].update({"target/release/rbgp": "ABC"})))
         def change_input(root, key, value):
             alter_json(root / "provenance.json", lambda data: data["inputs"].update({key: value}))
         rejected("canonical-changed-fraction", lambda root: change_input(root, "changed_fraction", "0.2"))
@@ -3054,7 +3070,8 @@ def self_test() -> None:
             except InvalidReceipt:
                 proofs[name] = True
         grouped_pair_drift("cross-role-environment", "environment", "cpu_model", "other-platform")
-        expected = {"default-roster", "mixed-roster", "mode-flags", "topology-mutation", "barrier-marker", "final-barrier-marker", "live-topology-gauge", "route-gauge", "route-family", "one-scrape-drift", "add-path", "config-count", "dirty-commit", "mismatched-commit", "commit-malformed", "canonical-changed-fraction", "canonical-control-secs", "canonical-bird-threads", "repeat-image-identity", "nonoverlap-order", "quiet-spacing", "preflight-raw", "cell-status", "manifest-changed-fraction", "cell-root-rows", "reload-log-rows", "percentile-order", "percentile-positive", "first-generation-bound", "observer-gap-bound", "row-invariants", "rss-raw", "grouped-output-isolation", "output-exact-roster", "output-audit-call", "ordering", "reused-identity", "cross-role-environment"}
+        grouped_pair_drift("cross-root-binaries", "binaries", "target/release/rustbgpd", "e" * 64)
+        expected = {"default-roster", "mixed-roster", "mode-flags", "topology-mutation", "barrier-marker", "final-barrier-marker", "live-topology-gauge", "route-gauge", "route-family", "one-scrape-drift", "add-path", "config-count", "dirty-commit", "mismatched-commit", "commit-malformed", "provenance-downgrade", "binary-roster", "binary-malformed", "canonical-changed-fraction", "canonical-control-secs", "canonical-bird-threads", "repeat-image-identity", "nonoverlap-order", "quiet-spacing", "preflight-raw", "cell-status", "manifest-changed-fraction", "cell-root-rows", "reload-log-rows", "percentile-order", "first-generation-bound", "observer-gap-bound", "row-invariants", "rss-raw", "grouped-output-isolation", "output-exact-roster", "output-audit-call", "ordering", "reused-identity", "cross-role-environment", "cross-root-binaries"}
         expected |= {"current-down", "reestablished", "flapped", "counter-malformed", "establishment-roster", "flap-roster", "row-session-loss"}
         expected |= {"preflip-private", "lane-gauge"}
         expected |= set(

--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -50,6 +50,21 @@ resolve_competitor_image() {
 }
 
 matrix_prepare_event() { :; }
+recheck_source_git_identity() {
+    local repo=$1 provenance_file=$2 stored current_commit current_tree current_dirty=false status
+    local stored_commit stored_tree stored_dirty
+    stored=$(jq -er '[.git.commit,.git.tree,(.git.dirty|tostring)] | @tsv' "$provenance_file") || return 1
+    IFS=$'\t' read -r stored_commit stored_tree stored_dirty <<<"$stored"
+    [[ $stored_commit =~ ^[0-9a-f]{40}$ && $stored_tree =~ ^[0-9a-f]{40}$ ]] || return 1
+    [[ $stored_dirty == true || $stored_dirty == false ]] || return 1
+    current_commit=$(git -C "$repo" rev-parse 'HEAD^{commit}') || return 1
+    current_tree=$(git -C "$repo" rev-parse 'HEAD^{tree}') || return 1
+    status=$(git -C "$repo" status --porcelain=v1) || return 1
+    [ -z "$status" ] || current_dirty=true
+    [ "$stored_commit" = "$current_commit" ] &&
+        [ "$stored_tree" = "$current_tree" ] &&
+        [ "$stored_dirty" = "$current_dirty" ]
+}
 prepare_selected_cell() {
     local cell=$1 status_file=$2 quiet_file=$3
     PREPARED_IMAGE_REF=""
@@ -75,7 +90,11 @@ if [ "${1:-}" = --self-test-prepare-order ]; then
     [ "$#" -eq 4 ] || exit 2
     trace=$2 selected=$3 status=$4
     matrix_prepare_event() { printf '%s\n' "$1" >>"$trace"; }
-    recheck_cell_provenance() { matrix_prepare_event "$1:live-verify"; [ -s "$status.provenance" ]; }
+    recheck_cell_provenance() {
+        matrix_prepare_event "$1:live-verify"
+        [ -n "${MATRIX_SELF_TEST_REPO:-}" ] &&
+            recheck_source_git_identity "$MATRIX_SELF_TEST_REPO" "$status.provenance"
+    }
     resolve_competitor_image() { printf 'sha256:%064d\n' 0; }
     wait_for_rustbgpd_quiet_host() { : >"$1"; }
     prepare_selected_cell "$selected" "$status" "$status.quiet"
@@ -147,10 +166,11 @@ recheck_cell_provenance() {
         provenance_require_sha256 "$REPO/$relative" "$expected" || return 1
     done < <(jq -r '.sources.common + .sources.generator + {(.sources.reloadstall.path):.sources.reloadstall.sha256} | to_entries[] | [.key,.value] | @tsv' "$file")
     if [ "$cell" = rustbgpd ]; then
-        provenance_require_sha256 "$REPO/$(jq -r '.workload.binary' "$file")" "$(jq -r '.workload.sha256' "$file")"
+        provenance_require_sha256 "$REPO/$(jq -r '.workload.binary' "$file")" "$(jq -r '.workload.sha256' "$file")" || return 1
     else
-        [ "$(docker image inspect --format '{{.Id}}' "$(jq -r '.workload.image_ref' "$file")")" = "$(jq -r '.workload.image_id' "$file")" ]
+        [ "$(docker image inspect --format '{{.Id}}' "$(jq -r '.workload.image_ref' "$file")")" = "$(jq -r '.workload.image_id' "$file")" ] || return 1
     fi
+    recheck_source_git_identity "$REPO" "$file"
 }
 
 # run_cell <cell>: everything for one matrix cell. Nonzero return = cell

--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -25,6 +25,8 @@ REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 source "$REPO/tests/soak/host-lock.sh"
 # shellcheck disable=SC1091 # REPO is resolved dynamically above
 source "$REPO/bench/scale/host-quiet.sh"
+# shellcheck disable=SC1091 # REPO is resolved dynamically above
+source "$REPO/bench/scale/provenance.sh"
 RSTALL="$REPO/bench/scale/reloadstall"
 HARNESS="$REPO/bench/scale/target/release/reloadstall"
 SAMPLER="$REPO/bench/scale/matrix/rss-sampler.sh"
@@ -39,28 +41,129 @@ FLAPSTORM="${FLAPSTORM:-}"
 ART="${ARTIFACTS_DIR:-$REPO/bench/scale/matrix/artifacts}"
 RSS_LIMIT_KIB=$((100 * 1024 * 1024)) # abort a cell past 100 GiB
 
-acquire_rustbgpd_host_lock || exit $?
+resolve_competitor_image() {
+    local image_ref=$1
+    docker image inspect --format '{{.Id}}' "$image_ref" 2>/dev/null || {
+        docker pull "$image_ref" >/dev/null &&
+            docker image inspect --format '{{.Id}}' "$image_ref"
+    }
+}
+
+matrix_prepare_event() { :; }
+prepare_selected_cell() {
+    local cell=$1 status_file=$2 quiet_file=$3
+    PREPARED_IMAGE_REF=""
+    PREPARED_IMAGE_ID=""
+    if [ -f "$status_file" ] && grep -qx pass "$status_file"; then
+        matrix_prepare_event "$cell:resume-verify"
+        recheck_cell_provenance "$cell" || return 1
+        return 10
+    fi
+    case $cell in
+        bird) PREPARED_IMAGE_REF=bird:3.3.1 ;;
+        openbgpd) PREPARED_IMAGE_REF=openbgpd/openbgpd:9.1 ;;
+    esac
+    if [ -n "$PREPARED_IMAGE_REF" ]; then
+        matrix_prepare_event "$cell:resolve"
+        PREPARED_IMAGE_ID=$(resolve_competitor_image "$PREPARED_IMAGE_REF") || return 1
+    fi
+    matrix_prepare_event "$cell:quiet"
+    wait_for_rustbgpd_quiet_host "$quiet_file"
+}
+
+if [ "${1:-}" = --self-test-prepare-order ]; then
+    [ "$#" -eq 4 ] || exit 2
+    trace=$2 selected=$3 status=$4
+    matrix_prepare_event() { printf '%s\n' "$1" >>"$trace"; }
+    recheck_cell_provenance() { matrix_prepare_event "$1:live-verify"; [ -s "$status.provenance" ]; }
+    resolve_competitor_image() { printf 'sha256:%064d\n' 0; }
+    wait_for_rustbgpd_quiet_host() { : >"$1"; }
+    prepare_selected_cell "$selected" "$status" "$status.quiet"
+    exit $?
+fi
 
 CELLS=("$@")
 [ ${#CELLS[@]} -eq 0 ] && CELLS=(rustbgpd bird openbgpd)
+for cell in "${CELLS[@]}"; do
+    case $cell in rustbgpd | bird | openbgpd) ;; *)
+        echo "unknown cell: $cell (want rustbgpd|bird|openbgpd)" >&2; exit 2 ;;
+    esac
+done
+acquire_rustbgpd_host_lock || exit $?
 
 [ -x "$HARNESS" ] || {
     echo "missing $HARNESS - build with: cd $RSTALL && cargo build --release" >&2
     exit 1
 }
+CAPTURED_COMMIT=$(git -C "$REPO" rev-parse HEAD) || exit 1
+CAPTURED_TREE=$(git -C "$REPO" rev-parse 'HEAD^{tree}') || exit 1
+CAPTURED_DIRTY=false
+[ -z "$(git -C "$REPO" status --porcelain=v1)" ] || CAPTURED_DIRTY=true
 mkdir -p "$ART"
+
+COMMON_SOURCES=(bench/scale/provenance.sh bench/scale/matrix/run-matrix.sh
+    bench/scale/matrix/verify-provenance.py bench/scale/matrix/rss-sampler.sh
+    bench/scale/host-quiet.sh tests/soak/host-lock.sh)
+declare -A SOURCE_HASHES
+snapshot_source() {
+    local relative=$1
+    SOURCE_HASHES[$relative]=$(provenance_sha256_file "$REPO/$relative") || return 1
+}
+for relative in "${COMMON_SOURCES[@]}" bench/scale/target/release/reloadstall; do
+    snapshot_source "$relative" || { echo "cannot hash $relative" >&2; exit 1; }
+done
+
+write_cell_provenance() {
+    local cell=$1 generator=$2 workload_kind=$3 workload_name=$4 workload_hash=$5
+    local common='{}' relative
+    snapshot_source "$generator" || return 1
+    for relative in "${COMMON_SOURCES[@]}"; do
+        common=$(jq -c --arg key "$relative" --arg value "${SOURCE_HASHES[$relative]}" '. + {($key):$value}' <<<"$common") || return 1
+    done
+    local workload
+    if [ "$workload_kind" = binary ]; then
+        workload=$(jq -cn --arg binary "$workload_name" --arg sha256 "$workload_hash" '{binary:$binary,sha256:$sha256}') || return 1
+    else
+        workload=$(jq -cn --arg image_ref "$workload_name" --arg image_id "$workload_hash" '{image_ref:$image_ref,image_id:$image_id}') || return 1
+    fi
+    jq -n --arg cell "$cell" --arg commit "$CAPTURED_COMMIT" \
+        --arg tree "$CAPTURED_TREE" --argjson dirty "$CAPTURED_DIRTY" \
+        --arg toolchain "$(rustc -Vv)" --arg host "$(uname -srvmo)" \
+        --argjson common "$common" --arg generator_path "$generator" \
+        --arg generator_hash "${SOURCE_HASHES[$generator]}" \
+        --arg reloadstall_hash "${SOURCE_HASHES[bench/scale/target/release/reloadstall]}" \
+        --argjson workload "$workload" \
+        '{schema:1,cell:$cell,git:{commit:$commit,tree:$tree,dirty:$dirty},toolchain:$toolchain,host:$host,sources:{common:$common,generator:{($generator_path):$generator_hash},reloadstall:{path:"bench/scale/target/release/reloadstall",sha256:$reloadstall_hash}},workload:$workload}' \
+        >"$ART/$cell/provenance.json" || return 1
+    python3 "$REPO/bench/scale/matrix/verify-provenance.py" \
+        "$ART/$cell/provenance.json" "$cell"
+}
+
+recheck_cell_provenance() {
+    local cell=$1 relative expected
+    local file="$ART/$cell/provenance.json"
+    python3 "$REPO/bench/scale/matrix/verify-provenance.py" "$file" "$cell" || return 1
+    while IFS=$'\t' read -r relative expected; do
+        provenance_require_sha256 "$REPO/$relative" "$expected" || return 1
+    done < <(jq -r '.sources.common + .sources.generator + {(.sources.reloadstall.path):.sources.reloadstall.sha256} | to_entries[] | [.key,.value] | @tsv' "$file")
+    if [ "$cell" = rustbgpd ]; then
+        provenance_require_sha256 "$REPO/$(jq -r '.workload.binary' "$file")" "$(jq -r '.workload.sha256' "$file")"
+    else
+        [ "$(docker image inspect --format '{{.Id}}' "$(jq -r '.workload.image_ref' "$file")")" = "$(jq -r '.workload.image_id' "$file")" ]
+    fi
+}
 
 # run_cell <cell>: everything for one matrix cell. Nonzero return = cell
 # failed; the campaign moves on.
 run_cell() {
-    local cell=$1
+    local cell=$1 prepared_image_ref=${2:-} prepared_image_id=${3:-}
     local cdir="$ART/$cell"
     # Short run dir: gen-scenario.py's gRPC UDS path must fit SUN_LEN.
     local run="/tmp/ixp-$cell"
     rm -rf "$run"
     mkdir -p "$cdir" "$run"
 
-    local daemon_pid="" container="" reload_cmd="" pid_arg=""
+    local daemon_pid="" container="" reload_cmd="" pid_arg="" generator image_ref image_id workload_hash
     local live a b
     case $cell in
     rustbgpd)
@@ -68,7 +171,12 @@ run_cell() {
             echo "missing $REPO/target/release/rustbgpd (cargo build --release)" >&2
             return 1
         }
+        generator=bench/scale/reloadstall/gen-scenario.py
+        workload_hash=$(provenance_sha256_file "$REPO/target/release/rustbgpd") || return 1
+        write_cell_provenance "$cell" "$generator" binary target/release/rustbgpd "$workload_hash" || return 1
+        recheck_cell_provenance "$cell" || return 1
         python3 "$RSTALL/gen-scenario.py" "$N_PEERS" "$run" "$PORT" || return 1
+        recheck_cell_provenance "$cell" || return 1
         "$REPO/target/release/rustbgpd" "$run/config.toml" \
             >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
@@ -76,22 +184,34 @@ run_cell() {
         pid_arg=$daemon_pid # frozen recipe: real PID, SIGHUP reloads
         ;;
     bird)
+        generator=bench/scale/reloadstall/gen-bird-scenario.py
+        image_ref=$prepared_image_ref image_id=$prepared_image_id
+        [ "$image_ref" = bird:3.3.1 ] && [[ $image_id =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+        write_cell_provenance "$cell" "$generator" image "$image_ref" "$image_id" || return 1
+        recheck_cell_provenance "$cell" || return 1
         python3 "$RSTALL/gen-bird-scenario.py" "$N_PEERS" "$run" "$PORT" \
             "$BIRD_THREADS" || return 1
+        recheck_cell_provenance "$cell" || return 1
         container="ixp-bird"
         docker rm -f "$container" >/dev/null 2>&1
         docker run -d --name "$container" --network=host -v "$run":/etc/bird \
-            bird:3.3.1 bird -f -c /etc/bird/bird.conf >/dev/null || return 1
+            "$image_id" bird -f -c /etc/bird/bird.conf >/dev/null || return 1
         reload_cmd="docker exec $container birdc configure"
         live="$run/gen.conf" a="$run/gen-a.conf" b="$run/gen-b.conf"
         pid_arg=0 # the outer sampler owns RSS
         ;;
     openbgpd)
+        generator=bench/scale/reloadstall/gen-obgpd-scenario.py
+        image_ref=$prepared_image_ref image_id=$prepared_image_id
+        [ "$image_ref" = openbgpd/openbgpd:9.1 ] && [[ $image_id =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+        write_cell_provenance "$cell" "$generator" image "$image_ref" "$image_id" || return 1
+        recheck_cell_provenance "$cell" || return 1
         python3 "$RSTALL/gen-obgpd-scenario.py" "$N_PEERS" "$run" "$PORT" || return 1
+        recheck_cell_provenance "$cell" || return 1
         container="ixp-obgpd"
         docker rm -f "$container" >/dev/null 2>&1
         docker run -d --name "$container" --network=host -v "$run":/etc/bgpd \
-            openbgpd/openbgpd:9.1 >/dev/null || return 1
+            "$image_id" >/dev/null || return 1
         reload_cmd="docker exec $container bgpctl reload"
         live="$run/gen.conf" a="$run/gen-a.conf" b="$run/gen-b.conf"
         pid_arg=0
@@ -158,18 +278,21 @@ run_cell() {
     fi
     cp -r "$run" "$cdir/scenario"
     echo "cell $cell: harness rc=$rc (artifacts: $cdir)"
+    [ "$rc" -ne 0 ] || recheck_cell_provenance "$cell" || return 1
     return "$rc"
 }
 
 for cell in "${CELLS[@]}"; do
     status_file="$ART/$cell/status"
-    if [ -f "$status_file" ] && grep -qx pass "$status_file"; then
+    prepare_rc=0
+    prepare_selected_cell "$cell" "$status_file" "$ART/$cell/quiet.tsv" || prepare_rc=$?
+    if [ "$prepare_rc" -eq 10 ]; then
         echo "cell $cell: already pass, skipping (rm $status_file to rerun)"
         continue
     fi
-    wait_for_rustbgpd_quiet_host "$ART/$cell/quiet.tsv" || exit $?
+    [ "$prepare_rc" -eq 0 ] || exit "$prepare_rc"
     echo "=== cell $cell start $(date -Is) ==="
-    if run_cell "$cell"; then
+    if run_cell "$cell" "$PREPARED_IMAGE_REF" "$PREPARED_IMAGE_ID"; then
         echo pass >"$status_file"
         echo "=== cell $cell PASS $(date -Is) ==="
     else

--- a/bench/scale/matrix/verify-provenance.py
+++ b/bench/scale/matrix/verify-provenance.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+from pathlib import Path
+
+HASH = re.compile(r"[0-9a-f]{64}")
+IMAGE = re.compile(r"sha256:[0-9a-f]{64}")
+COMMON = {
+    "bench/scale/provenance.sh",
+    "bench/scale/matrix/run-matrix.sh",
+    "bench/scale/matrix/verify-provenance.py",
+    "bench/scale/matrix/rss-sampler.sh",
+    "bench/scale/host-quiet.sh",
+    "tests/soak/host-lock.sh",
+}
+GENERATORS = {
+    "rustbgpd": "bench/scale/reloadstall/gen-scenario.py",
+    "bird": "bench/scale/reloadstall/gen-bird-scenario.py",
+    "openbgpd": "bench/scale/reloadstall/gen-obgpd-scenario.py",
+}
+
+def fail(message):
+    raise ValueError(message)
+
+def hashed_map(value, expected):
+    if not isinstance(value, dict) or set(value) != expected:
+        fail("wrong source hash roster")
+    if not all(isinstance(v, str) and HASH.fullmatch(v) for v in value.values()):
+        fail("malformed source hash")
+
+def verify(path, expected_cell):
+    data = json.loads(Path(path).read_text())
+    if set(data) != {"schema", "cell", "git", "toolchain", "host", "sources", "workload"} or data["schema"] != 1:
+        fail("wrong provenance schema")
+    cell = data["cell"]
+    if cell not in GENERATORS:
+        fail("unknown cell")
+    if cell != expected_cell:
+        fail("provenance cell does not match requested cell")
+    git = data["git"]
+    if set(git) != {"commit", "tree", "dirty"} or not re.fullmatch(r"[0-9a-f]{40}", git["commit"]) or not re.fullmatch(r"[0-9a-f]{40}", git["tree"]) or not isinstance(git["dirty"], bool):
+        fail("malformed git identity")
+    if not isinstance(data["toolchain"], str) or not data["toolchain"] or not isinstance(data["host"], str) or not data["host"]:
+        fail("missing toolchain or host")
+    sources = data["sources"]
+    if set(sources) != {"common", "generator", "reloadstall"}:
+        fail("wrong source fields")
+    hashed_map(sources["common"], COMMON)
+    hashed_map(sources["generator"], {GENERATORS[cell]})
+    if set(sources["reloadstall"]) != {"path", "sha256"} or sources["reloadstall"]["path"] != "bench/scale/target/release/reloadstall" or not HASH.fullmatch(sources["reloadstall"]["sha256"]):
+        fail("malformed reloadstall identity")
+    workload = data["workload"]
+    if cell == "rustbgpd":
+        if set(workload) != {"binary", "sha256"} or workload["binary"] != "target/release/rustbgpd" or not HASH.fullmatch(workload["sha256"]):
+            fail("malformed rustbgpd workload")
+    elif set(workload) != {"image_ref", "image_id"} or workload["image_ref"] != {"bird": "bird:3.3.1", "openbgpd": "openbgpd/openbgpd:9.1"}[cell] or not IMAGE.fullmatch(workload["image_id"]):
+        fail("malformed competitor workload")
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) != 3 or sys.argv[2] not in GENERATORS:
+            fail("usage: verify-provenance.py CELL/provenance.json EXPECTED_CELL")
+        verify(sys.argv[1], sys.argv[2])
+    except (OSError, ValueError, json.JSONDecodeError, KeyError, TypeError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/bench/scale/provenance.sh
+++ b/bench/scale/provenance.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Shared byte-identity helpers for measured receipt inputs.
+
+provenance_sha256_file() {
+    local path=$1 digest
+    [ -f "$path" ] && [ ! -L "$path" ] && [ -r "$path" ] || return 1
+    digest=$(sha256sum -- "$path") || return 1
+    digest=${digest%% *}
+    [[ $digest =~ ^[0-9a-f]{64}$ ]] || return 1
+    printf '%s\n' "$digest"
+}
+
+provenance_require_sha256() {
+    local path=$1 expected=$2 actual
+    [[ $expected =~ ^[0-9a-f]{64}$ ]] || return 1
+    actual=$(provenance_sha256_file "$path") || return 1
+    [ "$actual" = "$expected" ]
+}

--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 root=$(git rev-parse --show-toplevel)
 # shellcheck disable=SC1091 # root is resolved dynamically above
 source "$root/tests/soak/host-lock.sh"
+# shellcheck disable=SC1091 # root is resolved dynamically above
+source "$root/bench/scale/provenance.sh"
 verifier="$root/bench/scale/rrtransport/verify_receipt.py"
 manifest="$root/bench/scale/rrtransport/Cargo.toml"
 binary="$root/bench/scale/target/release/rrtransport"
@@ -766,6 +768,7 @@ case ${1:-} in
     rm -rf "$receipt"
     mkdir -p "$receipt"
     tiny_binary="$root/bench/scale/target/debug/rrtransport"
+    tiny_binary_sha256=$(provenance_sha256_file "$tiny_binary") || exit 1
     run_grouped_commit_fixture "$receipt" 4 100
     printf 'observer\trss_kib\n' >"$receipt/rss.tsv"
     tiny_ready=$receipt/.startup-ready
@@ -774,6 +777,7 @@ case ${1:-} in
     launch_supervised "$receipt/harness.log" env \
       RRTRANSPORT_STARTUP_READY="$tiny_ready" RRTRANSPORT_STARTUP_GO="$tiny_go" \
       "$tiny_binary" rrtiny "$receipt"
+    provenance_require_sha256 "$tiny_binary" "$tiny_binary_sha256" || exit 1
     max_rss=0
     if ! gate_tiny_supervisor; then
       report_tiny_startup_failure "$receipt" || true
@@ -792,12 +796,13 @@ case ${1:-} in
       exit 1
     fi
     pid=
+    provenance_require_sha256 "$tiny_binary" "$tiny_binary_sha256" || exit 1
     rm -f "$tiny_ready" "$tiny_go"
     cp "$receipt/phase.json" "$receipt/phase.saved"
     python3 "$verifier" "$receipt" --write-rss "$max_rss"
     head=$(git -C "$root" rev-parse HEAD)
-    printf '{"commit":"%s","governors":["performance"],"load_before":"fixture","load_after":"fixture","pswpin_before":0,"pswpin_after":0,"pswpout_before":0,"pswpout_after":0,"rustc":"fixture","host":"fixture","competitors":[]}\n' \
-      "$head" >"$receipt/provenance.json"
+    printf '{"commit":"%s","governors":["performance"],"load_before":"fixture","load_after":"fixture","pswpin_before":0,"pswpin_after":0,"pswpout_before":0,"pswpout_after":0,"rustc":"fixture","host":"fixture","competitors":[],"rrtransport_binary_sha256":"%s"}\n' \
+      "$head" "$tiny_binary_sha256" >"$receipt/provenance.json"
     python3 "$verifier" "$receipt" --tiny
     exit
     ;;
@@ -826,6 +831,7 @@ available=$(awk '/MemAvailable:/ {print $2}' /proc/meminfo)
 
 head_before=$(git -C "$root" rev-parse HEAD)
 timeout -k 10 300 cargo build --manifest-path "$manifest" --locked --release
+binary_sha256=$(provenance_sha256_file "$binary") || exit 1
 mkdir -p "$output"; campaign_started=$SECONDS
 run_grouped_commit_fixture "$output" 1000 100000
 chmod 0444 "$output/grouped-commit.json"
@@ -842,19 +848,21 @@ for run in 1 2 3; do
   receipt="$output/run-$run"; mkdir -p "$receipt"
   cp "$output/grouped-commit.json" "$receipt/grouped-commit.json"
   printf 'observer\trss_kib\n' >"$receipt/rss.tsv"
+  provenance_require_sha256 "$binary" "$binary_sha256" || exit 1
   launch_supervised "$receipt/harness.log" timeout -k 10 300 "$binary" rr1000 "$receipt"
   wait_exe "$pid" "$(command -v timeout)"
   sampler_observation_reader=read_live_sampler_observation
   sample_supervisor "$binary" "$receipt" "$run" || exit 1
   python3 "$verifier" "$receipt" --write-rss "$max_rss"
+  provenance_require_sha256 "$binary" "$binary_sha256" || exit 1
   head_after=$(git -C "$root" rev-parse HEAD)
   [[ -z $(git -C "$root" status --porcelain) ]] || { echo "tree dirtied during run" >&2; exit 1; }
   [[ $head_before == "$head_after" ]] || { echo "HEAD changed during run" >&2; exit 1; }
   host_state after
   require_quiet after || { echo "host not quiet after attempt" >&2; exit 1; }
   [[ $before_pswpin == "$after_pswpin" && $before_pswpout == "$after_pswpout" ]] || { echo "swap I/O changed" >&2; exit 1; }
-  printf '{"commit":"%s","governors":["performance"],"load_before":"%s","load_after":"%s","pswpin_before":%s,"pswpin_after":%s,"pswpout_before":%s,"pswpout_after":%s,"rustc":"%s","host":"%s","competitors":[]}\n' \
-    "$head_before" "$before_load" "$after_load" "$before_pswpin" "$after_pswpin" "$before_pswpout" "$after_pswpout" "$(rustc -V)" "$(uname -srvmo)" >"$receipt/provenance.json"
+  printf '{"commit":"%s","governors":["performance"],"load_before":"%s","load_after":"%s","pswpin_before":%s,"pswpin_after":%s,"pswpout_before":%s,"pswpout_after":%s,"rustc":"%s","host":"%s","competitors":[],"rrtransport_binary_sha256":"%s"}\n' \
+    "$head_before" "$before_load" "$after_load" "$before_pswpin" "$after_pswpin" "$before_pswpout" "$after_pswpout" "$(rustc -V)" "$(uname -srvmo)" "$binary_sha256" >"$receipt/provenance.json"
   full_verify "$receipt"
 done
 printf 'pass\n' >"$output/COMPLETED"

--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -212,6 +212,9 @@ def verify(directory, tiny=False):
         fail("direct-PID RSS TSV checkpoints disagree")
 
     provenance = load(directory / "provenance.json")
+    binary_sha256 = provenance.get("rrtransport_binary_sha256")
+    if not isinstance(binary_sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", binary_sha256):
+        fail("rrtransport binary digest is missing or malformed")
     for key in ("commit", "governors", "load_before", "load_after"):
         if not provenance.get(key):
             fail(f"provenance {key} is missing")

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -79,7 +79,7 @@ rows=[f"127.{2+i//254}.{1+i%254}.1\t100000\t100000\t391\t0\t0\t0\t0\t100000\t7c5
 (d/"rss.json").write_text(json.dumps({"schema":2,"checkpoints":checkpoints,"process_tree_sampler_max_rss_kib":125})+"\n")
 (d/"provenance.json").write_text(json.dumps({"commit":"a"*40,"governors":["performance"],"load_before":"0.1",
  "load_after":"0.1","pswpin_before":0,"pswpin_after":0,"pswpout_before":0,"pswpout_after":0,"rustc":"rustc fixture",
- "host":"fixture","competitors":[]})+"\n")
+ "host":"fixture","competitors":[],"rrtransport_binary_sha256":"b"*64})+"\n")
 PY
 
 expect_red() {
@@ -172,6 +172,8 @@ fi
 if "$runner" --classify-rss 2097153 "$tmp/rss-over"; then echo "false green: rss ceiling" >&2; exit 1; fi
 grep -q '"root_failure":"rss_ceiling"' "$tmp/rss-over/failure.json"
 expect_red malformed-commit mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());d["commit"]="main";p.write_text(json.dumps(d))'
+expect_red missing-binary-digest mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());del d["rrtransport_binary_sha256"];p.write_text(json.dumps(d))'
+expect_red malformed-binary-digest mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());d["rrtransport_binary_sha256"]="ABC";p.write_text(json.dumps(d))'
 "$runner" --check-seam "$runner"
 cp "$runner" "$tmp/no-host-lock-call"
 # shellcheck disable=SC2016 # Exact production source text for destructive proof.

--- a/bench/tests/test-scale-host-quiet.sh
+++ b/bench/tests/test-scale-host-quiet.sh
@@ -186,13 +186,16 @@ PY
 
 check_driver_seam() {
     local driver=$1 name=$2 acquire_line quiet_line quiet_call workload workload_line
+    local prepare_call prepare_line helper_start helper_end resolve_call resolve_line
     grep -Fxq 'source "$REPO/tests/soak/host-lock.sh"' "$driver" || return 1
     grep -Fxq 'source "$REPO/bench/scale/host-quiet.sh"' "$driver" || return 1
     grep -Fxq 'acquire_rustbgpd_host_lock || exit $?' "$driver" || return 1
     case $name in
         matrix)
-            quiet_call='wait_for_rustbgpd_quiet_host "$ART/$cell/quiet.tsv" || exit $?'
-            workload_line='if run_cell "$cell"; then'
+            quiet_call='wait_for_rustbgpd_quiet_host "$quiet_file"'
+            resolve_call='PREPARED_IMAGE_ID=$(resolve_competitor_image "$PREPARED_IMAGE_REF") || return 1'
+            prepare_call='prepare_selected_cell "$cell" "$status_file" "$ART/$cell/quiet.tsv" || prepare_rc=$?'
+            workload_line='if run_cell "$cell" "$PREPARED_IMAGE_REF" "$PREPARED_IMAGE_ID"; then'
             ;;
         irrreload)
             grep -Fq 'wait_for_rustbgpd_quiet_host "$quiet"' "$driver" || return 1
@@ -210,6 +213,16 @@ check_driver_seam() {
     quiet_line=$(grep -nF "$quiet_call" "$driver" | cut -d: -f1)
     workload=$(grep -nF "$workload_line" "$driver" | head -n1 | cut -d: -f1)
     [[ -n $acquire_line && -n $quiet_line && -n $workload ]] || return 1
+    if [[ $name == matrix ]]; then
+        helper_start=$(grep -nF 'prepare_selected_cell() {' "$driver" | cut -d: -f1)
+        helper_end=$(awk -v start="$helper_start" 'NR > start && $0 == "}" { print NR; exit }' "$driver")
+        resolve_line=$(grep -nF "$resolve_call" "$driver" | cut -d: -f1)
+        prepare_line=$(grep -nF "$prepare_call" "$driver" | cut -d: -f1)
+        [[ -n $helper_start && -n $helper_end && -n $resolve_line && -n $prepare_line ]] || return 1
+        ((helper_start < resolve_line && resolve_line < quiet_line && quiet_line < helper_end &&
+            acquire_line < prepare_line && prepare_line < workload))
+        return
+    fi
     ((acquire_line < workload && quiet_line < workload))
 }
 
@@ -225,7 +238,9 @@ for spec in "$matrix:matrix" "$irrreload:irrreload" "$enhanced:enhanced"; do
             quiet-source) sed -i '\|source "$REPO/bench/scale/host-quiet.sh"|d' "$candidate" ;;
             acquire) sed -i '/acquire_rustbgpd_host_lock || exit \$?/d' "$candidate" ;;
             quiet-call)
-                if [[ $name == irrreload ]]; then
+                if [[ $name == matrix ]]; then
+                    sed -i '/wait_for_rustbgpd_quiet_host "$quiet_file"/d' "$candidate"
+                elif [[ $name == irrreload ]]; then
                     sed -i '/load_gate "$cell" || exit \$?/d' "$candidate"
                 else
                     sed -i '/wait_for_rustbgpd_quiet_host .* || exit \$?/d' "$candidate"

--- a/bench/tests/test-scale-provenance.sh
+++ b/bench/tests/test-scale-provenance.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+# shellcheck disable=SC1091
+source "$root/bench/scale/provenance.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+printf 'a\n' >"$tmp/a"
+printf 'b\n' >"$tmp/b"
+a=$(provenance_sha256_file "$tmp/a")
+[[ $a =~ ^[0-9a-f]{64}$ ]]
+provenance_require_sha256 "$tmp/a" "$a"
+if provenance_require_sha256 "$tmp/b" "$a"; then exit 1; fi
+printf 'changed\n' >"$tmp/a"
+if provenance_require_sha256 "$tmp/a" "$a"; then exit 1; fi
+if provenance_require_sha256 "$tmp/a" ABC; then exit 1; fi
+ln -s a "$tmp/link"
+if provenance_sha256_file "$tmp/link"; then exit 1; fi
+
+python3 - "$root" "$tmp" <<'PY'
+import json, pathlib, subprocess, sys
+root, tmp = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+h = "a" * 64
+common = {p: h for p in ("bench/scale/provenance.sh", "bench/scale/matrix/run-matrix.sh", "bench/scale/matrix/verify-provenance.py", "bench/scale/matrix/rss-sampler.sh", "bench/scale/host-quiet.sh", "tests/soak/host-lock.sh")}
+def value(cell="rustbgpd"):
+    generator = {"rustbgpd":"bench/scale/reloadstall/gen-scenario.py", "bird":"bench/scale/reloadstall/gen-bird-scenario.py", "openbgpd":"bench/scale/reloadstall/gen-obgpd-scenario.py"}[cell]
+    workload = {"binary":"target/release/rustbgpd", "sha256":h} if cell == "rustbgpd" else {"image_ref":{"bird":"bird:3.3.1","openbgpd":"openbgpd/openbgpd:9.1"}[cell], "image_id":"sha256:"+h}
+    return {"schema":1,"cell":cell,"git":{"commit":"b"*40,"tree":"c"*40,"dirty":False},"toolchain":"rustc","host":"host","sources":{"common":common,"generator":{generator:h},"reloadstall":{"path":"bench/scale/target/release/reloadstall","sha256":h}},"workload":workload}
+verify = root / "bench/scale/matrix/verify-provenance.py"
+def accepted(name, data, want, expected=None):
+    path=tmp/(name+".json"); path.write_text(json.dumps(data))
+    got=subprocess.run([sys.executable, str(verify), str(path), expected or data.get("cell", "rustbgpd")], capture_output=True).returncode == 0
+    assert got == want, (name, got)
+accepted("valid", value(), True)
+v=value(); del v["schema"]; accepted("missing-schema",v,False)
+v=value(); v["schema"]=0; accepted("wrong-schema",v,False)
+v=value(); v["sources"]["common"].pop("bench/scale/provenance.sh"); accepted("roster",v,False)
+v=value(); v["sources"]["common"]["bench/scale/matrix/verify-provenance.py"]="changed"; accepted("verifier-mutation",v,False)
+v=value(); v["workload"]={"binary":"target/release/rustbgpd","sha256":h,"image_id":"sha256:"+h}; accepted("oneof",v,False)
+v=value("bird"); v["workload"]["image_id"]="bird:latest"; accepted("image",v,False)
+v=value("bird"); v["workload"]["image_ref"]="bird:latest"; accepted("reference",v,False)
+accepted("cross-cell-copy", value("openbgpd"), False, "bird")
+PY
+
+# shellcheck disable=SC2016 # searching for literal shell source
+grep -Fq 'docker run -d --name "$container" --network=host' \
+  "$root/bench/scale/matrix/run-matrix.sh"
+# shellcheck disable=SC2016 # searching for literal shell source
+grep -Fq '"$image_id" bird -f' "$root/bench/scale/matrix/run-matrix.sh"
+
+trace="$tmp/prepare.trace"
+status="$tmp/status"
+"$root/bench/scale/matrix/run-matrix.sh" --self-test-prepare-order \
+  "$trace" bird "$status" >/dev/null
+[[ $(cat "$trace") == $'bird:resolve\nbird:quiet' ]]
+if grep -q openbgpd "$trace"; then exit 1; fi
+
+printf 'pass\n' >"$status"
+if "$root/bench/scale/matrix/run-matrix.sh" --self-test-prepare-order \
+  "$trace" bird "$status" >/dev/null; then
+  exit 1
+fi
+printf 'present\n' >"$status.provenance"
+resume_rc=0
+"$root/bench/scale/matrix/run-matrix.sh" --self-test-prepare-order \
+  "$trace" bird "$status" >/dev/null || resume_rc=$?
+[[ $resume_rc == 10 ]]
+[[ $(tail -n2 "$trace") == $'bird:resume-verify\nbird:live-verify' ]]
+echo "scale provenance tests pass"

--- a/bench/tests/test-scale-provenance.sh
+++ b/bench/tests/test-scale-provenance.sh
@@ -61,10 +61,45 @@ if "$root/bench/scale/matrix/run-matrix.sh" --self-test-prepare-order \
   "$trace" bird "$status" >/dev/null; then
   exit 1
 fi
-printf 'present\n' >"$status.provenance"
+
+source_repo="$tmp/source-repo"
+git init -q "$source_repo"
+git -C "$source_repo" config user.email scale-provenance@test.invalid
+git -C "$source_repo" config user.name scale-provenance-test
+printf 'source\n' >"$source_repo/input"
+git -C "$source_repo" add input
+git -C "$source_repo" commit -qm initial
+source_commit=$(git -C "$source_repo" rev-parse 'HEAD^{commit}')
+source_tree=$(git -C "$source_repo" rev-parse 'HEAD^{tree}')
+write_source_identity() {
+  jq -n --arg commit "$1" --arg tree "$2" --argjson dirty "$3" \
+    '{git:{commit:$commit,tree:$tree,dirty:$dirty}}' >"$status.provenance"
+}
+run_resume_check() {
+  MATRIX_SELF_TEST_REPO="$source_repo" \
+    "$root/bench/scale/matrix/run-matrix.sh" --self-test-prepare-order \
+      "$trace" bird "$status" >/dev/null
+}
+
+write_source_identity "$source_commit" "$source_tree" false
 resume_rc=0
-"$root/bench/scale/matrix/run-matrix.sh" --self-test-prepare-order \
-  "$trace" bird "$status" >/dev/null || resume_rc=$?
+run_resume_check || resume_rc=$?
 [[ $resume_rc == 10 ]]
 [[ $(tail -n2 "$trace") == $'bird:resume-verify\nbird:live-verify' ]]
+
+git -C "$source_repo" commit --allow-empty -qm changed-head
+if run_resume_check; then exit 1; fi
+git -C "$source_repo" reset -q --hard "$source_commit"
+
+write_source_identity "$source_commit" "$(printf 'f%.0s' {1..40})" false
+if run_resume_check; then exit 1; fi
+
+write_source_identity "$source_commit" "$source_tree" false
+printf 'dirty\n' >>"$source_repo/input"
+if run_resume_check; then exit 1; fi
+git -C "$source_repo" restore input
+
+resume_rc=0
+run_resume_check || resume_rc=$?
+[[ $resume_rc == 10 ]]
 echo "scale provenance tests pass"


### PR DESCRIPTION
## Summary

- bind every matrix receipt to the exact selected cell, workload sources, competitor reference, and resolved image identity
- bind IRR reload receipts to the exact four executed binaries and rrtransport receipts to the supervised executable bytes
- fail closed on resumed passes, source or image drift, cross-cell substitution, and artifact-root provenance mismatch
- document historical IRR schema-1 roots as attribution-only artifacts that cannot satisfy the stricter verifier, while emitting verifiable schema-2 provenance for new runs

## Verification

- `bash bench/tests/test-scale-provenance.sh`
- `bash bench/tests/test-rrtransport-receipt.sh`
- `python3 bench/scale/irrreload/verify-receipt.py self-test`
- IRR emitted-source contract: 19/19
- CI scale-split checker and six unit tests
- Bash syntax, scoped ShellCheck, Python compile, diff checks, and repository hooks

Linear: LAN-1355

No benchmark campaign or performance claim is included in this change.