### PR TITLE
docs: record the published wire, FSM, and RPKI registry releases

### DIFF
--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -93,8 +93,8 @@ Cease/Administrative Reset before authoritative cleanup, while earlier states
 still return cleanly to `Idle`. The public event enum remains
 `#[non_exhaustive]`, and no existing variant or method is removed. The paired
 wire release is API-additive and retains existing decoder result shapes; review
-the itemized "0.19.0 compatibility note" for its new observation surfaces and
-framing refinements.
+the itemized "0.19.0 compatibility note" in the wire README for its new
+observation surfaces and framing refinements.
 
 ## Key types
 

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -40,7 +40,7 @@ synchronous. `RtrClient` and `VrpManager` require a Tokio runtime.
 
 Origin validation uses prefix and validation-state types from the independently
 published wire crate. The `rustbgpd-rpki 0.1.x` release boundary pairs with
-`rustbgpd-wire 0.19.x`. Once both versions are registry-visible, consumers use:
+`rustbgpd-wire 0.19.x`. Both versions are registry-visible, so consumers use:
 
 ```toml
 [dependencies]
@@ -48,8 +48,8 @@ rustbgpd-rpki = "0.1.0"
 rustbgpd-wire = "0.19.0"
 ```
 
-Before both versions are registry-visible, or when testing a source
-checkout, use matching versioned paths from one rustbgpd checkout:
+When building against a source checkout instead, use matching versioned paths
+from one rustbgpd checkout:
 
 ```toml
 [dependencies]
@@ -119,14 +119,14 @@ The public modules are also part of the `0.1.x` API. They expose the advanced
 ASPA helpers (`ProviderAuth`, `verify`, `verify_detailed`, `verify_upstream`),
 the raw RTR PDU codec (`RtrPdu`, its version constants, `RtrDecodeError`, and
 `RtrEncodeError`), the client-side `RtrError`, and the module-qualified forms
-of the facade types. Publishing `0.1.0` freezes all of those public paths for
+of the facade types. Publishing `0.1.0` froze all of those public paths for
 the `0.1.x` compatibility line; they are not merely internal implementation
 details.
 
 ## Compatibility
 
 This is an alpha `0.x` crate. Its first public `0.1.x` line starts with
-`rustbgpd-wire 0.19`; no earlier `rustbgpd-rpki` release exists to preserve.
+`rustbgpd-wire 0.19`; no earlier `rustbgpd-rpki` release existed to preserve.
 Backward-compatible fixes and additions remain on that line. Removing or
 changing public items requires `0.2.0`, as does moving the public method
 signatures to an incompatible wire line, so shared types do not silently split

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -41,9 +41,9 @@ This document is the contract for embedders: which crate to depend on, what the
 
 All Cargo workspace packages are listed. Internal dependencies include normal and build dependencies, including target-specific dependencies; dev dependencies are excluded.
 
-`rustbgpd-wire` and `rustbgpd-fsm` have registry-published releases.
-`rustbgpd-rpki` is publish-enabled and its first release is prepared, but it is
-not yet registry-visible. `Disabled` means this repository's package manifest
+`rustbgpd-wire`, `rustbgpd-fsm`, and `rustbgpd-rpki` all have
+registry-published releases; `rustbgpd-rpki` is on the registry from its first
+release, `0.1.0`. `Disabled` means this repository's package manifest
 sets `publish = false`; it makes no claim about unrelated registry packages
 with a similar name. These workspace packages can still be consumed through
 git or path dependencies, including from outside this repository. A consumer
@@ -163,7 +163,7 @@ This is the "MRT reader / monitor / analyzer" consumer. Links only
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.18.0"
+rustbgpd-wire = "0.19.0"
 bytes = "1"
 ```
 
