### PR TITLE
fix(doctor): require retained readiness from every RPKI cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   RPKI validation counts, preserving RFC 9972 BMP path-count rows and safe
   withdrawal after ASPA or future validation-state updates.
 
+- `rbgp doctor` now requires every configured RPKI cache to have retained
+  accepted complete End-of-Data readiness before reporting a healthy nonzero
+  merged VRP table, while distinguishing not-ready caches from missing metric
+  rows and keeping CLI-vantage connectivity probes separate.
+
 - SIGHUP settlement fail-stop diagnostics now name the static reload step
   that fenced and whether an earlier effect was accepted. Non-SIGHUP owners
   report an explicit non-applicable step, while

--- a/crates/cli/src/commands/control.rs
+++ b/crates/cli/src/commands/control.rs
@@ -3,6 +3,8 @@ use crate::error::CliError;
 use crate::output::{self, JsonHealth};
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::{HealthRequest, MetricsRequest, ShutdownRequest, TriggerMrtDumpRequest};
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
 
 /// Sum a complete, unique, valid IPv4 + IPv6 RPKI VRP gauge snapshot.
 /// `Some(0)` distinguishes a synchronized empty table from an unusable snapshot.
@@ -43,6 +45,49 @@ pub(crate) fn rpki_vrp_count_sum(prometheus_text: &str) -> Option<u64> {
         by_family[index] = Some(value);
     }
     by_family[0]?.checked_add(by_family[1]?)
+}
+
+/// Parse the exact per-cache retained End-of-Data readiness gauge family.
+/// Any malformed exact-name row invalidates the snapshot; similarly-prefixed
+/// metric families are unrelated and ignored.
+pub(crate) fn rpki_cache_end_of_data_readiness(
+    prometheus_text: &str,
+) -> Option<BTreeMap<SocketAddr, bool>> {
+    const NAME: &str = "bgp_rpki_cache_end_of_data_ready";
+    let mut readiness = BTreeMap::new();
+
+    for line in prometheus_text.lines().map(str::trim) {
+        let Some(rest) = line.strip_prefix(NAME) else {
+            continue;
+        };
+        if !rest.starts_with('{') {
+            if rest.is_empty() || rest.as_bytes().first().is_some_and(u8::is_ascii_whitespace) {
+                return None;
+            }
+            continue;
+        }
+        let labels_and_value = rest.strip_prefix(r#"{cache=""#)?;
+        let (cache, value_text) = labels_and_value.split_once(r#""}"#)?;
+        if cache.is_empty()
+            || !value_text
+                .as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_whitespace)
+        {
+            return None;
+        }
+        let cache = cache.parse::<SocketAddr>().ok()?;
+        let mut fields = value_text.split_ascii_whitespace();
+        let value = match fields.next()? {
+            "0" => false,
+            "1" => true,
+            _ => return None,
+        };
+        if fields.next().is_some() || readiness.insert(cache, value).is_some() {
+            return None;
+        }
+    }
+    Some(readiness)
 }
 
 pub async fn health(connection: Connection, json: bool) -> Result<(), CliError> {
@@ -172,5 +217,37 @@ unrelated_metric 7
         ] {
             assert_eq!(rpki_vrp_count_sum(invalid), None, "{invalid}");
         }
+    }
+
+    #[test]
+    fn rpki_cache_readiness_requires_exact_typed_unique_samples() {
+        let parsed = rpki_cache_end_of_data_readiness(
+            "bgp_rpki_cache_end_of_data_ready{cache=\"192.0.2.1:8282\"} 1\n\
+             bgp_rpki_cache_end_of_data_ready{cache=\"[2001:db8::1]:8282\"} 0\n\
+             bgp_rpki_cache_end_of_data_ready_total{cache=\"192.0.2.1:8282\"} 9",
+        )
+        .unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed[&"192.0.2.1:8282".parse().unwrap()]);
+        assert!(!parsed[&"[2001:db8::1]:8282".parse().unwrap()]);
+
+        for invalid in [
+            "bgp_rpki_cache_end_of_data_ready 1",
+            "bgp_rpki_cache_end_of_data_ready{cache=\"192.0.2.1:8282\",extra=\"x\"} 1",
+            "bgp_rpki_cache_end_of_data_ready{other=\"192.0.2.1:8282\"} 1",
+            "bgp_rpki_cache_end_of_data_ready{cache=\"not-an-address\"} 1",
+            "bgp_rpki_cache_end_of_data_ready{cache=\"192.0.2.1:8282\"} 2",
+            "bgp_rpki_cache_end_of_data_ready{cache=\"192.0.2.1:8282\"} 1 extra",
+            "bgp_rpki_cache_end_of_data_ready{cache=\"[2001:db8::1]:8282\"} 1\n\
+             bgp_rpki_cache_end_of_data_ready{cache=\"[2001:0db8:0:0:0:0:0:1]:8282\"} 1",
+        ] {
+            assert_eq!(rpki_cache_end_of_data_readiness(invalid), None, "{invalid}");
+        }
+        assert_eq!(
+            rpki_cache_end_of_data_readiness(
+                "bgp_rpki_cache_end_of_data_readiness{cache=\"bad\"} 7"
+            ),
+            Some(BTreeMap::new())
+        );
     }
 }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1071,34 +1071,81 @@ fn deploy_targets(toml_text: &str) -> DeployTargets {
     }
 }
 
