### PR TITLE
docs: clarify distance-aware GTSM behavior

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -172,9 +172,13 @@ matching reachable when RFC 8654 extended messages are enabled (affected
 through 2.19.0), is a recent example of the vulnerability class the
 memory-safe-language row refers to.
 
-[^gtsm-distance]: rustbgpd sends with TTL / Hop Limit 255 and accepts an
-    optional `ttl_security_hops` value whose inbound floor is `256 - hops`;
-    omission preserves the exact-255 one-hop policy. The other implementations
+[^gtsm-distance]: Both GTSM speakers must transmit TTL / Hop Limit 255. On each
+    side, a maximum distance of `hops` sets that side's inbound floor to
+    `255 - (hops - 1)`, equivalently `256 - hops`. rustbgpd's
+    `ttl_security_hops` changes only its receive floor; it cannot make a peer
+    transmitting an ordinary lower TTL compatible. Omission preserves the
+    exact-255 one-hop policy, while a larger value supports bounded multihop.
+    The other implementations
     document equivalent distance-aware forms: FRR
     [`neighbor PEER ttl-security hops NUMBER`](https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-PEER-ttl-security-hops-NUMBER)
     (documented as mutually exclusive with `ebgp-multihop`), BIRD
@@ -192,8 +196,10 @@ memory-safe-language row refers to.
     to enable: it never lowers the outbound TTL / Hop Limit on a BGP socket and
     has no check refusing an eBGP peer for not being directly connected, so a
     non-adjacent peer is dialed with the kernel default TTL. That default path
-    has no distance guard; enable `ttl_security` with `ttl_security_hops` when
-    the peer's maximum distance should be bounded. This describes the
+    has no distance guard and does not fail fast on an off-subnet address typo.
+    There is no separate `ebgp_multihop` path that disables GTSM: enable
+    `ttl_security` with `ttl_security_hops` on a peer that also transmits GTSM
+    TTL / Hop Limit 255 when the distance should be bounded. This describes the
     mechanism, not an interoperability receipt.
     See [CONFIGURATION.md](CONFIGURATION.md) and
     [LIMITATIONS.md](LIMITATIONS.md).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1172,11 +1172,14 @@ connection carries the kernel default TTL like any other TCP connection. The
 same is true in the inbound direction: nothing inspects the arriving TTL unless
 `ttl_security` is set.
 
-Use GTSM when the distance should also be bounded. `ttl_security = true` alone
-preserves the strict adjacent-peer behavior: outbound TTL / Hop Limit is 255
-and inbound packets must arrive with 255. Add `ttl_security_hops = N` for a
-peer up to N hops away. The kernel then rejects inbound packets below `256 - N`
-while rustbgpd continues to send with 255:
+Use GTSM when the distance should also be bounded. Both speakers must transmit
+GTSM packets with TTL / Hop Limit 255. On each speaker, a configured maximum
+distance of `N` hops sets that speaker's receive floor to
+`255 - (N - 1)`, equivalently `256 - N`. `ttl_security = true` without an
+explicit hop count therefore preserves the one-hop policy: rustbgpd sends 255
+and accepts only 255. Add `ttl_security_hops = N` for a peer up to N hops away;
+rustbgpd still sends 255 while the kernel rejects packets arriving below the
+receive floor:
 
 ```toml
 [[neighbors]]
@@ -1186,11 +1189,27 @@ ttl_security = true
 ttl_security_hops = 9
 ```
 
-The hop value does not enable GTSM by itself; an explicit value with effective
-`ttl_security = false` is a configuration error. Pin the family's active-open
-source with `[global].listen_addresses` when a multihop session needs a stable
-local address. The per-implementation comparison and its sourcing live in
-[COMPARISON.md](COMPARISON.md).
+`ttl_security_hops` changes only rustbgpd's inbound floor. It does not rewrite
+packets received from the peer and cannot make an ordinary peer that transmits
+a lower TTL / Hop Limit compatible with GTSM; configure distance-aware GTSM on
+both sides. The hop value also does not enable GTSM by itself: an explicit value
+with effective `ttl_security = false` is a configuration error.
+
+There is no separate `ebgp_multihop` path that disables GTSM. Bounded multihop
+is the same GTSM path with a larger hop count. Without GTSM, multihop eBGP uses
+the kernel's default outbound TTL and performs no direct-connect check. That
+permits a routed peer, but also loses the fail-fast intent check that would
+reject an off-subnet address typo before attempting TCP. Pin the family's
+active-open source with `[global].listen_addresses` when a multihop session
+needs a stable local address.
+
+GTSM failures are scoped to the affected socket. An active open fails before
+`connect(2)` when its TTL policy cannot be installed. A passive accepted socket
+that cannot receive the required minimum is discarded. A listener-family
+socket whose GTSM policy cannot be installed is rejected; daemon startup fails
+only when no listener family remains usable, or when strict explicit endpoint
+binding requires the failed socket. The per-implementation comparison and its
+sourcing live in [COMPARISON.md](COMPARISON.md).
 
 ### BFD (RFC 5880 / 5881 / 5882)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1813,7 +1813,24 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
    - **Hold timer zero vs non-zero:** One side sends hold_time=0, the other expects keepalives
    - **Capability mismatch:** Check address family negotiation in OPEN logs
    - **MD5 mismatch:** TCP RST with no BGP-level error; check both sides' passwords
-   - **TTL security:** GTSM requires TTL=255; multi-hop peers will fail
+   - **TTL security:** Both GTSM speakers must transmit TTL / Hop Limit 255.
+     With `ttl_security_hops = N`, rustbgpd accepts packets at or above
+     `255 - (N - 1)` (`256 - N`); the knob changes only this receive floor and
+     cannot make a peer that transmits an ordinary lower TTL compatible.
+     Bounded multihop is supported, with distance-aware GTSM configured on
+     both sides. Packets below rustbgpd's receive floor are discarded by the
+     kernel before BGP processing and therefore produce no BGP NOTIFICATION.
+
+   There is no separate `ebgp_multihop` mode that disables GTSM. Without
+   GTSM, rustbgpd uses the kernel default outbound TTL and does not require an
+   eBGP peer to be directly connected. That permits routed peers, but an
+   off-subnet address typo is attempted instead of failing an intent check.
+
+   GTSM setup failures are socket-scoped: an active open fails before connect,
+   a passive accepted socket is discarded, and an affected listener-family
+   socket is rejected. The process fails startup only if no listener family
+   remains usable or strict explicit endpoint binding fails; do not interpret
+   one family/socket rejection as an unconditional daemon startup failure.
 
 4. **Verify from the remote side:**
    Check FRR/BIRD/peer logs for their view of the session attempt.


### PR DESCRIPTION
## Summary

- document the bidirectional TTL/Hop Limit 255 requirement and `256 - hops` receive floor
- clarify that `ttl_security_hops` changes only rustbgpd receive policy and supports bounded multihop
- distinguish non-GTSM multihop behavior and the socket-scoped failure boundaries
- note that below-floor packets are discarded before BGP and produce no NOTIFICATION

Linear: LAN-1386

## Validation

- `python3 scripts/check_public_tracker_ids.py`
- `just links`
- `git diff --check`
- exact three-document scope check