@@ -223,8 +223,8 @@ intentional split (ADR-0002: inherent methods, no I/O in the FSM).
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.18.0"
-rustbgpd-fsm = "0.5.0"
+rustbgpd-wire = "0.19.0"
+rustbgpd-fsm = "0.6.0"
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "time", "rt"] }
 ```
@@ -275,14 +275,14 @@ This makes it trivially testable and lets a sidecar plug in any transport
 An analyzer or policy controller that already has validated ROA payloads can
 construct an immutable table and classify a route without starting Tokio or an
 RTR session. The prefix and validation-state types are part of the published
-wire boundary. The RPKI crate's first registry release is prepared but not yet
-available, so this pre-publish example uses matching workspace paths.
+wire boundary. The RPKI crate's first registry release, `0.1.0`, is now
+available, so this example resolves entirely from crates.io.
 
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }
-rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }
+rustbgpd-rpki = "0.1.0"
+rustbgpd-wire = "0.19.0"
 ```
 
 ```rust
@@ -348,21 +348,20 @@ not want a full daemon in the loop (e.g. a minimal speaker in a constrained
 k8s pod) links `rustbgpd-wire` + `rustbgpd-fsm` and owns one or a few sessions.
 It does *not* get a RIB or best-path — it is a speaker, not a router. This is
 the gap Cilium fills by embedding GoBGP today. Links: `rustbgpd-wire` +
-`rustbgpd-fsm` + `tokio`. If it needs origin validation, add the RPKI crate
-after its first release. The prepared RPKI/wire pair is recorded in §7; before
-then, use matching workspace paths as in §3.4.
+`rustbgpd-fsm` + `tokio`. If it needs origin validation, add the RPKI crate as a
+registry dependency (§3.4); its published pairing with wire is recorded in §7.
 
 ---
 
 ## 4. Which crate to publish next, and why
 
-**Status: `wire` and `fsm` are published; their next paired boundary and
-`rpki`'s first publish are prepared. `rib`, `bmp`, `mrt`, and `policy` remain
-demand-gated.**
+**Status: `wire`, `fsm`, and `rpki` are published — the wire/FSM pair on its
+current paired boundary, `rpki` on its first release. `rib`, `bmp`, `mrt`, and
+`policy` remain demand-gated.**
 
-1. **`rustbgpd-wire` (published as `0.18.0`; `0.19.0` prepared).** This is the
-   foundation — dependent crate versions cannot publish before their wire
-   dependency exists on crates.io. `0.15.0` brought `Capability::PathsLimit`
+1. **`rustbgpd-wire` (published as `0.19.0`).** This is the foundation —
+   dependent crate versions cannot publish before their wire dependency exists
+   on crates.io. `0.15.0` brought `Capability::PathsLimit`
    with its `PathsLimitFamily` entry type (experimental capability code 76),
    the `Ord` implementation on `EvpnRouteKey`, and `#[non_exhaustive]` across
    the registry-tracking enums. The `0.16.0` release is additive at the API
@@ -430,14 +429,15 @@ demand-gated.**
    with independent inbound and outbound RFC 8654 ceilings). A consumer that
    asserts on accepted bytes or on exact `PathAttribute` variants must diff
    the itemized list in `crates/wire/README.md` under "0.18.0 compatibility
-   note" before upgrading. The prepared `0.19.0` line remains API-additive but
-   intentionally advances the 0.x boundary for new observation/framing APIs
-   and decode-behavior refinements. Its compatibility note includes the exact
-   role-sensitive disposition for Partial-bearing MED, ORIGINATOR_ID, and
-   CLUSTER_LIST, while MP_REACH_NLRI and MP_UNREACH_NLRI retain session reset.
+   note" before upgrading. `0.19.0` is the registry release consumers resolve
+   today. It remains API-additive but intentionally advances the 0.x boundary
+   for new observation/framing APIs and decode-behavior refinements. Its
+   compatibility note includes the exact role-sensitive disposition for
+   Partial-bearing MED, ORIGINATOR_ID, and CLUSTER_LIST, while MP_REACH_NLRI
+   and MP_UNREACH_NLRI retain session reset. Moving off `0.18.0` means moving
+   `rustbgpd-fsm` to `0.6.0` in the same step.
 
-2. **`rustbgpd-fsm` (published as `0.5.0`; `0.6.0` prepared).** The `0.4.0`
-   release makes no
+2. **`rustbgpd-fsm` (published as `0.6.0`).** The `0.4.0` release makes no
    FSM API changes of its own — it exists because the FSM's public surface
    re-exports `rustbgpd-wire` types (`Action` carries wire messages), so the
    wire `0.16.2 → 0.17.0` breaking transition changes the identity of those
@@ -479,22 +479,23 @@ demand-gated.**
      is `#[non_exhaustive]` or gets a constructor/default path. The published
      crate already has the forward-compat boundary: `PeerConfig`,
      `NegotiatedSession`, `Event`, and `Action` are `#[non_exhaustive]`.
-   The prepared `0.6.0` line pairs with wire `0.19.0`, which changes the
-   identity of wire types exposed through the FSM. It also adds
-   `Event::AdministrativeReset` to the non-exhaustive event enum.
+   The `0.6.0` line pairs with wire `0.19.0`, which changes the identity of
+   wire types exposed through the FSM, so an embedder still on `0.5.0` moves
+   both crates in one step. It also adds `Event::AdministrativeReset` to the
+   non-exhaustive event enum.
 
