### PR TITLE
test(interop): measure live AS_SET receiver behavior

### DIFF
--- a/tests/interop/configs/bgpd-m105-receiver.conf
+++ b/tests/interop/configs/bgpd-m105-receiver.conf
@@ -1,0 +1,20 @@
+# M105: OpenBGPD 9.2 as a route server receiver. reject as-set stays default.
+AS 65003
+router-id 10.105.0.3
+fib-update no
+
+neighbor 10.105.0.10 {
+	descr "m105-raw-rs-client"
+	remote-as 64512
+	local-address 10.105.0.3
+	holdtime 90
+	announce IPv4 unicast enforce
+	announce policy enforce
+	announce as-4byte enforce
+	enforce neighbor-as no
+	transparent-as yes
+	role rs
+}
+
+allow from any
+deny to any

--- a/tests/interop/configs/bird-m105-receiver.conf
+++ b/tests/interop/configs/bird-m105-receiver.conf
@@ -1,0 +1,20 @@
+# M105: BIRD 3.3.2 as a route server receiver. AS_SET defaults are untouched.
+log stderr all;
+router id 10.105.0.2;
+
+protocol device { scan time 10; }
+
+protocol bgp raw_peer {
+  local 10.105.0.2 as 65002;
+  neighbor 10.105.0.10 as 64512;
+  hold time 90;
+  local role rs_server;
+  require roles on;
+  rs client on;
+  enforce first as off;
+
+  ipv4 {
+    import all;
+    export none;
+  };
+}

--- a/tests/interop/configs/frr-bgpd-m105-receiver.conf
+++ b/tests/interop/configs/frr-bgpd-m105-receiver.conf
@@ -1,0 +1,24 @@
+frr version 10.3.1
+frr defaults traditional
+hostname frr-m105
+log stdout informational
+
+router bgp 65005
+ bgp router-id 10.105.0.5
+ bgp ebgp-requires-policy
+ neighbor 10.105.0.10 remote-as 64512
+ neighbor 10.105.0.10 description m105-raw-rs-client
+ neighbor 10.105.0.10 timers 30 90
+ no neighbor 10.105.0.10 enforce-first-as
+ neighbor 10.105.0.10 local-role rs-server strict-mode
+ !
+ address-family ipv4 unicast
+  neighbor 10.105.0.10 route-server-client
+  neighbor 10.105.0.10 route-map M105-PERMIT in
+  neighbor 10.105.0.10 route-map M105-DENY out
+ exit-address-family
+!
+route-map M105-PERMIT permit 10
+!
+route-map M105-DENY deny 10
+!

--- a/tests/interop/configs/gobgp-m105-receiver.toml
+++ b/tests/interop/configs/gobgp-m105-receiver.toml
@@ -1,0 +1,17 @@
+# M105: GoBGP 4.8.0 as a route server receiver. AS_SET defaults are untouched.
+[global.config]
+as = 65004
+router-id = "10.105.0.4"
+
+[[neighbors]]
+[neighbors.config]
+neighbor-address = "10.105.0.10"
+peer-as = 64512
+[neighbors.route-server.config]
+route-server-client = true
+[neighbors.apply-policy.config]
+default-import-policy = "accept-route"
+default-export-policy = "reject-route"
+[[neighbors.afi-safis]]
+[neighbors.afi-safis.config]
+afi-safi-name = "ipv4-unicast"

--- a/tests/interop/configs/rustbgpd-m105-receiver.toml
+++ b/tests/interop/configs/rustbgpd-m105-receiver.toml
@@ -1,0 +1,41 @@
+# M105: current rustbgpd as a single-member route server receiver.
+config_epoch = 2
+
+[global]
+asn = 65001
+router_id = "10.105.0.1"
+listen_port = 179
+ebgp_requires_policy = true
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+
+[policy.definitions.m105-import]
+default_action = "permit"
+
+[policy.definitions.m105-export]
+default_action = "deny"
+
+[[neighbors]]
+address = "10.105.0.10"
+remote_asn = 64512
+description = "m105-raw-rs-client"
+hold_time = 90
+families = ["ipv4_unicast"]
+route_server_client = true
+role = "route_server"
+strict_role = true
+import_policy_chain = ["m105-import"]
+export_policy_chain = ["m105-export"]

--- a/tests/interop/m105-live-as-set.clab.yml
+++ b/tests/interop/m105-live-as-set.clab.yml
@@ -1,0 +1,100 @@
+# M105 — live AS_SET receiver behavior across five current route servers.
+name: m105-live-as-set
+
+topology:
+  nodes:
+    switch:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      exec:
+        - ip link add br0 type bridge mcast_snooping 0
+        - ip link set eth1 master br0
+        - ip link set eth2 master br0
+        - ip link set eth3 master br0
+        - ip link set eth4 master br0
+        - ip link set eth5 master br0
+        - ip link set eth6 master br0
+        - ip link set eth1 up
+        - ip link set eth2 up
+        - ip link set eth3 up
+        - ip link set eth4 up
+        - ip link set eth5 up
+        - ip link set eth6 up
+        - ip link set br0 up
+
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      binds:
+        - ./configs/rustbgpd-m105-receiver.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
+        - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+      exec:
+        - ip addr add 10.105.0.1/24 dev eth1
+        - ip link set eth1 up
+      env:
+        RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
+
+    bird:
+      kind: linux
+      image: bird:v3.3.2-m101
+      cmd: sleep infinity
+      binds:
+        - ./configs/bird-m105-receiver.conf:/etc/bird/bird.conf:ro
+      exec:
+        - ip addr add 10.105.0.2/24 dev eth1
+        - ip link set eth1 up
+        - mkdir -p /run/bird
+
+    openbgpd:
+      kind: linux
+      image: openbgpd/openbgpd@sha256:b2e94bd1538102a89cff96867993eabb6dbb27720de4ab7b588860880e3e3bf9
+      cmd: sleep infinity
+      binds:
+        - ./configs/bgpd-m105-receiver.conf:/etc/bgpd.conf:ro
+      exec:
+        - ip addr add 10.105.0.3/24 dev eth1
+        - ip link set eth1 up
+
+    gobgp:
+      kind: linux
+      image: gobgp:v4.8.0-m103
+      cmd: sleep infinity
+      binds:
+        - ./configs/gobgp-m105-receiver.toml:/config/gobgp.toml:ro
+      exec:
+        - ip addr add 10.105.0.4/24 dev eth1
+        - ip link set eth1 up
+
+    frr:
+      kind: linux
+      image: quay.io/frrouting/frr@sha256:f90d26a9fd5c14fc5795a73b4254ac88bc3186c45bbeb220a225fb6182de812c
+      cmd: sleep infinity
+      binds:
+        - ./configs/frr-daemons:/etc/frr/daemons:ro
+        - ./configs/frr-bgpd-m105-receiver.conf:/etc/frr/frr.conf:ro
+        - /dev/null:/etc/frr/vtysh.conf:ro
+      exec:
+        - ip addr add 10.105.0.5/24 dev eth1
+        - ip link set eth1 up
+
+    raw:
+      kind: linux
+      image: bmpsink:m102
+      cmd: sleep infinity
+      binds:
+        - ./scripts/m105_raw_peer.py:/m105_raw_peer.py:ro
+      exec:
+        - ip addr add 10.105.0.10/24 dev eth1
+        - ip link set eth1 up
+
+  links:
+    - endpoints: ["switch:eth1", "rustbgpd:eth1"]
+    - endpoints: ["switch:eth2", "bird:eth1"]
+    - endpoints: ["switch:eth3", "openbgpd:eth1"]
+    - endpoints: ["switch:eth4", "gobgp:eth1"]
+    - endpoints: ["switch:eth5", "frr:eth1"]
+    - endpoints: ["switch:eth6", "raw:eth1"]

