### PR TITLE
test(interop): make M16 IPv6 startup deterministic

### DIFF
--- a/tests/interop/m16-llgr-frr.clab.yml
+++ b/tests/interop/m16-llgr-frr.clab.yml
@@ -21,7 +21,7 @@ topology:
         - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
-        - ip -6 addr add fd00:16::1/64 dev eth1
+        - ip -6 addr add fd00:16::1/64 dev eth1 nodad
         - ip link set eth1 up
       env:
         RUST_LOG: info
@@ -34,7 +34,7 @@ topology:
         - ./configs/frr-bgpd-m16-llgr.conf:/etc/frr/frr.conf:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1
-        - ip -6 addr add fd00:16::2/64 dev eth1
+        - ip -6 addr add fd00:16::2/64 dev eth1 nodad
         - ip link set eth1 up
 
   links:

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -39,6 +39,30 @@ fn rustbgpd_image_and_exec(topology: &serde_yaml::Value) -> (&str, Vec<&str>) {
 }
 
 #[test]
+fn m16_ipv6_addresses_disable_dad_on_both_nodes() {
+    // Destructive red proof: removing `nodad` from either node makes that
+    // node's exact IPv6 address command differ and this test fail.
+    let topology = topology("m16-llgr-frr.clab.yml");
+    for (node, expected) in [
+        ("rustbgpd", "ip -6 addr add fd00:16::1/64 dev eth1 nodad"),
+        ("frr", "ip -6 addr add fd00:16::2/64 dev eth1 nodad"),
+    ] {
+        let ipv6_commands: Vec<_> = topology["topology"]["nodes"][node]["exec"]
+            .as_sequence()
+            .unwrap_or_else(|| panic!("M16 {node} exec must be a sequence"))
+            .iter()
+            .filter_map(serde_yaml::Value::as_str)
+            .filter(|command| command.starts_with("ip -6 addr add "))
+            .collect();
+        assert_eq!(
+            ipv6_commands,
+            [expected],
+            "M16 {node} must disable IPv6 DAD before starting its session",
+        );
+    }
+}
+
+#[test]
 fn route_server_topologies_have_exact_control_plane_setup() {
     // Destructive red proof: adding either former `sysctl -w
     // net.ipv4.ip_forward=1` command makes the corresponding exact exec list


### PR DESCRIPTION
## Summary

- disable IPv6 DAD on both M16 topology addresses so they are usable before BGP startup
- pin the exact `nodad` commands to the named rustbgpd and FRR nodes in the topology contract
- preserve the existing M16 protocol assertions, 20-row receipt, and retry behavior

## Verification

- `cargo test --test interop_topology_commands`
- removing `nodad` from either node independently makes the focused contract fail on that node
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- push hooks: workspace tests and rustdoc

Linear: LAN-1392
