### PR TITLE
feat(rpki): expose RTR cache inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inner error; optional shutdown communication is escaped to ASCII and bounded
   to 512 bytes, while malformed communication remains omitted and warned.
 
+- `RpkiService.ListCaches` and `rbgp rpki caches` expose a bounded,
+  deterministic inventory of configured RTR caches, connection state, and
+  latest atomically accepted epoch. Accepted-empty tables remain distinguishable
+  from initial, expired, and flushed state; responses cap at 256 rows with exact
+  omission metadata, and the sensitive-read RPC remains outside narrow v1.
+
 - `EvpnService.ListDuplicateMacQuarantines` and `rbgp evpn
   duplicate-mac-quarantines` expose the current duplicate-MAC local-origin
   quarantine set as one deterministic, key-only snapshot. Responses are capped

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -15,7 +15,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 | **PeerGroupService** | Peer-group CRUD, neighbor-to-group assignment |
 | **RibService** | Received/best/advertised route queries (incl. EVPN), BLACKHOLE discard status, FIB route status, and BGP-LS route queries (ListBgpLsRoutes, RFC 9552); all unary — live route deltas stream through `EventService.WatchEvents` |
 | **BfdService** | BFD session queries (RFC 5880/5881/5882) |
-| **RpkiService** | Bounded route-origin validation against the current authoritative VRP table |
+| **RpkiService** | Bounded route-origin validation and configured RTR-cache accepted-epoch inventory |
 | **EventService** | Live event stream (`WatchEvents`), recent session/policy/EVPN history, and the durable `SubscribeFromEvent` cursor (ADR-0072) |
 | **InjectionService** | Inject/withdraw unicast, FlowSpec, and EVPN routes |
 | **ControlService** | Health, metrics, shutdown, MRT trigger |

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -600,6 +600,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         AuthTier::SensitiveRead,
     ),
     method(
+        "rustbgpd.v1.RpkiService",
+        "ListCaches",
+        "/rustbgpd.v1.RpkiService/ListCaches",
+        AuthTier::SensitiveRead,
+    ),
+    method(
         "rustbgpd.v1.EventService",
         "WatchEvents",
         "/rustbgpd.v1.EventService/WatchEvents",
@@ -789,7 +795,7 @@ mod tests {
     const INVENTORY_JSON: &str = include_str!("../../../docs/grpc-method-inventory.json");
     const INVENTORY_MD: &str = include_str!("../../../docs/grpc-method-inventory.md");
     const READ_TOTAL: &str = "| `read` | 0 | 0.0% |";
-    const SENSITIVE_TOTAL: &str = "| `sensitive_read` | 62 | 58.5% |";
+    const SENSITIVE_TOTAL: &str = "| `sensitive_read` | 63 | 58.9% |";
     const AUTHZ_SOURCE_PATH: &str = "crates/api/src/authz.rs";
     const PRIMARY_PROTO_PATH: &str = "proto/rustbgpd.proto";
     const ADDITIONAL_PROTO_PATHS: &[&str] =
@@ -1021,7 +1027,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 106);
+        assert_eq!(METHODS.len(), 107);
     }
 
     #[test]
@@ -1062,7 +1068,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 62);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 63);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 20);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 24);
     }
