### PR TITLE
release: prepare standalone crate boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,12 +236,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   DHAT receipt sanitizer accepts both historical and provenance-rich bgperf2
   row schemas without admitting unbounded host identity.
 
-- Prepare `rustbgpd-rpki 0.1.0` as the third independently published library
-  crate, with its current root and module API documented as the complete
+- Prepare `rustbgpd-wire 0.19.0` and `rustbgpd-fsm 0.6.0` as the next paired
+  standalone-library boundary. Wire adds observation and framing surfaces plus
+  revised RFC 7606 handling without removing public items; FSM moves its
+  exposed wire-type identity and adds the non-exhaustive
+  `Event::AdministrativeReset` variant.
+
+- Prepare `rustbgpd-rpki 0.1.0` for its first registry publish, with its current
+  root and module API documented as the complete
   `0.1.x` compatibility boundary. The package includes a compiled origin
   validation example, an explicit Tokio/plain-TCP RTR boundary, and a
   registry-aware CI bootstrap that begins semver checking automatically once
-  the first normal crates.io release is visible.
+  the first normal crates.io release is visible. Because no prior RPKI crate
+  release exists, the initial line starts directly on `rustbgpd-wire 0.19.0`.
 
 - `NeighborService.GetNeighborState` update-group comparisons now report
   `per_client_best` when two shared-staging group keys differ on the RFC 7947

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ categories = ["network-programming"]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire", version = "0.19.0" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.67.0" }
-rustbgpd-fsm = { path = "crates/fsm", version = "0.5.0" }
+rustbgpd-fsm = { path = "crates/fsm", version = "0.6.0" }
 rustbgpd-transport = { path = "crates/transport", version = "0.67.0" }
 rustbgpd-rib = { path = "crates/rib", version = "0.67.0" }
 rustbgpd-policy = { path = "crates/policy", version = "0.67.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-rustbgpd-wire = { path = "crates/wire", version = "0.18.0" }
+rustbgpd-wire = { path = "crates/wire", version = "0.19.0" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.67.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.5.0" }
 rustbgpd-transport = { path = "crates/transport", version = "0.67.0" }

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bytes",
  "thiserror 2.0.20",

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "rustbgpd-wire",

--- a/crates/fsm/CHANGELOG.md
+++ b/crates/fsm/CHANGELOG.md
@@ -5,6 +5,8 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+## 0.6.0 - 2026-08-30
+
 - **Additive FSM API:** Added `Event::AdministrativeReset`, which sends
   Cease/Administrative Reset before authoritative `SessionDown` when a BGP
   session exists and emits `SessionDown` in every earlier state. The daemon

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-fsm"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -85,6 +85,17 @@ is removed. The paired wire release is API-additive but changes decode
 acceptance and RFC 7606 classification across assigned attributes; review the
 itemized "0.18.0 compatibility note" in the wire README.
 
+`rustbgpd-fsm 0.6.0` moves the exposed wire-type boundary to
+`rustbgpd-wire 0.19.0`, so consumers must again upgrade the two crates together
+for their shared types to unify. The direct FSM API addition is
+`Event::AdministrativeReset`; in session-bearing states it sends
+Cease/Administrative Reset before authoritative cleanup, while earlier states
+still return cleanly to `Idle`. The public event enum remains
+`#[non_exhaustive]`, and no existing variant or method is removed. The paired
+wire release is API-additive and retains existing decoder result shapes; review
+the itemized "0.19.0 compatibility note" for its new observation surfaces and
+framing refinements.
+
 ## Key types
 
 - **`Session`** — the state machine: `handle_event(&mut self, Event) -> Vec<Action>` (state is mutated in place on `&mut self`)

--- a/crates/rpki/CHANGELOG.md
+++ b/crates/rpki/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-This changelog covers the independently published `rustbgpd-rpki` crate.
+This changelog covers the independently versioned `rustbgpd-rpki` crate.
 Daemon and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
+
+## 0.1.0 - 2026-08-30
 
 - Added an optional cache-inventory attachment with separate enhanced-update
   and bounded query handles. Existing `VrpUpdate`, `RtrClient::new`, and
@@ -14,12 +16,10 @@ Daemon and workspace changes remain in the repository-level `CHANGELOG.md`.
   result types. The helper walks only ancestor buckets, returns authorizers
   first, applies a 256-row hard cap with exact omission, and exposes the
   table's effective duplicate-collapsed VRPs without changing `validate`.
-
-## 0.1.0 - 2026-08-27
-
-- Initial independent crate release with immutable VRP and ASPA tables, RFC
-  6811 origin validation, role-aware ASPA path verification, a bounded RTR
-  client, and multi-cache snapshot management.
+- First independent crate release with immutable VRP and ASPA tables, RFC 6811
+  origin validation, role-aware ASPA path verification, a bounded RTR client,
+  and multi-cache snapshot management. Its public wire-type boundary starts on
+  `rustbgpd-wire 0.19.0`; there is no earlier RPKI compatibility line.
 - Established the `0.1.x` public boundary across both the crate-root facade and
   the public module paths, including the raw RTR PDU codec. Breaking Rust API
   or incompatible public wire-type changes require `0.2.0`.

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -40,7 +40,7 @@ synchronous. `RtrClient` and `VrpManager` require a Tokio runtime.
 
 Origin validation uses prefix and validation-state types from the independently
 published wire crate. The `rustbgpd-rpki 0.1.x` release boundary pairs with
-`rustbgpd-wire 0.19.x`. Registry consumers use:
+`rustbgpd-wire 0.19.x`. Once both versions are registry-visible, consumers use:
 
 ```toml
 [dependencies]
@@ -48,7 +48,7 @@ rustbgpd-rpki = "0.1.0"
 rustbgpd-wire = "0.19.0"
 ```
 
-When either version is not yet registry-visible, or when testing a source
+Before both versions are registry-visible, or when testing a source
 checkout, use matching versioned paths from one rustbgpd checkout:
 
 ```toml

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -39,12 +39,22 @@ synchronous. `RtrClient` and `VrpManager` require a Tokio runtime.
 ## Usage
 
 Origin validation uses prefix and validation-state types from the independently
-published wire crate:
+published wire crate. The `rustbgpd-rpki 0.1.x` release boundary pairs with
+`rustbgpd-wire 0.19.x`. Registry consumers use:
 
 ```toml
 [dependencies]
 rustbgpd-rpki = "0.1.0"
-rustbgpd-wire = "0.18.0"
+rustbgpd-wire = "0.19.0"
+```
+
+When either version is not yet registry-visible, or when testing a source
+checkout, use matching versioned paths from one rustbgpd checkout:
+
+```toml
+[dependencies]
+rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }
+rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }
 ```
 
 ```rust
