### PR TITLE
docs: add v0.68 operator upgrade notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-
-- SIGHUP settlement fail-stop diagnostics now name the static reload step
-  that fenced and whether an earlier effect was accepted. Non-SIGHUP owners
-  report an explicit non-applicable step, while
-  targets, configuration contents, and raw error text remain excluded.
-
-- The July bgperf2 receipt and its documentation mirrors now preserve the raw
-  historical rows without cross-daemon rankings. A fixed target order,
-  sampler threads that continued polling across later cells, incomplete
-  competitor build provenance, and an instrumented FRR build make the former
-  margins and ratios unsupported; rustbgpd's fresh no-cache and release-only
-  repeatability receipts remain valid.
-
-- BMP per-collector queue loss now resets only the affected connection
-  generation. A full or closed live fan-out queue closes that collector's TCP
-  session without BMP Termination; the existing one-second retry reconnects,
-  replays cached Peer Up state, and runs a fresh EoR-closed Loc-RIB dump when
-  configured. Healthy collectors still receive the triggering event, and
-  `bmp_collector_drops_total{phase="fan_out",reason}` records the reset trigger
-  exactly once.
-
 ### Added
 
 - M101 adds a hosted three-node IPv4-unicast route-server receipt against
@@ -191,6 +169,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- SIGHUP settlement fail-stop diagnostics now name the static reload step
+  that fenced and whether an earlier effect was accepted. Non-SIGHUP owners
+  report an explicit non-applicable step, while
+  targets, configuration contents, and raw error text remain excluded.
+
+- The July bgperf2 receipt and its documentation mirrors now preserve the raw
+  historical rows without cross-daemon rankings. A fixed target order,
+  sampler threads that continued polling across later cells, incomplete
+  competitor build provenance, and an instrumented FRR build make the former
+  margins and ratios unsupported; rustbgpd's fresh no-cache and release-only
+  repeatability receipts remain valid.
+
+- BMP per-collector queue loss now resets only the affected connection
+  generation. A full or closed live fan-out queue closes that collector's TCP
+  session without BMP Termination; the existing one-second retry reconnects,
+  replays cached Peer Up state, and runs a fresh EoR-closed Loc-RIB dump when
+  configured. Healthy collectors still receive the triggering event, and
+  `bmp_collector_drops_total{phase="fan_out",reason}` records the reset trigger
+  exactly once.
+
 - Linux BLACKHOLE and general unicast FIB reconciliation now walks bounded,
   ordered Loc-RIB pages instead of retaining a second full route snapshot.
   Each pass has a 30-second planning ceiling and two-second query slices;
@@ -237,9 +235,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - BMPv4 Route Monitoring now follows draft-ietf-grow-bmp-tlv-21's registry:
   Group=1, VRF/Table Name=2, Stateless Parsing=3, BGP Message=4, Sequence
   Number=5, Extended Flags=6, and Timestamp=7. BMPv3 remains byte-identical.
-  Path Marking is temporarily not emitted because its active draft still
-  self-assigns type 5, which now collides with Sequence Number; it will return
-  only after a non-colliding assignment is available.
 
 - Validation-cache and generated-dataset refreshes now distinguish a departed
   or non-Established session from a timed-out state query. Ambiguous queries
@@ -286,6 +281,77 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   it through the existing bounded RIB resync cadence. Repeated requests
   coalesce, a newer registration or peer teardown reaps stale intent, and a
   closed matching channel is counted as terminal loss instead of spinning.
