### PR TITLE
ci: publish native amd64 and arm64 container images

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,25 +3,28 @@ name: Container Image
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build and verify both native images without publishing
+        required: true
+        default: true
+        type: boolean
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-# Read-only default; `build-and-push` alone adds package publication.
 permissions:
   contents: read
 
 jobs:
   verify-tag-version:
-    # Fail-closed publication gate: the pushed tag `vX.Y.Z` must equal
-    # the workspace `[workspace.package] version` (X.Y.Z). A mismatch
-    # means the tag points at a commit that was never version-bumped
-    # for this release — no image may be published from it.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - name: Assert tag matches workspace version
+        if: github.event_name == 'push'
         run: |
           set -euo pipefail
           tag_version="${GITHUB_REF_NAME#v}"
@@ -30,13 +33,12 @@ jobs:
             echo "::error file=Cargo.toml::tag ${GITHUB_REF_NAME} does not match [workspace.package] version ${manifest_version}; refusing to publish"
             exit 1
           fi
-          echo "tag ${GITHUB_REF_NAME} matches workspace version ${manifest_version}"
+      - name: Confirm dispatch is verification only
+        if: github.event_name == 'workflow_dispatch'
+        run: test "${{ inputs.dry_run }}" = true
 
   test:
-    # Fail-closed publication gate: `build-and-push` `needs:` this, so
-    # the image cannot ship from a tagged commit whose tests did not
-    # run and pass in this exact workflow run.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -49,24 +51,26 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --locked --workspace
 
-  build-and-push:
+  build:
     needs: [verify-tag-version, test]
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            artifact: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            artifact: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-
     steps:
       - uses: actions/checkout@v7
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version from tag
+      - uses: docker/setup-buildx-action@v4
+      - name: Prepare image metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -74,27 +78,140 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
-      - name: Build image for verification
-        # Build (without pushing) into the local image store so artifact
-        # content can be asserted before anything reaches the registry.
-        # The push step below reuses these layers.
+      - name: Build native image for verification
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           load: true
           tags: rustbgpd:verify
