### PR TITLE
feat(transport): log BGP notifications structurally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Decoded inbound and attempted outbound BGP NOTIFICATIONs now emit exactly one
+  structured INFO record with peer, direction, outer code/subcode, and a human
+  description. Hard Reset records retain outer Cease/9 and identify the valid
+  inner error; optional shutdown communication is escaped to ASCII and bounded
+  to 512 bytes, while malformed communication remains omitted and warned.
+
 - `EvpnService.ListDuplicateMacQuarantines` and `rbgp evpn
   duplicate-mac-quarantines` expose the current duplicate-MAC local-origin
   quarantine set as one deterministic, key-only snapshot. Responses are capped

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1592,7 +1592,6 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::CollisionDump => {
-                info!(peer = %self.peer_label, "collision dump: sending Cease/7");
                 self.stop_requested = true;
                 self.reconnect_timer = None;
                 // Send Cease/7 NOTIFICATION
@@ -1601,6 +1600,7 @@ impl PeerSession {
                     cease_subcode::CONNECTION_COLLISION_RESOLUTION,
                     bytes::Bytes::new(),
                 );
+                self.log_notification(SessionNotificationDirection::Sent, &notif, None);
                 self.session_telemetry_metric_lease.latch_down_reason(
                     rustbgpd_telemetry::reason_labels::SessionDownReason::LocalNotification,
                 );

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -10,13 +10,65 @@ pub(super) fn notification_description(
 ) -> String {
     if notification.code == NotificationCode::Cease
         && notification.subcode == cease_subcode::HARD_RESET
-        && notification
-            .data
-            .starts_with(&[NotificationCode::Cease.as_u8(), cease_subcode::BFD_DOWN])
+        && notification.data.len() >= 2
     {
-        return "Hard Reset: BFD Down".to_string();
+        let inner_code = NotificationCode::from_u8(notification.data[0]);
+        let inner_subcode = notification.data[1];
+        return format!(
+            "Hard Reset: {}",
+            rustbgpd_wire::notification::description(inner_code, inner_subcode)
+        );
     }
     rustbgpd_wire::notification::description(notification.code, notification.subcode).to_string()
+}
+
+fn sanitized_notification_reason(reason: &str) -> String {
+    let mut sanitized = String::with_capacity(reason.len().min(512));
+    for character in reason.chars() {
+        for escaped in character.escape_default() {
+            if sanitized.len() == 512 {
+                return sanitized;
+            }
+            sanitized.push(escaped);
+        }
+    }
+    sanitized
+}
+
+impl PeerSession {
+    pub(super) fn log_notification(
+        &self,
+        direction: SessionNotificationDirection,
+        notification: &rustbgpd_wire::NotificationMessage,
+        reason: Option<&str>,
+    ) {
+        let direction = match direction {
+            SessionNotificationDirection::Sent => "sent",
+            SessionNotificationDirection::Received => "received",
+        };
+        let description = notification_description(notification);
+        if let Some(reason) = reason {
+            let reason = sanitized_notification_reason(reason);
+            info!(
+                peer = %self.peer_label,
+                direction,
+                code = notification.code.as_u8(),
+                subcode = notification.subcode,
+                description,
+                reason,
+                "BGP NOTIFICATION"
+            );
+        } else {
+            info!(
+                peer = %self.peer_label,
+                direction,
+                code = notification.code.as_u8(),
+                subcode = notification.subcode,
+                description,
+                "BGP NOTIFICATION"
+            );
+        }
+    }
 }
 
 impl PeerSession {
@@ -283,6 +335,11 @@ impl PeerSession {
                                 None
                             }
                         };
+                    self.log_notification(
+                        SessionNotificationDirection::Sent,
+                        &notif,
+                        shutdown_reason.as_deref(),
+                    );
                     self.record_notification_cause(SessionNotificationDirection::Sent, &notif);
                     // RFC 8538: track outbound Hard Reset to bypass GR
                     if code == NotificationCode::Cease && subcode == cease_subcode::HARD_RESET {

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -433,6 +433,7 @@ impl PeerSession {
             cease_subcode::OUT_OF_RESOURCES,
             bytes::Bytes::new(),
         );
+        self.log_notification(SessionNotificationDirection::Sent, &notif, None);
         self.record_notification_cause(SessionNotificationDirection::Sent, &notif);
         self.last_error = cause.to_string();
         // Classify the upcoming BMP Peer Down as the locally initiated
@@ -594,6 +595,11 @@ impl PeerSession {
                                         None
                                     }
                                 };
+                            self.log_notification(
+                                SessionNotificationDirection::Received,
+                                &notif,
+                                shutdown_reason.as_deref(),
+                            );
                             // Cache raw NOTIFICATION PDU for BMP Peer Down (reason 3: remote sent NOTIFICATION)
                             if self.bmp_tx.is_some() {
                                 self.last_down_reason =
@@ -611,14 +617,6 @@ impl PeerSession {
                             );
                             self.metrics
                                 .record_message_received(&self.peer_label, "notification");
-                            // Log shutdown communication reason (RFC 9003)
-                            if let Some(reason) = shutdown_reason.as_deref() {
-                                info!(
-                                    peer = %self.peer_label,
-                                    reason,
-                                    "peer sent shutdown communication"
-                                );
-                            }
                             self.emit_notification_event(
                                 SessionNotificationDirection::Received,
                                 &notif,
@@ -628,10 +626,6 @@ impl PeerSession {
                             if notif.code == NotificationCode::Cease
                                 && notif.subcode == cease_subcode::HARD_RESET
                             {
-                                info!(
-                                    peer = %self.peer_label,
-                                    "peer sent Cease/Hard Reset, GR will be skipped"
-                                );
                                 self.received_hard_reset = true;
                             }
                             Event::NotificationReceived(notif)

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -1,5 +1,159 @@
 use super::*;
 
+#[derive(Clone, Default)]
+struct NotificationLogCapture {
+    events: Arc<std::sync::Mutex<Vec<std::collections::BTreeMap<String, String>>>>,
+}
+
+impl tracing::Subscriber for NotificationLogCapture {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        *metadata.level() == tracing::Level::INFO
+    }
+
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        struct Visitor(std::collections::BTreeMap<String, String>);
+        impl tracing::field::Visit for Visitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                self.0
+                    .insert(field.name().to_string(), format!("{value:?}"));
+            }
+
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                self.0.insert(field.name().to_string(), value.to_string());
+            }
+
+            fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+                self.0.insert(field.name().to_string(), value.to_string());
+            }
+        }
+
+        let mut visitor = Visitor(std::collections::BTreeMap::new());
+        event.record(&mut visitor);
+        self.events.lock().unwrap().push(visitor.0);
+    }
+
+    fn enter(&self, _span: &tracing::span::Id) {}
+
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+fn capture_notification_log(
+    direction: SessionNotificationDirection,
+    notification: &NotificationMessage,
+    reason: Option<&str>,
+) -> Vec<std::collections::BTreeMap<String, String>> {
+    let subscriber = NotificationLogCapture::default();
+    let events = subscriber.events.clone();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    make_test_session(65001, 65002).log_notification(direction, notification, reason);
+    events.lock().unwrap().clone()
+}
+
+#[test]
+fn notification_logs_are_structured_once_per_direction() {
+    let notification = NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+        Bytes::new(),
+    );
+    for (direction, expected) in [
+        (SessionNotificationDirection::Received, "received"),
+        (SessionNotificationDirection::Sent, "sent"),
+    ] {
+        let events = capture_notification_log(direction, &notification, Some("maintenance"));
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].get("message").map(String::as_str),
+            Some("BGP NOTIFICATION")
+        );
+        assert_eq!(
+            events[0].get("direction").map(String::as_str),
+            Some(expected)
+        );
+        assert_eq!(events[0].get("code").map(String::as_str), Some("6"));
+        assert_eq!(events[0].get("subcode").map(String::as_str), Some("2"));
+        assert_eq!(
+            events[0].get("description").map(String::as_str),
+            Some("Administrative Shutdown")
+        );
+        assert_eq!(
+            events[0].get("reason").map(String::as_str),
+            Some("maintenance")
+        );
+    }
+}
+
+#[test]
+fn hard_reset_log_keeps_outer_code_and_decodes_inner_description() {
+    let notification = NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::HARD_RESET,
+        Bytes::from(vec![
+            NotificationCode::Cease.as_u8(),
+            cease_subcode::ADMINISTRATIVE_RESET,
+        ]),
+    );
+    let events =
+        capture_notification_log(SessionNotificationDirection::Received, &notification, None);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].get("code").map(String::as_str), Some("6"));
+    assert_eq!(events[0].get("subcode").map(String::as_str), Some("9"));
+    assert_eq!(
+        events[0].get("description").map(String::as_str),
+        Some("Hard Reset: Administrative Reset")
+    );
+    assert!(!events[0].contains_key("reason"));
+}
+
+#[test]
+fn notification_log_omits_invalid_or_missing_reason() {
+    let notification = NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::ADMINISTRATIVE_RESET,
+        Bytes::from_static(&[1, 0xff]),
+    );
+    let decoded = rustbgpd_wire::notification::extract_shutdown_communication(&notification)
+        .ok()
+        .flatten();
+    let events = capture_notification_log(
+        SessionNotificationDirection::Received,
+        &notification,
+        decoded,
+    );
+    assert_eq!(events.len(), 1);
+    assert!(!events[0].contains_key("reason"));
+}
+
+#[test]
+fn notification_log_reason_is_escaped_ascii_and_bounded() {
+    let notification = NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::ADMINISTRATIVE_RESET,
+        Bytes::new(),
+    );
+    let reason = format!("line\n🦀{}", "x".repeat(600));
+    let events = capture_notification_log(
+        SessionNotificationDirection::Sent,
+        &notification,
+        Some(&reason),
+    );
+    assert_eq!(events.len(), 1);
+    let logged = events[0].get("reason").unwrap();
+    assert_eq!(logged.len(), 512);
+    assert!(logged.is_ascii());
+    assert!(!logged.contains('\n'));
+    assert!(logged.contains("\\n"));
+    assert!(logged.contains("\\u{1f980}"));
+}
+
 #[tokio::test]
 async fn shutdown_aborts_inflight_connect_task() {
     let mut session = make_test_session(65001, 65002);

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -1,13 +1,43 @@
 use super::*;
 
+type NotificationLogFields = std::collections::BTreeMap<String, String>;
+type NotificationLogBuckets =
+    std::collections::HashMap<std::thread::ThreadId, Vec<NotificationLogFields>>;
+
 #[derive(Clone, Default)]
 struct NotificationLogCapture {
-    events: Arc<std::sync::Mutex<Vec<std::collections::BTreeMap<String, String>>>>,
+    events: Arc<std::sync::Mutex<NotificationLogBuckets>>,
+}
+
+fn notification_log_capture() -> &'static NotificationLogCapture {
+    static CAPTURE: std::sync::OnceLock<NotificationLogCapture> = std::sync::OnceLock::new();
+    CAPTURE.get_or_init(|| {
+        let capture = NotificationLogCapture::default();
+        tracing::subscriber::set_global_default(capture.clone())
+            .expect("notification tests require an unclaimed global tracing subscriber");
+        capture
+    })
 }
 
 impl tracing::Subscriber for NotificationLogCapture {
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        if notification_log_metadata(metadata) {
+            tracing::subscriber::Interest::sometimes()
+        } else {
+            tracing::subscriber::Interest::never()
+        }
+    }
+
     fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