+
+### Changed
+
+- `bmp_source_drops_total{peer,reason}` now also counts omitted periodic
+  reports as `state_query_timeout`; the existing warning expression, severity,
+  and timing are unchanged.
+- Debug rendering of address families now uses the canonical public labels;
+  unsupported or unconfigured known pairs use the `afi_N_safi_N` fallback.
+- `bgp_outbound_route_drops_total` now counts only terminal outbound work loss;
+  temporary collision-failback ROUTE-REFRESH saturation is retained and
+  retried instead.
+
+### Removed
+
+- BMPv4 Path Marking TLV emission is temporarily removed because its draft
+  type 5 assignment conflicts with the current Route Monitoring TLV registry.
+  BMPv3 output is unaffected.
+
+### Upgrade notes
+
+- **BMPv4 collector migration:** Route Monitoring TLV type assignments changed
+  from Group `4` to `1`, VRF/Table Name `5` to `2`, Stateless Parsing `6` to
+  `3`, BGP Message `7` to `4`, Sequence Number `1` to `5`, Extended Flags `2`
+  to `6`, and Timestamp `3` to `7`. Upgrade BMPv4 collectors before rustbgpd,
+  or temporarily configure the collector with `version = 3`; BMPv3 framing is
+  byte-identical. Path Marking is not emitted until its draft receives a
+  non-conflicting type, so consumers that require it must remain on the prior
+  release or tolerate its absence.
+- **BMP source-drop accounting:** `bmp_source_drops_total` adds the bounded
+  `state_query_timeout` reason. It means one periodic report was omitted and
+  will be retried on the next tick; `channel_full` and `channel_closed` mean a
+  source-channel event or report was lost. The shipped warning rule's
+  expression, severity, and timing are unchanged, and an increment alone does
+  not prove Route Monitoring divergence or a reset; use
+  `bmp_stream_diverged` as the authoritative divergence signal.
+- **Plain eBGP export default:** non-transitive Extended Communities are now
+  filtered after export policy on plain eBGP sessions. iBGP and transparent
+  route-server-client sessions are unaffected. Set the peer-group-inheritable
+  `send_non_transitive_extended_communities = true` only when deliberate
+  propagation across the AS boundary is required.
+- **Policy mutation errors:** preflight failures that were formerly collapsed
+  to gRPC `INTERNAL` now retain `NOT_FOUND`, `INVALID_ARGUMENT`, or
+  `FAILED_PRECONDITION` as applicable. Clients should branch on the status code
+  while continuing to use the stable `policy_preflight_rejected` diagnostic.
+- **Compensated mutation errors:** a failed runtime mutation whose effects were
+  fully repaired now prefixes its message with `runtime effects were fully
+  compensated; retry may repeat transient runtime changes:` and adds the
+  `rustbgpd-runtime-config-outcome: fully-compensated` response trailer. The
+  original gRPC status code remains authoritative; retry may repeat transient
+  runtime work even though the staged persistent candidate was discarded.
+- **Address-family diagnostics:** old Debug-form family spellings in read-side
+  diagnostics are replaced by canonical labels such as `ipv4_unicast`, with a
+  `afi_N_safi_N` fallback for unsupported or unconfigured known pairs. This is
+  display-only: no persisted configuration or stored value is rewritten during
+  upgrade.
+- **Opaque attribute validation:** malformed Tunnel Encapsulation (type 23) or
+  ATTR_SET (type 128) attributes that were previously re-advertised opaquely
+  now make affected NLRI treat-as-withdraw. Monitor
+  `bgp_update_malformed_total{disposition="treat_as_withdraw"}` and correct the
+  sending peer before retrying the route.
+- **BLACKHOLE reconciliation:** bounded full-table planning can report
+  `route_churn_deferred` while route churn prevents a stable
+  snapshot. No install token is consumed and no new guarded route is installed;
+  safe exact cleanup of stale daemon-owned entries may continue. Allow a later
+  reconcile to retry after churn settles.
+- **Outbound-drop alerting:** collision-failback ROUTE-REFRESH saturation is now
+  retried and excluded from `bgp_outbound_route_drops_total`, so the unchanged
+  critical alert may fire less often. An increment still means terminal
+  outbound work loss; inspect the writer and peer, then refresh outbound if an
+  advertised view was missed. The former inbound soft-reset advice no longer
+  applies to this counter.
 
 ## [0.67.0] — 2026-08-26
 

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -107,11 +107,12 @@ with per-rule unit tests in
 The loss alerts use a 10-minute counter-increase window and clear after
 the last increment ages out:
 
