### PR TITLE
release: prepare rustbgpd 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.68.0] — 2026-08-30
+
 ### Added
 
 - M100 adds a hosted, proof-only 20-cell receiver differential for an exact
@@ -178,7 +180,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   omits them rather than reporting a false lower bound. Path-aware retained
   identities keep the counts exact when Add-Path receive is negotiated.
 
-- The M77 GoBGP 4.6.0 receipt now peer-proves VPNv6 graceful restart and
+- The M77 GoBGP 4.8.0 receipt now peer-proves VPNv6 graceful restart and
   long-lived graceful restart over the existing IPv4 sessions. Deterministic
   blue/red VPNv6 routes are retained stale without client churn, reconciled
   exactly at End-of-RIB after a selective re-injection, promoted with the
@@ -266,6 +268,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Remove the unused EVPN `mass_withdraw` tracker API; receive-side
   mass-withdraw remains the stateless, route-event-driven projection owned by
   the daemon dataplane supervisor.
+
+- BMPv4 Path Marking TLV emission is temporarily removed because its draft
+  type 5 assignment conflicts with the current Route Monitoring TLV registry.
+  BMPv3 output is unaffected.
 
 ### Fixed
 
@@ -408,6 +414,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Eligible homogeneous route-server update groups now share unicast staging,
+  encoding, and exact-probe work, including safe own-source exclusion and
+  group-uniform OTC handling. Members with differing wire profiles and other
+  ineligible cases retain the exact per-member fallback for source flips,
+  lanes, withdrawals, export rejection, and prefix-limit filtering.
+
 - The IXP comparator refresh now records OpenBGPD 9.2 at 700 clients and
   400,400 routes. Policy delivery improves from the 9.1 refresh's 244–251 s
   to 201–206 s, and 50-member re-announcement fan-out improves from
@@ -432,11 +444,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   temporary collision-failback ROUTE-REFRESH saturation is retained and
   retried instead.
 
-### Removed
-
-- BMPv4 Path Marking TLV emission is temporarily removed because its draft
-  type 5 assignment conflicts with the current Route Monitoring TLV registry.
-  BMPv3 output is unaffected.
+- Dependency resolution moves the dev-only MRT oracle from `bgpkit-parser`
+  0.19.0 to 0.21.0, the wire crate's test-only direct `syn` requirement from
+  major line 2 to 3, and locked `uuid` from 1.24.1 to 1.26.0. Other consumers
+  retain their required `syn` lines; the parser and wire-test changes do not
+  enter the shipped daemon dependency graph.
 
 ### Upgrade notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "birdwatcher-adapter"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "axum",
  "clap",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "event-bridge"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "clap",
  "rustbgpd-api",
@@ -2904,7 +2904,7 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rs-config-render"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "clap",
  "rustbgpd-policy",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpctl"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "axum",
  "bgpkit-parser",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-api"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bfd"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-event-history"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "rusqlite",
  "rustbgpd-telemetry",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.20",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-linux"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "futures",
  "libc",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-mrt"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.20",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.67.0"
+version = "0.68.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -35,19 +35,19 @@ categories = ["network-programming"]
 [workspace.dependencies]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire", version = "0.19.0" }
-rustbgpd-bfd = { path = "crates/bfd", version = "0.67.0" }
+rustbgpd-bfd = { path = "crates/bfd", version = "0.68.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.6.0" }
-rustbgpd-transport = { path = "crates/transport", version = "0.67.0" }
-rustbgpd-rib = { path = "crates/rib", version = "0.67.0" }
-rustbgpd-policy = { path = "crates/policy", version = "0.67.0" }
-rustbgpd-api = { path = "crates/api", version = "0.67.0" }
-rustbgpd-telemetry = { path = "crates/telemetry", version = "0.67.0" }
+rustbgpd-transport = { path = "crates/transport", version = "0.68.0" }
+rustbgpd-rib = { path = "crates/rib", version = "0.68.0" }
+rustbgpd-policy = { path = "crates/policy", version = "0.68.0" }
+rustbgpd-api = { path = "crates/api", version = "0.68.0" }
+rustbgpd-telemetry = { path = "crates/telemetry", version = "0.68.0" }
 rustbgpd-rpki = { path = "crates/rpki", version = "0.1.0" }
