### PR TITLE
bench: gate rrtransport full-shape convergence

### DIFF
--- a/bench/scale/rrtransport/README.md
+++ b/bench/scale/rrtransport/README.md
@@ -76,6 +76,13 @@ written only after all three attempts pass the semantic verifier. Results are
 not comparable to the historical unavailable scratch harness and must not be
 published as an A/B.
 
+A three-attempt full campaign on 2026-08-29 ran at repository commit
+`05a71687ff3f4787eb1eb90a180fa7bd817e36c5`. Its three staged-convergence
+times were 295, 300, and 307 ms; exact wire-convergence times were 330, 334,
+and 329 ms. The full-shape verifier therefore rejects staged time above 354 ms
+or wire time above 385 ms, 15% over the respective observed maxima. The tiny
+CI correctness fixture does not apply these performance ceilings.
+
 CI never runs the scale shape. It runs the original smoke, a 4×100 real-TCP
 fixture through the same scale collector/verifier/RSS seams, and destructive
 parser/mechanics fixtures.

--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -14,6 +14,10 @@ SOURCES = 4
 WORKERS = 12
 TOTAL_NLRI = PEERS * PREFIXES
 RSS_LIMIT_KIB = 2 * 1024 * 1024
+# Seeded from a three-attempt full campaign on 2026-08-29: staged
+# 295/300/307 ms and wire 330/334/329 ms. Each limit is ceil(1.15 * max).
+STAGED_MS_LIMIT = 354
+WIRE_MS_LIMIT = 385
 SHAPE = (
     "rr1000-v1:peers=1000;prefixes=100000;sources=4;workers=12;"
     "afi=ipv4-unicast;role=ibgp-rr"
@@ -85,6 +89,16 @@ def verify(directory, tiny=False):
             fail(f"phase {key} is missing or invalid")
     if phase["injection_ms"] > min(phase["staged_ms"], phase["wire_ms"]):
         fail("injection completion follows a convergence timestamp")
+    if not tiny and phase["staged_ms"] > STAGED_MS_LIMIT:
+        fail(
+            f"staged convergence ceiling exceeded: {phase['staged_ms']} ms > "
+            f"{STAGED_MS_LIMIT} ms"
+        )
+    if not tiny and phase["wire_ms"] > WIRE_MS_LIMIT:
+        fail(
+            f"wire convergence ceiling exceeded: {phase['wire_ms']} ms > "
+            f"{WIRE_MS_LIMIT} ms"
+        )
 
     grouped = load(directory / "grouped-commit.json")
     expected_grouped = {

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -96,6 +96,16 @@ expect_red() {
 
 cp -a "$fixture" "$tmp/accepted"
 python3 "$verifier" "$tmp/accepted"
+cp -a "$fixture" "$tmp/timing-boundaries"
+mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);phase=p/"phase.json";d=json.loads(phase.read_text());d["staged_ms"]=354;d["wire_ms"]=385;phase.write_text(json.dumps(d));peers=p/"per-peer.tsv";rows=peers.read_text().splitlines();fields=rows[1].split("\t");fields[-1]="385";rows[1]="\t".join(fields);peers.write_text("\n".join(rows)+"\n")' \
+  "$tmp/timing-boundaries"
+python3 "$verifier" "$tmp/timing-boundaries"
+expect_red staged-time-ceiling mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["staged_ms"]=355;p.write_text(json.dumps(d))'
+grep -Fxq "FAIL: staged convergence ceiling exceeded: 355 ms > 354 ms" \
+  "$tmp/staged-time-ceiling.result"
+expect_red wire-time-ceiling mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);phase=p/"phase.json";d=json.loads(phase.read_text());d["wire_ms"]=386;phase.write_text(json.dumps(d));peers=p/"per-peer.tsv";rows=peers.read_text().splitlines();fields=rows[1].split("\t");fields[-1]="386";rows[1]="\t".join(fields);peers.write_text("\n".join(rows)+"\n")'
+grep -Fxq "FAIL: wire convergence ceiling exceeded: 386 ms > 385 ms" \
+  "$tmp/wire-time-ceiling.result"
 expect_red missing-internal-receipt mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])/"grouped-commit.json").unlink()'
 for field in routes_received_dispatches routes_received_withdrawals envelopes \
   routes_per_envelope; do


### PR DESCRIPTION
## Summary

- add full-shape staged and wire convergence ceilings to the existing rrtransport verifier
- seed the limits from three fresh verified runs at the merged main commit
- keep the tiny CI correctness fixture free of performance gates
- document the measured values and add exact-boundary plus over-limit red proofs

## Measurement

Three full 1,000-peer by 100,000-prefix runs completed with exact receipt verification:

| Run | Injection | Staged | Wire | Process-tree RSS max |
| --- | ---: | ---: | ---: | ---: |
| 1 | 35 ms | 295 ms | 330 ms | 378,444 KiB |
| 2 | 31 ms | 300 ms | 334 ms | 422,212 KiB |
| 3 | 34 ms | 307 ms | 329 ms | 377,752 KiB |

The limits are 15 percent over the observed maxima: 354 ms staged and 385 ms wire. Both remain below the previously observed 31 percent regression class.

## Validation

- all three full receipts pass the candidate verifier
- exact 354/385 ms boundary fixture passes
- 355 ms staged and 386 ms wire fixtures fail with the intended diagnostics
- tiny real-TCP receipt passes and remains timing-neutral
- rrtransport destructive receipt suite passes
- rrtransport tests: 7 passed
- rrtransport all-target Clippy with warnings denied passes
- Ruff, ShellCheck, formatting, commit hooks, and push hooks pass

Linear: LAN-1316
