### PR TITLE
fix(rib): account RPKI state during route mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The unpublished RIB crate no longer exposes unrestricted mutable Adj-RIB-In
+  iteration. Its sole internal all-route mutation callback now maintains exact
+  RPKI validation counts, preserving RFC 9972 BMP path-count rows and safe
+  withdrawal after ASPA or future validation-state updates.
+
 - SIGHUP settlement fail-stop diagnostics now name the static reload step
   that fenced and whether an earlier effect was accepted. Non-SIGHUP owners
   report an explicit non-applicable step, while

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -338,23 +338,47 @@ impl AdjRibIn {
             .filter(move |route| after.is_none_or(|cursor| route_query_key(route) > cursor))
     }
 
-    /// Iterate mutably over all stored routes.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Route> {
-        self.routes.iter_mut()
-    }
-
-    /// Visit mutably every unicast route whose prefix is covered by
-    /// `covering` — the prefix itself and all stored more-specifics
-    /// (network containment, same family). Uses the prefix trie for
-    /// O(covered) enumeration instead of an O(N) full scan.
-    pub fn for_each_covered_mut(&mut self, covering: &Prefix, mut f: impl FnMut(&mut Route)) {
-        let routes = &mut self.routes;
-        for (_, ids) in self.prefix_index.children(covering) {
-            for &(_, handle) in ids {
-                if let Some(route) = routes.get_mut(handle) {
-                    f(route);
-                }
+    /// Mutate every unicast route while maintaining exact RPKI path counts.
+    ///
+    /// This crate-private callback is the only whole-route mutation boundary.
+    /// Callers may update route data freely, but must preserve the indexed
+    /// `(prefix, path_id)` identity. Changes to `validation_state` are
+    /// reflected in the route family's counters before the next route is
+    /// visited.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a callback changes the route's indexed identity.
+    pub(crate) fn for_each_route_mut_accounting_rpki(
+        &mut self,
+        mut mutate: impl FnMut(&mut Route),
+    ) {
+        let Self {
+            routes,
+            rpki_counts_v4,
+            rpki_counts_v6,
+            ..
+        } = self;
+        for route in routes.iter_mut() {
+            let old_prefix = route.prefix;
+            let old_path_id = route.path_id;
+            let old_state = route.validation_state;
+            mutate(route);
+            assert_eq!(
+                (route.prefix, route.path_id),
+                (old_prefix, old_path_id),
+                "whole-route mutation must preserve indexed route identity"
+            );
+            let new_state = route.validation_state;
+            if old_state == new_state {
+                continue;
             }
+            let counts = match old_prefix {
+                Prefix::V4(_) => &mut *rpki_counts_v4,
+                Prefix::V6(_) => &mut *rpki_counts_v6,
+            };
+            counts.decrement(old_state);
+            counts.increment(new_state);
         }
     }
 
@@ -2621,6 +2645,47 @@ mod tests {
     }
 
     #[test]
+    fn accounted_route_mutation_preserves_rpki_counts_and_withdrawal() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+        let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+        route.validation_state = RpkiValidation::NotFound;
+        assert!(!rib.insert(route));
+
+        rib.for_each_route_mut_accounting_rpki(|route| {
+            route.validation_state = RpkiValidation::Valid;
+        });
+
+        assert_eq!(
+            rib.rpki_validation_counts(),
+            vec![(
+                (Afi::Ipv4, Safi::Unicast),
+                RpkiValidationCounts {
+                    invalid: 0,
+                    valid: 1,
+                    not_found: 0,
+                },
+            )]
+        );
+        assert!(rib.withdraw(&Prefix::V4(prefix), 0));
+        assert!(rib.rpki_validation_counts().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "whole-route mutation must preserve indexed route identity")]
+    fn accounted_route_mutation_rejects_identity_changes() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+        assert!(!rib.insert(make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))));
+
+        rib.for_each_route_mut_accounting_rpki(|route| {
+            route.path_id = 1;
+        });
+    }
+
+    #[test]
     fn vpn_insert_get_replace_withdraw_round_trip() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
@@ -3146,9 +3211,9 @@ mod tests {
             v6,
             Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
         ));
-        for route in rib.iter_mut() {
+        rib.for_each_route_mut_accounting_rpki(|route| {
             route.is_llgr_stale = true;
-        }
+        });
 
         let swept = rib.sweep_llgr_stale_family((Afi::Ipv4, Safi::Unicast));
         assert_eq!(swept, vec![Prefix::V4(v4)]);

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -532,7 +532,7 @@ impl RibManager {
         let mut changed_routes = 0_u64;
         let mut invalid_hops = AspaInvalidHopSummary::default();
         for rib in self.ribs.values_mut() {
-            for route in rib.iter_mut() {
+            rib.for_each_route_mut_accounting_rpki(|route| {
                 routes_scanned += 1;
                 // A table update can affect a verdict only when its customer
                 // ASN occurs in the route's AS_SEQUENCE or AS_SET. We still
@@ -542,7 +542,7 @@ impl RibManager {
                         .as_path()
                         .is_none_or(|path| path.asns().all(|asn| !changed.contains(&asn)))
                 }) {
-                    continue;
+                    return;
                 }
                 routes_revalidated += 1;
                 let result = validate_route_aspa_detailed(route, table);
@@ -554,7 +554,7 @@ impl RibManager {
                     changed_routes += 1;
                     affected.insert(route.prefix);
                 }
-            }
+            });
         }
 
         if !affected.is_empty() {


### PR DESCRIPTION
## Summary

- remove unrestricted mutable Adj-RIB-In iteration from the unpublished RIB crate
- route the sole internal all-route mutation through a counter-maintaining callback
- prove validation-state mutation preserves exact RFC 9972 counts and safe withdrawal

## Validation

- 1,244 RIB tests
- focused RPKI insert/replace/withdraw/revalidation and former-underflow coverage
- focused ASPA delta, completion-log, and stored-context coverage
- RIB all-target/all-feature Clippy
- full pre-push fmt, Clippy, test, and rustdoc hooks
- independent exact-head review