@@ -1079,6 +1085,14 @@ mod tests {
     fn route_origin_validation_is_sensitive_read() {
         assert_eq!(
             method_authz("/rustbgpd.v1.RpkiService/ValidateRouteOrigin").map(|method| method.tier),
+            Some(AuthTier::SensitiveRead)
+        );
+    }
+
+    #[test]
+    fn rpki_cache_inventory_is_sensitive_read() {
+        assert_eq!(
+            method_authz("/rustbgpd.v1.RpkiService/ListCaches").map(|method| method.tier),
             Some(AuthTier::SensitiveRead)
         );
     }
@@ -1169,7 +1183,7 @@ mod tests {
 
     #[test]
     fn markdown_totals_rejects_stale_percentage() {
-        let stale = INVENTORY_MD.replace(SENSITIVE_TOTAL, "| `sensitive_read` | 62 | 57.0% |");
+        let stale = INVENTORY_MD.replace(SENSITIVE_TOTAL, "| `sensitive_read` | 63 | 57.0% |");
         assert_eq!(
             verify_markdown_totals(&stale, &fixture_totals(), METHODS.len()),
             Err("percentage mismatch")
@@ -1219,7 +1233,7 @@ mod tests {
 
     #[test]
     fn markdown_totals_preserves_count_fence() {
-        let stale = INVENTORY_MD.replace(SENSITIVE_TOTAL, "| `sensitive_read` | 60 | 58.1% |");
+        let stale = INVENTORY_MD.replace(SENSITIVE_TOTAL, "| `sensitive_read` | 61 | 58.1% |");
         assert_eq!(
             verify_markdown_totals(&stale, &fixture_totals(), METHODS.len()),
             Err("counts mismatch")

--- a/crates/api/src/rpki_service.rs
+++ b/crates/api/src/rpki_service.rs
@@ -3,13 +3,14 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use rustbgpd_rpki::{MAX_COVERING_VRPS, VrpTable};
+use rustbgpd_rpki::{CacheQueryHandle, MAX_COVERING_VRPS, VrpTable};
 use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Prefix, RpkiValidation};
 use tonic::{Request, Response, Status};
 
 use crate::proto::rpki_service_server::RpkiService as RpkiServiceTrait;
 use crate::proto::{
-    CoveringVrp, RouteOriginValidation, ValidateRouteOriginRequest, ValidateRouteOriginResponse,
+    AcceptedRpkiCacheState, CoveringVrp, ListRpkiCachesRequest, ListRpkiCachesResponse,
+    RouteOriginValidation, RpkiCacheState, ValidateRouteOriginRequest, ValidateRouteOriginResponse,
 };
 
 /// Synchronous daemon-owned reader for the latest authoritative VRP snapshot.
@@ -23,13 +24,23 @@ pub type VrpSnapshotFn = Arc<dyn Fn() -> Option<Arc<VrpTable>> + Send + Sync>;
 #[derive(Clone)]
 pub struct RpkiService {
     snapshot: VrpSnapshotFn,
+    cache_queries: Option<CacheQueryHandle>,
 }
 
 impl RpkiService {
     /// Construct a service from the daemon's narrow synchronous snapshot read.
     #[must_use]
     pub fn new(snapshot: VrpSnapshotFn) -> Self {
-        Self { snapshot }
+        Self {
+            snapshot,
+            cache_queries: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_cache_queries(mut self, cache_queries: Option<CacheQueryHandle>) -> Self {
+        self.cache_queries = cache_queries;
+        self
     }
 }
 
@@ -74,6 +85,45 @@ const fn validation_to_proto(validation: RpkiValidation) -> RouteOriginValidatio
 
 #[tonic::async_trait]
 impl RpkiServiceTrait for RpkiService {
+    async fn list_caches(
+        &self,
+        _request: Request<ListRpkiCachesRequest>,
+    ) -> Result<Response<ListRpkiCachesResponse>, Status> {
+        let Some(queries) = self.cache_queries.clone() else {
+            return Ok(Response::new(ListRpkiCachesResponse {
+                caches: Vec::new(),
+                complete: true,
+                omitted: 0,
+            }));
+        };
+        let list = tokio::time::timeout(std::time::Duration::from_secs(2), queries.list())
+            .await
+            .map_err(|_| Status::deadline_exceeded("RPKI cache inventory query timed out"))?
+            .map_err(|_| Status::unavailable("RPKI cache inventory actor is unavailable"))?;
+        let caches = list
+            .rows
+            .into_iter()
+            .map(|row| RpkiCacheState {
+                address: row.server.to_string(),
+                connected: row.connected,
+                accepted: row.accepted.map(|accepted| AcceptedRpkiCacheState {
+                    protocol_version: accepted.protocol_version.map(u32::from),
+                    session_id: accepted.session_id.map(u32::from),
+                    serial: accepted.serial,
+                    vrp_v4_count: u64::try_from(accepted.vrp_v4_count).unwrap_or(u64::MAX),
+                    vrp_v6_count: u64::try_from(accepted.vrp_v6_count).unwrap_or(u64::MAX),
+                    aspa_count: u64::try_from(accepted.aspa_count).unwrap_or(u64::MAX),
+                    age_seconds: accepted.age_seconds,
+                }),
+            })
+            .collect();
+        Ok(Response::new(ListRpkiCachesResponse {
+            caches,
+            complete: list.omitted == 0,
+            omitted: list.omitted,
+        }))
+    }
+
     async fn validate_route_origin(
         &self,
         request: Request<ValidateRouteOriginRequest>,
@@ -191,6 +241,70 @@ mod tests {
         assert!(response.covering_vrps.is_empty());
         assert!(response.complete);
         assert_eq!(response.omitted, 0);
+    }
+
+    #[tokio::test]
+    async fn unconfigured_cache_inventory_is_empty_and_complete() {
+        let service = RpkiService::new(Arc::new(|| None));
+        let response = service
+            .list_caches(Request::new(ListRpkiCachesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(response.caches.is_empty());
+        assert!(response.complete);
+        assert_eq!(response.omitted, 0);
+    }
+
+    #[tokio::test]
+    async fn closed_cache_inventory_actor_is_unavailable() {
+        let (attachment, updates, queries) = rustbgpd_rpki::CacheInventoryAttachment::new([]);
+        drop(attachment);
+        drop(updates);
+        let service = RpkiService::new(Arc::new(|| None)).with_cache_queries(Some(queries));
+        let error = service
+            .list_caches(Request::new(ListRpkiCachesRequest {}))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Code::Unavailable);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cache_inventory_whole_query_timeout_is_deadline_exceeded() {
+        let (_attachment, _updates, queries) =
+            rustbgpd_rpki::CacheInventoryAttachment::new(["192.0.2.1:3323".parse().unwrap()]);
+        let service = RpkiService::new(Arc::new(|| None)).with_cache_queries(Some(queries));
+        let error = service
+            .list_caches(Request::new(ListRpkiCachesRequest {}))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Code::DeadlineExceeded);
+    }
+
+    #[tokio::test]
+    async fn configured_initial_cache_is_present_without_accepted_epoch() {
+        let (legacy_tx, legacy_rx) = tokio::sync::mpsc::channel(1);
+        let (rib_tx, _rib_rx) = tokio::sync::mpsc::channel(1);
+        let (attachment, updates, queries) =
+            rustbgpd_rpki::CacheInventoryAttachment::new(["192.0.2.1:3323".parse().unwrap()]);
+        let manager = tokio::spawn(
+            rustbgpd_rpki::VrpManager::new(legacy_rx, rib_tx)
+                .with_cache_inventory(attachment)
+                .run(),
+        );
+        let service = RpkiService::new(Arc::new(|| None)).with_cache_queries(Some(queries));
+        let response = service
+            .list_caches(Request::new(ListRpkiCachesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.caches.len(), 1);
+        assert_eq!(response.caches[0].address, "192.0.2.1:3323");
+        assert!(!response.caches[0].connected);
+        assert!(response.caches[0].accepted.is_none());
+        drop(legacy_tx);
+        drop(updates);
+        manager.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -65,6 +65,7 @@ use crate::runtime_config_settlement::{
     RuntimeConfigFenceReason, RuntimeConfigSettlementWatchdog,
 };
 use rustbgpd_rib::{RibReadinessQuery, RibUpdate};
+use rustbgpd_rpki::CacheQueryHandle;
 use rustbgpd_telemetry::BgpMetrics;
 
 const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
@@ -1002,6 +1003,8 @@ pub struct ServeConfig {
     /// The closure clones the table Arc and releases its watch borrow before
     /// returning; `None` means no first authoritative snapshot has arrived.
     pub vrp_snapshot: VrpSnapshotFn,
+    /// Bounded actor-owned RTR cache inventory query lane.
+    pub rpki_cache_queries: Option<CacheQueryHandle>,
     /// Optional MRT dump trigger channel (None if MRT not configured).
     pub mrt_trigger_tx: Option<MrtTriggerTx>,
     /// Live count provider for locally-originated Type 2 MAC routes
@@ -1510,6 +1513,7 @@ async fn run_listener(
     let peer_mgr_readiness_tx = config.peer_mgr_readiness_tx;
     let rib_readiness_tx = config.rib_readiness_tx;
     let vrp_snapshot = config.vrp_snapshot;
+    let rpki_cache_queries = config.rpki_cache_queries;
     let mrt_trigger_tx = config.mrt_trigger_tx;
     let evpn_originated_local_mac_count = config.evpn_originated_local_mac_count;
     let evpn_instance_status_snapshot = config.evpn_instance_status_snapshot;
@@ -1569,6 +1573,7 @@ async fn run_listener(
                 rib_query_tx,
                 rib_readiness_tx,
                 vrp_snapshot.clone(),
+                rpki_cache_queries.clone(),
                 peer_mgr_tx,
                 peer_mgr_readiness_tx,
                 asn,
@@ -1633,6 +1638,7 @@ async fn run_listener(
                 rib_query_tx,
                 rib_readiness_tx,
                 vrp_snapshot,
+                rpki_cache_queries,
                 peer_mgr_tx,
                 peer_mgr_readiness_tx,
                 asn,
@@ -1703,6 +1709,7 @@ async fn run_tcp_listener(
     rib_query_tx: mpsc::Sender<RibUpdate>,
     rib_readiness_tx: mpsc::Sender<RibReadinessQuery>,
     vrp_snapshot: VrpSnapshotFn,
+    rpki_cache_queries: Option<CacheQueryHandle>,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     peer_mgr_readiness_tx: mpsc::Sender<PeerManagerReadinessQuery>,
     asn: u32,
@@ -1844,7 +1851,7 @@ async fn run_tcp_listener(
         interceptor.clone(),
     ));
     routes.add_service(RpkiServiceServer::with_interceptor(
-        RpkiService::new(vrp_snapshot),
+        RpkiService::new(vrp_snapshot).with_cache_queries(rpki_cache_queries),
         interceptor.clone(),
     ));
     routes.add_service(InjectionServiceServer::with_interceptor(
@@ -1977,6 +1984,7 @@ async fn run_uds_listener(
     rib_query_tx: mpsc::Sender<RibUpdate>,
     rib_readiness_tx: mpsc::Sender<RibReadinessQuery>,
     vrp_snapshot: VrpSnapshotFn,
+    rpki_cache_queries: Option<CacheQueryHandle>,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     peer_mgr_readiness_tx: mpsc::Sender<PeerManagerReadinessQuery>,
     asn: u32,
@@ -2079,7 +2087,7 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(RpkiServiceServer::with_interceptor(
-        RpkiService::new(vrp_snapshot),
+        RpkiService::new(vrp_snapshot).with_cache_queries(rpki_cache_queries),
         interceptor.clone(),
     ));
     routes.add_service(InjectionServiceServer::with_interceptor(

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -82,6 +82,7 @@ rbgp neighbor-set set <name> --from-file set.json
 rbgp bfd
 rbgp bfd show <addr>
 rbgp rpki validate 192.0.2.0/24 64496       # complete verdict + bounded covering VRPs
+rbgp rpki caches                             # configured caches + accepted RTR epochs
 ```
 
 `rpki validate` requires the daemon's first authoritative VRP snapshot. Before

--- a/crates/cli/src/commands/rpki.rs
+++ b/crates/cli/src/commands/rpki.rs
@@ -10,8 +10,27 @@ use crate::error::CliError;
 use crate::output;
 use crate::proto::rpki_service_client::RpkiServiceClient;
 use crate::proto::{
-    CoveringVrp, RouteOriginValidation, ValidateRouteOriginRequest, ValidateRouteOriginResponse,
+    CoveringVrp, ListRpkiCachesRequest, ListRpkiCachesResponse, RouteOriginValidation,
+    ValidateRouteOriginRequest, ValidateRouteOriginResponse,
 };
+
+#[derive(Debug, Serialize)]
+struct JsonCache<'a> {
+    address: &'a str,
+    connected: bool,
+    accepted: Option<JsonAcceptedCache>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonAcceptedCache {
+    protocol_version: Option<u32>,
+    session_id: Option<u32>,
+    serial: Option<u32>,
+    vrp_v4_count: u64,
+    vrp_v6_count: u64,
+    aspa_count: u64,
+    age_seconds: u64,
+}
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 struct JsonCoveringVrp {
@@ -171,6 +190,99 @@ pub async fn validate(
     Ok(())
 }
 
+fn render_caches_human(response: &ListRpkiCachesResponse) -> String {
+    let mut rendered = String::new();
+    if response.caches.is_empty() {
+        rendered.push_str("RPKI caches: none\n");
+    } else {
+        writeln!(
+            rendered,
+            "{:<45} {:<12} {:>10} {:>10} {:>10} {:>10}",
+            "Address", "State", "VRP v4", "VRP v6", "ASPAs", "Age(s)"
+        )
+        .unwrap();
+        for cache in &response.caches {
+            if let Some(accepted) = &cache.accepted {
+                writeln!(
+                    rendered,
+                    "{:<45} {:<12} {:>10} {:>10} {:>10} {:>10}",
+                    cache.address,
+                    if cache.connected {
+                        "connected"
+                    } else {
+                        "retained"
+                    },
+                    accepted.vrp_v4_count,
+                    accepted.vrp_v6_count,
+                    accepted.aspa_count,
+                    accepted.age_seconds
+                )
+                .unwrap();
+            } else {
+                writeln!(
+                    rendered,
+                    "{:<45} {:<12} {:>10}",
+                    cache.address,
+                    if cache.connected {
+                        "syncing"
+                    } else {
+                        "disconnected"
+                    },
+                    "-"
+                )
+                .unwrap();
+            }
+        }
+    }
+    if response.complete {
+        rendered.push_str("Listing: complete\n");
+    } else {
+        writeln!(
+            rendered,
+            "Listing: incomplete ({} omitted)",
+            response.omitted
+        )
+        .unwrap();
+    }
+    rendered
+}
+
+fn caches_json(response: &ListRpkiCachesResponse) -> serde_json::Value {
+    let rows: Vec<_> = response
+        .caches
+        .iter()
+        .map(|cache| JsonCache {
+            address: &cache.address,
+            connected: cache.connected,
+            accepted: cache.accepted.as_ref().map(|state| JsonAcceptedCache {
+                protocol_version: state.protocol_version,
+                session_id: state.session_id,
+                serial: state.serial,
+                vrp_v4_count: state.vrp_v4_count,
+                vrp_v6_count: state.vrp_v6_count,
+                aspa_count: state.aspa_count,
+                age_seconds: state.age_seconds,
+            }),
+        })
+        .collect();
+    serde_json::json!({ "caches": rows, "complete": response.complete, "omitted": response.omitted })
+}
+
+pub async fn caches(connection: Connection, json: bool) -> Result<(), CliError> {
+    let mut client =
+        RpkiServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let response = client
+        .list_caches(ListRpkiCachesRequest {})
+        .await?
+        .into_inner();
+    if json {
+        output::print_json_pretty(&caches_json(&response))?;
+    } else {
+        print!("{}", render_caches_human(&response));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -271,6 +383,46 @@ mod tests {
         assert!(render_human(&empty).contains("Covering VRPs: none\nListing: complete\n"));
     }
 
+    #[test]
+    fn cache_inventory_human_and_json_are_presence_aware() {
+        let response = ListRpkiCachesResponse {
+            caches: vec![crate::proto::RpkiCacheState {
+                address: "192.0.2.1:3323".to_string(),
+                connected: false,
+                accepted: Some(crate::proto::AcceptedRpkiCacheState {
+                    protocol_version: Some(2),
+                    session_id: Some(7),
+                    serial: Some(11),
+                    vrp_v4_count: 10,
+                    vrp_v6_count: 20,
+                    aspa_count: 3,
+                    age_seconds: 4,
+                }),
+            }],
+            complete: false,
+            omitted: 1,
+        };
+        let human = render_caches_human(&response);
+        assert!(human.contains("192.0.2.1:3323"));
+        assert!(human.contains("retained"));
+        assert!(human.ends_with("Listing: incomplete (1 omitted)\n"));
+        assert_eq!(
+            caches_json(&response),
+            serde_json::json!({
+                "caches": [{
+                    "address": "192.0.2.1:3323", "connected": false,
+                    "accepted": { "protocol_version": 2, "session_id": 7, "serial": 11,
+                        "vrp_v4_count": 10, "vrp_v6_count": 20, "aspa_count": 3, "age_seconds": 4 }
+                }],
+                "complete": false, "omitted": 1
+            })
+        );
+        assert_eq!(
+            render_caches_human(&ListRpkiCachesResponse::default()),
+            "RPKI caches: none\nListing: incomplete (0 omitted)\n"
+        );
+    }
+
     #[derive(Clone)]
     struct MockRpki {
         request: Arc<Mutex<Option<server_proto::ValidateRouteOriginRequest>>>,
@@ -278,6 +430,15 @@ mod tests {
 
     #[tonic::async_trait]
     impl RpkiService for MockRpki {
+        async fn list_caches(
+            &self,
+            _request: Request<server_proto::ListRpkiCachesRequest>,
+        ) -> Result<Response<server_proto::ListRpkiCachesResponse>, Status> {
+            Ok(Response::new(
+                server_proto::ListRpkiCachesResponse::default(),
+            ))
+        }
+
         async fn validate_route_origin(
             &self,
             request: Request<server_proto::ValidateRouteOriginRequest>,

--- a/crates/cli/src/commands/rpki.rs
+++ b/crates/cli/src/commands/rpki.rs
@@ -221,13 +221,16 @@ fn render_caches_human(response: &ListRpkiCachesResponse) -> String {
             } else {
                 writeln!(
                     rendered,
-                    "{:<45} {:<12} {:>10}",
+                    "{:<45} {:<12} {:>10} {:>10} {:>10} {:>10}",
                     cache.address,
                     if cache.connected {
                         "syncing"
                     } else {
                         "disconnected"
                     },
+                    "-",
+                    "-",
+                    "-",
                     "-"
                 )
                 .unwrap();
@@ -420,6 +423,24 @@ mod tests {
         assert_eq!(
             render_caches_human(&ListRpkiCachesResponse::default()),
             "RPKI caches: none\nListing: incomplete (0 omitted)\n"
+        );
+
+        let unavailable = ListRpkiCachesResponse {
+            caches: vec![crate::proto::RpkiCacheState {
+                address: "[2001:db8::1]:3323".to_string(),
+                connected: false,
+                accepted: None,
+            }],
+            complete: true,
+            omitted: 0,
+        };
+        assert_eq!(
+            render_caches_human(&unavailable),
+            concat!(
+                "Address                                       State            VRP v4     VRP v6      ASPAs     Age(s)\n",
+                "[2001:db8::1]:3323                            disconnected          -          -          -          -\n",
+                "Listing: complete\n",
+            )
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1155,6 +1155,8 @@ enum BfdAction {
 
 #[derive(Subcommand)]
 enum RpkiAction {
+    /// List configured RTR caches and accepted validation epochs
+    Caches,
     /// Validate one CIDR prefix and origin ASN
     Validate {
         /// Route prefix in CIDR form, for example 192.0.2.0/24
@@ -2341,6 +2343,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
         },
 
         Command::Rpki { action } => match action {
+            RpkiAction::Caches => commands::rpki::caches(connection, json).await,
             RpkiAction::Validate { prefix, origin_asn } => {
                 commands::rpki::validate(connection, &prefix, origin_asn, json).await
             }

--- a/crates/rpki/CHANGELOG.md
+++ b/crates/rpki/CHANGELOG.md
@@ -5,6 +5,11 @@ Daemon and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- Added an optional cache-inventory attachment with separate enhanced-update
+  and bounded query handles. Existing `VrpUpdate`, `RtrClient::new`, and
+  `VrpManager::new` callers remain source-compatible; attached clients publish
+  contribution and accepted RTR epoch metadata atomically.
+
 - Added `VrpTable::covering_vrps` and the `CoveringVrp` / `CoveringVrps`
   result types. The helper walks only ancestor buckets, returns authorizers
   first, applies a 256-row hard cap with exact omission, and exposes the

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -22,7 +22,10 @@ newer. Release-by-release crate changes are recorded in the
 - **ASPA path verification** — a synchronous `AspaTable` plus role-aware path
   verification.
 - **Multi-cache merge** — a `VrpManager` that merges retained contributions
-  from multiple RTR caches and publishes immutable VRP and ASPA snapshots.
+  from multiple RTR caches and publishes immutable VRP and ASPA snapshots. An
+  optional `CacheInventoryAttachment` supplies distinct enhanced-update and
+  bounded query handles without changing the legacy constructors or
+  `VrpUpdate` contract.
 
 The standalone crate does not select BGP best paths or evaluate rustbgpd policy
 statements. In the daemon, `rustbgpd-rib` consumes these validation results in
@@ -98,6 +101,8 @@ The crate-root facade exports the primary application surface:
   `MAX_COVERING_VRPS`, `AspaRecord`, and `AspaTable`
 - `AspaInvalidHop`, `AspaVerificationResult`, and `ValidationSnapshot`
 - `RtrClient`, `RtrClientConfig`, `VrpUpdate`, and `RTR_EXPIRE_MAX_SECS`
+- `CacheInventoryAttachment`, `CacheUpdateHandle`, and `CacheQueryHandle` for
+  atomic accepted-epoch inventory when the optional attachment is used
 - `VrpManager`, `RpkiTableUpdate`, and `AspaTableUpdate`
 
 The public modules are also part of the `0.1.x` API. They expose the advanced

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -63,7 +63,10 @@ pub use rtr_client::{
     EXPIRE_MAX_SECS as RTR_EXPIRE_MAX_SECS, RtrClient, RtrClientConfig, VrpUpdate,
 };
 pub use vrp::{CoveringVrp, CoveringVrps, MAX_COVERING_VRPS, VrpEntry, VrpTable};
-pub use vrp_manager::{AspaTableUpdate, RpkiTableUpdate, VrpManager};
+pub use vrp_manager::{
+    AcceptedCacheState, AspaTableUpdate, CacheInventoryAttachment, CacheList, CacheQueryError,
+    CacheQueryHandle, CacheState, CacheUpdateHandle, RpkiTableUpdate, VrpManager,
+};
 
 /// Snapshot of RPKI validation tables, broadcast to transport sessions
 /// via `tokio::sync::watch` for import-time route validation.

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -20,7 +20,7 @@
 //! supported RFC 8210 / 8210bis subset.
 
 use std::net::SocketAddr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -31,6 +31,7 @@ use tracing::{debug, info, warn};
 use crate::aspa::AspaRecord;
 use crate::rtr_codec::{RtrDecodeError, RtrEncodeError, RtrPdu};
 use crate::vrp::VrpEntry;
+use crate::vrp_manager::{CacheUpdateHandle, EnhancedVrpUpdate};
 
 /// Maximum read buffer size (256 KiB).
 const MAX_READ_BUF: usize = 256 * 1024;
@@ -203,6 +204,7 @@ pub struct RtrClient {
     /// The cache epoch backing the currently held data, if any.
     epoch: Option<CacheEpoch>,
     vrp_tx: mpsc::Sender<VrpUpdate>,
+    enhanced_tx: Option<CacheUpdateHandle>,
     refresh_interval: Duration,
     retry_interval: Duration,
     expire_interval: Duration,
@@ -244,6 +246,7 @@ impl RtrClient {
             last_end_of_data_at: None,
             data_expires_at: None,
             vrp_tx,
+            enhanced_tx: None,
             config,
             epoch: None,
             negotiated_version: crate::rtr_codec::RTR_VERSION_2,
@@ -252,6 +255,20 @@ impl RtrClient {
             max_transaction_records: MAX_TRANSACTION_RECORDS,
             max_transaction_bytes: MAX_TRANSACTION_BYTES,
             expire_observer: None,
+        }
+    }
+
+    /// Route validated cache epochs and connection lifecycle through the
+    /// manager's atomic cache-inventory attachment.
+    #[must_use]
+    pub fn with_cache_inventory(mut self, handle: CacheUpdateHandle) -> Self {
+        self.enhanced_tx = Some(handle);
+        self
+    }
+
+    async fn send_enhanced(&self, update: EnhancedVrpUpdate) {
+        if let Some(handle) = &self.enhanced_tx {
+            let _ = handle.0.send(update).await;
         }
     }
 
@@ -311,6 +328,11 @@ impl RtrClient {
 
     async fn connect_and_run(&mut self) -> Result<(), std::io::Error> {
         let mut stream = TcpStream::connect(self.config.server_addr).await?;
+        let mut disconnect_sent = false;
+        self.send_enhanced(EnhancedVrpUpdate::Connected {
+            server: self.config.server_addr,
+        })
+        .await;
         info!(
             server = %self.config.server_addr,
             rtr_version = self.negotiated_version,
@@ -322,6 +344,11 @@ impl RtrClient {
             // (the teardown Error Report, if any, was already sent).
             drop(stream);
             if self.should_fallback_to_v1(&error) {
+                self.send_enhanced(EnhancedVrpUpdate::Disconnected {
+                    server: self.config.server_addr,
+                    flush: false,
+                })
+                .await;
                 self.run_v1_fallback_session().await;
                 return Ok(());
             }
@@ -331,7 +358,23 @@ impl RtrClient {
                 error = %error,
                 "RTR session ended"
             );
+            disconnect_sent = true;
+            if error.disposition() != SessionEndDisposition::FlushAndDrop {
+                self.send_enhanced(EnhancedVrpUpdate::Disconnected {
+                    server: self.config.server_addr,
+                    flush: false,
+                })
+                .await;
+            }
             self.end_session(&error).await;
+        }
+
+        if !disconnect_sent {
+            self.send_enhanced(EnhancedVrpUpdate::Disconnected {
+                server: self.config.server_addr,
+                flush: false,
+            })
+            .await;
         }
 
         Ok(())
@@ -389,6 +432,11 @@ impl RtrClient {
 
         match TcpStream::connect(self.config.server_addr).await {
             Ok(mut stream) => {
+                let mut disconnect_sent = false;
+                self.send_enhanced(EnhancedVrpUpdate::Connected {
+                    server: self.config.server_addr,
+                })
+                .await;
                 info!(
                     server = %self.config.server_addr,
                     rtr_version = self.negotiated_version,
@@ -401,7 +449,22 @@ impl RtrClient {
                         error = %error,
                         "RTR session ended after v1 fallback"
                     );
+                    disconnect_sent = true;
+                    if error.disposition() != SessionEndDisposition::FlushAndDrop {
+                        self.send_enhanced(EnhancedVrpUpdate::Disconnected {
+                            server: self.config.server_addr,
+                            flush: false,
+                        })
+                        .await;
+                    }
                     self.end_session(&error).await;
+                }
+                if !disconnect_sent {
+                    self.send_enhanced(EnhancedVrpUpdate::Disconnected {
+                        server: self.config.server_addr,
+                        flush: false,
+                    })
+                    .await;
                 }
             }
             Err(error) => {
@@ -434,12 +497,26 @@ impl RtrClient {
         let now = TokioInstant::now();
         let expired = flush_now || self.data_expires_at.is_some_and(|at| now >= at);
         if expired {
-            let _ = self
-                .vrp_tx
-                .send(VrpUpdate::ServerDown {
-                    server: self.config.server_addr,
-                })
-                .await;
+            if let Some(handle) = &self.enhanced_tx {
+                let update = if flush_now {
+                    EnhancedVrpUpdate::Disconnected {
+                        server: self.config.server_addr,
+                        flush: true,
+                    }
+                } else {
+                    EnhancedVrpUpdate::Expired {
+                        server: self.config.server_addr,
+                    }
+                };
+                let _ = handle.0.send(update).await;
+            } else {
+                let _ = self
+                    .vrp_tx
+                    .send(VrpUpdate::ServerDown {
+                        server: self.config.server_addr,
+                    })
+                    .await;
+            }
             self.epoch = None;
             self.last_end_of_data_at = None;
             self.data_expires_at = None;
@@ -1125,7 +1202,46 @@ impl RtrClient {
                                 );
                             }
 
-                            let _ = self.vrp_tx.send(update).await;
+                            if let Some(handle) = &self.enhanced_tx {
+                                let update = match update {
+                                    VrpUpdate::FullTable {
+                                        server,
+                                        entries,
+                                        aspa_records,
+                                    } => EnhancedVrpUpdate::Full {
+                                        server,
+                                        entries,
+                                        aspa_records,
+                                        version: self.negotiated_version,
+                                        session_id,
+                                        serial,
+                                        accepted_at: Instant::now(),
+                                    },
+                                    VrpUpdate::IncrementalUpdate {
+                                        server,
+                                        announced,
+                                        withdrawn,
+                                        aspa_announced,
+                                        aspa_withdrawn,
+                                    } => EnhancedVrpUpdate::Incremental {
+                                        server,
+                                        announced,
+                                        withdrawn,
+                                        aspa_announced,
+                                        aspa_withdrawn,
+                                        version: self.negotiated_version,
+                                        session_id,
+                                        serial,
+                                        accepted_at: Instant::now(),
+                                    },
+                                    VrpUpdate::ServerDown { .. } => {
+                                        unreachable!("End of Data never emits ServerDown")
+                                    }
+                                };
+                                let _ = handle.0.send(update).await;
+                            } else {
+                                let _ = self.vrp_tx.send(update).await;
+                            }
                             return Ok(());
                         }
                         RtrPdu::CacheReset => {

--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -5,17 +5,162 @@
 //! snapshots. When either table changes, sends the updated snapshot to the
 //! RIB manager.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Instant;
 
 use rustc_hash::FxHashSet;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info};
 
 use crate::aspa::{AspaRecord, AspaTable};
 use crate::rtr_client::VrpUpdate;
 use crate::vrp::{VrpEntry, VrpTable};
+
+const CACHE_QUERY_CAPACITY: usize = 16;
+pub const MAX_CACHE_ROWS: usize = 256;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptedCacheState {
+    pub protocol_version: Option<u8>,
+    pub session_id: Option<u16>,
+    pub serial: Option<u32>,
+    pub vrp_v4_count: usize,
+    pub vrp_v6_count: usize,
+    pub aspa_count: usize,
+    pub age_seconds: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CacheState {
+    pub server: SocketAddr,
+    pub connected: bool,
+    pub accepted: Option<AcceptedCacheState>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CacheList {
+    pub rows: Vec<CacheState>,
+    pub omitted: u64,
+}
+
+pub struct CacheQuery {
+    reply: oneshot::Sender<CacheList>,
+}
+
+#[derive(Clone)]
+pub struct CacheQueryHandle(mpsc::Sender<CacheQuery>);
+
+impl CacheQueryHandle {
+    /// Request the current bounded cache inventory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CacheQueryError`] when the manager actor has stopped before
+    /// accepting or answering the request.
+    pub async fn list(&self) -> Result<CacheList, CacheQueryError> {
+        let (reply, rx) = oneshot::channel();
+        self.0
+            .send(CacheQuery { reply })
+            .await
+            .map_err(|_| CacheQueryError)?;
+        rx.await.map_err(|_| CacheQueryError)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CacheQueryError;
+
+#[derive(Debug)]
+pub(crate) enum EnhancedVrpUpdate {
+    Connected {
+        server: SocketAddr,
+    },
+    Disconnected {
+        server: SocketAddr,
+        flush: bool,
+    },
+    Expired {
+        server: SocketAddr,
+    },
+    Full {
+        server: SocketAddr,
+        entries: Vec<VrpEntry>,
+        aspa_records: Vec<AspaRecord>,
+        version: u8,
+        session_id: u16,
+        serial: u32,
+        accepted_at: Instant,
+    },
+    Incremental {
+        server: SocketAddr,
+        announced: Vec<VrpEntry>,
+        withdrawn: Vec<VrpEntry>,
+        aspa_announced: Vec<AspaRecord>,
+        aspa_withdrawn: Vec<AspaRecord>,
+        version: u8,
+        session_id: u16,
+        serial: u32,
+        accepted_at: Instant,
+    },
+}
+
+#[derive(Clone)]
+pub struct CacheUpdateHandle(pub(crate) mpsc::Sender<EnhancedVrpUpdate>);
+
+pub struct CacheInventoryAttachment {
+    update_rx: mpsc::Receiver<EnhancedVrpUpdate>,
+    query_rx: mpsc::Receiver<CacheQuery>,
+    query_open: bool,
+    states: BTreeMap<SocketAddr, InternalCacheState>,
+}
+
+#[derive(Clone, Debug)]
+struct InternalCacheState {
+    connected: bool,
+    accepted: Option<AcceptedMetadata>,
+}
+
+#[derive(Clone, Debug)]
+struct AcceptedMetadata {
+    version: Option<u8>,
+    session_id: Option<u16>,
+    serial: Option<u32>,
+    accepted_at: Instant,
+}
+
+impl CacheInventoryAttachment {
+    #[must_use]
+    pub fn new(
+        servers: impl IntoIterator<Item = SocketAddr>,
+    ) -> (Self, CacheUpdateHandle, CacheQueryHandle) {
+        let (update_tx, update_rx) = mpsc::channel(256);
+        let (query_tx, query_rx) = mpsc::channel(CACHE_QUERY_CAPACITY);
+        let states = servers
+            .into_iter()
+            .map(|server| {
+                (
+                    server,
+                    InternalCacheState {
+                        connected: false,
+                        accepted: None,
+                    },
+                )
+            })
+            .collect();
+        (
+            Self {
+                update_rx,
+                query_rx,
+                query_open: true,
+                states,
+            },
+            CacheUpdateHandle(update_tx),
+            CacheQueryHandle(query_tx),
+        )
+    }
+}
 
 /// Message sent from VRP manager to RIB manager when the VRP table changes.
 #[derive(Debug, Clone)]
@@ -68,6 +213,7 @@ pub struct VrpManager {
     /// Sender for ASPA table snapshots to the RIB manager.
     aspa_rib_tx: Option<mpsc::Sender<AspaTableUpdate>>,
     readiness_observer: Option<Box<dyn Fn(SocketAddr, bool) + Send + Sync>>,
+    cache_inventory: Option<CacheInventoryAttachment>,
 }
 
 impl VrpManager {
@@ -86,7 +232,14 @@ impl VrpManager {
             rib_tx,
             aspa_rib_tx: None,
             readiness_observer: None,
+            cache_inventory: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_cache_inventory(mut self, attachment: CacheInventoryAttachment) -> Self {
+        self.cache_inventory = Some(attachment);
+        self
     }
 
     /// Set the ASPA table update sender.
@@ -109,10 +262,193 @@ impl VrpManager {
 
     /// Main event loop.
     pub async fn run(mut self) {
-        while let Some(update) = self.update_rx.recv().await {
-            self.handle_update(update).await;
+        loop {
+            if self.cache_inventory.is_none() {
+                let Some(update) = self.update_rx.recv().await else {
+                    break;
+                };
+                self.handle_update(update).await;
+                continue;
+            }
+            let Some(inventory) = self.cache_inventory.as_mut() else {
+                continue;
+            };
+            tokio::select! {
+                biased;
+                update = self.update_rx.recv() => match update {
+                    Some(update) => self.handle_update(update).await,
+                    None if inventory.update_rx.is_closed() => break,
+                    None => {},
+                },
+                update = inventory.update_rx.recv() => match update {
+                    Some(update) => self.handle_enhanced_update(update).await,
+                    None if self.update_rx.is_closed() => break,
+                    None => {},
+                },
+                query = inventory.query_rx.recv(), if inventory.query_open => match query {
+                    Some(query) => { let _ = query.reply.send(self.cache_list()); }
+                    None => inventory.query_open = false,
+                },
+            }
         }
         info!("VRP manager shutting down");
+    }
+
+    fn cache_list(&self) -> CacheList {
+        let Some(inventory) = &self.cache_inventory else {
+            return CacheList {
+                rows: Vec::new(),
+                omitted: 0,
+            };
+        };
+        let total = inventory.states.len();
+        let rows = inventory
+            .states
+            .iter()
+            .take(MAX_CACHE_ROWS)
+            .map(|(&server, state)| {
+                let accepted = state.accepted.as_ref().map(|metadata| {
+                    let table = self.server_tables.get(&server);
+                    let (vrp_v4_count, vrp_v6_count) = table.map_or((0, 0), |entries| {
+                        entries
+                            .iter()
+                            .fold((0, 0), |(v4, v6), entry| match entry.prefix {
+                                std::net::IpAddr::V4(_) => (v4 + 1, v6),
+                                std::net::IpAddr::V6(_) => (v4, v6 + 1),
+                            })
+                    });
+                    AcceptedCacheState {
+                        protocol_version: metadata.version,
+                        session_id: metadata.session_id,
+                        serial: metadata.serial,
+                        vrp_v4_count,
+                        vrp_v6_count,
+                        aspa_count: self.server_aspa_tables.get(&server).map_or(0, HashMap::len),
+                        age_seconds: metadata.accepted_at.elapsed().as_secs(),
+                    }
+                });
+                CacheState {
+                    server,
+                    connected: state.connected,
+                    accepted,
+                }
+            })
+            .collect();
+        CacheList {
+            rows,
+            omitted: u64::try_from(total.saturating_sub(MAX_CACHE_ROWS)).unwrap_or(u64::MAX),
+        }
+    }
+
+    async fn handle_enhanced_update(&mut self, update: EnhancedVrpUpdate) {
+        match update {
+            EnhancedVrpUpdate::Connected { server } => {
+                if let Some(state) = self
+                    .cache_inventory
+                    .as_mut()
+                    .and_then(|i| i.states.get_mut(&server))
+                {
+                    state.connected = true;
+                }
+            }
+            EnhancedVrpUpdate::Disconnected { server, flush } => {
+                if let Some(state) = self
+                    .cache_inventory
+                    .as_mut()
+                    .and_then(|i| i.states.get_mut(&server))
+                {
+                    state.connected = false;
+                    if flush {
+                        state.accepted = None;
+                    }
+                }
+                if flush {
+                    self.handle_update(VrpUpdate::ServerDown { server }).await;
+                }
+            }
+            EnhancedVrpUpdate::Expired { server } => {
+                if let Some(state) = self
+                    .cache_inventory
+                    .as_mut()
+                    .and_then(|i| i.states.get_mut(&server))
+                {
+                    state.accepted = None;
+                }
+                self.handle_update(VrpUpdate::ServerDown { server }).await;
+            }
+            EnhancedVrpUpdate::Full {
+                server,
+                entries,
+                aspa_records,
+                version,
+                session_id,
+                serial,
+                accepted_at,
+            } => {
+                self.handle_update(VrpUpdate::FullTable {
+                    server,
+                    entries,
+                    aspa_records,
+                })
+                .await;
+                self.set_accepted(
+                    server,
+                    Some(version),
+                    Some(session_id),
+                    Some(serial),
+                    accepted_at,
+                );
+            }
+            EnhancedVrpUpdate::Incremental {
+                server,
+                announced,
+                withdrawn,
+                aspa_announced,
+                aspa_withdrawn,
+                version,
+                session_id,
+                serial,
+                accepted_at,
+            } => {
+                self.handle_update(VrpUpdate::IncrementalUpdate {
+                    server,
+                    announced,
+                    withdrawn,
+                    aspa_announced,
+                    aspa_withdrawn,
+                })
+                .await;
+                self.set_accepted(
+                    server,
+                    Some(version),
+                    Some(session_id),
+                    Some(serial),
+                    accepted_at,
+                );
+            }
+        }
+    }
+
+    fn set_accepted(
+        &mut self,
+        server: SocketAddr,
+        version: Option<u8>,
+        session_id: Option<u16>,
+        serial: Option<u32>,
+        accepted_at: Instant,
+    ) {
+        if let Some(state) = self
+            .cache_inventory
+            .as_mut()
+            .and_then(|i| i.states.get_mut(&server))
+        {
+            state.accepted = Some(AcceptedMetadata {
+                version,
+                session_id,
+                serial,
+                accepted_at,
+            });
+        }
     }
 
     async fn handle_update(&mut self, update: VrpUpdate) {
@@ -122,6 +458,7 @@ impl VrpManager {
                 entries,
                 aspa_records,
             } => {
+                self.set_accepted(server, None, None, None, Instant::now());
                 info!(
                     %server,
                     vrps = entries.len(),
@@ -150,6 +487,7 @@ impl VrpManager {
                 aspa_announced,
                 aspa_withdrawn,
             } => {
+                self.set_accepted(server, None, None, None, Instant::now());
                 debug!(
                     %server,
                     vrps_announced = announced.len(),
@@ -740,5 +1078,196 @@ mod tests {
             update.table.authorized(65001, 65002),
             ProviderAuth::NotProviderPlus
         );
+    }
+
+    #[tokio::test]
+    async fn cache_inventory_tracks_atomic_epochs_retention_and_flush() {
+        let (_legacy_tx, legacy_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (attachment, _updates, _queries) = CacheInventoryAttachment::new([server1()]);
+        let mut mgr = VrpManager::new(legacy_rx, rib_tx).with_cache_inventory(attachment);
+
+        mgr.handle_enhanced_update(EnhancedVrpUpdate::Connected { server: server1() })
+            .await;
+        mgr.handle_enhanced_update(EnhancedVrpUpdate::Full {
+            server: server1(),
+            entries: vec![entry(Ipv4Addr::new(192, 0, 2, 0), 24, 24, 64_496)],
+            aspa_records: vec![AspaRecord {
+                customer_asn: 64_496,
+                provider_asns: vec![64_497],
+            }],
+            version: 2,
+            session_id: 7,
+            serial: 11,
+            accepted_at: Instant::now()
+                .checked_sub(std::time::Duration::from_secs(3))
+                .unwrap_or_else(Instant::now),
+        })
+        .await;
+        let row = mgr.cache_list().rows.pop().unwrap();
+        assert!(row.connected);
+        let accepted = row.accepted.unwrap();
+        assert_eq!(
+            (
+                accepted.protocol_version,
+                accepted.session_id,
+                accepted.serial
+            ),
+            (Some(2), Some(7), Some(11))
+        );
+        assert_eq!(
+            (
+                accepted.vrp_v4_count,
+                accepted.vrp_v6_count,
+                accepted.aspa_count
+            ),
+            (1, 0, 1)
+        );
+        assert!(accepted.age_seconds >= 3);
+
+        mgr.handle_enhanced_update(EnhancedVrpUpdate::Disconnected {
+            server: server1(),
+            flush: false,
+        })
+        .await;
+        let retained = mgr.cache_list().rows.pop().unwrap();
+        assert!(!retained.connected);
+        assert!(retained.accepted.is_some());
+
+        mgr.handle_enhanced_update(EnhancedVrpUpdate::Connected { server: server1() })
+            .await;
+        mgr.handle_enhanced_update(EnhancedVrpUpdate::Incremental {
+            server: server1(),
+            announced: vec![],
+            withdrawn: vec![],
+            aspa_announced: vec![],
+            aspa_withdrawn: vec![],
+            version: 2,
+            session_id: 7,
+            serial: 12,
+            accepted_at: Instant::now(),
+        })
+        .await;
+        assert_eq!(
+            mgr.cache_list().rows[0].accepted.as_ref().unwrap().serial,
+            Some(12)
+        );
+
+        mgr.handle_enhanced_update(EnhancedVrpUpdate::Disconnected {
+            server: server1(),
+            flush: true,
+        })
+        .await;
+        let flushed = mgr.cache_list().rows.pop().unwrap();
+        assert!(!flushed.connected);
+        assert!(flushed.accepted.is_none());
+        assert_eq!(mgr.connected_servers(), 0);
+    }
+
+    #[tokio::test]
+    async fn accepted_empty_legacy_metadata_expiry_and_cap_are_exact() {
+        let (_legacy_tx, legacy_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let servers: Vec<SocketAddr> = (0..257)
+            .map(|index| format!("[2001:db8::{:x}]:3323", index + 1).parse().unwrap())
+            .collect();
+        let first = servers[0];
+        let (attachment, _updates, _queries) = CacheInventoryAttachment::new(servers);
+        let mut mgr = VrpManager::new(legacy_rx, rib_tx).with_cache_inventory(attachment);
+        mgr.handle_update(VrpUpdate::FullTable {
+            server: first,
+            entries: vec![],
+            aspa_records: vec![],
+        })
+        .await;
+        let list = mgr.cache_list();
+        assert_eq!(list.rows.len(), 256);
+        assert_eq!(list.omitted, 1);
+        let accepted = list
+            .rows
+            .iter()
+            .find(|row| row.server == first)
+            .unwrap()
+            .accepted
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            (
+                accepted.protocol_version,
+                accepted.session_id,
+                accepted.serial
+            ),
+            (None, None, None)
+        );
+        assert_eq!(
+            (
+                accepted.vrp_v4_count,
+                accepted.vrp_v6_count,
+                accepted.aspa_count
+            ),
+            (0, 0, 0)
+        );
+        mgr.handle_enhanced_update(EnhancedVrpUpdate::Expired { server: first })
+            .await;
+        assert!(
+            mgr.cache_list()
+                .rows
+                .iter()
+                .find(|row| row.server == first)
+                .unwrap()
+                .accepted
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn query_senders_do_not_keep_manager_alive_after_update_lanes_close() {
+        let (legacy_tx, legacy_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let (attachment, updates, queries) = CacheInventoryAttachment::new([server1()]);
+        let task = tokio::spawn(
+            VrpManager::new(legacy_rx, rib_tx)
+                .with_cache_inventory(attachment)
+                .run(),
+        );
+        drop(legacy_tx);
+        drop(updates);
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(queries.list().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn closed_query_lane_does_not_stop_or_spin_the_update_actor() {
+        let (legacy_tx, legacy_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let (attachment, updates, queries) = CacheInventoryAttachment::new([server1()]);
+        let task = tokio::spawn(
+            VrpManager::new(legacy_rx, rib_tx)
+                .with_cache_inventory(attachment)
+                .run(),
+        );
+        drop(queries);
+        legacy_tx
+            .send(VrpUpdate::FullTable {
+                server: server1(),
+                entries: vec![entry(Ipv4Addr::new(192, 0, 2, 0), 24, 24, 64_496)],
+                aspa_records: vec![],
+            })
+            .await
+            .unwrap();
+        let update = tokio::time::timeout(std::time::Duration::from_secs(1), rib_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(update.table.len(), 1);
+        drop(legacy_tx);
+        drop(updates);
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap();
     }
 }

--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -262,6 +262,8 @@ impl VrpManager {
 
     /// Main event loop.
     pub async fn run(mut self) {
+        let mut legacy_updates_open = true;
+        let mut enhanced_updates_open = self.cache_inventory.is_some();
         loop {
             if self.cache_inventory.is_none() {
                 let Some(update) = self.update_rx.recv().await else {
@@ -270,20 +272,21 @@ impl VrpManager {
                 self.handle_update(update).await;
                 continue;
             }
+            if !legacy_updates_open && !enhanced_updates_open {
+                break;
+            }
             let Some(inventory) = self.cache_inventory.as_mut() else {
                 continue;
             };
             tokio::select! {
                 biased;
-                update = self.update_rx.recv() => match update {
+                update = self.update_rx.recv(), if legacy_updates_open => match update {
                     Some(update) => self.handle_update(update).await,
-                    None if inventory.update_rx.is_closed() => break,
-                    None => {},
+                    None => legacy_updates_open = false,
                 },
-                update = inventory.update_rx.recv() => match update {
+                update = inventory.update_rx.recv(), if enhanced_updates_open => match update {
                     Some(update) => self.handle_enhanced_update(update).await,
-                    None if self.update_rx.is_closed() => break,
-                    None => {},
+                    None => enhanced_updates_open = false,
                 },
                 query = inventory.query_rx.recv(), if inventory.query_open => match query {
                     Some(query) => { let _ = query.reply.send(self.cache_list()); }
@@ -1265,6 +1268,78 @@ mod tests {
         assert_eq!(update.table.len(), 1);
         drop(legacy_tx);
         drop(updates);
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn either_update_lane_can_close_while_the_other_updates_and_answers_queries() {
+        let (legacy_tx, legacy_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(2);
+        let (attachment, updates, queries) = CacheInventoryAttachment::new([server1()]);
+        let task = tokio::spawn(
+            VrpManager::new(legacy_rx, rib_tx)
+                .with_cache_inventory(attachment)
+                .run(),
+        );
+        drop(legacy_tx);
+        updates
+            .0
+            .send(EnhancedVrpUpdate::Full {
+                server: server1(),
+                entries: vec![entry(Ipv4Addr::new(192, 0, 2, 0), 24, 24, 64_496)],
+                aspa_records: vec![],
+                version: 2,
+                session_id: 7,
+                serial: 11,
+                accepted_at: Instant::now(),
+            })
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), rib_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let list = tokio::time::timeout(std::time::Duration::from_secs(1), queries.list())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(list.rows[0].accepted.as_ref().unwrap().serial, Some(11));
+        drop(updates);
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (legacy_tx, legacy_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(2);
+        let (attachment, updates, queries) = CacheInventoryAttachment::new([server1()]);
+        let task = tokio::spawn(
+            VrpManager::new(legacy_rx, rib_tx)
+                .with_cache_inventory(attachment)
+                .run(),
+        );
+        drop(updates);
+        legacy_tx
+            .send(VrpUpdate::FullTable {
+                server: server1(),
+                entries: vec![entry(Ipv4Addr::new(198, 51, 100, 0), 24, 24, 64_497)],
+                aspa_records: vec![],
+            })
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), rib_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let list = tokio::time::timeout(std::time::Duration::from_secs(1), queries.list())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(list.rows[0].accepted.as_ref().unwrap().vrp_v4_count, 1);
+        drop(legacy_tx);
         tokio::time::timeout(std::time::Duration::from_secs(1), task)
             .await
             .unwrap()

--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -69,8 +69,58 @@ impl CacheQueryHandle {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("RPKI cache inventory actor is unavailable")]
 pub struct CacheQueryError;
+
+#[derive(Debug, Default)]
+struct ServerVrpTable {
+    entries: HashSet<VrpEntry>,
+    v4_count: usize,
+    v6_count: usize,
+}
+
+impl ServerVrpTable {
+    fn from_entries(entries: impl IntoIterator<Item = VrpEntry>) -> Self {
+        let mut table = Self::default();
+        for entry in entries {
+            table.insert(entry);
+        }
+        table
+    }
+
+    fn insert(&mut self, entry: VrpEntry) -> bool {
+        let is_v4 = entry.prefix.is_ipv4();
+        if !self.entries.insert(entry) {
+            return false;
+        }
+        if is_v4 {
+            self.v4_count += 1;
+        } else {
+            self.v6_count += 1;
+        }
+        true
+    }
+
+    fn remove(&mut self, entry: &VrpEntry) -> bool {
+        if !self.entries.remove(entry) {
+            return false;
+        }
+        match entry.prefix {
+            std::net::IpAddr::V4(_) => self.v4_count -= 1,
+            std::net::IpAddr::V6(_) => self.v6_count -= 1,
+        }
+        true
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &VrpEntry> {
+        self.entries.iter()
+    }
+
+    const fn counts(&self) -> (usize, usize) {
+        (self.v4_count, self.v6_count)
+    }
+}
 
 #[derive(Debug)]
 pub(crate) enum EnhancedVrpUpdate {
@@ -192,9 +242,9 @@ pub struct AspaTableUpdate {
 
 /// Merges VRP and ASPA data from multiple RTR cache servers.
 pub struct VrpManager {
-    /// Per-server VRP entry sets. A set (not a list) so an incremental
-    /// withdraw is O(withdrawn) instead of O(withdrawn × table size).
-    server_tables: HashMap<SocketAddr, HashSet<VrpEntry>>,
+    /// Per-server VRP tables. Each table owns a set for bounded incremental
+    /// updates and cached family counts for bounded inventory queries.
+    server_tables: HashMap<SocketAddr, ServerVrpTable>,
     /// Per-server ASPA state, keyed by customer ASN.
     ///
     /// Keyed (not a record list) because 8210bis ASPA PDUs carry the
@@ -311,15 +361,10 @@ impl VrpManager {
             .take(MAX_CACHE_ROWS)
             .map(|(&server, state)| {
                 let accepted = state.accepted.as_ref().map(|metadata| {
-                    let table = self.server_tables.get(&server);
-                    let (vrp_v4_count, vrp_v6_count) = table.map_or((0, 0), |entries| {
-                        entries
-                            .iter()
-                            .fold((0, 0), |(v4, v6), entry| match entry.prefix {
-                                std::net::IpAddr::V4(_) => (v4 + 1, v6),
-                                std::net::IpAddr::V6(_) => (v4, v6 + 1),
-                            })
-                    });
+                    let (vrp_v4_count, vrp_v6_count) = self
+                        .server_tables
+                        .get(&server)
+                        .map_or((0, 0), ServerVrpTable::counts);
                     AcceptedCacheState {
                         protocol_version: metadata.version,
                         session_id: metadata.session_id,
@@ -469,7 +514,7 @@ impl VrpManager {
                     "full table from cache"
                 );
                 self.server_tables
-                    .insert(server, entries.into_iter().collect());
+                    .insert(server, ServerVrpTable::from_entries(entries));
                 // Later PDUs for the same customer ASN replace earlier
                 // ones within a full table (8210bis replacement semantics).
                 self.server_aspa_tables.insert(
@@ -515,7 +560,9 @@ impl VrpManager {
                 // set is mutated, and only by exactly these entries).
                 let mut delta = withdrawn.clone();
                 delta.extend(announced.iter().cloned());
-                table.extend(announced);
+                for entry in announced {
+                    table.insert(entry);
+                }
 
                 // ASPA incremental (8210bis semantics): a withdraw (which
                 // carries an empty provider set on the wire) removes the
@@ -635,7 +682,7 @@ impl VrpManager {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::sync::{Arc, Mutex};
 
     use super::*;
@@ -649,12 +696,33 @@ mod tests {
         }
     }
 
+    fn entry_v6(addr: Ipv6Addr, prefix_len: u8, max_len: u8, asn: u32) -> VrpEntry {
+        VrpEntry {
+            prefix: IpAddr::V6(addr),
+            prefix_len,
+            max_len,
+            origin_asn: asn,
+        }
+    }
+
     fn server1() -> SocketAddr {
         "10.0.0.1:3323".parse().unwrap()
     }
 
     fn server2() -> SocketAddr {
         "10.0.0.2:3323".parse().unwrap()
+    }
+
+    #[test]
+    fn cache_query_error_has_stable_error_contract() {
+        fn assert_error(error: &dyn std::error::Error) -> String {
+            error.to_string()
+        }
+
+        assert_eq!(
+            assert_error(&CacheQueryError),
+            "RPKI cache inventory actor is unavailable"
+        );
     }
 
     #[tokio::test]
@@ -1094,7 +1162,10 @@ mod tests {
             .await;
         mgr.handle_enhanced_update(EnhancedVrpUpdate::Full {
             server: server1(),
-            entries: vec![entry(Ipv4Addr::new(192, 0, 2, 0), 24, 24, 64_496)],
+            entries: vec![
+                entry(Ipv4Addr::new(192, 0, 2, 0), 24, 24, 64_496),
+                entry_v6("2001:db8::".parse().unwrap(), 32, 48, 64_496),
+            ],
             aspa_records: vec![AspaRecord {
                 customer_asn: 64_496,
                 provider_asns: vec![64_497],
@@ -1124,7 +1195,7 @@ mod tests {
                 accepted.vrp_v6_count,
                 accepted.aspa_count
             ),
-            (1, 0, 1)
+            (1, 1, 1)
         );
         assert!(accepted.age_seconds >= 3);
 
@@ -1141,8 +1212,16 @@ mod tests {
             .await;
         mgr.handle_enhanced_update(EnhancedVrpUpdate::Incremental {
             server: server1(),
-            announced: vec![],
-            withdrawn: vec![],
+            announced: vec![
+                // Duplicate announcement must not inflate the v6 count.
+                entry_v6("2001:db8::".parse().unwrap(), 32, 48, 64_496),
+                entry(Ipv4Addr::new(198, 51, 100, 0), 24, 24, 64_497),
+            ],
+            withdrawn: vec![
+                entry(Ipv4Addr::new(192, 0, 2, 0), 24, 24, 64_496),
+                // Absent withdrawal must not deflate the v4 count.
+                entry(Ipv4Addr::new(203, 0, 113, 0), 24, 24, 64_498),
+            ],
             aspa_announced: vec![],
             aspa_withdrawn: vec![],
             version: 2,
@@ -1155,6 +1234,8 @@ mod tests {
             mgr.cache_list().rows[0].accepted.as_ref().unwrap().serial,
             Some(12)
         );
+        let accepted = mgr.cache_list().rows[0].accepted.clone().unwrap();
+        assert_eq!((accepted.vrp_v4_count, accepted.vrp_v6_count), (1, 1));
 
         mgr.handle_enhanced_update(EnhancedVrpUpdate::Disconnected {
             server: server1(),

--- a/docs/API.md
+++ b/docs/API.md
@@ -57,7 +57,7 @@ not by itself make it v1-stable.
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup`, `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` | Peer-group CRUD and neighbor membership assignment |
 | `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `LookupBestPath`, `ListFlowSpecRoutes`, `ListEvpnRoutes`, `ListBgpLsRoutes`, `ListTopologyNodes`, `ListTopologyLinks`, `ListOrrStatus`, `ListVpnRoutes`, `ListRtcRoutes`, `ListLabeledRoutes`, `ListBlackholeDiscards`, `ListFibRoutes`, `ListFibTables`, `SetFibTable`, `DeleteFibTable`, `ListRouteEvents` | Query-only RIB route surfaces (incl. EVPN, BGP-LS, VPNv4/v6, RT-Constrain, and labeled-unicast), the RFC 9107 ORR / BGP-LS topology read surface (`ListTopologyNodes` / `ListTopologyLinks` / `ListOrrStatus`), BLACKHOLE discard status, paginated FIB status, runtime FIB-table CRUD, exact explain plus outside-v1 global LPM, and recent route-event history; live route streaming is owned by `EventService.WatchEvents` / `SubscribeFromEvent` |
 | `BfdService` | `GetBfdSessions` | Single-hop BFD session inspection for configured static neighbors |
-| `RpkiService` | `ValidateRouteOrigin` | Bounded point validation against the latest authoritative VRP snapshot |
+| `RpkiService` | `ValidateRouteOrigin`, `ListCaches` | Bounded point validation and configured RTR-cache accepted-epoch inventory |
 | `EventService` | `WatchEvents`, `SubscribeFromEvent`, `ListEvpnEvents`, `ListSessionEvents`, `ListPolicyEvents` | Unified live stream for route, session lifecycle, BGP NOTIFICATION metadata, policy mutation, EVPN route events, BFD session events, and FIB / BLACKHOLE dataplane status-row summary events, with `stream_lagged` warnings for bounded-source backpressure; durable cursor replay via `SubscribeFromEvent` when `[event_history].enabled = true`; plus bounded after-the-fact EVPN, session-lifecycle, and policy-mutation history. Per-MAC EVPN dataplane categories remain follow-up work |
 | `InjectionService` | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` | Programmatic route, FlowSpec, and EVPN injection |
 | `ControlService` | `GetHealth`, `GetMetrics`, `Shutdown`, `TriggerMrtDump` | Health, metrics, lifecycle, MRT dumps |
@@ -212,7 +212,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | `EventService` | All RPCs | None |
 | `EvpnService` | `GetEvpnRuntime`, `ListEvpnInstances`, `ListEvpnNexthops`, `ListEthernetSegments`, `ListIpVrfs`, `ListManagedNetdevs`, `GetIpVrf`, `ListDuplicateMacQuarantines` | `ClearDuplicateMacQuarantine`, `SetEthernetSegmentDrain`, `ApplyEvpnRuntime` |
 | `BfdService` | `GetBfdSessions` | None |
-| `RpkiService` | `ValidateRouteOrigin` | None |
+| `RpkiService` | `ValidateRouteOrigin`, `ListCaches` | None |
 | `gnmi.gNMI` | `Capabilities`, `Get`, `Subscribe` | `Set` (operator-only; transaction-backed OpenConfig subset — static numbered-neighbor `neighbor-address`/`peer-as`/`description`/`peer-group` create/update/delete, peer-group catalog entries, dynamic-neighbor prefixes, and the commit-confirmed extension via ADR-0076; unsupported paths return `UNIMPLEMENTED`) |
 | `InjectionService` | None | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` |
 | `ControlService` | `GetHealth`, `GetMetrics` | `Shutdown`, `TriggerMrtDump` |
@@ -2536,6 +2536,24 @@ authoritative snapshot the RPC returns `FAILED_PRECONDITION`; a received empty
 snapshot is authoritative and returns `not_found` with a complete empty list.
 This surface does not expose cache provenance, readiness, raw RTR data, or cache
 management.
+
+`ListCaches` exposes configured RTR endpoints in canonical address order,
+current transport connectivity, and the latest atomically accepted End of Data
+epoch. `accepted` is present for an accepted empty table and absent before the
+first accepted epoch or after expiry/fatal flush. Protocol version, session ID,
+and serial are optional for compatibility with legacy embedded update
+producers. Counts are derived from the retained per-cache contribution, and
+`age_seconds` is monotonic whole seconds. Results are capped at 256 rows with
+exact `complete`/`omitted`; an unconfigured daemon returns a complete empty
+list. A closed actor returns `UNAVAILABLE`, while the two-second whole-query
+budget returns `DEADLINE_EXCEEDED`.
+
+```bash
+rbgp rpki caches
+
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{}' localhost:50051 rustbgpd.v1.RpkiService/ListCaches
+```
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -793,7 +793,7 @@ This matrix tracks every protocol behavior: its RFC basis, implementation status
 | TCP-AO | 5925 | Post-v1 | BIRD | Static and direct dynamic-prefix keyrings; fail-closed accept validation and live API/CLI health; successor install, observation-gated RNext selection/deprecation, and later deprecated unselected-MKT deletion |
 | BMP exporter | 7854 | post-v0.3.0 | — | Implemented (ADR-0041); reconnect replay + periodic stats + coordinated-shutdown termination |
 | MRT dump export | 6396 | post-v0.3.0 | — | Implemented (ADR-0044); TABLE_DUMP_V2 periodic + on-demand, gzip optional |
-| RPKI / RTR client | 8210 | post-v0.3.0 | — | Implemented (ADR-0034); bounded read-only point validation is available through `RpkiService`, while cache management remains deferred |
+| RPKI / RTR client | 8210 | post-v0.3.0 | — | Implemented (ADR-0034); `RpkiService` provides bounded point validation and read-only configured-cache accepted-epoch inventory, while cache mutation remains deferred |
 
 This matrix is updated with every milestone. "Interop Tested" means validated
 by a documented containerlab or privileged-netns procedure. CI-gated rows are

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 106,
+  "method_count": 107,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 62,
+    "sensitive_read": 63,
     "mutating": 20,
     "operator_only": 24
   },
@@ -94,6 +94,7 @@
     { "service": "rustbgpd.v1.RibService", "method": "ListOrrStatus", "path": "/rustbgpd.v1.RibService/ListOrrStatus", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.BfdService", "method": "GetBfdSessions", "path": "/rustbgpd.v1.BfdService/GetBfdSessions", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RpkiService", "method": "ValidateRouteOrigin", "path": "/rustbgpd.v1.RpkiService/ValidateRouteOrigin", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.RpkiService", "method": "ListCaches", "path": "/rustbgpd.v1.RpkiService/ListCaches", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "WatchEvents", "path": "/rustbgpd.v1.EventService/WatchEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListEvpnEvents", "path": "/rustbgpd.v1.EventService/ListEvpnEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListSessionEvents", "path": "/rustbgpd.v1.EventService/ListSessionEvents", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -193,11 +193,12 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `GetBfdSessions` | `sensitive_read` | ADR-0067 BFD session snapshot — peer addresses, state, diagnostics, and strict flag. |
 
-### RpkiService (1 RPC)
+### RpkiService (2 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
 | `ValidateRouteOrigin` | `sensitive_read` | Bounded origin-validation diagnostic over the current authoritative VRP table. Exposes effective covering ROAs and origin ASNs; outside the narrow v1 contract. |
+| `ListCaches` | `sensitive_read` | Bounded configured-cache inventory with connection state and the latest atomically accepted RTR epoch; outside the narrow v1 contract. |
 
 ### EventService (5 RPCs)
 
@@ -259,13 +260,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 62 | 58.5% |
-| `mutating` | 20 | 18.9% |
-| `operator_only` | 24 | 22.6% |
-| **Total** | **106** | **100%** |
+| `sensitive_read` | 63 | 58.9% |
+| `mutating` | 20 | 18.7% |
+| `operator_only` | 24 | 22.4% |
+| **Total** | **107** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 106
-total is 102 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 107
+total is 103 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 
@@ -344,7 +345,7 @@ specific method if the model warrants it.
 
 ## Code matrix
 
-`crates/api/src/authz.rs` contains the same 106-method classification
+`crates/api/src/authz.rs` contains the same 107-method classification
 as a static Rust table. `docs/grpc-method-inventory.json` is the
 machine-readable export for auditors, tooling, and generated clients. The
 `authz` tests parse `proto/rustbgpd.proto` and fail if a new RPC is added

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -690,7 +690,19 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:rbgp-rpki-command-$line[1]:"
         case $line[1] in
-            (validate)
+            (caches)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(validate)
 _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -716,7 +728,11 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:rbgp-rpki-help-command-$line[1]:"
         case $line[1] in
-            (validate)
+            (caches)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(validate)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -3117,7 +3133,11 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:rbgp-help-rpki-command-$line[1]:"
         case $line[1] in
-            (validate)
+            (caches)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(validate)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -5174,9 +5194,15 @@ _rbgp__subcmd__help__subcmd__rib__subcmd__vpn_commands() {
 (( $+functions[_rbgp__subcmd__help__subcmd__rpki_commands] )) ||
 _rbgp__subcmd__help__subcmd__rpki_commands() {
     local commands; commands=(
+'caches:List configured RTR caches and accepted validation epochs' \
 'validate:Validate one CIDR prefix and origin ASN' \
     )
     _describe -t commands 'rbgp help rpki commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rpki__subcmd__caches_commands] )) ||
+_rbgp__subcmd__help__subcmd__rpki__subcmd__caches_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rpki caches commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__help__subcmd__rpki__subcmd__validate_commands] )) ||
 _rbgp__subcmd__help__subcmd__rpki__subcmd__validate_commands() {
@@ -5875,18 +5901,30 @@ _rbgp__subcmd__rib__subcmd__vpn_commands() {
 (( $+functions[_rbgp__subcmd__rpki_commands] )) ||
 _rbgp__subcmd__rpki_commands() {
     local commands; commands=(
+'caches:List configured RTR caches and accepted validation epochs' \
 'validate:Validate one CIDR prefix and origin ASN' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp rpki commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__rpki__subcmd__caches_commands] )) ||
+_rbgp__subcmd__rpki__subcmd__caches_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rpki caches commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__rpki__subcmd__help_commands] )) ||
 _rbgp__subcmd__rpki__subcmd__help_commands() {
     local commands; commands=(
+'caches:List configured RTR caches and accepted validation epochs' \
 'validate:Validate one CIDR prefix and origin ASN' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp rpki help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rpki__subcmd__help__subcmd__caches_commands] )) ||
+_rbgp__subcmd__rpki__subcmd__help__subcmd__caches_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rpki help caches commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__rpki__subcmd__help__subcmd__help_commands] )) ||
 _rbgp__subcmd__rpki__subcmd__help__subcmd__help_commands() {

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -790,6 +790,9 @@ _rbgp() {
             rbgp__subcmd__help__subcmd__rib,vpn)
                 cmd="rbgp__subcmd__help__subcmd__rib__subcmd__vpn"
                 ;;
+            rbgp__subcmd__help__subcmd__rpki,caches)
+                cmd="rbgp__subcmd__help__subcmd__rpki__subcmd__caches"
+                ;;
             rbgp__subcmd__help__subcmd__rpki,validate)
                 cmd="rbgp__subcmd__help__subcmd__rpki__subcmd__validate"
                 ;;
@@ -1108,11 +1111,17 @@ _rbgp() {
             rbgp__subcmd__rib__subcmd__help,vpn)
                 cmd="rbgp__subcmd__rib__subcmd__help__subcmd__vpn"
                 ;;
+            rbgp__subcmd__rpki,caches)
+                cmd="rbgp__subcmd__rpki__subcmd__caches"
+                ;;
             rbgp__subcmd__rpki,help)
                 cmd="rbgp__subcmd__rpki__subcmd__help"
                 ;;
             rbgp__subcmd__rpki,validate)
                 cmd="rbgp__subcmd__rpki__subcmd__validate"
+                ;;
+            rbgp__subcmd__rpki__subcmd__help,caches)
+                cmd="rbgp__subcmd__rpki__subcmd__help__subcmd__caches"
                 ;;
             rbgp__subcmd__rpki__subcmd__help,help)
                 cmd="rbgp__subcmd__rpki__subcmd__help__subcmd__help"
@@ -5739,8 +5748,22 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__help__subcmd__rpki)
-            opts="validate"
+            opts="caches validate"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rpki__subcmd__caches)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -8379,7 +8402,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rpki)
-            opts="-s -j -h --addr --token-file --json --no-color --help validate help"
+            opts="-s -j -h --addr --token-file --json --no-color --help caches validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8404,9 +8427,49 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        rbgp__subcmd__rpki__subcmd__help)
-            opts="validate help"
+        rbgp__subcmd__rpki__subcmd__caches)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rpki__subcmd__help)
+            opts="caches validate help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rpki__subcmd__help__subcmd__caches)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -321,18 +321,25 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "show" -d 'Show a single BFD session by peer address'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from validate help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from validate help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from validate help" -s j -l json -d 'Output in JSON format'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from validate help" -l no-color -d 'Disable colored output'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from validate help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from validate help" -f -a "validate" -d 'Validate one CIDR prefix and origin ASN'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from validate help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -f -a "caches" -d 'List configured RTR caches and accepted validation epochs'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -f -a "validate" -d 'Validate one CIDR prefix and origin ASN'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from help" -f -a "caches" -d 'List configured RTR caches and accepted validation epochs'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from help" -f -a "validate" -d 'Validate one CIDR prefix and origin ASN'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s a -l family -d 'Address family filter (ipv4_unicast, ipv6_unicast)' -r
@@ -1158,6 +1165,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "softreset" -d 'Trigger soft reset (inbound)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "refresh-out" -d 'Re-send this peer\'s current exportable outbound routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from bfd" -f -a "show" -d 'Show a single BFD session by peer address'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rpki" -f -a "caches" -d 'List configured RTR caches and accepted validation epochs'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rpki" -f -a "validate" -d 'Validate one CIDR prefix and origin ASN'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "received" -d 'Show received routes from a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "advertised" -d 'Show advertised routes to a neighbor'

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1922,6 +1922,34 @@ service RpkiService {
   // snapshot. Covering VRPs are bounded to 256 effective rows; the validation
   // verdict is computed from the complete table before diagnostic truncation.
   rpc ValidateRouteOrigin(ValidateRouteOriginRequest) returns (ValidateRouteOriginResponse);
+  // List configured RTR caches and their latest atomically accepted epoch.
+  rpc ListCaches(ListRpkiCachesRequest) returns (ListRpkiCachesResponse);
+}
+
+message ListRpkiCachesRequest {}
+
+message AcceptedRpkiCacheState {
+  optional uint32 protocol_version = 1;
+  optional uint32 session_id = 2;
+  optional uint32 serial = 3;
+  uint64 vrp_v4_count = 4;
+  uint64 vrp_v6_count = 5;
+  uint64 aspa_count = 6;
+  uint64 age_seconds = 7;
+}
+
+message RpkiCacheState {
+  string address = 1;
+  bool connected = 2;
+  // Present only after a validated End of Data; an accepted empty table is
+  // represented by a present message whose counts are zero.
+  optional AcceptedRpkiCacheState accepted = 3;
+}
+
+message ListRpkiCachesResponse {
+  repeated RpkiCacheState caches = 1;
+  bool complete = 2;
+  uint64 omitted = 3;
 }
 
 message ValidateRouteOriginRequest {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3812,6 +3812,7 @@ async fn run<T>(
         mpsc::channel::<PeerManagerReadinessQuery>(64);
     let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::channel(1);
 
+    let mut rpki_cache_queries = None;
     // Spawn RPKI subsystem (VRP manager + per-cache RTR clients)
     if let Some(ref rpki_config) = config.rpki
         && !rpki_config.cache_servers.is_empty()
@@ -3822,9 +3823,19 @@ async fn run<T>(
         // ASPA table channel (VrpManager → RIB)
         let (aspa_table_tx, mut aspa_table_rx) = mpsc::channel(16);
 
+        let configured_cache_addrs: Vec<std::net::SocketAddr> = rpki_config
+            .cache_servers
+            .iter()
+            .filter_map(|server| server.address.parse().ok())
+            .collect();
+        let (cache_inventory, cache_update_handle, cache_query_handle) =
+            rustbgpd_rpki::CacheInventoryAttachment::new(configured_cache_addrs);
+        rpki_cache_queries = Some(cache_query_handle);
+
         // Spawn VRP + ASPA manager
         let readiness_metrics = metrics.clone();
         let vrp_mgr = rustbgpd_rpki::VrpManager::new(vrp_update_rx, rpki_table_tx)
+            .with_cache_inventory(cache_inventory)
             .with_aspa_tx(aspa_table_tx)
             .with_readiness_observer(move |server, ready| {
                 readiness_metrics.set_rpki_cache_end_of_data_ready(&server.to_string(), ready);
@@ -3901,6 +3912,7 @@ async fn run<T>(
             let cache_label = addr.to_string();
             metrics.set_rpki_cache_end_of_data_ready(&cache_label, false);
             let client = rustbgpd_rpki::RtrClient::new(client_config, vrp_update_tx.clone())
+                .with_cache_inventory(cache_update_handle.clone())
                 .with_expire_observer(move |secs| {
                     expire_metrics.set_rpki_cache_effective_expire_seconds(&cache_label, secs);
                 });
@@ -4774,6 +4786,7 @@ async fn run<T>(
             // walking the table or building a response.
             Arc::new(move || rx.borrow().vrp_table.clone())
         },
+        rpki_cache_queries,
         mrt_trigger_tx,
         evpn_originated_local_mac_count: {
             let counts = evpn_originated_local_mac_counts.clone();


### PR DESCRIPTION
Implements LAN-1385.

Adds a bounded outside-v1 ListCaches RPC and rbgp caches output backed by atomic RTR cache epochs, while preserving the published rustbgpd-rpki 0.1.0 API. Cache lifecycle, accepted-empty readiness, retention, expiry, fatal flush, omission counts, TCP/UDS authorization, inventories, docs, and completions are covered.

Validated locally with the workspace suite, RPKI/API/CLI lifecycle tests, stable-v1 and authz inventories, source-equivalent cargo-semver-checks, Clippy, rustdoc, completion idempotence, and full hooks. The local M84 deployment stopped before topology creation because sudo requires an interactive password; the current-head hosted M84 37/0 lane is the remaining strict merge gate.