### PR TITLE
ci: stage pinned BIRD sources for M83 and M101

### DIFF
--- a/.github/actions/stage-bird3-artifact/action.yml
+++ b/.github/actions/stage-bird3-artifact/action.yml
@@ -1,22 +1,41 @@
-name: "Stage verified BIRD 3 source archive"
+name: "Stage verified BIRD source archive"
 description: >-
-  Download the same-run BIRD 3 source archive, verify its immutable checksum
+  Download a same-run BIRD source archive, verify its immutable checksum
   and source version offline, and stage it into the interop image build
   context.
+inputs:
+  version:
+    description: "Exact BIRD source version"
+    required: false
+    default: "3.3.1"
+  sha256:
+    description: "Exact BIRD source archive SHA-256"
+    required: false
+    default: "d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
+  artifact-name:
+    description: "Same-run artifact containing the source archive"
+    required: false
+    default: "bird3-v3.3.1-source"
+  stage-directory:
+    description: "Directory in the interop Docker build context"
+    required: false
+    default: "tests/interop/bird3-archive"
 runs:
   using: "composite"
   steps:
-    - name: Download verified BIRD 3 archive
+    - name: Download verified BIRD archive
       uses: actions/download-artifact@v8
       with:
-        name: bird3-v3.3.1-source
+        name: ${{ inputs.artifact-name }}
         path: ${{ runner.temp }}/bird3-artifact
 
-    - name: Stage exact BIRD 3 archive offline
+    - name: Stage exact BIRD archive offline
       shell: bash
       run: |
         set -euo pipefail
         .github/scripts/install-bird3.sh \
+          --version "${{ inputs.version }}" \
+          --sha256 "${{ inputs.sha256 }}" \
           --stage-archive \
-          "$RUNNER_TEMP/bird3-artifact/bird-3.3.1.tar.gz" \
-          tests/interop/bird3-archive
+          "$RUNNER_TEMP/bird3-artifact/bird-${{ inputs.version }}.tar.gz" \
+          "${{ inputs.stage-directory }}"

--- a/.github/scripts/install-bird3.sh
+++ b/.github/scripts/install-bird3.sh
@@ -2,8 +2,34 @@
 
 set -euo pipefail
 
-readonly BIRD3_VERSION="3.3.1"
-readonly BIRD3_SHA256="d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
+BIRD3_VERSION="3.3.1"
+BIRD3_SHA256="d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
+BIRD3_COVERAGE_LABEL=""
+while [[ ${1:-} == --version || ${1:-} == --sha256 || ${1:-} == --coverage-label ]]; do
+    option=$1
+    [[ $# -ge 2 ]] || {
+        echo "install-bird3: ${option} requires a value" >&2
+        exit 2
+    }
+    case "$option" in
+        --version) BIRD3_VERSION=$2 ;;
+        --sha256) BIRD3_SHA256=$2 ;;
+        --coverage-label) BIRD3_COVERAGE_LABEL=$2 ;;
+    esac
+    shift 2
+done
+[[ $BIRD3_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "install-bird3: invalid BIRD version: ${BIRD3_VERSION}" >&2
+    exit 2
+}
+[[ $BIRD3_SHA256 =~ ^[0-9a-f]{64}$ ]] || {
+    echo "install-bird3: invalid BIRD SHA-256" >&2
+    exit 2
+}
+if [[ -z $BIRD3_COVERAGE_LABEL ]]; then
+    BIRD3_COVERAGE_LABEL="M43 (TCP-AO interop vs BIRD ${BIRD3_VERSION}) skipped"
+fi
+readonly BIRD3_VERSION BIRD3_SHA256 BIRD3_COVERAGE_LABEL
 readonly BIRD3_ASSET="bird-${BIRD3_VERSION}.tar.gz"
 readonly BIRD3_URL="https://bird.nic.cz/download/${BIRD3_ASSET}"
 readonly BIRD3_ATTEMPTS=3
@@ -77,7 +103,7 @@ announce_unavailable() {
     local url=${1:?url}
     local message
 
-    message="M43 (TCP-AO interop vs BIRD ${BIRD3_VERSION}) skipped: the pinned"
+    message="${BIRD3_COVERAGE_LABEL}: the pinned"
     message+=" bird ${BIRD3_VERSION} source archive is unavailable upstream"
     message+=" after ${BIRD3_ATTEMPTS} attempts (${url})."
     message+=" This is third-party unavailability, not a rustbgpd failure;"
@@ -311,7 +337,7 @@ self_test() (
 )
 
 usage() {
-    echo "usage: $0 --prepare-archive ARCHIVE | --stage-archive ARCHIVE STAGE_DIR | --self-test" >&2
+    echo "usage: $0 [--version VERSION --sha256 SHA256] [--coverage-label LABEL] (--prepare-archive ARCHIVE | --stage-archive ARCHIVE STAGE_DIR | --self-test)" >&2
     return 2
 }
 

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -230,6 +230,72 @@ jobs:
       - name: Restore, prepare, and upload exact gobgp archive
         uses: ./.github/actions/prepare-gobgp-artifact
 
+  bird2192_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact BIRD 2.19.2 archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact BIRD 2.19.2 archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/bird2192-cache/bird-2.19.2.tar.gz
+          key: bird2192-v2.19.2-source-aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660
+      - name: Prepare exact BIRD 2.19.2 archive
+        run: |
+          set -euo pipefail
+          .github/scripts/install-bird3.sh \
+            --version 2.19.2 \
+            --sha256 aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660 \
+            --coverage-label "M83 BIRD 2.19.2 image blocked" \
+            --prepare-archive \
+            "$RUNNER_TEMP/bird2192-cache/bird-2.19.2.tar.gz"
+      - name: Upload verified BIRD 2.19.2 archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: bird2192-v2.19.2-source
+          path: ${{ runner.temp }}/bird2192-cache/bird-2.19.2.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  bird332_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact BIRD 3.3.2 archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact BIRD 3.3.2 archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/bird332-cache/bird-3.3.2.tar.gz
+          key: bird332-v3.3.2-source-21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c
+      - name: Prepare exact BIRD 3.3.2 archive
+        run: |
+          set -euo pipefail
+          .github/scripts/install-bird3.sh \
+            --version 3.3.2 \
+            --sha256 21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c \
+            --coverage-label "M101 BIRD 3.3.2 image blocked" \
+            --prepare-archive \
+            "$RUNNER_TEMP/bird332-cache/bird-3.3.2.tar.gz"
+      - name: Upload verified BIRD 3.3.2 archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: bird332-v3.3.2-source
+          path: ${{ runner.temp }}/bird332-cache/bird-3.3.2.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
@@ -971,7 +1037,7 @@ jobs:
           script: tests/interop/scripts/test-m82-evpn-bundle-synthetic-gobgp.sh
 
   m83:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, bird2192_archive, prime_dev_image]
     name: M83 — route-server profile, multi-stack (BIRD 2.19.2 + GoBGP 4.8.0 + FRR + RTR)
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -1001,10 +1067,24 @@ jobs:
           target: dev
           cache-from: type=gha,scope=rustbgpd-dev
 
+      - name: Stage verified BIRD 2.19.2 archive
+        uses: ./.github/actions/stage-bird3-artifact
+        with:
+          version: "2.19.2"
+          sha256: aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660
+          artifact-name: bird2192-v2.19.2-source
+
       - name: Build bird:v2.19.2-m83
         # BIRD 2.19.2 + tshark: the member stack that carries the byte-level
         # RFC 7947 transparency / OTC / EoR wire assertions.
-        run: docker build -t bird:v2.19.2-m83 -f tests/interop/Dockerfile.bird-v2192 tests/interop
+        uses: docker/build-push-action@v7
+        with:
+          context: tests/interop
+          file: tests/interop/Dockerfile.bird-v2192
+          load: true
+          tags: bird:v2.19.2-m83
+          cache-from: type=gha,scope=bird2192-m83
+          cache-to: type=gha,mode=max,scope=bird2192-m83,ignore-error=true
 
       - name: Build gobgp:v4.8.0-m83
         run: >-
@@ -2027,7 +2107,7 @@ jobs:
           max_attempts: "1"
 
   m101:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, bird332_archive, prime_dev_image]
     name: M101 — BIRD 3.3.2 real-wire attribute discard at a route server
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -2056,8 +2136,22 @@ jobs:
           target: dev
           cache-from: type=gha,scope=rustbgpd-dev
 
