### PR TITLE
bench: support scale peers beyond two-octet ASN range

### DIFF
--- a/bench/scale/reloadstall/README.md
+++ b/bench/scale/reloadstall/README.md
@@ -32,13 +32,13 @@ reload is rejected before its CSV row if any session is down, post-completion
 stable-marker evidence is missing, or a daemon UPDATE fails to decode. Each
 valid reload emits a `reloadstall_csv` record for durable raw receipts.
 
-Reload and flapstorm runs gate initial convergence on exact unique-prefix bitmap
-coverage at every observer: the full table minus its own slice. Duplicate,
-own-slice, and out-of-range announcements cannot advance completion;
-the bitmap is disarmed before the pre-churn evidence barrier and churn begin.
-One `first_exact_bitmap` receipt records the mode and fleet coverage. Historical
-zero-reload, non-flap convergence-only runs retain the cumulative announcement
-gate unchanged.
+Reload, flapstorm, and `--convergence-only` runs gate initial convergence on
+exact unique-prefix bitmap coverage at every observer: the full table minus its
+own slice. Duplicate, own-slice, and out-of-range announcements cannot advance
+completion. Reload and flapstorm runs disarm the bitmap before the pre-churn
+evidence barrier and churn begin; convergence-only keeps it armed through the
+ready/ack evidence boundary and rechecks it before exiting. One
+`first_exact_bitmap` receipt records the mode and fleet coverage.
 
 Depends only on `crates/wire` (wire encode/decode for the stub sessions).
 

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -2737,8 +2737,7 @@ mod tests {
 
     #[test]
     fn stub_open_crosses_the_four_octet_asn_boundary() {
-        for (peer, true_asn, expected_my_as) in
-            [(1023, 65_535, u16::MAX), (1024, 65_536, AS_TRANS)]
+        for (peer, true_asn, expected_my_as) in [(1023, 65_535, u16::MAX), (1024, 65_536, AS_TRANS)]
         {
             assert_eq!(stub_asn(peer), true_asn);
             let open = stub_open(peer, true_asn);

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -106,7 +106,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::BytesMut;
 use rustbgpd_wire::capability::{Afi, Capability, Safi};
-use rustbgpd_wire::constants::{HEADER_LEN, MAX_MESSAGE_LEN};
+use rustbgpd_wire::constants::{AS_TRANS, HEADER_LEN, MAX_MESSAGE_LEN};
 use rustbgpd_wire::header::peek_message_length;
 use rustbgpd_wire::message::{decode_message, encode_message, Message};
 use rustbgpd_wire::open::OpenMessage;
@@ -841,18 +841,12 @@ async fn establish_stream_with_retry(
     }
 }
 
-async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
-    let local = stub_addr(i);
-
-    // iBGP-RR mode: every stub OPENs with the shared local AS (the
-    // daemon's own ASN); otherwise the per-stub eBGP ASN.
-    let open_asn = match ibgp_rr_asn() {
-        0 => stub_asn(i),
-        shared => shared,
-    };
-    let open = OpenMessage {
+fn stub_open(i: u32, open_asn: u32) -> OpenMessage {
+    OpenMessage {
         version: 4,
-        my_as: u16::try_from(open_asn).unwrap(),
+        // RFC 6793: the legacy two-octet field carries AS_TRANS when the
+        // speaker's real ASN does not fit; capability 65 retains that ASN.
+        my_as: u16::try_from(open_asn).unwrap_or(AS_TRANS),
         hold_time: HOLD_TIME,
         bgp_identifier: Ipv4Addr::new(
             240,
@@ -868,7 +862,19 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
             Capability::FourOctetAs { asn: open_asn },
             Capability::RouteRefresh,
         ],
+    }
+}
+
+async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
+    let local = stub_addr(i);
+
+    // iBGP-RR mode: every stub OPENs with the shared local AS (the
+    // daemon's own ASN); otherwise the per-stub eBGP ASN.
+    let open_asn = match ibgp_rr_asn() {
+        0 => stub_asn(i),
+        shared => shared,
     };
+    let open = stub_open(i, open_asn);
     let bytes = encode_message(&Message::Open(open)).map_err(|e| format!("open encode: {e}"))?;
     let ka = encode_message(&Message::Keepalive).unwrap();
     let (stream, retries) =
@@ -2727,6 +2733,28 @@ mod tests {
         }))
         .unwrap()
         .to_vec()
+    }
+
+    #[test]
+    fn stub_open_crosses_the_four_octet_asn_boundary() {
+        for (peer, true_asn, expected_my_as) in
+            [(1023, 65_535, u16::MAX), (1024, 65_536, AS_TRANS)]
+        {
+            assert_eq!(stub_asn(peer), true_asn);
+            let open = stub_open(peer, true_asn);
+            assert_eq!(open.my_as, expected_my_as);
+            assert_eq!(open.four_byte_as(), true_asn);
+
+            let mut wire = encode_message(&Message::Open(open)).unwrap().freeze();
+            let Message::Open(decoded) = decode_message(&mut wire, MAX_MESSAGE_LEN).unwrap() else {
+                panic!("encoded stub OPEN decoded as another message type");
+            };
+            assert_eq!(decoded.my_as, expected_my_as);
+            assert_eq!(decoded.four_byte_as(), true_asn);
+            assert!(decoded
+                .capabilities
+                .contains(&Capability::FourOctetAs { asn: true_asn }));
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- encode `AS_TRANS` in the legacy OPEN field when a generated scale peer's ASN exceeds 65,535
- retain the peer's real `u32` ASN in capability 65 and round-trip both sides of the boundary through the wire codec
- correct the harness README to describe convergence-only's existing exact bitmap accounting

## Why

The scale harness assigns peer ASN `64512 + index`. Peer index 1,024 is ASN 65,536, so the previous direct `u16` conversion panicked before any benchmark above 1,024 peers could run. RFC 6793 requires `AS_TRANS` in the two-octet OPEN field while the Four-Octet AS capability carries the real ASN.

This changes benchmark tooling only; daemon behavior, release versions, and public performance claims are unchanged.

## Validation

- reloadstall unit suite: 32 passed
- reloadstall all-target Clippy with warnings denied
- full pre-push formatting, workspace Clippy/tests, and rustdoc gates passed
- exact v0.68 candidate `d3e6c357` with harness commit `1d14149b`:
  - 2,500 peers: 2,500 sessions, exact 399,840 table-minus-own-source routes per observer, zero parse errors
  - 5,000 peers: 5,000 sessions, exact 399,920 table-minus-own-source routes per observer, zero parse errors

The second commit changes only rustfmt output and the README wording, so the measured code path is unchanged at the PR head.
