### PR TITLE
ci: execute netns calibration contract offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,9 @@ jobs:
           bash -n bench/tests/test-vpn-query-receipt.sh
           bash -n bench/tests/test-vpn-query-campaign.sh
           bash -n bench/run-vpn-query-campaign.sh
+          bash -n bench/netns-calibration/run-vm.sh \
+            bench/netns-calibration/guest-smoke.sh \
+            bench/tests/test-netns-calibration-vm.sh
           shellcheck bench/scale/host-quiet.sh \
             bench/scale/provenance.sh \
             bench/scale/matrix/run-matrix.sh \
@@ -429,6 +432,9 @@ jobs:
           shellcheck bench/tests/test-vpn-query-receipt.sh
           shellcheck bench/tests/test-vpn-query-campaign.sh \
             bench/run-vpn-query-campaign.sh
+          shellcheck -x bench/netns-calibration/run-vm.sh \
+            bench/netns-calibration/guest-smoke.sh \
+            bench/tests/test-netns-calibration-vm.sh
           bash bench/tests/test-route-server-1000-receipt.sh
           bash bench/tests/test-scale-host-quiet.sh
           bash bench/tests/test-vpn-query-receipt.sh
@@ -436,6 +442,7 @@ jobs:
           bash bench/tests/test-compare-criterion-harness.sh
           bash bench/tests/test-rib-memory-comparator.sh
           bash bench/tests/test-route-paging-driver.sh
+          bash bench/tests/test-netns-calibration-vm.sh
           python3 bench/tests/test_verify_mrt_attribute_scratch_campaign.py
           bash -n bench/scale/compare-rrharness.sh
           bash bench/tests/test-rrharness-driver.sh

--- a/bench/netns-calibration/README.md
+++ b/bench/netns-calibration/README.md
@@ -82,6 +82,10 @@ needed for the Stage-A contract suite:
 bash bench/tests/test-netns-calibration-vm.sh
 ```
 
+The `scale / receipt checks` CI job runs this exact offline suite and
+syntax-checks all three shell surfaces. It does not boot QEMU; the image-pinned
+live smoke remains the separately authorized invocation above.
+
 The suite destructively proves the closed profile matrix, exact no-network KVM
 plan, source lifecycle anchors, guest failure cleanup, provenance binding,
 artifact inventory and size limits, sanitation, and final manifest.


### PR DESCRIPTION
## Summary

- run the existing netns-calibration destructive contract in the scale/receipt CI job
- syntax-check and ShellCheck the VM runner, guest smoke, and offline contract together
- document the boundary between this fast offline gate and the separately authorized image-pinned QEMU smoke

## Validation

- `bash bench/tests/test-netns-calibration-vm.sh`
- Bash syntax and ShellCheck for all three shell surfaces
- `actionlint .github/workflows/ci.yml`
- `python3 scripts/check_ci_scale_split_contract.py`
- `python3 -m unittest -v scripts.test_check_ci_scale_split_contract` (6 tests)
- commit and push hooks, including workspace Clippy and documentation

The CI addition does not boot QEMU, require KVM, access the network, or need privilege.