@@ -115,11 +125,12 @@ details.
 
 ## Compatibility
 
-This is an alpha `0.x` crate. Backward-compatible fixes and additions remain on
-the `0.1.x` line. Removing or changing public items requires `0.2.0`. Public
-method signatures use types from `rustbgpd-wire 0.18`; moving that dependency
-to an incompatible wire line also requires an RPKI minor-version bump so the
-shared types do not silently split in one dependency graph.
+This is an alpha `0.x` crate. Its first public `0.1.x` line starts with
+`rustbgpd-wire 0.19`; no earlier `rustbgpd-rpki` release exists to preserve.
+Backward-compatible fixes and additions remain on that line. Removing or
+changing public items requires `0.2.0`, as does moving the public method
+signatures to an incompatible wire line, so shared types do not silently split
+in one dependency graph.
 
 ## License
 

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -27,6 +27,8 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 - Added one canonical address-family label table plus `parse_family` and
   `family_label` helpers for the twelve AFI/SAFI pairs accepted by rustbgpd's
   configuration and control-plane APIs.
+- Added `is_dataplane_route_type` as the canonical EVPN route-type classifier
+  for the type 1, 2, and 5 routes projected into the kernel dataplane.
 - Added `PathAttribute::only_to_customer()` for reading either typed OTC
   representation without discarding the Partial flag.
 

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -5,6 +5,8 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+## 0.19.0 - 2026-08-30
+
 - Enforced Partial clear on typed MED, ORIGINATOR_ID, and CLUSTER_LIST. The
   strict decoder returns Attribute Flags Error with the exact attribute;
   revised decoding maps MED to treat-as-withdraw and the route-reflector

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-wire"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -36,6 +36,11 @@ these additions and decode-behavior refinements when upgrading:
 - Tunnel Encapsulation and ATTR_SET stay payload-opaque, but their declared
   nested lengths must now frame exactly. Malformed values receive their
   registered RFC 7606 dispositions instead of being accepted opaquely.
+- Partial is rejected on typed MED, ORIGINATOR_ID, and CLUSTER_LIST. Strict
+  decoding returns Attribute Flags Error with the exact offending attribute;
+  revised decoding treats MED as withdraw and treats the route-reflector
+  attributes as discard on eBGP or withdraw on iBGP. MP_REACH_NLRI and
+  MP_UNREACH_NLRI retain their existing session-reset contract.
 
 ### 0.18.0 compatibility note
 

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -16,6 +16,27 @@ Requires Rust 1.95 or newer.
 
 Release-by-release crate changes are recorded in the [changelog](CHANGELOG.md).
 
+### 0.19.0 compatibility note
+
+`rustbgpd-wire` 0.19.0 is API-additive and moves to the next 0.x
+compatibility line under the crate's published release policy. No public item
+is removed and no existing signature is changed. Consumers should account for
+these additions and decode-behavior refinements when upgrading:
+
+- `CONFIGURED_FAMILIES`, `parse_family`, and `family_label` provide one
+  canonical label boundary for the twelve configured AFI/SAFI pairs.
+- `PathAttribute::only_to_customer` reads both canonical and received
+  Partial-preserving OTC variants.
+- `is_dataplane_route_type` identifies EVPN route types 1, 2, and 5 without
+  coupling callers to the route enum.
+- `EvpnNlriDiscardObservations`, `decode_evpn_nlri_counted`, and
+  `UpdateMessage::parse_revised_observed` expose sparse, bounded counts of
+  unsupported EVPN route types discarded under RFC 7606. The established
+  `decode_evpn_nlri` and `parse_revised` result shapes remain unchanged.
+- Tunnel Encapsulation and ATTR_SET stay payload-opaque, but their declared
+  nested lengths must now frame exactly. Malformed values receive their
+  registered RFC 7606 dispositions instead of being accepted opaquely.
+
 ### 0.18.0 compatibility note
 
 `rustbgpd-wire` 0.18.0 is API-additive but deliberately uses the next 0.x
@@ -228,7 +249,7 @@ Add the codec and its buffer type as direct dependencies:
 
 ```toml
 [dependencies]
-rustbgpd-wire = "0.18.0"
+rustbgpd-wire = "0.19.0"
 bytes = "1"
 ```
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -1,7 +1,7 @@
 # Embedding rustbgpd — the Rust BGP library map
 
 rustbgpd is not one crate; it is a layered workspace. The bottom layers are
-published as daemon-independent crates: a pure BGP message codec
+packaged as daemon-independent crates: a pure BGP message codec
 (`rustbgpd-wire`), a pure RFC 4271 state machine (`rustbgpd-fsm`), and RPKI/RTR
 validation components (`rustbgpd-rpki`). They are consumable by Rust projects —
 monitors, analyzers, test harnesses, MRT readers, RPKI validators, k8s sidecars,
@@ -41,13 +41,14 @@ This document is the contract for embedders: which crate to depend on, what the
 
 All Cargo workspace packages are listed. Internal dependencies include normal and build dependencies, including target-specific dependencies; dev dependencies are excluded.
 
-`rustbgpd-wire`, `rustbgpd-fsm`, and `rustbgpd-rpki` are registry-published
-releases from this workspace. `Disabled` means this repository's package
-manifest sets `publish = false`; it makes no claim about unrelated registry
-packages with a similar name. These workspace packages can still be consumed
-through git or path dependencies, including from outside this repository. A
-consumer that needs the daemon's gRPC surface can instead generate a client
-from the proto (§3.5).
+`rustbgpd-wire` and `rustbgpd-fsm` have registry-published releases.
+`rustbgpd-rpki` is publish-enabled and its first release is prepared, but it is
+not yet registry-visible. `Disabled` means this repository's package manifest
+sets `publish = false`; it makes no claim about unrelated registry packages
+with a similar name. These workspace packages can still be consumed through
+git or path dependencies, including from outside this repository. A consumer
+that needs the daemon's gRPC surface can instead generate a client from the
+proto (§3.5).
 
 This map records the current workspace topology, not a publication sequence.
 Notably, `rustbgpd-rib` depends on `rustbgpd-bmp`; §4 discusses future
@@ -274,13 +275,14 @@ This makes it trivially testable and lets a sidecar plug in any transport
 An analyzer or policy controller that already has validated ROA payloads can
 construct an immutable table and classify a route without starting Tokio or an
 RTR session. The prefix and validation-state types are part of the published