--- a/tests/interop/m105-live-as-set/README.md
+++ b/tests/interop/m105-live-as-set/README.md
@@ -1,0 +1,43 @@
+# M105 live AS_SET discovery
+
+M105 sends the same two IPv4 routes from one raw route-server client to five
+current route-server implementations: rustbgpd, BIRD 3.3.2, OpenBGPD 9.2,
+GoBGP 4.8.0, and FRR 10.3.1. The first route has an ordinary AS_SEQUENCE; the
+second has a two-member AS_SET. No daemon's AS_SET policy default is changed.
+
+The live driver records whether each receiver installs the AS_SET route, checks
+that the session and process remain live, withdraws both routes, and saves the
+observations beside packet-level evidence. It does not encode an expected
+per-daemon outcome.
+
+Run from the repository root:
+
+```console
+containerlab deploy -t tests/interop/m105-live-as-set.clab.yml
+M105_ARTIFACT_DIR="$HOME/artifacts/m105-live-as-set-$(date -u +%Y%m%dT%H%M%SZ)" \
+  bash tests/interop/scripts/test-m105-live-as-set.sh
+```
+
+The artifact directory contains image/config identities, the raw-peer event
+log, the PCAP and decoded payload rows, the packet-oracle receipt, and the
+per-daemon outcome matrix. Public documentation and CI wiring remain out of
+scope until the observed matrix is reviewed.
+
+## Current observation
+
+Repeated local runs on 2026-08-29 produced the same receiver matrix:
+
+| Receiver | AS_SET route |
+|---|---|
+| rustbgpd 0.67.0 | Not installed |
+| BIRD 3.3.2 | Not installed |
+| OpenBGPD 9.2 | Not installed |
+| GoBGP 4.8.0 | Installed in accepted Adj-RIB-In |
+| FRR 10.3.1 | Installed |
+
+All five sessions remained Established, the ordinary AS_SEQUENCE control was
+accepted by all five receivers, and both prefixes disappeared after the raw
+client withdrew them. “Not installed” deliberately does not guess whether an
+implementation classified the UPDATE as a policy rejection or
+treat-as-withdraw; the native receiver snapshots only establish absence from the
+accepted route surface.

