### PR TITLE
fix: expose dataplane reconcile planning failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `bgp_dataplane_reconcile_planning_failures_total{actor,reason}` exposes
+  bounded pre-kernel planning aborts for the general FIB and BLACKHOLE discard
+  reconcilers. Each abort emits one structured warning while preserving the
+  last successful status snapshot, ownership, unresolved/adoption bookkeeping,
+  and kernel state; general-FIB shutdown cancellation is not counted.
+
 - M101 adds a hosted three-node IPv4-unicast route-server receipt against
   checksum-built BIRD 3.3.2 and digest-pinned FRR 10.3.1. A BIRD-originated
   optional-transitive-partial type-40 attribute is pinned as the exact raw

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -457,6 +457,7 @@ struct BgpMetricsInner {
     fib_routes_rejected: IntCounterVec,
     fib_routes_unresolved: IntGauge,
     fib_kernel_failures: IntCounterVec,
+    dataplane_reconcile_planning_failures: IntCounterVec,
     kernel_route_notify_dropped: IntCounterVec,
     kernel_route_notify_subscription_failures: IntCounterVec,
     netlink_subscription_overruns: IntCounterVec,
@@ -1529,6 +1530,20 @@ impl BgpMetrics {
             &["action"],
         )
         .expect("valid metric definition");
+
+        let dataplane_reconcile_planning_failures = IntCounterVec::new(
+            Opts::new(
+                "bgp_dataplane_reconcile_planning_failures_total",
+                "Pre-kernel dataplane reconcile planning failures by actor and bounded reason.",
+            ),
+            &["actor", "reason"],
+        )
+        .expect("valid metric definition");
+        for actor in ["general_fib", "blackhole_discard"] {
+            for reason in ["send_failed", "reply_dropped", "query_failed", "timeout"] {
+                dataplane_reconcile_planning_failures.with_label_values(&[actor, reason]);
+            }
+        }
 
         let kernel_route_notify_dropped = IntCounterVec::new(
             Opts::new(
@@ -2626,6 +2641,9 @@ impl BgpMetrics {
             .register(Box::new(fib_kernel_failures.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(dataplane_reconcile_planning_failures.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(kernel_route_notify_dropped.clone()))
             .expect("metric not already registered");
         registry
@@ -3004,6 +3022,7 @@ impl BgpMetrics {
             fib_routes_rejected,
             fib_routes_unresolved,
             fib_kernel_failures,
+            dataplane_reconcile_planning_failures,
             kernel_route_notify_dropped,
             kernel_route_notify_subscription_failures,
             netlink_subscription_overruns,
@@ -4336,6 +4355,19 @@ impl BgpMetrics {
         self.0
             .fib_kernel_failures
             .with_label_values(&[action])
+            .inc();
+    }
+
+    /// Record one pre-kernel dataplane reconcile planning failure.
+    pub fn record_dataplane_reconcile_planning_failure(&self, actor: &str, reason: &str) {
+        debug_assert!(matches!(actor, "general_fib" | "blackhole_discard"));
+        debug_assert!(matches!(
+            reason,
+            "send_failed" | "reply_dropped" | "query_failed" | "timeout"
+        ));
+        self.0
+            .dataplane_reconcile_planning_failures
+            .with_label_values(&[actor, reason])
             .inc();
     }
 
@@ -6225,6 +6257,35 @@ mod tests {
             m.0.fib_kernel_failures.with_label_values(&["dump"]).get(),
             1
         );
+    }
+
+    #[test]
+    fn dataplane_planning_failure_labels_are_fully_bounded() {
+        let m = BgpMetrics::new();
+        for actor in ["general_fib", "blackhole_discard"] {
+            for reason in ["send_failed", "reply_dropped", "query_failed", "timeout"] {
+                assert_eq!(
+                    m.0.dataplane_reconcile_planning_failures
+                        .with_label_values(&[actor, reason])
+                        .get(),
+                    0
+                );
+                m.record_dataplane_reconcile_planning_failure(actor, reason);
+            }
+        }
+        let family = m
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_dataplane_reconcile_planning_failures_total")
+            .expect("planning failure family registered");
+        assert_eq!(family.get_metric().len(), 8);
+        assert!(family.get_metric().iter().all(|metric| {
+            metric
+                .get_counter()
+                .as_ref()
+                .is_some_and(|counter| (counter.value() - 1.0).abs() < f64::EPSILON)
+        }));
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -1570,8 +1570,10 @@ block is configured. `state` is a `FibRouteState` enum (`FIB_ROUTE_STATE_INSTALL
 carries values such as `owned`, `foreign_route_exists`,
 `next_hop_family_unsupported`, `peer_not_allowed`,
 `route_limit_exceeded`, `owned_route_drifted`, `next_hop_unresolved`, `dump_failed:DETAIL`,
-`rib_query_failed:DETAIL`, or a kernel apply error such as
-`install_failed:DETAIL`.
+or a kernel apply error such as `install_failed:DETAIL`. When a pre-kernel
+planning query fails, this RPC preserves the last successful status snapshot;
+use `bgp_dataplane_reconcile_planning_failures_total` and the matching
+structured warning for the current failure.
 
 `ListFibRoutesRequest` supports optional filters for `table_name`, `state`,
 `reason`, exact `prefix` + `prefix_length`, and `peer_address`; filters compose

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1503,6 +1503,7 @@ a snapshot or bounded history query.
 | `bgp_blackhole_discard_reaped_total` | Post-startup cleanup events for adopted-but-unclaimed kernel discard routes |
 | `bgp_blackhole_discard_rejected_total{reason}` | Pre-install rejection transitions; `reason` is bounded to `broad_prefix`, `not_ebgp`, `active_limit_exceeded`, or `install_rate_limited` |
 | `bgp_blackhole_discard_kernel_failures_total{action}` | Kernel-operation failure events; `action` is bounded to `setup`, `install`, `remove`, or `dump` |
+| `bgp_dataplane_reconcile_planning_failures_total{actor="blackhole_discard",reason}` | Pre-kernel planning aborts; `reason` is bounded to `send_failed`, `reply_dropped`, `query_failed`, or `timeout` |
 
 Use `rbgp rib blackholes` for the current per-prefix decision details.
 Reconcile planning is bounded to 30 seconds with two-second RIB query slices.
@@ -1533,11 +1534,22 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_fib_kernel_failures_total{action="install"}` | Kernel rejected an add operation for a reason other than a classified unresolved next hop |
 | `bgp_fib_kernel_failures_total{action="replace"}` | Kernel rejected a replace operation for a reason other than a classified unresolved next hop |
 | `bgp_fib_kernel_failures_total{action="remove"}` | Kernel rejected a remove operation |
+| `bgp_dataplane_reconcile_planning_failures_total{actor="general_fib",reason}` | Pre-kernel planning aborts; the last successful status snapshot and all kernel/ownership state remain unchanged |
 | `bgp_kernel_route_notify_dropped_total{actor,reason="channel_full"}` | Kernel route-event wake feed dropped an event before the FIB or BLACKHOLE reconciler could consume it; periodic reconcile remains the repair backstop |
 | `bgp_kernel_route_notify_subscription_failures_total{actor,group}` | The FIB or BLACKHOLE reconciler failed to subscribe to an IPv4/IPv6 route multicast group and is running with periodic-only kernel-drift repair |
 | `bgp_netlink_subscription_overruns_total{actor}` | The kernel reported a receive-buffer overrun to the `link_carrier`, `general_fib`, or `blackhole_discard` NETLINK_ROUTE actor. Each increment is one overrun notification—not a count of lost events—and proves only that one or more multicast events may have been lost |
 | `bgp_session_notification_outstanding` | Current lossless session notifications from sender entry through successful PeerManager dequeue. This includes synchronous in-flight reservations plus queued notifications; handling occurs after the value is decremented. |
 | `bgp_session_notification_outstanding_high_watermark` | Monotonic daemon-lifetime high-water mark of that outstanding population. It resets only when the daemon restarts and is not an exact per-flap or per-round peak. |
+
+Alert on recent planning aborts without assuming the status RPC was refreshed:
+
+```promql
+increase(bgp_dataplane_reconcile_planning_failures_total[10m]) > 0
+```
+
+Correlate `actor` and bounded `reason` with the structured warning; its `stage`
+field is diagnostic context, not a metric label. General-FIB shutdown
+cancellation is not counted.
 
 The three netlink-overrun series are materialized at zero. A non-zero value
 does not identify which multicast group lost events and does not prove that a

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1396,6 +1396,7 @@ short version for first deployment:
 | Routes received but not installed | `rbgp rib`, then `rbgp rib received <peer> --rejected`; for the statement-level trace, `rbgp policy explain --neighbor <peer> --prefix <CIDR>` (opt-in: needs `[policy.explain] enabled = true`) |
 | Reload didn't change behavior | `rustbgpd --diff <file>` + cross-reference [reload matrix](reload-matrix.md) |
 | FIB programming failures | `bgp_fib_kernel_failures_total` Prometheus counter + `journalctl` for `kernel-dataplane` lines |
+| FIB or BLACKHOLE planning stops before kernel access | `increase(bgp_dataplane_reconcile_planning_failures_total[10m]) > 0` + matching structured warning; status remains the last successful snapshot |
 | EVPN-specific issues | [`evpn-vtep-troubleshooting.md`](evpn-vtep-troubleshooting.md) |
 | Anything not above | [`OPERATIONS.md`](OPERATIONS.md) "Debugging" section |
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2370,8 +2370,7 @@ message FibRouteStatus {
   // "next_hop_family_unsupported", "peer_not_allowed",
   // "route_limit_exceeded", "foreign_route_exists", "owned_route_drifted",
   // and "next_hop_unresolved"; failure values are prefixed diagnostics such as
-  // "dump_failed:DETAIL",
-  // "rib_query_failed:DETAIL", "install_failed:DETAIL",
+  // "dump_failed:DETAIL", "install_failed:DETAIL",
   // "replace_failed:DETAIL", or "remove_failed:DETAIL". Treat text after
   // ':' as diagnostic detail.
   string reason = 9;

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -557,8 +557,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 203:
-        raise ValueError(f"emitted metric roster changed: expected 203, got {len(inventory)}")
+    if len(inventory) != 204:
+        raise ValueError(f"emitted metric roster changed: expected 204, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,10 +47,10 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 203)
+        self.assertEqual(len(self.inventory), 204)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            190,
+            191,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
@@ -58,10 +58,10 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 97)
         self.assertEqual(len(self.rule_refs), 42)
-        self.assertEqual(len(self.public_doc_refs), 192)
-        self.assertEqual(len(self.doc_refs), 192)
+        self.assertEqual(len(self.public_doc_refs), 193)
+        self.assertEqual(len(self.doc_refs), 193)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 197)
+        self.assertEqual(len(consumers), 198)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("203 emitted families", stdout.getvalue())
-        self.assertIn("192 normative-doc families", stdout.getvalue())
-        self.assertIn("197 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("204 emitted families", stdout.getvalue())
+        self.assertIn("193 normative-doc families", stdout.getvalue())
+        self.assertIn("198 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -30,6 +30,7 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
             added,
             {
                 "bgp_evpn_nlri_discarded_total",
+                "bgp_dataplane_reconcile_planning_failures_total",
                 "bgp_path_attribute_discarded_total",
                 "bgp_peer_session_state",
                 "bgp_rib_policy_transition_total",

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -582,7 +582,7 @@ async fn query_best_route_pages(
     rib_tx: &mpsc::Sender<RibUpdate>,
     config: BlackholeConfig,
     planning_deadline: tokio::time::Instant,
-) -> Option<(Vec<Candidate>, rustbgpd_rib::RoutePageVersion, bool)> {
+) -> Result<(Vec<Candidate>, rustbgpd_rib::RoutePageVersion, bool), &'static str> {
     let mut after = None;
     let mut derived = Vec::new();
     let mut first_version = None;
@@ -590,7 +590,7 @@ async fn query_best_route_pages(
     loop {
         let deadline = planning_request_deadline(planning_deadline);
         if tokio::time::Instant::now() >= deadline {
-            return None;
+            return Err("timeout");
         }
         let (reply, rx) = oneshot::channel();
         let query = async {
@@ -601,10 +601,14 @@ async fn query_best_route_pages(
                     reply,
                 })
                 .await
-                .map_err(|_| ())?;
-            rx.await.map_err(|_| ())?.map_err(|_| ())
+                .map_err(|_| "send_failed")?;
+            rx.await
+                .map_err(|_| "reply_dropped")?
+                .map_err(|_| "query_failed")
         };
-        let page = tokio::time::timeout_at(deadline, query).await.ok()?.ok()?;
+        let page = tokio::time::timeout_at(deadline, query)
+            .await
+            .map_err(|_| "timeout")??;
         if let Some(first) = first_version {
             churned |= first != page.observed_version;
         } else {
@@ -613,7 +617,7 @@ async fn query_best_route_pages(
         derived.extend(derive_desired(config, &page.routes));
         match page.next_cursor {
             Some(cursor) => after = Some(cursor),
-            None => return Some((derived, first_version?, churned)),
+            None => return Ok((derived, first_version.ok_or("query_failed")?, churned)),
         }
     }
 }
@@ -622,7 +626,7 @@ async fn exact_best_routes(
     rib_tx: &mpsc::Sender<RibUpdate>,
     prefixes: Vec<Prefix>,
     planning_deadline: tokio::time::Instant,
-) -> Option<(Vec<Option<Route>>, rustbgpd_rib::RoutePageVersion, bool)> {
+) -> Result<(Vec<Option<Route>>, rustbgpd_rib::RoutePageVersion, bool), &'static str> {
     let mut routes = Vec::with_capacity(prefixes.len());
     let mut version = None;
     let mut churned = false;
@@ -637,10 +641,14 @@ async fn exact_best_routes(
                     reply,
                 })
                 .await
-                .map_err(|_| ())?;
-            rx.await.map_err(|_| ())?.map_err(|_| ())
+                .map_err(|_| "send_failed")?;
+            rx.await
+                .map_err(|_| "reply_dropped")?
+                .map_err(|_| "query_failed")
         };
-        let exact = tokio::time::timeout_at(deadline, query).await.ok()?.ok()?;
+        let exact = tokio::time::timeout_at(deadline, query)
+            .await
+            .map_err(|_| "timeout")??;
         if let Some(first) = version {
             churned |= first != exact.observed_version;
         } else {
@@ -648,23 +656,27 @@ async fn exact_best_routes(
         }
         routes.extend(exact.routes);
     }
-    Some((routes, version?, churned))
+    Ok((routes, version.ok_or("query_failed")?, churned))
 }
 
 async fn query_dataplane_versions(
     rib_tx: &mpsc::Sender<RibUpdate>,
     planning_deadline: tokio::time::Instant,
-) -> Option<rustbgpd_rib::DataplaneVersions> {
+) -> Result<rustbgpd_rib::DataplaneVersions, &'static str> {
     let deadline = planning_request_deadline(planning_deadline);
     let (reply, rx) = oneshot::channel();
     let query = async {
         rib_tx
             .send(RibUpdate::QueryDataplaneVersions { deadline, reply })
             .await
-            .map_err(|_| ())?;
-        rx.await.map_err(|_| ())?.map_err(|_| ())
+            .map_err(|_| "send_failed")?;
+        rx.await
+            .map_err(|_| "reply_dropped")?
+            .map_err(|_| "query_failed")
     };
-    tokio::time::timeout_at(deadline, query).await.ok()?.ok()
+    tokio::time::timeout_at(deadline, query)
+        .await
+        .map_err(|_| "timeout")?
 }
 
 #[expect(
@@ -682,11 +694,20 @@ async fn reconcile_once<F>(
     F: BlackholeFib,
 {
     let planning_deadline = tokio::time::Instant::now() + PLANNING_TIMEOUT;
-    let Some((mut derived, first_version, mut churned)) =
-        query_best_route_pages(rib_tx, config, planning_deadline).await
-    else {
-        return;
-    };
+    let (mut derived, first_version, mut churned) =
+        match query_best_route_pages(rib_tx, config, planning_deadline).await {
+            Ok(result) => result,
+            Err(reason) => {
+                metrics.record_dataplane_reconcile_planning_failure("blackhole_discard", reason);
+                warn!(
+                    actor = "blackhole_discard",
+                    reason,
+                    stage = "route_pages",
+                    "dataplane reconcile planning failed"
+                );
+                return;
+            }
+        };
     let provisional_desired: HashSet<Prefix> = derived
         .iter()
         .filter(|candidate| candidate.installable)
@@ -703,11 +724,21 @@ async fn reconcile_once<F>(
         .into_iter()
         .collect();
     if !protected.is_empty() {
-        let Some((exact, exact_version, exact_churn)) =
-            exact_best_routes(rib_tx, protected, planning_deadline).await
-        else {
-            return;
-        };
+        let (exact, exact_version, exact_churn) =
+            match exact_best_routes(rib_tx, protected, planning_deadline).await {
+                Ok(result) => result,
+                Err(reason) => {
+                    metrics
+                        .record_dataplane_reconcile_planning_failure("blackhole_discard", reason);
+                    warn!(
+                        actor = "blackhole_discard",
+                        reason,
+                        stage = "exact_routes",
+                        "dataplane reconcile planning failed"
+                    );
+                    return;
+                }
+            };
         churned |= exact_churn || exact_version != first_version;
         for route in exact.into_iter().flatten() {
             if let Some(candidate) = derive_desired(config, std::slice::from_ref(&route))
@@ -719,8 +750,18 @@ async fn reconcile_once<F>(
             }
         }
     }
-    let Some(seal) = query_dataplane_versions(rib_tx, planning_deadline).await else {
-        return;
+    let seal = match query_dataplane_versions(rib_tx, planning_deadline).await {
+        Ok(seal) => seal,
+        Err(reason) => {
+            metrics.record_dataplane_reconcile_planning_failure("blackhole_discard", reason);
+            warn!(
+                actor = "blackhole_discard",
+                reason,
+                stage = "version_seal",
+                "dataplane reconcile planning failed"
+            );
+            return;
+        }
     };
     churned |= seal.routes != first_version;
     let guarded_churn = churned
@@ -742,6 +783,13 @@ async fn reconcile_once<F>(
     let mut current_rejected = HashSet::new();
 
     if tokio::time::Instant::now() >= planning_deadline {
+        metrics.record_dataplane_reconcile_planning_failure("blackhole_discard", "timeout");
+        warn!(
+            actor = "blackhole_discard",
+            reason = "timeout",
+            stage = "post_seal",
+            "dataplane reconcile planning failed"
+        );
         return;
     }
 
@@ -2003,15 +2051,33 @@ pub(super) mod tests {
         }));
     }
 
+    #[derive(Clone, Copy)]
+    enum PlanningFailure {
+        Send,
+        Page,
+        Exact,
+        Seal,
+    }
+
+    impl PlanningFailure {
+        const fn reason(self) -> &'static str {
+            match self {
+                Self::Send => "send_failed",
+                Self::Page => "reply_dropped",
+                Self::Exact => "query_failed",
+                Self::Seal => "timeout",
+            }
+        }
+    }
+
     #[tokio::test]
     async fn page_exact_and_seal_failures_leave_blackhole_state_unpublished_and_untouched() {
-        #[derive(Clone, Copy)]
-        enum Failure {
-            Page,
-            Exact,
-            Seal,
-        }
-        for failure in [Failure::Page, Failure::Exact, Failure::Seal] {
+        for failure in [
+            PlanningFailure::Send,
+            PlanningFailure::Page,
+            PlanningFailure::Exact,
+            PlanningFailure::Seal,
+        ] {
             let prefix = v4(32);
             let desired = route(
                 prefix,
@@ -2023,21 +2089,26 @@ pub(super) mod tests {
             let cursor_route = route(cursor, RouteOrigin::Ebgp, Vec::new());
             let (rib_tx, mut rib_rx) = mpsc::channel(8);
             tokio::spawn(async move {
+                if matches!(failure, PlanningFailure::Send) {
+                    drop(rib_rx);
+                    return;
+                }
                 let mut page_calls = 0usize;
                 while let Some(update) = rib_rx.recv().await {
                     match update {
                         RibUpdate::QueryBestRoutesPage { reply, .. } => {
                             page_calls += 1;
-                            if matches!(failure, Failure::Page) && page_calls == 2 {
+                            if matches!(failure, PlanningFailure::Page) && page_calls == 2 {
                                 drop(reply);
                             } else {
-                                let (routes, next_cursor) = if matches!(failure, Failure::Page) {
-                                    (vec![cursor_route.clone()], Some(cursor))
-                                } else if matches!(failure, Failure::Seal) {
-                                    (vec![desired.clone()], None)
-                                } else {
-                                    (Vec::new(), None)
-                                };
+                                let (routes, next_cursor) =
+                                    if matches!(failure, PlanningFailure::Page) {
+                                        (vec![cursor_route.clone()], Some(cursor))
+                                    } else if matches!(failure, PlanningFailure::Seal) {
+                                        (vec![desired.clone()], None)
+                                    } else {
+                                        (Vec::new(), None)
+                                    };
                                 let _ = reply.send(Ok(rustbgpd_rib::BestRoutesPage {
                                     routes,
                                     next_cursor,
@@ -2046,12 +2117,16 @@ pub(super) mod tests {
                             }
                         }
                         RibUpdate::QueryBestRoutesExact { reply, .. } => {
-                            if matches!(failure, Failure::Exact) {
-                                drop(reply);
+                            if matches!(failure, PlanningFailure::Exact) {
+                                let _ = reply.send(Err(
+                                    rustbgpd_rib::DataplaneExactQueryError::BudgetExceeded,
+                                ));
                             }
                         }
                         RibUpdate::QueryDataplaneVersions { reply, .. } => {
-                            if matches!(failure, Failure::Seal) {
+                            if matches!(failure, PlanningFailure::Seal) {
+                                tokio::time::sleep(RIB_QUERY_TIMEOUT + Duration::from_millis(10))
+                                    .await;
                                 drop(reply);
                             }
                         }
@@ -2059,6 +2134,9 @@ pub(super) mod tests {
                     }
                 }
             });
+            if matches!(failure, PlanningFailure::Send) {
+                rib_tx.closed().await;
+            }
             let metrics = BgpMetrics::with_registry(Registry::new());
             let sentinel = vec![BlackholeStatus {
                 prefix,
@@ -2091,6 +2169,7 @@ pub(super) mod tests {
             assert!(state.adoption.swept && state.adoption.pending.is_empty());
             assert_eq!(*status_rx.borrow(), sentinel);
             assert!(gauge_value(&metrics, "bgp_blackhole_discard_active").abs() < f64::EPSILON);
+            assert_planning_failure_value(&metrics, "blackhole_discard", failure.reason(), 1.0);
         }
     }
 
@@ -2158,6 +2237,7 @@ pub(super) mod tests {
         assert!(fib.install_calls.is_empty() && fib.remove_calls.is_empty());
         assert!(state.owned.is_empty() && state.ownership.prefixes.is_empty());
         assert_eq!(*status_rx.borrow(), sentinel);
+        assert_planning_failure_value(&test_metrics, "blackhole_discard", "timeout", 1.0);
     }
 
     fn rib_with_routes(routes: Vec<Route>) -> mpsc::Sender<RibUpdate> {
@@ -2393,6 +2473,48 @@ pub(super) mod tests {
                 })
             })
             .unwrap_or(0.0)
+    }
+
+    fn planning_failure_value(metrics: &BgpMetrics, actor: &str, reason: &str) -> f64 {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_dataplane_reconcile_planning_failures_total")
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .iter()
+                    .find(|metric| {
+                        let labels: HashMap<_, _> = metric
+                            .get_label()
+                            .iter()
+                            .map(|label| (label.name(), label.value()))
+                            .collect();
+                        labels.get("actor") == Some(&actor) && labels.get("reason") == Some(&reason)
+                    })
+                    .cloned()
+            })
+            .and_then(|metric| {
+                metric
+                    .get_counter()
+                    .as_ref()
+                    .map(prometheus::proto::Counter::value)
+            })
+            .unwrap_or(0.0)
+    }
+
+    fn assert_planning_failure_value(
+        metrics: &BgpMetrics,
+        actor: &str,
+        reason: &str,
+        expected: f64,
+    ) {
+        let actual = planning_failure_value(metrics, actor, reason);
+        assert!(
+            (actual - expected).abs() < f64::EPSILON,
+            "expected {expected}, got {actual} for {actor}/{reason}"
+        );
     }
 
     fn gauge_value(metrics: &BgpMetrics, name: &str) -> f64 {

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -928,7 +928,16 @@ where
             result = query_peer_groups_versioned(rib_query_tx, planning_deadline) => result,
         } {
             Ok(groups) => groups,
-            Err(_) => return false,
+            Err(reason) => {
+                metrics.record_dataplane_reconcile_planning_failure("general_fib", reason);
+                warn!(
+                    actor = "general_fib",
+                    reason,
+                    stage = "peer_groups",
+                    "dataplane reconcile planning failed"
+                );
+                return false;
+            }
         }
     } else {
         (BTreeMap::new(), rustbgpd_rib::RoutePageVersion::default())
@@ -942,7 +951,11 @@ where
             config.link_bandwidth_weighted, planning_deadline, &mut builder,
         ) => match result {
             Ok(result) => result,
-            Err(_) => return false,
+            Err(reason) => {
+                metrics.record_dataplane_reconcile_planning_failure("general_fib", reason);
+                warn!(actor = "general_fib", reason, stage = "route_pages", "dataplane reconcile planning failed");
+                return false;
+            }
         },
     };
     let mut intent = builder.finish();
@@ -960,19 +973,32 @@ where
     let mut exact_restored_keys = BTreeSet::new();
     if !absent_prefixes.is_empty() {
         let mut exact_builder = FibIntentBuilder::new(&config.tables, &peer_groups);
-        let Ok((exact_version, exact_churn)) = query_fib_exact(
-            rib_query_tx,
-            absent_prefixes,
-            max_install_paths(config),
-            config.multipath_relax,
-            config.link_bandwidth_weighted,
-            planning_deadline,
-            &mut exact_builder,
-            &mut exact_present,
-        )
-        .await
-        else {
-            return false;
+        let result = tokio::select! {
+            biased;
+            () = shutdown.cancelled() => return false,
+            result = query_fib_exact(
+                rib_query_tx,
+                absent_prefixes,
+                max_install_paths(config),
+                config.multipath_relax,
+                config.link_bandwidth_weighted,
+                planning_deadline,
+                &mut exact_builder,
+                &mut exact_present,
+            ) => result,
+        };
+        let (exact_version, exact_churn) = match result {
+            Ok(result) => result,
+            Err(reason) => {
+                metrics.record_dataplane_reconcile_planning_failure("general_fib", reason);
+                warn!(
+                    actor = "general_fib",
+                    reason,
+                    stage = "exact_routes",
+                    "dataplane reconcile planning failed"
+                );
+                return false;
+            }
         };
         route_churn |= exact_churn || exact_version != first_route_version;
         let exact_intent = exact_builder.finish();
@@ -987,8 +1013,22 @@ where
             .frozen_eligible_keys
             .extend(exact_intent.frozen_eligible_keys);
     }
-    let Ok(seal) = query_versions(rib_query_tx, planning_deadline).await else {
-        return false;
+    let seal = match tokio::select! {
+        biased;
+        () = shutdown.cancelled() => return false,
+        result = query_versions(rib_query_tx, planning_deadline) => result,
+    } {
+        Ok(seal) => seal,
+        Err(reason) => {
+            metrics.record_dataplane_reconcile_planning_failure("general_fib", reason);
+            warn!(
+                actor = "general_fib",
+                reason,
+                stage = "version_seal",
+                "dataplane reconcile planning failed"
+            );
+            return false;
+        }
     };
     route_churn |= seal.routes != first_route_version;
     let peer_group_churn = config
@@ -1016,6 +1056,13 @@ where
         }
     }
     if tokio::time::Instant::now() >= planning_deadline {
+        metrics.record_dataplane_reconcile_planning_failure("general_fib", "timeout");
+        warn!(
+            actor = "general_fib",
+            reason = "timeout",
+            stage = "post_seal",
+            "dataplane reconcile planning failed"
+        );
         return false;
     }
     let kernel = tokio::select! {
@@ -3763,6 +3810,48 @@ mod tests {
             })
     }
 
+    fn planning_failure_value(metrics: &BgpMetrics, actor: &str, reason: &str) -> f64 {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_dataplane_reconcile_planning_failures_total")
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .iter()
+                    .find(|metric| {
+                        let labels: BTreeMap<_, _> = metric
+                            .get_label()
+                            .iter()
+                            .map(|label| (label.name(), label.value()))
+                            .collect();
+                        labels.get("actor") == Some(&actor) && labels.get("reason") == Some(&reason)
+                    })
+                    .cloned()
+            })
+            .and_then(|metric| {
+                metric
+                    .get_counter()
+                    .as_ref()
+                    .map(prometheus::proto::Counter::value)
+            })
+            .unwrap_or(0.0)
+    }
+
+    fn assert_planning_failure_value(
+        metrics: &BgpMetrics,
+        actor: &str,
+        reason: &str,
+        expected: f64,
+    ) {
+        let actual = planning_failure_value(metrics, actor, reason);
+        assert!(
+            (actual - expected).abs() < f64::EPSILON,
+            "expected {expected}, got {actual} for {actor}/{reason}"
+        );
+    }
+
     #[cfg(target_os = "linux")]
     fn netlink_error(raw_errno: i32) -> rtnetlink::Error {
         let mut message = rtnetlink::packet_core::ErrorMessage::default();
@@ -5174,6 +5263,10 @@ mod tests {
             let version = rustbgpd_rib::RoutePageVersion::default();
             let (rib_tx, mut rib_rx) = mpsc::channel(8);
             tokio::spawn(async move {
+                if matches!(failure, Failure::Groups) {
+                    drop(rib_rx);
+                    return;
+                }
                 let mut page_calls = 0usize;
                 while let Some(update) = rib_rx.recv().await {
                     match update {
@@ -5210,11 +5303,15 @@ mod tests {
                         }
                         RibUpdate::QueryFibInstallCandidatesExact { reply, .. } => {
                             if matches!(failure, Failure::Exact) {
-                                drop(reply);
+                                let _ = reply.send(Err(
+                                    rustbgpd_rib::DataplaneExactQueryError::BudgetExceeded,
+                                ));
                             }
                         }
                         RibUpdate::QueryDataplaneVersions { reply, .. } => {
                             if matches!(failure, Failure::Seal) {
+                                tokio::time::sleep(RIB_QUERY_TIMEOUT + Duration::from_millis(10))
+                                    .await;
                                 drop(reply);
                             }
                         }
@@ -5222,6 +5319,9 @@ mod tests {
                     }
                 }
             });
+            if matches!(failure, Failure::Groups) {
+                rib_tx.closed().await;
+            }
             let mut group_table = table("edge", 1000, 200, &["ipv4_unicast"]);
             group_table.allowed_peer_groups = vec!["edge".to_string()];
             let config = config_with(vec![group_table]);
@@ -5240,6 +5340,7 @@ mod tests {
             let (status_tx, status_rx) = watch::channel(sentinel.clone());
             let (event_tx, mut event_rx) = broadcast::channel(16);
             let mut fib = FakeFib::default();
+            let test_metrics = metrics();
             fib.kernel.routes.insert(
                 owned_route.key,
                 FibKernelRoute {
@@ -5253,7 +5354,7 @@ mod tests {
                     &config,
                     &rib_tx,
                     &mut fib,
-                    &metrics(),
+                    &test_metrics,
                     &status_tx,
                     &event_tx,
                     &mut owned,
@@ -5269,6 +5370,109 @@ mod tests {
             assert_eq!(unresolved, unresolved_before);
             assert_eq!(*status_rx.borrow(), sentinel);
             assert!(event_rx.try_recv().is_err());
+            let reason = match failure {
+                Failure::Groups => "send_failed",
+                Failure::Page => "reply_dropped",
+                Failure::Exact => "query_failed",
+                Failure::Seal => "timeout",
+            };
+            assert_planning_failure_value(&test_metrics, "general_fib", reason, 1.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancellation_is_not_a_planning_failure() {
+        #[derive(Clone, Copy)]
+        enum Stage {
+            Entry,
+            Exact,
+            Seal,
+        }
+        for stage in [Stage::Entry, Stage::Exact, Stage::Seal] {
+            let prefix = v4(24);
+            let owned_route = fib_route(prefix, ip("192.0.2.2"));
+            let config = config();
+            let shutdown = CancellationToken::new();
+            let cancel = shutdown.clone();
+            let (rib_tx, mut rib_rx) = mpsc::channel(4);
+            tokio::spawn(async move {
+                while let Some(update) = rib_rx.recv().await {
+                    match update {
+                        RibUpdate::QueryFibInstallCandidatesPage { reply, .. } => {
+                            let _ = reply.send(Ok(rustbgpd_rib::FibInstallCandidatesPage {
+                                candidates: Vec::new(),
+                                next_cursor: None,
+                                observed_version: rustbgpd_rib::RoutePageVersion::default(),
+                            }));
+                        }
+                        RibUpdate::QueryFibInstallCandidatesExact { reply, .. }
+                            if matches!(stage, Stage::Exact) =>
+                        {
+                            cancel.cancel();
+                            std::future::pending::<()>().await;
+                            drop(reply);
+                        }
+                        RibUpdate::QueryFibInstallCandidatesExact {
+                            prefixes, reply, ..
+                        } => {
+                            let _ = reply.send(Ok(rustbgpd_rib::ExactFibInstallCandidates {
+                                candidates: vec![None; prefixes.len()],
+                                observed_version: rustbgpd_rib::RoutePageVersion::default(),
+                            }));
+                        }
+                        RibUpdate::QueryDataplaneVersions { reply, .. }
+                            if matches!(stage, Stage::Seal) =>
+                        {
+                            cancel.cancel();
+                            std::future::pending::<()>().await;
+                            drop(reply);
+                        }
+                        _ => {}
+                    }
+                }
+            });
+            if matches!(stage, Stage::Entry) {
+                shutdown.cancel();
+            }
+            let mut fib = FakeFib::default();
+            let mut owned = FibOwnedState {
+                routes: BTreeMap::from([(owned_route.key, owned_route.clone())]),
+            };
+            let mut unresolved = unresolved_with(owned_route.clone());
+            let owned_before = owned.clone();
+            let unresolved_before = unresolved.clone();
+            let sentinel = vec![status_for_route(
+                &owned_route,
+                FibRuntimeState::Installed,
+                "last_good".to_string(),
+            )];
+            let (status_tx, status_rx) = watch::channel(sentinel.clone());
+            let (event_tx, _) = broadcast::channel(1);
+            let metrics = metrics();
+
+            assert!(
+                !reconcile_once_with_events(
+                    &config,
+                    &rib_tx,
+                    &mut fib,
+                    &metrics,
+                    &status_tx,
+                    &event_tx,
+                    &mut owned,
+                    &mut unresolved,
+                    HeldRetry::All,
+                    &shutdown,
+                )
+                .await
+            );
+            assert_eq!(fib.dump_calls, 0);
+            assert!(fib.applied.is_empty());
+            assert_eq!(owned, owned_before);
+            assert_eq!(unresolved, unresolved_before);
+            assert_eq!(*status_rx.borrow(), sentinel);
+            for reason in ["send_failed", "reply_dropped", "query_failed", "timeout"] {
+                assert_planning_failure_value(&metrics, "general_fib", reason, 0.0);
+            }
         }
     }
 
@@ -5314,13 +5518,14 @@ mod tests {
         let mut fib = FakeFib::default();
         let mut owned = FibOwnedState::default();
         let mut unresolved = UnresolvedHolds::default();
+        let test_metrics = metrics();
 
         assert!(
             !reconcile_once_with_events(
                 &config(),
                 &rib_tx,
                 &mut fib,
-                &metrics(),
+                &test_metrics,
                 &status_tx,
                 &event_tx,
                 &mut owned,
@@ -5335,6 +5540,7 @@ mod tests {
         assert!(owned.routes.is_empty() && unresolved.routes.is_empty());
         assert_eq!(*status_rx.borrow(), sentinel);
         assert!(event_rx.try_recv().is_err());
+        assert_planning_failure_value(&test_metrics, "general_fib", "timeout", 1.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- expose one bounded planning-failure counter for general FIB and BLACKHOLE reconciliation
- emit structured warnings for non-shutdown pre-kernel aborts while preserving the last successful state snapshot
- keep kernel, ownership, unresolved, adoption, status, and event state untouched on planning failure
- remove the unreachable `rib_query_failed:DETAIL` API reason and document the counter/log recovery contract

## Validation

- telemetry: 114/114
- general FIB: 104/104
- BLACKHOLE: 54/54
- entry, exact-query, and version-seal cancellation proof
- metric consumer: 30/30 and live 204 emitted / 198 consumed / 6 allowlisted
- metric release notes: 9/9 and live 8 added / 0 removed
- API: 697/697; v1 stable-surface and proto inventory checks pass
- workspace all-target Clippy with warnings denied
- locked workspace tests and doctests
- full pre-push formatting, Clippy, test, and documentation hooks
- independent exact-head review approved

Linear: LAN-1380