-wire boundary, so consumers name both compatible crate lines directly.
+wire boundary. The RPKI crate's first registry release is prepared but not yet
+available, so this pre-publish example uses matching workspace paths.
 
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-rpki = "0.1.0"
-rustbgpd-wire = "0.18.0"
+rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }
+rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }
 ```
 
 ```rust
@@ -346,18 +348,19 @@ not want a full daemon in the loop (e.g. a minimal speaker in a constrained
 k8s pod) links `rustbgpd-wire` + `rustbgpd-fsm` and owns one or a few sessions.
 It does *not* get a RIB or best-path — it is a speaker, not a router. This is
 the gap Cilium fills by embedding GoBGP today. Links: `rustbgpd-wire` +
-`rustbgpd-fsm` + `tokio`. If it needs origin validation, add the published
-`rustbgpd-rpki 0.1` line with its compatible direct `rustbgpd-wire 0.18`
-dependency.
+`rustbgpd-fsm` + `tokio`. If it needs origin validation, add the RPKI crate
+after its first release. The prepared RPKI/wire pair is recorded in §7; before
+then, use matching workspace paths as in §3.4.
 
 ---
 
 ## 4. Which crate to publish next, and why
 
-**Status: `wire`, `fsm`, and `rpki` are published; `rib`, `bmp`, `mrt`, and
-`policy` remain demand-gated.**
+**Status: `wire` and `fsm` are published; their next paired boundary and
+`rpki`'s first publish are prepared. `rib`, `bmp`, `mrt`, and `policy` remain
+demand-gated.**
 
-1. **`rustbgpd-wire` (published as `0.18.0`).** This is the
+1. **`rustbgpd-wire` (published as `0.18.0`; `0.19.0` prepared).** This is the
    foundation — dependent crate versions cannot publish before their wire
    dependency exists on crates.io. `0.15.0` brought `Capability::PathsLimit`
    with its `PathsLimitFamily` entry type (experimental capability code 76),
@@ -427,9 +430,14 @@ dependency.
    with independent inbound and outbound RFC 8654 ceilings). A consumer that
    asserts on accepted bytes or on exact `PathAttribute` variants must diff
    the itemized list in `crates/wire/README.md` under "0.18.0 compatibility
-   note" before upgrading.
+   note" before upgrading. The prepared `0.19.0` line remains API-additive but
+   intentionally advances the 0.x boundary for new observation/framing APIs
+   and decode-behavior refinements. Its compatibility note includes the exact
+   role-sensitive disposition for Partial-bearing MED, ORIGINATOR_ID, and
+   CLUSTER_LIST, while MP_REACH_NLRI and MP_UNREACH_NLRI retain session reset.
 
-2. **`rustbgpd-fsm` (published as `0.5.0`).** The `0.4.0` release makes no
+2. **`rustbgpd-fsm` (published as `0.5.0`; `0.6.0` prepared).** The `0.4.0`
+   release makes no
    FSM API changes of its own — it exists because the FSM's public surface
    re-exports `rustbgpd-wire` types (`Action` carries wire messages), so the
    wire `0.16.2 → 0.17.0` breaking transition changes the identity of those
@@ -471,8 +479,12 @@ dependency.
      is `#[non_exhaustive]` or gets a constructor/default path. The published
      crate already has the forward-compat boundary: `PeerConfig`,
      `NegotiatedSession`, `Event`, and `Action` are `#[non_exhaustive]`.
+   The prepared `0.6.0` line pairs with wire `0.19.0`, which changes the
+   identity of wire types exposed through the FSM. It also adds
+   `Event::AdministrativeReset` to the non-exhaustive event enum.
 
-3. **`rustbgpd-rpki` (published as `0.1.0`).** Why it is independent:
+3. **`rustbgpd-rpki` (first publish prepared as `0.1.0`; not
+   registry-visible).** Why it is independent:
    - Its direct dependencies are `rustbgpd-wire`, `tokio`, `tracing`,
      `smallvec`, `thiserror`, and `rustc-hash`; it has no `rib`/`policy` edge.
    - Synchronous `VrpTable` / `AspaTable` validation can be embedded without a
@@ -480,7 +492,9 @@ dependency.
      acquisition layer.
    - The `0.1.x` compatibility boundary covers the crate-root facade and every
      public module path, including the raw RTR PDU codec. Breaking Rust API or
-     an incompatible public wire-type move requires `0.2.0`.
+     an incompatible public wire-type move after first publish requires
+     `0.2.0`. There is no earlier public RPKI line to bump away from, so the
+     first `0.1.0` release starts directly on wire `0.19.0`.
 
 4. **Later: `rib`, `bmp`, `mrt`, `policy`.** These pull in heavier deps
    (`prefix-trie`, `ipnet`, `flate2`, `chrono`) and have more churn. Publish