--- a/tests/interop/scripts/m105_capture_oracle.py
+++ b/tests/interop/scripts/m105_capture_oracle.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Verify the exact M105 raw-client messages from decoded TCP payload rows."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import struct
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+MARKER = b"\xff" * 16
+RAW = "10.105.0.10"
+RECEIVERS = {
+    "10.105.0.1": "rustbgpd",
+    "10.105.0.2": "bird",
+    "10.105.0.3": "openbgpd",
+    "10.105.0.4": "gobgp",
+    "10.105.0.5": "frr",
+}
+BASELINE = "198.51.104.0/24"
+PROBE = "198.51.105.0/24"
+
+
+def need(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def reassemble(parts: list[tuple[int, bytes]]) -> bytes:
+    need(bool(parts), "TCP stream has no payload")
+    base = min(sequence for sequence, _ in parts)
+    cursor = base
+    output = bytearray()
+    for sequence, payload in sorted(parts):
+        need(sequence <= cursor, f"TCP gap before sequence {sequence}")
+        overlap = cursor - sequence
+        if overlap:
+            start = sequence - base
+            need(start >= 0, "TCP segment precedes stream base")
+            need(
+                output[start : start + min(overlap, len(payload))] == payload[:overlap],
+                "conflicting TCP overlap",
+            )
+        if overlap < len(payload):
+            output.extend(payload[overlap:])
+            cursor = sequence + len(payload)
+    return bytes(output)
+
+
+def messages(data: bytes) -> list[tuple[int, bytes]]:
+    decoded: list[tuple[int, bytes]] = []
+    cursor = 0
+    while cursor < len(data):
+        need(len(data) - cursor >= 19, "trailing partial BGP header")
+        need(data[cursor : cursor + 16] == MARKER, "BGP marker mismatch")
+        length, message_type = struct.unpack("!HB", data[cursor + 16 : cursor + 19])
+        need(19 <= length <= 4096, f"invalid BGP length {length}")
+        need(cursor + length <= len(data), "trailing partial BGP message")
+        decoded.append((message_type, data[cursor + 19 : cursor + length]))
+        cursor += length
+    return decoded
+
+
+def capabilities(body: bytes) -> dict[int, list[bytes]]:
+    need(len(body) >= 10 and body[0] == 4, "invalid raw OPEN")
+    length = body[9]
+    optional = body[10 : 10 + length]
+    need(len(optional) == length, "truncated OPEN optional parameters")
+    found: dict[int, list[bytes]] = defaultdict(list)
+    cursor = 0
+    while cursor < len(optional):
+        need(cursor + 2 <= len(optional) and optional[cursor] == 2, "unexpected OPEN parameter")
+        parameter_length = optional[cursor + 1]
+        value = optional[cursor + 2 : cursor + 2 + parameter_length]
+        need(len(value) == parameter_length, "truncated OPEN parameter")
+        cursor += 2 + parameter_length
+        cap_cursor = 0
+        while cap_cursor < len(value):
+            need(cap_cursor + 2 <= len(value), "truncated capability header")
+            code = value[cap_cursor]
+            cap_length = value[cap_cursor + 1]
+            cap_value = value[cap_cursor + 2 : cap_cursor + 2 + cap_length]
+            need(len(cap_value) == cap_length, "truncated capability value")
+            found[code].append(cap_value)
+            cap_cursor += 2 + cap_length
+    return dict(found)
+
+
+def decode_nlri(raw: bytes) -> list[str]:
+    prefixes: list[str] = []
+    cursor = 0
+    while cursor < len(raw):
+        length = raw[cursor]
+        cursor += 1
+        octets = (length + 7) // 8
+        need(length <= 32 and cursor + octets <= len(raw), "invalid IPv4 NLRI")
+        packed = raw[cursor : cursor + octets] + b"\x00" * (4 - octets)
+        cursor += octets
+        prefixes.append(str(ipaddress.IPv4Network((packed, length), strict=False)))
+    return prefixes
+
+
+def update(body: bytes) -> tuple[list[str], dict[int, tuple[int, bytes]], list[str]]:
+    need(len(body) >= 4, "short UPDATE")
+    withdrawn_length = int.from_bytes(body[:2], "big")
+    need(2 + withdrawn_length + 2 <= len(body), "truncated withdrawn routes")
+    withdrawn = decode_nlri(body[2 : 2 + withdrawn_length])
+    cursor = 2 + withdrawn_length
+    attributes_length = int.from_bytes(body[cursor : cursor + 2], "big")
+    attributes_raw = body[cursor + 2 : cursor + 2 + attributes_length]
+    need(len(attributes_raw) == attributes_length, "truncated path attributes")
+    announced = decode_nlri(body[cursor + 2 + attributes_length :])
+    attributes: dict[int, tuple[int, bytes]] = {}
+    cursor = 0
+    while cursor < len(attributes_raw):
+        need(cursor + 3 <= len(attributes_raw), "truncated attribute header")
+        flags = attributes_raw[cursor]
+        code = attributes_raw[cursor + 1]
+        cursor += 2
+        if flags & 0x10:
+            need(cursor + 2 <= len(attributes_raw), "truncated extended attribute length")
+            length = int.from_bytes(attributes_raw[cursor : cursor + 2], "big")
+            cursor += 2
+        else:
+            length = attributes_raw[cursor]
+            cursor += 1
+        value = attributes_raw[cursor : cursor + length]
+        need(len(value) == length, "truncated attribute value")
+        need(code not in attributes, f"duplicate attribute {code}")
+        attributes[code] = (flags, value)
+        cursor += length
+    return withdrawn, attributes, announced
+
+
+def verify_announcement(
+    attributes: dict[int, tuple[int, bytes]],
+    *,
+    segment_type: int,
+    members: tuple[int, ...],
+) -> None:
+    expected_codes = {1, 2, 3, 8, 32}
+    need(set(attributes) == expected_codes, f"attribute codes differ: {set(attributes)}")
+    need(attributes[1] == (0x40, b"\x00"), "ORIGIN differs")
+    path = bytes([segment_type, len(members)]) + b"".join(
+        member.to_bytes(4, "big") for member in members
+    )
+    need(attributes[2] == (0x40, path), "AS_PATH differs")
+    need(attributes[3] == (0x40, ipaddress.IPv4Address(RAW).packed), "NEXT_HOP differs")
+    need(attributes[8] == (0xC0, struct.pack("!HH", 64512, 105)), "COMMUNITIES differs")
+    need(
+        attributes[32] == (0xC0, struct.pack("!III", 64512, 105, 1)),
+        "LARGE_COMMUNITIES differs",
+    )
+
+
+def verify_stream(data: bytes, destination: str) -> dict[str, object]:
+    decoded = messages(data)
+    opens = [body for message_type, body in decoded if message_type == 1]
+    need(len(opens) == 1, f"{destination}: expected one OPEN")
+    caps = capabilities(opens[0])
+    need(int.from_bytes(opens[0][1:3], "big") == 64512, f"{destination}: OPEN AS differs")
+    need(caps.get(65) == [(64512).to_bytes(4, "big")], f"{destination}: capability 65 differs")
+    need(caps.get(9) == [b"\x02"], f"{destination}: BGP Role differs")
+    need(struct.pack("!HBB", 1, 0, 1) in caps.get(1, []), f"{destination}: IPv4 capability absent")
+
+    baseline = []
+    probe = []
+    withdrawals = []
+    for message_type, body in decoded:
+        if message_type != 2:
+            continue
+        withdrawn, attributes, announced = update(body)
+        if announced == [BASELINE]:
+            baseline.append(attributes)
+        if announced == [PROBE]:
+            probe.append(attributes)
+        if set(withdrawn) == {BASELINE, PROBE}:
+            withdrawals.append((attributes, announced))
+    need(len(baseline) == 1, f"{destination}: baseline UPDATE count differs")
+    need(len(probe) == 1, f"{destination}: AS_SET UPDATE count differs")
+    need(len(withdrawals) == 1, f"{destination}: withdrawal UPDATE count differs")
+    verify_announcement(baseline[0], segment_type=2, members=(64512,))
+    verify_announcement(probe[0], segment_type=1, members=(64512, 64513))
+    need(withdrawals[0] == ({}, []), f"{destination}: withdrawal carries reachability")
+    return {
+        "destination": destination,
+        "open_role": "rs-client",
+        "baseline_as_path": {"segment_type": 2, "members": [64512]},
+        "as_set_path": {"segment_type": 1, "members": [64512, 64513]},
+        "next_hop": RAW,
+        "community": "64512:105",
+        "large_community": "64512:105:1",
+        "withdrawn": [BASELINE, PROBE],
+    }
+
+
+def analyze(lines: list[str]) -> dict[str, object]:
+    streams: dict[tuple[str, str], list[tuple[int, bytes]]] = defaultdict(list)
+    for line_number, raw_line in enumerate(lines, 1):
+        fields = raw_line.rstrip("\n").split("\t")
+        need(len(fields) == 5, f"row {line_number}: expected five TSV fields")
+        stream, source, destination, sequence, payload = fields
+        if source != RAW or destination not in RECEIVERS or not payload:
+            continue
+        streams[(stream, destination)].append(
+            (int(sequence), bytes.fromhex(payload.replace(":", "")))
+        )
+    by_destination: dict[str, list[tuple[int, bytes]]] = defaultdict(list)
+    for (_, destination), parts in streams.items():
+        need(destination not in by_destination, f"{destination}: multiple raw TCP streams")
+        by_destination[destination] = parts
+    need(set(by_destination) == set(RECEIVERS), "capture receiver set differs")
+    receivers = {
+        RECEIVERS[destination]: verify_stream(reassemble(parts), destination)
+        for destination, parts in sorted(by_destination.items())
+    }
+    return {"schema": "m105-wire/1", "raw_client": RAW, "receivers": receivers}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} PAYLOADS.tsv", file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    receipt = analyze(path.read_text(encoding="utf-8").splitlines(keepends=True))
+    print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as error:
+        print(f"M105 packet oracle failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tests/interop/scripts/m105_raw_peer.py
+++ b/tests/interop/scripts/m105_raw_peer.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""One raw route-server client feeding the five M105 receivers."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import socket
+import struct
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+MARKER = b"\xff" * 16
+TYPE_OPEN = 1
+TYPE_UPDATE = 2
+TYPE_NOTIFICATION = 3
+TYPE_KEEPALIVE = 4
+CAP_MULTIPROTOCOL = 1
+CAP_BGP_ROLE = 9
+CAP_FOUR_OCTET_AS = 65
+ROLE_ROUTE_SERVER = 1
+ROLE_ROUTE_SERVER_CLIENT = 2
+ATTR_OPTIONAL = 0x80
+ATTR_TRANSITIVE = 0x40
+ATTR_ORIGIN = 1
+ATTR_AS_PATH = 2
+ATTR_NEXT_HOP = 3
+ATTR_COMMUNITIES = 8
+ATTR_LARGE_COMMUNITIES = 32
+LOCAL_AS = 64512
+RAW_ADDR = "10.105.0.10"
+BASELINE_PREFIX = "198.51.104.0/24"
+AS_SET_PREFIX = "198.51.105.0/24"
+EVENTS = Path("/tmp/m105-events.jsonl")
+READY = Path("/tmp/m105-ready")
+TRIGGERS = (
+    (Path("/tmp/m105-send-baseline"), "baseline"),
+    (Path("/tmp/m105-send-as-set"), "as_set"),
+    (Path("/tmp/m105-send-withdraw"), "withdraw"),
+)
+STOP = Path("/tmp/m105-stop")
+EXPECTED = {
+    "10.105.0.1": ("rustbgpd", 65001),
+    "10.105.0.2": ("bird", 65002),
+    "10.105.0.3": ("openbgpd", 65003),
+    "10.105.0.4": ("gobgp", 65004),
+    "10.105.0.5": ("frr", 65005),
+}
+
+event_lock = threading.Lock()
+sessions_lock = threading.Lock()
+sessions: dict[str, "Session"] = {}
+worker_errors: list[str] = []
+
+
+def emit(peer: str, event: str, **fields: Any) -> None:
+    row = {"peer": peer, "event": event, **fields}
+    with event_lock:
+        with EVENTS.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+def message(message_type: int, body: bytes = b"") -> bytes:
+    return MARKER + struct.pack("!HB", 19 + len(body), message_type) + body
+
+
+def capability(code: int, value: bytes) -> bytes:
+    return bytes([code, len(value)]) + value
+
+
+def open_message() -> bytes:
+    capabilities = b"".join(
+        (
+            capability(CAP_MULTIPROTOCOL, struct.pack("!HBB", 1, 0, 1)),
+            capability(CAP_FOUR_OCTET_AS, struct.pack("!I", LOCAL_AS)),
+            capability(CAP_BGP_ROLE, bytes([ROLE_ROUTE_SERVER_CLIENT])),
+        )
+    )
+    optional = bytes([2, len(capabilities)]) + capabilities
+    body = struct.pack(
+        "!BHHIB",
+        4,
+        LOCAL_AS,
+        90,
+        int(ipaddress.IPv4Address(RAW_ADDR)),
+        len(optional),
+    )
+    return message(TYPE_OPEN, body + optional)
+
+
+def recvn(stream: socket.socket, count: int) -> bytes:
+    data = bytearray()
+    while len(data) < count:
+        chunk = stream.recv(count - len(data))
+        if not chunk:
+            raise EOFError("peer closed the TCP stream")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def read_message(stream: socket.socket) -> tuple[int, bytes]:
+    header = recvn(stream, 19)
+    if header[:16] != MARKER:
+        raise RuntimeError("BGP marker mismatch")
+    length, message_type = struct.unpack("!HB", header[16:19])
+    if not 19 <= length <= 4096:
+        raise RuntimeError(f"invalid BGP message length {length}")
+    return message_type, recvn(stream, length - 19)
+
+
+def parse_capabilities(body: bytes, expected_as: int) -> int | None:
+    if len(body) < 10 or body[0] != 4:
+        raise RuntimeError("invalid receiver OPEN")
+    header_as = int.from_bytes(body[1:3], "big")
+    if header_as != expected_as:
+        raise RuntimeError(f"receiver OPEN AS {header_as}, expected {expected_as}")
+    optional_length = body[9]
+    optional = body[10 : 10 + optional_length]
+    if len(optional) != optional_length:
+        raise RuntimeError("truncated receiver OPEN parameters")
+    capabilities: dict[int, list[bytes]] = {}
+    cursor = 0
+    while cursor < len(optional):
+        if cursor + 2 > len(optional) or optional[cursor] != 2:
+            raise RuntimeError("unexpected receiver OPEN parameter")
+        length = optional[cursor + 1]
+        value = optional[cursor + 2 : cursor + 2 + length]
+        if len(value) != length:
+            raise RuntimeError("truncated receiver capability parameter")
+        cursor += 2 + length
+        cap_cursor = 0
+        while cap_cursor < len(value):
+            if cap_cursor + 2 > len(value):
+                raise RuntimeError("truncated receiver capability")
+            code = value[cap_cursor]
+            cap_length = value[cap_cursor + 1]
+            cap_value = value[cap_cursor + 2 : cap_cursor + 2 + cap_length]
+            if len(cap_value) != cap_length:
+                raise RuntimeError("truncated receiver capability value")
+            capabilities.setdefault(code, []).append(cap_value)
+            cap_cursor += 2 + cap_length
+    four_as = capabilities.get(CAP_FOUR_OCTET_AS, [])
+    if four_as != [expected_as.to_bytes(4, "big")]:
+        raise RuntimeError("receiver four-octet-AS capability mismatch")
+    if struct.pack("!HBB", 1, 0, 1) not in capabilities.get(CAP_MULTIPROTOCOL, []):
+        raise RuntimeError("receiver did not advertise IPv4 unicast")
+    roles = capabilities.get(CAP_BGP_ROLE, [])
+    if roles and roles != [bytes([ROLE_ROUTE_SERVER])]:
+        raise RuntimeError(f"receiver advertised incompatible BGP Role {roles!r}")
+    return roles[0][0] if roles else None
+
+
+def nlri(prefix: str) -> bytes:
+    network = ipaddress.IPv4Network(prefix)
+    octets = (network.prefixlen + 7) // 8
+    return bytes([network.prefixlen]) + network.network_address.packed[:octets]
+
+
+def attribute(flags: int, code: int, value: bytes) -> bytes:
+    if len(value) > 255:
+        raise ValueError("M105 attributes use one-octet lengths")
+    return bytes([flags, code, len(value)]) + value
+
+
+def common_attributes(as_path: bytes) -> bytes:
+    standard = struct.pack("!HH", LOCAL_AS, 105)
+    large = struct.pack("!III", LOCAL_AS, 105, 1)
+    return b"".join(
+        (
+            attribute(ATTR_TRANSITIVE, ATTR_ORIGIN, b"\x00"),
+            attribute(ATTR_TRANSITIVE, ATTR_AS_PATH, as_path),
+            attribute(
+                ATTR_TRANSITIVE,
+                ATTR_NEXT_HOP,
+                ipaddress.IPv4Address(RAW_ADDR).packed,
+            ),
+            attribute(ATTR_OPTIONAL | ATTR_TRANSITIVE, ATTR_COMMUNITIES, standard),
+            attribute(
+                ATTR_OPTIONAL | ATTR_TRANSITIVE,
+                ATTR_LARGE_COMMUNITIES,
+                large,
+            ),
+        )
+    )
+
+
+def update(announced: str, as_path: bytes) -> bytes:
+    attributes = common_attributes(as_path)
+    body = b"\x00\x00" + len(attributes).to_bytes(2, "big") + attributes
+    return message(TYPE_UPDATE, body + nlri(announced))
+
+
+def withdrawal() -> bytes:
+    withdrawn = nlri(BASELINE_PREFIX) + nlri(AS_SET_PREFIX)
+    return message(TYPE_UPDATE, len(withdrawn).to_bytes(2, "big") + withdrawn + b"\x00\x00")
+
+
+def reverse_update_has_prefix(body: bytes) -> bool:
+    if len(body) < 4:
+        return True
+    withdrawn_length = int.from_bytes(body[:2], "big")
+    cursor = 2 + withdrawn_length
+    if cursor + 2 > len(body):
+        return True
+    attributes_length = int.from_bytes(body[cursor : cursor + 2], "big")
+    attributes = body[cursor + 2 : cursor + 2 + attributes_length]
+    announced = body[cursor + 2 + attributes_length :]
+    if withdrawn_length or announced:
+        return True
+    cursor = 0
+    while cursor < len(attributes):
+        if cursor + 3 > len(attributes):
+            return True
+        flags = attributes[cursor]
+        code = attributes[cursor + 1]
+        cursor += 2
+        if flags & 0x10:
+            if cursor + 2 > len(attributes):
+                return True
+            length = int.from_bytes(attributes[cursor : cursor + 2], "big")
+            cursor += 2
+        else:
+            length = attributes[cursor]
+            cursor += 1
+        value = attributes[cursor : cursor + length]
+        if len(value) != length:
+            return True
+        cursor += length
+        if code == 14 and len(value) > 5:
+            next_hop_length = value[3]
+            nlri_cursor = 4 + next_hop_length
+            if nlri_cursor < len(value):
+                nlri_cursor += 1
+            if nlri_cursor < len(value):
+                return True
+    return False
+
+
+@dataclass
+class Session:
+    peer: str
+    stream: socket.socket
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    alive: bool = True
+
+    def send(self, payload: bytes) -> None:
+        with self.lock:
+            self.stream.sendall(payload)
+
+
+def serve_connection(stream: socket.socket, remote: str) -> None:
+    peer, expected_as = EXPECTED[remote]
+    try:
+        stream.settimeout(1)
+        stream.sendall(open_message())
+        saw_open = False
+        saw_keepalive = False
+        sent_keepalive = False
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and not (saw_open and saw_keepalive):
+            try:
+                message_type, body = read_message(stream)
+            except TimeoutError:
+                continue
+            if message_type == TYPE_OPEN:
+                role = parse_capabilities(body, expected_as)
+                emit(peer, "open", remote_as=expected_as, role=role)
+                saw_open = True
+                if not sent_keepalive:
+                    stream.sendall(message(TYPE_KEEPALIVE))
+                    sent_keepalive = True
+            elif message_type == TYPE_KEEPALIVE:
+                saw_keepalive = True
+            elif message_type == TYPE_NOTIFICATION:
+                emit(
+                    peer,
+                    "notification",
+                    code=body[0] if body else None,
+                    subcode=body[1] if len(body) > 1 else None,
+                )
+                raise RuntimeError("receiver sent a notification during handshake")
+        if not (saw_open and saw_keepalive):
+            raise RuntimeError("receiver handshake did not complete")
+        session = Session(peer=peer, stream=stream)
+        with sessions_lock:
+            sessions[peer] = session
+        emit(peer, "established", remote=remote)
+
+        while not STOP.exists():
+            try:
+                message_type, body = read_message(stream)
+            except TimeoutError:
+                continue
+            if message_type == TYPE_NOTIFICATION:
+                emit(
+                    peer,
+                    "notification",
+                    code=body[0] if body else None,
+                    subcode=body[1] if len(body) > 1 else None,
+                )
+            elif message_type == TYPE_UPDATE:
+                emit(
+                    peer,
+                    "reverse_update",
+                    prefix_bearing=reverse_update_has_prefix(body),
+                    length=len(body),
+                )
+    except EOFError:
+        emit(peer, "closed")
+    except Exception as error:  # noqa: BLE001 - errors become fixture evidence.
+        emit(peer, "reader_error", detail=str(error))
+        with sessions_lock:
+            worker_errors.append(f"{peer}: {error}")
+    finally:
+        with sessions_lock:
+            if peer in sessions:
+                sessions[peer].alive = False
+        try:
+            stream.close()
+        except OSError:
+            pass
+
+
+def snapshot_sessions() -> list[Session]:
+    with sessions_lock:
+        return [sessions[name] for name in sorted(sessions)]
+
+
+def send_phase(phase: str) -> None:
+    if phase == "baseline":
+        payload = update(BASELINE_PREFIX, b"\x02\x01" + struct.pack("!I", LOCAL_AS))
+    elif phase == "as_set":
+        payload = update(
+            AS_SET_PREFIX,
+            b"\x01\x02" + struct.pack("!II", LOCAL_AS, LOCAL_AS + 1),
+        )
+    elif phase == "withdraw":
+        payload = withdrawal()
+    else:
+        raise ValueError(f"unknown phase {phase}")
+    current = snapshot_sessions()
+    if len(current) != len(EXPECTED) or not all(item.alive for item in current):
+        raise RuntimeError(f"cannot send {phase}: receiver set is not fully live")
+    for session in current:
+        session.send(payload)
+        emit(session.peer, "send", phase=phase, bytes=len(payload))
+
+
+def wait_for_trigger(path: Path, phase: str) -> None:
+    next_keepalive = time.monotonic()
+    while not path.exists():
+        if STOP.exists():
+            raise RuntimeError(f"stopped before {phase} trigger")
+        if time.monotonic() >= next_keepalive:
+            for session in snapshot_sessions():
+                if session.alive:
+                    session.send(message(TYPE_KEEPALIVE))
+            next_keepalive = time.monotonic() + 15
+        time.sleep(0.1)
+    send_phase(phase)
+
+
+def main() -> int:
+    for path in (EVENTS, READY, STOP, *(item[0] for item in TRIGGERS)):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("0.0.0.0", 179))
+    listener.listen(len(EXPECTED))
+    listener.settimeout(0.5)
+    emit("fixture", "listening", address=RAW_ADDR, receivers=len(EXPECTED))
+    threads: list[threading.Thread] = []
+    deadline = time.monotonic() + 120
+    try:
+        while time.monotonic() < deadline:
+            with sessions_lock:
+                if len(sessions) == len(EXPECTED):
+                    break
+            try:
+                stream, address = listener.accept()
+            except TimeoutError:
+                continue
+            remote = address[0]
+            if remote not in EXPECTED:
+                stream.close()
+                emit("fixture", "unexpected_connection", remote=remote)
+                continue
+            thread = threading.Thread(
+                target=serve_connection,
+                args=(stream, remote),
+                name=f"m105-{EXPECTED[remote][0]}",
+                daemon=True,
+            )
+            thread.start()
+            threads.append(thread)
+        with sessions_lock:
+            connected = sorted(sessions)
+        if connected != sorted(peer for peer, _ in EXPECTED.values()):
+            raise RuntimeError(f"receiver set incomplete: {connected}")
+        READY.write_text("ready\n", encoding="utf-8")
+        emit("fixture", "ready", peers=connected)
+        for path, phase in TRIGGERS:
+            wait_for_trigger(path, phase)
+        while not STOP.exists():
+            for session in snapshot_sessions():
+                if session.alive:
+                    session.send(message(TYPE_KEEPALIVE))
+            time.sleep(5)
+        with sessions_lock:
+            errors = list(worker_errors)
+        if errors:
+            raise RuntimeError("; ".join(errors))
+        emit("fixture", "stopped")
+        return 0
+    finally:
+        listener.close()
+        for session in snapshot_sessions():
+            try:
+                session.stream.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            session.stream.close()
+        for thread in threads:
+            thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:  # noqa: BLE001 - stderr is retained as evidence.
+        emit("fixture", "fatal", detail=str(error))
+        print(f"M105 raw peer failed: {error}", file=os.sys.stderr)
+        raise

