### PR TITLE
feat(bench): add pinned-kernel netns calibration harness

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -9,6 +9,14 @@ binary tarballs, and the default (runtime) container image. The
 only with `--workspace` and ship only in the `dev` image target used
 by the interop/soak labs.
 
+## Pinned-kernel netns calibration
+
+`netns-calibration/` is the offline-verifiable QEMU/KVM boundary for
+timing-sensitive Linux netlink receipts that need exact kernel and iproute2
+identities. It uses closed, dated Ubuntu 22.04/24.04 cloud-image tuples, never
+mistakes a Docker container for a kernel matrix, and ships no production code.
+See [`netns-calibration/README.md`](netns-calibration/README.md).
+
 ## evpn-load
 
 `evpn-load/` is the EVPN scale load generator — a deliberately minimal

--- a/bench/netns-calibration/README.md
+++ b/bench/netns-calibration/README.md
@@ -1,0 +1,87 @@
+# Pinned-kernel netns calibration
+
+This directory provides the offline-verifiable VM boundary required before a
+timing-sensitive Linux netlink receipt can compare kernels. It does not contain
+the raw-bridge MAC+IP skew campaign itself and does not change production
+behavior.
+
+The ordinary Docker netns harness isolates privileged tests and cleans their
+namespaces, but its containers share the host kernel. This runner instead boots
+one of two closed, dated Ubuntu cloud-image tuples under QEMU/KVM:
+
+| Profile | Official image | Kernel | iproute2 |
+| --- | --- | --- | --- |
+| `baseline-jammy-5.15` | Ubuntu 22.04 release 20260826 | `5.15.0-190-generic` | `5.15.0-1ubuntu2.2` |
+| `current-noble-6.8` | Ubuntu 24.04 release 20260826 | `6.8.0-138-generic` | `6.1.0-1ubuntu6.4` |
+
+`profiles.json` pins each dated URL, image SHA-256, guest package identity,
+QEMU/cloud-image-utils package identity and approved Debian artifact hash, and
+the fixed VM shape. The runner checks installed files against dpkg metadata and
+executes only the package-owned `/usr/bin/qemu-system-x86_64` and
+`/usr/bin/cloud-localds` paths, ignoring same-named commands earlier in
+`PATH`. It retains those paths and the actual tool-binary hashes. The verifier also
+contains the exact closed tuples, so editing the data file cannot silently add
+an arbitrary kernel. The Ubuntu image files are inputs: `run-vm.sh` never
+downloads, installs, or updates anything.
+
+## Boundary
+
+Run the host script as the normal user. It requires read/write access to
+`/dev/kvm`; it deliberately refuses software emulation and must not be run
+through `sudo`. The only elevated context is root inside the disposable guest.
+That guest receives no NIC, host home, repository, credentials, or ambient host
+environment. It sees only a fresh read-only payload share and a fresh writable
+guest-receipt directory.
+
+The QEMU disk is in snapshot mode, so guest writes go to a temporary overlay.
+The host verifies the base image before and after the run. A process-group trap
+terminates QEMU and removes the seed/payload directory on every exit. The guest
+independently creates and deletes one netns containing a VLAN-filtering bridge,
+two veth pairs, and VLAN 10/20 membership, then requires the exact pre-run netns
+inventory before reporting success.
+
+Before QEMU starts, the runner requires:
+
+- the exact approved image SHA-256 and exact pinned host package versions;
+- a clean checkout whose `HEAD` equals `origin/main`;
+- the shared nonblocking rustbgpd host lock; and
+- two accepted quiet-host samples at least 30 seconds apart.
+
+The output is closed to `request.json`, `host.json`, `plan.json`, `quiet.tsv`,
+`console.log`, `guest/guest.json`, `guest/kernel.config`, and a final
+`SHA256SUMS`. The verifier rejects missing, extra, symlinked, oversized,
+unsanitized, or cross-profile artifacts. The manifest is written only after an
+explicit post-VM base-image check; the EXIT trap repeats that check and removes
+the manifest on every nonzero outcome, so an unsuccessful run stays unsealed.
+
+## Invocation
+
+After an independent review has authorized a live smoke and the exact image is
+already present locally:
+
+```bash
+bench/netns-calibration/run-vm.sh \
+  baseline-jammy-5.15 \
+  /path/to/ubuntu-22.04-server-cloudimg-amd64.img \
+  /path/to/fresh-baseline-receipt
+```
+
+Repeat with `current-noble-6.8` and its pinned image. A successful environment
+smoke proves only that the version-pinned privileged netns boundary works. The
+later raw-bridge calibration must separately predeclare workload parameters,
+timestamp decoded messages on the single `RTNLGRP_NEIGH` stream, run real
+ARP/ND under serial and burst profiles, and publish its own bounded
+`run.json`/`samples.csv`/`report.json` receipt.
+
+## Offline verification
+
+No QEMU package, image, KVM access, network, Docker daemon, or privilege is
+needed for the Stage-A contract suite:
+
+```bash
+bash bench/tests/test-netns-calibration-vm.sh
+```
+
+The suite destructively proves the closed profile matrix, exact no-network KVM
+plan, source lifecycle anchors, guest failure cleanup, provenance binding,
+artifact inventory and size limits, sanitation, and final manifest.

--- a/bench/netns-calibration/guest-smoke.sh
+++ b/bench/netns-calibration/guest-smoke.sh
@@ -48,8 +48,8 @@ inside_guest() {
     fi
 
     ip -n "$NETNS" link add rbgpbr0 type bridge vlan_filtering 1
-    ip -n "$NETNS" link add rbgpce10 type veth peer name rgbph10
-    ip -n "$NETNS" link add rbgpce20 type veth peer name rgbph20
+    ip -n "$NETNS" link add rbgpce10 type veth peer name rbgph10
+    ip -n "$NETNS" link add rbgpce20 type veth peer name rbgph20
     ip -n "$NETNS" link set rbgpce10 master rbgpbr0
     ip -n "$NETNS" link set rbgpce20 master rbgpbr0
     ip netns exec "$NETNS" bridge vlan add dev rbgpce10 vid 10 pvid untagged

--- a/bench/netns-calibration/guest-smoke.sh
+++ b/bench/netns-calibration/guest-smoke.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# cloud-init user-data and in-guest smoke for the pinned-kernel VM harness.
+set -euo pipefail
+
+NETNS=rustbgpd-cal-smoke
+NETNS_CREATED=false
+
+cleanup_guest() {
+    local rc=$?
+    if [ "$NETNS_CREATED" = true ]; then
+        ip netns del "$NETNS" >/dev/null 2>&1 || rc=1
+        NETNS_CREATED=false
+    fi
+    return "$rc"
+}
+
+inside_guest() {
+    if [ "$#" -ne 1 ]; then
+        echo "usage: guest-smoke.sh --inside RECEIPT_DIR" >&2
+        return 2
+    fi
+    local output=$1 before after kernel package_kernel package_iproute
+    local ip_path bridge_path ip_hash bridge_hash config_hash ip_version profile
+    if [ "${RUSTBGPD_GUEST_SMOKE_TEST_FAIL_AFTER_CREATE:-}" != 1 ]; then
+        [ "$(id -u)" -eq 0 ] || { echo "guest smoke must run as root" >&2; return 1; }
+    fi
+    if [ ! -d "$output" ] || [ -L "$output" ]; then
+        echo "bad guest receipt directory" >&2
+        return 1
+    fi
+    if [ -e "$output/guest.json" ] || [ -e "$output/kernel.config" ]; then
+        echo "guest receipt directory is not fresh" >&2
+        return 1
+    fi
+    if [ "${RUSTBGPD_GUEST_SMOKE_TEST_FAIL_AFTER_CREATE:-}" != 1 ]; then
+        if [ ! -r /mnt/payload/profiles.json ] || [ ! -r /mnt/payload/request.json ]; then
+            echo "guest payload is incomplete" >&2
+            return 1
+        fi
+    fi
+
+    before=$(ip netns list | LC_ALL=C sort)
+    trap cleanup_guest EXIT
+    ip netns add "$NETNS"
+    NETNS_CREATED=true
+    if [ "${RUSTBGPD_GUEST_SMOKE_TEST_FAIL_AFTER_CREATE:-}" = 1 ]; then
+        return 97
+    fi
+
+    ip -n "$NETNS" link add rbgpbr0 type bridge vlan_filtering 1
+    ip -n "$NETNS" link add rbgpce10 type veth peer name rgbph10
+    ip -n "$NETNS" link add rbgpce20 type veth peer name rgbph20
+    ip -n "$NETNS" link set rbgpce10 master rbgpbr0
+    ip -n "$NETNS" link set rbgpce20 master rbgpbr0
+    ip netns exec "$NETNS" bridge vlan add dev rbgpce10 vid 10 pvid untagged
+    ip netns exec "$NETNS" bridge vlan add dev rbgpce20 vid 20 pvid untagged
+    ip -n "$NETNS" link set rbgpbr0 up
+    ip -n "$NETNS" link set rbgpce10 up
+    ip -n "$NETNS" link set rbgpce20 up
+    # shellcheck disable=SC2016 # Expansion belongs to the in-netns shell.
+    ip netns exec "$NETNS" sh -c \
+        '[ "$(cat /sys/class/net/rbgpbr0/bridge/vlan_filtering)" = 1 ]'
+    ip netns exec "$NETNS" bridge vlan show dev rbgpce10 | grep -Eq '(^|[[:space:]])10([[:space:]]|$)'
+    ip netns exec "$NETNS" bridge vlan show dev rbgpce20 | grep -Eq '(^|[[:space:]])20([[:space:]]|$)'
+
+    ip netns delete "$NETNS"
+    NETNS_CREATED=false
+    trap - EXIT
+    after=$(ip netns list | LC_ALL=C sort)
+    [ "$after" = "$before" ] || { echo "guest netns inventory changed" >&2; return 1; }
+
+    kernel=$(uname -r)
+    [ -r "/boot/config-$kernel" ] || { echo "guest kernel config is unavailable" >&2; return 1; }
+    cp -- "/boot/config-$kernel" "$output/kernel.config.tmp"
+    mv -- "$output/kernel.config.tmp" "$output/kernel.config"
+    package_kernel=$(dpkg-query -W -f='${Version}' "linux-image-$kernel")
+    package_iproute=$(dpkg-query -W -f='${Version}' iproute2)
+    ip_path=$(command -v ip)
+    bridge_path=$(command -v bridge)
+    ip_hash=$(sha256sum -- "$ip_path"); ip_hash=${ip_hash%% *}
+    bridge_hash=$(sha256sum -- "$bridge_path"); bridge_hash=${bridge_hash%% *}
+    config_hash=$(sha256sum -- "$output/kernel.config"); config_hash=${config_hash%% *}
+    ip_version=$(ip -Version 2>&1)
+    profile=$(python3 -c 'import json; print(json.load(open("/mnt/payload/request.json"))["profile"])')
+
+    python3 - "$output/guest.json.tmp" "$profile" "$kernel" "$package_kernel" \
+        "$package_iproute" "$ip_version" "$ip_hash" "$bridge_hash" "$config_hash" \
+        "$(printf '%s' "$before" | sha256sum | cut -d' ' -f1)" \
+        "$(printf '%s' "$after" | sha256sum | cut -d' ' -f1)" <<'PY'
+import json, pathlib, sys
+(
+    output, profile, kernel, kernel_package, iproute_package, ip_version,
+    ip_hash, bridge_hash, config_hash, before_hash, after_hash,
+) = sys.argv[1:]
+payload = {
+    "after_netns_sha256": after_hash,
+    "before_netns_sha256": before_hash,
+    "bridge_binary_sha256": bridge_hash,
+    "ip_binary_sha256": ip_hash,
+    "ip_version_output": ip_version,
+    "iproute2_package_version": iproute_package,
+    "kernel_config_sha256": config_hash,
+    "kernel_package_version": kernel_package,
+    "kernel_release": kernel,
+    "profile": profile,
+    "schema": 1,
+    "smoke": {
+        "bridge_vlan_filtering": True,
+        "deterministic_cleanup": True,
+        "netns": True,
+        "veth": True,
+        "vlan_10": True,
+        "vlan_20": True,
+    },
+    "status": "pass",
+    "uid": 0,
+}
+pathlib.Path(output).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+    mv -- "$output/guest.json.tmp" "$output/guest.json"
+}
+
+bootstrap_guest() {
+    local rc=0
+    mkdir -p /mnt/payload /mnt/receipt
+    mount -t 9p -o trans=virtio,version=9p2000.L,ro payload /mnt/payload || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        mount -t 9p -o trans=virtio,version=9p2000.L receipt /mnt/receipt || rc=$?
+    fi
+    if [ "$rc" -eq 0 ]; then
+        env -i PATH=/usr/sbin:/usr/bin:/sbin:/bin \
+            /mnt/payload/guest-smoke.sh --inside /mnt/receipt || rc=$?
+    fi
+    sync || true
+    poweroff -f || true
+    return "$rc"
+}
+
+case ${1:-} in
+    --inside)
+        shift
+        inside_guest "$@"
+        ;;
+    "")
+        bootstrap_guest
+        ;;
+    *)
+        echo "unknown guest-smoke mode: $1" >&2
+        exit 2
+        ;;
+esac