@@ -502,7 +516,7 @@ dependency.
 | 1 | **BGP test harness / fuzzer** (à la GoBGP's `internal/testing`, or a Rust peer for FRR interop CI) | Replays PCAPs/MRT, speaks BGP to a device under test, asserts on received UPDATEs | `rustbgpd-wire` (decode/encode), `rustbgpd-fsm` (drive a peer) | `decode_message`, `encode_message`, `Message`/`ParsedUpdate`, `Session::handle_event` | **Highest-leverage, lowest-friction.** Pure codec + pure FSM. No network state, no RIB. This is the crate's natural first friend — we should ship one in-tree as `examples/peer-loop/` to prove the embedding story. |
 | 2 | **MRT route collector / analyzer** (à la BGPKIT-parser use case, but with *encode* too) | Reads RFC 6396 dumps, decodes UPDATEs, builds reports; some also synthesize test traffic | `rustbgpd-wire` for decode; optionally `rustbgpd-mrt` later for the dump container | `decode_message`, `ParsedUpdate`, `PathAttribute`, `Prefix`, EVPN/FlowSpec/BGP-LS NLRI types | **Strong fit.** The wire crate already decodes everything BGPKIT-parser parses *plus* BGP-LS, ORF, PMSI, OTC. The gap is the MRT container — `rustbgpd-mrt` closes it but is not yet published. |
 | 3 | **k8s BGP sidecar / minimal speaker** (the Cilium-embeds-GoBGP niche, in Rust) | Advertises pod/service CIDRs to a top-of-rack router; needs a *speaker*, not a router | `rustbgpd-wire` + `rustbgpd-fsm` (+ `rustbgpd-rpki` for origin validation) | `Session`, `PeerConfig`, `Action`, `encode_message`, `VrpTable` | **Real but hard.** This is GoBGP's library-reach moat: Cilium embeds the full GoBGP library (not just the codec) to get a session runtime + RIB + policy. rustbgpd offers only codec+FSM as a library today; the sidecar would have to own the RIB-less "speaker" path itself. Honest: we are not displacing Cilium's GoBGP embedding in 2026; we are the option for a *Rust-native* sidecar that wants no CGo and a smaller blast radius. |
-| 4 | **RPKI validator / RTR cache client** (à la Routinator consumer, or a VRP-driven policy gate) | Maintains a VRP table from one or more RTR caches; validates origins | `rustbgpd-rpki` (`VrpTable`, `RtrClient`, `VrpManager`), `rustbgpd-wire` (`RpkiValidation`) | `VrpTable::validate`, `RtrClient` async session, `VrpManager` merge | **Published fit.** Table validation is synchronous; cache acquisition and merging are Tokio-coupled. The validation-state type lives in the compatible wire line. |
+| 4 | **RPKI validator / RTR cache client** (à la Routinator consumer, or a VRP-driven policy gate) | Maintains a VRP table from one or more RTR caches; validates origins | `rustbgpd-rpki` (`VrpTable`, `RtrClient`, `VrpManager`), `rustbgpd-wire` (`RpkiValidation`) | `VrpTable::validate`, `RtrClient` async session, `VrpManager` merge | **Prepared fit, pending first publish.** Table validation is synchronous; cache acquisition and merging are Tokio-coupled. The validation-state type lives in the compatible wire line. |
 | 5 | **BMP monitor / telemetry sink** (à la OpenBMP, or a Rust BMP collector) | Receives RFC 7854 BMP messages, decodes per-peer UPDATEs, exports metrics | `rustbgpd-wire` (decode embedded UPDATEs), `rustbgpd-bmp` later | `decode_message`, `PathAttribute`, `MpReachNlri` | **Medium.** BMP message framing is small; the value is the embedded UPDATE decode, which `wire` already does. `rustbgpd-bmp` is the container/framing; publish it once a collector asks. |
 
 ---
@@ -548,18 +562,23 @@ To be the de facto Rust BGP codec, the concrete gaps:
 
 ## 7. Published-crate release boundary
 
-`rustbgpd-wire 0.18.0`, `rustbgpd-fsm 0.5.0`, and `rustbgpd-rpki 0.1.0` are
-published and are the versions the §3 dependency examples name. The wire/FSM
-pair moved together because the FSM re-exports codec types. RPKI starts its own
-alpha line but also exposes wire types in public method signatures, so an
-incompatible wire move requires the corresponding RPKI compatibility-line
-bump. The ordering rules that govern future publishes are:
+Registry-visible releases are `rustbgpd-wire 0.18.0` and
+`rustbgpd-fsm 0.5.0`; `rustbgpd-rpki` has no registry release. The registry
+dependency examples in §3 name only those published versions.
+
+The prepared package boundary is `rustbgpd-wire 0.19.0`,
+`rustbgpd-fsm 0.6.0`, and first-publish `rustbgpd-rpki 0.1.0`. The wire/FSM
+pair moves together because the FSM re-exports codec types. RPKI also exposes
+wire types in public method signatures, but there is no frozen RPKI baseline:
+its first `0.1.0` line can start directly on wire `0.19.0`. After that publish,
+an incompatible wire move requires the corresponding RPKI compatibility-line
+bump. The ordering rules that govern these publishes are:
 
 - Publish `rustbgpd-wire` first, then verify it is registry-visible. Only then
-  run the fully verified package/dry-run gate for `rustbgpd-fsm`. Cargo
-  normalizes the FSM's path dependency to a caret requirement on the wire
-  version, so a full FSM package verify cannot resolve before that wire release
-  is present in the registry.
+  run the fully verified package/dry-run gates for `rustbgpd-fsm` and
+  `rustbgpd-rpki`. Cargo normalizes their path dependencies to a caret
+  requirement on the wire version, so either full package verify may fail to
+  resolve before that wire release is present in the registry.
 - Keep the dependency examples in §3 pinned to the versions actually available
   from crates.io — never to a version not yet published.
 - Publish a changed wire compatibility line before packaging either FSM or RPKI

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -771,9 +771,11 @@ changed.
 3. Update `version` in `crates/wire/Cargo.toml`
 4. Roll `crates/wire/CHANGELOG.md` and add a `rustbgpd-wire` entry in the
    repository-level `CHANGELOG.md`
-5. `cargo publish -p rustbgpd-wire --dry-run`
-6. `cargo publish -p rustbgpd-wire`
-7. Verify the version is visible in the registry, update the declared current
+5. Run `cargo package --locked -p rustbgpd-wire --list` and inspect the exact
+   package inventory and normalized manifest.
+6. `cargo publish --locked -p rustbgpd-wire --dry-run`
+7. `cargo publish --locked -p rustbgpd-wire`
+8. Verify the version is visible in the registry, update the declared current
    boundary and dependency snippets in `docs/EMBEDDING.md`, then run
    `python3 scripts/check_embedding_versions.py`.
 
@@ -797,7 +799,9 @@ do not force an FSM release for every daemon tag.
      fields on an existing `#[non_exhaustive]` config struct when its
      constructor preserves the prior defaults.
    - **Minor**: additive events/actions/helpers, new public types, or other
-     non-breaking negotiation surfaces.
+     non-breaking negotiation surfaces. An incompatible `rustbgpd-wire`
+     dependency move also requires an FSM minor bump because wire types appear
+     in the public FSM API.
    - **Major**: changed method signatures, removed variants, or enum/struct
      shape changes not protected by `#[non_exhaustive]`.
    The `semver-checks` workflow applies the same crates.io comparison to this
@@ -805,9 +809,13 @@ do not force an FSM release for every daemon tag.
 3. Update `version` in `crates/fsm/Cargo.toml`
 4. Roll `crates/fsm/CHANGELOG.md` and add a `rustbgpd-fsm` entry in the
    repository-level `CHANGELOG.md`
-5. `cargo publish -p rustbgpd-fsm --dry-run`
-6. `cargo publish -p rustbgpd-fsm`
-7. Verify the version is visible in the registry, update the declared current
+5. Run `cargo package --locked -p rustbgpd-fsm --list` and inspect the exact
+   package inventory and normalized manifest.
+6. `cargo publish --locked -p rustbgpd-fsm --dry-run`. When this release moves
+   to a new wire line, a resolver failure is expected until that wire version
+   is registry-visible; do not weaken verification with `--no-verify`.
+7. `cargo publish --locked -p rustbgpd-fsm`
+8. Verify the version is visible in the registry, update the declared current
    boundary and dependency snippets in `docs/EMBEDDING.md`, then run
    `python3 scripts/check_embedding_versions.py`.
 
@@ -815,15 +823,19 @@ do not force an FSM release for every daemon tag.
 
 The RPKI crate has its own version in `crates/rpki/Cargo.toml`, decoupled from
 the daemon workspace version. Its synchronous table API and asynchronous RTR
-client share one published compatibility boundary.
+client will share one public compatibility boundary after the first publish.
 
 1. **Did `crates/rpki/` or its public examples/docs change since the last
    `rustbgpd-rpki` publish?**
    - If no: skip. Do not publish a no-op release.
    - If yes: continue.
 2. Decide semver bump:
+   - **First publish**: establish `0.1.0` directly on the intended compatible
+     wire line. With no registry baseline, there is no obsolete RPKI line to
+     bump away from.
    - **Patch**: backward-compatible fixes, docs/test improvements, or additive
-     public API within the current `0.x` compatibility line.
+     public API after the first release within the current `0.x`
+     compatibility line.
    - **Minor**: removed/changed public items, incompatible enum or struct shape
      changes, or an incompatible `rustbgpd-wire` dependency move because wire
      types appear in public RPKI method signatures.
@@ -836,7 +848,10 @@ client share one published compatibility boundary.
 5. Run `cargo package --locked -p rustbgpd-rpki --list`; inspect the exact
    package inventory and normalized manifest. Normal dependencies must resolve
    from crates.io with no path-only edge.
-6. Run `cargo publish --locked -p rustbgpd-rpki --dry-run`.
+6. Run `cargo publish --locked -p rustbgpd-rpki --dry-run`. For the initial
+   release prepared against a new wire line, a resolver failure is expected
+   until that wire version is registry-visible; do not weaken verification
+   with `--no-verify`.
 7. Publish `rustbgpd-rpki`, verify the version and ownership are visible in the
    registry, then manually dispatch `semver-checks.yml` at the publish commit.
    The checked package set must now include RPKI.
@@ -847,5 +862,5 @@ For the initial `0.1.0` publish only, the semver workflow permits the exact
 `rustbgpd-rpki 0.1.0` package to have no baseline while crates.io returns 404
 for its name. Any other missing package/version, a claimed name without a
 normal release, or an ambiguous registry response fails closed. Recheck the
-name immediately before removing `publish = false` and immediately before the
-real publish.
+name immediately before the real publish; the package is already
+publish-enabled in its manifest.

--- a/scripts/check_embedding_versions.py
+++ b/scripts/check_embedding_versions.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 
+ROOT = Path(__file__).resolve().parents[1]
 PACKAGES = ("wire", "fsm", "rpki")
+PUBLISHED_VERSIONS = {"wire": "0.18.0", "fsm": "0.5.0"}
+MANIFESTS = {
+    "wire": ("rustbgpd-wire", Path("crates/wire/Cargo.toml"), "crates/wire"),
+    "fsm": ("rustbgpd-fsm", Path("crates/fsm/Cargo.toml"), "crates/fsm"),
+    "rpki": ("rustbgpd-rpki", Path("crates/rpki/Cargo.toml"), "crates/rpki"),
+}
 HEADING = re.compile(r"^(#{1,6})\s+(?:\d+(?:\.\d+)*\.?\s+)?(.+?)\s*$", re.MULTILINE)
 SECTION_HEADING = re.compile(r"^(#{2,3})\s+", re.MULTILINE)
 
@@ -23,9 +31,42 @@ def section(document: str, level: int, title: str) -> tuple[str, str | None]:
     return document[heading.end() : end], None
 
 
-def check(document: str) -> list[str]:
+def manifest_versions(root: Path = ROOT) -> dict[str, str]:
+    root_manifest = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    workspace_dependencies = root_manifest.get("workspace", {}).get("dependencies", {})
+    versions = {}
+    for package, (cargo_name, relative_manifest, expected_path) in MANIFESTS.items():
+        manifest = tomllib.loads((root / relative_manifest).read_text(encoding="utf-8"))
+        package_table = manifest.get("package", {})
+        if package_table.get("name") != cargo_name:
+            raise ValueError(f"manifest-package-name:{package}")
+        version = package_table.get("version")
+        if not isinstance(version, str):
+            raise ValueError(f"manifest-package-version:{package}")
+        if package_table.get("publish") in (False, []):
+            raise ValueError(f"manifest-publish-disabled:{package}")
+
+        dependency = workspace_dependencies.get(cargo_name)
+        if not isinstance(dependency, dict):
+            raise ValueError(f"workspace-pin:{package}")
+        if dependency.get("version") != version or dependency.get("path") != expected_path:
+            raise ValueError(f"workspace-pin:{package}")
+        versions[package] = version
+    return versions
+
+
+def labeled_paragraph(body: str, label: str) -> tuple[str, str | None]:
+    paragraphs = [paragraph for paragraph in body.strip().split("\n\n") if paragraph]
+    matches = [paragraph for paragraph in paragraphs if paragraph.startswith(label)]
+    if len(matches) != 1:
+        return "", f"boundary-paragraph:{label}"
+    return matches[0], None
+
+
+def check(document: str, prepared_versions: dict[str, str] | None = None) -> list[str]:
     errors: list[str] = []
     requested = {
+        "map": (2, "Crate map and publish status"),
         "boundary": (2, "Published-crate release boundary"),
         "decode": (3, "Decode an UPDATE (codec-only — the canonical embedder)"),
         "session": (3, 'Build a session (codec + FSM — the "minimal speaker" consumer)'),
@@ -40,31 +81,114 @@ def check(document: str) -> list[str]:
     if errors:
         return errors
 
-    boundary = sections["boundary"].lstrip().split("\n\n", 1)[0]
+    if prepared_versions is None:
+        try:
+            prepared_versions = manifest_versions()
+        except (OSError, tomllib.TOMLDecodeError, ValueError) as error:
+            return [f"manifest-version-contract:{error}"]
+    if set(prepared_versions) != set(PACKAGES):
+        return ["manifest-version-contract:package-set"]
+
+    map_status = re.sub(r"\s+", " ", sections["map"])
+    expected_map_status = (
+        "`rustbgpd-wire` and `rustbgpd-fsm` have registry-published releases. "
+        "`rustbgpd-rpki` is publish-enabled and its first release is prepared, "
+        "but it is not yet registry-visible."
+    )
+    if expected_map_status not in map_status:
+        errors.append("publication-map-state")
+
+    registry_boundary, error = labeled_paragraph(
+        sections["boundary"], "Registry-visible releases are"
+    )
+    if error:
+        errors.append(error)
+    prepared_boundary, error = labeled_paragraph(
+        sections["boundary"], "The prepared package boundary is"
+    )
+    if error:
+        errors.append(error)
+    if errors:
+        return errors
+
     package_pattern = "|".join(PACKAGES)
-    current = re.findall(rf"`rustbgpd-({package_pattern}) ([^`]+)`", boundary)
-    versions = dict(current)
-    if len(current) != len(PACKAGES) or set(versions) != set(PACKAGES):
-        return ["current-boundary-version"]
+    published_pattern = "|".join(PUBLISHED_VERSIONS)
+    published = re.findall(rf"`rustbgpd-({published_pattern}) ([^`]+)`", registry_boundary)
+    if len(published) != len(PUBLISHED_VERSIONS) or dict(published) != PUBLISHED_VERSIONS:
+        errors.append("current-boundary-version")
+    if not re.search(r"`rustbgpd-rpki` has no registry release", registry_boundary):
+        errors.append("rpki-registry-state")
+
+    prepared = re.findall(rf"`rustbgpd-({package_pattern}) ([^`]+)`", prepared_boundary)
+    if len(prepared) != len(PACKAGES) or dict(prepared) != prepared_versions:
+        errors.append("prepared-boundary-version")
 
     examples = {
-        "wire": (sections["decode"], sections["session"], sections["rpki"]),
+        "wire": (sections["decode"], sections["session"]),
         "fsm": (sections["session"],),
-        "rpki": (sections["rpki"],),
     }
     for package, bodies in examples.items():
         assignment = re.compile(rf'^rustbgpd-{package} = "([^"]+)"$', re.MULTILINE)
         found = [match for body in bodies for match in assignment.findall(body)]
-        if found != [versions[package]] * len(bodies):
+        if not found or any(version != PUBLISHED_VERSIONS[package] for version in found):
             errors.append(f"{package}-snippet-version")
 
+    expected_paths = {
+        "rpki": (
+            f'{{ version = "{prepared_versions["rpki"]}", path = "../rustbgpd/crates/rpki" }}'
+        ),
+        "wire": (
+            f'{{ version = "{prepared_versions["wire"]}", path = "../rustbgpd/crates/wire" }}'
+        ),
+    }
+    assignment = re.compile(r"^rustbgpd-(rpki|wire)\s*=\s*(.+)$", re.MULTILINE)
+    rpki_assignments = assignment.findall(sections["rpki"])
+    for package, expected in expected_paths.items():
+        values = [value for found_package, value in rpki_assignments if found_package == package]
+        if not values or any(value != expected for value in values):
+            diagnostic = (
+                "rpki-registry-snippet"
+                if any("path" not in value for value in values)
+                else "rpki-path-snippet"
+            )
+            errors.append(diagnostic)
+
     publish = re.findall(
-        rf"^\d+\. \*\*`rustbgpd-({package_pattern})` \(published as `([^`]+)`\)\.\*\*",
+        rf"^\d+\. \*\*`rustbgpd-({published_pattern})` "
+        r"\(published as `([^`]+)`; `([^`]+)` prepared\)\.\*\*",
         sections["publish"],
         re.MULTILINE,
     )
-    if len(publish) != len(PACKAGES) or dict(publish) != versions:
+    published_status = {package: version for package, version, _ in publish}
+    prepared_status = {package: version for package, _, version in publish}
+    rpki_status = re.findall(
+        r"^\d+\. \*\*`rustbgpd-rpki` \(first publish prepared as `([^`]+)`;\s+"
+        r"not\s+registry-visible\)\.\*\*",
+        sections["publish"],
+        re.MULTILINE,
+    )
+    if (
+        len(publish) != len(PUBLISHED_VERSIONS)
+        or published_status != PUBLISHED_VERSIONS
+        or prepared_status
+        != {package: prepared_versions[package] for package in PUBLISHED_VERSIONS}
+        or rpki_status != [prepared_versions["rpki"]]
+    ):
         errors.append("publish-status-version")
+
+    rpki_pair = re.findall(
+        r"first `([^`]+)` release starts directly on wire `([^`]+)`",
+        sections["publish"],
+    )
+    if rpki_pair != [(prepared_versions["rpki"], prepared_versions["wire"])]:
+        errors.append("rpki-prepared-pair")
+
+    fsm_pair = re.findall(
+        r"The prepared `([^`]+)` line pairs with wire `([^`]+)`",
+        sections["publish"],
+    )
+    if fsm_pair != [(prepared_versions["fsm"], prepared_versions["wire"])]:
+        errors.append("fsm-prepared-pair")
 
     return errors
 
@@ -72,7 +196,7 @@ def check(document: str) -> list[str]:
 def main() -> int:
     if len(sys.argv) > 2:
         raise SystemExit(f"usage: {Path(sys.argv[0]).name} [EMBEDDING.md]")
-    default = Path(__file__).resolve().parents[1] / "docs" / "EMBEDDING.md"
+    default = ROOT / "docs" / "EMBEDDING.md"
     path = Path(sys.argv[1]) if len(sys.argv) == 2 else default
     errors = check(path.read_text(encoding="utf-8"))
     if errors:

--- a/scripts/check_embedding_versions.py
+++ b/scripts/check_embedding_versions.py
@@ -151,7 +151,7 @@ def check(document: str, prepared_versions: dict[str, str] | None = None) -> lis
                 if any("path" not in value for value in values)
                 else "rpki-path-snippet"
             )
-            errors.append(diagnostic)
+            errors.append(f"{package}:{diagnostic}")
 
     publish = re.findall(
         rf"^\d+\. \*\*`rustbgpd-({published_pattern})` "

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -59,19 +59,21 @@ class EmbeddingVersionContractTests(unittest.TestCase):
         """Fails if either pre-publish path dependency drifts."""
         mutations = (
             (
+                "rpki",
                 'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }',
                 'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki-old" }',
             ),
             (
+                "wire",
                 'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }',
                 'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire-old" }',
             ),
         )
-        for current, old in mutations:
-            with self.subTest(current=current):
+        for package, current, old in mutations:
+            with self.subTest(package=package):
                 self.assert_fails(
                     self.replace_nth(current, old),
-                    "rpki-path-snippet",
+                    f"{package}:rpki-path-snippet",
                 )
 
     def test_rpki_registry_snippet_is_rejected(self) -> None:
@@ -86,7 +88,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                         'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }',
                         replacement,
                     ),
-                    "rpki-registry-snippet",
+                    "rpki:rpki-registry-snippet",
                 )
 
     def test_publication_map_state_is_guarded(self) -> None:

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -7,6 +7,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.check_embedding_versions import manifest_versions
+
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECKER = ROOT / "scripts" / "check_embedding_versions.py"
@@ -39,7 +41,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
     def test_each_wire_snippet_is_guarded(self) -> None:
         """Fails if any wire dependency example drifts to 0.15.0."""
         old = 'rustbgpd-wire = "0.18.0"'
