### PR TITLE
Support scoped BFD for IPv6 link-local peers

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -790,12 +790,16 @@ jobs:
       - name: ADR-0061 FIB runtime netns test
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime
 
-      # This ephemeral hosted invocation denies AF_INET6 to prove the current
-      # IPv4-only BFD actor does not depend on that family. Future selectors
-      # that open address families can reuse the same opt-in harness profile.
+      # This supplementary invocation denies AF_INET6 to prove the IPv4 BFD
+      # path does not depend on that family. It is intentionally omitted from
+      # the canonical selector receipt below.
       - name: ADR-0067 BFD runtime netns test (IPv4-only, AF_INET6 absent)
         env:
+          NETNS_SELECTOR_RECEIPT: ""
           SECCOMP_PROFILE: crates/evpn-linux/tests/docker/seccomp-deny-af-inet6.json
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh bfd_runtime_ipv4
+
+      - name: ADR-0067 BFD runtime netns tests (IPv4 and IPv6 link-local)
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh bfd_runtime
 
       - name: ADR-0089 VLAN-scoped FDB netns test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   metric agree; established, stale, held, disabled, previously established,
   ambiguous, and unattributed peers remain silent.
 
+- Single-hop asynchronous BFD now supports static IPv6 link-local neighbors.
+  rustbgpd resolves the neighbor's required `interface` to a startup-pinned
+  scope, transmits through the shared IPv6 socket with that scope, and accepts
+  control packets only when kernel packet-info reports the same receive
+  interface. Missing or unresolvable scopes fail startup before BFD sockets are
+  prepared; global IPv4/IPv6 behavior and public BFD peer identity are
+  unchanged.
+
 - Decoded inbound and attempted outbound BGP NOTIFICATIONs now emit exactly one
   structured INFO record with peer, direction, outer code/subcode, and a human
   description. Hard Reset records retain outer Cease/9 and identify the valid

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -132,7 +132,7 @@ case "${1:-all}" in
     fdb_nhg_cve)        TEST_BIN="netns_fdb_nhg"; FILTER="cve_guard_blocks_install_when_learning_enabled" ;;
     fib_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="fib_runtime::tests::netns_general_unicast_fib_" ;;
     bfd_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="bfd_runtime::tests::netns::" ;;
-    bfd_runtime_ipv4)   FILTER=""; RUSTBGPD_TEST_FILTER="bfd_runtime::tests::netns::session_reaches_up_and_detects_down" ;;
+    bfd_runtime_ipv4)   FILTER="bfd_runtime::tests::netns::session_reaches_up_and_detects_down"; RUSTBGPD_TEST_FILTER="$FILTER" ;;
     bgp_unnumbered)     TEST_BIN="netns_bgp_unnumbered"; FILTER="" ;;
     link_carrier)       TEST_BIN="netns_link_carrier"; FILTER="" ;;
     ac_gate)            TEST_BIN="netns_ac_gate"; FILTER="" ;;

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -43,6 +43,8 @@
 #       (ADR-0061 Slice 4 general unicast FIB runtime validation)
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh bfd_runtime
 #       (ADR-0067 single-hop BFD actor netns validation)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh bfd_runtime_ipv4
+#       (ADR-0067 IPv4-only BFD actor netns validation)
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh bgp_unnumbered
 #       (ADR-0069 BGP unnumbered Linux/socket primitive spike)
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier
@@ -100,8 +102,9 @@ DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 
 # Test selector. `bum_*` runs the Gate 8b harness; `fdb_nhg` runs
 # the ADR-0059 slice 3b FDB nexthop group integration test;
-# `fib_runtime` / `bfd_runtime` run same-module `-p rustbgpd` daemon
-# runtime tests (ADR-0061 FIB / ADR-0067 BFD). `bgp_unnumbered` runs the
+# `fib_runtime` / `bfd_runtime` / `bfd_runtime_ipv4` run same-module
+# `-p rustbgpd` daemon runtime tests (ADR-0061 FIB / ADR-0067 BFD).
+# `bgp_unnumbered` runs the
 # ADR-0069 evpn-linux integration proof; `link_carrier` runs the
 # ADR-0085 RTNLGRP_LINK carrier monitor proof; `dataplane_vlan_fdb`
 # runs the ADR-0089 VLAN-scoped FDB proof; `svd_fdb_vni` runs the
@@ -129,6 +132,7 @@ case "${1:-all}" in
     fdb_nhg_cve)        TEST_BIN="netns_fdb_nhg"; FILTER="cve_guard_blocks_install_when_learning_enabled" ;;
     fib_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="fib_runtime::tests::netns_general_unicast_fib_" ;;
     bfd_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="bfd_runtime::tests::netns::" ;;
+    bfd_runtime_ipv4)   FILTER=""; RUSTBGPD_TEST_FILTER="bfd_runtime::tests::netns::session_reaches_up_and_detects_down" ;;
     bgp_unnumbered)     TEST_BIN="netns_bgp_unnumbered"; FILTER="" ;;
     link_carrier)       TEST_BIN="netns_link_carrier"; FILTER="" ;;
     ac_gate)            TEST_BIN="netns_ac_gate"; FILTER="" ;;
@@ -153,7 +157,7 @@ case "${1:-all}" in
     l3_single_path_cycle) TEST_BIN="netns_l3_install"; FILTER="linux_dataplane_installs_and_withdraws_l3_triple" ;;
     l3_foreign_route_cycle) TEST_BIN="netns_l3_install"; FILTER="linux_dataplane_foreign_route_survives_l3_cycle" ;;
     *)
-        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier, ac_gate, nexthop_raw, foreign_state_l2, foreign_state_nhid, foreign_state_l3, l3_route_event, dataplane_vlan_fdb, dataplane_remote_mac, vlan_local_mac_attribution, macip_vlan_attribution, svd_fdb_vni, l3_multipath, l3_all_active_writer, managed_bridge, managed_vxlan, managed_svd_vxlan, managed_vlan_upper, managed_ready, managed_ip_vrf_ready, l3_single_path_cycle, l3_foreign_route_cycle" >&2
+        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bfd_runtime_ipv4, bgp_unnumbered, link_carrier, ac_gate, nexthop_raw, foreign_state_l2, foreign_state_nhid, foreign_state_l3, l3_route_event, dataplane_vlan_fdb, dataplane_remote_mac, vlan_local_mac_attribution, macip_vlan_attribution, svd_fdb_vni, l3_multipath, l3_all_active_writer, managed_bridge, managed_vxlan, managed_svd_vxlan, managed_vlan_upper, managed_ready, managed_ip_vrf_ready, l3_single_path_cycle, l3_foreign_route_cycle" >&2
         exit 2
         ;;
 esac

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -290,12 +290,12 @@ memory-safe-language row refers to.
     events + Prometheus. RFC 5882 BGP coupling ships in both **strict** (withhold
     BGP until BFD Up) and **non-strict** (tear BGP down on BFD-down before the
     hold timer) modes; the non-strict path is cross-checked against FRR `bfdd` by
-    interop test M51, and strict mode is covered by unit tests. v1 is IPv4 +
-    IPv6 **global**, static neighbors only. Deferred: multihop (RFC 5883),
+    interop test M51, and strict mode is covered by unit tests. IPv4, IPv6
+    global, and interface-scoped IPv6 link-local static neighbors are
+    supported; link-local RX is pinned to the configured interface through
+    `IPV6_PKTINFO`, and M51 exercises it against FRR. Deferred: multihop (RFC 5883),
     echo / demand mode, authentication, C-bit / GR-aware nuance, static-route
-    BFD tracking, dynamic-neighbor BFD, hardware / offload, and BFD over
-    IPv6 link-local / unnumbered peers → v1.1 (BGP unnumbered itself shipped —
-    ADR-0069 / M53).
+    BFD tracking, dynamic-neighbor BFD, and hardware / offload.
 
 [^fuzz]: Every entry in this row means in-tree fuzz targets; the scope
     differs. rustbgpd carries libFuzzer targets in

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -901,7 +901,7 @@ complete atomic block. There is no probe or automatic legacy fallback.
 | `max_prefix_restart_seconds` | non-zero u32 | no | unset | Opt in to one timed restart attempt after max-prefix teardown. Omit to retain the indefinite fail-closed latch until explicit enable; failure to deliver the timed session `Start` command consumes the attempt and stays latched off |
 | `md5_password`         | string   | no       | --      | TCP MD5 authentication password (RFC 2385, Linux only) |
 | `tcp_ao`               | table or array | no | -- | Ordered TCP-AO keyring for static neighbors (RFC 5925; Linux; append a non-preferred successor, then select it in a later observation-gated SIGHUP generation) |
-| `bfd`                  | table    | no       | --      | Single-hop BFD attachment referencing a `[[bfd_profiles]]` entry (RFC 5880/5881/5882; static neighbors only, restart-required edits) |
+| `bfd`                  | table    | no       | --      | Single-hop BFD attachment referencing a `[[bfd_profiles]]` entry (RFC 5880/5881/5882; static neighbors only, including interface-scoped IPv6 link-local peers; restart-required edits) |
 | `ttl_security`         | bool     | no       | false   | Enable GTSM / TTL security (RFC 5082, Linux only). Outbound packets use TTL/Hop-Limit 255. Without `ttl_security_hops`, inbound packets must arrive with exactly 255, preserving the historical one-hop policy |
 | `ttl_security_hops`    | non-zero u8 | no    | 1 when GTSM is enabled | Maximum expected peer distance for GTSM (1--255). Requires effective `ttl_security = true`; inbound packets below `256 - ttl_security_hops` are dropped by `IP_MINTTL` / `IPV6_MINHOPCOUNT`. Inherits from peer groups and may be overridden per neighbor |
 | `families`             | [string] | no       | (auto)  | Address families to negotiate (see below)        |
@@ -1241,6 +1241,14 @@ address = "10.0.0.3"
 remote_asn = 65003
 peer_group = "edge"
 bfd = { profile = "fast", enabled = false }   # opt this neighbor out
