### PR TITLE
bench: restore one-reload IRR smoke

### DIFF
--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -943,7 +943,7 @@ run_cell() {
         echo "cell $cell: reload phase attribution validation failed" >&2
         rc=90
     fi
-    if [ -n "$dataset_stage_cmd" ] && [ "$rc" -eq 0 ] &&
+    if [ "$CAMPAIGN_KIND" != smoke ] && [ -n "$dataset_stage_cmd" ] && [ "$rc" -eq 0 ] &&
         ! python3 "$VERIFY" dataset-refresh --daemon-log "$cdir/daemon.log" \
             --reload-log "$cdir/reloadstall.log" --manifest "$run/manifest.json" \
             --output "$cdir/dataset-refresh-summary.csv"; then

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -100,6 +100,9 @@ fn irr_reload_phase_receipt_is_semantically_fail_closed() {
     assert!(verifier.contains("phase records are reordered"));
     assert!(verifier.contains("missing/duplicate record"));
     assert!(verifier.contains("dataset refresh summary requires four ordered SIGHUP triggers"));
+    assert!(runner.contains(
+        r#"if [ "$CAMPAIGN_KIND" != smoke ] && [ -n "$dataset_stage_cmd" ] && [ "$rc" -eq 0 ] &&"#
+    ));
     assert!(runner.contains("dataset-refresh-summary.csv"));
 }
 


### PR DESCRIPTION
## Summary

- skip the canonical four-reload dataset-refresh summary only for the one-reload IRR smoke
- retain the unchanged four-trigger validator for every full measured campaign
- make the smoke/full boundary load-bearing in the existing contract test

## Validation

- current-generation smoke: rustbgpd SIGHUP, rustbgpd transaction, BIRD 3.3.2, and OpenBGPD 9.2 all passed
- IRR reload contract suite: 20 passed
- focused smoke/full protocol and semantic fail-closed tests pass
- IRR verifier self-test passes
- Bash syntax, source-aware ShellCheck, formatting, commit hooks, and push hooks pass

The failed pre-fix smoke is preserved separately. This change does not alter the validator, the measured four-reload shape, or any performance claim.

Linear: LAN-1395