-rustbgpd-bmp = { path = "crates/bmp", version = "0.67.0" }
-rustbgpd-mrt = { path = "crates/mrt", version = "0.67.0" }
-rustbgpd-evpn = { path = "crates/evpn", version = "0.67.0" }
-rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.67.0" }
-rustbgpd-event-history = { path = "crates/event-history", version = "0.67.0" }
+rustbgpd-bmp = { path = "crates/bmp", version = "0.68.0" }
+rustbgpd-mrt = { path = "crates/mrt", version = "0.68.0" }
+rustbgpd-evpn = { path = "crates/evpn", version = "0.68.0" }
+rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.68.0" }
+rustbgpd-event-history = { path = "crates/event-history", version = "0.68.0" }
 
 # External dependencies — pinned across workspace
 bytes = "1"

--- a/README.md
+++ b/README.md
@@ -72,10 +72,9 @@ reproducible receipt:
 
 The rustbgpd/BIRD IXP-matrix figures above are from the v0.64.0 same-host
 refresh (measured 2026-08-08). The OpenBGPD 9.2 comparator amendment was
-measured 2026-08-30 on post-v0.67.0 repository commits that are not yet
-contained in a stable rustbgpd tag; it is supplemental rather than
-release-tagged evidence. The original campaign and all earlier bands are
-preserved in the receipt.
+measured 2026-08-30 on the v0.68.0 release line before the final tag; it is
+supplemental rather than exact-tag evidence. The original campaign and all
+earlier bands are preserved in the receipt.
 
 **Status: public alpha.** Feature-complete for the initial programmable
 control-plane target and expanding toward cloud / AI-scale data-center
@@ -292,8 +291,8 @@ cargo build --release -p rustbgpd -p rustbgpctl -p rs-config-render -p birdwatch
 
 ### Docker
 
-Release images are published to GHCR (versioned tags, e.g.
-`ghcr.io/lance0/rustbgpd:0.67.0`), or build locally:
+Tagged releases publish versioned images to GHCR (for this release,
+`ghcr.io/lance0/rustbgpd:0.68.0`); alternatively, build locally:
 
 ```bash
 docker build -t rustbgpd .                    # daemon + rbgp + birdwatcher-adapter, nonroot
@@ -497,7 +496,7 @@ evolving API.**
 | Dimension | Current state |
 |-----------|---------------|
 | **Target use case** | Data-center fabric pilots, IXP route servers, programmable BGP control planes, lab/test environments |
-| **Maturity** | Public alpha (v0.67.0) |
+| **Maturity** | Public alpha (v0.68.0) |
 | **Adopter support** | Reporting channels, compatibility boundaries, and proof limits are documented in [SUPPORT.md](SUPPORT.md). |
 | **Narrow stable contract** | The machine-pinned [route-server / route-reflector v1 contract](docs/v1-stable-contract.md) covers only its inventoried control-plane roles and surfaces; the project and all unlisted features remain alpha. |
 | **Implemented** | Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full gRPC/CLI management. Linux FIB integration is default-off and scoped to RFC 7999 discard routes and configured unicast tables (including ECMP and weighted multipath); broader routing-suite features remain future work. |

--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.20",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "bytes",
  "libc",

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -690,27 +690,34 @@ Before rolling any versions:
    updated in CHANGELOG.md, README.md, and ROADMAP.md. Also sweep
    `(post-vX.Y.Z)` annotations in ROADMAP.md and the Maturity row in README.md.
 3. Bump versions:
-   - Root `Cargo.toml`: `[workspace.package] version` plus every internal
-     `rustbgpd-*` pin in `[workspace.dependencies]`. Library crates that
-     publish independently, such as `rustbgpd-wire`, may carry both `path`
-     and `version` so downstream publish dry-runs resolve from crates.io;
-     do not remove those version pins during the workspace bump.
+   - Root `Cargo.toml`: move `[workspace.package] version` and every
+     daemon-line internal `rustbgpd-*` pin in `[workspace.dependencies]` to
+     the new workspace version. Keep the independently versioned
+     `rustbgpd-wire`, `rustbgpd-fsm`, and `rustbgpd-rpki` pins at the versions
+     selected by their own crate manifests and release steps; never align them
+     to the daemon workspace bump. Retain both `path` and `version` so
+     downstream publish dry-runs resolve from crates.io.
    - `crates/wire/Cargo.toml`: bump **only** if `crates/wire/src/` changed
      since the last wire publish (see semver rules in the next section).
      Land the wire bump in its **own commit** before the workspace bump so
      the wire publish is reproducible from the commit alone.
 4. Run the full checklist above (fmt, clippy `-D warnings`, test, doc
    `-D warnings`, release build)
-5. Commit (workspace): `release: prep vX.Y.Z — bump workspace, roll CHANGELOG`
-6. **Annotated** tag (lightweight tags break the release-history convention
-   here): `git tag -a vX.Y.Z -m "vX.Y.Z — <one-line headline>"`
-7. Push: `git push origin main && git push origin vX.Y.Z`
+5. Commit the final release candidate (workspace):
+   `release: prep vX.Y.Z — bump workspace, roll CHANGELOG`
+6. Push the final release candidate to `main`: `git push origin main`.
+7. Wait for every applicable gate to pass on that exact final `main` SHA.
+   When an independently published crate changed, manually dispatch
+   `semver-checks.yml` at the release commit because it has no push trigger.
    - If this cycle touched `.github/workflows/release.yml`, run the
-     dispatch dry-run to green **before pushing the tag** (after the
-     workflow change is on `main`): `gh workflow run release.yml -f
-     dry_run=true` — workflow edits otherwise meet their first
-     execution on the live tag.
-8. Verify CI passes on the tag (build matrix x86_64 + aarch64, doc, GHCR
+     dispatch dry-run to green in this step, after the workflow change is on
+     `main`: `gh workflow run release.yml -f dry_run=true`. Workflow edits
+     otherwise meet their first execution on the live tag.
+8. Create and push the **annotated** tag only after step 7 is green
+   (lightweight tags break the release-history convention here):
+   `git tag -a vX.Y.Z -m "vX.Y.Z — <one-line headline>"`, then
+   `git push origin vX.Y.Z`.
+9. Verify CI passes on the tag (build matrix x86_64 + aarch64, doc, GHCR
    push, release.yml binary build + GitHub Release creation). Both
    publication workflows are fail-closed: `release.yml` and
    `container.yml` each gate publication on a `verify-tag-version` job
@@ -719,7 +726,7 @@ Before rolling any versions:
    commit). If you tagged a commit without the version bump, the tag
    build fails and publishes nothing — fix the bump, delete the tag,
    and re-tag.
-9. **Verify container image published to GHCR** via `docker/metadata-action`'s
+10. **Verify container image published to GHCR** via `docker/metadata-action`'s
    semver pattern:
    - `ghcr.io/lance0/rustbgpd:X.Y.Z` (exact, immutable)
    - `ghcr.io/lance0/rustbgpd:X.Y` (rolls forward within the minor)
@@ -727,8 +734,8 @@ Before rolling any versions:
      tags via the action's default `latest=auto` flavor)
    These **container-image** tags are emitted **without** the `v` prefix —
    `0.45.0`, not `v0.45.0` (`docker/metadata-action` strips it). The **git tag
-   stays `vX.Y.Z`** (step 6); only the image tag drops the `v`.
-10. **Verify release tarballs and packages** under
+   stays `vX.Y.Z`** (step 8); only the image tag drops the `v`.
+11. **Verify release tarballs and packages** under
     [GitHub Releases](https://github.com/lance0/rustbgpd/releases) — each
     tag should publish version-less `rustbgpd-linux-amd64.tar.gz` and
     `rustbgpd-linux-arm64.tar.gz`, per-arch `.deb`/`.rpm` packages, the
@@ -749,7 +756,7 @@ Before rolling any versions:
       checksums-linux-amd64.txt | sha256sum -c -
     ```
 
