### PR TITLE
bench(rib): measure mass selection-deferral family release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,8 @@ jobs:
       # separates "broken" from "nobody ran it". Smoke only — no timings.
       - name: Smoke every criterion bench target
         run: bash bench/smoke-benches.sh
+      - name: Smoke selection-deferral release receipt
+        run: cargo test --locked -p rustbgpd-rib --features bench-internals --bench selection_deferral_release -- --self-test
       # LAN-572 keeps the real MRT snapshot encoder benchmark usable in both
       # deliberately incompatible builds: bare-jemalloc timing, and opt-in
       # allocation/growth diagnostics.  `--smoke` bounds both executions for

--- a/bench/smoke-benches.sh
+++ b/bench/smoke-benches.sh
@@ -13,7 +13,7 @@
 # timing it happens to produce is meaningless and is not reported.
 #
 # The target list comes from `cargo metadata`, so a bench target is covered the
-# day it lands rather than when someone remembers to register it here. The five
+# day it lands rather than when someone remembers to register it here. The six
 # non-criterion harnesses are excluded by name; renaming one drops its
 # exclusion and this script then fails loudly instead of skipping it silently.
 
@@ -52,7 +52,10 @@ done
 #                        per process, driven by prefix/path/index-mode flags.
 #   vpn_query_*          are one-cell timing/allocation executables. CI runs
 #                        their exact 256-route smoke separately.
