### PR TITLE
perf(rib): share route-server release fanout

### DIFF
--- a/bench/scale/rrtransport/src/rr1000.rs
+++ b/bench/scale/rrtransport/src/rr1000.rs
@@ -581,14 +581,20 @@ mod tests {
                 .collect(),
         );
         let mut seed_inventory = None;
+        let mut seed_encode = None;
         for receiver in &mut receivers {
             let seeded = receiver.try_recv().unwrap();
             assert_eq!(seeded.announce.len(), prefixes);
-            assert!(seeded.shared_group_encode.is_none());
-            if let Some(first) = &seed_inventory {
-                assert!(Arc::ptr_eq(first, &seeded.announce));
+            assert_eq!(seeded.announce_source_exclusion, None);
+            let encode = seeded.shared_group_encode.as_ref().unwrap();
+            if let (Some(first_inventory), Some(first_encode)) = (&seed_inventory, &seed_encode) {
+                assert!(
+                    Arc::ptr_eq(first_inventory, &seeded.announce)
+                        && Arc::ptr_eq(first_encode, encode)
+                );
             } else {
                 seed_inventory = Some(Arc::clone(&seeded.announce));
+                seed_encode = Some(Arc::clone(encode));
             }
             assert!(receiver.try_recv().is_err());
         }
@@ -600,7 +606,7 @@ mod tests {
         assert!(fast_path);
         let mut shared_encode = None;
         let mut shared_announce = None;
-        for receiver in &mut receivers {
+        for (index, receiver) in receivers.iter_mut().enumerate() {
             let update = receiver.try_recv().unwrap();
             assert_eq!(update.announce.len(), prefixes);
             assert_ne!(update.announce[0].attributes, seed_inventory[0].attributes);
@@ -616,6 +622,10 @@ mod tests {
             );
             let encode = update.shared_group_encode.as_ref().unwrap();
             let announce = &update.announce;
+            assert_eq!(
+                update.announce_source_exclusion,
+                Some(RibManager::bench_peer_address(index))
+            );
             if let (Some(first_encode), Some(first_announce)) = (&shared_encode, &shared_announce) {
                 assert!(Arc::ptr_eq(first_encode, encode) && Arc::ptr_eq(first_announce, announce));
             } else {
@@ -649,7 +659,7 @@ mod tests {
                      \"fixture_peers\":{peers},\"fixture_prefixes\":{prefixes},\
                      \"seed\":{{\"routes_received_dispatches\":1,\"routes_received_withdrawals\":0,\
                      \"envelopes\":{peers},\"routes_per_envelope\":{prefixes},\
-                     \"shared_group_encode\":false,\"community\":\"65000:100\"}},\
+                     \"shared_group_encode\":true,\"community\":\"65000:100\"}},\
                      \"transition\":{{\"fast_path\":{fast_path},\"routes_received_dispatches\":0,\
                      \"routes_received_withdrawals\":0,\
                      \"probe_accounting\":\"policy_transition_receipt\",\

--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -94,7 +94,7 @@ def verify(directory, tiny=False):
         "fixture_prefixes": prefixes,
         "seed": {"routes_received_dispatches": 1,
                  "routes_received_withdrawals": 0, "envelopes": peers,
-                 "routes_per_envelope": prefixes, "shared_group_encode": False,
+                 "routes_per_envelope": prefixes, "shared_group_encode": True,
                  "community": "65000:100"},
         "transition": {
             "fast_path": True, "routes_received_dispatches": 0,

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -63,7 +63,7 @@ checkpoints={"established":point(100,105,1000,1100,1200,1300),
 (d/"grouped-commit.json").write_text(json.dumps({"schema":2,
  "timing":"test_profile_untimed_rpol_community_transition",
  "fixture_peers":1000,"fixture_prefixes":100000,
- "seed":{"routes_received_dispatches":1,"routes_received_withdrawals":0,"envelopes":1000,"routes_per_envelope":100000,"shared_group_encode":False,"community":"65000:100"},
+ "seed":{"routes_received_dispatches":1,"routes_received_withdrawals":0,"envelopes":1000,"routes_per_envelope":100000,"shared_group_encode":True,"community":"65000:100"},
  "transition":{"fast_path":True,"routes_received_dispatches":0,
   "routes_received_withdrawals":0,"probe_accounting":"policy_transition_receipt",
   "plan_builds":1,"full_exact_probes":100000,"route_shell_materializations":100000,
@@ -115,7 +115,7 @@ done
 for phase in seed transition; do
   expect_red "$phase-community" mutate -c "import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/'grouped-commit.json';d=json.loads(p.read_text());d['$phase']['community']='wrong';p.write_text(json.dumps(d))"
 done
-expect_red seed-shared-encode mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"grouped-commit.json";d=json.loads(p.read_text());d["seed"]["shared_group_encode"]=True;p.write_text(json.dumps(d))'
+expect_red seed-shared-encode mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"grouped-commit.json";d=json.loads(p.read_text());d["seed"]["shared_group_encode"]=False;p.write_text(json.dumps(d))'
 for checkpoint in established staged wire; do
   for series in jemalloc_allocated_bytes jemalloc_active_bytes \
     jemalloc_resident_bytes jemalloc_mapped_bytes; do

--- a/crates/rib/benches/selection_deferral_release.rs
+++ b/crates/rib/benches/selection_deferral_release.rs
@@ -11,12 +11,12 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use rustbgpd_rib::{
-    ExactExportCandidate, ExactExportEncoder, ExactExportError, ExactExportResult,
-    ExactExportSnapshot, OutboundRouteUpdate, RibManager, RibUpdate, Route, RouteOrigin,
-    SelectionDeferralConfig, SelectionDeferralWaiterConfig,
+    ExactExportCandidate, ExactExportEncoder, ExactExportError, ExactExportErrorCode,
+    ExactExportResult, ExactExportSnapshot, OutboundRouteUpdate, RibManager, RibUpdate, Route,
+    RouteOrigin, SelectionDeferralConfig, SelectionDeferralWaiterConfig,
 };
 use rustbgpd_telemetry::BgpMetrics;
-use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, Prefix, RpkiValidation, Safi};
+use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, MAX_MESSAGE_LEN, Prefix, RpkiValidation, Safi};
 use tokio::sync::mpsc;
 
 const FLEET_PEERS: usize = 700;
@@ -24,6 +24,7 @@ const FLEET_ROUTES: usize = 400_400;
 const SELF_TEST_PEERS: usize = 4;
 const SELF_TEST_ROUTES: usize = 64;
 const LEDGER_IDENTITY_LIMIT: usize = 1_000_000;
+const HOMOGENEOUS_WIRE_PROFILE: u64 = 1;
 
 const IPV4_UNICAST: (Afi, Safi) = (Afi::Ipv4, Safi::Unicast);
 const IPV6_UNICAST: (Afi, Safi) = (Afi::Ipv6, Safi::Unicast);
@@ -123,10 +124,22 @@ struct Receipt {
     peers_with_route_payload: usize,
 }
 
-#[derive(Debug)]
-struct PermissiveExactExport;
+#[derive(Clone, Copy, Debug)]
+struct HomogeneousExactExport {
+    wire_profile: u64,
+    max_len: usize,
+}
 
-impl ExactExportSnapshot for PermissiveExactExport {
+impl HomogeneousExactExport {
+    fn fixture() -> Self {
+        Self {
+            wire_profile: HOMOGENEOUS_WIRE_PROFILE,
+            max_len: usize::from(MAX_MESSAGE_LEN),
+        }
+    }
+}
+
+impl ExactExportSnapshot for HomogeneousExactExport {
     fn owner_id(&self) -> u64 {
         1
     }
@@ -141,9 +154,43 @@ impl ExactExportSnapshot for PermissiveExactExport {
     ) -> Result<ExactExportResult, ExactExportError> {
         Ok(ExactExportResult {
             encoded_len: 0,
-            max_len: usize::MAX,
+            max_len: self.max_len,
             generation: 0,
         })
+    }
+
+    fn reuse_successful_probes(
+        &self,
+        source: &dyn ExactExportSnapshot,
+        encoded_lengths: &[usize],
+    ) -> Option<Vec<Result<ExactExportResult, ExactExportError>>> {
+        let source = source.as_any().downcast_ref::<Self>()?;
+        if self.wire_profile != source.wire_profile {
+            return None;
+        }
+
+        Some(
+            encoded_lengths
+                .iter()
+                .map(|&encoded_len| {
+                    if encoded_len > self.max_len {
+                        Err(ExactExportError::new(
+                            ExactExportErrorCode::MessageTooLong,
+                            format_args!(
+                                "encoded UPDATE is {encoded_len} bytes; negotiated maximum is {} bytes",
+                                self.max_len
+                            ),
+                        ))
+                    } else {
+                        Ok(ExactExportResult {
+                            encoded_len,
+                            max_len: self.max_len,
+                            generation: 0,
+                        })
+                    }
+                })
+                .collect(),
+        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -151,13 +198,13 @@ impl ExactExportSnapshot for PermissiveExactExport {
     }
 }
 
-impl ExactExportEncoder for PermissiveExactExport {
+impl ExactExportEncoder for HomogeneousExactExport {
     fn owner_id(&self) -> u64 {
         1
     }
 
     fn snapshot(&self) -> Arc<dyn ExactExportSnapshot> {
-        Arc::new(Self)
+        Arc::new(*self)
     }
 }
 
@@ -409,7 +456,7 @@ fn run(mode: Mode, peers: usize, total_routes: usize) -> Receipt {
         &gated_families,
         &sendable_families,
         gated_families.len().saturating_add(4),
-        |_| Arc::new(PermissiveExactExport),
+        |_| Arc::new(HomogeneousExactExport::fixture()),
     );
 
     if mode.is_overflow() {
@@ -631,6 +678,32 @@ fn assert_rejected(label: &str, receipt: &Receipt, mutate: impl FnOnce(&mut Rece
 }
 
 fn self_test() {
+    let profile = HomogeneousExactExport::fixture();
+    let incompatible = HomogeneousExactExport {
+        wire_profile: HOMOGENEOUS_WIRE_PROFILE + 1,
+        ..profile
+    };
+    assert!(
+        profile
+            .reuse_successful_probes(&incompatible, &[64])
+            .is_none(),
+        "wire-profile mismatch must decline exact-probe reuse"
+    );
+    let reused = profile
+        .reuse_successful_probes(&profile, &[profile.max_len, profile.max_len + 1])
+        .expect("matching wire profiles reuse successful probes");
+    assert!(
+        reused[0].is_ok(),
+        "message at the ceiling must remain valid"
+    );
+    assert!(
+        matches!(
+            &reused[1],
+            Err(error) if error.code() == ExactExportErrorCode::MessageTooLong
+        ),
+        "message beyond the ceiling must be rejected"
+    );
+
     let receipt = run(Mode::Seven, SELF_TEST_PEERS, SELF_TEST_ROUTES);
     validate(&receipt).expect("uncorrupted self-test receipt validates");
     assert_rejected("query_depth", &receipt, |row| {

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -133,6 +133,11 @@ pub(in crate::manager) struct SharedUnicastPrecommit<'a> {
 #[derive(Default)]
 pub(in crate::manager) struct OutboundCommitBatch {
     pub(in crate::manager) unicast: AlignedUnicastPayload,
+    /// The shared plain-group staging pass already applied the group-uniform
+    /// OTC egress gate to every unicast announcement in this batch.
+    pub(in crate::manager) unicast_otc_prechecked: bool,
+    pub(in crate::manager) announce_source_exclusion: Option<IpAddr>,
+    pub(in crate::manager) shared_group_encode: Option<Arc<crate::update::SharedGroupEncode>>,
     pub(in crate::manager) withdraw: Vec<(Prefix, u32)>,
     pub(in crate::manager) end_of_rib: Vec<(Afi, Safi)>,
     pub(in crate::manager) refresh_markers: Vec<(Afi, Safi, RouteRefreshSubtype)>,
@@ -570,29 +575,42 @@ fn reconcile_exact_export_overlay(
     rejected: &mut HashSet<crate::update::ExactExportKey>,
     candidate_keys: Vec<crate::update::ExactExportKey>,
     probe_results: Vec<Result<crate::update::ExactExportResult, crate::update::ExactExportError>>,
+    source_excluded: Vec<bool>,
     previously_advertised: &HashSet<crate::update::ExactExportKey>,
 ) -> ExactExportOverlayDecision {
+    debug_assert_eq!(candidate_keys.len(), source_excluded.len());
     let mut owed_withdrawals = HashSet::new();
     let mut new_rejections = Vec::new();
     let keep = candidate_keys
         .into_iter()
         .zip(probe_results)
-        .map(|(key, result)| match result {
-            Ok(_) => {
-                rejected.remove(&key);
-                true
-            }
-            Err(error) => {
-                let newly_rejected = rejected.insert(key.clone());
-                if newly_rejected && previously_advertised.contains(&key) {
-                    owed_withdrawals.insert(key.clone());
+        .zip(source_excluded)
+        .map(
+            |((key, result), source_excluded)| match (source_excluded, result) {
+                (true, _) => {
+                    // Transport removes this route before encoding. A conservative
+                    // shared probe may still have inspected it, but its result is
+                    // not part of this peer's wire view and must not create or
+                    // retain a sparse rejection entry.
+                    rejected.remove(&key);
+                    true
                 }
-                if newly_rejected {
-                    new_rejections.push((key, error));
+                (false, Ok(_)) => {
+                    rejected.remove(&key);
+                    true
                 }
-                false
-            }
-        })
+                (false, Err(error)) => {
+                    let newly_rejected = rejected.insert(key.clone());
+                    if newly_rejected && previously_advertised.contains(&key) {
+                        owed_withdrawals.insert(key.clone());
+                    }
+                    if newly_rejected {
+                        new_rejections.push((key, error));
+                    }
+                    false
+                }
+            },
+        )
         .collect();
     ExactExportOverlayDecision {
         keep,
@@ -2109,6 +2127,9 @@ impl RibManager {
                     mut announce,
                     mut next_hop_override,
                 },
+            unicast_otc_prechecked,
+            announce_source_exclusion,
+            mut shared_group_encode,
             mut withdraw,
             end_of_rib,
             refresh_markers,
@@ -2128,10 +2149,14 @@ impl RibManager {
         #[cfg(feature = "bench-internals")]
         let bench_per_client_best_resync = self.peer_per_client_best.contains(&peer)
             && (self.dirty_peers.contains(&peer) || self.force_outbound_peers.contains(&peer));
-        // Every arm below is provably false without an active deferral state:
-        // `selection_deferred` / `selection_convergence_held` short-circuit on
-        // `None`. Guard once so the common no-gate commit skips all the scans.
-        let gated = self.selection_deferral.is_some()
+        // Every arm below is provably false without an active family gate.
+        // The deferral object intentionally retains released-family history,
+        // so `Option::is_some` is too broad after startup convergence: guard
+        // on the O(1) active map instead and skip every route-vector scan.
+        let gated = self
+            .selection_deferral
+            .as_ref()
+            .is_some_and(super::selection_deferral::SelectionDeferral::has_active_gates)
             && (announce
                 .iter()
                 .any(|route| self.selection_deferred(prefix_family(&route.prefix)))
@@ -2184,7 +2209,10 @@ impl RibManager {
         if let Some(prefixes) = otc_reconcile_prefixes {
             let blocked = announce
                 .iter()
-                .filter(|route| otc_egress_blocked(route, local_role))
+                .filter(|route| {
+                    announce_source_exclusion != Some(route.peer)
+                        && otc_egress_blocked(route, local_role)
+                })
                 .cloned()
                 .collect();
             self.reconcile_peer_otc_blocked(peer, prefixes, blocked);
@@ -2234,9 +2262,11 @@ impl RibManager {
         // stages the first permitted candidate regardless of OTC and defers
         // egress enforcement here (ADR-0126 Decision 5), matching the
         // ungrouped per-client-best path.
-        if announce
-            .iter()
-            .any(|route| otc_egress_blocked(route, local_role))
+        if !unicast_otc_prechecked
+            && announce.iter().any(|route| {
+                announce_source_exclusion != Some(route.peer)
+                    && otc_egress_blocked(route, local_role)
+            })
         {
             let per_client_best_member = self
                 .grouped_member_of(peer)
@@ -2256,7 +2286,12 @@ impl RibManager {
             // copied into a fresh one; blocked routes are inspected in place
             // and never cloned.
             for (route, next_hop) in announce.iter().zip(next_hop_override.iter()) {
-                if otc_egress_blocked(route, local_role) {
+                if announce_source_exclusion == Some(route.peer) {
+                    // Keep the shared slice aligned; transport suppresses
+                    // this route before encoding for this member.
+                    permitted.push(route.clone());
+                    permitted_next_hops.push(next_hop.clone());
+                } else if otc_egress_blocked(route, local_role) {
                     // A per-client-best group member's prior wire view is
                     // group-derived (no per-peer unicast Adj-RIB-Out), so
                     // the previously-advertised gate below cannot see it. A
@@ -2290,6 +2325,9 @@ impl RibManager {
             }
             announce = permitted.into();
             next_hop_override = permitted_next_hops.into();
+            // The permitted subset is member-specific, so the group's
+            // pre-encoded bytes no longer describe this envelope.
+            shared_group_encode = None;
         }
         let otc_blocked: Vec<crate::route::Route> = self
             .pending_otc_blocked
@@ -2354,25 +2392,15 @@ impl RibManager {
                 labeled_announce.len(),
                 rtc_announce.len(),
             ];
-            let candidates = announce
-                .iter()
-                .zip(next_hop_override.iter())
-                .map(|(route, next_hop)| ExactExportCandidate::Unicast {
-                    route,
-                    next_hop_override: next_hop.as_ref(),
-                })
-                .chain(flowspec_announce.iter().map(ExactExportCandidate::FlowSpec))
-                .chain(evpn_announce.iter().map(ExactExportCandidate::Evpn))
-                .chain(bgpls_announce.iter().map(ExactExportCandidate::BgpLs))
-                .chain(vpn_announce.iter().map(ExactExportCandidate::Vpn))
-                .chain(labeled_announce.iter().map(ExactExportCandidate::Labeled))
-                .chain(rtc_announce.iter().map(ExactExportCandidate::Rtc))
-                .collect::<Vec<_>>();
             // Ordinary clean update-group members receive Arc clones of one
-            // shared unicast payload. Reuse a prior member's successful
-            // encoded lengths only when the concrete target snapshot proves
-            // it can safely recheck them. Mixed-family envelopes stay on the
-            // ordinary exact batch path so result ordering remains unchanged.
+            // shared unicast payload. A compatible target first proves the
+            // cached cohort's largest successful message: monotone ceiling
+            // acceptance then proves every shorter route without allocating
+            // or scanning a routes-long result vector for each member. A
+            // failed maximum falls back to the full cached-length vector so
+            // individual rejected routes remain exact. Mixed-family
+            // envelopes stay on the ordinary batch path so result ordering
+            // remains unchanged.
             let has_non_unicast_payload = !flowspec_announce.is_empty()
                 || !flowspec_withdraw.is_empty()
                 || !evpn_announce.is_empty()
@@ -2386,10 +2414,57 @@ impl RibManager {
                 || !rtc_announce.is_empty()
                 || !rtc_withdraw.is_empty();
             let cache_eligible = !announce.is_empty()
-                && candidates.len() == announce.len()
                 && !has_non_unicast_payload
                 && shared_unicast_precommit.is_some();
-            let reused_results = cache_eligible
+            let maximum_fast_path_eligible = cache_eligible
+                && shared_unicast_precommit
+                    .as_ref()
+                    .is_some_and(|precommit| precommit.lazy_group_prior.is_some())
+                && !self.peer_unexportable.contains_key(&peer);
+            #[cfg(test)]
+            let maximum_fast_path_eligible =
+                maximum_fast_path_eligible && !self.test_force_exact_export_slow_path;
+            let reused_maximum = maximum_fast_path_eligible
+                .then(|| {
+                    shared_unicast_precommit.as_mut().and_then(|precommit| {
+                        precommit.probe_cache.reuse_grouped_exact_export_maximum(
+                            precommit.group_id,
+                            &announce,
+                            &next_hop_override,
+                            snapshot.as_ref(),
+                        )
+                    })
+                })
+                .flatten()
+                .and_then(Result::ok);
+            if reused_maximum.is_some() {
+                #[cfg(any(test, feature = "bench-internals"))]
+                {
+                    self.adj_rib_out_commit_stats.exact_probe_cache_reuses = self
+                        .adj_rib_out_commit_stats
+                        .exact_probe_cache_reuses
+                        .saturating_add(announce.len());
+                }
+            }
+            let candidates = if reused_maximum.is_some() {
+                Vec::new()
+            } else {
+                announce
+                    .iter()
+                    .zip(next_hop_override.iter())
+                    .map(|(route, next_hop)| ExactExportCandidate::Unicast {
+                        route,
+                        next_hop_override: next_hop.as_ref(),
+                    })
+                    .chain(flowspec_announce.iter().map(ExactExportCandidate::FlowSpec))
+                    .chain(evpn_announce.iter().map(ExactExportCandidate::Evpn))
+                    .chain(bgpls_announce.iter().map(ExactExportCandidate::BgpLs))
+                    .chain(vpn_announce.iter().map(ExactExportCandidate::Vpn))
+                    .chain(labeled_announce.iter().map(ExactExportCandidate::Labeled))
+                    .chain(rtc_announce.iter().map(ExactExportCandidate::Rtc))
+                    .collect::<Vec<_>>()
+            };
+            let reused_results = (!candidates.is_empty() && cache_eligible)
                 .then(|| {
                     shared_unicast_precommit.as_mut().and_then(|precommit| {
                         precommit.probe_cache.reuse_grouped_exact_export_ceiling(
@@ -2411,6 +2486,8 @@ impl RibManager {
                 }
                 debug_assert_eq!(results.len(), candidates.len());
                 results
+            } else if candidates.is_empty() {
+                Vec::new()
             } else {
                 #[cfg(any(test, feature = "bench-internals"))]
                 {
@@ -2452,14 +2529,17 @@ impl RibManager {
                     .exact_probe_nonzero_encoded_lengths = self
                     .adj_rib_out_commit_stats
                     .exact_probe_nonzero_encoded_lengths
-                    .saturating_add(
-                        probe_results
-                            .iter()
-                            .filter(|result| {
-                                result.as_ref().is_ok_and(|result| result.encoded_len > 0)
-                            })
-                            .count(),
-                    );
+                    .saturating_add(reused_maximum.as_ref().map_or_else(
+                        || {
+                            probe_results
+                                .iter()
+                                .filter(|result| {
+                                    result.as_ref().is_ok_and(|result| result.encoded_len > 0)
+                                })
+                                .count()
+                        },
+                        |result| usize::from(result.encoded_len > 0) * announce.len(),
+                    ));
             }
 
             // The common grouped path is deliberately keyless: when every
@@ -2467,12 +2547,13 @@ impl RibManager {
             // no candidate can be owed a withdrawal and no overlay entry can
             // need reconciliation. The immutable target snapshot remains on
             // the outbound envelope for transport's owner/generation fence.
-            let fast_path = !candidates.is_empty()
-                && shared_unicast_precommit
-                    .as_ref()
-                    .is_some_and(|precommit| precommit.lazy_group_prior.is_some())
-                && probe_results.iter().all(Result::is_ok)
-                && !self.peer_unexportable.contains_key(&peer);
+            let fast_path = reused_maximum.is_some()
+                || (!candidates.is_empty()
+                    && shared_unicast_precommit
+                        .as_ref()
+                        .is_some_and(|precommit| precommit.lazy_group_prior.is_some())
+                    && probe_results.iter().all(Result::is_ok)
+                    && !self.peer_unexportable.contains_key(&peer));
             #[cfg(test)]
             let fast_path = {
                 let enabled = fast_path && !self.test_force_exact_export_slow_path;
@@ -2484,12 +2565,28 @@ impl RibManager {
             };
 
             if !fast_path {
+                // Reconciliation may filter this member's announce inventory.
+                // A shared encode cell is only valid while every member still
+                // carries the identical Arc-backed payload; transport proves
+                // profile equivalence, but it cannot recover a route removed
+                // here by this member's exact-export ceiling.
+                shared_group_encode = None;
                 // Keys and prior advertised state are fallback-only. A clean
                 // grouped member materializes its staged prior at most once,
                 // and only when a failed probe can actually owe a withdrawal.
                 let candidate_keys = candidates
                     .iter()
                     .map(ExactExportCandidate::key)
+                    .collect::<Vec<_>>();
+                let source_excluded = candidates
+                    .iter()
+                    .map(|candidate| {
+                        matches!(
+                            candidate,
+                            ExactExportCandidate::Unicast { route, .. }
+                                if announce_source_exclusion == Some(route.peer)
+                        )
+                    })
                     .collect::<Vec<_>>();
                 let has_probe_failure = probe_results.iter().any(Result::is_err);
                 let mut previously_advertised = group_prior;
@@ -2514,6 +2611,7 @@ impl RibManager {
                     self.peer_unexportable.entry(peer).or_default(),
                     candidate_keys,
                     probe_results,
+                    source_excluded,
                     &previously_advertised,
                 );
                 let keep = decision.keep;
@@ -2646,13 +2744,17 @@ impl RibManager {
         // capacity, and a prefix blocked here never reaches Adj-RIB-Out, the
         // grouped admitted set, or the wire. Withdrawals are untouched.
         let limited = self.outbound_prefix_limits.contains_key(&peer);
-        self.enforce_outbound_prefix_limits(
+        let capacity_filtered = self.enforce_outbound_prefix_limits(
             peer,
             grouped_unicast_count.is_some(),
+            announce_source_exclusion,
             &mut announce,
             &mut next_hop_override,
             &withdraw,
         );
+        if capacity_filtered {
+            shared_group_encode = None;
+        }
         // A limited grouped member's advertised count is its admitted
         // projection, which enforcement above just moved.
         let grouped_unicast_count = if limited {
@@ -2838,7 +2940,7 @@ impl RibManager {
             permit,
             OutboundRouteUpdate {
                 exact_export_snapshot,
-                announce_source_exclusion: None,
+                announce_source_exclusion,
                 announce,
                 withdraw,
                 end_of_rib,
@@ -2858,7 +2960,7 @@ impl RibManager {
                 rtc_withdraw,
                 otc_blocked,
                 request_refresh_all_negotiated: false,
-                shared_group_encode: None,
+                shared_group_encode,
             },
         );
         #[cfg(feature = "bench-internals")]
@@ -4629,6 +4731,8 @@ impl RibManager {
         // best).
         let group_stage = self.stage_update_groups(&best_changed, &all_affected, &mut export_memo);
         let mut shared_unicast_probe_cache = SharedUnicastProbeCache::default();
+        let mut shared_group_encodes: HashMap<usize, Arc<crate::update::SharedGroupEncode>> =
+            HashMap::new();
         // LAN-474 emit-time filter: whether a group's pass carries any
         // control-tagged announce delta, memoized per (group, rs_asn) —
         // one delta scan per group per pass, not per member. Untagged
@@ -4989,6 +5093,9 @@ impl RibManager {
             // pre-built shared emission: the announce payload is an Arc
             // clone shared across members, not a per-member Vec build.
             let mut shared_unicast: Option<super::update_groups::SharedUnicastPayload> = None;
+            let mut unicast_otc_prechecked = false;
+            let mut announce_source_exclusion = None;
+            let mut shared_group_encode = None;
             let mut fs_announce = Vec::new();
             let mut fs_withdraw = Vec::new();
             let mut evpn_announce = Vec::new();
@@ -5028,6 +5135,7 @@ impl RibManager {
                     .copied()
                     .zip(self.peer_asn.get(&peer).copied());
                 if let Some(group) = self.group_ribs.get(&gid) {
+                    unicast_otc_prechecked = !group.per_client_best;
                     if resync {
                         Self::assemble_group_resync(
                             group,
@@ -5077,11 +5185,23 @@ impl RibManager {
                                 .entry((gid, rs_asn))
                                 .or_insert_with(|| stage.has_tagged_route(rs_asn))
                         });
-                        if stage.shared_applies_to(peer) && !rs_diverges {
+                        let shared_exact = stage.shared_applies_to(peer);
+                        let shared_with_source_exclusion = !shared_exact
+                            && stage.shared_applies_with_source_exclusion(peer)
+                            && stage.shared_has_payload_after_source_exclusion(peer);
+                        if (shared_exact || shared_with_source_exclusion) && !rs_diverges {
                             // Common case: this member's matrix output IS
-                            // the shared emission — enqueue Arc clones.
+                            // the shared emission after transport omits any
+                            // newly staged own-source routes. Enqueue Arc
+                            // clones and one encode cell for the whole group.
                             shared_unicast =
                                 Some((stage.shared_announce.clone(), stage.shared_nh.clone()));
+                            announce_source_exclusion =
+                                shared_with_source_exclusion.then_some(peer);
+                            shared_group_encode =
+                                Some(Arc::clone(shared_group_encodes.entry(gid).or_insert_with(
+                                    || Arc::new(crate::update::SharedGroupEncode::default()),
+                                )));
                             unicast.withdraw.extend_from_slice(&stage.shared_withdraw);
                         } else {
                             super::update_groups::emit_group_deltas_for_member(
@@ -5758,6 +5878,9 @@ impl RibManager {
                 if self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
                     peer,
                     OutboundCommitBatch {
+                        unicast_otc_prechecked,
+                        announce_source_exclusion,
+                        shared_group_encode,
                         withdraw: unicast.withdraw,
                         end_of_rib: pending_eor.clone(),
                         flowspec_announce: fs_announce,

--- a/crates/rib/src/manager/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/outbound_prefix_limits.rs
@@ -346,6 +346,7 @@ impl RibManager {
         &self,
         peer: IpAddr,
         grouped: bool,
+        announce_source_exclusion: Option<IpAddr>,
         announce: &[crate::route::Route],
         withdraw: &[(Prefix, u32)],
     ) -> Vec<FamilyVerdict> {
@@ -399,6 +400,7 @@ impl RibManager {
                 &freed,
                 announce
                     .iter()
+                    .filter(|route| announce_source_exclusion != Some(route.peer))
                     .map(|route| &route.prefix)
                     .filter(|prefix| prefix_family(prefix).0 == afi),
                 is_admitted,
@@ -420,11 +422,13 @@ impl RibManager {
     /// Apply this peer's outbound unicast prefix limits to one final batch.
     ///
     /// Runs at the per-peer commit seam: after export policy, split horizon,
-    /// RFC 9234 OTC, and exact-export precommit have each removed everything
+    /// RFC 9234 OTC, and exact-export precommit have identified everything
     /// this peer must not receive, and before any Adj-RIB-Out or grouped
-    /// admitted-set mutation and before the envelope is enqueued. Routes an
-    /// earlier gate rejected therefore consume no capacity, and a blocked
-    /// prefix never reaches Adj-RIB-Out or the wire.
+    /// admitted-set mutation and before the envelope is enqueued. A shared
+    /// split-horizon payload remains intact for transport, so the explicit
+    /// source exclusion is ignored for admission. Routes an earlier gate
+    /// rejected therefore consume no capacity, and a blocked prefix never
+    /// reaches Adj-RIB-Out or the wire.
     ///
     /// The session stays Established: excess announcements are dropped from
     /// the outgoing vector, nothing already advertised is withdrawn, and no
@@ -435,13 +439,20 @@ impl RibManager {
         &mut self,
         peer: IpAddr,
         grouped: bool,
+        announce_source_exclusion: Option<IpAddr>,
         announce: &mut Arc<[crate::route::Route]>,
         next_hop_override: &mut Arc<[Option<rustbgpd_policy::NextHopAction>]>,
         withdraw: &[(Prefix, u32)],
-    ) {
-        let verdicts = self.outbound_limit_verdicts(peer, grouped, announce, withdraw);
+    ) -> bool {
+        let verdicts = self.outbound_limit_verdicts(
+            peer,
+            grouped,
+            announce_source_exclusion,
+            announce,
+            withdraw,
+        );
         if verdicts.is_empty() {
-            return;
+            return false;
         }
 
         let blocked: HashSet<Prefix> = verdicts
@@ -452,7 +463,10 @@ impl RibManager {
             let (kept_routes, kept_next_hops): (Vec<_>, Vec<_>) = announce
                 .iter()
                 .zip(next_hop_override.iter())
-                .filter(|(route, _)| !blocked.contains(&route.prefix))
+                .filter(|(route, _)| {
+                    announce_source_exclusion == Some(route.peer)
+                        || !blocked.contains(&route.prefix)
+                })
                 .map(|(route, next_hop)| (route.clone(), next_hop.clone()))
                 .unzip();
             *announce = kept_routes.into();
@@ -462,7 +476,7 @@ impl RibManager {
         // One record per family: (afi, prefixes blocked, episode transition).
         let mut episodes: Vec<(Afi, usize, Option<bool>)> = Vec::new();
         let Some(limits) = self.outbound_prefix_limits.get_mut(&peer) else {
-            return;
+            return false;
         };
         for family_verdict in verdicts {
             if grouped {
@@ -524,6 +538,7 @@ impl RibManager {
         // Adj-RIB-Out commit, so an ungrouped peer's usage would still read
         // the pre-batch count. The commit path refreshes them from the same
         // admitted truth the API reports, once that truth exists.
+        !blocked.is_empty()
     }
 
     /// Distinct admitted prefixes for one limited family.

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -417,6 +417,10 @@ impl SelectionDeferral {
         self.active.contains_key(&family)
     }
 
+    pub(super) fn has_active_gates(&self) -> bool {
+        !self.active.is_empty()
+    }
+
     pub(super) fn selection_deferred(&self, family: (Afi, Safi)) -> bool {
         self.active
             .get(&family)

--- a/crates/rib/src/manager/tests/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/tests/outbound_prefix_limits.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashSet;
 use std::num::NonZeroU32;
+use std::sync::Arc;
 
 use rustbgpd_wire::RouteRefreshSubtype;
 
@@ -270,6 +271,49 @@ fn source_v6_routes(source: Ipv6Addr, segments: &[u16]) -> Vec<Route> {
             make_v6_route(prefix, source)
         })
         .collect()
+}
+
+#[test]
+fn source_excluded_route_does_not_consume_grouped_capacity() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 9));
+    set_ipv4_limit(&mut manager, peer, 1);
+
+    let IpAddr::V4(peer_source) = peer else {
+        unreachable!()
+    };
+    let own_route = crate::test_support::make_route(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 9), 32),
+        peer_source,
+    );
+    let effective_route = crate::test_support::make_route(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 10), 32),
+        Ipv4Addr::new(192, 0, 2, 113),
+    );
+    let mut announce: Arc<[Route]> = vec![own_route.clone(), effective_route.clone()].into();
+    let mut next_hop_override = vec![None, None].into();
+
+    assert!(!manager.enforce_outbound_prefix_limits(
+        peer,
+        true,
+        Some(peer),
+        &mut announce,
+        &mut next_hop_override,
+        &[],
+    ));
+    assert_eq!(announce.len(), 2);
+    assert_eq!(announce[0].prefix, own_route.prefix);
+    assert_eq!(announce[0].peer, own_route.peer);
+    assert_eq!(announce[1].prefix, effective_route.prefix);
+    assert_eq!(announce[1].peer, effective_route.peer);
+    let limits = manager.outbound_prefix_limits.get(&peer).unwrap();
+    assert_eq!(limits.grouped_len(Afi::Ipv4), 1);
+    assert!(limits.grouped_contains(&effective_route.prefix));
+    assert!(!limits.grouped_contains(&Prefix::V4(Ipv4Prefix::new(
+        Ipv4Addr::new(203, 0, 113, 9),
+        32,
+    ))));
 }
 
 /// Inertness: with no limit configured — the state of every peer today —

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -14,6 +14,7 @@ use super::*;
 
 #[path = "update_groups_harness.rs"]
 mod update_groups_harness;
+use crate::manager::distribution::OutboundCommitBatch;
 use update_groups_harness::{RunningManager, spawn_running_manager};
 
 #[test]
@@ -543,16 +544,23 @@ fn exact_update_semantic(update: &OutboundRouteUpdate) -> ExactUpdateSemantic {
         .exact_export_snapshot
         .as_ref()
         .map(|snapshot| (snapshot.owner_id(), snapshot.generation()));
+    assert_eq!(update.announce.len(), update.next_hop_override.len());
+    let (announce, next_hop_override): (Vec<_>, Vec<_>) = update
+        .announce
+        .iter()
+        .zip(update.next_hop_override.iter())
+        .filter(|(route, _)| update.announce_source_exclusion != Some(route.peer))
+        .unzip();
     ExactUpdateSemantic {
         snapshot,
         payload: format!(
             "{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{}",
-            update.announce_source_exclusion,
-            update.announce,
+            Option::<IpAddr>::None,
+            announce,
             update.withdraw,
             update.end_of_rib,
             update.refresh_markers,
-            update.next_hop_override,
+            next_hop_override,
             update.flowspec_announce,
             update.flowspec_withdraw,
             update.evpn_announce,
@@ -705,6 +713,178 @@ fn distribution_clones_metrics_once_per_pass() {
             Err(mpsc::error::TryRecvError::Empty)
         ));
     }
+}
+
+/// A plain route-server-shaped group whose members are also route sources
+/// must keep the ordinary delta on the shared fanout path. Split horizon is
+/// represented by transport-side source exclusion, so one announce `Arc`,
+/// one encode cell, and one exact batch serve the whole cohort.
+#[test]
+fn grouped_source_exceptions_share_payload_and_exact_proof() {
+    const PEERS: usize = 4;
+    const ROUTES: usize = 3;
+
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let peers: Vec<_> = (0..PEERS)
+        .map(|index| IpAddr::V4(Ipv4Addr::new(10, 63, 3, u8::try_from(index + 1).unwrap())))
+        .collect();
+    let mut receivers = Vec::new();
+    for (index, &peer) in peers.iter().enumerate() {
+        receivers.push(register_direct_exact_peer(
+            &mut manager,
+            peer,
+            Arc::new(CohortExactEncoder {
+                owner: u64::try_from(index + 1).unwrap(),
+                profile: 63,
+                max_len: 4_096,
+                generation: AtomicUsize::new(0),
+                advance_generation: false,
+                probes: Arc::clone(&probes),
+                reuses: Arc::clone(&reuses),
+            }),
+        ));
+        assert!(manager.grouped_member_of(peer).is_some());
+    }
+
+    manager.adj_rib_out_commit_stats = AdjRibOutCommitStats::default();
+    let IpAddr::V4(source) = peers[0] else {
+        unreachable!()
+    };
+    let prefixes: Vec<_> = (0..ROUTES)
+        .map(|index| {
+            Ipv4Prefix::new(
+                Ipv4Addr::new(203, 0, u8::try_from(120 + index).unwrap(), 0),
+                24,
+            )
+        })
+        .collect();
+    distribute_direct_routes(&mut manager, source, prefixes);
+
+    let mut announces = Vec::new();
+    let mut encode_cells = Vec::new();
+    for (member, receiver) in peers.iter().zip(&mut receivers) {
+        if *member == peers[0] {
+            assert!(
+                receiver.try_recv().is_err(),
+                "an all-own-source payload remains a no-op for its source"
+            );
+            continue;
+        }
+        let update = receiver.try_recv().unwrap();
+        assert_eq!(update.announce.len(), ROUTES);
+        assert_eq!(update.announce_source_exclusion, None);
+        assert_eq!(
+            update
+                .announce
+                .iter()
+                .filter(|route| update.announce_source_exclusion != Some(route.peer))
+                .count(),
+            ROUTES,
+            "source exclusion must preserve the historical per-member wire view"
+        );
+        announces.push(update.announce.clone());
+        encode_cells.push(update.shared_group_encode.clone().unwrap());
+        assert!(receiver.try_recv().is_err());
+    }
+    assert!(
+        announces
+            .iter()
+            .all(|announce| Arc::ptr_eq(announce, &announces[0]))
+    );
+    assert!(
+        encode_cells
+            .iter()
+            .all(|cell| Arc::ptr_eq(cell, &encode_cells[0]))
+    );
+    assert_eq!(probes.load(Ordering::Relaxed), ROUTES);
+    assert_eq!(announces.len(), PEERS - 1);
+    assert_eq!(reuses.load(Ordering::Relaxed), PEERS - 2);
+    assert_eq!(manager.adj_rib_out_commit_stats.exact_probe_batches, 1);
+    assert_eq!(
+        manager.adj_rib_out_commit_stats.exact_probe_candidates,
+        ROUTES
+    );
+    assert_eq!(
+        manager.adj_rib_out_commit_stats.exact_probe_cache_reuses,
+        ROUTES * (PEERS - 2)
+    );
+}
+
+#[test]
+fn source_excluded_exact_failure_never_enters_the_peer_overlay() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 63, 4, 1));
+    let probes = Arc::new(AtomicUsize::new(0));
+    manager.handle_update(RibUpdate::SetPeerExportContext {
+        peer,
+        session_id: 0,
+        local_role: Some(rustbgpd_wire::BgpRole::Customer),
+    });
+    let mut outbound = register_direct_exact_peer(
+        &mut manager,
+        peer,
+        Arc::new(CohortExactEncoder {
+            owner: 1,
+            profile: 64,
+            max_len: 128,
+            generation: AtomicUsize::new(0),
+            advance_generation: false,
+            probes: Arc::clone(&probes),
+            reuses: Arc::new(AtomicUsize::new(0)),
+        }),
+    );
+
+    let IpAddr::V4(peer_source) = peer else {
+        unreachable!()
+    };
+    let own_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 120, 0), 24);
+    let mut own_route = crate::test_support::make_route(own_prefix, peer_source);
+    Arc::make_mut(&mut own_route.attributes).extend([
+        PathAttribute::Communities(vec![0xFDE8_0002]),
+        PathAttribute::OnlyToCustomer(64_512),
+    ]);
+    let other_route = crate::test_support::make_route(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 121, 0), 24),
+        Ipv4Addr::new(192, 0, 2, 64),
+    );
+    let mut batch = OutboundCommitBatch::with_unicast(
+        vec![own_route.clone(), other_route.clone()].into(),
+        vec![None, None].into(),
+    );
+    batch.announce_source_exclusion = Some(peer);
+    batch.shared_group_encode = Some(Arc::new(crate::update::SharedGroupEncode::default()));
+
+    assert!(
+        manager.try_send_and_commit_outbound_update_with_group_prior(
+            peer,
+            batch,
+            HashSet::new(),
+            None,
+        )
+    );
+    let update = outbound.try_recv().unwrap();
+    assert_eq!(update.announce_source_exclusion, Some(peer));
+    assert_eq!(update.announce.len(), 2);
+    assert_eq!(update.announce[0].prefix, own_route.prefix);
+    assert_eq!(update.announce[0].peer, own_route.peer);
+    assert_eq!(update.announce[1].prefix, other_route.prefix);
+    assert_eq!(update.announce[1].peer, other_route.peer);
+    assert!(update.withdraw.is_empty());
+    assert!(
+        update.shared_group_encode.is_none(),
+        "a member-specific exact fallback cannot retain shared encoded bytes"
+    );
+    assert_eq!(probes.load(Ordering::Relaxed), 2);
+    assert!(
+        !manager.peer_unexportable.contains_key(&peer),
+        "the rejected own-source route is absent from this peer's wire view"
+    );
+    assert!(!manager.peer_otc_blocked.contains_key(&peer));
+    assert!(!manager.pending_otc_blocked.contains_key(&peer));
 }
 
 #[test]
@@ -1316,8 +1496,21 @@ async fn run_clean_transition_equivalence(force_ungrouped: bool) -> Vec<Vec<Stri
     })
     .await
     .unwrap();
-    for receiver in &mut receivers {
-        assert_eq!(receiver.recv().await.unwrap().announce.len(), 2);
+    for (index, receiver) in receivers.iter_mut().enumerate() {
+        let update = receiver.recv().await.unwrap();
+        assert_eq!(
+            update.announce_source_exclusion,
+            (!force_ungrouped).then_some(peers[index])
+        );
+        assert_eq!(update.announce.len(), if force_ungrouped { 2 } else { 3 });
+        assert_eq!(
+            update
+                .announce
+                .iter()
+                .filter(|route| update.announce_source_exclusion != Some(route.peer))
+                .count(),
+            2
+        );
     }
 
     let (reply, response) = oneshot::channel();

--- a/crates/rib/src/manager/update_groups/payload.rs
+++ b/crates/rib/src/manager/update_groups/payload.rs
@@ -290,6 +290,14 @@ pub(in crate::manager) struct GroupStageOutput {
     /// withdraw), or a consumed lane transition's `emit_target`
     /// (member-scoped emission the shared payload does not carry).
     pub(super) exceptions: HashSet<IpAddr>,
+    /// Exception members that cannot be expressed as the shared announce
+    /// payload plus own-source exclusion and therefore still need the full
+    /// per-member matrix walk.
+    source_exclusion_unsafe: HashSet<IpAddr>,
+    /// Number of shared announcements sourced by each member. This makes the
+    /// all-own-source no-op test O(1): emitting an otherwise empty envelope
+    /// changes marker ordering even though transport would encode no UPDATE.
+    shared_source_counts: HashMap<IpAddr, usize>,
 }
 
 impl GroupStageOutput {
@@ -306,6 +314,27 @@ impl GroupStageOutput {
     /// source-flip matrix output.
     pub(in crate::manager) fn shared_applies_to(&self, member: IpAddr) -> bool {
         !self.exceptions.contains(&member)
+    }
+
+    /// Whether the shared announcement plus transport-side own-source
+    /// exclusion is exactly this member's source-flip result. This covers a
+    /// cold-table announce whose only exception is the newly staged route's
+    /// source: the member must see nothing for that slot, and no displaced
+    /// advertisement or exception lane is owed.
+    pub(in crate::manager) fn shared_applies_with_source_exclusion(&self, member: IpAddr) -> bool {
+        !self.source_exclusion_unsafe.contains(&member)
+    }
+
+    /// Whether own-source exclusion leaves an announcement or the shared
+    /// payload carries a withdrawal. If neither is true, the historical
+    /// per-member matrix correctly emits no envelope for this member.
+    pub(in crate::manager) fn shared_has_payload_after_source_exclusion(
+        &self,
+        member: IpAddr,
+    ) -> bool {
+        !self.shared_withdraw.is_empty()
+            || self.shared_source_counts.get(&member).copied().unwrap_or(0)
+                < self.shared_announce.len()
     }
 
     /// Whether this pass carries a control-form community for `rs_asn`
@@ -406,11 +435,16 @@ impl GroupStageOutput {
         for delta in &self.deltas {
             if let Some((route, flag)) = &delta.new {
                 self.exceptions.insert(route.peer);
+                if delta.old_source.is_some() || delta.lane.is_some() {
+                    self.source_exclusion_unsafe.insert(route.peer);
+                }
+                *self.shared_source_counts.entry(route.peer).or_default() += 1;
                 nh.push(flag.clone());
                 announce.push(route.clone());
             } else {
                 if let Some(source) = delta.old_source {
                     self.exceptions.insert(source);
+                    self.source_exclusion_unsafe.insert(source);
                 }
                 self.shared_withdraw.push((delta.prefix, delta.path_id));
             }
@@ -425,6 +459,7 @@ impl GroupStageOutput {
         for delta in &self.lane_deltas {
             if let Some(target) = delta.emit_target {
                 self.exceptions.insert(target);
+                self.source_exclusion_unsafe.insert(target);
             }
         }
         self.shared_announce = announce.into();

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -2163,6 +2163,28 @@ fn member_emission(out: &GroupStageOutput, member: IpAddr) -> (Vec<Route>, Vec<(
             "shared/walk withdraw diverged for {member}"
         );
     }
+    if out.shared_applies_with_source_exclusion(member) {
+        let filtered = out
+            .shared_announce
+            .iter()
+            .filter(|route| route.peer != member)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            announce.len(),
+            filtered.len(),
+            "source-excluded shared/walk announce count diverged for {member}"
+        );
+        for (walked, shared) in announce.iter().zip(filtered) {
+            assert!(
+                routes_equal(walked, shared),
+                "source-excluded shared/walk announce diverged for {member}"
+            );
+        }
+        assert_eq!(
+            withdraw, out.shared_withdraw,
+            "source-excluded shared/walk withdraw diverged for {member}"
+        );
+    }
     (announce, withdraw)
 }
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -924,9 +924,9 @@ pub struct OutboundRouteUpdate {
     /// or belongs to another encoder implementation.
     pub exact_export_snapshot: Option<Arc<dyn ExactExportSnapshot>>,
     /// Optional source peer omitted from the shared unicast announce view.
-    /// Set only by a preflighted clean group-transition envelope; ordinary
-    /// updates materialize their already-filtered member view and leave this
-    /// `None`.
+    /// Set by preflighted shared group fanout when transport-side exclusion
+    /// is exactly equivalent to materializing the member's split-horizon
+    /// view.
     pub announce_source_exclusion: Option<IpAddr>,
     /// Routes to announce to this peer. `Arc`-shared so an update-group
     /// fanout enqueues ONE staged announce vector to every in-sync
@@ -993,8 +993,8 @@ pub struct OutboundRouteUpdate {
     /// peer's natural re-advertisement.
     pub request_refresh_all_negotiated: bool,
     /// Encode-once cell shared by every member envelope of one grouped
-    /// fanout (set only by the clean group-transition seam alongside
-    /// `announce_source_exclusion`). `None` = ordinary per-session encode.
+    /// fanout whose exact-export preflight retained the identical announce
+    /// inventory. `None` = ordinary per-session encode.
     pub shared_group_encode: Option<Arc<SharedGroupEncode>>,
 }
 


### PR DESCRIPTION
## Summary

- keep ordinary update-group source exceptions on the shared announce path when transport-side own-source exclusion is semantically exact
- reuse one compatible exact-export maximum proof and one encode-once cell across clean members, while retaining the full per-member fallback for source flips, lanes, withdrawals, exact-export rejection, and incompatible wire profiles
- exclude transport-suppressed own routes from per-peer OTC state, exact-rejection overlays, and outbound prefix-cap admission
- skip released selection-deferral history and redundant plain-group OTC scans during commit
- make the LAN-1188 benchmark model a homogeneous route-server fleet with an explicit wire-profile identity and the standard 4,096-byte BGP message ceiling

## Measured result

Five unchanged-main repetitions held IPv4 release at 53.308–54.187 s (53.613 s median). The corrected homogeneous 700-peer / 400,400-route fixture completes in 0.797 s with 700/700 EoRs, 700/700 payloads, and exact route-count/checksum parity. That fixture is about 67x faster, with 616 MB peak RSS.

The timing is scoped to the fully reusable homogeneous-wire-profile case. Production only reuses successful probes for compatible wire encodings and applies each target profile message ceiling; mixed profiles form separate cohorts or retain the existing per-member fallback.

## Validation

- `cargo test --locked -p rustbgpd-rib --lib` (1,246 passed; 2 ignored)
- `cargo clippy --locked -p rustbgpd-rib --all-targets --features bench-internals -- -D warnings`
- `cargo test --locked -p rrtransport grouped_commit_receipt_fixture`
- `cargo clippy --locked -p rrtransport --all-targets -- -D warnings`
- selection-deferral benchmark self-test, including profile-mismatch and message-ceiling guards
- fresh uncontended full IPv4 fleet receipt
- rrtransport receipt verifier destructive tests
- repository commit and pre-push checks

Linear: LAN-1188
