### PR TITLE
ci: fetch history for release test jobs

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -40,6 +40,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable


### PR DESCRIPTION
## Summary

- fetch full Git history in the release-binary test job
- apply the same checkout contract to the container-publication test job
- leave verification, build, and publication-only checkouts shallow

## Why

The exact-head release dry-run reached the M104 offline contract test, but the
default depth-one checkout could not resolve its pinned historical boundary
commit. Both tag-publication workflows run the same workspace test suite, so
their test jobs need repository history for that ancestry proof.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/container.yml`
- `python3 scripts/check_ci_image_primer_contract.py`
- `python3 scripts/check_release_install_contract.py`
- `python3 scripts/check_ci_scale_split_contract.py`
- 68 focused workflow-contract unit tests
- M104 offline contract self-test
- commit and push hooks