-3. **`rustbgpd-rpki` (first publish prepared as `0.1.0`; not
-   registry-visible).** Why it is independent:
+3. **`rustbgpd-rpki` (published as `0.1.0`).** This is the crate's first
+   registry release. Why it is independent:
    - Its direct dependencies are `rustbgpd-wire`, `tokio`, `tracing`,
      `smallvec`, `thiserror`, and `rustc-hash`; it has no `rib`/`policy` edge.
    - Synchronous `VrpTable` / `AspaTable` validation can be embedded without a
      runtime. `RtrClient` and `VrpManager` are the explicitly Tokio-coupled
      acquisition layer.
    - The `0.1.x` compatibility boundary covers the crate-root facade and every
-     public module path, including the raw RTR PDU codec. Breaking Rust API or
-     an incompatible public wire-type move after first publish requires
-     `0.2.0`. There is no earlier public RPKI line to bump away from, so the
-     first `0.1.0` release starts directly on wire `0.19.0`.
+     public module path, including the raw RTR PDU codec. That first publish
+     froze those paths: breaking Rust API or an incompatible public wire-type
+     move now requires `0.2.0`. There was no earlier public RPKI line to bump
+     away from, so the first `0.1.0` release starts directly on wire `0.19.0`.
 
 4. **Later: `rib`, `bmp`, `mrt`, `policy`.** These pull in heavier deps
    (`prefix-trie`, `ipnet`, `flate2`, `chrono`) and have more churn. Publish
