### PR TITLE
fix(wire): reject Partial on non-transitive attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Recognized optional non-transitive attributes now reject an invalid Partial
+  flag. MED uses treat-as-withdraw; ORIGINATOR_ID and CLUSTER_LIST use
+  attribute-discard on eBGP and treat-as-withdraw on iBGP. MP_REACH and
+  MP_UNREACH retain their exact UPDATE `3/4` session-reset behavior. The policy
+  is uniform rather than configurable and uses the existing malformed-UPDATE
+  log and disposition metric.
+
 - Outbound TCP connect failures now surface once per failed-connect episode
   instead of remaining below the default log level: a cold peer's first socket
   failure is INFO, the first failure after an Established epoch and the first

--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+const RELEASED_PARTIAL_MED: [u8; 7] = [0xa0, 0x04, 0x04, 0x00, 0x00, 0x00, 0x64];
+const RELEASED_PARTIAL_ORIGINATOR_ID: [u8; 7] = [0xa0, 0x09, 0x04, 0xc0, 0x00, 0x02, 0x09];
+const RELEASED_PARTIAL_CLUSTER_LIST: [u8; 7] = [0xa0, 0x0a, 0x04, 0xc0, 0x00, 0x02, 0x0a];
+const RELEASED_PARTIAL_MP_REACH: [u8; 16] = [
+    0xa0, 0x0e, 0x0d, 0x00, 0x01, 0x01, 0x04, 0x0a, 0x69, 0x00, 0x0a, 0x00, 0x18, 0xc6, 0x33, 0x64,
+];
+const RELEASED_PARTIAL_MP_UNREACH: [u8; 10] =
+    [0xa0, 0x0f, 0x07, 0x00, 0x01, 0x01, 0x18, 0xc6, 0x33, 0x64];
+
 /// RFC 7606 §7.4 + §2: a malformed MED treats the UPDATE as though its
 /// routes had been withdrawn — previously accepted routes for the same
 /// NLRI are removed — and the session stays Established. Load-bearing metric
@@ -56,6 +65,145 @@ async fn rfc7606_treat_as_withdraw_removes_routes_and_keeps_session() {
         "treat-as-withdraw must keep the session Established"
     );
     assert_single_malformed_disposition(&session, "treat_as_withdraw");