-11. **Verify GitHub release notes**: check that the release created by CI has
+12. **Verify GitHub release notes**: check that the release created by CI has
     accurate notes. The `release` workflow extracts the matching
     `## [X.Y.Z]` block out of `CHANGELOG.md` via awk and fails the tag build
     if the section is missing; if GitHub shows the auto-generated commit list
@@ -768,7 +775,10 @@ changed.
 2. Decide semver bump (see below). The `semver-checks` workflow already
    compared the crate against its latest crates.io release on the PR, so a
    bump it reported as required is not optional.
-3. Update `version` in `crates/wire/Cargo.toml`
+3. Update `version` in `crates/wire/Cargo.toml`, its matching root workspace
+   dependency pin, root `Cargo.lock`, and `bench/scale/Cargo.lock`. Keep the
+   wire publish ahead of dependent FSM or RPKI releases when moving to a new
+   wire line.
 4. Roll `crates/wire/CHANGELOG.md` and add a `rustbgpd-wire` entry in the
    repository-level `CHANGELOG.md`
 5. Run `cargo package --locked -p rustbgpd-wire --list` and inspect the exact
@@ -806,7 +816,9 @@ do not force an FSM release for every daemon tag.
      shape changes not protected by `#[non_exhaustive]`.
    The `semver-checks` workflow applies the same crates.io comparison to this
    crate on the PR.