--- a/tests/interop/scripts/test-m105-live-as-set.sh
+++ b/tests/interop/scripts/test-m105-live-as-set.sh
@@ -153,6 +153,7 @@ m105_on_exit() {
             docker exec "$container" cat "$path" \
                 >"$ARTIFACT_DIR/${name}.partial.log" 2>/dev/null || true
         done
+        docker logs "$FRR" >"$ARTIFACT_DIR/frr.partial.log" 2>&1 || true
     fi
     cleanup_capture
     _cleanup_on_exit

--- a/tests/interop/scripts/test-m105-live-as-set.sh
+++ b/tests/interop/scripts/test-m105-live-as-set.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# M105 — live AS_SET receiver behavior across five current route servers.
+set -euo pipefail
+
+TOPO=m105-live-as-set
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLEANUP="${CLEANUP:-1}"
+INTEROP_TEST_OPERATOR_AUTH=1
+export CLEANUP INTEROP_TEST_OPERATOR_AUTH
+# shellcheck disable=SC1091 # resolved from SCRIPT_DIR at runtime
+source "$SCRIPT_DIR/test-lib.sh"
+
+BIRD="clab-${TOPO}-bird"
+OPENBGPD="clab-${TOPO}-openbgpd"
+GOBGP="clab-${TOPO}-gobgp"
+FRR="clab-${TOPO}-frr"
+RAW="clab-${TOPO}-raw"
+RAW_ADDR=10.105.0.10
+BASELINE=198.51.104.0/24
+PROBE=198.51.105.0/24
+CAPTURE_IMAGE=bmpsink:m102
+CAPTURE_CONTAINER=m105-live-as-set-capture
+CAPTURE_VOLUME=m105-live-as-set-capture
+ARTIFACT_DIR="${M105_ARTIFACT_DIR:-/tmp/m105-live-as-set-artifacts}"
+CAPTURE_RUNNING=0
+
+declare -A OUTCOMES=()
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+check() {
+    local label=${1:?}
+    shift
+    if "$@"; then
+        printf 'PASS: %s\n' "$label"
+    else
+        die "$label"
+    fi
+}
+
+wait_until() {
+    local label=${1:?}
+    shift
+    for _ in $(seq 1 45); do
+        "$@" >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    echo "timeout waiting for $label" >&2
+    return 1
+}
+
+process_running() {
+    local container=${1:?} process=${2:?}
+    docker exec "$container" sh -c 'grep -qx "$1" /proc/[0-9]*/comm 2>/dev/null' sh "$process"
+}
+
+configured_image_is_local() {
+    local container=${1:?} image=${2:?}
+    [ "$(docker inspect -f '{{.Config.Image}}' "$container")" = "$image" ] \
+        && [ "$(docker inspect -f '{{.Image}}' "$container")" \
+            = "$(docker image inspect -f '{{.Id}}' "$image")" ]
+}
+
+bird_identity() {
+    configured_image_is_local "$BIRD" bird:v3.3.2-m101 \
+        && [ "$(docker exec "$BIRD" bird --version 2>&1)" = "BIRD version 3.3.2" ]
+}
+
+openbgpd_identity() {
+    local image='openbgpd/openbgpd@sha256:b2e94bd1538102a89cff96867993eabb6dbb27720de4ab7b588860880e3e3bf9'
+    configured_image_is_local "$OPENBGPD" "$image" \
+        && [ "$(docker exec "$OPENBGPD" bgpd -V 2>&1)" = "OpenBGPD 9.2" ]
+}
+
+gobgp_identity() {
+    configured_image_is_local "$GOBGP" gobgp:v4.8.0-m103 \
+        && [ "$(docker exec "$GOBGP" gobgpd --version 2>&1)" = "gobgpd version 4.8.0" ]
+}
+
+frr_identity() {
+    local image='quay.io/frrouting/frr@sha256:f90d26a9fd5c14fc5795a73b4254ac88bc3186c45bbeb220a225fb6182de812c'
+    configured_image_is_local "$FRR" "$image" \
+        && [ "$(docker exec "$FRR" /usr/lib/frr/bgpd --version 2>&1 | sed -n 1p)" \
+            = "bgpd version 10.3.1_git" ]
+}
+
+preflight_receivers() {
+    check "rustbgpd image is the current local build" \
+        configured_image_is_local "$RUSTBGPD" rustbgpd:dev
+    check "BIRD image and runtime are exact" bird_identity
+    check "OpenBGPD image and runtime are exact" openbgpd_identity
+    check "GoBGP image and runtime are exact" gobgp_identity
+    check "FRR image and runtime are exact" frr_identity
+
+    check "rustbgpd accepts its M105 config" \
+        docker exec "$RUSTBGPD" rustbgpd --check --strict /etc/rustbgpd/config.toml
+    check "BIRD accepts its M105 config" \
+        docker exec "$BIRD" bird -p -c /etc/bird/bird.conf
+    check "OpenBGPD accepts its M105 config" \
+        docker exec "$OPENBGPD" bgpd -n -f /etc/bgpd.conf
+    check "GoBGP accepts its M105 config" \
+        docker exec "$GOBGP" gobgpd -d -f /config/gobgp.toml
+    check "FRR accepts its M105 config" \
+        docker exec "$FRR" /usr/lib/frr/bgpd -C -f /etc/frr/frr.conf
+}
+
+write_identities() {
+    jq -n \
+        --arg rust_image "$(docker inspect -f '{{.Image}}' "$RUSTBGPD")" \
+        --arg rust_version "$(docker exec "$RUSTBGPD" rustbgpd --version 2>&1)" \
+        --arg bird_image "$(docker inspect -f '{{.Image}}' "$BIRD")" \
+        --arg bird_version "$(docker exec "$BIRD" bird --version 2>&1)" \
+        --arg open_image "$(docker inspect -f '{{.Image}}' "$OPENBGPD")" \
+        --arg open_version "$(docker exec "$OPENBGPD" bgpd -V 2>&1)" \
+        --arg gobgp_image "$(docker inspect -f '{{.Image}}' "$GOBGP")" \
+        --arg gobgp_version "$(docker exec "$GOBGP" gobgpd --version 2>&1)" \
+        --arg frr_image "$(docker inspect -f '{{.Image}}' "$FRR")" \
+        --arg frr_version "$(docker exec "$FRR" /usr/lib/frr/bgpd --version 2>&1 | sed -n 1p)" \
+        --arg capture_image "$(docker image inspect -f '{{.Id}}' "$CAPTURE_IMAGE")" \
+        '{schema:"m105-identities/1",receivers:{rustbgpd:{image:$rust_image,version:$rust_version},bird:{image:$bird_image,version:$bird_version},openbgpd:{image:$open_image,version:$open_version},gobgp:{image:$gobgp_image,version:$gobgp_version},frr:{image:$frr_image,version:$frr_version}},raw_and_capture_image:$capture_image}' \
+        >"$ARTIFACT_DIR/identities.json"
+}
+
+cleanup_capture() {
+    set +e
+    if docker container inspect "$CAPTURE_CONTAINER" >/dev/null 2>&1; then
+        if [ "$(docker inspect -f '{{.State.Running}}' "$CAPTURE_CONTAINER" 2>/dev/null)" = true ]; then
+            timeout 10 docker kill --signal=SIGINT "$CAPTURE_CONTAINER" >/dev/null 2>&1
+            timeout 10 docker wait "$CAPTURE_CONTAINER" >/dev/null 2>&1
+        fi
+        docker rm -f "$CAPTURE_CONTAINER" >/dev/null 2>&1
+    fi
+    docker volume rm -f "$CAPTURE_VOLUME" >/dev/null 2>&1
+}
+
+m105_on_exit() {
+    local status=$?
+    trap - EXIT INT TERM HUP
+    if [ "$status" -ne 0 ] && [ -d "$ARTIFACT_DIR" ]; then
+        docker exec "$RAW" cat /tmp/m105-events.jsonl \
+            >"$ARTIFACT_DIR/events.partial.jsonl" 2>/dev/null || true
+        docker exec "$RAW" cat /tmp/m105-raw.log \
+            >"$ARTIFACT_DIR/raw-peer.partial.log" 2>/dev/null || true
+        for pair in \
+            "$RUSTBGPD:/tmp/m105-rustbgpd.log:rustbgpd" \
+            "$BIRD:/tmp/m105-bird.log:bird" \
+            "$OPENBGPD:/tmp/m105-openbgpd.log:openbgpd" \
+            "$GOBGP:/tmp/m105-gobgp.log:gobgp"; do
+            IFS=: read -r container path name <<<"$pair"
+            docker exec "$container" cat "$path" \
+                >"$ARTIFACT_DIR/${name}.partial.log" 2>/dev/null || true
+        done
+    fi
+    cleanup_capture
+    _cleanup_on_exit
+    exit "$status"
+}
+trap m105_on_exit EXIT INT TERM HUP
+
+start_capture() {
+    cleanup_capture
+    docker volume create --label rustbgpd.interop.milestone=M105 "$CAPTURE_VOLUME" >/dev/null
+    docker run -d --name "$CAPTURE_CONTAINER" \
+        --label rustbgpd.interop.milestone=M105 \
+        --network "container:$RAW" \
+        --cap-add=NET_ADMIN --cap-add=NET_RAW \
+        --mount "type=volume,src=$CAPTURE_VOLUME,dst=/capture" \
+        "$CAPTURE_IMAGE" tshark -p -i any \
+        -f 'tcp port 179 and net 10.105.0.0/24' -w /capture/m105.pcap >/dev/null
+    for _ in $(seq 1 20); do
+        if [ "$(docker inspect -f '{{.State.Running}}' "$CAPTURE_CONTAINER" 2>/dev/null)" = true ] \
+            && docker logs "$CAPTURE_CONTAINER" 2>&1 | grep 'Capturing on' >/dev/null; then
+            CAPTURE_RUNNING=1
+            return 0
+        fi
+        sleep .25
+    done
+    return 1
+}
+
+stop_capture() {
+    [ "$CAPTURE_RUNNING" -eq 1 ] || return 1
+    timeout 10 docker kill --signal=SIGINT "$CAPTURE_CONTAINER" >/dev/null
+    local status
+    status=$(timeout 10 docker wait "$CAPTURE_CONTAINER")
+    case "$status" in 0|130) ;; *) return 1 ;; esac
+    CAPTURE_RUNNING=0
+    docker run --rm \
+        --mount "type=volume,src=$CAPTURE_VOLUME,dst=/capture,readonly" \
+        "$CAPTURE_IMAGE" sh -ec 'test -s /capture/m105.pcap; cat /capture/m105.pcap' \
+        >"$ARTIFACT_DIR/m105.pcap"
+    docker run --rm \
+        --mount "type=volume,src=$CAPTURE_VOLUME,dst=/capture,readonly" \
+        "$CAPTURE_IMAGE" tshark -r /capture/m105.pcap -Y 'tcp.len > 0' \
+        -T fields -E 'separator=/t' \
+        -e tcp.stream -e ip.src -e ip.dst -e tcp.seq_raw -e tcp.payload \
+        >"$ARTIFACT_DIR/payloads.tsv"
+}
+
+start_daemons() {
+    docker exec -d "$RUSTBGPD" sh -c \
+        '/usr/local/bin/start-rustbgpd.sh >/tmp/m105-rustbgpd.log 2>&1'
+    docker exec -d "$BIRD" sh -c \
+        'bird -d -c /etc/bird/bird.conf >/tmp/m105-bird.log 2>&1'
+    docker exec "$OPENBGPD" sh -c \
+        'mkdir -p /run/bgpd; rm -f /run/bgpd/bgpd.sock.* /run/bgpd/bgpd.rsock*; bgpd -d -f /etc/bgpd.conf >/tmp/m105-openbgpd.log 2>&1 &'
+    docker exec -d "$GOBGP" sh -c \
+        'gobgpd -f /config/gobgp.toml >/tmp/m105-gobgp.log 2>&1'
+    docker exec "$FRR" /usr/lib/frr/frrinit.sh start >/dev/null
+}
+
+rs_ctl() {
+    docker exec "$RUSTBGPD" rbgp -s http://127.0.0.1:50051 "$@" 2>/dev/null
+}
+
+rust_has() {
+    rs_ctl rib received "$RAW_ADDR" -a ipv4 -j \
+        | jq -e --arg prefix "$1" 'any(.[]?; .prefix == $prefix)' >/dev/null
+}
+
+rust_absent() {
+    rs_ctl rib received "$RAW_ADDR" -a ipv4 -j \
+        | jq -e --arg prefix "$1" 'all(.[]?; .prefix != $prefix)' >/dev/null
+}
+
+bird_has() {
+    docker exec "$BIRD" birdc -r show route for "$1" protocol raw_peer all 2>/dev/null \
+        | grep -F "$1" >/dev/null
+}
+
+bird_absent() {
+    local output
+    output=$(docker exec "$BIRD" birdc -r show route for "$1" protocol raw_peer all 2>/dev/null)
+    ! grep -F "$1" <<<"$output" >/dev/null
+}
+
+open_has() {
+    docker exec "$OPENBGPD" bgpctl -j show rib "$1" 2>/dev/null \
+        | jq -e --arg prefix "$1" 'any(.rib[]?; .prefix == $prefix)' >/dev/null
+}
+
+open_absent() {
+    docker exec "$OPENBGPD" bgpctl -j show rib "$1" 2>/dev/null \
+        | jq -e --arg prefix "$1" 'all(.rib[]?; .prefix != $prefix)' >/dev/null
+}
+
+gobgp_has() {
+    # A route-server-client path remains in the peer's accepted Adj-RIB-In;
+    # GoBGP does not copy this single-client control into its global table.
+    docker exec "$GOBGP" gobgp neighbor "$RAW_ADDR" adj-in -a ipv4 -j 2>/dev/null \
+        | jq -e --arg prefix "$1" 'has($prefix) and (.[$prefix] | length > 0)' >/dev/null
+}
+
+gobgp_absent() {
+    docker exec "$GOBGP" gobgp neighbor "$RAW_ADDR" adj-in -a ipv4 -j 2>/dev/null \
+        | jq -e --arg prefix "$1" '((.[$prefix] // []) | length) == 0' >/dev/null
+}
+
+frr_has() {
+    docker exec "$FRR" vtysh -c "show bgp ipv4 unicast $1 json" 2>/dev/null \
+        | jq -e '.paths | length > 0' >/dev/null
+}
+
+frr_absent() {
+    docker exec "$FRR" vtysh -c "show bgp ipv4 unicast $1 json" 2>/dev/null \
+        | jq -e '((.paths // []) | length) == 0' >/dev/null
+}
+
+rust_established() {
+    rs_ctl neighbor "$RAW_ADDR" 2>/dev/null | grep -i established >/dev/null
+}
+
+bird_established() {
+    docker exec "$BIRD" birdc -r show protocols raw_peer 2>/dev/null \
+        | grep -i established >/dev/null
+}
+
+open_established() {
+    docker exec "$OPENBGPD" bgpctl -j show 2>/dev/null \
+        | jq -e 'any(.neighbors[]?; .remote_addr == "10.105.0.10" and .state == "Established")' >/dev/null
+}
+
+gobgp_established() {
+    docker exec "$GOBGP" gobgp neighbor "$RAW_ADDR" 2>/dev/null \
+        | grep -i established >/dev/null
+}
+
+frr_established() {
+    docker exec "$FRR" vtysh -c "show bgp neighbors $RAW_ADDR json" 2>/dev/null \
+        | jq -e --arg peer "$RAW_ADDR" '.[$peer].bgpState == "Established"' >/dev/null
+}
+
+all_have() {
+    local prefix=${1:?}
+    rust_has "$prefix" && bird_has "$prefix" && open_has "$prefix" \
+        && gobgp_has "$prefix" && frr_has "$prefix"
+}
+
+all_absent() {
+    local prefix=${1:?}
+    rust_absent "$prefix" && bird_absent "$prefix" && open_absent "$prefix" \
+        && gobgp_absent "$prefix" && frr_absent "$prefix"
+}
+
+all_established() {
+    rust_established && bird_established && open_established \
+        && gobgp_established && frr_established
+}
+
+report_presence() {
+    local prefix=${1:?} receiver
+    for receiver in rust bird open gobgp frr; do
+        if "${receiver}_has" "$prefix"; then
+            printf 'presence %s %s: installed\n' "$receiver" "$prefix" >&2
+        else
+            printf 'presence %s %s: absent-or-uninspectable\n' "$receiver" "$prefix" >&2
+        fi
+    done
+}
+
+all_processes_running() {
+    process_running "$RUSTBGPD" rustbgpd \
+        && process_running "$BIRD" bird \
+        && process_running "$OPENBGPD" bgpd \
+        && process_running "$GOBGP" gobgpd \
+        && process_running "$FRR" bgpd
+}
+
+raw_events_clean() {
+    docker exec "$RAW" sh -c '
+        test -s /tmp/m105-events.jsonl || exit 2
+        grep -Eq "$1" /tmp/m105-events.jsonl
+        case $? in
+            0) exit 1 ;;
+            1) exit 0 ;;
+            *) exit 2 ;;
+        esac
+    ' sh '"event":"(notification|closed|reader_error|fatal)"|"prefix_bearing":true'
+}
+
+both_routes_absent() {
+    all_absent "$BASELINE" && all_absent "$PROBE"
+}
+
+raw_listener_ready() {
+    docker exec "$RAW" sh -c \
+        'test -s /tmp/m105-events.jsonl && grep -F '"'"'"event":"listening"'"'"' /tmp/m105-events.jsonl >/dev/null'
+}
+
+record_outcomes() {
+    local receiver
+    for receiver in rust bird open gobgp frr; do
+        if "${receiver}_has" "$PROBE"; then
+            OUTCOMES[$receiver]=installed
+        elif "${receiver}_absent" "$PROBE"; then
+            OUTCOMES[$receiver]=not_installed
+        else
+            die "could not classify $receiver AS_SET observation"
+        fi
+    done
+    jq -n \
+        --arg rustbgpd "${OUTCOMES[rust]}" \
+        --arg bird "${OUTCOMES[bird]}" \
+        --arg openbgpd "${OUTCOMES[open]}" \
+        --arg gobgp "${OUTCOMES[gobgp]}" \
+        --arg frr "${OUTCOMES[frr]}" \
+        '{schema:"m105-outcomes/1",prefix:"198.51.105.0/24",as_path:{segment_type:1,members:[64512,64513]},outcomes:{rustbgpd:$rustbgpd,bird:$bird,openbgpd:$openbgpd,gobgp:$gobgp,frr:$frr}}' \
+        >"$ARTIFACT_DIR/outcomes.json"
+}
+
+snapshot_as_set_observations() {
+    local directory="$ARTIFACT_DIR/observations"
+    mkdir -p "$directory"
+    rs_ctl rib received "$RAW_ADDR" -a ipv4 -j >"$directory/rustbgpd.json"
+    docker exec "$BIRD" birdc -r show route for "$PROBE" protocol raw_peer all \
+        >"$directory/bird.txt"
+    docker exec "$OPENBGPD" bgpctl -j show rib "$PROBE" \
+        >"$directory/openbgpd.json"
+    docker exec "$GOBGP" gobgp neighbor "$RAW_ADDR" adj-in -a ipv4 -j \
+        >"$directory/gobgp.json"
+    docker exec "$FRR" vtysh -c "show bgp ipv4 unicast $PROBE json" \
+        >"$directory/frr.json"
+}
+
+mkdir -p "$ARTIFACT_DIR"
+preflight_receivers
+write_identities
+
+docker exec -d "$RAW" sh -c 'python3 /m105_raw_peer.py >/tmp/m105-raw.log 2>&1'
+wait_until "raw listener" raw_listener_ready
+check "capture sidecar is ready before receiver startup" start_capture
+start_daemons
+wait_until "all five raw sessions" docker exec "$RAW" test -s /tmp/m105-ready
+check "all five receiver sessions established" all_established
+
+docker exec "$RAW" touch /tmp/m105-send-baseline
+if ! wait_until "baseline route at all five receivers" all_have "$BASELINE"; then
+    report_presence "$BASELINE"
+    die "ordinary AS_SEQUENCE control did not reach every receiver"
+fi
+check "ordinary AS_SEQUENCE control reaches every receiver" all_have "$BASELINE"
+
+docker exec "$RAW" touch /tmp/m105-send-as-set
+sleep 5
+snapshot_as_set_observations
+record_outcomes
+check "all receiver sessions survive the AS_SET observation" all_established
+check "all receiver daemons remain live" all_processes_running
+check "raw peer saw no notification, closure, error, or reverse route" raw_events_clean
+
+docker exec "$RAW" touch /tmp/m105-send-withdraw
+wait_until "baseline withdrawal at all receivers" all_absent "$BASELINE"
+wait_until "AS_SET withdrawal at all receivers" all_absent "$PROBE"
+check "both routes are absent after withdrawal" both_routes_absent
+check "all receiver sessions survive withdrawal" all_established
+check "raw peer remains clean through withdrawal" raw_events_clean
+
+docker exec "$RAW" touch /tmp/m105-stop
+sleep 1
+docker exec "$RAW" cat /tmp/m105-events.jsonl >"$ARTIFACT_DIR/events.jsonl"
+docker exec "$RAW" cat /tmp/m105-raw.log >"$ARTIFACT_DIR/raw-peer.log"
+check "capture flushes with payload evidence" stop_capture
+python3 "$SCRIPT_DIR/m105_capture_oracle.py" "$ARTIFACT_DIR/payloads.tsv" \
+    >"$ARTIFACT_DIR/wire.json"
+check "packet oracle covers all five receivers" jq -e \
+    '.schema == "m105-wire/1" and (.receivers | keys | sort) == ["bird","frr","gobgp","openbgpd","rustbgpd"]' \
+    "$ARTIFACT_DIR/wire.json"
+
+printf 'M105 artifacts: %s\n' "$ARTIFACT_DIR"
+jq . "$ARTIFACT_DIR/outcomes.json"
+printf 'M105 live discovery complete\n'


