### PR TITLE
fix(transport): surface episodic TCP connect failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Outbound TCP connect failures now surface once per failed-connect episode
+  instead of remaining below the default log level: a cold peer's first socket
+  failure is INFO, the first failure after an Established epoch and the first
+  internal connect-task failure are WARN, and subsequent retries remain DEBUG.
+  Every retry still refreshes `last_error`, and a successful TCP connection
+  re-arms visibility without changing the FSM or ConnectRetry cadence.
+
 - The unpublished RIB crate no longer exposes unrestricted mutable Adj-RIB-In
   iteration. Its sole internal all-route mutation callback now maintains exact
   RPKI validation counts, preserving RFC 9972 BMP path-count rows and safe

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -1,7 +1,8 @@
 use super::{
-    BmpEvent, Bytes, Event, Message, NotificationCode, OwnedReadHalf, PeerDownReason, PeerSession,
-    RibUpdate, RouteRefreshSubtype, SessionNotificationDirection, TcpStream, TransportError,
-    cease_subcode, debug, error, info, warn,
+    BmpEvent, Bytes, ConnectFailureEpisode, ConnectFailureSource, Event, Message, NotificationCode,
+    OwnedReadHalf, PeerDownReason, PeerSession, RibUpdate, RouteRefreshSubtype,
+    SessionNotificationDirection, TcpStream, TransportError, cease_subcode, debug, error, info,
+    warn,
 };
 use crate::config::TransportConfig;
 use rustbgpd_wire::{AddressPrefixOrf, OrfAction, OrfEntries, OrfMatch, OrfType};