--- a/bench/netns-calibration/profiles.json
+++ b/bench/netns-calibration/profiles.json
@@ -1,0 +1,51 @@
+{
+  "host_tools": {
+    "cloud_image_utils": {
+      "deb_sha256": "c4203167b5f2ccc8d7e2ff66f6ed5bb55d1ce467511d27732b91e1389e15cd9e",
+      "package": "cloud-image-utils",
+      "path": "/usr/bin/cloud-localds",
+      "version": "0.33-1"
+    },
+    "qemu_system_x86": {
+      "deb_sha256": "14602e262627adac030329d2cecfee5f6c0938b34566ff2ea2d4c9a9eb02430d",
+      "package": "qemu-system-x86",
+      "path": "/usr/bin/qemu-system-x86_64",
+      "version": "1:8.2.2+ds-0ubuntu1.18"
+    }
+  },
+  "profiles": [
+    {
+      "guest": {
+        "iproute2_package_version": "5.15.0-1ubuntu2.2",
+        "kernel_package_version": "5.15.0-190.200",
+        "kernel_release": "5.15.0-190-generic"
+      },
+      "name": "baseline-jammy-5.15",
+      "role": "baseline",
+      "source": {
+        "sha256": "c0a5af17e6c0f76351fe07e2fffef3011dab1facb8a8ed5701dcf648dabd4f0a",
+        "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260826/ubuntu-22.04-server-cloudimg-amd64.img"
+      }
+    },
+    {
+      "guest": {
+        "iproute2_package_version": "6.1.0-1ubuntu6.4",
+        "kernel_package_version": "6.8.0-138.138",
+        "kernel_release": "6.8.0-138-generic"
+      },
+      "name": "current-noble-6.8",
+      "role": "current",
+      "source": {
+        "sha256": "d0fe84bb5f80853425fa6be28e2c106f30104c3cfe8611933f2e65c9b63f0e30",
+        "url": "https://cloud-images.ubuntu.com/releases/noble/release-20260826/ubuntu-24.04-server-cloudimg-amd64.img"
+      }
+    }
+  ],
+  "schema": 1,
+  "vm": {
+    "machine": "pc-q35-8.2",
+    "memory_mib": 2048,
+    "timeout_seconds": 300,
+    "vcpus": 2
+  }
+}

--- a/bench/netns-calibration/run-vm.sh
+++ b/bench/netns-calibration/run-vm.sh
@@ -7,6 +7,10 @@ if [ "$EUID" -eq 0 ]; then
     exit 1
 fi
 
+for tool in python3 realpath setsid sha256sum timeout; do
+    command -v "$tool" >/dev/null || { echo "required tool is missing: $tool" >&2; exit 1; }
+done
+
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO=$(cd -- "$SCRIPT_DIR/../.." && pwd)
 PROFILES="$SCRIPT_DIR/profiles.json"