### PR DESCRIPTION
## Result

Adds a re-runnable live lab for one exact AS_SET announcement across current rustbgpd, BIRD, OpenBGPD, GoBGP, and FRR route-server receivers. Repeated local runs produced the same discovery matrix: rustbgpd/BIRD/OpenBGPD did not install the route; GoBGP accepted it in Adj-RIB-In; FRR installed it. The ordinary AS_SEQUENCE control reached every receiver, all sessions remained Established through withdrawal, and packet capture verified the exact OPEN, attributes, and withdrawal on every stream.

The lab records native receiver observations plus raw packet evidence and deliberately does not encode per-daemon outcomes as pass/fail. This PR adds no production behavior change, public compatibility claim, or CI job.

## Verification

- Full live five-daemon matrix: `M105_ARTIFACT_DIR=$HOME/artifacts/m105-live-as-set-20260829T221758Z bash tests/interop/scripts/test-m105-live-as-set.sh`
- `bash -n tests/interop/scripts/test-m105-live-as-set.sh`
- `shellcheck -x tests/interop/scripts/test-m105-live-as-set.sh`
- `ruff check` and `ruff format --check` on both Python helpers
- `python3 scripts/check_ci_image_primer_contract.py`
- `python3 -m unittest -q scripts/test_check_ci_image_primer_contract.py` (48 tests)
- repository pre-commit `cargo fmt --check` and `cargo clippy`

Linear: LAN-1372