-- `BgpOutboundRouteDrops` is critical because the full outbound distribution
-  channel has already discarded outbound BGP work. Inspect the peer writer,
-  daemon log, and last error to identify the failed path and correct the
-  bottleneck. Then refresh outbound for a missed advertised view, or soft reset
-  inbound for a missed inbound ROUTE-REFRESH request.
+- `BgpOutboundRouteDrops` is critical because outbound BGP work was terminally
+  lost before reaching the peer writer. Temporary collision-failback
+  ROUTE-REFRESH saturation is retained and retried, so it does not increment
+  this counter. Inspect the peer writer, daemon log, and last error to identify
+  the failed path and correct the bottleneck, then refresh outbound if the peer
+  missed an advertised view.
 - `BgpSendHoldExpired` is critical because RFC 9687 expiry has already torn
   down the session without a NOTIFICATION after the remote endpoint stopped
   draining TCP. Inspect the writer and peer before allowing the session to
@@ -127,13 +128,16 @@ the last increment ages out:
   Treat all incremental session history as potentially incomplete and
   resnapshot current neighbor state. The alert clears after the last source
   drop ages out of its 10-minute window; a flat historical counter stays quiet.
-- `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` are
-  warning severity because routing is unaffected, but the BMP mirror is now
-  lossy: a dropped per-peer event forces a synthetic PeerDown/PeerUp so
-  collectors rebuild that peer, a dropped Loc-RIB event leaves Loc-RIB
-  collectors stale until their next reconnect, and a collector-side drop
-  leaves that collector incomplete until it reconnects. Find the slow
-  consumer via `bmp_collector_drops_total` and the
+- `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` are warning
+  severity because routing is unaffected. For `BmpSourceDrops`,
+  `channel_full` and `channel_closed` mean a source-channel event or report was
+  lost, while `state_query_timeout` means one periodic report was omitted and
+  will be retried on the next tick. An increment alone does not prove that the
+  Route Monitoring stream diverged or reset; `bmp_stream_diverged` is the
+  authoritative per-peer divergence signal. A dropped Loc-RIB event leaves
+  Loc-RIB collectors stale until their next reconnect, and a collector-side
+  drop leaves that collector incomplete until it reconnects. Inspect source
+  pressure, session responsiveness, `bmp_collector_drops_total`, and the
   `bmp_loc_rib_dump_live_buffer_*` gauges.
 
 The rules intentionally alert on the exported loss counters, not adjacent

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -430,8 +430,9 @@ groups:
             dashboard p99 and transition state before retrying a reload.
 
       - alert: BgpOutboundRouteDrops
-        # A full outbound distribution channel drops BGP work instead of
-        # delaying it; the failed path can be advertisement or refresh work.
+        # This counter records terminal outbound work loss. Temporary
+        # collision-failback ROUTE-REFRESH saturation is retained and retried,
+        # so it does not increment this family.
         expr: increase(bgp_outbound_route_drops_total[10m]) > 0
         for: 0m
         labels:
@@ -442,10 +443,10 @@ groups:
             bgp_outbound_route_drops_total for peer {{ $labels.peer }} on
             {{ $labels.instance }} increased by
             {{ $value | printf "%.0f" }} in the last 10 minutes. Outbound BGP
-            work was lost before reaching the peer writer; inspect the writer,
-            peer, daemon log, and last error to identify the failed path. Once
-            healthy, refresh outbound for a missed advertised view or soft
-            reset inbound for a missed inbound ROUTE-REFRESH request.
+            work was terminally lost before reaching the peer writer; inspect
+            the writer, peer, daemon log, and last error to identify the failed
+            path. Once healthy, refresh outbound if the peer missed an
+            advertised view.
 
       - alert: BgpSendHoldExpired
         # RFC 9687 expiry means the remote peer stopped draining TCP long
@@ -593,26 +594,26 @@ groups:
 
       - alert: BmpSourceDrops
         # The per-peer PeerSession→BmpManager channel is lossy by design
