### PR TITLE
ci: execute standalone paging benchmark smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,14 +189,14 @@ jobs:
       - run: cargo check --locked -p rustbgpd-transport --features bench-internals --benches
       # API owns the feature-gated event-history producer bench.
       - run: cargo check --locked -p rustbgpd-api --features bench-internals --benches
-      # `--no-run` above proves the bench targets compile, not that they run.
+      # `cargo check` above proves the bench targets compile, not that they run.
       # A fixture the codec later made illegal (RFC 9774 AS_SET in the wire
       # `rich` AS_PATH) compiled clean and panicked on first iteration, so two
-      # benchmark groups stopped executing without any gate noticing. Criterion
-      # `--test` mode runs every benchmark body once, unmeasured, which is what
-      # separates "broken" from "nobody ran it". Smoke only — no timings.
-      - name: Smoke every criterion bench target
-        run: bash bench/smoke-benches.sh
+      # benchmark groups stopped executing without any gate noticing. `cargo
+      # test --bench` runs every Criterion body once; bounded native CLI
+      # fixtures exercise both paging receipt harnesses. Smoke only — no timings.
+      - name: Smoke benchmark targets without dedicated checks
+        run: bash bench/smoke-benches.sh --locked
       - name: Smoke selection-deferral release receipt
         run: cargo test --locked -p rustbgpd-rib --features bench-internals --bench selection_deferral_release -- --self-test
       # LAN-572 keeps the real MRT snapshot encoder benchmark usable in both

--- a/bench/README.md
+++ b/bench/README.md
@@ -294,11 +294,13 @@ result). Guard test: `bench/tests/test_verify_mrt_growth_campaign.py`.
 
 ## Bench smoke check
 
-`smoke-benches.sh` proves every Criterion bench target still
-*executes* by running each benchmark body exactly once in `--test`
-mode (no measurement). The target list comes from `cargo metadata`, so
-new bench targets are covered automatically; the non-criterion
-harnesses are excluded by name.
+`smoke-benches.sh` gives every metadata-enumerated bench target execution
+coverage unless CI already invokes its native smoke contract. Criterion
+benchmark bodies run exactly once through `cargo test --bench` (no measurement), while
+`route_paging` and `dataplane_prefix_paging` run bounded multi-page fixtures
+through their custom CLIs. The other four custom harnesses retain their
+separate CI smoke invocations. The target list comes from `cargo metadata`, so
+new bench targets are covered automatically.
 
 ## Scale drivers
 

--- a/bench/smoke-benches.sh
+++ b/bench/smoke-benches.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 #
-# Prove every criterion bench target still *executes*.
+# Exercise every bench target that is not already smoked by a dedicated CI
+# step.
 #
 # Benches are outside the gate battery, so a bench that panics on its first
 # iteration is indistinguishable from one nobody ran. `cargo bench --no-run`
 # does not close that: an attribute fixture that a codec change made illegal
-# compiles fine and only fails when the body runs. `cargo test --bench` puts
-# criterion in `--test` mode — every benchmark body runs exactly once with no
-# measurement, which is the cheapest thing that actually catches it.
+# compiles fine and only fails when the body runs. `cargo test --bench` runs
+# every criterion benchmark body exactly once with no measurement, which is
+# the cheapest thing that actually catches it. The two paging receipt harnesses
+# are custom CLIs, so they use bounded multi-page fixtures below instead.
 #
 # This is a smoke check, not a measurement. It reports pass/fail only; any
 # timing it happens to produce is meaningless and is not reported.
 #
 # The target list comes from `cargo metadata`, so a bench target is covered the
-# day it lands rather than when someone remembers to register it here. The six
-# non-criterion harnesses are excluded by name; renaming one drops its
-# exclusion and this script then fails loudly instead of skipping it silently.
+# day it lands rather than when someone remembers to register it here. Four
+# custom harnesses with separate CI smoke steps are excluded by package/target
+# key; renaming one drops its exclusion and this script then fails loudly
+# instead of skipping it silently.
 
 set -euo pipefail
 
@@ -39,23 +42,33 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-# Excluded — standalone measurement harnesses with their own CLIs rather than
-# criterion, so they reject criterion's `--test` flag:
+# Standalone measurement harnesses have their own CLIs rather than criterion.
+# They accept Cargo's libtest-compatible `--bench` marker; two have bounded
+# invocations in this script:
+#
+#   route_paging         CSV receipt harness; one complete traversal per
+#                        process, driven by --routes/--page-size/--scope.
+#   dataplane_prefix_paging
+#                        CSV-to-stdout receipt harness; one complete traversal
+#                        per process, driven by prefix/path/index-mode flags.
+#
+# The remaining four are excluded here because CI executes their native smoke
+# contracts separately:
 #
 #   snapshot_allocation  needs a `timing|diagnostic` mode plus --commit and
 #                        --output. CI smokes both modes separately through the
 #                        harness's own `--smoke` bound.
-#   route_paging         CSV receipt harness; one complete traversal per
-#                        process, driven by --route-count/--output.
-#   dataplane_prefix_paging
-#                        CSV-to-stdout receipt harness; one complete traversal
-#                        per process, driven by prefix/path/index-mode flags.
 #   vpn_query_*          are one-cell timing/allocation executables. CI runs
 #                        their exact 256-route smoke separately.
 #   selection_deferral_release
 #                        fixed-fleet receipt harness with its own CLI and
 #                        bounded self-test, which CI runs separately.