+      - name: Stage verified BIRD 3.3.2 archive
+        uses: ./.github/actions/stage-bird3-artifact
+        with:
+          version: "3.3.2"
+          sha256: 21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c
+          artifact-name: bird332-v3.3.2-source
+
       - name: Build checksum-pinned BIRD 3.3.2 image
-        run: docker build -t bird:v3.3.2-m101 -f tests/interop/Dockerfile.bird-v332 tests/interop
+        uses: docker/build-push-action@v7
+        with:
+          context: tests/interop
+          file: tests/interop/Dockerfile.bird-v332
+          load: true
+          tags: bird:v3.3.2-m101
+          cache-from: type=gha,scope=bird332-m101
+          cache-to: type=gha,mode=max,scope=bird332-m101,ignore-error=true
 
       - name: Pull digest-pinned FRR 10.3.1 image
         run: docker pull quay.io/frrouting/frr@sha256:f90d26a9fd5c14fc5795a73b4254ac88bc3186c45bbeb220a225fb6182de812c
@@ -2137,7 +2231,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [classify_changes, grpcurl_archive, gnmic_archive, gobgp_archive, prime_dev_image, m1,
+    needs: [classify_changes, grpcurl_archive, gnmic_archive, gobgp_archive, bird2192_archive,
+      bird332_archive, prime_dev_image, m1,
       m13, m80, m15, m10, m14, m17, m73, m74, m75, m76, m77, m78, m79, m22, m24,
       m81, m82, m83, m85, m94, m86, m25, m29, m30, m34, m35, m35b, m35c,
       m41, m44, m54, m55, m56, m45, m57, m63, m64,
@@ -2145,7 +2240,8 @@ jobs:
     env:
       NEEDS_CONTEXT: ${{ toJSON(needs) }}
       EXPECTED_JOBS: >-
-        classify_changes grpcurl_archive gnmic_archive gobgp_archive prime_dev_image
+        classify_changes grpcurl_archive gnmic_archive gobgp_archive bird2192_archive
+        bird332_archive prime_dev_image
         m1 m13 m80 m15 m10
         m14 m17 m73 m74 m75 m76 m77 m78 m79 m22 m24 m81 m82 m83 m85 m94
         m86 m25 m29 m30 m34 m35 m35b m35c m41 m44 m54 m55 m56 m45 m57

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Hosted M83 and M101 interop jobs now consume independently cached,
+  checksum- and source-version-verified BIRD 2.19.2 and 3.3.2 archives from
+  required same-run producers before building their images with dedicated
+  Buildx cache scopes. Their Dockerfiles recheck staged bytes before extraction
+  and retain a bounded three-attempt download only for cold local builds; the
+  existing M43 BIRD 3.3.1 unavailable-upstream tolerance is unchanged.
+
 - `rbgp doctor` warns on a narrowly evidenced first-session GTSM stall when
   effective TTL-security configuration and the authoritative administrative
   metric agree; established, stale, held, disabled, previously established,

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -123,6 +123,16 @@ BIRD3_CACHE_SEAMS = (
     "cache-from: type=gha,scope=bird3-tcpao",
     "cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true",
 )
+BIRD2192_VERSION = "2.19.2"
+BIRD2192_SHA256 = "aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660"
+BIRD2192_ARCHIVE = f"bird-{BIRD2192_VERSION}.tar.gz"
+BIRD2192_ARTIFACT = f"bird2192-v{BIRD2192_VERSION}-source"
+BIRD2192_CACHE_KEY = f"{BIRD2192_ARTIFACT}-{BIRD2192_SHA256}"
+BIRD332_VERSION = "3.3.2"
+BIRD332_SHA256 = "21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c"
+BIRD332_ARCHIVE = f"bird-{BIRD332_VERSION}.tar.gz"
+BIRD332_ARTIFACT = f"bird332-v{BIRD332_VERSION}-source"
+BIRD332_CACHE_KEY = f"{BIRD332_ARTIFACT}-{BIRD332_SHA256}"
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
     "audit.yml": "1829597143324f5361dfdfece50ddeffd6f7d5934b72198f1837fbdf25339fd3",
@@ -141,14 +151,14 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 90,
+        "actions/checkout@v7": 92,
         "dtolnay/rust-toolchain@v1 # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@v1 # 1.95": 2,
         "docker/setup-buildx-action@v4": 47,
-        "docker/build-push-action@v7": 48,
-        "actions/cache@v6": 5,
-        "actions/upload-artifact@v7": 7,
+        "docker/build-push-action@v7": 50,
+        "actions/cache@v6": 7,
+        "actions/upload-artifact@v7": 9,
         "actions/download-artifact@v8": 6,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
@@ -386,8 +396,11 @@ def check(root: Path) -> list[str]:
         bird3_installer.read_text() if bird3_installer.is_file() else ""
     )
     for seam in (
-        f'readonly BIRD3_VERSION="{BIRD3_VERSION}"',
-        f'readonly BIRD3_SHA256="{BIRD3_SHA256}"',
+        f'BIRD3_VERSION="{BIRD3_VERSION}"',
+        f'BIRD3_SHA256="{BIRD3_SHA256}"',
+        "--version",
+        "--sha256",
+        "--coverage-label",
         'readonly BIRD3_ASSET="bird-${BIRD3_VERSION}.tar.gz"',
         "https://bird.nic.cz/download/${BIRD3_ASSET}",
         "readonly BIRD3_ATTEMPTS=3",
@@ -497,6 +510,7 @@ def check(root: Path) -> list[str]:
             ["grpcurl_archive"]
             + ([] if setup else ["gnmic_archive"])
             + ["gobgp_archive"]
+            + ([] if setup else ["bird2192_archive", "bird332_archive"])
             + (["bird3_archive"] if setup else [])
         )
         gobgp_consumers = (
@@ -654,6 +668,99 @@ def check(root: Path) -> list[str]:
             )
             if bird3_producer.count(exact_bird3_path) != 2:
                 errors.append(f"{name}:bird3_archive cache/artifact paths drifted")
+        else:
+            bird_producers = (
+                (
+                    "bird2192_archive",
+                    "BIRD 2.19.2",
+                    BIRD2192_VERSION,
+                    BIRD2192_SHA256,
+                    BIRD2192_ARCHIVE,
+                    BIRD2192_ARTIFACT,
+                    BIRD2192_CACHE_KEY,
+                    "bird2192-cache",
+                    "M83 BIRD 2.19.2 image blocked",
+                ),
+                (
+                    "bird332_archive",
+                    "BIRD 3.3.2",
+                    BIRD332_VERSION,
+                    BIRD332_SHA256,
+                    BIRD332_ARCHIVE,
+                    BIRD332_ARTIFACT,
+                    BIRD332_CACHE_KEY,
+                    "bird332-cache",
+                    "M101 BIRD 3.3.2 image blocked",
+                ),
+            )
+            for (
+                producer_name,
+                display,
+                version,
+                checksum,
+                archive,
+                artifact,
+                cache_key,
+                cache_dir,
+                coverage_label,
+            ) in bird_producers:
+                producer = jobs.get(producer_name, "")
+                exact_path = (
+                    f"path: ${{{{ runner.temp }}}}/{cache_dir}/{archive}"
+                )
+                for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
+                    if not _has_line(producer, f"    {seam}"):
+                        errors.append(
+                            f"interop.yml:{producer_name} missing job-level {seam}"
+                        )
+                for seam in (
+                    f"name: Prepare exact {display} archive",
+                    "runs-on: ubuntu-latest",
+                    "timeout-minutes: 10",
+                    CHECKOUT,
+                    "ref: ${{ github.sha }}",
+                    "uses: actions/cache@v6",
+                    exact_path,
+                    f"key: {cache_key}",
+                    f"--version {version}",
+                    f"--sha256 {checksum}",
+                    f'--coverage-label "{coverage_label}"',
+                    "--prepare-archive",
+                    f'"$RUNNER_TEMP/{cache_dir}/{archive}"',
+                    "uses: actions/upload-artifact@v7",
+                    f"name: {artifact}",
+                    "if-no-files-found: error",
+                    "retention-days: 1",
+                    "compression-level: 0",
+                ):
+                    if seam not in producer:
+                        errors.append(f"interop.yml:{producer_name} missing {seam}")
+                for forbidden in (
+                    "restore-keys:",
+                    "continue-on-error:",
+                    "actions/download-artifact@",
+                    "--stage-archive",
+                ):
+                    if forbidden in producer:
+                        errors.append(
+                            f"interop.yml:{producer_name} permits {forbidden}"
+                        )
+                if producer.count("uses: actions/cache@v6") != 1:
+                    errors.append(
+                        f"interop.yml:{producer_name} must restore one exact cache"
+                    )
+                if producer.count("--prepare-archive") != 1:
+                    errors.append(
+                        f"interop.yml:{producer_name} must prepare one archive"
+                    )
+                if producer.count("uses: actions/upload-artifact@v7") != 1:
+                    errors.append(
+                        f"interop.yml:{producer_name} must upload one artifact"
+                    )
+                if producer.count(exact_path) != 2:
+                    errors.append(
+                        f"interop.yml:{producer_name} cache/artifact paths drifted"
+                    )
         primer = jobs.get("prime_dev_image", "")
         if (
             _canonical_yaml_contract(primer)
@@ -662,7 +769,15 @@ def check(root: Path) -> list[str]:
             errors.append(f"{name}: primer exact job contract drifted")
         for job_name in roster:
             job = jobs.get(job_name, "")
-            if not setup and job_name in ("m54", "m56"):
+            if not setup and job_name == "m83":
+                expected_needs = (
+                    "    needs: [grpcurl_archive, bird2192_archive, prime_dev_image]"
+                )
+            elif not setup and job_name == "m101":
+                expected_needs = (
+                    "    needs: [grpcurl_archive, bird332_archive, prime_dev_image]"
+                )
+            elif not setup and job_name in ("m54", "m56"):
                 expected_needs = (
                     "    needs: [grpcurl_archive, gnmic_archive, prime_dev_image]"
                 )
@@ -693,29 +808,71 @@ def check(root: Path) -> list[str]:
                 errors.append(
                     f"{name}:{job_name}: gobgp build precedes the staged artifact"
                 )
-            expected_bird3 = 1 if setup and job_name == "m43" else 0
+            bird_contracts = (
+                {
+                    "m43": (
+                        "file: tests/interop/Dockerfile.bird3",
+                        BIRD3_CACHE_SEAMS,
+                        ("name: Stage verified BIRD 3 archive",),
+                    )
+                }
+                if setup
+                else {
+                    "m83": (
+                        "file: tests/interop/Dockerfile.bird-v2192",
+                        (
+                            "cache-from: type=gha,scope=bird2192-m83",
+                            "cache-to: type=gha,mode=max,scope=bird2192-m83,ignore-error=true",
+                        ),
+                        (
+                            "name: Stage verified BIRD 2.19.2 archive",
+                            'version: "2.19.2"',
+                            f"sha256: {BIRD2192_SHA256}",
+                            f"artifact-name: {BIRD2192_ARTIFACT}",
+                        ),
+                    ),
+                    "m101": (
+                        "file: tests/interop/Dockerfile.bird-v332",
+                        (
+                            "cache-from: type=gha,scope=bird332-m101",
+                            "cache-to: type=gha,mode=max,scope=bird332-m101,ignore-error=true",
+                        ),
+                        (
+                            "name: Stage verified BIRD 3.3.2 archive",
+                            'version: "3.3.2"',
+                            f"sha256: {BIRD332_SHA256}",
+                            f"artifact-name: {BIRD332_ARTIFACT}",
+                        ),
+                    ),
+                }
+            )
+            expected_bird3 = 1 if job_name in bird_contracts else 0
             if job.count(BIRD3_ACTION) != expected_bird3:
                 errors.append(f"{name}:{job_name}: bird3 stage consumer drifted")
-            if job.count(BIRD3_BUILD) != expected_bird3:
-                errors.append(
-                    f"{name}:{job_name}: bird3 image build inventory drifted"
-                )
-            if expected_bird3 and not (
-                0 <= job.find(BIRD3_ACTION) < job.find(BIRD3_BUILD)
-            ):
-                errors.append(
-                    f"{name}:{job_name}: bird3 build precedes the staged artifact"
-                )
             if expected_bird3:
-                for seam in BIRD3_CACHE_SEAMS:
+                bird_build, cache_seams, action_inputs = bird_contracts[job_name]
+                if job.count(bird_build) != 1:
+                    errors.append(
+                        f"{name}:{job_name}: bird image build inventory drifted"
+                    )
+                if not (0 <= job.find(BIRD3_ACTION) < job.find(bird_build)):
+                    errors.append(
+                        f"{name}:{job_name}: bird build precedes the staged artifact"
+                    )
+                for seam in (*cache_seams, *action_inputs):
                     if seam not in job:
                         errors.append(
-                            f"{name}:{job_name}: bird3 buildx layer cache missing {seam}"
+                            f"{name}:{job_name}: bird artifact/build seam missing {seam}"
                         )
+                expected_build_push = 1 if setup else 2
+                if job.count(BUILD_PUSH) != expected_build_push:
+                    errors.append(
+                        f"{name}:{job_name}: must use build-push-action for rustbgpd and BIRD"
+                    )
             if not setup and job_name == "m83":
                 m83_required = {
-                    "needs: [grpcurl_archive, prime_dev_image]": 1,
-                    "docker build -t bird:v2.19.2-m83 -f tests/interop/Dockerfile.bird-v2192 tests/interop": 1,
+                    "needs: [grpcurl_archive, bird2192_archive, prime_dev_image]": 1,
+                    "tags: bird:v2.19.2-m83": 1,
                     "--build-arg GOBGP_VERSION=4.8.0": 1,
                     "--build-arg GOBGP_SHA256=43b570ae5cc1afab7aebdd9d8f4536e27656465848270c8a6f5fda1ffe093a03": 1,
                     "-t gobgp:v4.8.0-m83 -f tests/interop/Dockerfile.gobgp-v47 tests/interop": 1,
@@ -737,7 +894,7 @@ def check(root: Path) -> list[str]:
                 for seam in (IMPORT, "load: true", "tags: rustbgpd:dev", "target: dev"):
                     if seam not in job:
                         errors.append(f"{name}:{job_name}: consumer missing {seam}")
-                if "cache-to:" in job:
+                if "cache-to:" in job and job_name not in bird_contracts:
                     errors.append(f"{name}:{job_name}: consumer exports a cache")
                 expected_gnmic = 1 if job_name in ("m54", "m56") else 0
                 if job.count(GNMIC_ACTION) != expected_gnmic:
@@ -820,8 +977,13 @@ def check(root: Path) -> list[str]:
     m101 = _jobs(texts["interop.yml"]).get("m101", "")
     m101_required = {
         GRPCURL_ACTION: 1,
+        BIRD3_ACTION: 1,
+        f"artifact-name: {BIRD332_ARTIFACT}": 1,
         "name: Build checksum-pinned BIRD 3.3.2 image": 1,
-        "docker build -t bird:v3.3.2-m101 -f tests/interop/Dockerfile.bird-v332 tests/interop": 1,
+        "file: tests/interop/Dockerfile.bird-v332": 1,
+        "tags: bird:v3.3.2-m101": 1,
+        "cache-from: type=gha,scope=bird332-m101": 1,
+        "cache-to: type=gha,mode=max,scope=bird332-m101,ignore-error=true": 1,
         "name: Pull digest-pinned FRR 10.3.1 image": 1,
         "docker pull quay.io/frrouting/frr@sha256:f90d26a9fd5c14fc5795a73b4254ac88bc3186c45bbeb220a225fb6182de812c": 1,
         "uses: ./.github/actions/run-interop-test": 1,
@@ -1099,12 +1261,19 @@ def check(root: Path) -> list[str]:
         if forbidden in gobgp_action:
             errors.append(f"stage-gobgp-artifact permits {forbidden}")
     for seam in (
+        "inputs:",
+        'default: "3.3.1"',
+        f'default: "{BIRD3_SHA256}"',
+        f'default: "{BIRD3_ARTIFACT}"',
+        'default: "tests/interop/bird3-archive"',
         "uses: actions/download-artifact@v8",
-        f"name: {BIRD3_ARTIFACT}",
+        "name: ${{ inputs.artifact-name }}",
         "path: ${{ runner.temp }}/bird3-artifact",
+        '--version "${{ inputs.version }}"',
+        '--sha256 "${{ inputs.sha256 }}"',
         "--stage-archive",
-        f'"$RUNNER_TEMP/bird3-artifact/{BIRD3_ARCHIVE}"',
-        "tests/interop/bird3-archive",
+        '"$RUNNER_TEMP/bird3-artifact/bird-${{ inputs.version }}.tar.gz"',
+        '"${{ inputs.stage-directory }}"',
     ):
         if seam not in bird3_action:
             errors.append(f"stage-bird3-artifact missing {seam}")
@@ -1123,6 +1292,8 @@ def check(root: Path) -> list[str]:
     ):
         if forbidden in bird3_action:
             errors.append(f"stage-bird3-artifact permits {forbidden}")
+    if bird3_action.count("default:") != 4:
+        errors.append("stage-bird3-artifact exact default inventory drifted")
     # split(...)[-1] returns the whole file when the step name drifts, which
     # turns every seam check below into a file-wide search that passes
     # vacuously. Scope the region only once the anchor is known to be present.
@@ -1191,8 +1362,8 @@ def check(root: Path) -> list[str]:
     )
     if "osrg/gobgp/releases" in gobgp_surfaces:
         errors.append("gobgp release URL escaped the installer/Dockerfile")
-    if texts["interop.yml"].count(BIRD3_ACTION) != 0:
-        errors.append("interop.yml: bird3 stage must remain kernel-only")
+    if texts["interop.yml"].count(BIRD3_ACTION) != 2:
+        errors.append("interop.yml: BIRD stage consumer inventory drifted")
     if texts["kernel-dataplane.yml"].count(BIRD3_ACTION) != 1:
         errors.append("kernel-dataplane.yml: bird3 stage consumer inventory drifted")
     bird3_surfaces = "\n".join(
@@ -1288,6 +1459,41 @@ def check(root: Path) -> list[str]:
         errors.append("Dockerfile.bird3: extraction precedes checksum verification")
     if re.search(r"BIRD_VERSION=latest|/download/latest", bird3):
         errors.append("Dockerfile.bird3: floating BIRD release is forbidden")
+    for dockerfile, version, checksum in (
+        ("Dockerfile.bird-v2192", BIRD2192_VERSION, BIRD2192_SHA256),
+        ("Dockerfile.bird-v332", BIRD332_VERSION, BIRD332_SHA256),
+    ):
+        source = (root / "tests" / "interop" / dockerfile).read_text()
+        for seam in (
+            f"ARG BIRD_VERSION={version}",
+            f"ARG BIRD_SHA256={checksum}",
+            "COPY bird3-archive/ /tmp/bird-archive/",
+            'archive="bird-${BIRD_VERSION}.tar.gz"',
+            'target="/tmp/bird-archive/${archive}"',
+            'if [ ! -f "${target}" ]; then',
+            "--connect-timeout 10 --max-time 120",
+            "https://bird.nic.cz/download/${archive}",
+            '--output "${target}.download"',
+            'if [ "${attempt}" -ge 3 ]; then',
+            'echo "${BIRD_SHA256}  ${target}" | sha256sum --check --strict',
+            'tar -xzf "${target}" -C /tmp/bird --strip-components=1',
+            'test "$(bird --version 2>&1)" = "BIRD version ${BIRD_VERSION}"',
+        ):
+            if seam not in source:
+                errors.append(f"{dockerfile}: pinned source seam missing: {seam}")
+        if source.count("bird.nic.cz/download/") != 1:
+            errors.append(f"{dockerfile}: download URL inventory drifted")
+        if not (
+            0
+            <= source.find("COPY bird3-archive/ /tmp/bird-archive/")
+            < source.find(
+                'echo "${BIRD_SHA256}  ${target}" | sha256sum --check --strict'
+            )
+            < source.find('tar -xzf "${target}" -C /tmp/bird --strip-components=1')
+        ):
+            errors.append(f"{dockerfile}: copy/check/extract ordering drifted")
+        if re.search(r"BIRD_VERSION=latest|/download/latest", source):
+            errors.append(f"{dockerfile}: floating BIRD release is forbidden")
     return errors
 
 

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -86,6 +86,16 @@ PR_FILES = {
 
 
 class PrimerContractTests(unittest.TestCase):
+    def copy_bird_dockerfiles(self, root):
+        interop = root / "tests" / "interop"
+        interop.mkdir(parents=True, exist_ok=True)
+        for name in (
+            "Dockerfile.bird3",
+            "Dockerfile.bird-v2192",
+            "Dockerfile.bird-v332",
+        ):
+            shutil.copy2(ROOT / "tests" / "interop" / name, interop / name)
+
     def mutate(self, relative, old, new="", occurrence=0):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -120,8 +130,7 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
-            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
-            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
+            self.copy_bird_dockerfiles(root)
             path = root / relative
             text = path.read_text()
             start = 0
@@ -156,9 +165,7 @@ class PrimerContractTests(unittest.TestCase):
         shutil.copy2(
             ROOT / "tests" / "interop" / "Dockerfile.gobgp", interop / "Dockerfile.gobgp"
         )
-        shutil.copy2(
-            ROOT / "tests" / "interop" / "Dockerfile.bird3", interop / "Dockerfile.bird3"
-        )
+        self.copy_bird_dockerfiles(root)
         scripts = root / ".github" / "scripts"
         scripts.mkdir(parents=True)
         for name in (
@@ -249,8 +256,7 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
-            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
-            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
+            self.copy_bird_dockerfiles(root)
             gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
             gnmic_installer.parent.mkdir(parents=True)
             shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
@@ -279,8 +285,7 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
-            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
-            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
+            self.copy_bird_dockerfiles(root)
             installer = root / ".github" / "scripts" / "install-grpcurl.sh"
             installer.parent.mkdir(parents=True)
             shutil.copy2(ROOT / installer.relative_to(root), installer)
@@ -308,7 +313,9 @@ class PrimerContractTests(unittest.TestCase):
         if workflow == "interop.yml":
             artifacts.append("gnmic_archive")
         artifacts.append("gobgp_archive")
-        if workflow == "kernel-dataplane.yml":
+        if workflow == "interop.yml":
+            artifacts.extend(("bird2192_archive", "bird332_archive"))
+        else:
             artifacts.append("bird3_archive")
         expected = ["classify_changes", *artifacts, "prime_dev_image", *roster]
         if workflow == "kernel-dataplane.yml":
@@ -346,7 +353,9 @@ class PrimerContractTests(unittest.TestCase):
             if workflow == "interop.yml":
                 artifacts.append("gnmic_archive")
             artifacts.append("gobgp_archive")
-            if workflow == "kernel-dataplane.yml":
+            if workflow == "interop.yml":
+                artifacts.extend(("bird2192_archive", "bird332_archive"))
+            else:
                 artifacts.append("bird3_archive")
             skipped = {
                 job: "skipped" for job in [*artifacts, "prime_dev_image", *roster]
@@ -387,7 +396,7 @@ class PrimerContractTests(unittest.TestCase):
                         ).returncode,
                     )
             gobgp_consumers = (
-                ("m74", "m75", "m81", "m82", "m83")
+                ("m74", "m75", "m81", "m82")
                 if workflow == "interop.yml"
                 else ("m65", "m71", "m72")
             )
@@ -408,6 +417,20 @@ class PrimerContractTests(unittest.TestCase):
                             {"bird3_archive": "failure", "m43": "skipped"},
                         ).returncode,
                     )
+            else:
+                for producer, consumer in (
+                    ("bird2192_archive", "m83"),
+                    ("bird332_archive", "m101"),
+                ):
+                    with self.subTest(workflow=workflow, producer=producer):
+                        self.assertNotEqual(
+                            0,
+                            self.run_aggregate(
+                                workflow,
+                                "true",
+                                {producer: "failure", consumer: "skipped"},
+                            ).returncode,
+                        )
             for run_labs, results in (
                 ("", {}),
                 ("unknown", {}),
@@ -900,7 +923,7 @@ class PrimerContractTests(unittest.TestCase):
         action = ".github/actions/stage-bird3-artifact/action.yml"
         for old, new in (
             ("actions/download-artifact@v8", "actions/download-artifact@main"),
-            ("name: bird3-v3.3.1-source", "name: bird3-latest"),
+            ('default: "bird3-v3.3.1-source"', 'default: "bird3-latest"'),
             ("--stage-archive", "--prepare-archive"),
             (
                 "set -euo pipefail",
@@ -912,13 +935,127 @@ class PrimerContractTests(unittest.TestCase):
 
         installer = ".github/scripts/install-bird3.sh"
         for old, new in (
-            ('readonly BIRD3_VERSION="3.3.1"', 'readonly BIRD3_VERSION="latest"'),
+            ('BIRD3_VERSION="3.3.1"', 'BIRD3_VERSION="latest"'),
             (checksum, "0" * 64),
             ("curl -fsSL", "curl -sL"),
             ("--connect-timeout 10", "--connect-timeout 0"),
         ):
             with self.subTest(seam=old):
                 self.mutate(installer, old, new)
+
+    def test_required_interop_bird_producers_are_load_bearing(self):
+        relative = ".github/workflows/interop.yml"
+        specs = (
+            (
+                "bird2192_archive",
+                "2.19.2",
+                "aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660",
+                "bird2192-cache",
+                "bird2192-v2.19.2-source",
+            ),
+            (
+                "bird332_archive",
+                "3.3.2",
+                "21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c",
+                "bird332-cache",
+                "bird332-v3.3.2-source",
+            ),
+        )
+        for job, version, checksum, cache_dir, artifact in specs:
+            archive = f"bird-{version}.tar.gz"
+            cache_key = f"{artifact}-{checksum}"
+            for old, new in (
+                (f"  {job}:\n", f"  removed_{job}:\n"),
+                (f"key: {cache_key}", "key: bird-latest"),
+                (f"--version {version}", "--version latest"),
+                (f"--sha256 {checksum}", "--sha256 " + "0" * 64),
+                (f"name: {artifact}", "name: bird-latest"),
+            ):
+                with self.subTest(job=job, seam=old):
+                    self.mutate(relative, old, new)
+            upload_tail = (
+                f"          name: {artifact}\n"
+                f"          path: ${{{{ runner.temp }}}}/{cache_dir}/{archive}\n"
+                "          if-no-files-found: error\n"
+                "          retention-days: 1\n"
+                "          compression-level: 0\n"
+            )
+            with self.subTest(job=job, seam="compression zero"):
+                self.mutate(
+                    relative,
+                    upload_tail,
+                    upload_tail.replace("compression-level: 0", "compression-level: 9"),
+                )
+            exact_path = (
+                f"path: ${{{{ runner.temp }}}}/{cache_dir}/{archive}"
+            )
+            for occurrence in (0, 1):
+                with self.subTest(job=job, seam="exact path", occurrence=occurrence):
+                    self.mutate(
+                        relative,
+                        exact_path,
+                        f"path: ${{{{ runner.temp }}}}/{cache_dir}/wrong.tar.gz",
+                        occurrence=occurrence,
+                    )
+            with self.subTest(job=job, seam="no restore keys"):
+                self.mutate(
+                    relative,
+                    f"          key: {cache_key}\n",
+                    f"          key: {cache_key}\n          restore-keys: bird-\n",
+                )
+
+    def test_parameterized_bird_stage_action_is_load_bearing(self):
+        relative = ".github/actions/stage-bird3-artifact/action.yml"
+        for old, new in (
+            ("name: ${{ inputs.artifact-name }}", "name: bird3-v3.3.1-source"),
+            ('--version "${{ inputs.version }}"', "--version 3.3.1"),
+            ('--sha256 "${{ inputs.sha256 }}"', "--sha256 " + "0" * 64),
+            (
+                '"$RUNNER_TEMP/bird3-artifact/bird-${{ inputs.version }}.tar.gz"',
+                '"$RUNNER_TEMP/bird3-artifact/bird-3.3.1.tar.gz"',
+            ),
+            ('"${{ inputs.stage-directory }}"', "tests/interop/bird3-archive"),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
+
+    def test_m83_m101_bird_archive_dockerfiles_are_load_bearing(self):
+        specs = (
+            (
+                "tests/interop/Dockerfile.bird-v2192",
+                "2.19.2",
+                "aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660",
+            ),
+            (
+                "tests/interop/Dockerfile.bird-v332",
+                "3.3.2",
+                "21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c",
+            ),
+        )
+        for relative, version, checksum in specs:
+            for old, new in (
+                (f"ARG BIRD_VERSION={version}", "ARG BIRD_VERSION=latest"),
+                (f"ARG BIRD_SHA256={checksum}", "ARG BIRD_SHA256=" + "0" * 64),
+                (
+                    "COPY bird3-archive/ /tmp/bird-archive/",
+                    "RUN mkdir -p /tmp/bird-archive",
+                ),
+                ('if [ ! -f "${target}" ]; then', "if true; then"),
+                (
+                    'if [ "${attempt}" -ge 3 ]; then',
+                    'if [ "${attempt}" -ge 999 ]; then',
+                ),
+                (
+                    'echo "${BIRD_SHA256}  ${target}" | sha256sum --check --strict',
+                    "true # checksum skipped",
+                ),
+                (
+                    'tar -xzf "${target}" -C /tmp/bird --strip-components=1',
+                    'tar -xzf "${target}" -C /tmp/bird',
+                ),
+            ):
+                with self.subTest(dockerfile=relative, seam=old):
+                    self.mutate(relative, old, new)
 
     def test_gnmic_installer_executable_mode_is_load_bearing(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -939,8 +1076,7 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
-            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
-            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
+            self.copy_bird_dockerfiles(root)
             scripts = root / ".github" / "scripts"
             scripts.mkdir(parents=True)
             for name in (
@@ -975,8 +1111,7 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
-            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
-            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
+            self.copy_bird_dockerfiles(root)
             scripts = root / ".github" / "scripts"
             scripts.mkdir(parents=True)
             for name in (
@@ -1011,8 +1146,7 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
-            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
-            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
+            self.copy_bird_dockerfiles(root)
             scripts = root / ".github" / "scripts"
             scripts.mkdir(parents=True)
             for name in (
@@ -1038,6 +1172,11 @@ class PrimerContractTests(unittest.TestCase):
                 "needs: [classify_changes, grpcurl_archive, "
                 + ("gnmic_archive, " if workflow == "interop.yml" else "")
                 + "gobgp_archive, "
+                + (
+                    "bird2192_archive,\n      bird332_archive, "
+                    if workflow == "interop.yml"
+                    else ""
+                )
                 + ("bird3_archive, " if workflow == "kernel-dataplane.yml" else "")
                 + "prime_dev_image, "
             )
@@ -1414,18 +1553,25 @@ class PrimerContractTests(unittest.TestCase):
         relative = ".github/workflows/interop.yml"
         m83_needs = (
             "  m83:\n"
-            "    needs: [grpcurl_archive, prime_dev_image]\n"
+            "    needs: [grpcurl_archive, bird2192_archive, prime_dev_image]\n"
         )
         workflow = (ROOT / relative).read_text()
         self.assertEqual(1, workflow.count(m83_needs), "M83 needs seam must be unique")
         self.mutate(
             relative,
             m83_needs,
-            "  m83:\n    needs: [grpcurl_archive]\n",
+            "  m83:\n    needs: [grpcurl_archive, prime_dev_image]\n",
         )
 
         for old in (
-            "        run: docker build -t bird:v2.19.2-m83 -f tests/interop/Dockerfile.bird-v2192 tests/interop\n",
+            "      - name: Stage verified BIRD 2.19.2 archive\n",
+            '          version: "2.19.2"\n',
+            "          sha256: aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660\n",
+            "          artifact-name: bird2192-v2.19.2-source\n",
+            "          file: tests/interop/Dockerfile.bird-v2192\n",
+            "          tags: bird:v2.19.2-m83\n",
+            "          cache-from: type=gha,scope=bird2192-m83\n",
+            "          cache-to: type=gha,mode=max,scope=bird2192-m83,ignore-error=true\n",
             "          --build-arg GOBGP_VERSION=4.8.0\n",
             "          --build-arg GOBGP_SHA256=43b570ae5cc1afab7aebdd9d8f4536e27656465848270c8a6f5fda1ffe093a03\n",
             "          -t gobgp:v4.8.0-m83 -f tests/interop/Dockerfile.gobgp-v47 tests/interop\n",
@@ -1457,9 +1603,16 @@ class PrimerContractTests(unittest.TestCase):
         relative = ".github/workflows/interop.yml"
         for old in (
             "  m101:\n",
-            "    needs: [grpcurl_archive, prime_dev_image]\n",
+            "    needs: [grpcurl_archive, bird332_archive, prime_dev_image]\n",
+            "      - name: Stage verified BIRD 3.3.2 archive\n",
+            '          version: "3.3.2"\n',
+            "          sha256: 21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c\n",
+            "          artifact-name: bird332-v3.3.2-source\n",
             "      - name: Build checksum-pinned BIRD 3.3.2 image\n",
-            "        run: docker build -t bird:v3.3.2-m101 -f tests/interop/Dockerfile.bird-v332 tests/interop\n",
+            "          file: tests/interop/Dockerfile.bird-v332\n",
+            "          tags: bird:v3.3.2-m101\n",
+            "          cache-from: type=gha,scope=bird332-m101\n",
+            "          cache-to: type=gha,mode=max,scope=bird332-m101,ignore-error=true\n",
             "      - name: Pull digest-pinned FRR 10.3.1 image\n",
             "        run: docker pull quay.io/frrouting/frr@sha256:f90d26a9fd5c14fc5795a73b4254ac88bc3186c45bbeb220a225fb6182de812c\n",
             "          label: M101\n",

--- a/tests/interop/Dockerfile.bird-v2192
+++ b/tests/interop/Dockerfile.bird-v2192
@@ -17,17 +17,46 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
         perl \
         pkg-config \
         tshark \
-    && curl -fsSLo /tmp/bird.tar.gz \
-        "https://bird.nic.cz/download/bird-${BIRD_VERSION}.tar.gz" \
-    && echo "${BIRD_SHA256}  /tmp/bird.tar.gz" | sha256sum -c - \
-    && mkdir /tmp/bird \
-    && tar -xzf /tmp/bird.tar.gz -C /tmp/bird --strip-components=1 \
-    && cd /tmp/bird \
-    && ./configure --prefix=/usr --sysconfdir=/etc/bird --localstatedir=/run/bird \
-    && make -j"$(nproc)" \
-    && make install \
-    && test "$(bird --version 2>&1)" = "BIRD version ${BIRD_VERSION}" \
-    && rm -rf /tmp/bird /tmp/bird.tar.gz /var/lib/apt/lists/* \
-    && mkdir -p /etc/bird /run/bird
+    && rm -rf /var/lib/apt/lists/*
+
+# Hosted CI stages a checksum- and version-verified same-run artifact before
+# this build. The absent-archive branch is only for cold local builds and is
+# deliberately bounded to three attempts.
+COPY bird3-archive/ /tmp/bird-archive/
+
+RUN set -eux; \
+    archive="bird-${BIRD_VERSION}.tar.gz"; \
+    target="/tmp/bird-archive/${archive}"; \
+    if [ ! -f "${target}" ]; then \
+        attempt=1; \
+        while :; do \
+            rm -f "${target}.download"; \
+            if curl --fail --location --silent --show-error \
+                --connect-timeout 10 --max-time 120 \
+                "https://bird.nic.cz/download/${archive}" \
+                --output "${target}.download" \
+                && echo "${BIRD_SHA256}  ${target}.download" | sha256sum --check --strict; then \
+                mv "${target}.download" "${target}"; \
+                break; \
+            fi; \
+            rm -f "${target}.download"; \
+            if [ "${attempt}" -ge 3 ]; then \
+                echo "BIRD ${BIRD_VERSION} local archive fallback failed after ${attempt} attempts" >&2; \
+                exit 1; \
+            fi; \
+            sleep $((attempt * 5)); \
+            attempt=$((attempt + 1)); \
+        done; \
+    fi; \
+    echo "${BIRD_SHA256}  ${target}" | sha256sum --check --strict; \
+    mkdir /tmp/bird; \
+    tar -xzf "${target}" -C /tmp/bird --strip-components=1; \
+    cd /tmp/bird; \
+    ./configure --prefix=/usr --sysconfdir=/etc/bird --localstatedir=/run/bird; \
+    make -j"$(nproc)"; \
+    make install; \
+    test "$(bird --version 2>&1)" = "BIRD version ${BIRD_VERSION}"; \
+    rm -rf /tmp/bird /tmp/bird-archive; \
+    mkdir -p /etc/bird /run/bird
 
 CMD ["sleep", "infinity"]

--- a/tests/interop/Dockerfile.bird-v332
+++ b/tests/interop/Dockerfile.bird-v332
@@ -17,17 +17,46 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
         perl \
         pkg-config \
         tshark \
-    && curl -fsSLo /tmp/bird.tar.gz \
-        "https://bird.nic.cz/download/bird-${BIRD_VERSION}.tar.gz" \
-    && echo "${BIRD_SHA256}  /tmp/bird.tar.gz" | sha256sum --check --strict \
-    && mkdir /tmp/bird \
-    && tar -xzf /tmp/bird.tar.gz -C /tmp/bird --strip-components=1 \
-    && cd /tmp/bird \
-    && ./configure --prefix=/usr --sysconfdir=/etc/bird --localstatedir=/run/bird \
-    && make -j"$(nproc)" \
-    && make install \
-    && test "$(bird --version 2>&1)" = "BIRD version ${BIRD_VERSION}" \
-    && rm -rf /tmp/bird /tmp/bird.tar.gz /var/lib/apt/lists/* \
-    && mkdir -p /etc/bird /run/bird
+    && rm -rf /var/lib/apt/lists/*
+
+# Hosted CI stages a checksum- and version-verified same-run artifact before
+# this build. The absent-archive branch is only for cold local builds and is
+# deliberately bounded to three attempts.
+COPY bird3-archive/ /tmp/bird-archive/
+
+RUN set -eux; \
+    archive="bird-${BIRD_VERSION}.tar.gz"; \
+    target="/tmp/bird-archive/${archive}"; \
+    if [ ! -f "${target}" ]; then \
+        attempt=1; \
+        while :; do \
+            rm -f "${target}.download"; \
+            if curl --fail --location --silent --show-error \
+                --connect-timeout 10 --max-time 120 \
+                "https://bird.nic.cz/download/${archive}" \
+                --output "${target}.download" \
+                && echo "${BIRD_SHA256}  ${target}.download" | sha256sum --check --strict; then \
+                mv "${target}.download" "${target}"; \
+                break; \
+            fi; \
+            rm -f "${target}.download"; \
+            if [ "${attempt}" -ge 3 ]; then \
+                echo "BIRD ${BIRD_VERSION} local archive fallback failed after ${attempt} attempts" >&2; \
+                exit 1; \
+            fi; \
+            sleep $((attempt * 5)); \
+            attempt=$((attempt + 1)); \
+        done; \
+    fi; \
+    echo "${BIRD_SHA256}  ${target}" | sha256sum --check --strict; \
+    mkdir /tmp/bird; \
+    tar -xzf "${target}" -C /tmp/bird --strip-components=1; \
+    cd /tmp/bird; \
+    ./configure --prefix=/usr --sysconfdir=/etc/bird --localstatedir=/run/bird; \
+    make -j"$(nproc)"; \
+    make install; \
+    test "$(bird --version 2>&1)" = "BIRD version ${BIRD_VERSION}"; \
+    rm -rf /tmp/bird /tmp/bird-archive; \
+    mkdir -p /etc/bird /run/bird
 
 CMD ["sleep", "infinity"]

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -104,6 +104,33 @@ fn m83_pins_refreshed_incumbent_images_and_preflights_before_capture() {
         "quay.io/frrouting/frr:10.3.1"
     );
 
+    let dockerfile = fs::read_to_string(interop_path("Dockerfile.bird-v2192"))
+        .expect("read M83 BIRD Dockerfile");
+    for required in [
+        "ARG BIRD_VERSION=2.19.2",
+        "ARG BIRD_SHA256=aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660",
+        "COPY bird3-archive/ /tmp/bird-archive/",
+        "if [ ! -f \"${target}\" ]; then",
+        "if [ \"${attempt}\" -ge 3 ]; then",
+        "sha256sum --check --strict",
+        "test \"$(bird --version 2>&1)\" = \"BIRD version ${BIRD_VERSION}\"",
+    ] {
+        assert!(
+            dockerfile.contains(required),
+            "M83 BIRD build lost `{required}`"
+        );
+    }
+    let copy = dockerfile
+        .find("COPY bird3-archive/ /tmp/bird-archive/")
+        .expect("M83 copies the staged archive directory");
+    let checksum = dockerfile
+        .rfind("sha256sum --check --strict")
+        .expect("M83 checks the staged archive");
+    let extract = dockerfile
+        .find("tar -xzf \"${target}\" -C /tmp/bird --strip-components=1")
+        .expect("M83 extracts the checked archive");
+    assert!(copy < checksum && checksum < extract);
+
     let script = fs::read_to_string(interop_path("scripts/test-m83-routeserver-multistack.sh"))
         .expect("read M83 script");
     for exact_version in [
@@ -272,6 +299,9 @@ fn m101_pins_peer_identity_and_real_wire_attribute_discard_contract() {
     for required in [
         "ARG BIRD_VERSION=3.3.2",
         "ARG BIRD_SHA256=21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c",
+        "COPY bird3-archive/ /tmp/bird-archive/",
+        "if [ ! -f \"${target}\" ]; then",
+        "if [ \"${attempt}\" -ge 3 ]; then",
         "sha256sum --check --strict",
         "test \"$(bird --version 2>&1)\" = \"BIRD version ${BIRD_VERSION}\"",
     ] {
@@ -281,6 +311,16 @@ fn m101_pins_peer_identity_and_real_wire_attribute_discard_contract() {
         );
     }
     assert!(dockerfile.contains(BIRD_SHA256));
+    let copy = dockerfile
+        .find("COPY bird3-archive/ /tmp/bird-archive/")
+        .expect("M101 copies the staged archive directory");
+    let checksum = dockerfile
+        .rfind("sha256sum --check --strict")
+        .expect("M101 checks the staged archive");
+    let extract = dockerfile
+        .find("tar -xzf \"${target}\" -C /tmp/bird --strip-components=1")
+        .expect("M101 extracts the checked archive");
+    assert!(copy < checksum && checksum < extract);
 
     let bird_config =
         fs::read_to_string(interop_path("configs/bird-m101.conf")).expect("read M101 BIRD config");


### PR DESCRIPTION
## Summary

- stage checksum- and source-version-verified BIRD 2.19.2 and 3.3.2 archives from required same-run producers
- build the M83 and M101 images through Buildx with dedicated cache scopes
- preserve M43 behavior while extending the installer, contract checker, destructive tests, and topology assertions

## Validation

- independent Judge: `GO_COMMIT_PR`; nine-path manifest SHA-256 `461569f3a0ed9dc6891d6cfc959bc2cb8d5778dcf5159cd261f3e7ad267177b2`
- `cargo fmt --all --check`
- `bash -n .github/scripts/install-bird3.sh`
- `shellcheck .github/scripts/install-bird3.sh`
- `.github/scripts/install-bird3.sh --self-test`
- `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py` (46 passed)
- `python3 scripts/check_ci_image_primer_contract.py`
- exact M83 and M101 topology contract tests
- Ruff, Actionlint, Python byte-compilation, and `git diff --check`

## Linear

- https://linear.app/lance0/issue/LAN-1391