@@ -516,7 +517,7 @@ demand-gated.**
 | 1 | **BGP test harness / fuzzer** (à la GoBGP's `internal/testing`, or a Rust peer for FRR interop CI) | Replays PCAPs/MRT, speaks BGP to a device under test, asserts on received UPDATEs | `rustbgpd-wire` (decode/encode), `rustbgpd-fsm` (drive a peer) | `decode_message`, `encode_message`, `Message`/`ParsedUpdate`, `Session::handle_event` | **Highest-leverage, lowest-friction.** Pure codec + pure FSM. No network state, no RIB. This is the crate's natural first friend — we should ship one in-tree as `examples/peer-loop/` to prove the embedding story. |
 | 2 | **MRT route collector / analyzer** (à la BGPKIT-parser use case, but with *encode* too) | Reads RFC 6396 dumps, decodes UPDATEs, builds reports; some also synthesize test traffic | `rustbgpd-wire` for decode; optionally `rustbgpd-mrt` later for the dump container | `decode_message`, `ParsedUpdate`, `PathAttribute`, `Prefix`, EVPN/FlowSpec/BGP-LS NLRI types | **Strong fit.** The wire crate already decodes everything BGPKIT-parser parses *plus* BGP-LS, ORF, PMSI, OTC. The gap is the MRT container — `rustbgpd-mrt` closes it but is not yet published. |
 | 3 | **k8s BGP sidecar / minimal speaker** (the Cilium-embeds-GoBGP niche, in Rust) | Advertises pod/service CIDRs to a top-of-rack router; needs a *speaker*, not a router | `rustbgpd-wire` + `rustbgpd-fsm` (+ `rustbgpd-rpki` for origin validation) | `Session`, `PeerConfig`, `Action`, `encode_message`, `VrpTable` | **Real but hard.** This is GoBGP's library-reach moat: Cilium embeds the full GoBGP library (not just the codec) to get a session runtime + RIB + policy. rustbgpd offers only codec+FSM as a library today; the sidecar would have to own the RIB-less "speaker" path itself. Honest: we are not displacing Cilium's GoBGP embedding in 2026; we are the option for a *Rust-native* sidecar that wants no CGo and a smaller blast radius. |
-| 4 | **RPKI validator / RTR cache client** (à la Routinator consumer, or a VRP-driven policy gate) | Maintains a VRP table from one or more RTR caches; validates origins | `rustbgpd-rpki` (`VrpTable`, `RtrClient`, `VrpManager`), `rustbgpd-wire` (`RpkiValidation`) | `VrpTable::validate`, `RtrClient` async session, `VrpManager` merge | **Prepared fit, pending first publish.** Table validation is synchronous; cache acquisition and merging are Tokio-coupled. The validation-state type lives in the compatible wire line. |
+| 4 | **RPKI validator / RTR cache client** (à la Routinator consumer, or a VRP-driven policy gate) | Maintains a VRP table from one or more RTR caches; validates origins | `rustbgpd-rpki` (`VrpTable`, `RtrClient`, `VrpManager`), `rustbgpd-wire` (`RpkiValidation`) | `VrpTable::validate`, `RtrClient` async session, `VrpManager` merge | **Strong fit, resolvable from crates.io today.** Table validation is synchronous; cache acquisition and merging are Tokio-coupled. The validation-state type lives in the compatible wire line. |
 | 5 | **BMP monitor / telemetry sink** (à la OpenBMP, or a Rust BMP collector) | Receives RFC 7854 BMP messages, decodes per-peer UPDATEs, exports metrics | `rustbgpd-wire` (decode embedded UPDATEs), `rustbgpd-bmp` later | `decode_message`, `PathAttribute`, `MpReachNlri` | **Medium.** BMP message framing is small; the value is the embedded UPDATE decode, which `wire` already does. `rustbgpd-bmp` is the container/framing; publish it once a collector asks. |
 
 ---
@@ -562,17 +563,20 @@ To be the de facto Rust BGP codec, the concrete gaps:
 
 ## 7. Published-crate release boundary
 
-Registry-visible releases are `rustbgpd-wire 0.18.0` and
-`rustbgpd-fsm 0.5.0`; `rustbgpd-rpki` has no registry release. The registry
+Registry-visible releases are `rustbgpd-wire 0.19.0`,
+`rustbgpd-fsm 0.6.0`, and `rustbgpd-rpki 0.1.0`. The registry
 dependency examples in §3 name only those published versions.
 
 The prepared package boundary is `rustbgpd-wire 0.19.0`,
-`rustbgpd-fsm 0.6.0`, and first-publish `rustbgpd-rpki 0.1.0`. The wire/FSM
-pair moves together because the FSM re-exports codec types. RPKI also exposes
-wire types in public method signatures, but there is no frozen RPKI baseline:
-its first `0.1.0` line can start directly on wire `0.19.0`. After that publish,
-an incompatible wire move requires the corresponding RPKI compatibility-line
-bump. The ordering rules that govern these publishes are:
+`rustbgpd-fsm 0.6.0`, and first-published `rustbgpd-rpki 0.1.0` — the versions
+the working tree carries. All three are now on the registry, so this boundary
+currently coincides with the paragraph above and nothing is staged ahead of
+crates.io; the two diverge again as soon as the tree takes its next version.
+The wire/FSM pair moved together because the FSM re-exports codec types. RPKI
+also exposes wire types in public method signatures, and it had no frozen
+baseline, so its first `0.1.0` line starts on wire `0.19.0`. That baseline now
+exists: a further incompatible wire move requires the corresponding RPKI
+compatibility-line bump. The ordering rules that govern these publishes are:
 
 - Publish `rustbgpd-wire` first, then verify it is registry-visible. Only then
   run the fully verified package/dry-run gates for `rustbgpd-fsm` and

--- a/scripts/check_embedding_versions.py
+++ b/scripts/check_embedding_versions.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGES = ("wire", "fsm", "rpki")
-PUBLISHED_VERSIONS = {"wire": "0.18.0", "fsm": "0.5.0"}
+PUBLISHED_VERSIONS = {"wire": "0.19.0", "fsm": "0.6.0", "rpki": "0.1.0"}
 MANIFESTS = {
     "wire": ("rustbgpd-wire", Path("crates/wire/Cargo.toml"), "crates/wire"),
     "fsm": ("rustbgpd-fsm", Path("crates/fsm/Cargo.toml"), "crates/fsm"),
@@ -91,9 +91,9 @@ def check(document: str, prepared_versions: dict[str, str] | None = None) -> lis
 
     map_status = re.sub(r"\s+", " ", sections["map"])
     expected_map_status = (
-        "`rustbgpd-wire` and `rustbgpd-fsm` have registry-published releases. "
-        "`rustbgpd-rpki` is publish-enabled and its first release is prepared, "
-        "but it is not yet registry-visible."
+        "`rustbgpd-wire`, `rustbgpd-fsm`, and `rustbgpd-rpki` all have "
+        "registry-published releases; `rustbgpd-rpki` is on the registry from "
+        "its first release, `0.1.0`."
     )
     if expected_map_status not in map_status:
         errors.append("publication-map-state")
@@ -112,20 +112,18 @@ def check(document: str, prepared_versions: dict[str, str] | None = None) -> lis
         return errors
 
     package_pattern = "|".join(PACKAGES)
-    published_pattern = "|".join(PUBLISHED_VERSIONS)
-    published = re.findall(rf"`rustbgpd-({published_pattern}) ([^`]+)`", registry_boundary)
+    published = re.findall(rf"`rustbgpd-({package_pattern}) ([^`]+)`", registry_boundary)
     if len(published) != len(PUBLISHED_VERSIONS) or dict(published) != PUBLISHED_VERSIONS:
         errors.append("current-boundary-version")
-    if not re.search(r"`rustbgpd-rpki` has no registry release", registry_boundary):
-        errors.append("rpki-registry-state")
 
     prepared = re.findall(rf"`rustbgpd-({package_pattern}) ([^`]+)`", prepared_boundary)
     if len(prepared) != len(PACKAGES) or dict(prepared) != prepared_versions:
         errors.append("prepared-boundary-version")
 
     examples = {
-        "wire": (sections["decode"], sections["session"]),
+        "wire": (sections["decode"], sections["session"], sections["rpki"]),
         "fsm": (sections["session"],),
+        "rpki": (sections["rpki"],),
     }
     for package, bodies in examples.items():
         assignment = re.compile(rf'^rustbgpd-{package} = "([^"]+)"$', re.MULTILINE)
@@ -133,46 +131,24 @@ def check(document: str, prepared_versions: dict[str, str] | None = None) -> lis
         if not found or any(version != PUBLISHED_VERSIONS[package] for version in found):
             errors.append(f"{package}-snippet-version")
 
-    expected_paths = {
-        "rpki": (
-            f'{{ version = "{prepared_versions["rpki"]}", path = "../rustbgpd/crates/rpki" }}'
-        ),
-        "wire": (
-            f'{{ version = "{prepared_versions["wire"]}", path = "../rustbgpd/crates/wire" }}'
-        ),
-    }
-    assignment = re.compile(r"^rustbgpd-(rpki|wire)\s*=\s*(.+)$", re.MULTILINE)
-    rpki_assignments = assignment.findall(sections["rpki"])
-    for package, expected in expected_paths.items():
-        values = [value for found_package, value in rpki_assignments if found_package == package]
-        if not values or any(value != expected for value in values):
-            diagnostic = (
-                "rpki-registry-snippet"
-                if any("path" not in value for value in values)
-                else "rpki-path-snippet"
-            )
-            errors.append(f"{package}:{diagnostic}")
-
+    # An entry carries "; `X` prepared" only while the working tree runs ahead of
+    # the registry. Omitting the clause is itself a claim -- that the manifest
+    # version is the published one -- so it is compared against the manifest
+    # either way, and a staged version cannot hide by dropping the clause.
     publish = re.findall(
-        rf"^\d+\. \*\*`rustbgpd-({published_pattern})` "
-        r"\(published as `([^`]+)`; `([^`]+)` prepared\)\.\*\*",
+        rf"^\d+\. \*\*`rustbgpd-({package_pattern})` \(published as `([^`]+)`"
+        r"(?:; `([^`]+)` prepared)?\)\.\*\*",
         sections["publish"],
         re.MULTILINE,
     )
     published_status = {package: version for package, version, _ in publish}
-    prepared_status = {package: version for package, _, version in publish}
-    rpki_status = re.findall(
-        r"^\d+\. \*\*`rustbgpd-rpki` \(first publish prepared as `([^`]+)`;\s+"
-        r"not\s+registry-visible\)\.\*\*",
-        sections["publish"],
-        re.MULTILINE,
-    )
+    prepared_status = {
+        package: prepared or version for package, version, prepared in publish
+    }
     if (
         len(publish) != len(PUBLISHED_VERSIONS)
         or published_status != PUBLISHED_VERSIONS
-        or prepared_status
-        != {package: prepared_versions[package] for package in PUBLISHED_VERSIONS}
-        or rpki_status != [prepared_versions["rpki"]]
+        or prepared_status != prepared_versions
     ):
         errors.append("publish-status-version")
 
@@ -180,15 +156,15 @@ def check(document: str, prepared_versions: dict[str, str] | None = None) -> lis
         r"first `([^`]+)` release starts directly on wire `([^`]+)`",
         sections["publish"],
     )
-    if rpki_pair != [(prepared_versions["rpki"], prepared_versions["wire"])]:
-        errors.append("rpki-prepared-pair")
+    if rpki_pair != [(PUBLISHED_VERSIONS["rpki"], PUBLISHED_VERSIONS["wire"])]:
+        errors.append("rpki-wire-pair")
 
     fsm_pair = re.findall(
-        r"The prepared `([^`]+)` line pairs with wire `([^`]+)`",
+        r"The `([^`]+)` line pairs with wire `([^`]+)`",
         sections["publish"],
     )
-    if fsm_pair != [(prepared_versions["fsm"], prepared_versions["wire"])]:
-        errors.append("fsm-prepared-pair")
+    if fsm_pair != [(PUBLISHED_VERSIONS["fsm"], PUBLISHED_VERSIONS["wire"])]:
+        errors.append("fsm-wire-pair")
 
     return errors
 

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.check_embedding_versions import manifest_versions
+from scripts.check_embedding_versions import check, manifest_versions
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -40,8 +40,8 @@ class EmbeddingVersionContractTests(unittest.TestCase):
 
     def test_each_wire_snippet_is_guarded(self) -> None:
         """Fails if any wire dependency example drifts to 0.15.0."""
-        old = 'rustbgpd-wire = "0.18.0"'
-        for occurrence in (0, 1):
+        old = 'rustbgpd-wire = "0.19.0"'
+        for occurrence in (0, 1, 2):
             with self.subTest(occurrence=occurrence):
                 self.assert_fails(
                     self.replace_nth(old, 'rustbgpd-wire = "0.15.0"', occurrence),
@@ -51,52 +51,35 @@ class EmbeddingVersionContractTests(unittest.TestCase):
     def test_fsm_snippet_is_guarded(self) -> None:
         """Fails if the FSM dependency example drifts to 0.3.1."""
         self.assert_fails(
-            self.replace_nth('rustbgpd-fsm = "0.5.0"', 'rustbgpd-fsm = "0.3.1"'),
+            self.replace_nth('rustbgpd-fsm = "0.6.0"', 'rustbgpd-fsm = "0.3.1"'),
             "fsm-snippet-version",
         )
 
-    def test_rpki_path_snippets_are_guarded(self) -> None:
-        """Fails if either pre-publish path dependency drifts."""
-        mutations = (
-            (
-                "rpki",
-                'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }',
-                'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki-old" }',
-            ),
-            (
-                "wire",
-                'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }',
-                'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire-old" }',
-            ),
+    def test_rpki_snippet_is_guarded(self) -> None:
+        """Fails if the RPKI dependency example drifts from the published release."""
+        self.assert_fails(
+            self.replace_nth('rustbgpd-rpki = "0.1.0"', 'rustbgpd-rpki = "0.0.1"'),
+            "rpki-snippet-version",
         )
-        for package, current, old in mutations:
-            with self.subTest(package=package):
-                self.assert_fails(
-                    self.replace_nth(current, old),
-                    f"{package}:rpki-path-snippet",
-                )
 
-    def test_rpki_registry_snippet_is_rejected(self) -> None:
-        """Fails if the absent RPKI release is presented as a registry dependency."""
+    def test_rpki_path_snippet_is_rejected(self) -> None:
+        """Fails if the published RPKI release is demoted back to a path dependency."""
         for replacement in (
-            'rustbgpd-rpki = "0.1.0"',
+            'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }',
             'rustbgpd-rpki = { version = "0.1.0" }',
         ):
             with self.subTest(replacement=replacement):
                 self.assert_fails(
-                    self.replace_nth(
-                        'rustbgpd-rpki = { version = "0.1.0", path = "../rustbgpd/crates/rpki" }',
-                        replacement,
-                    ),
-                    "rpki:rpki-registry-snippet",
+                    self.replace_nth('rustbgpd-rpki = "0.1.0"', replacement),
+                    "rpki-snippet-version",
                 )
 
     def test_publication_map_state_is_guarded(self) -> None:
-        """Fails if §1 claims that RPKI is already registry-published."""
+        """Fails if §1 stops claiming that all three crates are registry-published."""
         self.assert_fails(
             self.replace_nth(
-                "not yet registry-visible",
-                "already registry-published",
+                "`rustbgpd-rpki` is on the registry from its first",
+                "`rustbgpd-rpki` is absent from the registry despite its first",
             ),
             "publication-map-state",
         )
@@ -104,8 +87,9 @@ class EmbeddingVersionContractTests(unittest.TestCase):
     def test_publish_statuses_are_guarded(self) -> None:
         """Fails if any numbered publish heading names an old version."""
         published_mutations = (
-            ("wire", "0.18.0", "0.17.2"),
-            ("fsm", "0.5.0", "0.4.1"),
+            ("wire", "0.19.0", "0.17.2"),
+            ("fsm", "0.6.0", "0.4.1"),
+            ("rpki", "0.1.0", "0.0.1"),
         )
         for package, current, old in published_mutations:
             with self.subTest(package=package):
@@ -114,33 +98,9 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                     "publish-status-version",
                 )
 
-        prepared_mutations = (
-            (
-                "wire",
-                "`rustbgpd-wire` (published as `0.18.0`; `0.19.0` prepared)",
-                "`rustbgpd-wire` (published as `0.18.0`; `0.18.1` prepared)",
-            ),
-            (
-                "fsm",
-                "`rustbgpd-fsm` (published as `0.5.0`; `0.6.0` prepared)",
-                "`rustbgpd-fsm` (published as `0.5.0`; `0.5.1` prepared)",
-            ),
-            (
-                "rpki",
-                "first publish prepared as `0.1.0`; not\n   registry-visible",
-                "first publish prepared as `0.0.1`; not\n   registry-visible",
-            ),
-        )
-        for package, current, old in prepared_mutations:
-            with self.subTest(package=f"{package}-prepared"):
-                self.assert_fails(
-                    self.replace_nth(current, old),
-                    "publish-status-version",
-                )
-
     def test_current_boundary_is_guarded(self) -> None:
-        """Fails if §7 loses any authoritative current-version slot."""
-        for package, version in (("wire", "0.18.0"), ("fsm", "0.5.0")):
+        """Fails if §7 loses any authoritative registry-version slot."""
+        for package, version in (("wire", "0.19.0"), ("fsm", "0.6.0"), ("rpki", "0.1.0")):
             with self.subTest(package=package):
                 self.assert_fails(
                     self.replace_nth(
@@ -150,14 +110,6 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                     "current-boundary-version",
                 )
 
-        self.assert_fails(
-            self.replace_nth(
-                "`rustbgpd-rpki` has no registry release",
-                "`rustbgpd-rpki` has a registry release",
-            ),
-            "rpki-registry-state",
-        )
-
     def test_prepared_boundary_is_guarded(self) -> None:
         """Fails if §7 loses any authoritative prepared-version slot."""
         for package, version in (("wire", "0.19.0"), ("fsm", "0.6.0"), ("rpki", "0.1.0")):
@@ -166,6 +118,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
                     self.replace_nth(
                         f"`rustbgpd-{package} {version}`",
                         f"rustbgpd-{package} {version}",
+                        1,
                     ),
                     "prepared-boundary-version",
                 )
@@ -173,43 +126,70 @@ class EmbeddingVersionContractTests(unittest.TestCase):
     def test_coordinated_published_version_drift_is_rejected(self) -> None:
         """Published prose and snippets cannot drift together from the known release."""
         self.assert_fails(
-            DOCUMENT.replace("0.18.0", "9.9.9"),
+            DOCUMENT.replace("0.19.0", "9.9.9"),
             "current-boundary-version",
         )
 
     def test_coordinated_prepared_version_drift_is_rejected(self) -> None:
         """Prepared prose and snippets stay anchored to package manifests."""
         self.assert_fails(
-            DOCUMENT.replace("0.19.0", "9.9.9"),
+            DOCUMENT.replace("0.6.0", "9.9.9"),
             "prepared-boundary-version",
         )
 
-    def test_rpki_prepared_wire_pair_is_guarded(self) -> None:
+    def test_prepared_clause_expresses_a_tree_ahead_of_the_registry(self) -> None:
+        """The published/prepared split survives this release's zero-width gap.
+
+        Today every manifest version is also on crates.io, so no §4 entry carries
+        a prepared clause. The next version bump reopens the gap; re-adding the
+        clause and moving the §7 prepared paragraph must still validate.
+        """
+        changed = DOCUMENT.replace(
+            "1. **`rustbgpd-wire` (published as `0.19.0`).**",
+            "1. **`rustbgpd-wire` (published as `0.19.0`; `0.20.0` prepared).**",
+            1,
+        )
+        marker = "`rustbgpd-wire 0.19.0`"
+        second = changed.find(marker, changed.find(marker) + 1)
+        self.assertGreaterEqual(second, 0)
+        changed = changed[:second] + "`rustbgpd-wire 0.20.0`" + changed[second + len(marker) :]
+        self.assertEqual(
+            check(changed, {"wire": "0.20.0", "fsm": "0.6.0", "rpki": "0.1.0"}),
+            [],
+        )
+
+    def test_a_staged_version_cannot_hide_by_omitting_the_prepared_clause(self) -> None:
+        """An absent clause claims tree == registry, so a bumped tree is rejected."""
+        errors = check(DOCUMENT, {"wire": "0.20.0", "fsm": "0.6.0", "rpki": "0.1.0"})
+        self.assertIn("publish-status-version", errors)
+        self.assertIn("prepared-boundary-version", errors)
+
+    def test_rpki_wire_pair_is_guarded(self) -> None:
         """The first RPKI line cannot silently pair back to wire 0.18."""
         self.assert_fails(
             self.replace_nth(
                 "first `0.1.0` release starts directly on wire `0.19.0`",
                 "first `0.1.0` release starts directly on wire `0.18.0`",
             ),
-            "rpki-prepared-pair",
+            "rpki-wire-pair",
         )
 
-    def test_fsm_prepared_wire_pair_is_guarded(self) -> None:
-        """The prepared FSM line cannot silently pair back to wire 0.18."""
+    def test_fsm_wire_pair_is_guarded(self) -> None:
+        """The published FSM line cannot silently pair back to wire 0.18."""
         self.assert_fails(
             self.replace_nth(
-                "The prepared `0.6.0` line pairs with wire `0.19.0`",
-                "The prepared `0.6.0` line pairs with wire `0.18.0`",
+                "The `0.6.0` line pairs with wire `0.19.0`",
+                "The `0.6.0` line pairs with wire `0.18.0`",
             ),
-            "fsm-prepared-pair",
+            "fsm-wire-pair",
         )
 
-    def test_status_parser_rejects_false_rpki_publish(self) -> None:
-        """Fails if the absent RPKI release is relabeled as published."""
+    def test_status_parser_rejects_stale_rpki_prepublish_label(self) -> None:
+        """Fails if the published RPKI release is relabeled as merely prepared."""
         self.assert_fails(
             self.replace_nth(
-                "(first publish prepared as `0.1.0`; not\n   registry-visible)",
-                "(published as `0.1.0`)",
+                "3. **`rustbgpd-rpki` (published as `0.1.0`).**",
+                "3. **`rustbgpd-rpki` (first publish prepared as `0.1.0`).**",
             ),
             "publish-status-version",
         )
@@ -232,7 +212,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
         marker = "## 7. Published-crate release boundary\n\n"
         changed = DOCUMENT.replace(
             marker,
-            marker + "This section separates live releases from staged packages.\n\n",
+            marker + "This section records the live registry state of the crates.\n\n",
             1,
         )
         self.assertEqual(self.run_checker(changed).returncode, 0)
@@ -240,8 +220,8 @@ class EmbeddingVersionContractTests(unittest.TestCase):
     def test_duplicate_truthful_dependency_assignments_are_allowed(self) -> None:
         """A second equivalent example does not make the version contract ambiguous."""
         assignments = (
-            'rustbgpd-wire = "0.18.0"',
-            'rustbgpd-wire = { version = "0.19.0", path = "../rustbgpd/crates/wire" }',
+            'rustbgpd-wire = "0.19.0"',
+            'rustbgpd-rpki = "0.1.0"',
         )
         for assignment in assignments:
             with self.subTest(assignment=assignment):


### PR DESCRIPTION
`rustbgpd-wire 0.19.0`, `rustbgpd-fsm 0.6.0`, and the first `rustbgpd-rpki
0.1.0` are now registry-visible. The embedding documentation describes what is
live on crates.io rather than what the working tree carries, so it still named
the previous wire/FSM pair and an RPKI crate with no registry release.

## `docs/EMBEDDING.md`

- §1 publish-status prose: all three crates now have registry-published
  releases, with RPKI on the registry from `0.1.0`.
- §3.1 / §3.3 dependency snippets: wire `0.19.0`, FSM `0.6.0`.
- §3.4: the RPKI example resolved through matching workspace paths because no
  registry release existed. It is now a plain registry dependency on
  `rustbgpd-rpki 0.1.0` + `rustbgpd-wire 0.19.0`, and the surrounding prose
  says so.
- §3.5 Shape B: origin validation is a registry dependency rather than
  something to add after a future first release.
- §4 status banner and all three numbered entries: wire, FSM, and RPKI each
  read as a published release. The wire and FSM entries lose their trailing
  "prepared" clause and instead state what an embedder still on the previous
  line must do; the RPKI entry becomes a real published entry and records that
  its first publish froze the `0.1.x` public paths.
- §5 consumer table, RPKI validator row: no longer pending a first publish.
- §7 registry-visible paragraph: the published trio.
- §7 prepared package boundary: reworked to read as the shipped state while
  keeping the ordering rules, and it now records that this boundary coincides
  with the registry until the tree takes its next version.

## `scripts/check_embedding_versions.py`

The checker hardcodes the registry versions and the expected §1, §7, and §4
phrasing, so the documentation change could not land without it. The
prepared-versus-published distinction is retained: the prepared boundary
paragraph still anchors to the workspace manifests, independently of the
registry versions.

The §4 status parser now accepts an optional ``; `X` prepared`` clause per
entry. Omitting the clause is itself a claim -- that the manifest version is
the published one -- and is checked against the manifest either way, so a
version staged ahead of the registry cannot hide by dropping the clause. The
RPKI-specific pre-publish parser and the path-dependency snippet contract are
replaced by the same registry-snippet check the other crates already use.

## `scripts/test_check_embedding_versions.py`

Expectations move to the published trio, and every negative case picks a new
wrong value so it still fails. Two tests cover the next release cycle
directly: one re-opens the published/prepared gap and expects a clean run, the
other bumps a manifest version without adding the clause and expects a
rejection.

## Crate READMEs

- `crates/rpki/README.md`: the registry snippet is no longer gated on a future
  publish, the path snippet is scoped to source checkouts, and the `0.1.0`
  publish is recorded as having happened.
- `crates/fsm/README.md`: the `0.6.0` compatibility note points at the wire
  README for the itemized `0.19.0` note, matching the `0.5.0` note above it.
- `crates/wire/README.md`: no change needed; its snippet and compatibility
  notes already named `0.19.0`.

## Gates

| Gate | Exit |
|------|------|
| `python3 -m unittest -v scripts/test_check_embedding_versions.py` | 0 (22 tests) |
| `python3 scripts/check_embedding_versions.py` | 0 |
| `python3 scripts/check_release_checklist_paths.py` | 0 |
| `cargo fmt --all -- --check` | 0 |

The embedding crate-map contract that shares the same CI job
(`check_embedding_crate_map.py` and its tests) also exits 0.