+}
+
+/// RFC 4271 §4.3 requires Partial clear on optional non-transitive MED. The
+/// released-receiver byte string therefore takes the existing RFC 7606 §7.4
+/// treat-as-withdraw path: the replacement is withdrawn, the session remains
+/// Established, and the existing disposition metric records exactly one row.
+#[tokio::test]
+async fn partial_optional_nontransitive_med_withdraws_and_keeps_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&[]), &[prefix]))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected initial accepted route");
+    };
+    assert_eq!(announced.len(), 1);
+
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&RELEASED_PARTIAL_MED),
+            &[prefix],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("Partial MED must reach the RIB as a withdrawal")
+    else {
+        panic!("expected treat-as-withdraw RoutesReceived");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![(Prefix::V4(prefix), 0)]);
+    assert!(rib_rx.try_recv().is_err());
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
+}
+
+/// RFC 7606 §§7.9-7.10 make malformed route-reflector attributes
+/// neighbor-specific. These exact released-receiver bytes are discarded on
+/// eBGP so their routes survive, but treat the same replacement as withdrawn
+/// on iBGP. Both recoverable branches keep the session Established.
+#[tokio::test]
+async fn partial_optional_nontransitive_rr_attributes_follow_neighbor_role() {
+    let cases: [(u8, &[u8], Ipv4Addr); 2] = [
+        (
+            rustbgpd_wire::constants::attr_type::ORIGINATOR_ID,
+            &RELEASED_PARTIAL_ORIGINATOR_ID,
+            Ipv4Addr::new(203, 0, 113, 9),
+        ),
+        (
+            rustbgpd_wire::constants::attr_type::CLUSTER_LIST,
+            &RELEASED_PARTIAL_CLUSTER_LIST,
+            Ipv4Addr::new(203, 0, 113, 10),
+        ),
+    ];
+
+    for (type_code, partial_attribute, address) in cases {
+        let prefix = Ipv4Prefix::new(address, 32);
+        let (mut ebgp, mut ebgp_rib_rx) = make_test_session_with_rib(65001, 65002);
+        let (client, _server) = connected_stream_pair().await;
+        ebgp.test_install_stream(client);
+        establish_test_session(&mut ebgp, 65002).await;
+        rfc7606_drain(&mut ebgp_rib_rx);
+        ebgp.process_update(rfc7606_update(
+            rfc7606_attr_bytes(partial_attribute),
+            &[prefix],
+        ))
+        .await;
+        let RibUpdate::RoutesReceived { announced, .. } = ebgp_rib_rx
+            .try_recv()
+            .expect("eBGP attribute-discard route must reach the RIB")
+        else {
+            panic!("expected eBGP announcement");
+        };
+        let [route] = announced.as_slice() else {
+            panic!("expected one eBGP route");
+        };
+        assert_eq!(route.prefix, Prefix::V4(prefix));
+        assert!(
+            route
+                .attributes
+                .iter()
+                .all(|attribute| attribute.type_code() != type_code),
+            "type {type_code}: discarded eBGP attribute reached the RIB"
+        );
+        assert!(ebgp_rib_rx.try_recv().is_err());
+        assert_eq!(ebgp.known_prefix_count(), 1);
+        assert_eq!(ebgp.fsm.state(), SessionState::Established);
+        assert_single_malformed_disposition(&ebgp, "attribute_discard");
+
+        let (mut ibgp, mut ibgp_rib_rx) = make_test_session_with_rib(65001, 65001);
+        let (client, _server) = connected_stream_pair().await;
+        ibgp.test_install_stream(client);
+        establish_test_session(&mut ibgp, 65001).await;
+        rfc7606_drain(&mut ibgp_rib_rx);
+        ibgp.process_update(rfc7606_update(rfc7606_attr_bytes(&[]), &[prefix]))
+            .await;
+        let RibUpdate::RoutesReceived { announced, .. } = ibgp_rib_rx.try_recv().unwrap() else {
+            panic!("expected initial iBGP route");
+        };
+        assert_eq!(announced.len(), 1);
+
+        ibgp.process_update(rfc7606_update(
+            rfc7606_attr_bytes(partial_attribute),
+            &[prefix],
+        ))
+        .await;
+        let RibUpdate::RoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = ibgp_rib_rx
+            .try_recv()
+            .expect("iBGP treat-as-withdraw must reach the RIB")
+        else {
+            panic!("expected iBGP withdrawal");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![(Prefix::V4(prefix), 0)]);
+        assert!(ibgp_rib_rx.try_recv().is_err());
+        assert_eq!(ibgp.known_prefix_count(), 0);
+        assert_eq!(ibgp.fsm.state(), SessionState::Established);
+        assert_single_malformed_disposition(&ibgp, "treat_as_withdraw");
+
+        assert_eq!(update_malformed_count(&ebgp, "attribute_discard"), 1);
+        assert_eq!(update_malformed_count(&ibgp, "attribute_discard"), 0);
+        assert_eq!(update_malformed_count(&ebgp, "treat_as_withdraw"), 0);
+        assert_eq!(update_malformed_count(&ibgp, "treat_as_withdraw"), 1);
+    }
 }
 
 /// RFC 9234 / RFC 7606 field regression from the 2025 Qrator incident: the
@@ -937,6 +1085,47 @@ async fn rfc7606_mp_partial_flag_resets_with_exact_attribute_flags_error() {
             malformed_mp,
             "type {type_code}, extended={extended}: exact received attribute bytes"
         );