+
+# Link-local BGP and BFD use the neighbor's required interface scope.
+[[neighbors]]
+address = "fe80::2"
+interface = "eth1"
+remote_asn = 65002
+families = ["ipv6_unicast"]
+bfd = { profile = "fast" }
 ```
 
 `[neighbors.bfd]` / `[peer_groups.<name>.bfd]` fields:
@@ -1269,11 +1277,15 @@ BGP.) Genuine failures — a detection timeout or a remote-signaled
 operator disable/delete of the neighbor stops BGP through the normal lifecycle,
 not this path.
 
-BFD is **static-neighbors only** in v1 — a `[[dynamic_neighbors]]` range whose
-peer group enables BFD is rejected at config time. v1 covers IPv4 + IPv6
-**global** addresses. BFD on IPv6 link-local / unnumbered peers is still
-deferred even though the BGP neighbor itself can be interface scoped. Like
-TCP-AO, BFD edits are **restart-required**: on SIGHUP rustbgpd pins
+BFD is **static-neighbors only** — a `[[dynamic_neighbors]]` range whose peer
+group enables BFD is rejected at config time. IPv4, IPv6 global, and IPv6
+link-local neighbors are supported. A link-local neighbor already requires a
+unique bare address plus `interface`; startup resolves that interface to the
+BFD transmit scope and rejects an unresolvable name before preparing sockets.
+Receive-side `IPV6_PKTINFO` must report the same interface for every link-local
+control packet, including zero-discriminator bootstrap packets. The public BFD
+status and metric key remains the bare peer address under the existing unique
+link-local-address rule. Like TCP-AO, BFD edits are **restart-required**: on SIGHUP rustbgpd pins
 `[[bfd_profiles]]` and neighbor / peer-group `bfd` back to the live snapshot and
 reports them as restart-required in `--diff`. Inspect sessions with
 `rbgp bfd` / `BfdService.GetBfdSessions` (see [API.md](API.md)); an older daemon

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -86,9 +86,9 @@ full gate ladder.
   that are neither Current nor RNext. Key edits/reordering, selected or
   non-deprecated-key deletion, and protected-owner CRUD require a daemon restart.
 - TCP MD5 and GTSM are supported.
-- BFD supports IPv4/IPv6 global-address single-hop asynchronous sessions for
-  static neighbors. Multihop BFD (RFC 5883), echo, demand mode,
-  authentication, dynamic-neighbor BFD, and IPv6 link-local BFD remain
+- BFD supports IPv4, IPv6 global, and interface-scoped IPv6 link-local
+  single-hop asynchronous sessions for static neighbors. Multihop BFD (RFC
+  5883), echo, demand mode, authentication, and dynamic-neighbor BFD remain
   follow-up work. This deferral is scoped to BFD sessions only. It says
   nothing about BGP sessions to non-adjacent peers: those require no separate
   enablement and can be distance-bounded with `ttl_security_hops`.

--- a/docs/adr/0067-bfd-single-hop.md
+++ b/docs/adr/0067-bfd-single-hop.md
@@ -178,11 +178,12 @@ this makes the *effective* session set fully expressible inline, which the
 restart-required reload pin (below) relies on to represent "inherits the group
 but BFD is off" without editing peer-group membership. Validation checks
 that the referenced profile name is defined and that the interval/multiplier
-bounds hold, mirroring the peer-group-reference validation. It also **rejects
-effective BFD on an IPv6 link-local (`fe80::/10`) neighbor** — link-local BFD is
-deferred to v1.1 (see the spike), so the actor would otherwise send to an
-unscoped peer and never converge; failing config load is clearer than a session
-that silently stays Down.
+bounds hold, mirroring the peer-group-reference validation. An IPv6 link-local
+neighbor already requires `interface`; BFD resolves that name to a scope at
+startup, fails before socket preparation if it cannot, and uses the scope on
+the shared IPv6 transmit socket. Receive-side `IPV6_PKTINFO` must report the
+same interface before either discriminator path can reach the FSM. Global
+IPv4/IPv6 sessions remain unscoped.
 
 **Restart-required:** the actor resolves its session set once at startup, so
 BFD edits (`[[bfd_profiles]]`, neighbor/peer-group `bfd`) are restart-required —
@@ -201,8 +202,9 @@ reconfiguration is a later enhancement.
 - Behavior is staged behind observability: metrics and the gRPC/CLI surface land
   before any BFD-driven BGP teardown exists.
 - Validation: deterministic FSM + codec unit tests (no time, no sockets);
-  config parse/validation tests; a privileged netns test (two actors reach Up,
-  dropping traffic drives Down within the detection window, TTL≠255 is rejected);
+  config parse/validation tests; privileged netns tests (global and veth
+  link-local sessions reach Up, wrong-interface and TTL≠255 traffic is rejected,
+  and dropping traffic drives Down within the detection window);
   coupling-logic unit tests with fakes; and **M51** containerlab interop against
   FRR with `bfdd = yes` (BGP + BFD Up, induced failure drops BGP faster than the
   hold timer, recovery reconnects, asserted via both `vtysh show bfd peers` and
@@ -216,15 +218,18 @@ reconfiguration is a later enhancement.
 - Timer precision: a 300 ms interval under CPU load held **max jitter 0.61 ms,
   avg 0.21 ms** over 20 samples — ample margin for a 300 ms × 3 detection
   window. No timer concern.
-- **IPv6 link-local / unnumbered → deferred to v1.1.** At the time of this spike
+- **IPv6 link-local / unnumbered was initially deferred.** At the time of this spike
   the BGP side could not peer over link-local: `Neighbor` had no interface field,
   the address parsed as a bare `IpAddr` (no `%scope`), and `resolve_neighbor`
   built an unscoped `SocketAddr`. Link-local BFD first needs link-local **BGP**
   peering (a neighbor interface field + scoped connect). The BFD-side mechanics
   (scope_id TX, `PKTINFO` ifindex RX) are already proven. **Update:** scoped
   link-local BGP peering has since shipped (ADR-0069 / M53), so the prerequisite
-  now exists; link-local BFD becomes a small add keyed by the same scoped peer
-  identity but remains deferred to v1.1. **BFD v1 ships IPv4 + IPv6 global.**
+  now exists. Link-local BFD now carries that resolved scope privately through
+  its desired session and actor entry, uses scoped `sendto`, and rejects receive
+  packet-info from any other interface. M51 retains its numbered strict/failure/
+  recovery/AdminDown receipts and adds a distinct non-strict link-local FRR
+  session.
 
 ## Deferred (explicit non-scope)
 
@@ -234,8 +239,6 @@ reconfiguration is a later enhancement.
 - **C-bit / GR-aware** control-plane-independence nuance.
 - **Static-route BFD tracking** and **dynamic-neighbor (inbound-promoted) BFD** —
   static neighbors only in v1.
-- **IPv6 link-local / unnumbered** peering → **v1.1** (gated on link-local BGP
-  peering, per the spike).
 - **Hardware / offload.**
 
 ## Alternatives considered

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -20,7 +20,7 @@
 //! zero-discriminator bootstrap), and executes the resulting
 //! [`rustbgpd_bfd::Action`]s.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr, SocketAddrV6};
 
 use crate::config::{BfdConfig, Config};
 
@@ -34,6 +34,14 @@ use crate::config::{BfdConfig, Config};
 pub struct BfdSessionParams {
     /// Peer IP address (the BGP neighbor).
     pub peer: IpAddr,
+    /// Linux interface index for an IPv6 link-local peer. Global IPv4/IPv6
+    /// sessions are deliberately unscoped (`None`). This stays inside the
+    /// daemon runtime and is not part of the public BFD status identity.
+    pub(crate) scope_id: Option<u32>,
+    /// Concrete control-packet destination derived together with `scope_id`.
+    /// Keeping this in the startup-pinned runtime value makes a missing scope
+    /// impossible to discover as a best-effort transmit failure later.
+    pub(crate) destination: SocketAddr,
     /// Desired minimum transmit interval (microseconds).
     pub desired_min_tx_us: u32,
     /// Required minimum receive interval (microseconds).
@@ -57,6 +65,18 @@ pub struct BfdRuntimeConfig {
     /// One entry per BFD-enabled neighbor.
     pub sessions: Vec<BfdSessionParams>,
 }
+
+/// Checked BFD startup derivation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BfdRuntimeConfigError(String);
+
+impl std::fmt::Display for BfdRuntimeConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for BfdRuntimeConfigError {}
 
 /// A BFD session state change delivered to `PeerManager` (ADR-0067 step 4) over
 /// the per-peer coalescing channel from [`state_change_channel`] — distinct
@@ -203,11 +223,23 @@ impl BfdRuntimeConfig {
         self.sessions.iter().any(|s| s.peer.is_ipv6())
     }
 
+    fn validate_destinations(&self) -> Result<(), BfdRuntimeConfigError> {
+        for session in &self.sessions {
+            let expected = bfd_destination(session.peer, session.scope_id)?;
+            if session.destination != expected {
+                return Err(BfdRuntimeConfigError(format!(
+                    "BFD peer {} has inconsistent runtime destination {} (expected {expected})",
+                    session.peer, session.destination
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Resolve the BFD session set from the daemon config: every static
     /// neighbor whose own `bfd` (or inherited peer-group `bfd`) names a defined
     /// profile. Config validation has already checked the profile references.
-    #[must_use]
-    pub fn from_config(config: &Config) -> BfdRuntimeConfig {
+    pub fn from_config(config: &Config) -> Result<BfdRuntimeConfig, BfdRuntimeConfigError> {
         let mut sessions = Vec::new();
         for neighbor in &config.neighbors {
             let Some(bfd) = resolve_bfd(
@@ -222,14 +254,43 @@ impl BfdRuntimeConfig {
             if !bfd.enabled {
                 continue;
             }
-            let Ok(peer) = neighbor.address.parse::<IpAddr>() else {
-                continue;
+            let peer = neighbor.address.parse::<IpAddr>().map_err(|error| {
+                BfdRuntimeConfigError(format!(
+                    "neighbor {:?}: failed to derive configured BFD session address: {error}",
+                    neighbor.address
+                ))
+            })?;
+            let profile = config
+                .bfd_profiles
+                .iter()
+                .find(|p| p.name == bfd.profile)
+                .ok_or_else(|| {
+                    BfdRuntimeConfigError(format!(
+                        "neighbor {:?}: configured BFD profile {:?} is missing",
+                        neighbor.address, bfd.profile
+                    ))
+                })?;
+            let scope_id = if is_ipv6_link_local(peer) {
+                let interface = neighbor.interface.as_deref().ok_or_else(|| {
+                    BfdRuntimeConfigError(format!(
+                        "neighbor {:?}: IPv6 link-local BFD requires a configured interface",
+                        neighbor.address
+                    ))
+                })?;
+                Some(nix::net::if_::if_nametoindex(interface).map_err(|error| {
+                    BfdRuntimeConfigError(format!(
+                        "neighbor {:?} interface {:?}: failed to resolve IPv6 link-local BFD scope: {error}",
+                        neighbor.address, interface
+                    ))
+                })?)
+            } else {
+                None
             };
-            let Some(profile) = config.bfd_profiles.iter().find(|p| p.name == bfd.profile) else {
-                continue;
-            };
+            let destination = bfd_destination(peer, scope_id)?;
             sessions.push(BfdSessionParams {
                 peer,
+                scope_id,
+                destination,
                 desired_min_tx_us: profile.min_tx_interval.saturating_mul(1000),
                 required_min_rx_us: profile.min_rx_interval.saturating_mul(1000),
                 // Validation rejects multiplier > 255 / interval > u32::MAX/1000,
@@ -239,7 +300,35 @@ impl BfdRuntimeConfig {
                 enabled: true,
             });
         }
-        BfdRuntimeConfig { sessions }
+        Ok(BfdRuntimeConfig { sessions })
+    }
+}
+
+fn is_ipv6_link_local(peer: IpAddr) -> bool {
+    matches!(peer, IpAddr::V6(v6) if {
+        let octets = v6.octets();
+        octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80
+    })
+}
+
+pub(crate) fn bfd_destination(
+    peer: IpAddr,
+    scope_id: Option<u32>,
+) -> Result<SocketAddr, BfdRuntimeConfigError> {
+    match (peer, scope_id) {
+        (IpAddr::V6(v6), Some(scope_id)) if is_ipv6_link_local(peer) && scope_id != 0 => {
+            Ok(SocketAddr::V6(SocketAddrV6::new(v6, 3784, 0, scope_id)))
+        }
+        (IpAddr::V6(_), None) if is_ipv6_link_local(peer) => Err(BfdRuntimeConfigError(format!(
+            "BFD peer {peer} is IPv6 link-local but has no interface scope"
+        ))),
+        (IpAddr::V6(_), Some(0)) if is_ipv6_link_local(peer) => Err(BfdRuntimeConfigError(
+            format!("BFD peer {peer} has invalid zero interface scope"),
+        )),
+        (_, Some(scope_id)) => Err(BfdRuntimeConfigError(format!(
+            "global BFD peer {peer} unexpectedly carries interface scope {scope_id}"
+        ))),
+        (_, None) => Ok(SocketAddr::new(peer, 3784)),
     }
 }
 
@@ -450,6 +539,12 @@ mod linux {
 
     /// Open the required family sockets without spawning the BFD actor.
     pub fn prepare_runtime(config: &BfdRuntimeConfig) -> std::io::Result<Option<PreparedRuntime>> {
+        config.validate_destinations().map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid BFD runtime configuration: {error}"),
+            )
+        })?;
         let sockets = prepare_runtime_sockets(
             config.needs_ipv4(),
             config.needs_ipv6(),
@@ -490,6 +585,12 @@ mod linux {
     struct Entry {
         session: Session,
         peer: IpAddr,
+        /// Required receive/transmit interface for an IPv6 link-local peer.
+        /// Global IPv4/IPv6 sessions remain unscoped.
+        scope_id: Option<u32>,
+        /// Prevalidated concrete destination; link-local addresses include the
+        /// required interface scope.
+        destination: SocketAddr,
         strict: bool,
         /// Our local discriminator for this session (RFC 5880 §6.8.1) — held so
         /// it can be released back to the allocator and removed from the
@@ -636,8 +737,8 @@ mod linux {
                         if drained {
                             g.clear_ready();
                         }
-                        for (src, pkt) in pkts {
-                            actor.on_packet(src, &pkt, metrics, status_tx).await;
+                        for packet in pkts {
+                            actor.on_packet(packet, metrics, status_tx).await;
                         }
                     }
                 }
@@ -647,8 +748,8 @@ mod linux {
                         if drained {
                             g.clear_ready();
                         }
-                        for (src, pkt) in pkts {
-                            actor.on_packet(src, &pkt, metrics, status_tx).await;
+                        for packet in pkts {
+                            actor.on_packet(packet, metrics, status_tx).await;
                         }
                     }
                 }
@@ -700,6 +801,8 @@ mod linux {
             let entry = Entry {
                 session,
                 peer: params.peer,
+                scope_id: params.scope_id,
+                destination: params.destination,
                 strict: params.strict,
                 local_discriminator: discr,
                 last_diagnostic: Diagnostic::None,
@@ -796,21 +899,27 @@ mod linux {
 
         async fn on_packet(
             &mut self,
-            src: IpAddr,
-            pkt: &ControlPacket,
+            packet: ReceivedPacket,
             metrics: &BgpMetrics,
             status_tx: &watch::Sender<Vec<BfdStatus>>,
         ) {
-            let Some(peer) = demux_target(
+            let ReceivedPacket {
+                src,
+                ifindex,
+                packet: pkt,
+            } = packet;
+            let Some(peer) = scoped_demux_target(
                 &self.by_discriminator,
                 src,
                 pkt.your_discriminator,
-                self.sessions.contains_key(&src),
+                ifindex,
+                |candidate| self.sessions.get(&candidate).map(|entry| entry.scope_id),
             ) else {
                 debug!(
                     peer = %src,
+                    received_scope = ?ifindex,
                     your_discriminator = pkt.your_discriminator,
-                    "BFD packet not matched to a session; ignoring"
+                    "BFD packet not matched to a session and interface scope; ignoring"
                 );
                 return;
             };
@@ -819,7 +928,7 @@ mod linux {
             };
             let before_state = entry.session.state();
             let before_remote_admin_down = entry.session.remote_admin_down();
-            let actions = entry.session.handle(Event::PacketReceived(pkt.clone()));
+            let actions = entry.session.handle(Event::PacketReceived(pkt));
             let changed = operator_status_changed(
                 before_state,
                 before_remote_admin_down,
@@ -979,7 +1088,9 @@ mod linux {
 
         async fn send(&self, peer: IpAddr, pkt: &ControlPacket) {
             let bytes = pkt.encode();
-            let dst = SocketAddr::new(peer, BFD_CONTROL_PORT);
+            let Some(dst) = self.sessions.get(&peer).map(|entry| entry.destination) else {
+                return;
+            };
             let sock = if peer.is_ipv4() {
                 self.tx_v4.as_ref()
             } else {
@@ -1028,6 +1139,36 @@ mod linux {
         }
     }
 
+    /// Enforce receive-interface identity for any packet involving a
+    /// link-local address. This gate runs after selecting the candidate session
+    /// but before the packet reaches its FSM, so neither zero-discriminator
+    /// bootstrap nor non-zero discriminator demux can bypass scope.
+    fn receive_scope_matches(
+        src: IpAddr,
+        peer: IpAddr,
+        expected_scope: Option<u32>,
+        received_scope: Option<u32>,
+    ) -> bool {
+        if super::is_ipv6_link_local(src) || super::is_ipv6_link_local(peer) {
+            expected_scope.is_some() && expected_scope == received_scope
+        } else {
+            true
+        }
+    }
+
+    fn scoped_demux_target(
+        by_discriminator: &HashMap<u32, IpAddr>,
+        src: IpAddr,
+        your_discriminator: u32,
+        received_scope: Option<u32>,
+        session_scope: impl Fn(IpAddr) -> Option<Option<u32>>,
+    ) -> Option<IpAddr> {
+        let source_exists = session_scope(src).is_some();
+        let peer = demux_target(by_discriminator, src, your_discriminator, source_exists)?;
+        let expected_scope = session_scope(peer)?;
+        receive_scope_matches(src, peer, expected_scope, received_scope).then_some(peer)
+    }
+
     fn next_timer_sleep(timers: &BinaryHeap<Reverse<Deadline>>) -> tokio::time::Sleep {
         match timers.peek() {
             Some(Reverse(d)) => tokio::time::sleep_until(d.at),
@@ -1038,13 +1179,19 @@ mod linux {
     }
 
     /// Outcome of one `recvmsg`.
-    enum Recv {
+    pub(super) enum Recv {
         /// A valid control packet from `(source IP)`.
-        Packet(IpAddr, ControlPacket),
+        Packet(ReceivedPacket),
         /// A datagram was received but dropped (bad TTL, address, or decode).
         Discard,
         /// Nothing more to read (would-block or error).
         Done,
+    }
+
+    pub(super) struct ReceivedPacket {
+        pub(super) src: IpAddr,
+        pub(super) ifindex: Option<u32>,
+        pub(super) packet: ControlPacket,
     }
 
     /// Read up to `budget` datagrams from a non-blocking RX socket, validating
@@ -1055,11 +1202,11 @@ mod linux {
     /// whether the socket was fully drained (`false` = budget exhausted with
     /// data possibly still queued — the caller must keep the socket marked
     /// ready and come back).
-    fn drain_socket(fd: i32, budget: usize) -> (Vec<(IpAddr, ControlPacket)>, bool) {
+    fn drain_socket(fd: i32, budget: usize) -> (Vec<ReceivedPacket>, bool) {
         let mut out = Vec::new();
         for _ in 0..budget {
             match recv_one(fd) {
-                Recv::Packet(src, pkt) => out.push((src, pkt)),
+                Recv::Packet(packet) => out.push(packet),
                 Recv::Discard => {}
                 Recv::Done => return (out, true),
             }
@@ -1067,7 +1214,7 @@ mod linux {
         (out, false)
     }
 
-    fn recv_one(fd: i32) -> Recv {
+    pub(super) fn recv_one(fd: i32) -> Recv {
         let mut buf = [0u8; 256];
         let mut iov = [IoSliceMut::new(&mut buf)];
         let mut cmsg = nix::cmsg_space!([u8; 256]);
@@ -1081,11 +1228,15 @@ mod linux {
             return Recv::Done;
         };
         let mut ttl: Option<i32> = None;
+        let mut ifindex: Option<u32> = None;
         if let Ok(cmsgs) = msg.cmsgs() {
             for c in cmsgs {
                 match c {
                     ControlMessageOwned::Ipv4Ttl(t) | ControlMessageOwned::Ipv6HopLimit(t) => {
                         ttl = Some(t);
+                    }
+                    ControlMessageOwned::Ipv6PacketInfo(info) => {
+                        ifindex = Some(info.ipi6_ifindex);
                     }
                     _ => {}
                 }
@@ -1113,7 +1264,11 @@ mod linux {
         }
         let n = msg.bytes;
         match ControlPacket::decode(&buf[..n]) {
-            Ok(pkt) => Recv::Packet(src, pkt),
+            Ok(packet) => Recv::Packet(ReceivedPacket {
+                src,
+                ifindex,
+                packet,
+            }),
             Err(_) => Recv::Discard,
         }
     }
@@ -1166,6 +1321,21 @@ mod linux {
                 format!("failed to enable {option} on {family} BFD receive socket {bind}: {error}"),
             )
         })?;
+        if v6 {
+            nix::sys::socket::setsockopt(
+                &socket,
+                nix::sys::socket::sockopt::Ipv6RecvPacketInfo,
+                &true,
+            )
+            .map_err(|error| {
+                std::io::Error::new(
+                    std::io::Error::from(error).kind(),
+                    format!(
+                        "failed to enable IPV6_RECVPKTINFO on IPv6 BFD receive socket {bind}: {error}"
+                    ),
+                )
+            })?;
+        }
         Ok(socket.into())
     }
 
@@ -1174,7 +1344,7 @@ mod linux {
     const BFD_SRC_PORT_MIN: u16 = 49152;
     const BFD_SRC_PORT_MAX: u16 = 65535;
 
-    fn tx_socket(v6: bool) -> std::io::Result<std::net::UdpSocket> {
+    pub(super) fn tx_socket(v6: bool) -> std::io::Result<std::net::UdpSocket> {
         let domain = if v6 { Domain::IPV6 } else { Domain::IPV4 };
         let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
         if v6 {
@@ -1220,7 +1390,7 @@ mod linux {
         unsafe_code,
         reason = "BFD receive TTL requires the raw Linux socket-option ABI"
     )]
-    fn enable_recv_ttl(fd: i32, v6: bool) -> std::io::Result<()> {
+    pub(super) fn enable_recv_ttl(fd: i32, v6: bool) -> std::io::Result<()> {
         let on: libc::c_int = 1;
         let (level, opt) = if v6 {
             (libc::IPPROTO_IPV6, libc::IPV6_RECVHOPLIMIT)
@@ -1249,10 +1419,11 @@ mod linux {
     mod unit {
         use super::{
             BFD_SRC_PORT_MIN, Deadline, FamilySockets, enable_recv_ttl, kind_key,
-            prepare_runtime_sockets, rx_socket_with,
+            prepare_runtime_sockets, rx_socket_with, scoped_demux_target,
         };
         use rustbgpd_bfd::{ControlPacket, Diagnostic, SessionState, TimerKind};
-        use std::net::IpAddr;
+        use std::collections::HashMap;
+        use std::net::{IpAddr, SocketAddr, SocketAddrV6};
         use std::os::fd::AsRawFd;
         use tokio::io::unix::AsyncFd;
         use tokio::time::Instant;
@@ -1314,6 +1485,110 @@ mod linux {
         }
 
         #[test]
+        fn transmit_destination_scopes_only_link_local_ipv6() {
+            use super::super::{BfdRuntimeConfigError, bfd_destination};
+
+            let link_local: IpAddr = "fe80::2".parse().unwrap();
+            assert_eq!(
+                bfd_destination(link_local, Some(17)),
+                Ok(SocketAddr::V6(SocketAddrV6::new(
+                    "fe80::2".parse().unwrap(),
+                    3784,
+                    0,
+                    17
+                )))
+            );
+            assert_eq!(
+                bfd_destination(link_local, None),
+                Err(BfdRuntimeConfigError(
+                    "BFD peer fe80::2 is IPv6 link-local but has no interface scope".to_string()
+                )),
+                "link-local transmit must fail closed without a scope"
+            );
+            assert_eq!(
+                bfd_destination(link_local, Some(0)),
+                Err(BfdRuntimeConfigError(
+                    "BFD peer fe80::2 has invalid zero interface scope".to_string()
+                )),
+                "link-local transmit must fail closed with an invalid scope"
+            );
+
+            let global_v6: IpAddr = "2001:db8::2".parse().unwrap();
+            assert_eq!(
+                bfd_destination(global_v6, None),
+                Ok("[2001:db8::2]:3784".parse().unwrap())
+            );
+            let global_v4: IpAddr = "192.0.2.2".parse().unwrap();
+            assert_eq!(
+                bfd_destination(global_v4, None),
+                Ok("192.0.2.2:3784".parse().unwrap())
+            );
+        }
+
+        #[test]
+        fn link_local_scope_gates_zero_and_nonzero_discriminator_demux() {
+            let peer: IpAddr = "fe80::2".parse().unwrap();
+            let by_discriminator = HashMap::from([(41_u32, peer)]);
+            let session_scope = |candidate| (candidate == peer).then_some(Some(17));
+
+            for discriminator in [0, 41] {
+                assert_eq!(
+                    scoped_demux_target(
+                        &by_discriminator,
+                        peer,
+                        discriminator,
+                        Some(17),
+                        session_scope,
+                    ),
+                    Some(peer),
+                    "matching receive scope must admit discriminator {discriminator}"
+                );
+                assert_eq!(
+                    scoped_demux_target(
+                        &by_discriminator,
+                        peer,
+                        discriminator,
+                        None,
+                        session_scope,
+                    ),
+                    None,
+                    "missing pktinfo must drop discriminator {discriminator}"
+                );
+                assert_eq!(
+                    scoped_demux_target(
+                        &by_discriminator,
+                        peer,
+                        discriminator,
+                        Some(18),
+                        session_scope,
+                    ),
+                    None,
+                    "wrong interface must drop discriminator {discriminator}"
+                );
+            }
+
+            let global: IpAddr = "2001:db8::2".parse().unwrap();
+            let global_disc = HashMap::from([(42_u32, global)]);
+            let global_scope = |candidate| (candidate == global).then_some(None);
+            assert_eq!(
+                scoped_demux_target(&global_disc, global, 42, None, global_scope),
+                Some(global),
+                "global IPv6 behavior remains unscoped"
+            );
+        }
+
+        #[test]
+        fn ipv6_receive_socket_enables_packet_info() {
+            let socket = rx_socket_with(true, 0, enable_recv_ttl).expect("IPv6 receive socket");
+            let enabled = nix::sys::socket::getsockopt(
+                &socket,
+                nix::sys::socket::sockopt::Ipv6RecvPacketInfo,
+            )
+            .expect("read IPV6_RECVPKTINFO");
+            assert!(enabled);
+        }
+
+        #[test]
         fn configured_startup_propagates_socket_open_failure() {
             // Load-bearing proof: changing `prepare_runtime_sockets` back to
             // the old log-and-continue behavior (`Err(_) => Ok(None)`) makes
@@ -1331,6 +1606,33 @@ mod linux {
             assert_eq!(
                 error.to_string(),
                 "BFD IPv4 socket startup failed: injected UDP/3784 collision"
+            );
+        }
+
+        #[test]
+        fn missing_link_local_scope_fails_before_socket_preparation() {
+            use super::super::{BfdRuntimeConfig, BfdSessionParams};
+
+            let config = BfdRuntimeConfig {
+                sessions: vec![BfdSessionParams {
+                    peer: "fe80::2".parse().unwrap(),
+                    scope_id: None,
+                    destination: "[fe80::2]:3784".parse().unwrap(),
+                    desired_min_tx_us: 300_000,
+                    required_min_rx_us: 300_000,
+                    detect_mult: 3,
+                    strict: false,
+                    enabled: true,
+                }],
+            };
+            let Err(error) = super::prepare_runtime(&config) else {
+                panic!("missing scope must fail at startup preflight");
+            };
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+            assert!(
+                error.to_string().contains("fe80::2")
+                    && error.to_string().contains("no interface scope"),
+                "actionable startup error: {error}"
             );
         }
 
@@ -1507,7 +1809,10 @@ mod linux {
 
             let (pkts, drained) = super::drain_socket(rx.as_raw_fd(), 8);
             assert!(drained, "both datagrams fit the budget");
-            let discs: Vec<u32> = pkts.iter().map(|(_, p)| p.my_discriminator).collect();
+            let discs: Vec<u32> = pkts
+                .iter()
+                .map(|received| received.packet.my_discriminator)
+                .collect();
             assert_eq!(
                 discs,
                 vec![0x600D],
@@ -1556,6 +1861,8 @@ mod linux {
             let config = BfdRuntimeConfig {
                 sessions: vec![BfdSessionParams {
                     peer: "127.0.0.9".parse().expect("ip"),
+                    scope_id: None,
+                    destination: "127.0.0.9:3784".parse().expect("socket address"),
                     desired_min_tx_us: 100_000,
                     required_min_rx_us: 100_000,
                     detect_mult: 3,
@@ -1660,16 +1967,113 @@ remote_asn = 65002
 bfd = { profile = "fast", strict = true }
 "#,
         );
-        let rc = BfdRuntimeConfig::from_config(&config);
+        let rc = BfdRuntimeConfig::from_config(&config).expect("derive BFD runtime");
         assert!(rc.enabled());
         assert_eq!(rc.sessions.len(), 1);
         let s = &rc.sessions[0];
         assert_eq!(s.peer, ip("10.0.0.2"));
+        assert_eq!(s.scope_id, None, "global IPv4 remains unscoped");
         // Profile ms intervals become microseconds for the FSM.
         assert_eq!(s.desired_min_tx_us, 250_000);
         assert_eq!(s.required_min_rx_us, 200_000);
         assert_eq!(s.detect_mult, 4);
         assert!(s.strict);
+    }
+
+    #[test]
+    fn from_config_resolves_link_local_interface_scope() {
+        let config = config_with(
+            r#"
+[[bfd_profiles]]
+name = "p"
+
+[[neighbors]]
+address = "fe80::2"
+interface = "lo"
+remote_asn = 65002
+bfd = { profile = "p" }
+"#,
+        );
+        let rc = BfdRuntimeConfig::from_config(&config).expect("resolve link-local scope");
+        assert_eq!(rc.sessions.len(), 1);
+        assert_eq!(rc.sessions[0].peer, ip("fe80::2"));
+        assert_eq!(
+            rc.sessions[0].scope_id,
+            Some(nix::net::if_::if_nametoindex("lo").expect("loopback interface"))
+        );
+    }
+
+    #[test]
+    fn from_config_resolves_inherited_link_local_interface_scope() {
+        let config = config_with(
+            r#"
+[[bfd_profiles]]
+name = "p"
+
+[peer_groups.fabric]
+bfd = { profile = "p" }
+
+[[neighbors]]
+address = "fe80::3"
+interface = "lo"
+remote_asn = 65003
+peer_group = "fabric"
+"#,
+        );
+        let rc = BfdRuntimeConfig::from_config(&config).expect("resolve inherited scope");
+        assert_eq!(rc.sessions.len(), 1);
+        assert_eq!(rc.sessions[0].peer, ip("fe80::3"));
+        assert_eq!(
+            rc.sessions[0].scope_id,
+            Some(nix::net::if_::if_nametoindex("lo").expect("loopback interface"))
+        );
+    }
+
+    #[test]
+    fn link_local_disabled_override_runs_no_session() {
+        let config = config_with(
+            r#"
+[[bfd_profiles]]
+name = "p"
+
+[peer_groups.fabric]
+bfd = { profile = "p" }
+
+[[neighbors]]
+address = "fe80::4"
+interface = "lo"
+remote_asn = 65004
+peer_group = "fabric"
+bfd = { profile = "p", enabled = false }
+"#,
+        );
+        let rc = BfdRuntimeConfig::from_config(&config).expect("disabled BFD needs no scope");
+        assert!(rc.sessions.is_empty());
+    }
+
+    #[test]
+    fn nonexistent_link_local_interface_fails_checked_derivation() {
+        let config = config_with(
+            r#"
+[[bfd_profiles]]
+name = "p"
+
+[[neighbors]]
+address = "fe80::5"
+interface = "rustbgpd-no-such-interface"
+remote_asn = 65005
+bfd = { profile = "p" }
+"#,
+        );
+        let error = BfdRuntimeConfig::from_config(&config)
+            .expect_err("missing interface must fail before socket preparation");
+        let message = error.to_string();
+        assert!(message.contains("fe80::5"), "neighbor context: {message}");
+        assert!(
+            message.contains("rustbgpd-no-such-interface"),
+            "interface context: {message}"
+        );
+        assert!(message.contains("failed to resolve"), "reason: {message}");
     }
 
     #[test]
@@ -1691,9 +2095,10 @@ remote_asn = 65002
 peer_group = "rrc"
 "#,
         );
-        let rc = BfdRuntimeConfig::from_config(&config);
+        let rc = BfdRuntimeConfig::from_config(&config).expect("derive BFD runtime");
         assert_eq!(rc.sessions.len(), 1);
         assert_eq!(rc.sessions[0].peer, ip("10.0.0.2"));
+        assert_eq!(rc.sessions[0].scope_id, None);
         assert!(!rc.sessions[0].strict);
     }
 
@@ -1719,7 +2124,7 @@ peer_group = "rrc"
 bfd = { profile = "p", enabled = false }
 "#,
         );
-        let rc = BfdRuntimeConfig::from_config(&config);
+        let rc = BfdRuntimeConfig::from_config(&config).expect("derive BFD runtime");
         // Only the inheriting neighbor runs a session; the override disables it.
         assert_eq!(rc.sessions.len(), 1);
         assert_eq!(rc.sessions[0].peer, ip("10.0.0.2"));
@@ -1751,7 +2156,7 @@ peer_group = "rrc"
 bfd = { profile = "own", strict = true }
 "#,
         );
-        let rc = BfdRuntimeConfig::from_config(&config);
+        let rc = BfdRuntimeConfig::from_config(&config).expect("derive BFD runtime");
         assert_eq!(rc.sessions.len(), 1);
         let s = &rc.sessions[0];
         assert_eq!(s.desired_min_tx_us, 150_000);
@@ -1768,7 +2173,7 @@ address = "10.0.0.2"
 remote_asn = 65002
 "#,
         );
-        let rc = BfdRuntimeConfig::from_config(&config);
+        let rc = BfdRuntimeConfig::from_config(&config).expect("derive BFD runtime");
         assert!(rc.sessions.is_empty());
         assert!(!rc.enabled());
     }
@@ -1800,7 +2205,8 @@ remote_asn = 65003
 bfd = {{ profile = "p" }}
 "#
         ));
-        let candidate_families = BfdRuntimeConfig::from_config(&candidate);
+        let candidate_families =
+            BfdRuntimeConfig::from_config(&candidate).expect("derive candidate BFD runtime");
         assert!(
             candidate_families.needs_ipv6(),
             "candidate must genuinely ask for a new family"
@@ -1809,7 +2215,7 @@ bfd = {{ profile = "p" }}
             crate::config::pin_bfd_startup_only_runtime(&mut candidate, &live),
             "a BFD-attachment change must be classified restart-required"
         );
-        let rc = BfdRuntimeConfig::from_config(&candidate);
+        let rc = BfdRuntimeConfig::from_config(&candidate).expect("derive pinned BFD runtime");
         assert!(rc.needs_ipv4());
         assert!(
             !rc.needs_ipv6(),
@@ -1948,6 +2354,7 @@ bfd = {{ profile = "p" }}
     // mirroring `fib_runtime`'s pattern.
     #[cfg(target_os = "linux")]
     mod netns {
+        use super::super::linux::{Recv, enable_recv_ttl, recv_one};
         use super::super::{
             BfdRuntimeConfig, BfdSessionParams, BfdStatus, prepare_runtime, spawn_prepared,
         };
@@ -1955,10 +2362,11 @@ bfd = {{ profile = "p" }}
         use rustbgpd_bfd::{ControlPacket, Diagnostic, SessionState};
         use rustbgpd_telemetry::BgpMetrics;
         use socket2::{Domain, Protocol, Socket, Type};
-        use std::net::{IpAddr, SocketAddr};
+        use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
+        use std::os::fd::AsRawFd;
         use std::process::Command;
         use std::sync::Arc;
-        use std::sync::atomic::{AtomicU16, Ordering};
+        use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
         use std::time::Duration;
         use tokio::sync::{broadcast, watch};
         use tokio_util::sync::CancellationToken;
@@ -1966,12 +2374,26 @@ bfd = {{ profile = "p" }}
         const PEER_DISC: u32 = 0x0A0B_0C0D;
         const ACTOR_ADDR: &str = "127.0.0.1";
         const PEER_ADDR: &str = "127.0.0.2";
+        const LL_ACTOR_ADDR: &str = "fe80::51";
+        const LL_PEER_ADDR: &str = "fe80::52";
+        const LL_WRONG_ACTOR_ADDR: &str = "fe80::53";
+        const LL_ACTOR_IF: &str = "bfda";
+        const LL_PEER_IF: &str = "bfdp";
+        const LL_WRONG_ACTOR_IF: &str = "bfdwa";
+        const LL_WRONG_PEER_IF: &str = "bfdwp";
         const PORT: u16 = 3784;
 
         // Peer responder mode, shared via a watch channel.
         const MODE_TTL_BAD: u8 = 0; // reply with TTL=1 (must be discarded)
         const MODE_TTL_GOOD: u8 = 1; // reply with TTL=255 (valid)
         const MODE_SILENT: u8 = 2; // stop replying
+
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum LinkLocalResponderMode {
+            WrongInterface,
+            IntendedInterface,
+            Silent,
+        }
 
         fn netns_gate() -> bool {
             std::env::var("EVPN_LINUX_NETNS").as_deref() == Ok("1")
@@ -1999,8 +2421,8 @@ bfd = {{ profile = "p" }}
         }
 
         impl Netns {
-            fn create() -> Self {
-                let name = format!("rustbgpd-bfd-{}", std::process::id());
+            fn create(suffix: &str) -> Self {
+                let name = format!("rustbgpd-bfd-{suffix}-{}", std::process::id());
                 try_run("ip", &["netns", "delete", &name]);
                 run("ip", &["netns", "add", &name]);
                 // Bring up loopback and assign 127.0.0.1/8 so both the actor
@@ -2012,6 +2434,46 @@ bfd = {{ profile = "p" }}
                 run("ip", &["-n", &name, "link", "set", "lo", "up"]);
                 Self { name }
             }
+
+            fn create_link_local() -> Self {
+                let ns = Self::create("ll");
+                for (actor_if, peer_if) in [
+                    (LL_ACTOR_IF, LL_PEER_IF),
+                    (LL_WRONG_ACTOR_IF, LL_WRONG_PEER_IF),
+                ] {
+                    run(
+                        "ip",
+                        &[
+                            "-n", &ns.name, "link", "add", actor_if, "type", "veth", "peer",
+                            "name", peer_if,
+                        ],
+                    );
+                    run("ip", &["-n", &ns.name, "link", "set", actor_if, "up"]);
+                    run("ip", &["-n", &ns.name, "link", "set", peer_if, "up"]);
+                }
+                for (address, interface) in [
+                    (LL_ACTOR_ADDR, LL_ACTOR_IF),
+                    (LL_PEER_ADDR, LL_PEER_IF),
+                    (LL_WRONG_ACTOR_ADDR, LL_WRONG_ACTOR_IF),
+                    (LL_PEER_ADDR, LL_WRONG_PEER_IF),
+                ] {
+                    run(
+                        "ip",
+                        &[
+                            "-n",
+                            &ns.name,
+                            "-6",
+                            "addr",
+                            "add",
+                            &format!("{address}/64"),
+                            "dev",
+                            interface,
+                            "nodad",
+                        ],
+                    );
+                }
+                ns
+            }
         }
 
         impl Drop for Netns {
@@ -2020,16 +2482,12 @@ bfd = {{ profile = "p" }}
             }
         }
 
-        fn reexec_inner(ns: &Netns) {
+        fn reexec_inner(ns: &Netns, test_name: &str) {
             let exe = std::env::current_exe().expect("self-exe");
             let status = Command::new("ip")
                 .args(["netns", "exec", &ns.name])
                 .arg(&exe)
-                .args([
-                    "--exact",
-                    "--nocapture",
-                    "bfd_runtime::tests::netns::session_reaches_up_and_detects_down",
-                ])
+                .args(["--exact", "--nocapture", test_name])
                 .env("RUSTBGPD_BFD_NETNS_INNER", "1")
                 .env("EVPN_LINUX_NETNS", "1")
                 .status()
@@ -2059,6 +2517,40 @@ bfd = {{ profile = "p" }}
             assert!(bound, "no free peer source port in 49152..=65535");
             s.set_nonblocking(true).unwrap();
             tokio::net::UdpSocket::from_std(s.into()).unwrap()
+        }
+
+        fn link_local_peer_rx(scope_id: u32) -> std::net::UdpSocket {
+            let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+            socket.set_reuse_address(true).unwrap();
+            socket.set_only_v6(true).unwrap();
+            let peer: Ipv6Addr = LL_PEER_ADDR.parse().unwrap();
+            socket
+                .bind(&SocketAddrV6::new(peer, PORT, 0, scope_id).into())
+                .unwrap();
+            enable_recv_ttl(socket.as_raw_fd(), true).unwrap();
+            nix::sys::socket::setsockopt(
+                &socket,
+                nix::sys::socket::sockopt::Ipv6RecvPacketInfo,
+                &true,
+            )
+            .unwrap();
+            socket.set_nonblocking(true).unwrap();
+            socket.into()
+        }
+
+        fn link_local_peer_tx(source_scope: u32) -> tokio::net::UdpSocket {
+            let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+            socket.set_only_v6(true).unwrap();
+            socket.set_unicast_hops_v6(255).unwrap();
+            let source: Ipv6Addr = LL_PEER_ADDR.parse().unwrap();
+            let bound = (49152_u16..=65535).any(|port| {
+                socket
+                    .bind(&SocketAddrV6::new(source, port, 0, source_scope).into())
+                    .is_ok()
+            });
+            assert!(bound, "no free scoped IPv6 BFD source port");
+            socket.set_nonblocking(true).unwrap();
+            tokio::net::UdpSocket::from_std(socket.into()).unwrap()
         }
 
         // A control packet from the hand-rolled peer that drives a Down actor
@@ -2119,6 +2611,75 @@ bfd = {{ profile = "p" }}
                             cur_ttl = ttl;
                         }
                         let _ = tx_sock.send_to(&peer_init(actor_disc), actor).await;
+                    }
+                }
+            }
+        }
+
+        #[expect(
+            clippy::too_many_arguments,
+            reason = "netns responder carries both intended and adversarial interface scopes"
+        )]
+        async fn link_local_peer_responder(
+            rx: std::net::UdpSocket,
+            good_tx: tokio::net::UdpSocket,
+            wrong_tx: tokio::net::UdpSocket,
+            peer_scope: u32,
+            wrong_peer_scope: u32,
+            mode_rx: watch::Receiver<LinkLocalResponderMode>,
+            observed_source: Arc<AtomicBool>,
+            observed_interface: Arc<AtomicBool>,
+            wrong_send_succeeded: Arc<AtomicBool>,
+            stop: CancellationToken,
+        ) -> Result<(), String> {
+            let good_actor = SocketAddr::V6(SocketAddrV6::new(
+                LL_ACTOR_ADDR.parse().unwrap(),
+                PORT,
+                0,
+                peer_scope,
+            ));
+            let wrong_actor = SocketAddr::V6(SocketAddrV6::new(
+                LL_WRONG_ACTOR_ADDR.parse().unwrap(),
+                PORT,
+                0,
+                wrong_peer_scope,
+            ));
+            let expected_source: IpAddr = LL_ACTOR_ADDR.parse().unwrap();
+            loop {
+                tokio::select! {
+                    biased;
+                    () = stop.cancelled() => return Ok(()),
+                    () = tokio::time::sleep(Duration::from_millis(10)) => {
+                        let Recv::Packet(received) = recv_one(rx.as_raw_fd()) else {
+                            continue;
+                        };
+                        // `recv_one` admits only Hop-Limit 255 and an RFC 5881
+                        // source port. Its pktinfo also proves which veth
+                        // received the actor's shared-socket transmit.
+                        observed_source.store(received.src == expected_source, Ordering::Relaxed);
+                        observed_interface.store(
+                            received.ifindex == Some(peer_scope),
+                            Ordering::Relaxed,
+                        );
+                        let actor_disc = received.packet.my_discriminator;
+                        if actor_disc == 0
+                            || *mode_rx.borrow() == LinkLocalResponderMode::Silent
+                        {
+                            continue;
+                        }
+                        let response = peer_init(actor_disc);
+                        if *mode_rx.borrow() == LinkLocalResponderMode::WrongInterface {
+                            wrong_tx
+                                .send_to(&response, wrong_actor)
+                                .await
+                                .map_err(|error| format!("wrong-interface BFD send failed: {error}"))?;
+                            wrong_send_succeeded.store(true, Ordering::Relaxed);
+                        } else {
+                            good_tx
+                                .send_to(&response, good_actor)
+                                .await
+                                .map_err(|error| format!("intended-interface BFD send failed: {error}"))?;
+                        }
                     }
                 }
             }
@@ -2191,8 +2752,11 @@ bfd = {{ profile = "p" }}
                 return;
             }
             if !is_inner() {
-                let ns = Netns::create();
-                reexec_inner(&ns);
+                let ns = Netns::create("v4");
+                reexec_inner(
+                    &ns,
+                    "bfd_runtime::tests::netns::session_reaches_up_and_detects_down",
+                );
                 return;
             }
 
@@ -2200,6 +2764,8 @@ bfd = {{ profile = "p" }}
             let config = BfdRuntimeConfig {
                 sessions: vec![BfdSessionParams {
                     peer: peer_ip,
+                    scope_id: None,
+                    destination: "127.0.0.2:3784".parse().unwrap(),
                     desired_min_tx_us: 100_000,
                     required_min_rx_us: 100_000,
                     detect_mult: 3,
@@ -2330,6 +2896,147 @@ bfd = {{ profile = "p" }}
 
             peer_stop.cancel();
             let _ = peer_task.await;
+            handle.shutdown().await;
+        }
+
+        #[tokio::test]
+        #[expect(clippy::too_many_lines, reason = "scoped IPv6 netns scenario")]
+        async fn link_local_session_enforces_interface_scope_and_detects_down() {
+            if !netns_gate() {
+                eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run the privileged BFD netns test");
+                return;
+            }
+            if !is_inner() {
+                let ns = Netns::create_link_local();
+                reexec_inner(
+                    &ns,
+                    "bfd_runtime::tests::netns::link_local_session_enforces_interface_scope_and_detects_down",
+                );
+                return;
+            }
+
+            let actor_scope = nix::net::if_::if_nametoindex(LL_ACTOR_IF).unwrap();
+            let peer_scope = nix::net::if_::if_nametoindex(LL_PEER_IF).unwrap();
+            let wrong_peer_scope = nix::net::if_::if_nametoindex(LL_WRONG_PEER_IF).unwrap();
+            let peer_ip: IpAddr = LL_PEER_ADDR.parse().unwrap();
+
+            // Bind the hand-rolled peer specifically to its intended veth.
+            // The actor itself still uses one shared wildcard IPv6 socket.
+            let peer_rx = link_local_peer_rx(peer_scope);
+            let good_tx = link_local_peer_tx(peer_scope);
+            let wrong_tx = link_local_peer_tx(wrong_peer_scope);
+            let config = BfdRuntimeConfig {
+                sessions: vec![BfdSessionParams {
+                    peer: peer_ip,
+                    scope_id: Some(actor_scope),
+                    destination: SocketAddr::V6(SocketAddrV6::new(
+                        LL_PEER_ADDR.parse().unwrap(),
+                        PORT,
+                        0,
+                        actor_scope,
+                    )),
+                    desired_min_tx_us: 100_000,
+                    required_min_rx_us: 100_000,
+                    detect_mult: 3,
+                    strict: false,
+                    enabled: true,
+                }],
+            };
+            let prepared = prepare_runtime(&config).expect("scoped actor sockets open");
+            let metrics = BgpMetrics::with_registry(Registry::new());
+            let (status_tx, status_rx) = watch::channel(Vec::new());
+            let (event_tx, _event_rx) = broadcast::channel(64);
+            let (_desired_tx, desired_rx) = watch::channel(config);
+            let (state_change_tx, _state_change_rx) = super::super::state_change_channel();
+            let shutdown = CancellationToken::new();
+            let handle = spawn_prepared(
+                prepared,
+                desired_rx,
+                metrics,
+                status_tx,
+                event_tx,
+                state_change_tx,
+                shutdown.clone(),
+            )
+            .expect("scoped actor starts");
+
+            let (mode_tx, mode_rx) = watch::channel(LinkLocalResponderMode::WrongInterface);
+            let peer_stop = CancellationToken::new();
+            let observed_source = Arc::new(AtomicBool::new(false));
+            let observed_interface = Arc::new(AtomicBool::new(false));
+            let wrong_send_succeeded = Arc::new(AtomicBool::new(false));
+            let peer_task = tokio::spawn(link_local_peer_responder(
+                peer_rx,
+                good_tx,
+                wrong_tx,
+                peer_scope,
+                wrong_peer_scope,
+                mode_rx,
+                Arc::clone(&observed_source),
+                Arc::clone(&observed_interface),
+                Arc::clone(&wrong_send_succeeded),
+                peer_stop.clone(),
+            ));
+
+            // Replies use the correct link-local source but arrive through the
+            // adversarial veth. Non-zero discriminator knowledge must not let
+            // them bypass the configured-interface gate.
+            assert!(
+                !wait_for(
+                    &status_rx,
+                    peer_ip,
+                    SessionState::Up,
+                    Duration::from_millis(1500),
+                )
+                .await,
+                "link-local BFD came Up from the wrong receive interface"
+            );
+            assert!(
+                observed_source.load(Ordering::Relaxed),
+                "actor transmit did not use the intended link-local source"
+            );
+            assert!(
+                observed_interface.load(Ordering::Relaxed),
+                "actor transmit did not arrive on the intended peer interface with Hop-Limit 255"
+            );
+            assert!(
+                wrong_send_succeeded.load(Ordering::Relaxed),
+                "adversarial peer packet was never successfully sent through the wrong interface"
+            );
+
+            // Switch only the peer's output interface. The same peer address
+            // and packet now arrive with matching IPV6_PKTINFO and reach Up.
+            mode_tx
+                .send(LinkLocalResponderMode::IntendedInterface)
+                .unwrap();
+            assert!(
+                wait_for(
+                    &status_rx,
+                    peer_ip,
+                    SessionState::Up,
+                    Duration::from_secs(5),
+                )
+                .await,
+                "link-local BFD did not reach Up on the configured interface"
+            );
+
+            mode_tx.send(LinkLocalResponderMode::Silent).unwrap();
+            assert!(
+                wait_for(
+                    &status_rx,
+                    peer_ip,
+                    SessionState::Down,
+                    Duration::from_secs(5),
+                )
+                .await,
+                "link-local BFD did not detect loss"
+            );
+
+            peer_stop.cancel();
+            peer_task
+                .await
+                .expect("link-local responder task join")
+                .expect("link-local responder completed without send failures");
             handle.shutdown().await;
         }
     }

--- a/src/config/tests/dataplane.rs
+++ b/src/config/tests/dataplane.rs
@@ -479,9 +479,7 @@ metric = 200
 }
 
 #[test]
-fn bfd_rejects_ipv6_link_local_neighbor() {
-    // v1 ships IPv4 + IPv6 global only; link-local BFD is deferred to v1.1
-    // even though BGP link-local peers now carry interface scope.
+fn bfd_accepts_ipv6_link_local_neighbor_with_interface() {
     let toml = format!(
         r#"
 {}
@@ -491,23 +489,23 @@ name = "fast"
 
 [[neighbors]]
 address = "fe80::1"
-interface = "eth0"
+interface = "lo"
 remote_asn = 65003
 bfd = {{ profile = "fast" }}
 "#,
         valid_toml()
     );
-    let err = parse(&toml).unwrap_err();
-    let ConfigError::InvalidBfd { reason } = err else {
-        panic!("expected InvalidBfd, got {err}");
-    };
-    assert!(reason.contains("link-local"), "unexpected: {reason}");
+    let config = parse(&toml).expect("scoped link-local BFD is valid");
+    let neighbor = config
+        .neighbors
+        .iter()
+        .find(|neighbor| neighbor.address == "fe80::1")
+        .expect("link-local neighbor");
+    assert_eq!(neighbor.interface.as_deref(), Some("lo"));
 }
 
 #[test]
-fn bfd_link_local_rejected_via_peer_group_inheritance() {
-    // Inheriting BFD from a peer-group must also be rejected on a link-local
-    // neighbor — the effective config is what matters, not just the inline form.
+fn bfd_link_local_accepts_peer_group_inheritance() {
     let toml = format!(
         r#"
 {}
@@ -520,17 +518,19 @@ bfd = {{ profile = "fast" }}
 
 [[neighbors]]
 address = "fe80::2"
-interface = "eth0"
+interface = "lo"
 remote_asn = 65003
 peer_group = "rrc"
 "#,
         valid_toml()
     );
-    let err = parse(&toml).unwrap_err();
-    let ConfigError::InvalidBfd { reason } = err else {
-        panic!("expected InvalidBfd, got {err}");
-    };
-    assert!(reason.contains("link-local"), "unexpected: {reason}");
+    let config = parse(&toml).expect("inherited scoped link-local BFD is valid");
+    let neighbor = config
+        .neighbors
+        .iter()
+        .find(|neighbor| neighbor.address == "fe80::2")
+        .expect("link-local neighbor");
+    assert_eq!(neighbor.interface.as_deref(), Some("lo"));
 }
 
 #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -3315,37 +3315,7 @@ fn validate_bfd(config: &Config) -> Result<(), ConfigError> {
         }
     }
 
-    // v1 ships IPv4 + IPv6 global only. BGP link-local peers carry interface
-    // scope, but the BFD actor still keys and sends sessions by bare address.
-    // Reject it up front with an actionable error rather than silently failing
-    // to converge (ADR-0067 defers link-local BFD to v1.1).
-    for neighbor in &config.neighbors {
-        // Effective BFD = own block, else inherited from the peer group; a
-        // disabled (`enabled = false`) block runs no session, so it does not
-        // count.
-        let group = config.peer_group_for_neighbor(neighbor)?;
-        let effective_bfd = neighbor
-            .bfd
-            .as_ref()
-            .or_else(|| group.and_then(|group| group.bfd.as_ref()));
-        let has_effective_bfd = effective_bfd.is_some_and(|b| b.enabled);
-        if has_effective_bfd && is_ipv6_link_local(&neighbor.address) {
-            return Err(ConfigError::InvalidBfd {
-                reason: format!(
-                    "neighbor {:?}: BFD on IPv6 link-local addresses is not supported in v1 \
-                     (BFD link-local session scoping is deferred to v1.1)",
-                    neighbor.address
-                ),
-            });
-        }
-    }
     Ok(())
-}
-
-/// Whether `addr` parses to an IPv6 link-local address (`fe80::/10`).
-fn is_ipv6_link_local(addr: &str) -> bool {
-    addr.parse::<std::net::Ipv6Addr>()
-        .is_ok_and(|a| is_ipv6_link_local_addr(&a))
 }
 
 fn is_ipv6_link_local_addr(addr: &std::net::Ipv6Addr) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3497,7 +3497,9 @@ async fn run<T>(
     // these resources reserves the operator's configured addresses, but no
     // BFD actor, BGP accept loop, or metrics HTTP server runs before its
     // existing activation barrier below.
-    let bfd_initial = bfd_runtime::BfdRuntimeConfig::from_config(&config);
+    let bfd_initial = bfd_runtime::BfdRuntimeConfig::from_config(&config).unwrap_or_else(|error| {
+        fatal_startup_error("failed to resolve configured BFD sessions", error);
+    });
     let bfd_prepared = bfd_runtime::prepare_runtime(&bfd_initial).unwrap_or_else(|error| {
         fatal_startup_error(
             "failed to acquire sockets for configured BFD sessions",

--- a/src/peer_manager/tests/bfd.rs
+++ b/src/peer_manager/tests/bfd.rs
@@ -42,6 +42,9 @@ fn fake_bfd_peer_handle(counters: Arc<BfdCouplingCounters>) -> PeerHandle {
 fn bfd_params(peer: IpAddr, strict: bool) -> crate::bfd_runtime::BfdSessionParams {
     crate::bfd_runtime::BfdSessionParams {
         peer,
+        scope_id: None,
+        destination: crate::bfd_runtime::bfd_destination(peer, None)
+            .expect("global test peer destination"),
         desired_min_tx_us: 300_000,
         required_min_rx_us: 300_000,
         detect_mult: 3,
@@ -551,6 +554,52 @@ async fn republish_reflects_disable_and_readd() {
     // Re-add (reconfigure delete→add) → re-enabled so the actor restarts it.
     mgr.set_bfd_peer_disabled(peer, false);
     assert_eq!(enabled_now(&rx), Some(true), "re-added peer re-enabled");
+}
+
+#[tokio::test]
+async fn republish_preserves_link_local_scope_across_reconcile() {
+    let peer: IpAddr = "fe80::2".parse().unwrap();
+    let params = crate::bfd_runtime::BfdSessionParams {
+        peer,
+        scope_id: Some(71),
+        destination: crate::bfd_runtime::bfd_destination(peer, Some(71))
+            .expect("scoped test peer destination"),
+        desired_min_tx_us: 300_000,
+        required_min_rx_us: 300_000,
+        detect_mult: 3,
+        strict: false,
+        enabled: true,
+    };
+    let configured = std::collections::HashMap::from([(peer, params)]);
+    let (desired_tx, desired_rx) = watch::channel(crate::bfd_runtime::BfdRuntimeConfig::default());
+    let (_state_tx, state_rx) = crate::bfd_runtime::state_change_channel();
+    let mut mgr = test_peer_manager().with_bfd_coupling(desired_tx, state_rx, configured);
+
+    mgr.republish_bfd_desired();
+    let session = desired_rx
+        .borrow()
+        .sessions
+        .iter()
+        .find(|session| session.peer == peer)
+        .cloned()
+        .expect("configured link-local BFD session");
+    assert!(session.enabled);
+    assert_eq!(session.scope_id, Some(71));
+
+    mgr.set_bfd_peer_disabled(peer, true);
+    let session = desired_rx
+        .borrow()
+        .sessions
+        .iter()
+        .find(|session| session.peer == peer)
+        .cloned()
+        .expect("disabled session remains in desired set for actor drain");
+    assert!(!session.enabled);
+    assert_eq!(
+        session.scope_id,
+        Some(71),
+        "PeerManager clone/reconcile must not erase the startup-resolved scope"
+    );
 }
 
 /// Regression: a genuine BFD Down must tear down a pending inbound collision

--- a/tests/interop/configs/frr-bgpd-m51-bfd.conf
+++ b/tests/interop/configs/frr-bgpd-m51-bfd.conf
@@ -19,9 +19,18 @@ router bgp 65002
  neighbor 10.0.0.1 timers 30 90
  neighbor 10.0.0.1 bfd
  neighbor 10.0.0.1 bfd profile fast
+ neighbor fe80::51 remote-as 65001
+ neighbor fe80::51 interface eth1
+ neighbor fe80::51 description rustbgpd-m51-link-local
+ neighbor fe80::51 bfd
+ neighbor fe80::51 bfd profile fast
  !
  address-family ipv4 unicast
   network 203.0.113.51/32
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  neighbor fe80::51 activate
  exit-address-family
 !
 ip route 203.0.113.51/32 10.0.0.2

--- a/tests/interop/configs/rustbgpd-m51-bfd-strict.toml
+++ b/tests/interop/configs/rustbgpd-m51-bfd-strict.toml
@@ -30,6 +30,17 @@ description = "frr1-m51-strict"
 hold_time = 90
 bfd = { profile = "fast", strict = true }
 
+# Additive link-local coverage stays non-strict; only the numbered neighbor is
+# used by the remote-AdminDown strict oracle.
+[[neighbors]]
+address = "fe80::52"
+interface = "eth1"
+remote_asn = 65002
+description = "frr1-m51-link-local"
+hold_time = 90
+families = ["ipv6_unicast"]
+bfd = { profile = "fast" }
+
 [security.grpc]
 enforcement = "tier"
 

--- a/tests/interop/configs/rustbgpd-m51-bfd.toml
+++ b/tests/interop/configs/rustbgpd-m51-bfd.toml
@@ -30,6 +30,18 @@ description = "frr1-m51"
 hold_time = 90
 bfd = { profile = "fast" }
 
+# IPv6 link-local BGP + BFD shares the same fabric interface and actor socket.
+# The neighbor remains non-strict so M51's numbered strict-mode phase below is
+# still isolated to 10.0.0.2.
+[[neighbors]]
+address = "fe80::52"
+interface = "eth1"
+remote_asn = 65002
+description = "frr1-m51-link-local"
+hold_time = 90
+families = ["ipv6_unicast"]
+bfd = { profile = "fast" }
+
 [security.grpc]
 enforcement = "tier"
 

--- a/tests/interop/m51-bfd-frr.clab.yml
+++ b/tests/interop/m51-bfd-frr.clab.yml
@@ -38,6 +38,7 @@ topology:
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
+        - ip -6 addr replace fe80::51/64 dev eth1 nodad
         - ip link set eth1 up
       env:
         RUST_LOG: info
@@ -50,10 +51,12 @@ topology:
         - ./configs/frr-bgpd-m51-bfd.conf:/etc/frr/frr.conf:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1
+        - ip -6 addr replace fe80::52/64 dev eth1 nodad
         - ip link set eth1 up
 
   links:
     - endpoints: ["rustbgpd:eth1", "frr1:eth1"]
 
-# Network: 10.0.0.0/24 — rustbgpd (10.0.0.1) ↔ frr1 (10.0.0.2).
-# rustbgpd AS 65001; FRR AS 65002. BFD fast profile, BGP hold timer 90 s.
+# Network: numbered 10.0.0.0/24 plus distinct scoped link-local addresses
+# fe80::51%eth1 (rustbgpd) ↔ fe80::52%eth1 (FRR). rustbgpd AS 65001; FRR
+# AS 65002. BFD fast profile, BGP hold timer 90 s.

--- a/tests/interop/scripts/test-m51-bfd-frr.sh
+++ b/tests/interop/scripts/test-m51-bfd-frr.sh
@@ -31,6 +31,9 @@ source "$SCRIPT_DIR/test-lib.sh"
 FRR1="clab-${TOPO}-frr1"
 PEER="10.0.0.2"
 FRR_BFD_PEER="10.0.0.1"
+LL_PEER="fe80::52"
+FRR_LL_BFD_PEER="fe80::51"
+LL_INTERFACE="eth1"
 STRICT_CONFIG="/etc/rustbgpd/config-strict.toml"
 STRICT_LOG="/tmp/rustbgpd-m51-strict.log"
 
@@ -45,6 +48,13 @@ grpc_bfd_state() {
     # State of the BFD session to $PEER as reported by rustbgpd, e.g.
     # "BFD_SESSION_STATE_UP". Empty if the session is absent.
     grpc_bfd_json \
+        | jq -r '.sessions[0].state // ""'
+}
+
+grpc_ll_bfd_state() {
+    grpcurl_call \
+        -d "{\"peer_address\": \"$LL_PEER\"}" \
+        "$GRPC_ADDR" rustbgpd.v1.BfdService/GetBfdSessions 2>/dev/null \
         | jq -r '.sessions[0].state // ""'
 }
 
@@ -73,6 +83,23 @@ grpc_bgp_json() {
     grpcurl_call \
         -d "{\"address\": \"$PEER\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
+}
+
+grpc_ll_bgp_json() {
+    grpcurl_call \
+        -d "{\"address\": \"$LL_PEER\", \"interface\": \"$LL_INTERFACE\"}" \
+        "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
+}
+
+grpc_ll_bgp_state() {
+    local snapshot
+    snapshot=$(grpc_ll_bgp_json) || return 1
+    printf '%s\n' "$snapshot" | jq -er '
+        select(type == "object")
+        | select((.stale // false) == false)
+        | .state
+        | select(type == "string" and length > 0)
+    '
 }
 
 grpc_bgp_authoritative_json() {
@@ -116,9 +143,24 @@ wait_grpc_bgp_established() {
     return 1
 }
 
+wait_grpc_ll_bgp_established() {
+    local label=$1 attempts=${2:-30} state
+    for _ in $(seq 1 "$attempts"); do
+        if state=$(grpc_ll_bgp_state) && [ "$state" = "SESSION_STATE_ESTABLISHED" ]; then
+            ok "$label BGP state is authoritatively Established"
+            return 0
+        fi
+        sleep 1
+    done
+    fail "$label BGP state did not reach authoritative Established"
+    dump_state_on_failure
+    return 1
+}
+
 frr_bfd_status() {
     docker exec "$FRR1" vtysh -c "show bfd peers json" 2>/dev/null \
-        | jq -r '.[0].status // ""'
+        | jq -r --arg peer "$FRR_BFD_PEER" \
+            '[.[] | select([.. | strings] | index($peer))][0].status // ""'
 }
 
 frr_bgp_connections_established() {
@@ -177,9 +219,17 @@ dump_state_on_failure() {
     grpcurl_call \
         -d "{\"peer_address\": \"$PEER\"}" \
         "$GRPC_ADDR" rustbgpd.v1.BfdService/GetBfdSessions >&2 2>&1 || true
+    echo "===== rustbgpd link-local GetBfdSessions (raw) =====" >&2
+    grpcurl_call \
+        -d "{\"peer_address\": \"$LL_PEER\"}" \
+        "$GRPC_ADDR" rustbgpd.v1.BfdService/GetBfdSessions >&2 2>&1 || true
     echo "===== rustbgpd GetNeighborState (raw) =====" >&2
     grpcurl_call \
         -d "{\"address\": \"$PEER\"}" \
+        "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState >&2 2>&1 || true
+    echo "===== rustbgpd link-local GetNeighborState (raw) =====" >&2
+    grpcurl_call \
+        -d "{\"address\": \"$LL_PEER\", \"interface\": \"$LL_INTERFACE\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState >&2 2>&1 || true
     echo "===== frr1 vtysh: show bfd peers =====" >&2
     docker exec "$FRR1" vtysh -c 'show bfd peers' >&2 2>&1 || true
@@ -201,6 +251,20 @@ wait_grpc_bfd() {
     return 1
 }
 
+wait_grpc_ll_bfd() {
+    local want=$1 label=$2 attempts=${3:-30}
+    for _ in $(seq 1 "$attempts"); do
+        [ "$(grpc_ll_bfd_state)" = "$want" ] && {
+            ok "rustbgpd link-local BFD session $label"
+            return 0
+        }
+        sleep 1
+    done
+    fail "rustbgpd link-local BFD session did not reach $label"
+    dump_state_on_failure
+    return 1
+}
+
 wait_grpc_bfd_remote_admin_down() {
     local want=$1 label=$2 attempts=${3:-30} observed
     for _ in $(seq 1 "$attempts"); do
@@ -216,6 +280,9 @@ wait_grpc_bfd_remote_admin_down() {
 }
 
 wait_grpc_bfd "BFD_SESSION_STATE_UP" "Up"
+wait_frr_established "$FRR1" "$FRR_LL_BFD_PEER" "rustbgpd ↔ frr1 link-local"
+wait_grpc_ll_bgp_established "link-local"
+wait_grpc_ll_bfd "BFD_SESSION_STATE_UP" "Up"
 
 for _ in $(seq 1 30); do
     [ "$(frr_bfd_status)" = "up" ] && break
@@ -281,6 +348,47 @@ else
     dump_state_on_failure
 fi
 
+# The same bfdd loss must be visible on the additive scoped session without
+# weakening the numbered-session oracle above.
+LL_BFD_DROPPED=0
+for _ in $(seq 1 10); do
+    state=$(grpc_ll_bfd_state)
+    if [ "$state" != "BFD_SESSION_STATE_UP" ] && [ -n "$state" ]; then
+        LL_BFD_DROPPED=1
+        break
+    fi
+    sleep 1
+done
+if [ "$LL_BFD_DROPPED" -eq 1 ]; then
+    ok "rustbgpd link-local BFD detected bfdd loss"
+else
+    fail "rustbgpd link-local BFD did not detect bfdd loss"
+    dump_state_on_failure
+fi
+
+LL_BGP_DOWN=0
+LL_BGP_UNKNOWN=0
+for _ in $(seq 1 10); do
+    if ! state=$(grpc_ll_bgp_state); then
+        LL_BGP_UNKNOWN=1
+        break
+    fi
+    if [ "$state" != "SESSION_STATE_ESTABLISHED" ]; then
+        LL_BGP_DOWN=1
+        break
+    fi
+    sleep 1
+done
+if [ "$LL_BGP_UNKNOWN" -eq 1 ]; then
+    fail "rustbgpd link-local BGP state became unavailable or stale during teardown"
+    dump_state_on_failure
+elif [ "$LL_BGP_DOWN" -eq 1 ]; then
+    ok "rustbgpd tore down link-local BGP after BFD loss"
+else
+    fail "rustbgpd did not tear down link-local BGP after BFD loss"
+    dump_state_on_failure
+fi
+
 # --- 3. Recovery: watchfrr restarts bfdd → BFD + BGP re-establish -----------
 
 log "Waiting for BFD + BGP to recover (watchfrr restarts bfdd)..."
@@ -288,6 +396,10 @@ log "Waiting for BFD + BGP to recover (watchfrr restarts bfdd)..."
 # registration + the BFD three-way handshake, so allow a generous window.
 wait_grpc_bfd "BFD_SESSION_STATE_UP" "Up again" 60
 wait_frr_established "$FRR1" "10.0.0.1" "rustbgpd ↔ frr1 (recovered)"
+wait_grpc_ll_bfd "BFD_SESSION_STATE_UP" "Up again" 60
+wait_frr_established "$FRR1" "$FRR_LL_BFD_PEER" \
+    "rustbgpd ↔ frr1 link-local (recovered)"
+wait_grpc_ll_bgp_established "link-local recovery" 60
 
 # --- 4. Strict: remote AdminDown permits BGP while local BFD stays Down ------
 
@@ -308,6 +420,8 @@ else
 fi
 start_rustbgpd \
     "exec /usr/local/bin/rustbgpd $STRICT_CONFIG >$STRICT_LOG 2>&1"
+wait_grpc_ll_bfd "BFD_SESSION_STATE_UP" "Up after strict-config restart" 60
+wait_grpc_ll_bgp_established "link-local after strict-config restart" 60
 wait_grpc_bfd "BFD_SESSION_STATE_DOWN" "Down (strict startup)"
 wait_grpc_bfd_remote_admin_down "false" "explicitly false at strict startup"
 


### PR DESCRIPTION
## Summary

- resolve the configured interface for IPv6 link-local BFD peers at startup and carry the private scope through the runtime actor
- send scoped link-local control packets through the shared IPv6 socket and require matching `IPV6_PKTINFO` before either discriminator path reaches the FSM
- extend M51 and the privileged netns proof with link-local establishment, wrong-interface rejection, failure detection, and recovery while retaining the existing numbered strict/AdminDown coverage
- update the BFD configuration, limitation, comparison, ADR, and changelog descriptions

## Compatibility

- global IPv4 and IPv6 BFD behavior is unchanged
- public BFD status, protocol, metric, PeerManager, and RIB identities remain keyed by the existing bare peer address
- missing or unresolvable link-local interface scopes fail startup before BFD socket preparation

## Validation

- `cargo test --locked --workspace`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo doc --locked --workspace --lib --no-deps`
- privileged BFD netns selector: 2 passed, 0 failed
- M51 FRR interop: 32 passed, 0 failed
- formatting, shellcheck, public tracker ID, clippy-reason, release-path, metric-consumer, performance-receipt, and internal-link checks