-
-      - name: Assert license files present in image
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+      - name: Verify native runtime image
+        env:
+          EXPECTED_PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
-          docker run --rm --entrypoint /bin/sh rustbgpd:verify -c \
-            'test -f /LICENSE-MIT && test -f /LICENSE-APACHE'
-
-      - name: Build and push
+          expected_os="${EXPECTED_PLATFORM%/*}"
+          expected_arch="${EXPECTED_PLATFORM#*/}"
+          test "$(docker image inspect rustbgpd:verify --format '{{.Os}}')" = "$expected_os"
+          test "$(docker image inspect rustbgpd:verify --format '{{.Architecture}}')" = "$expected_arch"
+          test "$(docker image inspect rustbgpd:verify --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$GITHUB_SHA"
+          docker run --rm --entrypoint /bin/sh rustbgpd:verify -c 'test -f /LICENSE-MIT && test -f /LICENSE-APACHE'
+          docker run --rm --entrypoint rustbgpd rustbgpd:verify --version
+          docker run --rm --entrypoint rbgp rustbgpd:verify --version
+          docker run --rm --entrypoint birdwatcher-adapter rustbgpd:verify --help
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push native image by digest
+        if: github.event_name == 'push'
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+      - name: Record native digest
+        if: github.event_name == 'push'
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - name: Upload native digest
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ matrix.artifact }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-manifest:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download native digests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract version tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Prepare index description
+        env:
+          LABELS: ${{ steps.meta.outputs.labels }}
+        run: |
+          set -euo pipefail
+          test "$(grep -c '^org.opencontainers.image.description=' <<< "$LABELS")" -eq 1
+          description="$(sed -n 's/^org.opencontainers.image.description=//p' <<< "$LABELS")"
+          test -n "$description"
+          echo "INDEX_DESCRIPTION=$description" >> "$GITHUB_ENV"
+      - name: Publish exact two-platform manifest
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          mapfile -t digest_files < <(find /tmp/digests -maxdepth 1 -type f -printf '%f\n' | sort)
+          test "${#digest_files[@]}" -eq 2
+          sources=()
+          for digest in "${digest_files[@]}"; do
+            [[ "$digest" =~ ^[0-9a-f]{64}$ ]]
+            sources+=("${REGISTRY}/${IMAGE_NAME}@sha256:${digest}")
+          done
+          tag_args=()
+          while IFS= read -r tag; do
+            test -n "$tag" && tag_args+=(--tag "$tag")
+          done <<< "$TAGS"
+          test "${#tag_args[@]}" -ge 4
+          test -n "$INDEX_DESCRIPTION"
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=${INDEX_DESCRIPTION}" \
+            "${tag_args[@]}" "${sources[@]}"
+      - name: Verify manifest platforms and tag identity
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          mapfile -t tags < <(printf '%s\n' "$TAGS" | sed '/^$/d')
+          test "${#tags[@]}" -ge 2
+          canonical="$(docker buildx imagetools inspect "${tags[0]}" --format '{{json .Manifest}}' | jq -r '.digest')"
+          [[ "$canonical" =~ ^sha256:[0-9a-f]{64}$ ]]
+          manifest="$(docker buildx imagetools inspect "${tags[0]}" --format '{{json .Manifest}}')"
+          test "$(jq -r '.manifests | length' <<< "$manifest")" -eq 2
+          test "$(jq -r '.annotations["org.opencontainers.image.description"]' <<< "$manifest")" = "$INDEX_DESCRIPTION"
+          platforms="$(jq -r '[.manifests[].platform | (.os + "/" + .architecture)] | sort | join("\n")' <<< "$manifest")"
+          test "$platforms" = $'linux/amd64\nlinux/arm64'
+          for tag in "${tags[@]}"; do
+            digest="$(docker buildx imagetools inspect "$tag" --format '{{json .Manifest}}' | jq -r '.digest')"
+            [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            test "$digest" = "$canonical"
+          done

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -152,6 +152,7 @@ jobs:
           pattern: digest-*
           path: /tmp/digests
           merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Release containers are now built and runtime-verified on native Linux amd64
+  and arm64 runners before a single exact two-platform GHCR manifest is
+  published. A fail-closed dry-run dispatch exercises both native builds
+  without registry authentication or publication.
+
 ### Fixed
 
 - An unexpected exit or panic in the configured RPKI subsystem now triggers

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,11 +20,12 @@ Linux aarch64. Published binaries use a glibc 2.31 baseline; see the
 and Windows daemon builds are unsupported: they may not compile or run, and
 there is no degraded daemon mode for those systems.
 
-Daemon runtime, interoperability, and privileged CI run on Linux x86_64.
-Linux aarch64 is cross-built and release-packaged, but is not natively
-executed in CI. Pure, kernel-independent crates and transport or socket
-abstractions with non-Linux fallbacks may remain portable and testable; that
-does not expand daemon platform support.
+Published release containers are built and runtime-verified natively on Linux
+x86_64 and Linux aarch64. Broader daemon, interoperability, and privileged CI
+remains Linux x86_64; release packages and tarballs use their documented
+cross-build path where applicable. Pure, kernel-independent crates and
+transport or socket abstractions with non-Linux fallbacks may remain portable
+and testable; that does not expand daemon platform support.
 
 RFC 8212 enforcement remains opt-in under
 [ADR-0112](docs/adr/0112-rfc-8212-ebgp-requires-policy.md).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -807,7 +807,10 @@ privileged runner is available.
 ### Supported Platforms
 
 - **v1:** Linux x86_64 and aarch64 are the supported daemon targets.
-- Native daemon/runtime CI is Linux x86_64; aarch64 is cross-built and packaged.
+- Published containers are built and runtime-verified natively on Linux x86_64
+  and aarch64. Broader daemon, interoperability, and privileged CI remains
+  Linux x86_64; packages and tarballs retain their documented cross-build path
+  where applicable.
 - Non-Linux daemon builds are unsupported. See the canonical
   [platform support contract](../SUPPORT.md#platform-support).
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -723,7 +723,8 @@ Before rolling any versions:
    tag. Then verify both tag-triggered publication workflows pass: **Release
    Binaries** (`release.yml`, including the x86_64 + aarch64 build matrix,
    artifacts, and GitHub Release) and **Container Image** (`container.yml`,
-   including the GHCR push). Both are fail-closed: each gates publication on a
+   including native amd64 + arm64 runtime verification and the GHCR manifest
+   push). Both are fail-closed: each gates publication on a
    `verify-tag-version` job (tag `vX.Y.Z` must equal the workspace
    `[workspace.package]` version) and a `test` job (`cargo test --workspace` on
    the tagged commit). If you tagged a commit without the version bump, the tag
@@ -737,7 +738,12 @@ Before rolling any versions:
      tags via the action's default `latest=auto` flavor)
    These **container-image** tags are emitted **without** the `v` prefix —
    `0.45.0`, not `v0.45.0` (`docker/metadata-action` strips it). The **git tag
-   stays `vX.Y.Z`** (step 8); only the image tag drops the `v`.
+   stays `vX.Y.Z`** (step 8); only the image tag drops the `v`. The container
+   workflow must show both native architecture jobs green and the published
+   manifest must contain exactly `linux/amd64` and `linux/arm64`. When
+   `.github/workflows/container.yml` changes, dispatch it from `main` with
+   `dry_run=true` before the next tag; dispatches build, load, and runtime-check
+   both architectures but cannot authenticate to GHCR or publish.
 11. **Verify release tarballs and packages** under
     [GitHub Releases](https://github.com/lance0/rustbgpd/releases) — each
     tag should publish version-less `rustbgpd-linux-amd64.tar.gz` and

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -360,7 +360,8 @@ sudo install -m 0755 \
 
 ### Container image
 
-A container image is built on every tagged release and published to
+A container image is built and runtime-verified natively on Linux amd64 and
+arm64 for every tagged release, then published as one two-platform manifest on
 GHCR. Three tag flavors are available per the
 `docker/metadata-action` rules in
 [`.github/workflows/container.yml`](../.github/workflows/container.yml):


### PR DESCRIPTION
## Summary

- build and runtime-verify release containers on native Linux amd64 and arm64 runners
- push architecture images by digest, then publish one exact two-platform manifest for every emitted release tag
- preserve the existing OCI label set and GHCR package description while rejecting malformed digests or extra manifest entries
- add a default-true manual dry run that exercises both native builds without registry login or publication
- document the native container proof without broadening the existing x86_64 interop and privileged-CI boundary

## Verification

- `actionlint .github/workflows/container.yml`
- `python3 scripts/check_developer_tooling.py`
- release-checklist path tests and gate
- release-install contract tests and gate
- public tracker-ID tests and gate
- `git diff --check`
- commit hooks: workspace formatting, Clippy, and documentation

## Post-merge proof

Dispatch **Container Image** from merged `main` with `dry_run=true`. Both native matrix jobs must pass, and every login, digest-upload, push, and manifest-publication step must remain skipped.
