### PR TITLE
fix: supervise RPKI subsystem tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- An unexpected exit or panic in the configured RPKI subsystem now triggers
+  coordinated shutdown and exit 1. Ordinary RTR reconnect and data-expiry
+  handling remain non-fatal.
+
 ### Documentation
 
 - Publish the current v0.68.0 benchmark evidence bundle: exact-release

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -739,6 +739,14 @@ NOTIFICATIONs where the actor that sends them is still alive), and exits 1 for
 `Restart=on-failure`. An intentional shutdown still stops the peer manager as
 part of the ordered teardown and exits 0.
 
+### RPKI subsystem task exits unexpectedly
+
+The daemon treats an unexpected return or panic from the VRP manager, either
+validation-table forwarder, or any configured RTR client task as fatal. It logs
+`RPKI subsystem task exited unexpectedly`, performs the ordinary coordinated
+shutdown, and exits 1 for `Restart=on-failure`. Ordinary cache connection
+failures and data expiry continue through the retry behavior below.
+
 ### RPKI cache unreachable
 
 Each RTR client reconnects independently after a fixed `retry_interval`
@@ -1781,6 +1789,7 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 | `gRPC server exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `RIB manager exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `peer manager task exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
+| `RPKI subsystem task exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `BGP listener task exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `BGP accept-forwarding task exited unexpectedly` | ERROR | Fatal — coordinated shutdown follows |
 | `config reload complete` | INFO | SIGHUP reload completed |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -474,9 +474,10 @@ Notes on the sandbox:
   immediately if legacy BGP mode binds neither family, explicit
   `listen_addresses` cannot bind every configured endpoint, or a configured
   `prometheus_addr` health listener cannot bind. An unexpected gRPC server,
-  RIB manager, peer manager, BGP listener task, or inbound accept-forwarding
-  task exit instead runs the coordinated peer teardown before exit 1. These components are not
-  respawned in place; the supervisor is the recovery path.
+  RIB manager, peer manager, RPKI subsystem task, BGP listener task, or inbound
+  accept-forwarding task exit instead runs the coordinated peer teardown before
+  exit 1. These components are not respawned in place; the supervisor is the
+  recovery path.
   Exit 70 is also a failure: it is the runtime-config settlement watchdog's
   fail-stop recovery request and must remain restartable. `RestartSec=5`
   retries a transient failure, while `StartLimitBurst=5` and

--- a/src/main.rs
+++ b/src/main.rs
@@ -2461,8 +2461,8 @@ fn main() -> ExitCode {
                   A running daemon exits 1 on a component failure that ends it\n     \
                   (legacy BGP mode bound neither family; an explicit listen_addresses\n     \
                   endpoint failed to bind; configured metrics/readiness bind failure;\n     \
-                  or unexpected RIB manager, peer manager, gRPC server,\n     \
-                  BGP listener task, or BGP accept-forwarding task exit)\n  \
+                  or unexpected RIB manager, peer manager, RPKI subsystem,\n     \
+                  gRPC server, BGP listener task, or BGP accept-forwarding task exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
                     env!("CARGO_PKG_VERSION")

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ use rustbgpd_transport::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 use tracing::{error, info, warn};
 
 use crate::config::{
@@ -2377,8 +2377,8 @@ reported at least one warning. For
 neither family; explicit
 .B listen_addresses
 mode could not bind every configured endpoint; a configured metrics/readiness
-listener failed to bind; or the RIB manager, peer manager, gRPC server,
-BGP listener task, or BGP accept-forwarding task exited unexpectedly),
+listener failed to bind; or the RIB manager, peer manager, RPKI subsystem,
+gRPC server, BGP listener task, or BGP accept-forwarding task exited unexpectedly),
 so that a supervisor configured
 with
 .B Restart=on\-failure
@@ -2985,6 +2985,10 @@ const TEST_INITIAL_PEER_REJECTION_AT_ENV: &str = "RUSTBGPD_TEST_INITIAL_PEER_REJ
 /// value is `1`; all others are ignored with a sanitized warning.
 const TEST_PEER_MANAGER_PANIC_ENV: &str = "RUSTBGPD_TEST_PEER_MANAGER_PANIC";
 
+/// Test-only fault injection; never set this in production. The only accepted
+/// value is `rtr_client_panic`; all others are ignored without echoing them.
+const TEST_RPKI_TASK_EXIT_ENV: &str = "RUSTBGPD_TEST_RPKI_TASK_EXIT";
+
 fn resolve_test_peer_manager_panic() -> bool {
     match std::env::var(TEST_PEER_MANAGER_PANIC_ENV) {
         Err(std::env::VarError::NotPresent) => false,
@@ -2994,6 +2998,25 @@ fn resolve_test_peer_manager_panic() -> bool {
             false
         }
     }
+}
+
+fn resolve_test_rpki_client_panic() -> bool {
+    match std::env::var(TEST_RPKI_TASK_EXIT_ENV) {
+        Err(std::env::VarError::NotPresent) => false,
+        Ok(value) if value == "rtr_client_panic" => true,
+        Ok(_) | Err(std::env::VarError::NotUnicode(_)) => {
+            warn!("ignoring invalid {TEST_RPKI_TASK_EXIT_ENV}; expected rtr_client_panic");
+            false
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RpkiTaskKind {
+    VrpManager,
+    VrpForwarder,
+    AspaForwarder,
+    RtrClient,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -3148,6 +3171,7 @@ async fn run<T>(
     let test_bgp_ingress_exit = resolve_test_bgp_ingress_exit();
     let test_initial_peer_rejection_at = resolve_test_initial_peer_rejection_at();
     let test_peer_manager_panic = resolve_test_peer_manager_panic();
+    let test_rpki_client_panic = resolve_test_rpki_client_panic();
 
     let mut config = accepted.config();
     // Snapshot the gRPC listener config as it was at process start.
@@ -3815,6 +3839,8 @@ async fn run<T>(
     let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::channel(1);
 
     let mut rpki_cache_queries = None;
+    let mut rpki_supervisor: Option<JoinHandle<Result<RpkiTaskKind, tokio::task::JoinError>>> =
+        None;
     // Spawn RPKI subsystem (VRP manager + per-cache RTR clients)
     if let Some(ref rpki_config) = config.rpki
         && !rpki_config.cache_servers.is_empty()
@@ -3842,13 +3868,17 @@ async fn run<T>(
             .with_readiness_observer(move |server, ready| {
                 readiness_metrics.set_rpki_cache_end_of_data_ready(&server.to_string(), ready);
             });
-        tokio::spawn(vrp_mgr.run());
+        let mut rpki_tasks = JoinSet::new();
+        rpki_tasks.spawn(async move {
+            vrp_mgr.run().await;
+            RpkiTaskKind::VrpManager
+        });
 
         // Forward VRP table updates to RIB manager + validation watch
         let rpki_rib_tx = rib_tx.clone();
         let rpki_peer_mgr_tx = peer_mgr_tx.clone();
         let validation_tx_vrp = validation_watch_tx.clone();
-        tokio::spawn(async move {
+        rpki_tasks.spawn(async move {
             while let Some(update) = rpki_table_rx.recv().await {
                 validation_tx_vrp.send_modify(|snapshot| {
                     snapshot.vrp_table = Some(std::sync::Arc::clone(&update.table));
@@ -3865,13 +3895,14 @@ async fn run<T>(
                 )
                 .await;
             }
+            RpkiTaskKind::VrpForwarder
         });
 
         // Forward ASPA table updates to RIB manager + validation watch
         let aspa_rib_tx = rib_tx.clone();
         let aspa_peer_mgr_tx = peer_mgr_tx.clone();
         let validation_tx_aspa = validation_watch_tx.clone();
-        tokio::spawn(async move {
+        rpki_tasks.spawn(async move {
             while let Some(update) = aspa_table_rx.recv().await {
                 validation_tx_aspa.send_modify(|snapshot| {
                     snapshot.aspa_table = Some(std::sync::Arc::clone(&update.table));
@@ -3888,10 +3919,11 @@ async fn run<T>(
                 )
                 .await;
             }
+            RpkiTaskKind::AspaForwarder
         });
 
         // Spawn one RTR client per configured cache server
-        for server in &rpki_config.cache_servers {
+        for (cache_ordinal, server) in rpki_config.cache_servers.iter().enumerate() {
             let addr: std::net::SocketAddr = match server.address.parse() {
                 Ok(a) => a,
                 Err(e) => {
@@ -3919,8 +3951,21 @@ async fn run<T>(
                     expire_metrics.set_rpki_cache_effective_expire_seconds(&cache_label, secs);
                 });
             info!(server = %addr, "spawning RTR client for RPKI cache");
-            tokio::spawn(client.run());
+            rpki_tasks.spawn(async move {
+                assert!(
+                    !(test_rpki_client_panic && cache_ordinal == 0),
+                    "injected RTR client task panic"
+                );
+                client.run().await;
+                RpkiTaskKind::RtrClient
+            });
         }
+        rpki_supervisor = Some(tokio::spawn(async move {
+            rpki_tasks
+                .join_next()
+                .await
+                .expect("configured RPKI subsystem must contain tasks")
+        }));
     }
 
     // Spawn MRT manager (periodic TABLE_DUMP_V2 snapshots)
@@ -5225,7 +5270,7 @@ async fn run<T>(
     }
 
     // Wait for shutdown signal, Shutdown RPC, SIGHUP, or an unexpected
-    // supervised-component exit (gRPC, RIB, BGP ingress, peer manager).
+    // supervised-component exit (gRPC, RIB, RPKI, BGP ingress, peer manager).
     //
     // SIGHUP runs `reload_config` on a dedicated tokio task so the
     // signal-arm dispatch returns immediately. Without this, the SIGHUP
@@ -5311,6 +5356,18 @@ async fn run<T>(
                 error!(?result, "peer manager task exited unexpectedly");
                 info!("initiating shutdown due to peer manager task failure");
                 peer_mgr_exited = true;
+                component_failed = true;
+                break;
+            }
+            result = async {
+                match rpki_supervisor.as_mut() {
+                    Some(handle) => Some(handle.await),
+                    None => std::future::pending().await,
+                }
+            } => {
+                error!(?result, "RPKI subsystem task exited unexpectedly");
+                info!("initiating shutdown due to RPKI subsystem task failure");
+                rpki_supervisor = None;
                 component_failed = true;
                 break;
             }
@@ -5494,6 +5551,10 @@ async fn run<T>(
     daemon_gate.begin_shutdown();
     runtime_config_lock.close();
     info!("initiating coordinated shutdown");
+    if let Some(handle) = rpki_supervisor.take() {
+        handle.abort();
+        let _ = handle.await;
+    }
     let settlement_wait = runtime_config_settlement.clone();
     tokio::task::spawn_blocking(move || settlement_wait.wait_until_idle_or_fail_stop())
         .await

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -935,11 +935,11 @@ fn help_and_man_distinguish_bgp_bind_modes_and_supervised_exits() {
     let help = output("--help");
     assert!(help.contains("legacy BGP mode bound neither family; an explicit listen_addresses"));
     assert!(help.contains("endpoint failed to bind; configured metrics/readiness bind failure;"));
-    assert!(help.contains("or unexpected RIB manager, peer manager, gRPC server,"));
-    assert!(help.contains("BGP listener task, or BGP accept-forwarding task exit"));
+    assert!(help.contains("or unexpected RIB manager, peer manager, RPKI subsystem,"));
+    assert!(help.contains("gRPC server, BGP listener task, or BGP accept-forwarding task exit"));
     let man = output("--man");
     assert!(man.contains("legacy BGP listen mode could bind\nneither family; explicit\n.B listen_addresses\nmode could not bind every configured endpoint"));
-    assert!(man.contains("the RIB manager, peer manager, gRPC server,\nBGP listener task, or BGP accept-forwarding task exited unexpectedly"));
+    assert!(man.contains("the RIB manager, peer manager, RPKI subsystem,\ngRPC server, BGP listener task, or BGP accept-forwarding task exited unexpectedly"));
 }
 
 #[test]

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -3,8 +3,9 @@
 //! Operator-initiated shutdown (SIGTERM) exits 0; a component failure
 //! exits non-zero, so supervisors like systemd with `Restart=on-failure`
 //! restart the daemon instead of treating it as a clean stop. Live proofs cover
-//! startup binds, the RIB manager, both inbound-admission tasks, and the peer
-//! manager; the Shutdown RPC proof pins the intentional exit-0 path beside them.
+//! startup binds, the RIB manager, RPKI subsystem, both inbound-admission tasks,
+//! and the peer manager; the Shutdown RPC proof pins the intentional exit-0 path
+//! beside them.
 
 use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
@@ -163,6 +164,17 @@ fn write_rib_fault_config(dir: &Path) -> PathBuf {
         ),
     )
     .expect("write RIB fault config");
+    config_path
+}
+
+fn write_rpki_fault_config(dir: &Path) -> PathBuf {
+    let config_path = write_config(dir, DAEMON_CHOOSES, DAEMON_CHOOSES);
+    let config = std::fs::read_to_string(&config_path).expect("read test config");
+    std::fs::write(
+        &config_path,
+        format!("{config}\n[rpki]\n[[rpki.cache_servers]]\naddress = \"127.0.0.1:3323\"\n"),
+    )
+    .expect("write RPKI fault config");
     config_path
 }
 
@@ -513,6 +525,95 @@ fn operations_key_log_table_covers_supervised_failures() {
             "missing exact operations row {expected_row:?}"
         );
     }
+
+    let rpki_diagnostic = "RPKI subsystem task exited unexpectedly";
+    assert_eq!(production.matches(rpki_diagnostic).count(), 1);
+    assert!(production.contains("match rpki_supervisor.as_mut()"));
+    assert!(production.contains("None => std::future::pending().await"));
+    assert!(production.contains("rpki_supervisor = None;"));
+    assert!(production.contains("component_failed = true;"));
+    let expected_row =
+        format!("| `{rpki_diagnostic}` | ERROR | Fatal — coordinated shutdown follows |");
+    assert!(key_log_table.lines().any(|line| line == expected_row));
+}
+
+#[test]
+fn rpki_client_panic_uses_common_shutdown_and_exits_nonzero() {
+    let temp = private_tempdir();
+    let config_path = write_rpki_fault_config(temp.path());
+    let mut daemon = spawn_daemon_with_env(
+        temp.path(),
+        &config_path,
+        Some(("RUSTBGPD_TEST_RPKI_TASK_EXIT", "rtr_client_panic")),
+    );
+    let status = daemon.wait_within(Duration::from_secs(30));
+    let logs = daemon.logs();
+
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "RPKI task panic must exit 1\n{logs}"
+    );
+    for message in [
+        "injected RTR client task panic",
+        "RPKI subsystem task exited unexpectedly",
+        "initiating shutdown due to RPKI subsystem task failure",
+        "initiating coordinated shutdown",
+        "rustbgpd exiting",
+    ] {
+        assert!(logs.contains(message), "missing {message:?}\n{logs}");
+    }
+
+    let reports = std::fs::read_dir(temp.path().join("runtime/crash"))
+        .expect("panic report directory")
+        .flatten()
+        .map(|entry| std::fs::read_to_string(entry.path()).expect("read panic report"))
+        .collect::<Vec<_>>();
+    assert_eq!(reports.len(), 1, "one durable panic report: {reports:?}");
+    assert!(reports[0].contains("injected RTR client task panic"));
+}
+
+#[test]
+fn rpki_supervision_covers_every_task_and_common_teardown() {
+    let source = include_str!("../src/main.rs");
+    let setup = source
+        .split_once("let mut rpki_tasks = JoinSet::new();")
+        .expect("RPKI task set must be explicit")
+        .1
+        .split_once("// Spawn MRT manager")
+        .expect("RPKI setup boundary")
+        .0;
+    for kind in [
+        "RpkiTaskKind::VrpManager",
+        "RpkiTaskKind::VrpForwarder",
+        "RpkiTaskKind::AspaForwarder",
+        "RpkiTaskKind::RtrClient",
+    ] {
+        assert!(setup.contains(kind), "missing supervised task class {kind}");
+    }
+    assert_eq!(setup.matches("rpki_tasks.spawn(").count(), 4);
+    assert!(source.contains("None => std::future::pending().await"));
+    assert!(source.contains("RPKI subsystem task exited unexpectedly"));
+    let admission_close = source
+        .find("daemon_gate.begin_shutdown();")
+        .expect("shutdown admission must close");
+    let runtime_config_close = source
+        .find("runtime_config_lock.close();")
+        .expect("runtime-config admission must close");
+    let teardown_start = source
+        .find("if let Some(handle) = rpki_supervisor.take() {")
+        .expect("RPKI supervisor teardown");
+    let settlement_start = source
+        .find("let settlement_wait = runtime_config_settlement.clone();")
+        .expect("runtime-config settlement boundary");
+    assert!(
+        admission_close < runtime_config_close
+            && runtime_config_close < teardown_start
+            && teardown_start < settlement_start
+    );
+    let teardown = &source[teardown_start..settlement_start];
+    assert_eq!(teardown.matches("handle.abort();").count(), 1);
+    assert_eq!(teardown.matches("handle.await").count(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- retain the configured RPKI manager, table forwarders, and RTR clients under one aggregate supervisor
- route an unexpected RPKI task exit through the existing coordinated shutdown and exit-1 path
- stop RPKI updates as shutdown admission closes while preserving ordinary RTR retry and expiry behavior
- add deterministic process and structural proofs plus operator-facing failure guidance

## Validation

- `cargo fmt --check`
- focused `grpc_failure_exit_code` process, shutdown, ordering, and log-contract tests
- existing RPKI reconnect and retained-data test
- `just gate-contract`
- commit hooks: formatting and Clippy
- independent current-head review: GO_MERGE