-        for occurrence in (0, 1, 2):
+        for occurrence in (0, 1):
             with self.subTest(occurrence=occurrence):
                 self.assert_fails(
                     self.replace_nth(old, 'rustbgpd-wire = "0.15.0"', occurrence),
@@ -53,32 +55,90 @@ class EmbeddingVersionContractTests(unittest.TestCase):
             "fsm-snippet-version",
         )
 
-    def test_rpki_snippet_is_guarded(self) -> None:
-        """Fails if the RPKI dependency example drifts from its published line."""
+    def test_rpki_path_snippets_are_guarded(self) -> None:
+        """Fails if either pre-publish path dependency drifts."""
+        mutations = (
+            (
+                'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }',
+                'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki-old" }',
+            ),
+            (
+                'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }',
+                'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire-old" }',
+            ),
+        )
+        for current, old in mutations:
+            with self.subTest(current=current):
+                self.assert_fails(
+                    self.replace_nth(current, old),
+                    "rpki-path-snippet",
+                )
+
+    def test_rpki_registry_snippet_is_rejected(self) -> None:
+        """Fails if the absent RPKI release is presented as a registry dependency."""
+        for replacement in (
+            'rustbgpd-rpki = "0.1.0"',
+            'rustbgpd-rpki = { version = "0.1.0" }',
+        ):
+            with self.subTest(replacement=replacement):
+                self.assert_fails(
+                    self.replace_nth(
+                        'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }',
+                        replacement,
+                    ),
+                    "rpki-registry-snippet",
+                )
+
+    def test_publication_map_state_is_guarded(self) -> None:
+        """Fails if §1 claims that RPKI is already registry-published."""
         self.assert_fails(
-            self.replace_nth('rustbgpd-rpki = "0.1.0"', 'rustbgpd-rpki = "0.2.0"'),
-            "rpki-snippet-version",
+            self.replace_nth(
+                "not yet registry-visible",
+                "already registry-published",
+            ),
+            "publication-map-state",
         )
 
     def test_publish_statuses_are_guarded(self) -> None:
         """Fails if any numbered publish heading names an old version."""