-3. Update `version` in `crates/fsm/Cargo.toml`
+3. Update `version` in `crates/fsm/Cargo.toml`, its matching root workspace
+   dependency pin, root `Cargo.lock`, and `bench/scale/Cargo.lock`. When the
+   wire line also moves, publish wire first so the FSM package can resolve it.
 4. Roll `crates/fsm/CHANGELOG.md` and add a `rustbgpd-fsm` entry in the
    repository-level `CHANGELOG.md`
 5. Run `cargo package --locked -p rustbgpd-fsm --list` and inspect the exact
@@ -841,8 +853,8 @@ client will share one public compatibility boundary after the first publish.
      types appear in public RPKI method signatures.
    The `semver-checks` workflow compares every registry-visible release with
    its latest normal crates.io baseline.
-3. Update `version` in `crates/rpki/Cargo.toml` and the root workspace
-   dependency pin. Refresh every lockfile that resolves the path crate.
+3. Update `version` in `crates/rpki/Cargo.toml`, its matching root workspace
+   dependency pin, root `Cargo.lock`, and `bench/scale/Cargo.lock`.
 4. Roll `crates/rpki/CHANGELOG.md`, update the crate README, and add a
    `rustbgpd-rpki` entry in the repository-level `CHANGELOG.md`.
 5. Run `cargo package --locked -p rustbgpd-rpki --list`; inspect the exact

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -611,8 +611,8 @@ docker compose down
 For your own deployment:
 
 - **Image name and command**: published GHCR version tags have **no leading
-  `v`**: use `ghcr.io/lance0/rustbgpd:0.67.0`, not
-  `ghcr.io/lance0/rustbgpd:v0.67.0`. The production image runs as uid/gid 999
+  `v`**: use `ghcr.io/lance0/rustbgpd:0.68.0`, not
+  `ghcr.io/lance0/rustbgpd:v0.68.0`. The production image runs as uid/gid 999
   and its default command is exactly
   `rustbgpd /etc/rustbgpd/config.toml`. If the config is mounted under another
   container filename, pass that filename explicitly after the image, for
@@ -698,7 +698,7 @@ Use exactly one of these deployment paths:
      --ulimit nofile=65536:524288 \
      --mount=type=bind,source=/etc/rustbgpd,target=/etc/rustbgpd,readonly \
      --mount=type=bind,source=/var/lib/rustbgpd,target=/var/lib/rustbgpd \
-     ghcr.io/lance0/rustbgpd:0.67.0
+     ghcr.io/lance0/rustbgpd:0.68.0
    ```
 
 Do not omit the host state bind when overriding the image user. The directory
@@ -745,7 +745,7 @@ sudo install -o root -g root -m 0600 config.toml /etc/rustbgpd/config.toml
 sudo install -m 0644 examples/systemd/rustbgpd-container.service \
   /etc/systemd/system/rustbgpd-container.service
 sudo tee /etc/rustbgpd/rustbgpd-container.env >/dev/null <<'EOF'
-RUSTBGPD_IMAGE=ghcr.io/lance0/rustbgpd:0.67.0
+RUSTBGPD_IMAGE=ghcr.io/lance0/rustbgpd:0.68.0
 EOF
 sudo chmod 0644 /etc/rustbgpd/rustbgpd-container.env
 sudo systemctl daemon-reload
@@ -775,7 +775,7 @@ docker run --rm \
   --user=root \
   --cap-drop=ALL \
   --mount=type=bind,source=/etc/rustbgpd,target=/etc/rustbgpd,readonly \
-  ghcr.io/lance0/rustbgpd:0.67.0 \
+  ghcr.io/lance0/rustbgpd:0.68.0 \
   rustbgpd --check --strict /etc/rustbgpd/config.toml
 ```
 

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "rustbgpd-rs-rr-v1",
-  "baseline_release": "v0.67.0",
+  "baseline_release": "v0.68.0",
   "scope": "Narrow route-server and route-reflector product contract; unlisted surfaces are not stable by implication.",
   "roles": [
     {
@@ -403,6 +403,20 @@
       "semantic_toml_sha256": "c95411fc1f1b08f3e9370ea8aaa6ac405d8302fe42cddb6038c559c5ba0a5927",
       "validation_source": "src/config/tests/mod.rs",
       "validation_test": "config::tests::v1_stable_v0_66_route_server_fixture_parses",
+      "result": "accepted_without_config_migration"
+    },
+    {
+      "from_release": "v0.67.0",
+      "to_release": "v0.68.0",
+      "fixture_directory": "tests/fixtures/v1-stable/v0.67.0/route-server",
+      "source_directory": "examples/route-server",
+      "files": [
+        {"path": "config.toml", "sha256": "09d3a3a57247e18f7941f6594d659e5867e2b6e2835025809a74d9dbb010adee"},
+        {"path": "hygiene.rpol", "sha256": "9035313c7813273a64856780be66d790f25cafcb8a7f04e44ada16efb083e515"}
+      ],
+      "semantic_toml_sha256": "c95411fc1f1b08f3e9370ea8aaa6ac405d8302fe42cddb6038c559c5ba0a5927",
+      "validation_source": "src/config/tests/mod.rs",
+      "validation_test": "config::tests::v1_stable_v0_67_route_server_fixture_parses",
       "result": "accepted_without_config_migration"
     }
   ]

