### PR TITLE
test: freeze v0.67 route-server upgrade fixture

### DIFF
--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -384,6 +384,27 @@ fn v1_stable_v0_66_route_server_fixture_parses() {
         .unwrap_or_else(|err| panic!("v0.66.0 route-server config no longer validates: {err}"));
 }
 
+#[test]
+fn v1_stable_v0_67_route_server_fixture_parses() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/v1-stable/v0.67.0/route-server");
+    let config_path = fixture.join("config.toml");
+    let source = fs::read_to_string(&config_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read immutable v0.67.0 route-server fixture {}: {err}",
+            config_path.display()
+        );
+    });
+    let mut config: Config = toml::from_str(&source)
+        .unwrap_or_else(|err| panic!("v0.67.0 route-server config no longer parses: {err}"));
+    config
+        .load_rpol_files(Some(&fixture))
+        .unwrap_or_else(|err| panic!("v0.67.0 route-server rpol no longer loads: {err}"));
+    config
+        .validate()
+        .unwrap_or_else(|err| panic!("v0.67.0 route-server config no longer validates: {err}"));
+}
+
 const V1_EFFECTIVE_DEFAULTS_TOML: &str = r#"
 [global]
 asn = 65001

--- a/tests/fixtures/v1-stable/v0.67.0/route-server/config.toml
+++ b/tests/fixtures/v1-stable/v0.67.0/route-server/config.toml
@@ -1,0 +1,175 @@
+# IXP route server configuration
+#
+# rustbgpd as an IX route server with two members. Every member gets:
+# - transparent route-server mode (preserve original NEXT_HOP, no AS prepend)
+# - local BGP role "route_server" (RFC 9234: OTC attached on egress,
+#   role capability negotiated when the member also sets its role)
+# - dual-stack (IPv4 + IPv6 unicast)
+# - RPKI origin validation (drop invalid, prefer valid) and import
+#   hygiene (reject AS_SET, ASPA-invalid, and a dated dual-stack
+#   special-purpose prefix snapshot — see hygiene.rpol)
+#
+# Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
+# - member-alpha negotiates Add-Path send: it sees up to the eight best
+#   export-permitted candidates, subject to configured and negotiated
+#   Paths-Limit, and runs its own selection (the preferred mitigation);
+# - member-beta cannot do Add-Path, so it opts into per_client_best:
+#   when its export policy denies the best path, the route server
+#   advertises the best *permitted* candidate instead of hiding the
+#   prefix (the BIRD-`secondary` equivalent).
+#
+# Add more [[neighbors]] blocks for additional IXP members, or manage
+# them dynamically via gRPC at runtime.
+
+[global]
+asn = 65500
+router_id = "198.51.100.1"
+listen_port = 179
+# Optional exact bind/source endpoints (at most one per family). Useful when
+# two route-server instances share a host; changing these requires restart.
+# listen_addresses = ["198.51.100.1", "2001:db8::1"]
+# RFC 8212: a member session with no explicit policy carries nothing in
+# that direction. The export chain below is deliberately permit-all, and
+# this knob is what keeps that a decision: delete the chain and members
+# stop receiving routes, loudly, instead of inheriting the same permit-all
+# by omission. Startup-only — SIGHUP keeps the running value, so changing
+# it takes a daemon restart.
+ebgp_requires_policy = true
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# For remote management, prefer an mTLS proxy (see examples/envoy-mtls/).
+# For a loopback-only bearer listener, create the token file and uncomment
+# this complete principal-to-role mapping:
+# [global.telemetry.grpc_tcp]
+# address = "127.0.0.1:50051"
+# token_file = "/etc/rustbgpd/grpc-token"
+# principal = "remote-operator"
+# [security.grpc.roles]
+# remote-operator = "operator"
+
+# Local gRPC uses the implicit owner-only socket at
+# <runtime_state_dir>/grpc.sock and the local-operator identity.
+
+# --- RPKI origin validation ---
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"       # Routinator, rpki-client, etc.
+
+# --- Named policy definitions ---
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.reject-long-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "0.0.0.0/0"
+ge = 25
+le = 32
+action = "deny"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "::/0"
+ge = 49
+le = 128
+action = "deny"
+
+[policy.definitions.prefer-rpki-valid]
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "valid"
+action = "permit"
+set_local_pref = 200
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "not_found"
+action = "permit"
+set_local_pref = 100
+
+# --- Export policy: permit-all, on purpose ---
+#
+# An IX route server is transparent by design (RFC 7947): it hands each
+# member what that member's own filters selected, without imposing the
+# route server's opinion on top. So permit-all is the correct export
+# posture here — but it is *declared*, not inherited. A route server that
+# is permit-all because nobody wrote an export chain behaves identically
+# on the wire; only this chain, and this comment, record that it was a
+# choice rather than an omission.
+#
+# Per-member filtering (a member that wants a subset, or a bilateral
+# arrangement) belongs in that neighbor's `export_policy_chain`, which
+# overrides this globally applied one. member-beta's `per_client_best`
+# below is what makes such a per-member denial advertise the best
+# permitted candidate rather than hide the prefix.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
+[policy]
+# ixp-hygiene and reject-special-purpose live in hygiene.rpol; rpol and
+# TOML policies share one namespace and compose in one ordered chain.
+rpol_files = ["hygiene.rpol"]
+import_chain = [
+    "reject-rpki-invalid",
+    "ixp-hygiene",
+    "reject-special-purpose",
+    "reject-long-prefixes",
+    "prefer-rpki-valid",
+]
+export_chain = ["rs-transparent-export"]
+
+# Import-decision explain, off — stated rather than inherited, because on
+# a route server it is the memory decision that matters most. The cache is
+# per session, so its cost is multiplied by member count, and 4096 entries
+# cannot retain a member's full table anyway: a query for an arbitrary
+# prefix would be a coin-flip against an evicted answer. On a 1000-member
+# fleet whose members each announce more than 4096 prefixes, an enabled
+# cache at the default size saturates in the low gigabytes.
+#
+# For the member-facing "why is my route filtered?" question, prefer
+# `[policy.reject_retention]` (on by default) and
+# `rbgp rib received <member> --rejected` — it enumerates rejections with
+# reasons and does not need the prefix known in advance.
+#
+# Turn this on deliberately, with `cache_size` raised toward the member's
+# retained-prefix count, while you are diagnosing — not as a standing cost.
+[policy.explain]
+enabled = false
+
+# --- IXP member peers ---
+
+# Add-Path-capable member: sees up to the eight best export-permitted
+# candidates, subject to configured and negotiated Paths-Limit (preferred
+# path-hiding mitigation). Like `per_client_best`, Add-Path send places
+# the member on the per-peer distribution path (the `add_path_send`
+# fallback reason); update-group sharing applies to members using
+# neither mitigation.
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64501
+description = "member-alpha"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+role = "route_server"
+max_prefixes = 50000
+
+[neighbors.add_path]
+send = true
+send_max = 8
+
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied
+# (RFC 7947 §2.3.2 per-client best-path). Requires route_server_client.
+[[neighbors]]
+address = "198.51.100.3"
+remote_asn = 64502
+description = "member-beta"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+per_client_best = true
+role = "route_server"
+max_prefixes = 50000