-        mutations = (
+        published_mutations = (
             ("wire", "0.18.0", "0.17.2"),
             ("fsm", "0.5.0", "0.4.1"),
-            ("rpki", "0.1.0", "0.0.1"),
         )
-        for package, current, old in mutations:
+        for package, current, old in published_mutations:
             with self.subTest(package=package):
                 self.assert_fails(
-                    self.replace_nth(
-                        f"(published as `{current}`)", f"(published as `{old}`)"
-                    ),
+                    self.replace_nth(f"published as `{current}`", f"published as `{old}`"),
+                    "publish-status-version",
+                )
+
+        prepared_mutations = (
+            (
+                "wire",
+                "`rustbgpd-wire` (published as `0.18.0`; `0.19.0` prepared)",
+                "`rustbgpd-wire` (published as `0.18.0`; `0.18.1` prepared)",
+            ),
+            (
+                "fsm",
+                "`rustbgpd-fsm` (published as `0.5.0`; `0.6.0` prepared)",
+                "`rustbgpd-fsm` (published as `0.5.0`; `0.5.1` prepared)",
+            ),
+            (
+                "rpki",
+                "first publish prepared as `0.1.0`; not\n   registry-visible",
+                "first publish prepared as `0.0.1`; not\n   registry-visible",
+            ),
+        )
+        for package, current, old in prepared_mutations:
+            with self.subTest(package=f"{package}-prepared"):
+                self.assert_fails(
+                    self.replace_nth(current, old),
                     "publish-status-version",
                 )
 
     def test_current_boundary_is_guarded(self) -> None:
         """Fails if §7 loses any authoritative current-version slot."""
-        for package, version in (("wire", "0.18.0"), ("fsm", "0.5.0"), ("rpki", "0.1.0")):
+        for package, version in (("wire", "0.18.0"), ("fsm", "0.5.0")):
             with self.subTest(package=package):
                 self.assert_fails(
                     self.replace_nth(
@@ -88,26 +148,147 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                     "current-boundary-version",
                 )
 
-    def test_status_parser_rejects_prepared_as(self) -> None:
-        """Fails if an actual publish status changes from published to prepared."""
         self.assert_fails(
             self.replace_nth(
-                "(published as `0.18.0`)", "(prepared as `0.18.0`)"
+                "`rustbgpd-rpki` has no registry release",
+                "`rustbgpd-rpki` has a registry release",
+            ),
+            "rpki-registry-state",
+        )
+
+    def test_prepared_boundary_is_guarded(self) -> None:
+        """Fails if §7 loses any authoritative prepared-version slot."""
+        for package, version in (("wire", "0.19.0"), ("fsm", "0.6.0"), ("rpki", "0.1.0")):
+            with self.subTest(package=package):
+                self.assert_fails(
+                    self.replace_nth(
+                        f"`rustbgpd-{package} {version}`",
+                        f"rustbgpd-{package} {version}",
+                    ),
+                    "prepared-boundary-version",
+                )
+
+    def test_coordinated_published_version_drift_is_rejected(self) -> None:
+        """Published prose and snippets cannot drift together from the known release."""
+        self.assert_fails(
+            DOCUMENT.replace("0.18.0", "9.9.9"),
+            "current-boundary-version",
+        )
+
+    def test_coordinated_prepared_version_drift_is_rejected(self) -> None:
+        """Prepared prose and snippets stay anchored to package manifests."""
+        self.assert_fails(
+            DOCUMENT.replace("0.19.0", "9.9.9"),
+            "prepared-boundary-version",
+        )
+
+    def test_rpki_prepared_wire_pair_is_guarded(self) -> None:
+        """The first RPKI line cannot silently pair back to wire 0.18."""
+        self.assert_fails(
+            self.replace_nth(
+                "first `0.1.0` release starts directly on wire `0.19.0`",
+                "first `0.1.0` release starts directly on wire `0.18.0`",
+            ),
+            "rpki-prepared-pair",
+        )
+
+    def test_fsm_prepared_wire_pair_is_guarded(self) -> None:
+        """The prepared FSM line cannot silently pair back to wire 0.18."""
+        self.assert_fails(
+            self.replace_nth(
+                "The prepared `0.6.0` line pairs with wire `0.19.0`",
+                "The prepared `0.6.0` line pairs with wire `0.18.0`",
+            ),
+            "fsm-prepared-pair",
+        )
+
+    def test_status_parser_rejects_false_rpki_publish(self) -> None:
+        """Fails if the absent RPKI release is relabeled as published."""
+        self.assert_fails(
+            self.replace_nth(
+                "(first publish prepared as `0.1.0`; not\n   registry-visible)",
+                "(published as `0.1.0`)",
             ),
             "publish-status-version",
         )
 
     def test_heading_renumbering_and_unrelated_prepared_prose_are_allowed(self) -> None:
         changed = DOCUMENT
-        for old, new in (("## 7. ", "## 70. "), ("### 3.1 ", "### 30.1 "),
-                         ("### 3.3 ", "### 30.3 "), ("### 3.4 ", "### 30.4 "),
-                         ("## 4. ", "## 40. ")):
+        for old, new in (
+            ("## 7. ", "## 70. "),
+            ("### 3.1 ", "### 30.1 "),
+            ("### 3.3 ", "### 30.3 "),
+            ("### 3.4 ", "### 30.4 "),
+            ("## 4. ", "## 40. "),
+        ):
             changed = changed.replace(old, new, 1)
         changed += "\nAn unrelated consumer prepared its own deployment.\n"
         self.assertEqual(self.run_checker(changed).returncode, 0)
 
+    def test_labeled_boundary_paragraphs_allow_an_intro(self) -> None:
+        """A harmless intro does not displace either authoritative paragraph."""
+        marker = "## 7. Published-crate release boundary\n\n"
+        changed = DOCUMENT.replace(
+            marker,
+            marker + "This section separates live releases from staged packages.\n\n",
+            1,
+        )
+        self.assertEqual(self.run_checker(changed).returncode, 0)
+
+    def test_duplicate_truthful_dependency_assignments_are_allowed(self) -> None:
+        """A second equivalent example does not make the version contract ambiguous."""
+        assignments = (
+            'rustbgpd-wire = "0.18.0"',
+            'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }',
+        )
+        for assignment in assignments:
+            with self.subTest(assignment=assignment):
+                changed = DOCUMENT.replace(assignment, f"{assignment}\n{assignment}", 1)
+                self.assertEqual(self.run_checker(changed).returncode, 0)
+
+    def test_manifest_versions_guard_root_workspace_pins(self) -> None:
+        """Prepared package versions must match the root path/version pins."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "crates/wire").mkdir(parents=True)
+            (root / "crates/fsm").mkdir(parents=True)
+            (root / "crates/rpki").mkdir(parents=True)
+            (root / "Cargo.toml").write_text(
+                "[workspace]\n"
+                "[workspace.dependencies]\n"
+                'rustbgpd-wire = { version = "0.19.0", path = "crates/wire" }\n'
+                'rustbgpd-fsm = { version = "0.6.0", path = "crates/fsm" }\n'
+                'rustbgpd-rpki = { version = "0.1.0", path = "crates/rpki" }\n',
+                encoding="utf-8",
+            )
+            for path, package, version in (
+                ("crates/wire/Cargo.toml", "rustbgpd-wire", "0.19.0"),
+                ("crates/fsm/Cargo.toml", "rustbgpd-fsm", "0.6.0"),
+                ("crates/rpki/Cargo.toml", "rustbgpd-rpki", "0.1.0"),
+            ):
+                (root / path).write_text(
+                    f'[package]\nname = "{package}"\nversion = "{version}"\n',
+                    encoding="utf-8",
+                )
+            self.assertEqual(
+                manifest_versions(root),
+                {"wire": "0.19.0", "fsm": "0.6.0", "rpki": "0.1.0"},
+            )
+
+            root_manifest = (root / "Cargo.toml").read_text(encoding="utf-8")
+            (root / "Cargo.toml").write_text(
+                root_manifest.replace(
+                    'rustbgpd-wire = { version = "0.19.0"',
+                    'rustbgpd-wire = { version = "9.9.9"',
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "workspace-pin:wire"):
+                manifest_versions(root)
+
     def test_each_semantic_heading_is_required(self) -> None:
         titles = (
+            "Crate map and publish status",
             "Published-crate release boundary",
             "Decode an UPDATE (codec-only — the canonical embedder)",
             'Build a session (codec + FSM — the "minimal speaker" consumer)',


### PR DESCRIPTION
## Summary

- prepare rustbgpd-wire 0.19.0 and rustbgpd-fsm 0.6.0 as the next paired standalone-library boundary
- keep rustbgpd-rpki at 0.1.0 for its actual first publish, directly against wire 0.19.0
- correct documentation that previously described rustbgpd-rpki as already published
- align both lockfiles, crate changelogs, README compatibility notes, embedding guidance, and the release checklist
- derive prepared versions from package manifests while keeping registry-visible versions explicit

This prepares package boundaries only. It does not publish crates, change the daemon workspace version, create a tag, or roll the daemon release changelog.

## Validation

- full workspace/all-target Clippy with warnings denied
- wire, FSM, and RPKI package tests and warning-clean docs
- wire 0.18 to 0.19 and FSM 0.5 to 0.6 semver checks, including forced-minor baselines: 196/196 each
- package inventories: wire 39 files, FSM 17 files, RPKI 15 files
- wire locked publish dry-run, including package verification build
- FSM and RPKI dry-runs stop only on the expected unavailable registry dependency on rustbgpd-wire 0.19
- embedding, release-checklist, crate-map, metadata, lockfile, and public-tracker contracts
- 71 focused Python contract tests
- independent release-boundary review: GO

## Publish order

Publish wire first and verify 0.19.0 is registry-visible. Only then can the locked FSM and RPKI dry-runs and publishes resolve their normalized rustbgpd-wire dependency.