-EXCLUDED=(snapshot_allocation route_paging dataplane_prefix_paging vpn_query_timing vpn_query_allocation)
+#   selection_deferral_release
+#                        fixed-fleet receipt harness with its own CLI and
+#                        bounded self-test, which CI runs separately.
+EXCLUDED=(snapshot_allocation route_paging dataplane_prefix_paging vpn_query_timing vpn_query_allocation selection_deferral_release)
 
 mapfile -t targets < <(
   cargo metadata "${locked_args[@]}" --no-deps --format-version 1 | python3 -c '

--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -57,3 +57,8 @@ required-features = ["bench-internals"]
 name = "dataplane_prefix_paging"
 harness = false
 required-features = ["bench-internals"]
+
+[[bench]]
+name = "selection_deferral_release"
+harness = false
+required-features = ["bench-internals"]

--- a/crates/rib/benches/selection_deferral_release.rs
+++ b/crates/rib/benches/selection_deferral_release.rs
@@ -1,0 +1,703 @@
+//! One-shot LAN-1188 selection-deferral release measurement.
+//!
+//! Fixture construction is outside the timed interval. One ordinary Loc-RIB
+//! count query is queued before the exact production expiry call, then served
+//! through the manager's existing general-query drain. Each invocation emits
+//! one JSON receipt; no statistical campaign policy lives in this binary.
+
+use std::collections::{BTreeMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rustbgpd_rib::{
+    ExactExportCandidate, ExactExportEncoder, ExactExportError, ExactExportResult,
+    ExactExportSnapshot, OutboundRouteUpdate, RibManager, RibUpdate, Route, RouteOrigin,
+    SelectionDeferralConfig, SelectionDeferralWaiterConfig,
+};
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, Prefix, RpkiValidation, Safi};
+use tokio::sync::mpsc;
+
+const FLEET_PEERS: usize = 700;
+const FLEET_ROUTES: usize = 400_400;
+const SELF_TEST_PEERS: usize = 4;
+const SELF_TEST_ROUTES: usize = 64;
+const LEDGER_IDENTITY_LIMIT: usize = 1_000_000;
+
+const IPV4_UNICAST: (Afi, Safi) = (Afi::Ipv4, Safi::Unicast);
+const IPV6_UNICAST: (Afi, Safi) = (Afi::Ipv6, Safi::Unicast);
+const SEVEN_GATES: [(Afi, Safi); 7] = [
+    IPV4_UNICAST,
+    IPV6_UNICAST,
+    (Afi::Ipv4, Safi::FlowSpec),
+    (Afi::L2Vpn, Safi::Evpn),
+    (Afi::Ipv4, Safi::MplsVpn),
+    (Afi::Ipv4, Safi::LabeledUnicast),
+    (Afi::BgpLs, Safi::BgpLs),
+];
+
+// `bench_selection_deferral_inventory` layout.
+const LOC_V4_ROUTES: usize = 0;
+const LOC_V4_CHECKSUM: usize = 1;
+const LOC_V6_ROUTES: usize = 2;
+const LOC_V6_CHECKSUM: usize = 3;
+const ADJ_V4_ROUTES: usize = 4;
+const ADJ_V4_CHECKSUM: usize = 5;
+const ADJ_V6_ROUTES: usize = 6;
+const ADJ_V6_CHECKSUM: usize = 7;
+const SOURCE_STORES: usize = 8;
+const NONEMPTY_SOURCE_STORES: usize = 9;
+const MIN_SOURCE_ROUTES: usize = 10;
+const MAX_SOURCE_ROUTES: usize = 11;
+
+// `bench_selection_deferral_release_with_sentinel` layout.
+const RELEASE_NS: usize = 0;
+const SENTINEL_NS: usize = 1;
+const SENTINEL_COUNT: usize = 2;
+const PRIMARY_DEPTH: usize = 3;
+const QUERY_DEPTH_BEFORE: usize = 4;
+const QUERY_DEPTH_AFTER: usize = 5;
+const RELEASE_DELTA: usize = 6;
+const TIMEOUT_DELTA: usize = 7;
+const ACTIVE_GATES: usize = 8;
+const RELEASED_GATES: usize = 9;
+const TIMER_GATES: usize = 10;
+const LEDGER_CLEARED: usize = 11;
+const OBSERVED_GATES: usize = 12;
+const OVERFLOWS_BEFORE: usize = 13;
+
+type Families = Vec<(Afi, Safi)>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Control,
+    Ipv4,
+    Dual,
+    Seven,
+    Overflow,
+}
+
+impl Mode {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Control => "control_no_release",
+            Self::Ipv4 => "ipv4_normal",
+            Self::Dual => "dual_normal",
+            Self::Seven => "seven_gate_normal",
+            Self::Overflow => "dual_overflow_withdrawal",
+        }
+    }
+
+    const fn expires(self) -> bool {
+        !matches!(self, Self::Control)
+    }
+
+    const fn is_overflow(self) -> bool {
+        matches!(self, Self::Overflow)
+    }
+}
+
+#[derive(Debug)]
+enum Command {
+    Run(Mode),
+    SelfTest,
+    Help,
+}
+
+#[derive(Debug, Clone)]
+struct Receipt {
+    mode: String,
+    peers: usize,
+    expected_v4: usize,
+    expected_v6: usize,
+    expected_v4_checksum: u64,
+    expected_v6_checksum: u64,
+    gated_families: usize,
+    sendable_families: usize,
+    before: [u64; 12],
+    after: [u64; 12],
+    release: [u64; 14],
+    eor_markers: usize,
+    eor_complete_peers: usize,
+    peers_with_route_payload: usize,
+}
+
+#[derive(Debug)]
+struct PermissiveExactExport;
+
+impl ExactExportSnapshot for PermissiveExactExport {
+    fn owner_id(&self) -> u64 {
+        1
+    }
+
+    fn generation(&self) -> u64 {
+        0
+    }
+
+    fn probe_announcement(
+        &self,
+        _candidate: ExactExportCandidate<'_>,
+    ) -> Result<ExactExportResult, ExactExportError> {
+        Ok(ExactExportResult {
+            encoded_len: 0,
+            max_len: usize::MAX,
+            generation: 0,
+        })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl ExactExportEncoder for PermissiveExactExport {
+    fn owner_id(&self) -> u64 {
+        1
+    }
+
+    fn snapshot(&self) -> Arc<dyn ExactExportSnapshot> {
+        Arc::new(Self)
+    }
+}
+
+fn parse_args() -> Result<Command, String> {
+    let mut raw = std::env::args().skip(1);
+    let mut command = None;
+    while let Some(argument) = raw.next() {
+        match argument.as_str() {
+            // Cargo passes this libtest-compatible marker to custom benches.
+            "--bench" => {}
+            "--mode" => {
+                if command.is_some() {
+                    return Err("choose exactly one of --mode or --self-test".into());
+                }
+                let value = raw.next().ok_or("--mode requires a value")?;
+                let mode = match value.as_str() {
+                    "control" | "control-no-release" => Mode::Control,
+                    "ipv4" | "ipv4-normal" => Mode::Ipv4,
+                    "dual" | "dual-normal" => Mode::Dual,
+                    "seven" | "seven-gate-normal" => Mode::Seven,
+                    "overflow" | "dual-overflow-withdrawal" => Mode::Overflow,
+                    _ => {
+                        return Err(format!(
+                            "unknown mode {value:?}; expected control, ipv4, dual, seven, or overflow"
+                        ));
+                    }
+                };
+                command = Some(Command::Run(mode));
+            }
+            "--self-test" => {
+                if command.is_some() {
+                    return Err("choose exactly one of --mode or --self-test".into());
+                }
+                command = Some(Command::SelfTest);
+            }
+            "--help" | "-h" => {
+                if command.is_some() {
+                    return Err("--help cannot be combined with another command".into());
+                }
+                command = Some(Command::Help);
+            }
+            _ => return Err(format!("unknown argument: {argument}")),
+        }
+    }
+    command.ok_or_else(|| "one of --mode, --self-test, or --help is required".into())
+}
+
+fn help() {
+    println!(
+        "selection_deferral_release --mode control|ipv4|dual|seven|overflow\n\
+         selection_deferral_release --self-test\n\n\
+         Fleet modes are fixed at 700 route-server peers and 400,400 total routes.\n\
+         --self-test is fixed at 4 peers and 64 routes and runs no fleet campaign."
+    );
+}
+
+fn mode_families(mode: Mode) -> (Families, Families) {
+    match mode {
+        Mode::Control | Mode::Ipv4 => (vec![IPV4_UNICAST], vec![IPV4_UNICAST]),
+        Mode::Dual | Mode::Overflow => (
+            vec![IPV4_UNICAST, IPV6_UNICAST],
+            vec![IPV4_UNICAST, IPV6_UNICAST],
+        ),
+        Mode::Seven => (SEVEN_GATES.to_vec(), vec![IPV4_UNICAST, IPV6_UNICAST]),
+    }
+}
+
+fn expected_counts(mode: Mode, total: usize) -> (usize, usize) {
+    match mode {
+        Mode::Control | Mode::Ipv4 => (total, 0),
+        Mode::Dual | Mode::Seven | Mode::Overflow => {
+            assert_eq!(total % 2, 0, "dual fixture requires an even route count");
+            (total / 2, total / 2)
+        }
+    }
+}
+
+fn prefix_v4(index: usize, filler: bool) -> Prefix {
+    let base = if filler { 0x3000_0000 } else { 0x0b00_0000 };
+    let host = base + u32::try_from(index).expect("IPv4 fixture index fits the address space");
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(host), 32))
+}
+
+fn prefix_v6(index: usize, filler: bool) -> Prefix {
+    let base = if filler {
+        0x2001_0db8_0001_0000_0000_0000_0000_0000u128
+    } else {
+        0x2001_0db8_0000_0000_0000_0000_0000_0000u128
+    };
+    Prefix::V6(Ipv6Prefix::new(
+        Ipv6Addr::from(
+            base + u128::try_from(index).expect("IPv6 fixture index fits the address space"),
+        ),
+        128,
+    ))
+}
+
+fn make_route(
+    prefix: Prefix,
+    index: usize,
+    peers: usize,
+    attributes: &Arc<Vec<rustbgpd_wire::PathAttribute>>,
+) -> Route {
+    let peer = RibManager::bench_peer_address(index % peers);
+    let next_hop = match prefix {
+        Prefix::V4(_) => IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+        Prefix::V6(_) => IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0xffff, 0, 0, 0, 0, 1)),
+    };
+    Route {
+        prefix,
+        next_hop,
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer,
+        attributes: Arc::clone(attributes),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(192, 0, 2, 1),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+fn routes(v4: usize, v6: usize, peers: usize, filler: bool) -> Vec<Route> {
+    let attributes = Arc::new(Vec::new());
+    let mut routes = Vec::with_capacity(v4.saturating_add(v6));
+    for index in 0..v4 {
+        routes.push(make_route(
+            prefix_v4(index, filler),
+            index,
+            peers,
+            &attributes,
+        ));
+    }
+    for index in 0..v6 {
+        routes.push(make_route(
+            prefix_v6(index, filler),
+            v4.saturating_add(index),
+            peers,
+            &attributes,
+        ));
+    }
+    routes
+}
+
+fn expected_checksum(count: usize, ipv6: bool) -> u64 {
+    (0..count).fold(0, |checksum, index| {
+        let prefix = if ipv6 {
+            prefix_v6(index, false)
+        } else {
+            prefix_v4(index, false)
+        };
+        checksum.wrapping_add(RibManager::bench_selection_deferral_prefix_checksum(prefix))
+    })
+}
+
+fn withdraw_inventory(manager: &mut RibManager, v4: usize, v6: usize, peers: usize, filler: bool) {
+    let mut by_peer: BTreeMap<IpAddr, Vec<(Prefix, u32)>> = BTreeMap::new();
+    for index in 0..v4 {
+        by_peer
+            .entry(RibManager::bench_peer_address(index % peers))
+            .or_default()
+            .push((prefix_v4(index, filler), 0));
+    }
+    for index in 0..v6 {
+        by_peer
+            .entry(RibManager::bench_peer_address(
+                v4.saturating_add(index) % peers,
+            ))
+            .or_default()
+            .push((prefix_v6(index, filler), 0));
+    }
+    for (peer, withdrawn) in by_peer {
+        manager.bench_withdraw_loc_rib(peer, withdrawn);
+    }
+}
+
+fn selection_config(peers: usize, families: &[(Afi, Safi)]) -> SelectionDeferralConfig {
+    SelectionDeferralConfig {
+        timeout: Duration::from_secs(60),
+        waiters: (0..peers)
+            .map(|index| SelectionDeferralWaiterConfig {
+                peer: RibManager::bench_peer_address(index),
+                families: families.to_vec(),
+            })
+            .collect(),
+    }
+}
+
+fn manager() -> (RibManager, mpsc::Sender<RibUpdate>, mpsc::Sender<RibUpdate>) {
+    let (update_tx, update_rx) = mpsc::channel(8);
+    let (query_tx, query_rx) = mpsc::channel(8);
+    (
+        RibManager::new(update_rx, query_rx, None, None, BgpMetrics::new()),
+        update_tx,
+        query_tx,
+    )
+}
+
+fn drain_eor(
+    receivers: &mut [mpsc::Receiver<OutboundRouteUpdate>],
+    expected_families: &[(Afi, Safi)],
+) -> (usize, usize, usize) {
+    let expected = expected_families.iter().copied().collect::<HashSet<_>>();
+    let mut markers = 0usize;
+    let mut complete_peers = 0usize;
+    let mut peers_with_routes = 0usize;
+    for receiver in receivers {
+        let mut seen = HashSet::new();
+        let mut route_payload = false;
+        while let Ok(update) = receiver.try_recv() {
+            route_payload |= !update.announce.is_empty();
+            for family in update.end_of_rib {
+                assert!(
+                    seen.insert(family),
+                    "one release delivered duplicate EoR for {family:?}"
+                );
+                markers = markers.saturating_add(1);
+            }
+        }
+        complete_peers = complete_peers.saturating_add(usize::from(seen == expected));
+        peers_with_routes = peers_with_routes.saturating_add(usize::from(route_payload));
+    }
+    (markers, complete_peers, peers_with_routes)
+}
+
+fn run(mode: Mode, peers: usize, total_routes: usize) -> Receipt {
+    let (gated_families, sendable_families) = mode_families(mode);
+    let (expected_v4, expected_v6) = expected_counts(mode, total_routes);
+    let expected_v4_checksum = expected_checksum(expected_v4, false);
+    let expected_v6_checksum = expected_checksum(expected_v6, true);
+    let (mut manager, _update_tx, query_tx) = manager();
+
+    if mode.is_overflow() {
+        manager.bench_seed_loc_rib(routes(expected_v4, expected_v6, peers, false));
+        manager = manager.with_selection_deferral(selection_config(peers, &gated_families));
+    } else {
+        // The control is intentionally the exact gated setup with only the
+        // expiry call omitted; its sentinel observes the still-frozen table.
+        manager = manager.with_selection_deferral(selection_config(peers, &gated_families));
+    }
+
+    let mut receivers = manager.bench_register_selection_deferral_route_server_peers(
+        peers,
+        &gated_families,
+        &sendable_families,
+        gated_families.len().saturating_add(4),
+        |_| Arc::new(PermissiveExactExport),
+    );
+
+    if mode.is_overflow() {
+        withdraw_inventory(&mut manager, expected_v4, expected_v6, peers, false);
+        let accepted_filler = LEDGER_IDENTITY_LIMIT
+            .checked_sub(total_routes)
+            .expect("overflow fixture total stays below the production identity limit");
+        let filler_v4 = accepted_filler / 2 + peers;
+        let filler_v6 = accepted_filler - accepted_filler / 2 + peers;
+        manager.bench_seed_loc_rib(routes(filler_v4, filler_v6, peers, true));
+        withdraw_inventory(&mut manager, filler_v4, filler_v6, peers, true);
+    } else {
+        manager.bench_seed_loc_rib(routes(expected_v4, expected_v6, peers, false));
+        // Setup fanout belongs outside both the release timer and its control.
+        for receiver in &mut receivers {
+            while receiver.try_recv().is_ok() {}
+        }
+    }
+
+    let before = manager.bench_selection_deferral_inventory();
+    let release = manager.bench_selection_deferral_release_with_sentinel(
+        &query_tx,
+        &gated_families,
+        RibManager::bench_peer_address(0),
+        mode.expires(),
+    );
+    let after = manager.bench_selection_deferral_inventory();
+    let expected_eor = if mode.expires() {
+        sendable_families.as_slice()
+    } else {
+        &[]
+    };
+    let (eor_markers, eor_complete_peers, peers_with_route_payload) =
+        drain_eor(&mut receivers, expected_eor);
+
+    Receipt {
+        mode: mode.label().into(),
+        peers,
+        expected_v4,
+        expected_v6,
+        expected_v4_checksum,
+        expected_v6_checksum,
+        gated_families: gated_families.len(),
+        sendable_families: sendable_families.len(),
+        before,
+        after,
+        release,
+        eor_markers,
+        eor_complete_peers,
+        peers_with_route_payload,
+    }
+}
+
+fn validate(receipt: &Receipt) -> Result<(), String> {
+    let mode = match receipt.mode.as_str() {
+        "control_no_release" => Mode::Control,
+        "ipv4_normal" => Mode::Ipv4,
+        "dual_normal" => Mode::Dual,
+        "seven_gate_normal" => Mode::Seven,
+        "dual_overflow_withdrawal" => Mode::Overflow,
+        other => return Err(format!("unknown receipt mode {other:?}")),
+    };
+    let expected_total = receipt.expected_v4.saturating_add(receipt.expected_v6);
+    let expect_source_rows = |inventory: &[u64; 12], populated: bool| -> Result<(), String> {
+        if inventory[SOURCE_STORES] != receipt.peers as u64 {
+            return Err("source-store count mismatch".into());
+        }
+        let expected_nonempty = if populated { receipt.peers as u64 } else { 0 };
+        if inventory[NONEMPTY_SOURCE_STORES] != expected_nonempty {
+            return Err("nonempty source-store count mismatch".into());
+        }
+        let expected_min = if populated {
+            (expected_total / receipt.peers) as u64
+        } else {
+            0
+        };
+        let expected_max = if populated {
+            expected_total.div_ceil(receipt.peers) as u64
+        } else {
+            0
+        };
+        if inventory[MIN_SOURCE_ROUTES] != expected_min
+            || inventory[MAX_SOURCE_ROUTES] != expected_max
+        {
+            return Err("per-source distribution mismatch".into());
+        }
+        Ok(())
+    };
+
+    let expected_adj_populated = !mode.is_overflow();
+    expect_source_rows(&receipt.before, expected_adj_populated)?;
+    expect_source_rows(&receipt.after, expected_adj_populated)?;
+    let (adj_v4, adj_v4_checksum, adj_v6, adj_v6_checksum) = if expected_adj_populated {
+        (
+            receipt.expected_v4 as u64,
+            receipt.expected_v4_checksum,
+            receipt.expected_v6 as u64,
+            receipt.expected_v6_checksum,
+        )
+    } else {
+        (0, 0, 0, 0)
+    };
+    for inventory in [&receipt.before, &receipt.after] {
+        if inventory[ADJ_V4_ROUTES] != adj_v4
+            || inventory[ADJ_V4_CHECKSUM] != adj_v4_checksum
+            || inventory[ADJ_V6_ROUTES] != adj_v6
+            || inventory[ADJ_V6_CHECKSUM] != adj_v6_checksum
+        {
+            return Err("Adj-RIB-In count/checksum mismatch".into());
+        }
+    }
+
+    let before_loc_populated = mode.is_overflow();
+    let before_expected = if before_loc_populated {
+        (
+            receipt.expected_v4 as u64,
+            receipt.expected_v4_checksum,
+            receipt.expected_v6 as u64,
+            receipt.expected_v6_checksum,
+        )
+    } else {
+        (0, 0, 0, 0)
+    };
+    if (
+        receipt.before[LOC_V4_ROUTES],
+        receipt.before[LOC_V4_CHECKSUM],
+        receipt.before[LOC_V6_ROUTES],
+        receipt.before[LOC_V6_CHECKSUM],
+    ) != before_expected
+    {
+        return Err("pre-release Loc-RIB count/checksum mismatch".into());
+    }
+    let after_expected = if mode.is_overflow() || matches!(mode, Mode::Control) {
+        (0, 0, 0, 0)
+    } else {
+        (
+            receipt.expected_v4 as u64,
+            receipt.expected_v4_checksum,
+            receipt.expected_v6 as u64,
+            receipt.expected_v6_checksum,
+        )
+    };
+    if (
+        receipt.after[LOC_V4_ROUTES],
+        receipt.after[LOC_V4_CHECKSUM],
+        receipt.after[LOC_V6_ROUTES],
+        receipt.after[LOC_V6_CHECKSUM],
+    ) != after_expected
+    {
+        return Err("post-release Loc-RIB count/checksum mismatch".into());
+    }
+    let expected_sentinel = after_expected.0.saturating_add(after_expected.2);
+    if receipt.release[SENTINEL_COUNT] != expected_sentinel {
+        return Err("sentinel Loc-RIB count mismatch".into());
+    }
+    if receipt.release[PRIMARY_DEPTH] != 0
+        || receipt.release[QUERY_DEPTH_BEFORE] != 1
+        || receipt.release[QUERY_DEPTH_AFTER] != 0
+    {
+        return Err("actor/query depth contract mismatch".into());
+    }
+    if receipt.release[SENTINEL_NS] < receipt.release[RELEASE_NS] {
+        return Err("sentinel latency is shorter than release duration".into());
+    }
+    let expected_gates = receipt.gated_families as u64;
+    if mode.expires() {
+        if receipt.release[RELEASE_DELTA] != expected_gates
+            || receipt.release[TIMEOUT_DELTA] != expected_gates
+            || receipt.release[ACTIVE_GATES] != 0
+            || receipt.release[RELEASED_GATES] != expected_gates
+            || receipt.release[TIMER_GATES] != expected_gates
+            || receipt.release[OBSERVED_GATES] != expected_gates
+        {
+            return Err("release/timeout/gate state mismatch".into());
+        }
+        if receipt.release[LEDGER_CLEARED] != 1 {
+            return Err("selection-deferral ledger was not cleared".into());
+        }
+    } else if receipt.release[RELEASE_DELTA] != 0
+        || receipt.release[TIMEOUT_DELTA] != 0
+        || receipt.release[ACTIVE_GATES] != expected_gates
+        || receipt.release[RELEASED_GATES] != 0
+        || receipt.release[TIMER_GATES] != 0
+        || receipt.release[OBSERVED_GATES] != expected_gates
+        || receipt.release[LEDGER_CLEARED] != 0
+    {
+        return Err("no-release control state mismatch".into());
+    }
+    let expected_overflows = if mode.is_overflow() { 2 } else { 0 };
+    if receipt.release[OVERFLOWS_BEFORE] != expected_overflows {
+        return Err("overflow mode/counter mismatch".into());
+    }
+    let expected_eor_markers = if mode.expires() {
+        receipt.peers.saturating_mul(receipt.sendable_families)
+    } else {
+        0
+    };
+    if receipt.eor_markers != expected_eor_markers || receipt.eor_complete_peers != receipt.peers {
+        return Err("EoR delivery mismatch".into());
+    }
+    let expected_route_peers = if mode.expires() && !mode.is_overflow() && expected_total > 1 {
+        receipt.peers
+    } else {
+        0
+    };
+    if receipt.peers_with_route_payload != expected_route_peers {
+        return Err("released route payload delivery mismatch".into());
+    }
+    Ok(())
+}
+
+fn assert_rejected(label: &str, receipt: &Receipt, mutate: impl FnOnce(&mut Receipt)) {
+    let mut corrupted = receipt.clone();
+    mutate(&mut corrupted);
+    assert!(
+        validate(&corrupted).is_err(),
+        "self-test corruption {label:?} was not rejected"
+    );
+}
+
+fn self_test() {
+    let receipt = run(Mode::Seven, SELF_TEST_PEERS, SELF_TEST_ROUTES);
+    validate(&receipt).expect("uncorrupted self-test receipt validates");
+    assert_rejected("query_depth", &receipt, |row| {
+        row.release[QUERY_DEPTH_BEFORE] = 2;
+    });
+    assert_rejected("count", &receipt, |row| {
+        row.after[LOC_V4_ROUTES] = row.after[LOC_V4_ROUTES].saturating_add(1);
+    });
+    assert_rejected("checksum", &receipt, |row| {
+        row.after[LOC_V6_CHECKSUM] ^= 1;
+    });
+    assert_rejected("mode", &receipt, |row| {
+        row.mode = "unknown".into();
+    });
+    assert_rejected("missing_eor", &receipt, |row| {
+        row.eor_markers = row.eor_markers.saturating_sub(1);
+    });
+    assert_rejected("uncleared_state", &receipt, |row| {
+        row.release[LEDGER_CLEARED] = 0;
+    });
+    assert_rejected("release_counter", &receipt, |row| {
+        row.release[RELEASE_DELTA] = row.release[RELEASE_DELTA].saturating_sub(1);
+    });
+
+    let control = run(Mode::Control, SELF_TEST_PEERS, SELF_TEST_ROUTES);
+    validate(&control).expect("same-setup no-release control validates");
+    println!(
+        "{{\"self_test\":\"pass\",\"peers\":{SELF_TEST_PEERS},\"routes\":{SELF_TEST_ROUTES},\"corruptions_rejected\":7}}"
+    );
+}
+
+fn print_receipt(receipt: &Receipt) {
+    println!(
+        "{{\"mode\":\"{}\",\"peers\":{},\"expected_v4\":{},\"expected_v6\":{},\"expected_v4_checksum\":{},\"expected_v6_checksum\":{},\"gated_families\":{},\"sendable_families\":{},\"before\":{:?},\"after\":{:?},\"release\":{:?},\"eor_markers\":{},\"eor_complete_peers\":{},\"peers_with_route_payload\":{}}}",
+        receipt.mode,
+        receipt.peers,
+        receipt.expected_v4,
+        receipt.expected_v6,
+        receipt.expected_v4_checksum,
+        receipt.expected_v6_checksum,
+        receipt.gated_families,
+        receipt.sendable_families,
+        receipt.before,
+        receipt.after,
+        receipt.release,
+        receipt.eor_markers,
+        receipt.eor_complete_peers,
+        receipt.peers_with_route_payload,
+    );
+}
+
+fn main() {
+    match parse_args() {
+        Ok(Command::Help) => help(),
+        Ok(Command::SelfTest) => self_test(),
+        Ok(Command::Run(mode)) => {
+            let receipt = run(mode, FLEET_PEERS, FLEET_ROUTES);
+            if let Err(error) = validate(&receipt) {
+                eprintln!("selection-deferral receipt rejected: {error}");
+                std::process::exit(1);
+            }
+            print_receipt(&receipt);
+        }
+        Err(error) => {
+            eprintln!("selection_deferral_release: {error}");
+            eprintln!("use --help for usage");
+            std::process::exit(2);
+        }
+    }
+}

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -51,6 +51,24 @@ pub struct DataplanePrefixIndexBenchReceipt {
     pub index_bytes: usize,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct SelectionDeferralFamilyInventoryBenchReceipt {
+    routes: usize,
+    checksum: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct SelectionDeferralInventoryBenchReceipt {
+    loc_ipv4: SelectionDeferralFamilyInventoryBenchReceipt,
+    loc_ipv6: SelectionDeferralFamilyInventoryBenchReceipt,
+    adj_ipv4: SelectionDeferralFamilyInventoryBenchReceipt,
+    adj_ipv6: SelectionDeferralFamilyInventoryBenchReceipt,
+    source_stores: usize,
+    nonempty_source_stores: usize,
+    min_routes_per_source: usize,
+    max_routes_per_source: usize,
+}
+
 static POLICY_TRANSITION_RECEIPT_PRINTED: AtomicBool = AtomicBool::new(false);
 static PCB_ENUMERATION_PHASES: AtomicUsize = AtomicUsize::new(0);
 static PCB_ENUMERATED_PREFIXES: AtomicUsize = AtomicUsize::new(0);
@@ -198,6 +216,57 @@ fn bench_add_duration(total: &AtomicU64, elapsed: std::time::Duration) {
     });
 }
 
+fn selection_deferral_prefix_checksum(prefix: Prefix) -> u64 {
+    let raw = match prefix {
+        Prefix::V4(prefix) => {
+            u64::from(u32::from(prefix.addr))
+                ^ (u64::from(prefix.len) << 32)
+                ^ 0x04d5_1ec7_10a7_0001
+        }
+        Prefix::V6(prefix) => {
+            let address = u128::from(prefix.addr);
+            u64::try_from(address >> 64).expect("upper IPv6 half fits u64")
+                ^ u64::try_from(address & u128::from(u64::MAX)).expect("lower IPv6 half fits u64")
+                ^ (u64::from(prefix.len) << 48)
+                ^ 0x06d5_1ec7_10a7_0001
+        }
+    };
+    let mut mixed = raw.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    mixed ^ (mixed >> 31)
+}
+
+fn selection_deferral_add_inventory(
+    receipt: &mut SelectionDeferralFamilyInventoryBenchReceipt,
+    prefix: Prefix,
+) {
+    receipt.routes = receipt.routes.saturating_add(1);
+    receipt.checksum = receipt
+        .checksum
+        .wrapping_add(selection_deferral_prefix_checksum(prefix));
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Prometheus integer counters are exactly representable at benchmark scale"
+)]
+fn selection_deferral_counter_total(metrics: &rustbgpd_telemetry::BgpMetrics, name: &str) -> u64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .map_or(0, |family| {
+            family
+                .get_metric()
+                .iter()
+                .map(|metric| metric.get_counter().value() as u64)
+                .sum()
+        })
+}
+
 pub(in crate::manager) fn bench_record_per_client_best_candidates(
     cardinality: usize,
     heap_backed: bool,
@@ -296,6 +365,265 @@ pub struct AdjRibOutFanoutBenchReceipt {
 }
 
 impl RibManager {
+    /// Stable checksum contribution shared by the selection-deferral fixture
+    /// generator and the actor-owned inventory walk.
+    #[must_use]
+    pub fn bench_selection_deferral_prefix_checksum(prefix: Prefix) -> u64 {
+        selection_deferral_prefix_checksum(prefix)
+    }
+
+    /// Register one GR-waiting eBGP route-server session per synthetic peer.
+    /// The returned receivers retain release-time payloads and `EoR`s; only any
+    /// registration-time envelope is drained.
+    ///
+    /// # Panics
+    ///
+    /// Panics for an empty peer/family fixture, a peer index outside the
+    /// benchmark address space, or an invalid channel capacity.
+    #[must_use]
+    pub fn bench_register_selection_deferral_route_server_peers<F>(
+        &mut self,
+        n_peers: usize,
+        gate_families: &[(Afi, Safi)],
+        sendable_families: &[(Afi, Safi)],
+        channel_capacity: usize,
+        mut make_exact_export_encoder: F,
+    ) -> Vec<mpsc::Receiver<OutboundRouteUpdate>>
+    where
+        F: FnMut(u32) -> Arc<dyn ExactExportEncoder>,
+    {
+        assert!(n_peers > 0, "selection-deferral fixture needs peers");
+        assert!(
+            !gate_families.is_empty(),
+            "selection-deferral fixture needs gate families"
+        );
+        assert!(
+            !sendable_families.is_empty(),
+            "selection-deferral fixture needs sendable families"
+        );
+        let mut receivers = Vec::with_capacity(n_peers);
+        for index in 0..n_peers {
+            let peer = Self::bench_peer_address(index);
+            let session_id = u64::try_from(index)
+                .expect("bench peer index fits u64")
+                .saturating_add(1);
+            let peer_asn = 4_200_000_000u32
+                .saturating_add(u32::try_from(index).expect("bench peer index fits u32"));
+            self.handle_update(RibUpdate::SetPeerGracefulRestartContext {
+                peer,
+                session_id,
+                peer_restart_state: false,
+                peer_gr_families: gate_families.to_vec(),
+                peer_enhanced_refresh: true,
+            });
+            let (outbound_tx, mut outbound_rx) = mpsc::channel(channel_capacity);
+            self.pending_peer_export_encoders
+                .insert((peer, session_id), make_exact_export_encoder(peer_asn));
+            self.handle_peer_up(
+                peer,
+                session_id,
+                peer_asn,
+                Ipv4Addr::new(192, 0, 2, 1),
+                outbound_tx,
+                None,
+                sendable_families.to_vec(),
+                true,
+                false,
+                None,
+                false,
+                false,
+                Vec::new(),
+                0,
+                Vec::new(),
+                Vec::new(),
+            );
+            while outbound_rx.try_recv().is_ok() {}
+            receivers.push(outbound_rx);
+        }
+        receivers
+    }
+
+    /// Return exact commutative checksums and source-store occupancy without
+    /// cloning any route shell. The stable array layout is documented by the
+    /// sole bench target that consumes this feature-gated seam.
+    ///
+    /// # Panics
+    ///
+    /// Panics only on a platform whose `usize` route count exceeds `u64`.
+    #[must_use]
+    pub fn bench_selection_deferral_inventory(&self) -> [u64; 12] {
+        let mut receipt = SelectionDeferralInventoryBenchReceipt {
+            source_stores: self.ribs.len(),
+            min_routes_per_source: usize::MAX,
+            ..SelectionDeferralInventoryBenchReceipt::default()
+        };
+        for route in self.loc_rib.iter() {
+            match route.prefix {
+                Prefix::V4(_) => {
+                    selection_deferral_add_inventory(&mut receipt.loc_ipv4, route.prefix);
+                }
+                Prefix::V6(_) => {
+                    selection_deferral_add_inventory(&mut receipt.loc_ipv6, route.prefix);
+                }
+            }
+        }
+        for rib in self.ribs.values() {
+            let rows = rib.len();
+            if rows > 0 {
+                receipt.nonempty_source_stores = receipt.nonempty_source_stores.saturating_add(1);
+            }
+            receipt.min_routes_per_source = receipt.min_routes_per_source.min(rows);
+            receipt.max_routes_per_source = receipt.max_routes_per_source.max(rows);
+            for route in rib.iter() {
+                match route.prefix {
+                    Prefix::V4(_) => {
+                        selection_deferral_add_inventory(&mut receipt.adj_ipv4, route.prefix);
+                    }
+                    Prefix::V6(_) => {
+                        selection_deferral_add_inventory(&mut receipt.adj_ipv6, route.prefix);
+                    }
+                }
+            }
+        }
+        if self.ribs.is_empty() {
+            receipt.min_routes_per_source = 0;
+        }
+        [
+            u64::try_from(receipt.loc_ipv4.routes).expect("route count fits u64"),
+            receipt.loc_ipv4.checksum,
+            u64::try_from(receipt.loc_ipv6.routes).expect("route count fits u64"),
+            receipt.loc_ipv6.checksum,
+            u64::try_from(receipt.adj_ipv4.routes).expect("route count fits u64"),
+            receipt.adj_ipv4.checksum,
+            u64::try_from(receipt.adj_ipv6.routes).expect("route count fits u64"),
+            receipt.adj_ipv6.checksum,
+            u64::try_from(receipt.source_stores).expect("source-store count fits u64"),
+            u64::try_from(receipt.nonempty_source_stores).expect("source-store count fits u64"),
+            u64::try_from(receipt.min_routes_per_source).expect("source rows fit u64"),
+            u64::try_from(receipt.max_routes_per_source).expect("source rows fit u64"),
+        ]
+    }
+
+    fn bench_selection_deferral_ledger_cleared(&self) -> bool {
+        // `DeferredSelectionKeys` deliberately exposes no production
+        // introspection. Its derived Debug is exhaustive over every retained
+        // set/map/byte counter; compare that state to a fresh ledger while
+        // ignoring the fixture-local limit value.
+        fn without_limits(debug: &str) -> &str {
+            debug
+                .split_once(", limits:")
+                .map_or(debug, |(state, _)| state)
+        }
+        let actual = format!("{:?}", self.deferred_selection_keys);
+        let empty = format!(
+            "{:?}",
+            super::selection_deferral::DeferredSelectionKeys::default()
+        );
+        without_limits(&actual) == without_limits(&empty)
+    }
+
+    /// Queue one Loc-RIB-count sentinel, time the exact production expiry
+    /// call, then serve the sentinel through the production general-query drain.
+    /// `expire = false` is the same-setup control.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless primary updates and general queries are empty before the
+    /// sentinel is queued, its depth becomes exactly one, the query replies
+    /// synchronously, or the release leaves inconsistent gate/counter state.
+    #[must_use]
+    pub fn bench_selection_deferral_release_with_sentinel(
+        &mut self,
+        query_tx: &mpsc::Sender<RibUpdate>,
+        families: &[(Afi, Safi)],
+        snapshot_peer: IpAddr,
+        expire: bool,
+    ) -> [u64; 14] {
+        let primary_depth_before = self.rx.len();
+        assert_eq!(primary_depth_before, 0, "primary update lane must be empty");
+        assert_eq!(
+            self.query_rx.len(),
+            0,
+            "general query lane must start empty"
+        );
+
+        let releases_before = selection_deferral_counter_total(
+            &self.metrics,
+            "bgp_selection_deferral_releases_total",
+        );
+        let timeouts_before = selection_deferral_counter_total(
+            &self.metrics,
+            "bgp_selection_deferral_timeouts_total",
+        );
+        let overflows_before = selection_deferral_counter_total(
+            &self.metrics,
+            "bgp_selection_deferral_ledger_overflows_total",
+        );
+        let (reply, mut response) = oneshot::channel();
+        let sentinel_started = std::time::Instant::now();
+        query_tx
+            .try_send(RibUpdate::QueryLocRibCount { reply })
+            .expect("general query channel has one reserved sentinel slot");
+        let query_depth_before = self.query_rx.len();
+        assert_eq!(
+            query_depth_before, 1,
+            "exactly one sentinel query must be queued"
+        );
+        let release_duration = if expire {
+            let release_started = std::time::Instant::now();
+            self.expire_selection_deferral();
+            release_started.elapsed()
+        } else {
+            std::time::Duration::ZERO
+        };
+        self.drain_queries(1);
+        let sentinel_latency = sentinel_started.elapsed();
+        let sentinel_loc_rib_count = response
+            .try_recv()
+            .expect("Loc-RIB-count sentinel replies through the query drain");
+        let query_depth_after = self.query_rx.len();
+
+        let rows = self
+            .selection_deferral
+            .as_ref()
+            .map_or_else(Vec::new, |selection| selection.peer_snapshot(snapshot_peer));
+        let relevant = rows
+            .iter()
+            .filter(|row| families.contains(&(row.afi, row.safi)))
+            .collect::<Vec<_>>();
+        let active_gates_after = relevant.iter().filter(|row| row.active).count();
+        let released_gates_after = relevant.iter().filter(|row| !row.active).count();
+        let timer_released_gates_after = relevant
+            .iter()
+            .filter(|row| !row.active && row.release_reason == "timer")
+            .count();
+        let releases_after = selection_deferral_counter_total(
+            &self.metrics,
+            "bgp_selection_deferral_releases_total",
+        );
+        let timeouts_after = selection_deferral_counter_total(
+            &self.metrics,
+            "bgp_selection_deferral_timeouts_total",
+        );
+
+        [
+            u64::try_from(release_duration.as_nanos()).unwrap_or(u64::MAX),
+            u64::try_from(sentinel_latency.as_nanos()).unwrap_or(u64::MAX),
+            u64::try_from(sentinel_loc_rib_count).expect("Loc-RIB count fits u64"),
+            u64::try_from(primary_depth_before).expect("channel depth fits u64"),
+            u64::try_from(query_depth_before).expect("channel depth fits u64"),
+            u64::try_from(query_depth_after).expect("channel depth fits u64"),
+            releases_after.saturating_sub(releases_before),
+            timeouts_after.saturating_sub(timeouts_before),
+            u64::try_from(active_gates_after).expect("gate count fits u64"),
+            u64::try_from(released_gates_after).expect("gate count fits u64"),
+            u64::try_from(timer_released_gates_after).expect("gate count fits u64"),
+            u64::from(self.bench_selection_deferral_ledger_cleared()),
+            u64::try_from(relevant.len()).expect("gate count fits u64"),
+            overflows_before,
+        ]
+    }
+
     /// Populate the manager's actual production prefix-to-announcing-peers
     /// index from prebuilt keys. The caller can therefore place prefix/input
     /// construction before an allocator baseline and isolate index growth.

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -25,7 +25,7 @@ WORKFLOWS = tuple(
                  "release-install-contract", "release", "update-group-fault")
 )
 EXPECTED_ROOT_COMMANDS = {
-    WORKFLOWS[0]: Counter(build=1, check=6, clippy=2, doc=2, test=6),
+    WORKFLOWS[0]: Counter(build=1, check=6, clippy=2, doc=2, test=7),
     WORKFLOWS[1]: Counter(test=1),
     WORKFLOWS[2]: Counter(test=6),
     WORKFLOWS[3]: Counter(build=1, test=2),


### PR DESCRIPTION
Adds a bench-only harness for the mass selection-deferral release path, which had no measurement despite releasing every gated family in a single RIB actor turn with a complete Adj-RIB-In sweep per family.

## Scope

Three files, all bench-only:

- `crates/rib/Cargo.toml`
- `crates/rib/src/manager/bench_support.rs`
- `crates/rib/benches/selection_deferral_release.rs`

No production pacing, actor behavior, telemetry, or documentation change.

## Design

The harness drives the existing synchronous release and drain seams at fixed 700-peer / 400,400-route fleet shapes: single-family, dual-family, seven-gate, and overflow-withdrawal, plus a same-gated no-release control that separates setup cost from release cost.

Each run queues one Loc-RIB-count sentinel before release with query depth exactly one, times the entire synchronous release, then services the sentinel through the existing query-drain path. Receipts carry exact cardinalities, checksums, EoR markers, counter deltas, and gate state, so a run that measures the wrong thing fails rather than reporting a number.

## Validation

- `just gate` green in a worktree rebased onto current `main`: link check, developer tooling, `cargo fmt --check`, clippy-reasons, v1-stable-surface, tracker IDs, IXP docs, release-checklist paths, metric consumers, `cargo clippy --locked --workspace --all-targets -- -D warnings`, `cargo test --locked --workspace`, `cargo doc`
- `just gate-rib` green
- bounded 4-peer/64-route self-test passes and rejects all seven intentional receipt corruptions
- invalid `--mode` exits 2

Linear: LAN-1188