@@ -105,9 +109,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-for tool in setsid timeout sha256sum python3; do
-    command -v "$tool" >/dev/null || { echo "required tool is missing: $tool" >&2; exit 1; }
-done
 verify_dpkg_owned_tool() {
     local package=$1 path=$2 item owned=false
     if [ ! -f "$path" ] || [ -L "$path" ] || [ ! -x "$path" ]; then

--- a/bench/netns-calibration/run-vm.sh
+++ b/bench/netns-calibration/run-vm.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Run one closed pinned-kernel netns smoke in an isolated, networkless QEMU VM.
+set -euo pipefail
+
+if [ "$EUID" -eq 0 ]; then
+    echo "run pinned-kernel calibration as a normal user, never root" >&2
+    exit 1
+fi
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+PROFILES="$SCRIPT_DIR/profiles.json"
+VERIFIER="$SCRIPT_DIR/verify-receipt.py"
+GUEST="$SCRIPT_DIR/guest-smoke.sh"
+# shellcheck disable=SC1091 # REPO is resolved from this tracked script.
+source "$REPO/tests/soak/host-lock.sh"
+# shellcheck disable=SC1091 # REPO is resolved from this tracked script.
+source "$REPO/bench/scale/host-quiet.sh"
+
+usage() {
+    echo "usage: $0 PROFILE PINNED_CLOUD_IMAGE FRESH_RECEIPT_DIR" >&2
+}
+
+if [ "$#" -ne 3 ]; then
+    usage
+    exit 2
+fi
+PROFILE=$1
+IMAGE=$2
+OUTPUT=$3
+
+mapfile -t PROFILE_FIELDS < <(python3 "$VERIFIER" select "$PROFILES" "$PROFILE")
+[ "${#PROFILE_FIELDS[@]}" -eq 4 ] || { echo "profile selection failed" >&2; exit 1; }
+EXPECTED_IMAGE_SHA=${PROFILE_FIELDS[0]}
+EXPECTED_IMAGE_URL=${PROFILE_FIELDS[1]}
+QEMU_BIN=${PROFILE_FIELDS[2]}
+CLOUD_BIN=${PROFILE_FIELDS[3]}
+
+if [ ! -f "$IMAGE" ] || [ -L "$IMAGE" ] || [ ! -r "$IMAGE" ]; then
+    echo "pinned cloud image must be a readable regular file: $IMAGE" >&2
+    exit 1
+fi
+IMAGE=$(realpath -- "$IMAGE")
+IMAGE_SHA_BEFORE=$(sha256sum -- "$IMAGE"); IMAGE_SHA_BEFORE=${IMAGE_SHA_BEFORE%% *}
+[ "$IMAGE_SHA_BEFORE" = "$EXPECTED_IMAGE_SHA" ] || {
+    echo "pinned cloud image SHA-256 mismatch for $EXPECTED_IMAGE_URL" >&2
+    exit 1
+}
+
+if [ -e "$OUTPUT" ] || [ -L "$OUTPUT" ]; then
+    echo "receipt directory must not already exist: $OUTPUT" >&2
+    exit 1
+fi
+OUTPUT_PARENT=$(dirname -- "$OUTPUT")
+if [ ! -d "$OUTPUT_PARENT" ] || [ -L "$OUTPUT_PARENT" ] || [ ! -w "$OUTPUT_PARENT" ]; then
+    echo "receipt parent must be an existing writable real directory: $OUTPUT_PARENT" >&2
+    exit 1
+fi
+OUTPUT_PARENT=$(realpath -- "$OUTPUT_PARENT")
+OUTPUT="$OUTPUT_PARENT/$(basename -- "$OUTPUT")"
+mkdir -m 700 -- "$OUTPUT"
+mkdir -m 700 -- "$OUTPUT/guest"
+
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rustbgpd-netns-calibration.XXXXXX")
+QEMU_GROUP_PID=''
+verify_pinned_image_unchanged() {
+    local phase=$1 image_after=''
+    if [ ! -f "$IMAGE" ] || [ -L "$IMAGE" ]; then
+        echo "pinned cloud image disappeared during the run ($phase)" >&2
+        return 1
+    fi
+    image_after=$(sha256sum -- "$IMAGE" 2>/dev/null) || {
+        echo "pinned cloud image could not be hashed after the run ($phase)" >&2
+        return 1
+    }
+    image_after=${image_after%% *}
+    if [ "$image_after" != "$IMAGE_SHA_BEFORE" ]; then
+        echo "pinned cloud image changed during the run ($phase)" >&2
+        return 1
+    fi
+    return 0
+}
+cleanup() {
+    local rc=$?
+    trap - EXIT
+    if [ -n "$QEMU_GROUP_PID" ]; then
+        kill -TERM -- "-$QEMU_GROUP_PID" >/dev/null 2>&1 || true
+        wait "$QEMU_GROUP_PID" >/dev/null 2>&1 || true
+    fi
+    if ! verify_pinned_image_unchanged "exit"; then
+        rc=1
+    fi
+    if ! rm -rf -- "$TMP_DIR"; then
+        echo "failed to remove pinned-kernel calibration staging" >&2
+        rc=1
+    fi
+    if [ "$rc" -ne 0 ]; then
+        rm -f -- "$OUTPUT/SHA256SUMS" || rc=1
+        if [ -e "$OUTPUT/SHA256SUMS" ] || [ -L "$OUTPUT/SHA256SUMS" ]; then
+            echo "failed to unseal unsuccessful pinned-kernel receipt" >&2
+            rc=1
+        fi
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
+for tool in setsid timeout sha256sum python3; do
+    command -v "$tool" >/dev/null || { echo "required tool is missing: $tool" >&2; exit 1; }
+done
+verify_dpkg_owned_tool() {
+    local package=$1 path=$2 item owned=false
+    if [ ! -f "$path" ] || [ -L "$path" ] || [ ! -x "$path" ]; then
+        echo "approved package tool is not an executable regular file: $path" >&2
+        return 1
+    fi
+    while IFS= read -r item; do
+        if [ "$item" = "$path" ]; then
+            owned=true
+        fi
+    done < <(/usr/bin/dpkg-query -L "$package")
+    [ "$owned" = true ] || {
+        echo "$path is not owned by the verified $package package" >&2
+        return 1
+    }
+}
+verify_dpkg_owned_tool qemu-system-x86 "$QEMU_BIN"
+verify_dpkg_owned_tool cloud-image-utils "$CLOUD_BIN"
+if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+    echo "KVM access is required; timing receipts may not fall back to TCG" >&2
+    exit 1
+fi
+QEMU_PACKAGE_VERSION=$(/usr/bin/dpkg-query -W -f='${Version}' qemu-system-x86)
+CLOUD_PACKAGE_VERSION=$(/usr/bin/dpkg-query -W -f='${Version}' cloud-image-utils)
+[ "$QEMU_PACKAGE_VERSION" = "1:8.2.2+ds-0ubuntu1.18" ] || {
+    echo "qemu-system-x86 package version drift: $QEMU_PACKAGE_VERSION" >&2
+    exit 1
+}
+[ "$CLOUD_PACKAGE_VERSION" = "0.33-1" ] || {
+    echo "cloud-image-utils package version drift: $CLOUD_PACKAGE_VERSION" >&2
+    exit 1
+}
+DPKG_VERIFY=$(/usr/bin/dpkg --verify qemu-system-x86 cloud-image-utils)
+[ -z "$DPKG_VERIFY" ] || {
+    echo "installed QEMU/cloud-image-utils files differ from package metadata" >&2
+    exit 1
+}
+
+python3 "$VERIFIER" profiles "$PROFILES"
+python3 "$VERIFIER" source "$REPO"
+GIT_COMMIT=$(git -C "$REPO" rev-parse HEAD)
+ORIGIN_MAIN=$(git -C "$REPO" rev-parse origin/main)
+GIT_STATUS=$(git -C "$REPO" status --porcelain=v1 --untracked-files=all)
+GIT_STATUS_SHA=$(printf '%s' "$GIT_STATUS" | sha256sum | cut -d' ' -f1)
+if [ "$GIT_COMMIT" != "$ORIGIN_MAIN" ] || [ -n "$GIT_STATUS" ]; then
+    echo "publishable calibration requires a clean checkout at exact origin/main" >&2
+    exit 1
+fi
+
+PAYLOAD_DIR="$TMP_DIR/payload"
+mkdir -m 700 -- "$PAYLOAD_DIR"
+python3 - "$REPO" "$PROFILE" "$EXPECTED_IMAGE_URL" "$EXPECTED_IMAGE_SHA" \
+    "$GIT_COMMIT" "$ORIGIN_MAIN" "$GIT_STATUS_SHA" "$OUTPUT/request.json" <<'PY'
+import hashlib, json, pathlib, sys
+repo = pathlib.Path(sys.argv[1])
+profile, image_url, image_sha, commit, origin_main, status_sha, output = sys.argv[2:]
+paths = {
+    "guest": "bench/netns-calibration/guest-smoke.sh",
+    "host_lock": "tests/soak/host-lock.sh",
+    "host_quiet": "bench/scale/host-quiet.sh",
+    "profiles": "bench/netns-calibration/profiles.json",
+    "runner": "bench/netns-calibration/run-vm.sh",
+    "verifier": "bench/netns-calibration/verify-receipt.py",
+}
+payload = {
+    "git": {"commit": commit, "dirty": False, "origin_main": origin_main, "status_sha256": status_sha},
+    "image": {"sha256": image_sha, "url": image_url},
+    "profile": profile,
+    "schema": 1,
+    "sources": {name: hashlib.sha256((repo / path).read_bytes()).hexdigest() for name, path in paths.items()},
+}
+pathlib.Path(output).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+cp -- "$PROFILES" "$GUEST" "$OUTPUT/request.json" "$PAYLOAD_DIR/"
+chmod 500 "$PAYLOAD_DIR/guest-smoke.sh"
+chmod 400 "$PAYLOAD_DIR/profiles.json" "$PAYLOAD_DIR/request.json"
+
+QEMU_BIN_SHA=$(sha256sum -- "$QEMU_BIN"); QEMU_BIN_SHA=${QEMU_BIN_SHA%% *}
+CLOUD_BIN_SHA=$(sha256sum -- "$CLOUD_BIN"); CLOUD_BIN_SHA=${CLOUD_BIN_SHA%% *}
+QEMU_VERSION=$($QEMU_BIN --version | head -n 1)
+CPU_MODEL=$(awk -F: '$1 ~ /^model name[[:space:]]*$/ {sub(/^[[:space:]]+/, "", $2); print $2; exit}' /proc/cpuinfo)
+HOST_KERNEL=$(uname -srmo)
+python3 - "$OUTPUT/host.json" "$PROFILE" "$QEMU_BIN" "$QEMU_PACKAGE_VERSION" \
+    "$QEMU_BIN_SHA" "$QEMU_VERSION" "$CLOUD_BIN" "$CLOUD_PACKAGE_VERSION" \
+    "$CLOUD_BIN_SHA" "$CPU_MODEL" "$HOST_KERNEL" <<'PY'
+import json, pathlib, sys
+(
+    output, profile, qemu_path, qemu_package, qemu_sha, qemu_version,
+    cloud_path, cloud_package, cloud_sha, cpu_model, host_kernel,
+) = sys.argv[1:]
+payload = {
+    "cloud_image_utils": {
+        "binary_sha256": cloud_sha,
+        "approved_deb_sha256": "c4203167b5f2ccc8d7e2ff66f6ed5bb55d1ce467511d27732b91e1389e15cd9e",
+        "dpkg_verified": True,
+        "package": "cloud-image-utils",
+        "package_version": cloud_package,
+        "path": cloud_path,
+    },
+    "cpu_model": cpu_model,
+    "host_kernel": host_kernel,
+    "kvm_access": True,
+    "profile": profile,
+    "qemu_system_x86": {
+        "binary_sha256": qemu_sha,
+        "approved_deb_sha256": "14602e262627adac030329d2cecfee5f6c0938b34566ff2ea2d4c9a9eb02430d",
+        "dpkg_verified": True,
+        "package": "qemu-system-x86",
+        "package_version": qemu_package,
+        "path": qemu_path,
+        "version_output": qemu_version,
+    },
+    "schema": 1,
+}
+pathlib.Path(output).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+
+acquire_rustbgpd_host_lock
+wait_for_rustbgpd_quiet_host "$OUTPUT/quiet.tsv"
+
+cat >"$TMP_DIR/meta-data" <<EOF
+instance-id: rustbgpd-netns-calibration-$PROFILE-$GIT_COMMIT
+local-hostname: rustbgpd-calibration
+EOF
+cat >"$TMP_DIR/network-config" <<'EOF'
+version: 2
+ethernets: {}
+EOF
+SEED="$TMP_DIR/seed.img"
+"$CLOUD_BIN" --network-config="$TMP_DIR/network-config" \
+    "$SEED" "$PAYLOAD_DIR/guest-smoke.sh" "$TMP_DIR/meta-data"
+
+python3 - "$PROFILES" "$PROFILE" "$OUTPUT/plan.json" <<'PY'
+import importlib.util, json, pathlib, sys
+profiles_path, profile_name, output = map(pathlib.Path, (sys.argv[1], sys.argv[2], sys.argv[3]))
+spec = importlib.util.spec_from_file_location("netns_verify", profiles_path.parent / "verify-receipt.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+profiles = module.verify_profiles(profiles_path)
+profile = module.selected_profile(profiles, str(profile_name))
+payload = {
+    "args": module.expected_plan(profile, profiles["vm"], profiles["host_tools"]),
+    "profile": str(profile_name),
+    "schema": 1,
+}
+output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+python3 "$VERIFIER" plan "$PROFILES" "$OUTPUT/plan.json"
+
+python3 "$VERIFIER" argv "$PROFILES" "$PROFILE" "$IMAGE" "$SEED" \
+    "$PAYLOAD_DIR" "$OUTPUT/guest" >"$TMP_DIR/qemu-argv.nul"
+mapfile -d '' -t QEMU_COMMAND <"$TMP_DIR/qemu-argv.nul"
+[ "${QEMU_COMMAND[0]}" = "$QEMU_BIN" ] || {
+    echo "QEMU command rendering failed closed" >&2
+    exit 1
+}
+TIMEOUT_SECONDS=300
+setsid timeout --signal=TERM --kill-after=10s "${TIMEOUT_SECONDS}s" \
+    "${QEMU_COMMAND[@]}" >"$OUTPUT/console.log" 2>&1 &
+QEMU_GROUP_PID=$!
+set +e
+wait "$QEMU_GROUP_PID"
+QEMU_RC=$?
+set -e
+QEMU_GROUP_PID=''
+[ "$QEMU_RC" -eq 0 ] || {
+    echo "pinned-kernel VM failed with status $QEMU_RC" >&2
+    exit 1
+}
+
+verify_pinned_image_unchanged "pre-seal"
+python3 "$VERIFIER" receipt "$PROFILES" "$OUTPUT" --write-manifest
+echo "pinned-kernel netns smoke passed: $OUTPUT"

--- a/bench/netns-calibration/verify-receipt.py
+++ b/bench/netns-calibration/verify-receipt.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+"""Fail-closed verifier for pinned-kernel netns calibration VM receipts."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+EMPTY_SHA256 = hashlib.sha256(b"").hexdigest()
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+
+EXPECTED: dict[str, Any] = {
+    "host_tools": {
+        "cloud_image_utils": {
+            "deb_sha256": "c4203167b5f2ccc8d7e2ff66f6ed5bb55d1ce467511d27732b91e1389e15cd9e",
+            "package": "cloud-image-utils",
+            "path": "/usr/bin/cloud-localds",
+            "version": "0.33-1",
+        },
+        "qemu_system_x86": {
+            "deb_sha256": "14602e262627adac030329d2cecfee5f6c0938b34566ff2ea2d4c9a9eb02430d",
+            "package": "qemu-system-x86",
+            "path": "/usr/bin/qemu-system-x86_64",
+            "version": "1:8.2.2+ds-0ubuntu1.18",
+        },
+    },
+    "profiles": [
+        {
+            "guest": {
+                "iproute2_package_version": "5.15.0-1ubuntu2.2",
+                "kernel_package_version": "5.15.0-190.200",
+                "kernel_release": "5.15.0-190-generic",
+            },
+            "name": "baseline-jammy-5.15",
+            "role": "baseline",
+            "source": {
+                "sha256": "c0a5af17e6c0f76351fe07e2fffef3011dab1facb8a8ed5701dcf648dabd4f0a",
+                "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260826/ubuntu-22.04-server-cloudimg-amd64.img",
+            },
+        },
+        {
+            "guest": {
+                "iproute2_package_version": "6.1.0-1ubuntu6.4",
+                "kernel_package_version": "6.8.0-138.138",
+                "kernel_release": "6.8.0-138-generic",
+            },
+            "name": "current-noble-6.8",
+            "role": "current",
+            "source": {
+                "sha256": "d0fe84bb5f80853425fa6be28e2c106f30104c3cfe8611933f2e65c9b63f0e30",
+                "url": "https://cloud-images.ubuntu.com/releases/noble/release-20260826/ubuntu-24.04-server-cloudimg-amd64.img",
+            },
+        },
+    ],
+    "schema": 1,
+    "vm": {
+        "machine": "pc-q35-8.2",
+        "memory_mib": 2048,
+        "timeout_seconds": 300,
+        "vcpus": 2,
+    },
+}
+
+RECEIPT_FILES = {
+    "console.log": 2 * 1024 * 1024,
+    "guest/guest.json": 64 * 1024,
+    "guest/kernel.config": 2 * 1024 * 1024,
+    "host.json": 64 * 1024,
+    "plan.json": 64 * 1024,
+    "quiet.tsv": 64 * 1024,
+    "request.json": 64 * 1024,
+}
+QUIET_FIELDS = [
+    "sample",
+    "epoch_s",
+    "load1",
+    "pswpin",
+    "pswpout",
+    "governors",
+    "performance_governors",
+    "governor_count",
+    "competitors",
+    "quiet",
+    "failed_dimensions",
+    "original_attempt",
+]
+SOURCE_PATHS = {
+    "guest": "bench/netns-calibration/guest-smoke.sh",
+    "host_lock": "tests/soak/host-lock.sh",
+    "host_quiet": "bench/scale/host-quiet.sh",
+    "profiles": "bench/netns-calibration/profiles.json",
+    "runner": "bench/netns-calibration/run-vm.sh",
+    "verifier": "bench/netns-calibration/verify-receipt.py",
+}
+
+
+class VerificationError(ValueError):
+    """One closed receipt contract was violated."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VerificationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    require(path.is_file() and not path.is_symlink(), f"not a regular file: {path}")
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise VerificationError(f"cannot parse {path}: {exc}") from exc
+    require(isinstance(value, dict), f"{path} must contain one JSON object")
+    return value
+
+
+def sha256(path: Path) -> str:
+    require(path.is_file() and not path.is_symlink(), f"not a regular file: {path}")
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_profiles(path: Path) -> dict[str, Any]:
+    value = load_json(path)
+    require(value == EXPECTED, "profile document is not the closed approved tuple")
+    for profile in value["profiles"]:
+        url = profile["source"]["url"]
+        require("/release-20260826/" in url, f"profile uses a mutable URL: {url}")
+        require("/current/" not in url and "/release/" not in url, f"profile uses a mutable URL: {url}")
+        require(HEX_64.fullmatch(profile["source"]["sha256"]) is not None, "bad image SHA-256")
+    return value
+
+
+def selected_profile(profiles: dict[str, Any], name: str) -> dict[str, Any]:
+    matches = [item for item in profiles["profiles"] if item["name"] == name]
+    require(len(matches) == 1, f"unknown or duplicate profile: {name}")
+    return matches[0]
+
+
+def expected_plan(
+    profile: dict[str, Any], vm: dict[str, Any], host_tools: dict[str, Any]
+) -> list[str]:
+    return [
+        host_tools["qemu_system_x86"]["path"],
+        "-machine",
+        f"{vm['machine']},accel=kvm",
+        "-cpu",
+        "host",
+        "-smp",
+        str(vm["vcpus"]),
+        "-m",
+        str(vm["memory_mib"]),
+        "-name",
+        f"rustbgpd-netns-calibration-{profile['name']}",
+        "-display",
+        "none",
+        "-monitor",
+        "none",
+        "-no-reboot",
+        "-nic",
+        "none",
+        "-snapshot",
+        "-boot",
+        "order=c,strict=on",
+        "-drive",
+        "file=<IMAGE>,format=qcow2,if=virtio",
+        "-drive",
+        "file=<SEED>,format=raw,media=cdrom,readonly=on",
+        "-virtfs",
+        "local,path=<PAYLOAD>,mount_tag=payload,security_model=none,readonly=on",
+        "-virtfs",
+        "local,path=<GUEST_OUT>,mount_tag=receipt,security_model=none",
+        "-nographic",
+    ]
+
+
+def render_argv(
+    profile: dict[str, Any],
+    vm: dict[str, Any],
+    host_tools: dict[str, Any],
+    image: Path,
+    seed: Path,
+    payload: Path,
+    guest_output: Path,
+) -> list[str]:
+    replacements = {
+        "<IMAGE>": str(image),
+        "<SEED>": str(seed),
+        "<PAYLOAD>": str(payload),
+        "<GUEST_OUT>": str(guest_output),
+    }
+    for label, value in replacements.items():
+        require(value.startswith("/"), f"QEMU path is not absolute: {label}")
+        require("\0" not in value and "\n" not in value, f"QEMU path is not one line: {label}")
+    result = []
+    for argument in expected_plan(profile, vm, host_tools):
+        for label, value in replacements.items():
+            argument = argument.replace(label, value)
+        result.append(argument)
+    require(not any("<" in argument or ">" in argument for argument in result), "QEMU placeholder remained")
+    return result
+
+
+def verify_plan(profiles_path: Path, plan_path: Path) -> None:
+    profiles = verify_profiles(profiles_path)
+    plan = load_json(plan_path)
+    require(set(plan) == {"args", "profile", "schema"}, "plan has missing or extra fields")
+    require(plan["schema"] == 1, "plan schema mismatch")
+    profile = selected_profile(profiles, plan["profile"])
+    require(
+        plan["args"] == expected_plan(profile, profiles["vm"], profiles["host_tools"]),
+        "QEMU plan is not exact",
+    )
+    joined = " ".join(plan["args"])
+    require("-nic none" in joined, "QEMU plan does not disable networking")
+    require("accel=kvm" in joined and "-cpu host" in joined, "QEMU plan is not KVM-only")
+    require("-snapshot" in plan["args"], "QEMU plan can mutate its base image")
+    require("readonly=on" in joined, "payload/seed read-only contract missing")
+    for forbidden in ("-netdev", "-net user", "-nic user", "/home/", "<REPO>", "<HOME>"):
+        require(forbidden not in joined, f"forbidden QEMU plan token: {forbidden}")
+
+
+def verify_source_contract(repo: Path, runner: Path | None = None, guest: Path | None = None) -> None:
+    runner = runner or repo / SOURCE_PATHS["runner"]
+    guest = guest or repo / SOURCE_PATHS["guest"]
+    runner_text = runner.read_text()
+    guest_text = guest.read_text()
+    anchors = [
+        "if [ \"$EUID\" -eq 0 ]; then",
+        "SCRIPT_DIR=$(cd --",
+        "mapfile -t PROFILE_FIELDS",
+        "mkdir -m 700 -- \"$OUTPUT\"",
+        "trap cleanup EXIT",
+        "acquire_rustbgpd_host_lock",
+        "wait_for_rustbgpd_quiet_host",
+        "python3 \"$VERIFIER\" argv",
+        "TIMEOUT_SECONDS=300",
+        "setsid timeout --signal=TERM",
+        'verify_pinned_image_unchanged "pre-seal"',
+        "python3 \"$VERIFIER\" receipt",
+    ]
+    positions = []
+    for anchor in anchors:
+        require(runner_text.count(anchor) == 1, f"runner source anchor is not unique: {anchor}")
+        positions.append(runner_text.index(anchor))
+    require(positions == sorted(positions), "runner cleanup/lock/quiet/QEMU/verify order changed")
+    cleanup_start = runner_text.index("cleanup() {")
+    cleanup_end = runner_text.index("\n}\ntrap cleanup EXIT", cleanup_start)
+    cleanup = runner_text[cleanup_start:cleanup_end]
+    cleanup_anchors = [
+        'verify_pinned_image_unchanged "exit"',
+        'if ! rm -rf -- "$TMP_DIR"; then',
+        'if [ "$rc" -ne 0 ]; then',
+        'rm -f -- "$OUTPUT/SHA256SUMS"',
+        '[ -e "$OUTPUT/SHA256SUMS" ] || [ -L "$OUTPUT/SHA256SUMS" ]',
+        'exit "$rc"',
+    ]
+    cleanup_positions = []
+    for anchor in cleanup_anchors:
+        require(cleanup.count(anchor) == 1, f"runner cleanup anchor changed: {anchor}")
+        cleanup_positions.append(cleanup.index(anchor))
+    require(
+        cleanup_positions == sorted(cleanup_positions),
+        "runner must recheck the image and clean staging before unsealing failures",
+    )
+    image_messages = [
+        "pinned cloud image disappeared during the run",
+        "pinned cloud image could not be hashed after the run",
+        "pinned cloud image changed during the run",
+    ]
+    for message in image_messages:
+        require(runner_text.count(message) == 1, f"runner image recheck changed: {message}")
+    package_anchor = "/usr/bin/dpkg --verify qemu-system-x86 cloud-image-utils"
+    require(runner_text.count(package_anchor) == 1, "host package verification changed")
+    tool_anchors = [
+        "QEMU_BIN=${PROFILE_FIELDS[2]}",
+        "CLOUD_BIN=${PROFILE_FIELDS[3]}",
+        "verify_dpkg_owned_tool qemu-system-x86 \"$QEMU_BIN\"",
+        "verify_dpkg_owned_tool cloud-image-utils \"$CLOUD_BIN\"",
+        "\"$CLOUD_BIN\" --network-config=",
+        "\"${QEMU_COMMAND[@]}\" >\"$OUTPUT/console.log\"",
+    ]
+    for anchor in tool_anchors:
+        require(runner_text.count(anchor) == 1, f"runner tool-path anchor changed: {anchor}")
+    for forbidden in ("command -v qemu-system-x86_64", "command -v cloud-localds"):
+        require(forbidden not in runner_text, f"runner resolves a pinned tool through PATH: {forbidden}")
+    cleanup_anchor = 'ip netns del "$NETNS" >/dev/null 2>&1 || rc=1'
+    require(guest_text.count(cleanup_anchor) == 1, "guest failure cleanup is not unique")
+    guest_anchors = [
+        "trap cleanup_guest EXIT",
+        "ip netns add \"$NETNS\"",
+        "ip netns delete \"$NETNS\"",
+        "trap - EXIT",
+    ]
+    guest_positions = []
+    for anchor in guest_anchors:
+        require(guest_text.count(anchor) == 1, f"guest cleanup anchor is not unique: {anchor}")
+        guest_positions.append(guest_text.index(anchor))
+    require(guest_positions == sorted(guest_positions), "guest cleanup lifecycle changed")
+    require(guest_text.index(cleanup_anchor) < guest_positions[0], "guest trap does not use the cleanup helper")
+    bootstrap_anchors = [
+        "mount -t 9p -o trans=virtio,version=9p2000.L,ro payload",
+        "mount -t 9p -o trans=virtio,version=9p2000.L receipt",
+        "env -i PATH=/usr/sbin:/usr/bin:/sbin:/bin",
+        "poweroff -f",
+    ]
+    bootstrap_positions = []
+    for anchor in bootstrap_anchors:
+        require(guest_text.count(anchor) == 1, f"guest staging anchor is not unique: {anchor}")
+        bootstrap_positions.append(guest_text.index(anchor))
+    require(bootstrap_positions == sorted(bootstrap_positions), "guest staging lifecycle changed")
+    command = re.compile(r"^\s*(sudo|docker|curl|wget)\b", re.MULTILINE)
+    require(command.search(runner_text) is None, "runner gained a forbidden host command")
+    require(command.search(guest_text) is None, "guest gained a forbidden command")
+
+
+def verify_quiet(path: Path) -> None:
+    with path.open(newline="") as stream:
+        reader = csv.DictReader(stream, delimiter="\t")
+        require(reader.fieldnames == QUIET_FIELDS, "quiet receipt header mismatch")
+        rows = list(reader)
+    require(len(rows) == 2, "quiet receipt must retain exactly two samples")
+    require([row.get("sample") for row in rows] == ["1", "2"], "quiet sample order mismatch")
+    for row in rows:
+        require(set(row) == set(QUIET_FIELDS), "quiet receipt row shape mismatch")
+        require(row.get("quiet") == "true", "quiet receipt contains a failed sample")
+        require(row.get("failed_dimensions") == "none", "quiet receipt contains a failed dimension")
+        require(row.get("competitors") == "none", "quiet receipt contains a competing process")
+        for field in ("epoch_s", "pswpin", "pswpout", "performance_governors", "governor_count", "original_attempt"):
+            require(row[field].isdigit(), f"quiet receipt has a malformed integer: {field}")
+        require(re.fullmatch(r"[0-9]+(?:[.][0-9]+)?", row["load1"]) is not None, "bad quiet load")
+        require(float(row["load1"]) < 2.0, "quiet load threshold was not satisfied")
+        require(int(row["governor_count"]) > 0, "quiet receipt has no CPU governors")
+        require(
+            int(row["performance_governors"]) == int(row["governor_count"]),
+            "not every CPU used the performance governor",
+        )
+        governors = row["governors"].split(",")
+        require(len(governors) == int(row["governor_count"]), "quiet governor inventory mismatch")
+        require(set(governors) == {"performance"}, "quiet receipt used a non-performance governor")
+    require(rows[0]["pswpin"] == rows[1]["pswpin"], "swap-in moved between quiet samples")
+    require(rows[0]["pswpout"] == rows[1]["pswpout"], "swap-out moved between quiet samples")
+    require(int(rows[1]["epoch_s"]) - int(rows[0]["epoch_s"]) >= 30, "quiet samples are too close")
+    require(int(rows[0]["original_attempt"]) >= 1, "quiet attempt must be positive")
+    require(
+        int(rows[1]["original_attempt"]) > int(rows[0]["original_attempt"]),
+        "quiet attempts are not ordered",
+    )
+
+
+def exact_keys(value: dict[str, Any], keys: set[str], label: str) -> None:
+    require(set(value) == keys, f"{label} has missing or extra fields")
+
+
+def verify_receipt(profiles_path: Path, root: Path, write_manifest: bool) -> None:
+    profiles = verify_profiles(profiles_path)
+    require(root.is_dir() and not root.is_symlink(), "receipt root must be a real directory")
+    found: set[str] = set()
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        require(not path.is_symlink(), f"receipt contains a symlink: {relative}")
+        if path.is_dir():
+            require(relative == "guest", f"receipt contains an unexpected directory: {relative}")
+            continue
+        require(path.is_file(), f"receipt contains a non-regular path: {relative}")
+        found.add(relative)
+    allowed = set(RECEIPT_FILES)
+    if (root / "SHA256SUMS").exists():
+        allowed.add("SHA256SUMS")
+    require(found == allowed, f"receipt file set mismatch: got {sorted(found)}")
+    for relative, limit in RECEIPT_FILES.items():
+        require((root / relative).stat().st_size <= limit, f"receipt artifact is oversized: {relative}")
+
+    request = load_json(root / "request.json")
+    exact_keys(request, {"git", "image", "profile", "schema", "sources"}, "request")
+    require(request["schema"] == 1, "request schema mismatch")
+    profile = selected_profile(profiles, request["profile"])
+    require(request["image"] == profile["source"], "request mixed or changed its image tuple")
+    git = request["git"]
+    exact_keys(git, {"commit", "dirty", "origin_main", "status_sha256"}, "request git")
+    require(COMMIT.fullmatch(git["commit"]) is not None, "request commit is malformed")
+    require(git["commit"] == git["origin_main"], "request commit is not exact origin/main")
+    require(git["dirty"] is False and git["status_sha256"] == EMPTY_SHA256, "dirty source is not publishable")
+    repo = Path(__file__).resolve().parents[2]
+    require(set(request["sources"]) == set(SOURCE_PATHS), "request source inventory mismatch")
+    for name, relative in SOURCE_PATHS.items():
+        require(request["sources"][name] == sha256(repo / relative), f"source hash mismatch: {name}")
+
+    plan = load_json(root / "plan.json")
+    verify_plan(profiles_path, root / "plan.json")
+    require(plan["profile"] == request["profile"], "plan/request profile mismatch")
+
+    host = load_json(root / "host.json")
+    exact_keys(
+        host,
+        {
+            "cloud_image_utils",
+            "cpu_model",
+            "host_kernel",
+            "kvm_access",
+            "profile",
+            "qemu_system_x86",
+            "schema",
+        },
+        "host",
+    )
+    require(host["schema"] == 1 and host["profile"] == request["profile"], "host identity mismatch")
+    require(host["kvm_access"] is True, "receipt was not produced with KVM access")
+    require(isinstance(host["cpu_model"], str) and 0 < len(host["cpu_model"]) <= 160, "bad CPU model")
+    require(isinstance(host["host_kernel"], str) and 0 < len(host["host_kernel"]) <= 256, "bad host kernel")
+    for key in ("qemu_system_x86", "cloud_image_utils"):
+        tool = host[key]
+        keys = {
+            "approved_deb_sha256",
+            "binary_sha256",
+            "dpkg_verified",
+            "package",
+            "package_version",
+            "path",
+        }
+        if key == "qemu_system_x86":
+            keys.add("version_output")
+        exact_keys(tool, keys, key)
+        require(
+            {
+                "deb_sha256": tool["approved_deb_sha256"],
+                "package": tool["package"],
+                "path": tool["path"],
+                "version": tool["package_version"],
+            }
+            == profiles["host_tools"][key],
+            f"{key} package tuple mismatch",
+        )
+        require(tool["dpkg_verified"] is True, f"{key} package files were not verified")
+        require(HEX_64.fullmatch(tool["binary_sha256"]) is not None, f"bad {key} binary hash")
+        if key == "qemu_system_x86":
+            require(
+                isinstance(tool["version_output"], str) and tool["version_output"],
+                "missing QEMU version output",
+            )
+
+    verify_quiet(root / "quiet.tsv")
+    guest = load_json(root / "guest/guest.json")
+    exact_keys(
+        guest,
+        {
+            "after_netns_sha256",
+            "before_netns_sha256",
+            "bridge_binary_sha256",
+            "ip_binary_sha256",
+            "ip_version_output",
+            "iproute2_package_version",
+            "kernel_config_sha256",
+            "kernel_package_version",
+            "kernel_release",
+            "profile",
+            "schema",
+            "smoke",
+            "status",
+            "uid",
+        },
+        "guest",
+    )
+    expected_guest = profile["guest"]
+    require(guest["schema"] == 1 and guest["status"] == "pass", "guest did not report success")
+    require(guest["profile"] == request["profile"] and guest["uid"] == 0, "guest identity/privilege mismatch")
+    for field in ("kernel_release", "kernel_package_version", "iproute2_package_version"):
+        require(guest[field] == expected_guest[field], f"guest {field} mismatch")
+    for field in ("before_netns_sha256", "after_netns_sha256", "ip_binary_sha256", "bridge_binary_sha256"):
+        require(HEX_64.fullmatch(guest[field]) is not None, f"bad guest hash: {field}")
+    require(guest["before_netns_sha256"] == guest["after_netns_sha256"], "guest left netns residue")
+    require(guest["kernel_config_sha256"] == sha256(root / "guest/kernel.config"), "kernel config hash mismatch")
+    require(
+        guest["smoke"] == {
+            "bridge_vlan_filtering": True,
+            "deterministic_cleanup": True,
+            "netns": True,
+            "veth": True,
+            "vlan_10": True,
+            "vlan_20": True,
+        },
+        "guest smoke surface mismatch",
+    )
+
+    for relative in RECEIPT_FILES:
+        if relative.endswith((".json", ".tsv", ".log")):
+            text = (root / relative).read_text(errors="replace")
+            for forbidden in ("/home/", "github_pat_", "ghp_", "GITHUB_TOKEN", "AWS_SECRET", "Authorization:"):
+                require(forbidden not in text, f"unsanitized receipt content in {relative}")
+
+    manifest_path = root / "SHA256SUMS"
+    expected_manifest = "".join(f"{sha256(root / relative)}  {relative}\n" for relative in sorted(RECEIPT_FILES))
+    if manifest_path.exists():
+        require(manifest_path.is_file() and not manifest_path.is_symlink(), "bad SHA256SUMS path")
+        require(manifest_path.read_text() == expected_manifest, "SHA256SUMS does not seal the exact receipt")
+    elif write_manifest:
+        manifest_path.write_text(expected_manifest)
+    else:
+        raise VerificationError("receipt has no SHA256SUMS (pass --write-manifest only at finalization)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    profiles_parser = sub.add_parser("profiles")
+    profiles_parser.add_argument("profiles", type=Path)
+    select_parser = sub.add_parser("select")
+    select_parser.add_argument("profiles", type=Path)
+    select_parser.add_argument("name")
+    plan_parser = sub.add_parser("plan")
+    plan_parser.add_argument("profiles", type=Path)
+    plan_parser.add_argument("plan", type=Path)
+    argv_parser = sub.add_parser("argv")
+    argv_parser.add_argument("profiles", type=Path)
+    argv_parser.add_argument("name")
+    argv_parser.add_argument("image", type=Path)
+    argv_parser.add_argument("seed", type=Path)
+    argv_parser.add_argument("payload", type=Path)
+    argv_parser.add_argument("guest_output", type=Path)
+    source_parser = sub.add_parser("source")
+    source_parser.add_argument("repo", type=Path)
+    source_parser.add_argument("--runner", type=Path)
+    source_parser.add_argument("--guest", type=Path)
+    receipt_parser = sub.add_parser("receipt")
+    receipt_parser.add_argument("profiles", type=Path)
+    receipt_parser.add_argument("root", type=Path)
+    receipt_parser.add_argument("--write-manifest", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.command == "profiles":
+            verify_profiles(args.profiles)
+        elif args.command == "select":
+            profiles = verify_profiles(args.profiles)
+            profile = selected_profile(profiles, args.name)
+            print(profile["source"]["sha256"])
+            print(profile["source"]["url"])
+            print(profiles["host_tools"]["qemu_system_x86"]["path"])
+            print(profiles["host_tools"]["cloud_image_utils"]["path"])
+        elif args.command == "plan":
+            verify_plan(args.profiles, args.plan)
+        elif args.command == "argv":
+            profiles = verify_profiles(args.profiles)
+            profile = selected_profile(profiles, args.name)
+            argv = render_argv(
+                profile,
+                profiles["vm"],
+                profiles["host_tools"],
+                args.image,
+                args.seed,
+                args.payload,
+                args.guest_output,
+            )
+            sys.stdout.buffer.write(b"\0".join(item.encode() for item in argv) + b"\0")
+        elif args.command == "source":
+            verify_source_contract(args.repo.resolve(), args.runner, args.guest)
+        else:
+            verify_receipt(args.profiles, args.root, args.write_manifest)
+    except (OSError, VerificationError, ValueError, KeyError, TypeError) as exc:
+        print(f"netns calibration receipt error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/tests/test-netns-calibration-vm.sh
+++ b/bench/tests/test-netns-calibration-vm.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONDONTWRITEBYTECODE=1
+
+repo=$(git rev-parse --show-toplevel)
+profiles="$repo/bench/netns-calibration/profiles.json"
+verifier="$repo/bench/netns-calibration/verify-receipt.py"
+runner="$repo/bench/netns-calibration/run-vm.sh"
+guest="$repo/bench/netns-calibration/guest-smoke.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/netns-calibration-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+python3 "$verifier" profiles "$profiles"
+python3 "$verifier" source "$repo"
+
+python3 - "$repo" "$profiles" "$verifier" "$tmp" <<'PY'
+import copy, csv, hashlib, importlib.util, json, os, pathlib, shutil, subprocess, sys
+
+repo, profiles_path, verifier_path, tmp = map(pathlib.Path, sys.argv[1:])
+spec = importlib.util.spec_from_file_location("netns_verify", verifier_path)
+verify = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(verify)
+profiles = verify.verify_profiles(profiles_path)
+h = "a" * 64
+
+def run(*args):
+    return subprocess.run([sys.executable, str(verifier_path), *map(str, args)], capture_output=True, text=True)
+
+def expect(ok, name, *args):
+    result = run(*args)
+    assert (result.returncode == 0) == ok, (name, result.stdout, result.stderr)
+
+def write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+# Profile mutations must not turn the data file into policy.
+for name, mutate in {
+    "mutable-url": lambda p: p["profiles"][0]["source"].update(url=p["profiles"][0]["source"]["url"].replace("release-20260826", "current")),
+    "wrong-image": lambda p: p["profiles"][0]["source"].update(sha256=h),
+    "mixed-kernel": lambda p: p["profiles"][0]["guest"].update(kernel_release=p["profiles"][1]["guest"]["kernel_release"]),
+    "extra-profile": lambda p: p["profiles"].append(copy.deepcopy(p["profiles"][0])),
+    "qemu-drift": lambda p: p["host_tools"]["qemu_system_x86"].update(version="8.2.3"),
+    "qemu-path-drift": lambda p: p["host_tools"]["qemu_system_x86"].update(path="/opt/qemu-system-x86_64"),
+}.items():
+    candidate = copy.deepcopy(profiles); mutate(candidate)
+    path = tmp / f"profiles-{name}.json"; write_json(path, candidate)
+    expect(False, name, "profiles", path)
+
+profile = profiles["profiles"][0]
+plan = {
+    "args": verify.expected_plan(profile, profiles["vm"], profiles["host_tools"]),
+    "profile": profile["name"],
+    "schema": 1,
+}
+plan_path = tmp / "plan.json"; write_json(plan_path, plan)
+expect(True, "valid-plan", "plan", profiles_path, plan_path)
+for name, mutate in {
+    "plan-path-shadow": lambda p: p["args"].__setitem__(0, "qemu-system-x86_64"),
+    "plan-network": lambda p: p["args"].__setitem__(p["args"].index("none", p["args"].index("-nic")), "user"),
+    "plan-no-snapshot": lambda p: p["args"].remove("-snapshot"),
+    "plan-tcg": lambda p: p["args"].__setitem__(p["args"].index("pc-q35-8.2,accel=kvm"), "pc-q35-8.2,accel=tcg"),
+    "plan-cpu": lambda p: p["args"].__setitem__(p["args"].index("host", p["args"].index("-cpu")), "max"),
+    "plan-memory": lambda p: p["args"].__setitem__(p["args"].index("2048"), "4096"),
+    "plan-home-share": lambda p: p["args"].__setitem__(p["args"].index("local,path=<PAYLOAD>,mount_tag=payload,security_model=none,readonly=on"), "local,path=/home/user,mount_tag=payload,security_model=none,readonly=on"),
+    "plan-writable-payload": lambda p: p["args"].__setitem__(p["args"].index("local,path=<PAYLOAD>,mount_tag=payload,security_model=none,readonly=on"), "local,path=<PAYLOAD>,mount_tag=payload,security_model=none"),
+    "plan-writable-seed": lambda p: p["args"].__setitem__(p["args"].index("file=<SEED>,format=raw,media=cdrom,readonly=on"), "file=<SEED>,format=raw,media=cdrom"),
+}.items():
+    candidate = copy.deepcopy(plan); mutate(candidate)
+    path = tmp / f"plan-{name}.json"; write_json(path, candidate)
+    expect(False, name, "plan", profiles_path, path)
+
+argv = verify.render_argv(
+    profile,
+    profiles["vm"],
+    profiles["host_tools"],
+    pathlib.Path("/images/base.img"),
+    pathlib.Path("/staging/seed.img"),
+    pathlib.Path("/staging/payload"),
+    pathlib.Path("/receipts/guest"),
+)
+assert argv[0] == "/usr/bin/qemu-system-x86_64"
+assert "file=/images/base.img,format=qcow2,if=virtio" in argv
+assert "local,path=/staging/payload,mount_tag=payload,security_model=none,readonly=on" in argv
+assert not any("<" in item or ">" in item for item in argv)
+shadow = tmp / "path-shadow"
+shadow.mkdir()
+marker = tmp / "path-shadow-ran"
+for command in ("qemu-system-x86_64", "cloud-localds"):
+    executable = shadow / command
+    executable.write_text(f"#!/bin/sh\ntouch '{marker}'\nexit 99\n")
+    executable.chmod(0o755)
+shadow_env = {**os.environ, "PATH": f"{shadow}:{os.environ['PATH']}"}
+selected = subprocess.run(
+    [sys.executable, str(verifier_path), "select", str(profiles_path), profile["name"]],
+    capture_output=True,
+    text=True,
+    env=shadow_env,
+)
+assert selected.returncode == 0, selected.stderr
+assert selected.stdout.splitlines()[2:] == [
+    "/usr/bin/qemu-system-x86_64",
+    "/usr/bin/cloud-localds",
+]
+rendered = subprocess.run(
+    [
+        sys.executable,
+        str(verifier_path),
+        "argv",
+        str(profiles_path),
+        profile["name"],
+        "/images/base.img",
+        "/staging/seed.img",
+        "/staging/payload",
+        "/receipts/guest",
+    ],
+    capture_output=True,
+    env=shadow_env,
+)
+assert rendered.returncode == 0, rendered.stderr
+assert rendered.stdout.split(b"\0") == [*(item.encode() for item in argv), b""]
+assert not marker.exists()
+expect(
+    False,
+    "relative-qemu-path",
+    "argv",
+    profiles_path,
+    profile["name"],
+    "relative.img",
+    "/seed.img",
+    "/payload",
+    "/guest",
+)
+
+def valid_receipt(path):
+    (path / "guest").mkdir(parents=True)
+    config = b"CONFIG_NET_NS=y\nCONFIG_BRIDGE=y\n"
+    (path / "guest/kernel.config").write_bytes(config)
+    write_json(path / "request.json", {
+        "git": {"commit": "b"*40, "dirty": False, "origin_main": "b"*40, "status_sha256": verify.EMPTY_SHA256},
+        "image": profile["source"], "profile": profile["name"], "schema": 1,
+        "sources": {name: verify.sha256(repo / rel) for name, rel in verify.SOURCE_PATHS.items()},
+    })
+    write_json(path / "plan.json", plan)
+    write_json(path / "host.json", {
+        "cloud_image_utils": {
+            "approved_deb_sha256": profiles["host_tools"]["cloud_image_utils"]["deb_sha256"],
+            "binary_sha256": h,
+            "dpkg_verified": True,
+            "package": profiles["host_tools"]["cloud_image_utils"]["package"],
+            "package_version": profiles["host_tools"]["cloud_image_utils"]["version"],
+            "path": profiles["host_tools"]["cloud_image_utils"]["path"],
+        },
+        "cpu_model": "fixture cpu", "host_kernel": "Linux fixture x86_64", "kvm_access": True,
+        "profile": profile["name"],
+        "qemu_system_x86": {
+            "approved_deb_sha256": profiles["host_tools"]["qemu_system_x86"]["deb_sha256"],
+            "binary_sha256": h,
+            "dpkg_verified": True,
+            "package": profiles["host_tools"]["qemu_system_x86"]["package"],
+            "package_version": profiles["host_tools"]["qemu_system_x86"]["version"],
+            "path": profiles["host_tools"]["qemu_system_x86"]["path"],
+            "version_output": "QEMU emulator version 8.2.2",
+        },
+        "schema": 1,
+    })
+    header = ["sample","epoch_s","load1","pswpin","pswpout","governors","performance_governors","governor_count","competitors","quiet","failed_dimensions","original_attempt"]
+    with (path / "quiet.tsv").open("w", newline="") as stream:
+        writer = csv.writer(stream, delimiter="\t", lineterminator="\n"); writer.writerow(header)
+        writer.writerow([1,100,0.2,0,0,"performance",1,1,"none","true","none",1])
+        writer.writerow([2,130,0.3,0,0,"performance",1,1,"none","true","none",2])
+    (path / "console.log").write_text("generic guest console\n")
+    write_json(path / "guest/guest.json", {
+        "after_netns_sha256": h, "before_netns_sha256": h, "bridge_binary_sha256": h,
+        "ip_binary_sha256": h, "ip_version_output": "ip utility fixture",
+        "iproute2_package_version": profile["guest"]["iproute2_package_version"],
+        "kernel_config_sha256": hashlib.sha256(config).hexdigest(),
+        "kernel_package_version": profile["guest"]["kernel_package_version"],
+        "kernel_release": profile["guest"]["kernel_release"], "profile": profile["name"], "schema": 1,
+        "smoke": {"bridge_vlan_filtering": True,"deterministic_cleanup": True,"netns": True,"veth": True,"vlan_10": True,"vlan_20": True},
+        "status": "pass", "uid": 0,
+    })
+
+base = tmp / "receipt-base"; valid_receipt(base)
+expect(True, "valid-finalize", "receipt", profiles_path, base, "--write-manifest")
+expect(True, "valid-sealed", "receipt", profiles_path, base)
+unsealed = tmp / "receipt-unsuccessful"; shutil.copytree(base, unsealed)
+(unsealed / "SHA256SUMS").unlink()
+expect(False, "unsuccessful-receipt-is-unsealed", "receipt", profiles_path, unsealed)
+
+def receipt_mutation(name, mutate):
+    path = tmp / f"receipt-{name}"; shutil.copytree(base, path)
+    (path / "SHA256SUMS").unlink()
+    mutate(path)
+    expect(False, name, "receipt", profiles_path, path, "--write-manifest")
+
+def mutate_json(path, relative, mutate):
+    value = json.loads((path / relative).read_text())
+    mutate(value)
+    write_json(path / relative, value)
+
+def mutate_quiet(path, mutate):
+    quiet = path / "quiet.tsv"
+    with quiet.open(newline="") as stream:
+        rows = list(csv.reader(stream, delimiter="\t"))
+    mutate(rows)
+    with quiet.open("w", newline="") as stream:
+        csv.writer(stream, delimiter="\t", lineterminator="\n").writerows(rows)
+
+receipt_mutation("wrong-kernel", lambda p: (lambda x: (x.update(kernel_release="9.9.9"), write_json(p/"guest/guest.json",x)))(json.loads((p/"guest/guest.json").read_text())))
+receipt_mutation("mixed-profile", lambda p: (lambda x: (x.update(profile=profiles["profiles"][1]["name"]), write_json(p/"guest/guest.json",x)))(json.loads((p/"guest/guest.json").read_text())))
+receipt_mutation("tool-drift", lambda p: mutate_json(p, "host.json", lambda x: x["qemu_system_x86"].update(package_version="8.2.3")))
+receipt_mutation("tool-path-drift", lambda p: mutate_json(p, "host.json", lambda x: x["qemu_system_x86"].update(path="qemu-system-x86_64")))
+receipt_mutation("tool-unverified", lambda p: mutate_json(p, "host.json", lambda x: x["qemu_system_x86"].update(dpkg_verified=False)))
+receipt_mutation("no-kvm", lambda p: (lambda x: (x.update(kvm_access=False), write_json(p/"host.json",x)))(json.loads((p/"host.json").read_text())))
+receipt_mutation("dirty", lambda p: (lambda x: (x["git"].update(dirty=True), write_json(p/"request.json",x)))(json.loads((p/"request.json").read_text())))
+receipt_mutation("image-drift", lambda p: mutate_json(p, "request.json", lambda x: x["image"].update(sha256="c"*64)))
+receipt_mutation("commit-drift", lambda p: mutate_json(p, "request.json", lambda x: x["git"].update(origin_main="c"*40)))
+receipt_mutation("source-drift", lambda p: mutate_json(p, "request.json", lambda x: x["sources"].update(guest="c"*64)))
+receipt_mutation("config-drift", lambda p: (p/"guest/kernel.config").write_text("changed\n"))
+receipt_mutation("residue", lambda p: (lambda x: (x.update(after_netns_sha256="c"*64), write_json(p/"guest/guest.json",x)))(json.loads((p/"guest/guest.json").read_text())))
+receipt_mutation("quiet-spacing", lambda p: mutate_quiet(p, lambda rows: rows[2].__setitem__(1, "129")))
+receipt_mutation("quiet-swap", lambda p: mutate_quiet(p, lambda rows: rows[2].__setitem__(3, "1")))
+receipt_mutation("quiet-governor", lambda p: mutate_quiet(p, lambda rows: rows[1].__setitem__(5, "powersave")))
+receipt_mutation("quiet-extra-column", lambda p: mutate_quiet(p, lambda rows: [row.append("extra") for row in rows]))
+receipt_mutation("extra", lambda p: (p/"extra.txt").write_text("extra\n"))
+receipt_mutation("missing", lambda p: (p/"console.log").unlink())
+receipt_mutation("oversize", lambda p: (p/"console.log").write_bytes(b"x"*(2*1024*1024+1)))
+receipt_mutation("unsanitized", lambda p: (p/"console.log").write_text("/home/private/token\n"))
+
+symlink = tmp / "receipt-symlink"; shutil.copytree(base, symlink); (symlink/"SHA256SUMS").unlink()
+(symlink/"console.log").unlink(); (symlink/"console.log").symlink_to("request.json")
+expect(False, "symlink", "receipt", profiles_path, symlink, "--write-manifest")
+
+tampered = tmp / "receipt-manifest"; shutil.copytree(base, tampered)
+(tampered/"console.log").write_text("tampered\n")
+expect(False, "manifest", "receipt", profiles_path, tampered)
+PY
+
+# Exercise the runner's real cleanup functions without booting a VM. Every
+# unsuccessful exit must destroy the final seal, including image drift that is
+# discovered only by the EXIT recheck.
+cleanup_lib="$tmp/cleanup-functions.sh"
+sed -n '/^verify_pinned_image_unchanged() {/,/^trap cleanup EXIT$/p' "$runner" |
+    sed '$d' >"$cleanup_lib"
+bash -n "$cleanup_lib"
+for mode in failed-command image-drift image-disappeared; do
+    receipt="$tmp/receipt-cleanup-$mode"
+    image="$tmp/image-cleanup-$mode"
+    staging="$tmp/staging-cleanup-$mode"
+    cp -a "$tmp/receipt-base" "$receipt"
+    printf 'pinned image fixture\n' >"$image"
+    image_sha=$(sha256sum -- "$image"); image_sha=${image_sha%% *}
+    mkdir "$staging"
+    case $mode in
+        image-drift) printf 'drift\n' >>"$image" ;;
+        image-disappeared) rm -f -- "$image" ;;
+    esac
+    set +e
+    (
+        set -uo pipefail
+        export IMAGE=$image
+        export IMAGE_SHA_BEFORE=$image_sha
+        export OUTPUT=$receipt
+        export TMP_DIR=$staging
+        export QEMU_GROUP_PID=''
+        # shellcheck disable=SC1090 # Generated from the reviewed runner functions above.
+        source "$cleanup_lib"
+        if [ "$mode" = failed-command ]; then
+            false
+        fi
+        cleanup
+    ) >/dev/null 2>&1
+    cleanup_rc=$?
+    set -e
+    [ "$cleanup_rc" -ne 0 ]
+    [ ! -e "$receipt/SHA256SUMS" ]
+    [ ! -e "$staging" ]
+    if python3 "$verifier" receipt "$profiles" "$receipt" >/dev/null 2>&1; then
+        echo "false green: unsuccessful cleanup left a verifier-green receipt: $mode" >&2
+        exit 1
+    fi
+done
+
+# The guest's injected post-create failure must still run its deletion trap.
+fakebin="$tmp/fakebin"
+mkdir "$fakebin"
+state="$tmp/fake-netns-state"
+cat >"$fakebin/ip" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+state=${RUSTBGPD_FAKE_NETNS_STATE:?}
+if [ "$1" = netns ] && [ "$2" = list ]; then
+    [ ! -e "$state" ] || echo rustbgpd-cal-smoke
+elif [ "$1" = netns ] && [ "$2" = add ]; then
+    touch "$state"
+elif [ "$1" = netns ] && { [ "$2" = del ] || [ "$2" = delete ]; }; then
+    rm -f "$state"
+else
+    echo "unexpected fake ip invocation: $*" >&2
+    exit 1
+fi
+SH
+chmod +x "$fakebin/ip"
+mkdir "$tmp/guest-out"
+set +e
+PATH="$fakebin:$PATH" RUSTBGPD_FAKE_NETNS_STATE="$state" \
+    RUSTBGPD_GUEST_SMOKE_TEST_FAIL_AFTER_CREATE=1 \
+    "$guest" --inside "$tmp/guest-out" >/dev/null 2>&1
+guest_rc=$?
+set -e
+[ "$guest_rc" -eq 97 ]
+[ ! -e "$state" ]
+
+# Mutating any load-bearing lifecycle anchor must fail the independent source checker.
+for anchor in root trap package qemu-path cloud-path cloud-exec qemu-exec lock quiet render timeout qemu image-preseal image-exit unseal cleanup-exit verify guest-trap guest-delete guest-readonly guest-env; do
+    candidate_runner="$tmp/runner-$anchor.sh"
+    candidate_guest="$tmp/guest-$anchor.sh"
+    cp "$runner" "$candidate_runner"
+    cp "$guest" "$candidate_guest"
+    # shellcheck disable=SC2016 # Match candidate literal variable references.
+    case $anchor in
+        root) sed -i 's/if \[ "$EUID" -eq 0 \]/if [ 0 -eq 1 ]/' "$candidate_runner" ;;
+        trap) sed -i '/trap cleanup EXIT/d' "$candidate_runner" ;;
+        package) sed -i '/dpkg --verify qemu-system-x86 cloud-image-utils/d' "$candidate_runner" ;;
+        qemu-path) sed -i 's/QEMU_BIN=${PROFILE_FIELDS\[2\]}/QEMU_BIN=$(command -v qemu-system-x86_64)/' "$candidate_runner" ;;
+        cloud-path) sed -i 's/CLOUD_BIN=${PROFILE_FIELDS\[3\]}/CLOUD_BIN=$(command -v cloud-localds)/' "$candidate_runner" ;;
+        cloud-exec) sed -i 's/"$CLOUD_BIN" --network-config/cloud-localds --network-config/' "$candidate_runner" ;;
+        qemu-exec) sed -i 's/"${QEMU_COMMAND\[@\]}" >"$OUTPUT\/console.log"/qemu-system-x86_64 "${QEMU_COMMAND[@]:1}" >"$OUTPUT\/console.log"/' "$candidate_runner" ;;
+        lock) sed -i '/^acquire_rustbgpd_host_lock$/d' "$candidate_runner" ;;
+        quiet) sed -i '/^wait_for_rustbgpd_quiet_host/d' "$candidate_runner" ;;
+        render) sed -i '/python3 "$VERIFIER" argv/d' "$candidate_runner" ;;
+        timeout) sed -i 's/TIMEOUT_SECONDS=300/TIMEOUT_SECONDS=301/' "$candidate_runner" ;;
+        qemu) sed -i 's/setsid timeout --signal=TERM/setsid timeout --signal=INT/' "$candidate_runner" ;;
+        image-preseal) sed -i '/^verify_pinned_image_unchanged "pre-seal"$/d' "$candidate_runner" ;;
+        image-exit) sed -i '/verify_pinned_image_unchanged "exit"/d' "$candidate_runner" ;;
+        unseal) sed -i '/rm -f -- "$OUTPUT\/SHA256SUMS"/d' "$candidate_runner" ;;
+        cleanup-exit) sed -i 's/exit "$rc"/exit 0/' "$candidate_runner" ;;
+        verify) sed -i '/python3 "$VERIFIER" receipt/d' "$candidate_runner" ;;
+        guest-trap) sed -i '/trap cleanup_guest EXIT/d' "$candidate_guest" ;;
+        guest-delete) sed -i '/ip netns delete "$NETNS"$/d' "$candidate_guest" ;;
+        guest-readonly) sed -i 's/,ro payload/ payload/' "$candidate_guest" ;;
+        guest-env) sed -i 's/env -i PATH=/env PATH=/' "$candidate_guest" ;;
+    esac
+    if python3 "$verifier" source "$repo" --runner "$candidate_runner" --guest "$candidate_guest" \
+        >/dev/null 2>&1; then
+        echo "false green: source mutation accepted: $anchor" >&2
+        exit 1
+    fi
+done
+
+echo "PASS: pinned-kernel netns VM offline contract and destructive mutations"