+    }
+}
+
+/// The post-receipt MED and route-reflector policy must not downgrade either
+/// MP attribute. The exact released-receiver bytes retain their UPDATE 3/4
+/// notification data and session-reset disposition.
+#[tokio::test]
+async fn partial_optional_nontransitive_mp_bytes_still_reset() {
+    for partial_mp in [
+        &RELEASED_PARTIAL_MP_REACH[..],
+        &RELEASED_PARTIAL_MP_UNREACH[..],
+    ] {
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let (client, mut server) = connected_stream_pair().await;
+        session.test_install_stream(client);
+        establish_test_session(&mut session, 65002).await;
+        rfc7606_drain(&mut rib_rx);
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+
+        session
+            .process_update(rfc7606_update(rfc7606_attr_bytes(partial_mp), &[prefix]))
+            .await;
+
+        assert_ne!(session.fsm.state(), SessionState::Established);
+        while let Ok(message) = rib_rx.try_recv() {
+            assert!(
+                !matches!(message, RibUpdate::RoutesReceived { .. }),
+                "Partial MP route reached the RIB"
+            );
+        }
+        assert_single_malformed_disposition(&session, "session_reset");
+        let notification = read_until_notification(&mut server).await;
+        assert_eq!(
+            notification.code,
+            rustbgpd_wire::notification::NotificationCode::UpdateMessage
+        );
+        assert_eq!(
+            notification.subcode,
+            rustbgpd_wire::notification::update_subcode::ATTRIBUTE_FLAGS_ERROR
+        );
+        assert_eq!(notification.data.as_ref(), partial_mp);
     }
 }
 

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,11 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- Enforced Partial clear on typed MED, ORIGINATOR_ID, and CLUSTER_LIST. The
+  strict decoder returns Attribute Flags Error with the exact attribute;
+  revised decoding maps MED to treat-as-withdraw and the route-reflector
+  attributes to attribute-discard on eBGP or treat-as-withdraw on iBGP.
+  MP_REACH and MP_UNREACH retain their existing session-reset contract.
 - Added `EvpnNlriDiscardObservations`, `decode_evpn_nlri_counted`, and
   `UpdateMessage::parse_revised_observed` so callers can observe exact,
   bounded counts of EVPN route types discarded under RFC 7606 §5.4. Existing

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1258,11 +1258,20 @@ pub(crate) fn decode_path_attributes_revised_observed(
             Err(error) => {
                 // RFC 7606 §3 (c): an Optional/Transitive flag conflict is
                 // treat-as-withdraw for every attribute — the §7.6/§7.7
-                // attribute-discard covers length malformations only. max()
-                // keeps MP_REACH/MP_UNREACH at session-reset (§5.3 lists
-                // inconsistent flags among what makes the MP attribute
+                // attribute-discard covers length malformations only. A
+                // Partial-only ORIGINATOR_ID/CLUSTER_LIST conflict instead
+                // retains the §7.9/§7.10 neighbor-specific disposition:
+                // attribute-discard on eBGP, treat-as-withdraw on iBGP.
+                // max() keeps MP_REACH/MP_UNREACH at session-reset (§5.3
+                // lists inconsistent flags among what makes the MP attribute
                 // itself incorrect).
                 let mut disposition = malformed_attr_disposition(type_code, is_ibgp);
+                let received_class = flags & (attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
+                let partial_only_rr_attribute_error = matches!(
+                    type_code,
+                    attr_type::ORIGINATOR_ID | attr_type::CLUSTER_LIST
+                ) && received_class == attr_flags::OPTIONAL
+                    && flags & attr_flags::PARTIAL != 0;
                 if type_code == attr_type::AIGP && (flags & attr_flags::TRANSITIVE) != 0 {
                     // RFC 7311 §3.2 is more specific than RFC 7606 §3(c):
                     // an AIGP attribute with Transitive set is discarded.
@@ -1271,7 +1280,8 @@ pub(crate) fn decode_path_attributes_revised_observed(
                     &error,
                     DecodeError::UpdateAttributeError { subcode, .. }
                         if *subcode == update_subcode::ATTRIBUTE_FLAGS_ERROR
-                ) {
+                ) && !partial_only_rr_attribute_error
+                {
                     disposition = disposition.max(ErrorDisposition::TreatAsWithdraw);
                 }
                 if disposition == ErrorDisposition::SessionReset {
@@ -1665,15 +1675,20 @@ fn decode_attribute_value(
 ) -> Result<PathAttribute, DecodeError> {
     // Validate the required flags for known attribute types (RFC 4271 §6.3).
     // RFC 4271 §4.3 requires Partial=0 for optional non-transitive
-    // attributes. Enforce that bit for MP_REACH_NLRI / MP_UNREACH_NLRI,
-    // whose incorrect flags are fatal under RFC 7606 §5.3, and for the
-    // already-strict BGP-LS Attribute. Do not broaden the legacy flag surface
-    // of unrelated typed attributes here.
+    // attributes. Enforce that bit for all recognized attributes in that
+    // class. The revised decoder maps MED to treat-as-withdraw,
+    // ORIGINATOR_ID/CLUSTER_LIST by neighbor type, and keeps
+    // MP_REACH_NLRI/MP_UNREACH_NLRI on their existing fatal path.
     let flags_mask = attr_flags::OPTIONAL
         | attr_flags::TRANSITIVE
         | if matches!(
             type_code,
-            attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI | attr_type::BGP_LS
+            attr_type::MULTI_EXIT_DISC
+                | attr_type::ORIGINATOR_ID
+                | attr_type::CLUSTER_LIST
+                | attr_type::MP_REACH_NLRI
+                | attr_type::MP_UNREACH_NLRI
+                | attr_type::BGP_LS
         ) || registered_flags(type_code)
             .is_some_and(|registered| registered.partial_must_clear)
         {
@@ -6862,6 +6877,124 @@ mod tests {
         );
         // The legacy decoder still aborts on the same bytes.
         assert!(decode_path_attributes(&buf, true, &[]).is_err());
+    }
+    #[test]
+    fn partial_optional_nontransitive_released_bytes_have_exact_decoder_contracts() {
+        use ErrorDisposition::{AttributeDiscard, TreatAsWithdraw};
+
+        let cases: [(u8, &[u8], ErrorDisposition, ErrorDisposition); 3] = [
+            (
+                attr_type::MULTI_EXIT_DISC,
+                &[0xa0, 0x04, 0x04, 0x00, 0x00, 0x00, 0x64],
+                TreatAsWithdraw,
+                TreatAsWithdraw,
+            ),
+            (
+                attr_type::ORIGINATOR_ID,
+                &[0xa0, 0x09, 0x04, 0xc0, 0x00, 0x02, 0x09],
+                AttributeDiscard,
+                TreatAsWithdraw,
+            ),
+            (
+                attr_type::CLUSTER_LIST,
+                &[0xa0, 0x0a, 0x04, 0xc0, 0x00, 0x02, 0x0a],
+                AttributeDiscard,
+                TreatAsWithdraw,
+            ),
+        ];
+
+        for (type_code, wire, ebgp_disposition, ibgp_disposition) in cases {
+            let strict = decode_path_attributes(wire, true, &[]).unwrap_err();
+            assert!(matches!(
+                strict,
+                DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                    ref data,
+                    ..
+                } if data == wire
+            ));
+
+            let ebgp = decode_path_attributes_revised(wire, true, false, &[]).unwrap();
+            let ibgp = decode_path_attributes_revised(wire, true, true, &[]).unwrap();
+            for (role, decoded, expected) in [
+                ("eBGP", &ebgp, ebgp_disposition),
+                ("iBGP", &ibgp, ibgp_disposition),
+            ] {
+                assert!(decoded.attributes.is_empty(), "type {type_code} {role}");
+                let [malformed] = decoded.malformed.as_slice() else {
+                    panic!("type {type_code} {role}: expected one malformed attribute");
+                };
+                assert_eq!(malformed.type_code, type_code, "{role}");
+                assert_eq!(malformed.disposition, expected, "type {type_code} {role}");
+                assert!(matches!(
+                    &malformed.error,
+                    DecodeError::UpdateAttributeError {
+                        subcode,
+                        data,
+                        ..
+                    } if *subcode == update_subcode::ATTRIBUTE_FLAGS_ERROR && data == wire
+                ));
+            }
+            if matches!(
+                type_code,
+                attr_type::ORIGINATOR_ID | attr_type::CLUSTER_LIST
+            ) {
+                assert_ne!(
+                    ebgp.malformed[0].disposition, ibgp.malformed[0].disposition,
+                    "route-reflector attributes must retain the neighbor-specific branch"
+                );
+            }
+        }
+
+        for (type_code, value) in [
+            (attr_type::ORIGINATOR_ID, &[192, 0, 2, 9][..]),
+            (attr_type::CLUSTER_LIST, &[192, 0, 2, 10][..]),
+        ] {
+            let wrong_transitive = attr_bytes(
+                attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+                type_code,
+                value,
+            );
+            let decoded =
+                decode_path_attributes_revised(&wrong_transitive, true, false, &[]).unwrap();
+            assert_eq!(
+                decoded.malformed[0].disposition, TreatAsWithdraw,
+                "type {type_code}: the Partial-only exception must not weaken class errors"
+            );
+        }
+    }
+    #[test]
+    fn partial_mp_released_bytes_keep_exact_session_reset_contract() {
+        let cases: [&[u8]; 2] = [
+            &[
+                0xa0, 0x0e, 0x0d, 0x00, 0x01, 0x01, 0x04, 0x0a, 0x69, 0x00, 0x0a, 0x00, 0x18, 0xc6,
+                0x33, 0x64,
+            ],
+            &[0xa0, 0x0f, 0x07, 0x00, 0x01, 0x01, 0x18, 0xc6, 0x33, 0x64],
+        ];
+
+        for wire in cases {
+            let strict = decode_path_attributes(wire, true, &[]).unwrap_err();
+            assert!(matches!(
+                strict,
+                DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                    ref data,
+                    ..
+                } if data == wire
+            ));
+            for is_ibgp in [false, true] {
+                let revised = decode_path_attributes_revised(wire, true, is_ibgp, &[]).unwrap_err();
+                assert!(matches!(
+                    revised,
+                    DecodeError::UpdateAttributeError {
+                        subcode: update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                        ref data,
+                        ..
+                    } if data == wire
+                ));
+            }
+        }
     }
     #[test]
     fn revised_malformed_communities_is_treat_as_withdraw() {

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -41,9 +41,11 @@ impl ErrorDisposition {
 /// cannot be reliably located). `ATOMIC_AGGREGATE` and `AGGREGATOR` use
 /// attribute-discard for their RFC 7606 §7.6/§7.7 length errors; the BGP-LS
 /// Attribute uses attribute-discard for contained TLV-framing errors
-/// (RFC 9552 §8.2.2). Attribute-flag conflicts are upgraded separately to
-/// treat-as-withdraw per RFC 7606 §3(c). Everything else — including
-/// `AS_PATH` (§7.2) — is treat-as-withdraw.
+/// (RFC 9552 §8.2.2). Optional/Transitive class conflicts are upgraded
+/// separately to treat-as-withdraw per RFC 7606 §3(c); Partial-only
+/// `ORIGINATOR_ID` / `CLUSTER_LIST` errors retain the neighbor-specific
+/// disposition above. Everything else — including `AS_PATH` (§7.2) — is
+/// treat-as-withdraw.
 #[must_use]
 pub fn malformed_attr_disposition(type_code: u8, is_ibgp: bool) -> ErrorDisposition {
     match type_code {

--- a/docs/path-attribute-registry.md
+++ b/docs/path-attribute-registry.md
@@ -132,6 +132,25 @@ both routes are absent across that boundary. The hosted job also rejects altered
 flags, inverted expected outcomes, malformed command output, incomplete UPDATE
 attribute bounds, missing route reconstruction, and duplicate or missing rows.
 
+### Current-main receiver policy after M100
+
+M100 remains a version-scoped rustbgpd 0.67.0 observation. Current main now
+enforces the RFC 4271 requirement that Partial be clear on every recognized
+optional non-transitive attribute. The receiver action follows the existing
+per-attribute RFC 7606 disposition instead of adding a compatibility mode:
+
+| Partial-bearing attribute | eBGP | iBGP |
+|---|---|---|
+| MED | treat-as-withdraw | treat-as-withdraw |
+| ORIGINATOR_ID, CLUSTER_LIST | attribute-discard | treat-as-withdraw |
+| MP_REACH, MP_UNREACH | session reset with exact UPDATE `3/4` attribute data | session reset with exact UPDATE `3/4` attribute data |
+
+Attribute-discard preserves the routes in the UPDATE after removing the
+offending attribute. Treat-as-withdraw removes those routes while keeping the
+session Established. Each recoverable violation uses the existing warning and
+`bgp_update_malformed_total{peer,disposition}` series; there is no per-neighbor
+configuration knob or new metric.
+
 ## Assigned class fence
 
 This matrix audits only the registered Optional/Transitive class; bounded


### PR DESCRIPTION
## Summary

- reject the invalid Partial flag on typed optional non-transitive MED, ORIGINATOR_ID, and CLUSTER_LIST attributes
- map Partial MED to treat-as-withdraw; discard Partial route-reflector attributes from eBGP while treating them as withdrawn on iBGP
- preserve the existing MP_REACH/MP_UNREACH session-reset behavior with exact UPDATE 3/4 notification data

This is one uniform receiver policy, not a compatibility knob. It uses the existing malformed-UPDATE warning and disposition metric. RFC 4271 requires Partial to be clear on optional non-transitive attributes; RFC 7606 names Optional/Transitive class conflicts separately, so the Partial-only disposition follows the existing per-attribute and neighbor-role handling.

## Validation

- exact strict/revised wire decoder tests for the released M100 byte strings
- transport session/RIB/metric tests for MED and eBGP/iBGP route-reflector handling
- exact MP_REACH/MP_UNREACH session-reset and notification-data tests
- full wire and transport package suites
- package and workspace Clippy, formatting, docs, offline links, and push hooks
- independent standards and code-path review