--- a/examples/systemd/rustbgpd-container.service
+++ b/examples/systemd/rustbgpd-container.service
@@ -15,7 +15,7 @@ Group=root
 
 # RUSTBGPD_IMAGE is required. The other values below are overridable defaults.
 # Example EnvironmentFile:
-#   RUSTBGPD_IMAGE=ghcr.io/lance0/rustbgpd:0.67.0
+#   RUSTBGPD_IMAGE=ghcr.io/lance0/rustbgpd:0.68.0
 Environment=RUSTBGPD_CONFIG_DIR=/etc/rustbgpd
 Environment=RUSTBGPD_STATE_DIR=/var/lib/rustbgpd
 Environment=RUSTBGPD_CONFIG_FILE=/etc/rustbgpd/config.toml

--- a/scripts/check_metric_release_notes.py
+++ b/scripts/check_metric_release_notes.py
@@ -15,8 +15,8 @@ from types import ModuleType
 ROOT = Path(__file__).resolve().parents[1]
 BASELINE_RELEASE = "v0.67.0"
 BASELINE_COMMIT = "69b27812eecc66e7affc505fbe887259b48990f5"
-WORKSPACE_RELEASE = "0.67.0"
-TARGET_CHANGELOG_SECTION = "Unreleased"
+WORKSPACE_RELEASE = "0.68.0"
+TARGET_CHANGELOG_SECTION = "0.68.0"
 BASELINE = ROOT / "scripts/fixtures/metric-release-notes/v0.67.0.json"
 CHANGELOG = ROOT / "CHANGELOG.md"
 CARGO_MANIFEST = ROOT / "Cargo.toml"

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -111,10 +111,14 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
         self.assertEqual(added, {"bgp_new_name"})
         self.assertEqual(removed, {"bgp_old_name", "bgp_removed"})
 
-    def test_only_current_unreleased_section_counts(self):
+    def test_only_current_release_section_counts(self):
         changelog = """# Changelog
 
 ## [Unreleased]
+
+- `bgp_new_total`
+
+## [0.68.0] - 2026-08-30
 
 - Other change.
 
@@ -131,13 +135,13 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
             check.validate_release_notes(set(), {"bgp_new_total"}, section, {})
 
     def test_workspace_release_change_requires_explicit_target_review(self):
-        check.validate_workspace_release("0.67.0")
+        check.validate_workspace_release("0.68.0")
         with self.assertRaisesRegex(
             ValueError,
             "select the target changelog section explicitly and review whether the "
             "released metric baseline must roll",
         ):
-            check.validate_workspace_release("0.68.0")
+            check.validate_workspace_release("0.69.0")
 
     def test_exceptions_are_reasoned_narrow_and_nonredundant(self):
         with self.assertRaisesRegex(ValueError, "specific reasons"):


### PR DESCRIPTION
## Summary

- roll the daemon workspace and daemon-line internal crates to 0.68.0 while preserving rustbgpd-wire 0.19.0, rustbgpd-fsm 0.6.0, and rustbgpd-rpki 0.1.0
- synchronize both tracked lockfiles and advance the narrow v1 compatibility baseline with the consecutive v0.67.0 to v0.68.0 fixture
- roll the release notes, current image examples, metric release-note gate, and release runbook to the v0.68 boundary

The changelog includes the scoped homogeneous route-server fanout optimization and keeps its exact per-member fallbacks explicit. Historical v0.67 measurements and baselines remain historical.

## Release boundary

This prepares the release commit only. It does not create a tag, publish crates or images, or dispatch a workflow. The final merged main SHA must pass every applicable gate and the manual published-crate semver run before the annotated tag is created.

## Validation

- repository commit hooks: formatting and workspace Clippy
- repository push hook: workspace rustdoc
- locked Cargo metadata for the root workspace and scale workspace
- v1 stable-surface inventory
- metric release-note contract and 9 focused tests (8 additions, 0 removals)
- release-install contract and 16 focused tests
- release-checklist path contract and 12 focused tests
- embedding version contract and 20 focused tests
- release-note extraction/reflow self-test and full diff check