--- a/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
+++ b/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
@@ -124,9 +124,10 @@ because the upper-device ifindex carries the VLAN directly.
 
 ### 5. The freshness window is a heuristic and must be calibrated before implementation
 
-The kernel provides **no ordering guarantee** across the AF_INET / AF_INET6 and
-AF_BRIDGE `RTNLGRP_NEIGH` multicast groups: the ARP/ND event can arrive before,
-after, or concurrently with the corresponding FDB event. The freshness window
+The kernel provides **no causal-ordering guarantee** between AF_INET / AF_INET6
+and AF_BRIDGE messages delivered on the single `RTNLGRP_NEIGH` subscription and
+socket: the ARP/ND event can arrive before, after, or concurrently with the
+corresponding FDB event. The freshness window
 is therefore a **heuristic, not a proof** — it bounds the race, it does not
 eliminate it. The ADR does not choose a value; calibration must **measure the
 worst-case inter-arrival skew under load and set the window to roughly 2-3× it**.


### PR DESCRIPTION
Timing-sensitive EVPN netlink receipts cannot be reproduced across an exact supported-baseline and current kernel pair on rolling host kernels. This adds an offline, fail-closed calibration harness that makes such a pair reproducible.

## What it does

- Pins two dated Canonical LTS profiles (Jammy 5.15, Noble 6.8)
- Requires KVM and refuses to fall back to TCG, so timing receipts cannot silently come from emulation
- Runs snapshot, no-network, read-only against fresh staging
- Records exact tool, image, kernel, iproute2, config, git, and payload provenance
- Binds QEMU and `cloud-localds` to dpkg-owned absolute paths, so a PATH shadow cannot evade package provenance
- Refuses to run as root before touching lock or path state
- Takes the shared host lock with a two-sample quiet admission and cleans up deterministically

Also corrects a stale sentence in ADR-0093 that described multiple multicast group subscriptions, where the code opens a single `RTNLGRP_NEIGH` subscription.

## Validation

- `just gate` green in a worktree rebased onto current `main`, including `ruff check`, `actionlint`, clippy `-D warnings`, workspace tests, and `cargo doc`
- offline destructive mutation suite passes, covering QEMU version and path drift, PATH shadowing, relative-path plans, and TCG substitution
- `bash -n` and ShellCheck clean on all three shell entry points
- Python compiles

## Boundary

Live VM execution is separately gated. Nothing in this change downloads an image, boots a VM, installs packages, or publishes a receipt.

Linear: LAN-383