@@ -14,7 +15,81 @@ const ORF_RIB_REPLY_TIMEOUT: Duration = Duration::from_millis(500);
 
 impl PeerSession {
     pub(super) fn record_connect_failure(&mut self, error: &impl std::fmt::Display) {
-        self.last_error = error.to_string();
+        let error = error.to_string();
+        self.record_connect_failure_with_source(
+            error.clone(),
+            &error,
+            ConnectFailureSource::Socket,
+        );
+    }
+
+    pub(super) fn record_connect_task_failure(&mut self, error: &JoinError) {
+        let log_error = if error.is_cancelled() {
+            "connect task cancelled"
+        } else {
+            "connect task panicked"
+        };
+        self.record_connect_failure_with_source(
+            error.to_string(),
+            log_error,
+            ConnectFailureSource::Task,
+        );
+    }
+
+    fn record_connect_failure_with_source(
+        &mut self,
+        last_error: String,
+        log_error: &str,
+        source: ConnectFailureSource,
+    ) {
+        self.last_error = last_error;
+        let previously_established = self.flap_count > 0;
+        if self.connect_failure_episode.mark_reported(source) {
+            match source {
+                ConnectFailureSource::Socket if previously_established => warn!(
+                    peer = %self.peer_label,
+                    error = log_error,
+                    failure_source = "socket",
+                    previously_established,
+                    "TCP connect failed"
+                ),
+                ConnectFailureSource::Socket => info!(
+                    peer = %self.peer_label,
+                    error = log_error,
+                    failure_source = "socket",
+                    previously_established,
+                    "TCP connect failed"
+                ),
+                ConnectFailureSource::Task => warn!(
+                    peer = %self.peer_label,
+                    error = log_error,
+                    failure_source = "task",
+                    previously_established,
+                    "TCP connect task failed"
+                ),
+            }
+        } else {
+            match source {
+                ConnectFailureSource::Socket => debug!(
+                    peer = %self.peer_label,
+                    error = log_error,
+                    failure_source = "socket",
+                    previously_established,
+                    "TCP connect failed"
+                ),
+                ConnectFailureSource::Task => debug!(
+                    peer = %self.peer_label,
+                    error = log_error,
+                    failure_source = "task",
+                    previously_established,
+                    "TCP connect task failed"
+                ),
+            }
+        }
+    }
+
+    pub(super) fn reset_connect_failure_episode(&mut self) {
+        self.connect_failure_episode = ConnectFailureEpisode::default();
     }
 
     /// Handle the ORF section of an inbound ROUTE-REFRESH (RFC 5291/5292).

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -16,11 +16,7 @@ const ORF_RIB_REPLY_TIMEOUT: Duration = Duration::from_millis(500);
 impl PeerSession {
     pub(super) fn record_connect_failure(&mut self, error: &impl std::fmt::Display) {
         let error = error.to_string();
-        self.record_connect_failure_with_source(
-            error.clone(),
-            &error,
-            ConnectFailureSource::Socket,
-        );
+        self.record_connect_failure_with_source(error, None, ConnectFailureSource::Socket);
     }
 
     pub(super) fn record_connect_task_failure(&mut self, error: &JoinError) {
@@ -31,7 +27,7 @@ impl PeerSession {
         };
         self.record_connect_failure_with_source(
             error.to_string(),
-            log_error,
+            Some(log_error),
             ConnectFailureSource::Task,
         );
     }
@@ -39,10 +35,10 @@ impl PeerSession {
     fn record_connect_failure_with_source(
         &mut self,
         last_error: String,
-        log_error: &str,
+        bounded_log_error: Option<&str>,
         source: ConnectFailureSource,
     ) {
-        self.last_error = last_error;
+        let log_error = bounded_log_error.unwrap_or(&last_error);
         let previously_established = self.flap_count > 0;
         if self.connect_failure_episode.mark_reported(source) {
             match source {
@@ -86,6 +82,7 @@ impl PeerSession {
                 ),
             }
         }
+        self.last_error = last_error;
     }
 
     pub(super) fn reset_connect_failure_episode(&mut self) {

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -191,6 +191,30 @@ impl Drop for SessionTelemetryMetricLease {
     }
 }
 
+#[derive(Clone, Copy)]
+pub(super) enum ConnectFailureSource {
+    Socket,
+    Task,
+}
+
+#[derive(Default)]
+struct ConnectFailureEpisode {
+    socket_reported: bool,
+    task_reported: bool,
+}
+
+impl ConnectFailureEpisode {
+    fn mark_reported(&mut self, source: ConnectFailureSource) -> bool {
+        let reported = match source {
+            ConnectFailureSource::Socket => &mut self.socket_reported,
+            ConnectFailureSource::Task => &mut self.task_reported,
+        };
+        let first = !*reported;
+        *reported = true;
+        first
+    }
+}
+
 /// Runtime for a single BGP peer session.
 ///
 /// Owns the FSM, TCP stream, timers, and read buffer. Runs as a single
@@ -288,6 +312,10 @@ pub(crate) struct PeerSession {
     /// In-flight outbound TCP connect attempt. Polled by the main event loop
     /// so control commands remain responsive during connection establishment.
     connect_task: Option<ConnectTask>,
+    /// Visibility latch for one failed-connect episode. Ordinary socket errors
+    /// and internal task failures each get one default-visible record; a
+    /// successful TCP connection re-arms both without changing retry behavior.
+    connect_failure_episode: ConnectFailureEpisode,
     /// Receiver for outbound route updates from the RIB manager.
     outbound_rx: mpsc::Receiver<OutboundRouteUpdate>,
     /// Sender clone held to give to RIB manager on `PeerUp`.
@@ -1163,6 +1191,7 @@ impl PeerSession {
             stop_requested: false,
             reconnect_timer: None,
             connect_task: None,
+            connect_failure_episode: ConnectFailureEpisode::default(),
             outbound_rx,
             outbound_tx,
             import_policy,
@@ -1331,6 +1360,7 @@ impl PeerSession {
             stop_requested: false,
             reconnect_timer: None,
             connect_task: None,
+            connect_failure_episode: ConnectFailureEpisode::default(),
             outbound_rx,
             outbound_tx,
             import_policy,
@@ -1913,6 +1943,7 @@ impl PeerSession {
                     self.connect_task = None;
                     match result {
                         Ok(Ok((stream, tcp_ao_info))) => {
+                            self.reset_connect_failure_episode();
                             info!(peer = %self.peer_label, "TCP connected");
                             // Split the stream and spawn the writer task.
                             // Read half stays here for the read_tcp arm; the
@@ -1944,13 +1975,11 @@ impl PeerSession {
                             self.drive_fsm(Event::TcpConnectionConfirmed).await;
                         }
                         Ok(Err(e)) => {
-                            debug!(peer = %self.peer_label, error = %e, "TCP connect failed");
                             self.record_connect_failure(&e);
                             self.drive_fsm(Event::TcpConnectionFails).await;
                         }
                         Err(e) => {
-                            debug!(peer = %self.peer_label, error = %e, "TCP connect task failed");
-                            self.record_connect_failure(&e);
+                            self.record_connect_task_failure(&e);
                             self.drive_fsm(Event::TcpConnectionFails).await;
                         }
                     }

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -1,30 +1,29 @@
 use super::*;
 
-type NotificationLogFields = std::collections::BTreeMap<String, String>;
-type NotificationLogBuckets =
-    std::collections::HashMap<std::thread::ThreadId, Vec<NotificationLogFields>>;
+type SessionLogFields = std::collections::BTreeMap<String, String>;
+type SessionLogBuckets = std::collections::HashMap<std::thread::ThreadId, Vec<SessionLogFields>>;
 
 #[derive(Clone, Default)]
-struct NotificationLogCapture {
-    events: Arc<std::sync::Mutex<NotificationLogBuckets>>,
+struct SessionLogCapture {
+    events: Arc<std::sync::Mutex<SessionLogBuckets>>,
 }
 
-fn notification_log_capture() -> &'static NotificationLogCapture {
-    static CAPTURE: std::sync::OnceLock<NotificationLogCapture> = std::sync::OnceLock::new();
+fn session_log_capture() -> &'static SessionLogCapture {
+    static CAPTURE: std::sync::OnceLock<SessionLogCapture> = std::sync::OnceLock::new();
     CAPTURE.get_or_init(|| {
-        let capture = NotificationLogCapture::default();
+        let capture = SessionLogCapture::default();
         tracing::subscriber::set_global_default(capture.clone())
-            .expect("notification tests require an unclaimed global tracing subscriber");
+            .expect("session log tests require an unclaimed global tracing subscriber");
         capture
     })
 }
 
-impl tracing::Subscriber for NotificationLogCapture {
+impl tracing::Subscriber for SessionLogCapture {
     fn register_callsite(
         &self,
         metadata: &'static tracing::Metadata<'static>,
     ) -> tracing::subscriber::Interest {
-        if notification_log_metadata(metadata) {
+        if session_log_metadata(metadata) {
             tracing::subscriber::Interest::sometimes()
         } else {
             tracing::subscriber::Interest::never()
@@ -32,7 +31,7 @@ impl tracing::Subscriber for NotificationLogCapture {
     }
 
     fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
-        notification_log_metadata(metadata)
+        session_log_metadata(metadata)
             && self
                 .events
                 .lock()
@@ -63,9 +62,16 @@ impl tracing::Subscriber for NotificationLogCapture {
             fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
                 self.0.insert(field.name().to_string(), value.to_string());
             }
+
+            fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+                self.0.insert(field.name().to_string(), value.to_string());
+            }
         }
 
         let mut visitor = Visitor(std::collections::BTreeMap::new());
+        visitor
+            .0
+            .insert("level".to_string(), event.metadata().level().to_string());
         event.record(&mut visitor);
         if let Some(events) = self
             .events
@@ -82,6 +88,10 @@ impl tracing::Subscriber for NotificationLogCapture {
     fn exit(&self, _span: &tracing::span::Id) {}
 }
 
+fn session_log_metadata(metadata: &tracing::Metadata<'_>) -> bool {
+    notification_log_metadata(metadata) || connect_failure_log_metadata(metadata)
+}
+
 fn notification_log_metadata(metadata: &tracing::Metadata<'_>) -> bool {
     *metadata.level() == tracing::Level::INFO
         && ["direction", "code", "subcode", "description"]
@@ -89,13 +99,14 @@ fn notification_log_metadata(metadata: &tracing::Metadata<'_>) -> bool {
             .all(|field| metadata.fields().field(field).is_some())
 }
 
-fn capture_notification_log(
-    direction: SessionNotificationDirection,
-    notification: &NotificationMessage,
-    reason: Option<&str>,
-) -> Vec<NotificationLogFields> {
-    let session = make_test_session(65001, 65002);
-    let capture = notification_log_capture();
+fn connect_failure_log_metadata(metadata: &tracing::Metadata<'_>) -> bool {
+    ["peer", "error", "failure_source", "previously_established"]
+        .into_iter()
+        .all(|field| metadata.fields().field(field).is_some())
+}
+
+fn capture_session_logs(action: impl FnOnce()) -> Vec<SessionLogFields> {
+    let capture = session_log_capture();
     let thread_id = std::thread::current().id();
     assert!(
         capture
@@ -104,15 +115,24 @@ fn capture_notification_log(
             .unwrap()
             .insert(thread_id, Vec::new())
             .is_none(),
-        "notification log capture bucket was already armed for this thread"
+        "session log capture bucket was already armed for this thread"
     );
-    session.log_notification(direction, notification, reason);
+    action();
     capture
         .events
         .lock()
         .unwrap()
         .remove(&thread_id)
-        .expect("armed notification log capture bucket")
+        .expect("armed session log capture bucket")
+}
+
+fn capture_notification_log(
+    direction: SessionNotificationDirection,
+    notification: &NotificationMessage,
+    reason: Option<&str>,
+) -> Vec<SessionLogFields> {
+    let session = make_test_session(65001, 65002);
+    capture_session_logs(|| session.log_notification(direction, notification, reason))
 }
 
 #[test]
@@ -210,6 +230,132 @@ fn notification_log_reason_is_escaped_ascii_and_bounded() {
     assert!(!logged.contains('\n'));
     assert!(logged.contains("\\n"));
     assert!(logged.contains("\\u{1f980}"));
+}
+
+fn assert_connect_log(
+    event: &SessionLogFields,
+    level: &str,
+    message: &str,
+    source: &str,
+    previously_established: bool,
+    error: &str,
+) {
+    assert_eq!(event.get("level").map(String::as_str), Some(level));
+    assert_eq!(event.get("message").map(String::as_str), Some(message));
+    assert_eq!(event.get("peer").map(String::as_str), Some("10.0.0.2"));
+    assert_eq!(
+        event.get("failure_source").map(String::as_str),
+        Some(source)
+    );
+    assert_eq!(
+        event.get("previously_established").map(String::as_str),
+        Some(if previously_established {
+            "true"
+        } else {
+            "false"
+        })
+    );
+    assert_eq!(event.get("error").map(String::as_str), Some(error));
+}
+
+/// Mutants: raising every retry, suppressing the cold first failure, or using
+/// `last_error` as the episode latch changes this exact INFO/DEBUG pair.
+#[test]
+fn cold_connect_failure_logs_once_and_keeps_refreshing_last_error() {
+    let mut session = make_test_session(65001, 65002);
+    session.last_error = "prior non-connect failure".to_string();
+    let first = "Cannot assign requested address (os error 99)";
+    let retry = "Connection refused (os error 111)";
+
+    let events = capture_session_logs(|| {
+        session.record_connect_failure(&std::io::Error::other(first));
+        session.record_connect_failure(&std::io::Error::other(retry));
+    });
+
+    assert_eq!(events.len(), 2);
+    assert_connect_log(
+        &events[0],
+        "INFO",
+        "TCP connect failed",
+        "socket",
+        false,
+        first,
+    );
+    assert_connect_log(
+        &events[1],
+        "DEBUG",
+        "TCP connect failed",
+        "socket",
+        false,
+        retry,
+    );
+    assert_eq!(session.last_error, retry);
+}
+
+/// Mutants: consulting current FSM state rather than completed-epoch history,
+/// or sharing the socket/task bit, loses one of these warnings.
+#[tokio::test(flavor = "current_thread")]
+async fn established_socket_and_first_task_failures_warn_independently() {
+    let mut session = make_test_session(65001, 65002);
+    session.flap_count = 1;
+    let socket = "Network is unreachable (os error 101)";
+    let task = tokio::spawn(std::future::pending::<()>());
+    task.abort();
+    let task = task.await.unwrap_err();
+    let exact_task_error = task.to_string();
+
+    let events = capture_session_logs(|| {
+        session.record_connect_failure(&std::io::Error::other(socket));
+        session.record_connect_task_failure(&task);
+        session.record_connect_task_failure(&task);
+    });
+
+    assert_eq!(events.len(), 3);
+    assert_connect_log(
+        &events[0],
+        "WARN",
+        "TCP connect failed",
+        "socket",
+        true,
+        socket,
+    );
+    assert_connect_log(
+        &events[1],
+        "WARN",
+        "TCP connect task failed",
+        "task",
+        true,
+        "connect task cancelled",
+    );
+    assert_connect_log(
+        &events[2],
+        "DEBUG",
+        "TCP connect task failed",
+        "task",
+        true,
+        "connect task cancelled",
+    );
+    assert_eq!(session.last_error, exact_task_error);
+}
+
+/// Mutant: omitting the successful-connect reset leaves the second episode at
+/// DEBUG and hides the next outage from default-level logs.
+#[test]
+fn successful_connect_rearms_failure_visibility() {
+    let mut session = make_test_session(65001, 65002);
+    let error = "Connection timed out (os error 110)";
+
+    let events = capture_session_logs(|| {
+        session.record_connect_failure(&std::io::Error::other(error));
+        session.record_connect_failure(&std::io::Error::other(error));
+        session.reset_connect_failure_episode();
+        session.record_connect_failure(&std::io::Error::other(error));
+    });
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].get("level").map(String::as_str), Some("INFO"));
+    assert_eq!(events[1].get("level").map(String::as_str), Some("DEBUG"));
+    assert_eq!(events[2].get("level").map(String::as_str), Some("INFO"));
 }
 
 #[tokio::test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1774,6 +1774,8 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 | `starting rustbgpd` | INFO | Daemon started successfully |
 | `session established` | INFO | BGP session reached Established |
 | `session down` | INFO | BGP session left Established |
+| `TCP connect failed` | INFO / WARN | First socket failure in a failed-connect episode; WARN after an Established epoch, INFO for a peer that has not established yet |
+| `TCP connect task failed` | WARN | First internal connect-task failure in a failed-connect episode |
 | `received SIGTERM` / `received SIGINT` | INFO | Process signal received |
 | `shutdown initiated via gRPC` | INFO | `Shutdown` RPC called |
 | `gRPC server exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
@@ -1787,6 +1789,11 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 | `published GR restart marker with wall-clock fallback because boottime protection was unavailable` | WARN | Clock-domain sampling or representation failed; a complete bounded v1/v2 marker was selected. Check `publication_durability` on the final publication log for directory-sync status. |
 | `max-prefix limit exceeded` | WARN | Peer exceeded prefix limit |
 | `gRPC TCP listener bound to a non-loopback address` | WARN | Security posture warning |
+
+Later socket or task retries in the same failed-connect episode stay at DEBUG
+to avoid one default-visible record per ConnectRetry interval. Every retry still
+refreshes the neighbor's `Last Error`; a successful TCP connection re-arms both
+records for a later outage.
 
 ---
 


### PR DESCRIPTION
## Summary

- surface the first outbound TCP socket failure at the default log level while keeping steady-state retries at DEBUG
- distinguish cold-peer INFO from post-Established WARN and report internal connect-task failures once per episode
- preserve exact `last_error`, FSM events, and ConnectRetry cadence, with successful TCP connection re-arming visibility
- document the structured operator-visible messages and release behavior

## Validation

- `cargo test -p rustbgpd-transport session::tests::notification`
- `cargo test -p rustbgpd-transport session::tests::state_query::connect_failure_is_retained_for_neighbor_diagnostics`
- `cargo clippy -p rustbgpd-transport --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- local self-review of the one-commit five-file diff; rebase preserved the exact patch ID

Linear: https://linear.app/lance0/issue/LAN-1394/tcp-connect-failures-stay-at-debug-the-one-notification-adjacent-log