-EXCLUDED=(snapshot_allocation route_paging dataplane_prefix_paging vpn_query_timing vpn_query_allocation selection_deferral_release)
+EXCLUDED=(
+  rustbgpd-mrt/snapshot_allocation
+  rustbgpd-api/vpn_query_timing
+  rustbgpd-api/vpn_query_allocation
+  rustbgpd-rib/selection_deferral_release
+)
 
 mapfile -t targets < <(
   cargo metadata "${locked_args[@]}" --no-deps --format-version 1 | python3 -c '
@@ -77,10 +90,11 @@ fi
 status=0
 for target in "${targets[@]}"; do
   read -r package name features <<<"$target"
+  key="$package/$name"
 
   skip=
   for excluded in "${EXCLUDED[@]}"; do
-    if [ "$name" = "$excluded" ]; then
+    if [ "$key" = "$excluded" ]; then
       skip=1
       break
     fi
@@ -95,8 +109,21 @@ for target in "${targets[@]}"; do
     feature_args=(--features "$features")
   fi
 
+  bench_args=()
+  case "$key" in
+    rustbgpd-rib/route_paging)
+      # Grouped advertised routes exercise split horizon; 31 leaves a partial
+      # eighth page after the filtered rows are removed.
+      bench_args=(-- --routes 257 --page-size 31 --scope grouped-advertised --repetition 1)
+      ;;
+    rustbgpd-rib/dataplane_prefix_paging)
+      # Cross the harness's 1,024-prefix page boundary and retain multipath.
+      bench_args=(-- --prefixes 1025 --announcers 2 --max-paths 2 --mode eager --repetition 1)
+      ;;
+  esac
+
   echo "smoke $package/$name ${features:+[$features]}"
-  if ! cargo test "${locked_args[@]}" -p "$package" --bench "$name" "${feature_args[@]}"; then
+  if ! cargo test "${locked_args[@]}" -p "$package" --bench "$name" "${feature_args[@]}" "${bench_args[@]}"; then
     echo "::error::bench target $package/$name failed to execute" >&2
     if [ "$fail_fast" -eq 1 ]; then
       exit 1

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -168,27 +168,30 @@ workspace (`[package] rustbgpd` alongside `[workspace]`) with no
 `[[bench]]` target, `fib_projection`, is `bench-internals`-gated, which
 leaves the auto-discovered `src/lib.rs` libtest harness as the one thing that
 runs — and it declares no benchmarks. `cargo bench` at the root therefore
-measures nothing. `cargo bench --workspace` is not a substitute either: five
+measures nothing. `cargo bench --workspace` is not a substitute either: six
 targets are standalone CLIs rather than criterion harnesses and reject
 criterion's flags.
 
-Run each target explicitly with `-p <crate> --bench <name>`. Fifteen exist.
+Run each target explicitly with `-p <crate> --bench <name>`. Sixteen exist.
 Five build with default features (wire/`codec`, rib/`rib_ops`,
-policy/`policy_eval`, rpki/`validate`, mrt/`snapshot_allocation`); ten are
+policy/`policy_eval`, rpki/`validate`, mrt/`snapshot_allocation`); eleven are
 `bench-internals`-gated (transport/`fanout`, transport/`inbound_attrs`,
 transport/`explain_snapshot`, rustbgpd/`fib_projection`,
 rib/`route_paging`, rib/`evpn_dataplane_query`,
-rib/`dataplane_prefix_paging`, api/`event_history_producer`,
+rib/`dataplane_prefix_paging`, rib/`selection_deferral_release`,
+api/`event_history_producer`,
 api/`vpn_query_timing`, api/`vpn_query_allocation` — the last also requires
-the api crate's `vpn-query-allocation` feature). Five of the fifteen —
+the api crate's `vpn-query-allocation` feature). Six of the sixteen —
 `snapshot_allocation`, `route_paging`, `dataplane_prefix_paging`,
-`vpn_query_timing`, and `vpn_query_allocation` — are standalone measurement
-CLIs with their own argument contracts (`snapshot_allocation` hard-errors without a
-`timing|diagnostic` mode), not criterion harnesses.
+`selection_deferral_release`, `vpn_query_timing`, and `vpn_query_allocation` —
+are standalone measurement CLIs with their own argument contracts
+(`snapshot_allocation` hard-errors without a `timing|diagnostic` mode), not
+criterion harnesses.
 
 `bench/smoke-benches.sh` enumerates the target list from `cargo metadata`,
-excludes those five by name, and runs every remaining criterion target once
-in `--test` mode — the cheapest proof that each still executes.
+runs every criterion target once through `cargo test --bench`, and exercises
+`route_paging` and `dataplane_prefix_paging` with bounded multi-page native CLI
+fixtures. The four other custom harnesses retain dedicated CI smoke invocations.
 
 ```bash
 # Wire codec only


### PR DESCRIPTION
## Summary

- execute the route-paging and dataplane-prefix-paging custom harnesses with bounded multi-page fixtures in the existing benchmark smoke step
- retain exclusions only for the four custom harnesses that already have dedicated CI checks
- key exclusions by package and target, and pass `--locked` through the existing workflow
- correct the benchmark inventory to 16 targets and six custom harnesses

## Validation

- both focused paging harnesses passed (eight route pages; two dataplane pages and 1,025 prefixes)
- full smoke inventory passed: 12 executed, four intentionally skipped
- Bash syntax, ShellCheck, Actionlint, and `git diff --check`
- CI split-contract unit tests and live checker
- formatting, Clippy, and documentation checks

Linear: LAN-1398