-fn rpki_vrp_table_check(configured: bool, metrics: Option<&str>) -> Option<Check> {
-    if !configured {
+fn rpki_vrp_table_check(configured_caches: &[String], metrics: Option<&str>) -> Option<Check> {
+    if configured_caches.is_empty() {
         return None;
     }
-    let count = metrics.and_then(crate::commands::control::rpki_vrp_count_sum);
-    let (status, detail) = match count {
-        Some(count @ 1..) => (
-            CheckStatus::Ok,
-            format!("RPKI VRP table contains {count} IPv4+IPv6 entries"),
-        ),
-        Some(0) => (
-            CheckStatus::Warn,
-            "RPKI caches are configured but the daemon reports 0 VRPs; \
-             verify RTR synchronization before relying on NotFound decisions"
+    let Some(metrics) = metrics else {
+        return Some(Check {
+            name: "rpki.vrp_table".to_string(),
+            status: CheckStatus::Warn,
+            detail: "RPKI caches are configured but the metrics snapshot is unavailable; \
+                     rerun doctor after the metrics RPC succeeds"
                 .to_string(),
-        ),
-        None if metrics.is_some() => (
+        });
+    };
+    let count = crate::commands::control::rpki_vrp_count_sum(metrics);
+    let readiness = crate::commands::control::rpki_cache_end_of_data_readiness(metrics);
+    let configured = configured_caches
+        .iter()
+        .map(|cache| cache.parse::<std::net::SocketAddr>())
+        .collect::<Result<Vec<_>, _>>();
+    let (status, detail) = match (count, readiness, configured) {
+        (None, _, _) => (
             CheckStatus::Warn,
             "RPKI caches are configured but bgp_rpki_vrp_count is absent or malformed; \
              inspect /metrics and RTR synchronization"
                 .to_string(),
         ),
-        None => (
+        (_, None, _) => (
             CheckStatus::Warn,
-            "RPKI caches are configured but the metrics snapshot is unavailable; \
-             rerun doctor after the metrics RPC succeeds"
+            "RPKI caches are configured but bgp_rpki_cache_end_of_data_ready is malformed; \
+             inspect /metrics and RTR synchronization"
                 .to_string(),
         ),
+        (_, _, Err(_)) => (
+            CheckStatus::Warn,
+            "A configured RPKI cache address is invalid; expected IP:port or [IPv6]:port"
+                .to_string(),
+        ),
+        (Some(count), Some(readiness), Ok(configured)) => {
+            let not_ready = configured
+                .iter()
+                .filter(|cache| readiness.get(cache) == Some(&false))
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            let missing = configured
+                .iter()
+                .filter(|cache| !readiness.contains_key(cache))
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            if count > 0 && not_ready.is_empty() && missing.is_empty() {
+                (
+                    CheckStatus::Ok,
+                    format!(
+                        "RPKI VRP table contains {count} IPv4+IPv6 entries; every configured cache has retained accepted complete End-of-Data readiness"
+                    ),
+                )
+            } else {
+                let mut reasons = Vec::new();
+                if count == 0 {
+                    reasons.push("merged VRP count is 0".to_string());
+                }
+                if !not_ready.is_empty() {
+                    reasons.push(format!("not ready: {}", not_ready.join(", ")));
+                }
+                if !missing.is_empty() {
+                    reasons.push(format!("readiness missing: {}", missing.join(", ")));
+                }
+                (
+                    CheckStatus::Warn,
+                    format!(
+                        "RPKI merged-table prerequisites are incomplete ({})",
+                        reasons.join("; ")
+                    ),
+                )
+            }
+        }
     };
     Some(Check {
         name: "rpki.vrp_table".to_string(),
@@ -1828,10 +1875,9 @@ pub(crate) async fn run(
                     for check in tcp_ao_capability_checks(&toml_text, tcp_ao_support) {
                         reporter.record(check.name, check.status, check.detail);
                     }
-                    if let Some(check) = rpki_vrp_table_check(
-                        !deploy_targets(&toml_text).rpki_caches.is_empty(),
-                        metrics_text.as_deref(),
-                    ) {
+                    let rpki_caches = deploy_targets(&toml_text).rpki_caches;
+                    if let Some(check) = rpki_vrp_table_check(&rpki_caches, metrics_text.as_deref())
+                    {
                         reporter.record(check.name, check.status, check.detail);
                     }
                     if let Some(check) = authz_enforcement_check(&toml_text) {
@@ -3255,30 +3301,97 @@ paths = ["x"]
     /// Red proofs: zero-as-OK and dropping the configured guard fail below.
     #[test]
     fn rpki_vrp_table_check_distinguishes_configuration_and_snapshot_state() {
-        assert!(rpki_vrp_table_check(false, None).is_none());
+        let caches = vec!["192.0.2.1:8282".to_string()];
+        assert!(rpki_vrp_table_check(&[], None).is_none());
 
         let nonzero = rpki_vrp_table_check(
-            true,
-            Some("bgp_rpki_vrp_count{af=\"ipv4\"} 1\nbgp_rpki_vrp_count{af=\"ipv6\"} 2"),
+            &caches,
+            Some(
+                "bgp_rpki_vrp_count{af=\"ipv4\"} 1\n\
+                 bgp_rpki_vrp_count{af=\"ipv6\"} 2\n\
+                 bgp_rpki_cache_end_of_data_ready{cache=\"192.0.2.1:8282\"} 1",
+            ),
         )
         .unwrap();
         assert_eq!(nonzero.status, CheckStatus::Ok);
 
         let zero = rpki_vrp_table_check(
-            true,
+            &caches,
             Some("bgp_rpki_vrp_count{af=\"ipv4\"} 0\nbgp_rpki_vrp_count{af=\"ipv6\"} 0"),
         )
         .unwrap();
         assert_eq!(zero.status, CheckStatus::Warn);
+        assert!(zero.detail.contains("merged VRP count is 0"));
+        assert!(!zero.detail.contains("cache readiness is incomplete"));
         assert_eq!(
-            rpki_vrp_table_check(true, Some("unrelated_metric 1"))
+            rpki_vrp_table_check(&caches, Some("unrelated_metric 1"))
                 .unwrap()
                 .status,
             CheckStatus::Warn
         );
         assert_eq!(
-            rpki_vrp_table_check(true, None).unwrap().status,
+            rpki_vrp_table_check(&caches, None).unwrap().status,
             CheckStatus::Warn
+        );
+    }
+
+    #[test]
+    fn rpki_vrp_table_requires_every_configured_cache_ready() {
+        let caches = vec![
+            "192.0.2.1:8282".to_string(),
+            "[2001:db8::1]:8282".to_string(),
+        ];
+        let base = "bgp_rpki_vrp_count{af=\"ipv4\"} 1\n\
+                    bgp_rpki_vrp_count{af=\"ipv6\"} 2\n";
+        let not_ready = rpki_vrp_table_check(
+            &caches,
+            Some(&format!(
+                "{base}bgp_rpki_cache_end_of_data_ready{{cache=\"192.0.2.1:8282\"}} 1\n\
+                 bgp_rpki_cache_end_of_data_ready{{cache=\"[2001:0db8::1]:8282\"}} 0\n\
+                 bgp_rpki_cache_end_of_data_ready{{cache=\"198.51.100.9:8282\"}} 1"
+            )),
+        )
+        .unwrap();
+        assert_eq!(not_ready.status, CheckStatus::Warn);
+        assert!(not_ready.detail.contains("not ready: [2001:db8::1]:8282"));
+        assert!(!not_ready.detail.contains("198.51.100.9"));
+
+        let missing = rpki_vrp_table_check(
+            &caches,
+            Some(&format!(
+                "{base}bgp_rpki_cache_end_of_data_ready{{cache=\"192.0.2.1:8282\"}} 1"
+            )),
+        )
+        .unwrap();
+        assert_eq!(missing.status, CheckStatus::Warn);
+        assert!(
+            missing
+                .detail
+                .contains("readiness missing: [2001:db8::1]:8282")
+        );
+
+        let malformed = rpki_vrp_table_check(
+            &caches,
+            Some(&format!(
+                "{base}bgp_rpki_cache_end_of_data_ready{{cache=\"bad\"}} 1"
+            )),
+        )
+        .unwrap();
+        assert_eq!(malformed.status, CheckStatus::Warn);
+        assert!(malformed.detail.contains("is malformed"));
+
+        let invalid_config = rpki_vrp_table_check(
+            &["cache.example:8282".to_string()],
+            Some(&format!(
+                "{base}bgp_rpki_cache_end_of_data_ready{{cache=\"192.0.2.1:8282\"}} 1"
+            )),
+        )
+        .unwrap();
+        assert_eq!(invalid_config.status, CheckStatus::Warn);
+        assert!(
+            invalid_config
+                .detail
+                .contains("configured RPKI cache address is invalid")
         );
     }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -753,8 +753,12 @@ will cause route drops. The recommended policy is to deny `Invalid` and
 prefer `Valid`, leaving `NotFound` as a neutral fallback.
 `rbgp doctor` probes every configured cache from the `rbgp` process
 (`rpki.cache.<addr>.reachable_from_cli`). That raw connect is explicitly a
-CLI-network-vantage check and warns on failure; use the daemon-side
-`rpki.vrp_table` check to assess whether rustbgpd has synchronized VRPs.
+CLI-network-vantage connectivity check and warns on failure. The single
+daemon-side `rpki.vrp_table` check is green only when the merged VRP count is
+nonzero and every configured cache reports retained accepted complete
+End-of-Data readiness; it names configured caches whose readiness is `0`
+separately from caches missing from the metric snapshot. Neither result proves
+that an RTR TCP connection is currently established.
 
 `bgp_rpki_cache_end_of_data_ready{cache}` is `0` at startup, becomes `1` only
 after an accepted, complete, validated End of Data (including an empty table),
@@ -1841,7 +1845,7 @@ First-deploy checks (network probes are bounded to a 2s timeout; all are read-on
 | Check | What it probes | Red/yellow advice |
 |-------|----------------|-------------------|
 | `bgp.listener` | Daemon up: TCP connect to the BGP listen port. Daemon down: test-bind the port and release it | `CAP_NET_BIND_SERVICE` for ports below 1024; port-in-use is yellow (an unreachable daemon may hold it) |
-| `rpki.vrp_table` | With configured caches and a reachable daemon, sums the complete IPv4 + IPv6 `bgp_rpki_vrp_count` snapshot | yellow when the merged table is zero, missing, malformed, or unavailable; verify RTR synchronization and `/metrics` |
+| `rpki.vrp_table` | With configured caches and a reachable daemon, requires a nonzero complete IPv4 + IPv6 `bgp_rpki_vrp_count` snapshot and retained accepted complete End-of-Data readiness for every configured cache | yellow when the merged table is zero/missing/malformed/unavailable or a configured cache is not ready/missing from the readiness snapshot; this is retained readiness, not current RTR connectivity |
 | `rpki.cache.<addr>.reachable_from_cli` | TCP connect from the `rbgp` process to each `[rpki] cache_servers` entry | yellow on failure because this is CLI-network-vantage evidence, not daemon-side connectivity; use `rpki.vrp_table` for the daemon's VRP state |
 | `bmp.collector.<addr>.reachable_from_cli` | TCP connect from the `rbgp` process to each `[bmp] collectors` entry | yellow on failure because the daemon may have a different network vantage; inspect rustbgpd and collector logs for actual export state |
 | `gnmi_dialout.<name>.reachable_from_cli` | TCP connect from the `rbgp` process to each `[gnmi_dialout] targets` entry | yellow on failure because the daemon may have a different network vantage; inspect `gnmi_dialout_connected` and daemon logs for actual dial-out state |


### PR DESCRIPTION
## Summary

- parse the exact per-cache retained End-of-Data readiness metric into typed cache identities
- warn when any configured RPKI cache is not ready or missing from the snapshot
- keep retained readiness distinct from current RTR connectivity in operator guidance

## Validation

- full `rustbgpctl` test suite
- focused parser, doctor-state, and remote-daemon probe tests
- all-target/all-feature `rustbgpctl` Clippy
- full pre-push formatting, Clippy, tests, and rustdoc
- independent behavior and documentation review