--- a/tests/fixtures/v1-stable/v0.67.0/route-server/hygiene.rpol
+++ b/tests/fixtures/v1-stable/v0.67.0/route-server/hygiene.rpol
@@ -1,0 +1,166 @@
+# IXP import hygiene (rpol policy language, ADR-0096).
+#
+# Referenced from config.toml via `[policy] rpol_files` and the import
+# chain; edits hot-apply via SIGHUP. Run the in-language tests below
+# with `rbgp policy check hygiene.rpol`.
+
+# Dated starter snapshot of the IANA IPv4 and IPv6 Special-Purpose Address
+# Registries (both updated 2025-10-09; reviewed here 2026-07-15). The reject
+# set contains the two default routes plus active rows whose "Globally
+# Reachable" value is False. It is deliberately not a complete bogon feed:
+# terminated rows, unallocated space, multicast, and True/N/A rows outside a
+# rejected parent are omitted. Active True/N/A children of a rejected parent
+# must stay in this first set so the policy accepts them before the broad deny.
+prefix-set special-purpose-parent-exceptions {
+    192.0.0.9/32,
+    192.0.0.10/32,
+    2001::/32 le 128,
+    2001:1::1/128,
+    2001:1::2/128,
+    2001:1::3/128,
+    2001:3::/32 le 128,
+    2001:4:112::/48 le 128,
+    2001:20::/28 le 128,
+    2001:30::/28 le 128,
+}
+
+prefix-set non-global-special-purpose {
+    0.0.0.0/0,
+    0.0.0.0/8 le 32,
+    10.0.0.0/8 le 32,
+    100.64.0.0/10 le 32,
+    127.0.0.0/8 le 32,
+    169.254.0.0/16 le 32,
+    172.16.0.0/12 le 32,
+    192.0.0.0/24 le 32,
+    192.0.2.0/24 le 32,
+    192.88.99.2/32,
+    192.168.0.0/16 le 32,
+    198.18.0.0/15 le 32,
+    198.51.100.0/24 le 32,
+    203.0.113.0/24 le 32,
+    240.0.0.0/4 le 32,
+    ::/0,
+    ::/128,
+    ::1/128,
+    ::ffff:0:0/96 le 128,
+    64:ff9b:1::/48 le 128,
+    100::/64 le 128,
+    100:0:0:1::/64 le 128,
+    2001::/23 le 128,
+    2001:db8::/32 le 128,
+    3fff::/20 le 128,
+    5f00::/16 le 128,
+    fc00::/7 le 128,
+    fe80::/10 le 128,
+}
+
+policy reject-special-purpose {
+    term preserve-active-parent-exception {
+        if route.prefix in special-purpose-parent-exceptions { accept }
+    }
+    term reject-non-global { if route.prefix in non-global-special-purpose { reject } }
+}
+
+policy ixp-hygiene {
+    # Reject routes carrying an AS_SET (deprecated by RFC 9774; common
+    # IXP hygiene, arouteserver rejects them too). AS_PATHs render
+    # AS_SETs in braces — "65001 {65002 65003}" — so a literal `{`
+    # (escaped for the regex) matches any AS_SET segment.
+    term reject-as-set { if route.as-path matches "\\{" { reject } }
+    # Reject ASPA-invalid AS paths (draft-ietf-sidrops-aspa-verification).
+    # Inert (state = unknown) until ASPA objects are loaded from the
+    # RPKI cache; activates automatically once they are.
+    term reject-aspa-invalid { if route.aspa == invalid { reject } }
+    # Tag the RPKI origin-validation outcome as an RFC 8097 extended
+    # community (non-transitive opaque, type 0x43) so route-server
+    # clients can act on it without running their own validator.
+    # OV_INVALID never reaches clients here — the TOML import chain
+    # drops rpki-invalid routes — but tagging is harmless and keeps
+    # the terms uniform if that drop is ever relaxed.
+    term tag-ov-valid { if route.rpki == valid { add ext-community OV_VALID } }
+    term tag-ov-not-found { if route.rpki == not-found { add ext-community OV_NOT_FOUND } }
+    term tag-ov-invalid { if route.rpki == invalid { add ext-community OV_INVALID } }
+}
+
+test as-set-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501 {64502 64503}" }
+    expect ixp-hygiene == reject
+}
+
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
+test clean-route-falls-through {
+    route { prefix 203.0.113.0/24; as-path "64501 64510" }
+    expect ixp-hygiene == accept
+}
+
+test rpki-valid-is-tagged-ov-valid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki valid }
+    expect ixp-hygiene == accept with ext-community OV_VALID
+}
+
+test rpki-not-found-is-tagged-ov-not-found {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
+}
+
+test rpki-invalid-is-tagged-ov-invalid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki invalid }
+    expect ixp-hygiene == accept with ext-community OV_INVALID
+}
+
+test ipv4-default-is-rejected {
+    route { prefix 0.0.0.0/0 }
+    expect reject-special-purpose == reject
+}
+
+test ipv6-default-is-rejected {
+    route { prefix ::/0 }
+    expect reject-special-purpose == reject
+}
+
+test shared-address-more-specific-is-rejected {
+    route { prefix 100.65.0.0/24 }
+    expect reject-special-purpose == reject
+}
+
+test unique-local-more-specific-is-rejected {
+    route { prefix fd00:1::/48 }
+    expect reject-special-purpose == reject
+}
+
+test pcp-parent-exception-is-preserved {
+    route { prefix 192.0.0.9/32 }
+    expect reject-special-purpose == accept
+}
+
+test teredo-parent-exception-is-preserved {
+    route { prefix 2001:0:1234::/48 }
+    expect reject-special-purpose == accept
+}
+
+test as112-parent-exception-is-preserved {
+    route { prefix 2001:4:112::/48 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv4-falls-through {
+    route { prefix 8.8.8.0/24 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv6-falls-through {
+    route { prefix 2001:4860::/32 }
+    expect reject-special-purpose == accept
+}
+
+# This policy only classifies the dated special-purpose snapshot. The later
+# reject-long-prefixes chain member remains responsible for prefix-length caps.
+test too-long-parent-exception-falls-through {
+    route { prefix 2001:4:112::1/128 }
+    expect reject-special-purpose == accept
+}


### PR DESCRIPTION
## Summary

- preserve the exact v0.67.0 route-server example and RPOL as an immutable upgrade fixture
- parse, load, and validate that released configuration with the current daemon
- catch accidental v1-stable configuration drift before the v0.68 upgrade exercise

The consecutive v0.67.0 to v0.68.0 stable-surface exercise remains tied to the future workspace version bump; registering it while the workspace is still v0.67.0 would make the existing endpoint check fail correctly.

## Validation

- `cmp` against both files at tag `v0.67.0`
- `cargo test --locked v1_stable_v0_67_route_server_fixture_parses`
- `python3 scripts/check-v1-stable-surface.py`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