-        # (it never backpressures the session). Any increment means the
-        # collectors' Adj-RIB monitoring view for this peer is now wrong;
-        # a dropped RouteMonitoring forces a synthetic PeerDown/PeerUp reset
-        # once the channel drains, so the collector rebuilds from scratch.
+        # (it never backpressures the session). channel_full/channel_closed
+        # mean a source event or report was lost. state_query_timeout means
+        # one periodic report was omitted and will be retried next tick.
         expr: increase(bmp_source_drops_total[10m]) > 0
         for: 0m
         labels:
           severity: warning
         annotations:
           summary: >-
-            BMP events dropped for {{ $labels.peer }} ({{ $labels.reason }})
+            BMP source work not delivered for {{ $labels.peer }} ({{ $labels.reason }})
           description: >-
             bmp_source_drops_total for peer {{ $labels.peer }} on
             {{ $labels.instance }} increased by
             {{ $value | printf "%.0f" }} in the last 10 minutes
-            (reason={{ $labels.reason }}). The BMP manager is not draining the
-            per-peer event channel as fast as the session produces events;
-            collectors receive a peer-state reset and rebuild this peer's view.
-            Find the slow collector via bmp_collector_drops_total and the
-            bmp_loc_rib_dump_live_buffer_* gauges.
+            (reason={{ $labels.reason }}). A channel_full or channel_closed
+            increment means a source-channel event or report was lost; a
+            state_query_timeout increment means one periodic report was
+            omitted and will be retried on the next tick. Check
+            bmp_stream_diverged for authoritative per-peer divergence, then
+            inspect source-channel pressure and session responsiveness.
 
       - alert: BmpStreamDiverged
         expr: bmp_stream_diverged == 1

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -1342,11 +1342,10 @@ tests:
               description: >-
                 bgp_outbound_route_drops_total for peer 192.0.2.40 on
                 edge1:9179 increased by 1 in the last 10 minutes. Outbound BGP
-                work was lost before reaching the peer writer; inspect the
-                writer, peer, daemon log, and last error to identify the failed
-                path. Once healthy, refresh outbound for a missed advertised
-                view or soft reset inbound for a missed inbound ROUTE-REFRESH
-                request.
+                work was terminally lost before reaching the peer writer;
+                inspect the writer, peer, daemon log, and last error to
+                identify the failed path. Once healthy, refresh outbound if
+                the peer missed an advertised view.
           - exp_labels:
               severity: critical
               peer: 192.0.2.41
@@ -1356,11 +1355,10 @@ tests:
               description: >-
                 bgp_outbound_route_drops_total for peer 192.0.2.41 on
                 edge1:9179 increased by 1 in the last 10 minutes. Outbound BGP
-                work was lost before reaching the peer writer; inspect the
-                writer, peer, daemon log, and last error to identify the failed
-                path. Once healthy, refresh outbound for a missed advertised
-                view or soft reset inbound for a missed inbound ROUTE-REFRESH
-                request.
+                work was terminally lost before reaching the peer writer;
+                inspect the writer, peer, daemon log, and last error to
+                identify the failed path. Once healthy, refresh outbound if
+                the peer missed an advertised view.
           - exp_labels:
               severity: critical
               peer: 192.0.2.42
@@ -1370,11 +1368,10 @@ tests:
               description: >-
                 bgp_outbound_route_drops_total for peer 192.0.2.42 on
                 edge1:9179 increased by 1 in the last 10 minutes. Outbound BGP
-                work was lost before reaching the peer writer; inspect the
-                writer, peer, daemon log, and last error to identify the failed
-                path. Once healthy, refresh outbound for a missed advertised
-                view or soft reset inbound for a missed inbound ROUTE-REFRESH
-                request.
+                work was terminally lost before reaching the peer writer;
+                inspect the writer, peer, daemon log, and last error to
+                identify the failed path. Once healthy, refresh outbound if
+                the peer missed an advertised view.
       - eval_time: 21m
         alertname: BgpOutboundRouteDrops
         exp_alerts: []