-        *metadata.level() == tracing::Level::INFO
+        notification_log_metadata(metadata)
+            && self
+                .events
+                .lock()
+                .unwrap()
+                .contains_key(&std::thread::current().id())
     }
 
     fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
@@ -37,7 +67,14 @@ impl tracing::Subscriber for NotificationLogCapture {
 
         let mut visitor = Visitor(std::collections::BTreeMap::new());
         event.record(&mut visitor);
-        self.events.lock().unwrap().push(visitor.0);
+        if let Some(events) = self
+            .events
+            .lock()
+            .unwrap()
+            .get_mut(&std::thread::current().id())
+        {
+            events.push(visitor.0);
+        }
     }
 
     fn enter(&self, _span: &tracing::span::Id) {}
@@ -45,16 +82,37 @@ impl tracing::Subscriber for NotificationLogCapture {
     fn exit(&self, _span: &tracing::span::Id) {}
 }
 
+fn notification_log_metadata(metadata: &tracing::Metadata<'_>) -> bool {
+    *metadata.level() == tracing::Level::INFO
+        && ["direction", "code", "subcode", "description"]
+            .into_iter()
+            .all(|field| metadata.fields().field(field).is_some())
+}
+
 fn capture_notification_log(
     direction: SessionNotificationDirection,
     notification: &NotificationMessage,
     reason: Option<&str>,
-) -> Vec<std::collections::BTreeMap<String, String>> {
-    let subscriber = NotificationLogCapture::default();
-    let events = subscriber.events.clone();
-    let _guard = tracing::subscriber::set_default(subscriber);
-    make_test_session(65001, 65002).log_notification(direction, notification, reason);
-    events.lock().unwrap().clone()
+) -> Vec<NotificationLogFields> {
+    let session = make_test_session(65001, 65002);
+    let capture = notification_log_capture();
+    let thread_id = std::thread::current().id();
+    assert!(
+        capture
+            .events
+            .lock()
+            .unwrap()
+            .insert(thread_id, Vec::new())
+            .is_none(),
+        "notification log capture bucket was already armed for this thread"
+    );
+    session.log_notification(direction, notification, reason);
+    capture
+        .events
+        .lock()
+        .unwrap()
+        .remove(&thread_id)
+        .expect("armed notification log capture bucket")
 }
 
 #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2681,6 +2681,15 @@ system errors, task panic payloads, routes, attributes, policy data, and
 shutdown communication text. A locally sent Cease/8 retains the category while
 its canonical BGP description and wire payload remain unchanged.
 
+Every decoded inbound or attempted outbound BGP NOTIFICATION also emits one
+structured INFO record named `BGP NOTIFICATION`. The record includes `peer`,
+`direction`, the outer numeric `code` and `subcode`, and their human
+`description`. A valid Hard Reset keeps outer Cease/9 while its description
+identifies the decoded inner error. Valid RFC 9003 shutdown communication is an
+optional `reason`; it is escaped to printable ASCII and capped at 512 bytes.
+Malformed or absent communication is omitted, with malformed input retaining
+its separate warning.
+
 An RFC 9107 ORR peer's explain ranks the per-vantage candidate set the
 ORR export uses (with per-candidate cost output). When filtered or ignored
 topology inputs are present, the stable


### PR DESCRIPTION
## Summary

- emit one structured INFO record for each decoded inbound or attempted outbound BGP NOTIFICATION
- retain outer Hard Reset code/subcode while describing the decoded inner error
- escape and bound optional shutdown communication in logs
- document the operator-visible fields and add exact capture/cardinality coverage

Linear: LAN-1383

## Validation

- `cargo test -p rustbgpd-transport session::tests::notification`
- `cargo clippy -p rustbgpd-transport --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- pre-push test and rustdoc gates