@@ -1574,6 +1571,8 @@ tests:
         values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
       - series: 'bmp_source_drops_total{peer="192.0.2.62", reason="channel_full", instance="edge1:9179"}'
         values: "3x22"
+      - series: 'bmp_source_drops_total{peer="192.0.2.64", reason="state_query_timeout", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
       - series: 'bgp_outbound_route_drops_total{peer="192.0.2.63", instance="edge1:9179"}'
         values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
     alert_rule_test:
@@ -1589,30 +1588,49 @@ tests:
               reason: channel_full
               instance: edge1:9179
             exp_annotations:
-              summary: "BMP events dropped for 192.0.2.60 (channel_full)"
+              summary: "BMP source work not delivered for 192.0.2.60 (channel_full)"
               description: >-
                 bmp_source_drops_total for peer 192.0.2.60 on edge1:9179
                 increased by 1 in the last 10 minutes (reason=channel_full).
-                The BMP manager is not draining the per-peer event channel as
-                fast as the session produces events; collectors receive a
-                peer-state reset and rebuild this peer's view. Find the slow
-                collector via bmp_collector_drops_total and the
-                bmp_loc_rib_dump_live_buffer_* gauges.
+                A channel_full or channel_closed increment means a
+                source-channel event or report was lost; a state_query_timeout
+                increment means one periodic report was omitted and will be
+                retried on the next tick. Check bmp_stream_diverged for
+                authoritative per-peer divergence, then inspect source-channel
+                pressure and session responsiveness.
           - exp_labels:
               severity: warning
               peer: 192.0.2.61
               reason: channel_closed
               instance: edge1:9179
             exp_annotations:
-              summary: "BMP events dropped for 192.0.2.61 (channel_closed)"
+              summary: "BMP source work not delivered for 192.0.2.61 (channel_closed)"
               description: >-
                 bmp_source_drops_total for peer 192.0.2.61 on edge1:9179
                 increased by 1 in the last 10 minutes (reason=channel_closed).
-                The BMP manager is not draining the per-peer event channel as
-                fast as the session produces events; collectors receive a
-                peer-state reset and rebuild this peer's view. Find the slow
-                collector via bmp_collector_drops_total and the
-                bmp_loc_rib_dump_live_buffer_* gauges.
+                A channel_full or channel_closed increment means a
+                source-channel event or report was lost; a state_query_timeout
+                increment means one periodic report was omitted and will be
+                retried on the next tick. Check bmp_stream_diverged for
+                authoritative per-peer divergence, then inspect source-channel
+                pressure and session responsiveness.
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.64
+              reason: state_query_timeout
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BMP source work not delivered for 192.0.2.64 (state_query_timeout)"
+              description: >-
+                bmp_source_drops_total for peer 192.0.2.64 on edge1:9179
+                increased by 1 in the last 10 minutes
+                (reason=state_query_timeout). A channel_full or channel_closed
+                increment means a source-channel event or report was lost; a
+                state_query_timeout increment means one periodic report was
+                omitted and will be retried on the next tick. Check
+                bmp_stream_diverged for authoritative per-peer divergence,
+                then inspect source-channel pressure and session
+                responsiveness.
       - eval_time: 21m
         alertname: BmpSourceDrops
         exp_alerts: []


### PR DESCRIPTION
## Summary

- add the missing v0.68 operator migration notes across nine shipped behavior changes
- correct BMP source-drop and outbound terminal-loss alert guidance without changing expressions, severity, or timing
- add reason-specific Prometheus coverage for periodic BMP state-query timeouts
- fold the Unreleased changelog into one coherent Fixed section

## Validation

- Prometheus 3.4.1: 38 rules valid and rule tests pass
- all 38 alert expressions, `for`, and severity contracts unchanged
- Grafana dashboard checker tests and live checker pass
- metric consumer, release-note, public-tracker, and release-install checks pass
- exact four-file scope, formatting, Clippy, docs, and diff checks pass
- independent exact-head review approved

Linear: LAN-1378