### PR TITLE
bench: add raw bridge event-skew receipts

### DIFF
--- a/bench/netns-calibration/README.md
+++ b/bench/netns-calibration/README.md
@@ -1,8 +1,8 @@
 # Pinned-kernel netns calibration
 
-This directory provides the offline-verifiable VM boundary required before a
-timing-sensitive Linux netlink receipt can compare kernels. It does not contain
-the raw-bridge MAC+IP skew campaign itself and does not change production
+This directory provides the offline-verifiable VM boundary and the
+standard-library raw `RTMGRP_NEIGH` decoder required before a timing-sensitive
+Linux netlink receipt can compare kernels. It does not change production
 behavior.
 
 The ordinary Docker netns harness isolates privileged tests and cleans their
@@ -67,11 +67,60 @@ bench/netns-calibration/run-vm.sh \
 ```
 
 Repeat with `current-noble-6.8` and its pinned image. A successful environment
-smoke proves only that the version-pinned privileged netns boundary works. The
-later raw-bridge calibration must separately predeclare workload parameters,
-timestamp decoded messages on the single `RTNLGRP_NEIGH` stream, run real
-ARP/ND under serial and burst profiles, and publish its own bounded
-`run.json`/`samples.csv`/`report.json` receipt.
+smoke proves only that the version-pinned privileged netns boundary works.
+
+The ordinary three-argument invocation and its 300-second timeout remain the
+default. The raw-event campaign is a separate explicit mode:
+
+```bash
+bench/netns-calibration/run-vm.sh \
+  --raw-bridge-skew burst-8 \
+  baseline-jammy-5.15 \
+  /path/to/ubuntu-22.04-server-cloudimg-amd64.img \
+  /path/to/fresh-baseline-campaign-receipt
+```
+
+The other campaign profiles are `serial-1` and `burst-32`. Each materializes
+an exact 4,000-sample table with the guest's real bridge and port ifindexes
+before the first send. Samples are evenly divided across VLANs 10/20 and
+IPv4/IPv6. The profiles release one, eight, or 32 UDP sends together; no more
+than 32 samples are active. Each batch freezes after completion or five
+seconds, and the campaign has a 1,200-second internal wall inside a separate
+1,500-second VM timeout. Late events remain diagnostics and cannot change a
+frozen sample. `raw_bridge_skew.py --plan PROFILE` prints a deterministic
+shape preview with placeholder ifindexes, not an executable receipt.
+
+The campaign has no acceptance threshold. Until an external safe window and
+loss rule are predeclared, its output is descriptive and production behavior
+remains deferred. No pinned-image campaign is run by the offline suite.
+
+The decoder uses one `NETLINK_ROUTE` socket bound to the `RTMGRP_NEIGH` bitmask
+4 and rejects receive overflow, truncation, malformed framing, non-kernel
+events, clock regression, and ambiguous identity. IP-neighbor messages are
+paired only through the deterministic expected table; they never infer a VLAN.
+`RTM_DELNEIGH` observations and duplicate or missing sides remain explicit.
+The three campaign artifacts are staged in a fresh sibling directory, checked
+against a 10 MiB aggregate limit, and atomically published. The outer VM
+receipt verifier recomputes the exact plan and report, hard-requires zero
+wrong-tenant and ambiguous events, and seals the nested artifacts in the
+receipt manifest.
+
+For a disposable parser/pairing proof on the current host kernel, build the
+repository's netns test image and run the two-sample smoke. It sends real IPv4
+ARP and IPv6 ND traffic across VLANs 10 and 20, requires both FDB/neighbor
+pairs, and verifies zero wrong identity, ambiguity, and cleanup residue:
+
+```bash
+docker build -t rustbgpd-netns-tests:latest \
+  crates/evpn-linux/tests/docker
+docker run --rm --network none \
+  --cap-add NET_ADMIN --cap-add SYS_ADMIN \
+  --security-opt apparmor=unconfined \
+  -v "$PWD/bench/netns-calibration/raw_bridge_skew.py:/raw_bridge_skew.py:ro" \
+  rustbgpd-netns-tests:latest \
+  python3 /raw_bridge_skew.py \
+    --current-kernel-smoke --output /tmp/raw-bridge-skew-smoke
+```
 
 ## Offline verification
 

--- a/bench/netns-calibration/guest-smoke.sh
+++ b/bench/netns-calibration/guest-smoke.sh
@@ -19,7 +19,7 @@ inside_guest() {
         echo "usage: guest-smoke.sh --inside RECEIPT_DIR" >&2
         return 2
     fi
-    local output=$1 before after kernel package_kernel package_iproute
+    local output=$1 before after kernel package_kernel package_iproute campaign
     local ip_path bridge_path ip_hash bridge_hash config_hash ip_version profile
     if [ "${RUSTBGPD_GUEST_SMOKE_TEST_FAIL_AFTER_CREATE:-}" != 1 ]; then
         [ "$(id -u)" -eq 0 ] || { echo "guest smoke must run as root" >&2; return 1; }
@@ -68,6 +68,22 @@ inside_guest() {
     trap - EXIT
     after=$(ip netns list | LC_ALL=C sort)
     [ "$after" = "$before" ] || { echo "guest netns inventory changed" >&2; return 1; }
+
+    campaign=$(python3 -c \
+        'import json; print(json.load(open("/mnt/payload/request.json")).get("raw_bridge_skew", {}).get("profile", ""))')
+    if [ -n "$campaign" ]; then
+        [ -r /mnt/payload/raw_bridge_skew.py ] || {
+            echo "raw bridge skew campaign payload is missing" >&2
+            return 1
+        }
+        python3 /mnt/payload/raw_bridge_skew.py \
+            --campaign "$campaign" --output "$output/skew"
+        after=$(ip netns list | LC_ALL=C sort)
+        [ "$after" = "$before" ] || {
+            echo "raw bridge skew campaign left netns residue" >&2
+            return 1
+        }
+    fi
 
     kernel=$(uname -r)
     [ -r "/boot/config-$kernel" ] || { echo "guest kernel config is unavailable" >&2; return 1; }

--- a/bench/netns-calibration/profiles.json
+++ b/bench/netns-calibration/profiles.json
@@ -41,6 +41,17 @@
       }
     }
   ],
+  "raw_bridge_skew": {
+    "active_limits": {
+      "burst-32": 32,
+      "burst-8": 8,
+      "serial-1": 1
+    },
+    "censor_seconds": 5,
+    "pairs_per_profile": 4000,
+    "vm_timeout_seconds": 1500,
+    "wall_seconds": 1200
+  },
   "schema": 1,
   "vm": {
     "machine": "pc-q35-8.2",

--- a/bench/netns-calibration/raw_bridge_skew.py
+++ b/bench/netns-calibration/raw_bridge_skew.py
@@ -1,0 +1,965 @@
+#!/usr/bin/env python3
+"""Measure raw bridge-FDB to IP-neighbor notification skew on Linux."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import errno
+import ipaddress
+import json
+import math
+import os
+import select
+import shutil
+import socket
+import struct
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+NETLINK_ROUTE = 0
+RTMGRP_NEIGH = 4
+RTM_NEWNEIGH = 28
+RTM_DELNEIGH = 29
+NLMSG_OVERRUN = 4
+NLMSG_ERROR = 2
+AF_INET = int(socket.AF_INET)
+AF_INET6 = int(socket.AF_INET6)
+AF_BRIDGE = int(getattr(socket, "AF_BRIDGE", 7))
+NDA_DST, NDA_LLADDR, NDA_VLAN, NDA_MASTER, NDA_IFINDEX = 1, 2, 5, 9, 8
+MSG_TRUNC = getattr(socket, "MSG_TRUNC", 0x20)
+MAX_ARTIFACT_BYTES = 10 * 1024 * 1024
+VALID_NUD = 0x02 | 0x04 | 0x40 | 0x80
+INVALID_NUD = 0x01 | 0x08 | 0x10 | 0x20
+CAMPAIGNS = {"serial-1": 1, "burst-8": 8, "burst-32": 32}
+
+
+class MeasurementError(RuntimeError):
+    """The measurement lost data, identity, or its closed execution boundary."""
+
+
+def align4(value: int) -> int:
+    return (value + 3) & ~3
+
+
+@dataclass(frozen=True)
+class Event:
+    message: str
+    family: int
+    ifindex: int
+    state: int
+    flags: int
+    dst: str | None
+    lladdr: str | None
+    vlan: int | None
+    master: int | None
+    nda_ifindex: int | None
+    timestamp_ns: int
+
+
+def _attrs(data: bytes, offset: int, end: int) -> dict[int, bytes]:
+    result: dict[int, bytes] = {}
+    while offset < end:
+        if end - offset < 4:
+            raise MeasurementError("malformed rtattr framing")
+        length, kind = struct.unpack_from("=HH", data, offset)
+        if length < 4 or offset + length > end:
+            raise MeasurementError("malformed rtattr length")
+        kind &= 0x3FFF
+        if kind in result:
+            raise MeasurementError(f"duplicate rtattr {kind}")
+        result[kind] = data[offset + 4 : offset + length]
+        offset += align4(length)
+    if offset != end:
+        raise MeasurementError("unaligned rtattr framing")
+    return result
+
+
+def _exact_u16(value: bytes, name: str) -> int:
+    if len(value) != 2:
+        raise MeasurementError(f"bad {name} length")
+    return struct.unpack("=H", value)[0]
+
+
+def _exact_u32(value: bytes, name: str) -> int:
+    if len(value) != 4:
+        raise MeasurementError(f"bad {name} length")
+    return struct.unpack("=I", value)[0]
+
+
+def _decode_ip(family: int, value: bytes) -> str:
+    size = 4 if family == AF_INET else 16
+    if len(value) != size:
+        raise MeasurementError("bad NDA_DST length")
+    return str(ipaddress.ip_address(value))
+
+
+def parse_datagram(
+    data: bytes, sender_pid: int, msg_flags: int, timestamp_ns: int
+) -> list[Event]:
+    """Decode one datagram using its immediate post-receipt raw-clock time."""
+    if sender_pid != 0:
+        raise MeasurementError("relevant datagram has non-kernel sender")
+    if msg_flags & MSG_TRUNC:
+        raise MeasurementError("truncated netlink datagram")
+    events: list[Event] = []
+    offset = 0
+    while offset < len(data):
+        if len(data) - offset < 16:
+            raise MeasurementError("malformed nlmsghdr framing")
+        length, kind, _nlflags, seq, pid = struct.unpack_from("=IHHII", data, offset)
+        if length < 16 or offset + length > len(data):
+            raise MeasurementError("malformed nlmsg length")
+        if kind in (NLMSG_OVERRUN, NLMSG_ERROR):
+            raise MeasurementError("NLMSG_OVERRUN/ERROR")
+        if kind in (RTM_NEWNEIGH, RTM_DELNEIGH):
+            if seq != 0 or pid != 0:
+                raise MeasurementError("relevant event has non-kernel pid/sequence")
+            if length < 28:
+                raise MeasurementError("short ndmsg")
+            family, _pad1, _pad2, ifindex, state, ndflags, _ndtype = struct.unpack_from(
+                "=BBHiHBB", data, offset + 16
+            )
+            if family in (AF_BRIDGE, AF_INET, AF_INET6):
+                attrs = _attrs(data, offset + 28, offset + length)
+                dst = (
+                    _decode_ip(family, attrs[NDA_DST])
+                    if family in (AF_INET, AF_INET6) and NDA_DST in attrs
+                    else None
+                )
+                lladdr = attrs.get(NDA_LLADDR)
+                if lladdr is not None and len(lladdr) != 6:
+                    raise MeasurementError("bad NDA_LLADDR length")
+                events.append(
+                    Event(
+                        message="new" if kind == RTM_NEWNEIGH else "delete",
+                        family=family,
+                        ifindex=ifindex,
+                        state=state,
+                        flags=ndflags,
+                        dst=dst,
+                        lladdr=(
+                            ":".join(f"{part:02x}" for part in lladdr)
+                            if lladdr is not None
+                            else None
+                        ),
+                        vlan=(
+                            _exact_u16(attrs[NDA_VLAN], "NDA_VLAN")
+                            if NDA_VLAN in attrs
+                            else None
+                        ),
+                        master=(
+                            _exact_u32(attrs[NDA_MASTER], "NDA_MASTER")
+                            if NDA_MASTER in attrs
+                            else None
+                        ),
+                        nda_ifindex=(
+                            _exact_u32(attrs[NDA_IFINDEX], "NDA_IFINDEX")
+                            if NDA_IFINDEX in attrs
+                            else None
+                        ),
+                        timestamp_ns=timestamp_ns,
+                    )
+                )
+        aligned = align4(length)
+        if offset + aligned > len(data) or any(data[offset + length : offset + aligned]):
+            raise MeasurementError("bad nlmsg alignment padding")
+        offset += aligned
+    if offset != len(data):
+        raise MeasurementError("unaligned nlmsg framing")
+    return events
+
+
+class Observer:
+    """Exactly one standard-library NETLINK_ROUTE multicast socket."""
+
+    def __init__(self, receive_bytes: int = 4 * 1024 * 1024):
+        self.socket = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_ROUTE)
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, receive_bytes)
+        self.socket.bind((0, RTMGRP_NEIGH))
+
+    def receive(self, timeout_seconds: float | None = None) -> list[Event]:
+        if timeout_seconds is not None:
+            readable, _, _ = select.select([self.socket], [], [], max(0.0, timeout_seconds))
+            if not readable:
+                return []
+        try:
+            data, _ancillary, flags, address = self.socket.recvmsg(65536)
+        except OSError as exc:
+            if exc.errno == errno.ENOBUFS:
+                raise MeasurementError("NETLINK_ROUTE ENOBUFS") from exc
+            raise
+        timestamp_ns = time.clock_gettime_ns(time.CLOCK_MONOTONIC_RAW)
+        return parse_datagram(data, address[0], flags, timestamp_ns)
+
+    def close(self) -> None:
+        self.socket.close()
+
+
+class Pairer:
+    """Pair first qualifying NEW events against a deterministic expected table."""
+
+    def __init__(self, expected: list[dict[str, object]]):
+        self.expected = {str(row["sample_id"]): row for row in expected}
+        if len(self.expected) != len(expected):
+            raise MeasurementError("duplicate expected sample id")
+        self.sides = {
+            key: {"neighbor": [], "fdb": [], "delete": []} for key in self.expected
+        }
+        self.late = {
+            key: {"neighbor": 0, "fdb": 0, "delete": 0} for key in self.expected
+        }
+        self.frozen: set[str] = set()
+        self.wrong_tenant = 0
+        self.ambiguous_tenant = 0
+        self.last_timestamp = -1
+        self._fdb: dict[tuple[object, ...], str] = {}
+        self._neighbor: dict[tuple[object, ...], str] = {}
+        self._mac: dict[str, str] = {}
+        for sample_id, row in self.expected.items():
+            fdb = (
+                row["vlan"],
+                row["port_ifindex"],
+                row["bridge_ifindex"],
+                row["mac"],
+            )
+            neighbor = (row["family"], row["ip"], row["bridge_ifindex"], row["mac"])
+            mac = str(row["mac"])
+            if fdb in self._fdb or neighbor in self._neighbor or mac in self._mac:
+                raise MeasurementError("duplicate planned event identity")
+            self._fdb[fdb] = sample_id
+            self._neighbor[neighbor] = sample_id
+            self._mac[mac] = sample_id
+
+    def add(self, event: Event) -> None:
+        if event.timestamp_ns < self.last_timestamp:
+            raise MeasurementError("CLOCK_MONOTONIC_RAW regression")
+        self.last_timestamp = event.timestamp_ns
+        if event.message == "delete":
+            match = self._match(event, allow_partial=True)
+            if match is not None:
+                if match in self.frozen:
+                    self.late[match]["delete"] += 1
+                else:
+                    self.sides[match]["delete"].append(event)
+            return
+        if (event.state & VALID_NUD) == 0 or (event.state & INVALID_NUD) != 0:
+            return
+        match = self._match(event)
+        if match is None:
+            self.wrong_tenant += 1
+            return
+        side = "fdb" if event.family == AF_BRIDGE else "neighbor"
+        if match in self.frozen:
+            self.late[match][side] += 1
+        else:
+            self.sides[match][side].append(event)
+
+    def _match(self, event: Event, allow_partial: bool = False) -> str | None:
+        if event.family == AF_BRIDGE:
+            identity = (event.vlan, event.ifindex, event.master, event.lladdr)
+            match = self._fdb.get(identity)
+        else:
+            identity = (event.family, event.dst, event.ifindex, event.lladdr)
+            match = self._neighbor.get(identity)
+        if match is not None or not allow_partial or event.lladdr is None:
+            return match
+        return self._mac.get(event.lladdr)
+
+    def is_complete(self, sample_ids: list[str]) -> bool:
+        return all(
+            self.sides[sample_id]["neighbor"] and self.sides[sample_id]["fdb"]
+            for sample_id in sample_ids
+        )
+
+    def freeze(self, sample_ids: list[str]) -> None:
+        unknown = set(sample_ids) - self.expected.keys()
+        if unknown:
+            raise MeasurementError("cannot freeze an unknown sample")
+        self.frozen.update(sample_ids)
+
+    def rows(self) -> list[dict[str, object]]:
+        rows = []
+        for sample_id, expected in self.expected.items():
+            neighbor = self.sides[sample_id]["neighbor"]
+            fdb = self.sides[sample_id]["fdb"]
+            complete = bool(neighbor and fdb)
+            skew = neighbor[0].timestamp_ns - fdb[0].timestamp_ns if complete else None
+            if complete:
+                missing_reason = ""
+            elif not neighbor and not fdb:
+                missing_reason = "missing-fdb-and-neighbor"
+            elif not neighbor:
+                missing_reason = "missing-neighbor"
+            else:
+                missing_reason = "missing-fdb"
+            rows.append(
+                {
+                    **expected,
+                    "complete": complete,
+                    "missing_reason": missing_reason,
+                    "neighbor_ns": neighbor[0].timestamp_ns if neighbor else None,
+                    "fdb_ns": fdb[0].timestamp_ns if fdb else None,
+                    "skew_ns": skew,
+                    "duplicate_neighbor": max(0, len(neighbor) - 1),
+                    "duplicate_fdb": max(0, len(fdb) - 1),
+                    "delete_events": len(self.sides[sample_id]["delete"]),
+                    "late_neighbor": self.late[sample_id]["neighbor"],
+                    "late_fdb": self.late[sample_id]["fdb"],
+                    "late_delete": self.late[sample_id]["delete"],
+                }
+            )
+        return rows
+
+
+def percentile(values: list[int], fraction: float) -> int:
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(fraction * len(ordered)) - 1)]
+
+
+def _distribution(values: list[int]) -> dict[str, int | None]:
+    names = ("p50_ns", "p95_ns", "p99_ns", "p99_9_ns")
+    if not values:
+        return {"min_ns": None, **{name: None for name in names}, "max_ns": None}
+    result = {
+        name: percentile(values, quantile)
+        for name, quantile in zip(names, (0.5, 0.95, 0.99, 0.999))
+    }
+    return {"min_ns": min(values), **result, "max_ns": max(values)}
+
+
+def _summary(rows: list[dict[str, object]]) -> dict[str, object]:
+    complete = [row for row in rows if row["complete"]]
+    signed = [int(row["skew_ns"]) for row in complete]
+    directions = {
+        "fdb_first": sum(value > 0 for value in signed),
+        "neighbor_first": sum(value < 0 for value in signed),
+        "simultaneous": sum(value == 0 for value in signed),
+    }
+    denominator = len(signed)
+    return {
+        "expected": len(rows),
+        "complete": denominator,
+        "missing_neighbor": sum(row["neighbor_ns"] is None for row in rows),
+        "missing_fdb": sum(row["fdb_ns"] is None for row in rows),
+        "directions": {
+            name: {
+                "count": count,
+                "rate": count / denominator if denominator else None,
+            }
+            for name, count in directions.items()
+        },
+        "signed_skew": _distribution(signed),
+        "absolute_skew": _distribution([abs(value) for value in signed]),
+    }
+
+
+def build_report(
+    rows: list[dict[str, object]],
+    expected_count: int,
+    wrong_tenant: int,
+    ambiguous_tenant: int = 0,
+    acceptance: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if len(rows) != expected_count:
+        raise MeasurementError("incomplete denominator")
+    if wrong_tenant != 0 or ambiguous_tenant != 0:
+        raise MeasurementError("wrong-tenant or ambiguous event invalidated the run")
+    if acceptance is not None:
+        raise MeasurementError("acceptance requires an external predeclared statistical rule")
+    return {
+        "schema": 1,
+        **_summary(rows),
+        "duplicate_neighbor": sum(int(row["duplicate_neighbor"]) for row in rows),
+        "duplicate_fdb": sum(int(row["duplicate_fdb"]) for row in rows),
+        "late_neighbor": sum(int(row["late_neighbor"]) for row in rows),
+        "late_fdb": sum(int(row["late_fdb"]) for row in rows),
+        "late_delete": sum(int(row["late_delete"]) for row in rows),
+        "wrong_tenant": 0,
+        "ambiguous_tenant": 0,
+        "direction": "neighbor-minus-fdb",
+        "by_family": {
+            "ipv4": _summary([row for row in rows if row["family"] == AF_INET]),
+            "ipv6": _summary([row for row in rows if row["family"] == AF_INET6]),
+        },
+        "descriptive_only": True,
+        "acceptance": None,
+    }
+
+
+def check_artifacts(directory: Path) -> None:
+    total = 0
+    names = {"run.json", "samples.csv", "report.json"}
+    for name in names:
+        path = directory / name
+        if not path.is_file() or path.is_symlink() or path.stat().st_size > MAX_ARTIFACT_BYTES:
+            raise MeasurementError(f"invalid or oversized artifact: {name}")
+        total += path.stat().st_size
+    if {path.name for path in directory.iterdir()} != names or total > MAX_ARTIFACT_BYTES:
+        raise MeasurementError("artifact inventory or total size is invalid")
+
+
+def _default_ports(active_limit: int) -> dict[str, list[int]]:
+    return {
+        "10": list(range(110, 110 + active_limit)),
+        "20": list(range(210, 210 + active_limit)),
+    }
+
+
+def deterministic_plan(
+    profile: str,
+    bridge_ifindex: int = 100,
+    port_ifindexes: dict[str, list[int]] | None = None,
+) -> dict[str, object]:
+    if profile not in CAMPAIGNS:
+        raise MeasurementError("unknown campaign profile")
+    active_limit = CAMPAIGNS[profile]
+    ports = port_ifindexes if port_ifindexes is not None else _default_ports(active_limit)
+    if set(ports) != {"10", "20"} or any(
+        len(ports[str(vlan)]) != active_limit for vlan in (10, 20)
+    ):
+        raise MeasurementError("campaign topology does not match its active limit")
+    all_ifindexes = [bridge_ifindex, *ports["10"], *ports["20"]]
+    if any(type(value) is not int or value <= 0 for value in all_ifindexes):
+        raise MeasurementError("campaign topology has an invalid ifindex")
+    if len(set(all_ifindexes)) != len(all_ifindexes):
+        raise MeasurementError("campaign topology reuses an ifindex")
+    planned: list[dict[str, object]] = []
+    number = 0
+    for vlan in (10, 20):
+        for family in (AF_INET, AF_INET6):
+            family_name = "ipv4" if family == AF_INET else "ipv6"
+            phase = f"vlan-{vlan}-{family_name}"
+            for index in range(1000):
+                number += 1
+                ip = (
+                    f"10.{vlan}.{index // 254}.{index % 254 + 1}"
+                    if family == AF_INET
+                    else f"2001:db8:{vlan:x}::{index + 1:x}"
+                )
+                family_octet = 4 if family == AF_INET else 6
+                planned.append(
+                    {
+                        "sample_id": f"s{number:04d}",
+                        "profile": profile,
+                        "phase": phase,
+                        "vlan": vlan,
+                        "family": family,
+                        "ip": ip,
+                        "mac": (
+                            f"02:{vlan:02x}:{family_octet:02x}:"
+                            f"{index >> 8 & 255:02x}:{index & 255:02x}:01"
+                        ),
+                        "bridge_ifindex": bridge_ifindex,
+                        "port_ifindex": ports[str(vlan)][index % active_limit],
+                    }
+                )
+    return {
+        "schema": 1,
+        "profile": profile,
+        "active_limit": active_limit,
+        "censor_seconds": 5,
+        "wall_seconds": 1200,
+        "acceptance": None,
+        "topology": {
+            "bridge_ifindex": bridge_ifindex,
+            "port_ifindexes": ports,
+        },
+        "planned": planned,
+    }
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, allow_nan=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+SAMPLE_FIELDS = [
+    "sample_id",
+    "profile",
+    "phase",
+    "family",
+    "vlan",
+    "complete",
+    "missing_reason",
+    "neighbor_ns",
+    "fdb_ns",
+    "skew_ns",
+    "duplicate_neighbor",
+    "duplicate_fdb",
+    "delete_events",
+    "late_neighbor",
+    "late_fdb",
+    "late_delete",
+]
+
+
+def write_pairer_receipt(run: dict[str, object], pairer: Pairer, output: Path) -> None:
+    if output.exists() or output.is_symlink():
+        raise MeasurementError("receipt output must be fresh")
+    parent = output.parent
+    if not parent.is_dir() or parent.is_symlink():
+        raise MeasurementError("receipt parent must be a real directory")
+    rows = pairer.rows()
+    planned = cast(list[dict[str, object]], run["planned"])
+    report = build_report(
+        rows,
+        len(planned),
+        pairer.wrong_tenant,
+        pairer.ambiguous_tenant,
+        cast(dict[str, object] | None, run["acceptance"]),
+    )
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=parent))
+    try:
+        _write_json(staging / "run.json", run)
+        with (staging / "samples.csv").open(
+            "w", encoding="utf-8", newline=""
+        ) as stream:
+            writer = csv.DictWriter(
+                stream,
+                fieldnames=SAMPLE_FIELDS,
+                lineterminator="\n",
+                extrasaction="ignore",
+            )
+            writer.writeheader()
+            for row in rows:
+                encoded = dict(row)
+                encoded["complete"] = "true" if row["complete"] else "false"
+                for field in ("neighbor_ns", "fdb_ns", "skew_ns"):
+                    encoded[field] = "" if row[field] is None else row[field]
+                writer.writerow(encoded)
+        _write_json(staging / "report.json", report)
+        check_artifacts(staging)
+        staging.rename(output)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def write_receipt(run: dict[str, object], events: list[Event], output: Path) -> None:
+    pairer = Pairer(cast(list[dict[str, object]], run["planned"]))
+    for event in events:
+        pairer.add(event)
+    write_pairer_receipt(run, pairer, output)
+
+
+def _command(args: list[str], *, input_text: str | None = None) -> str:
+    try:
+        result = subprocess.run(
+            args,
+            check=True,
+            input=input_text,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or exc.stdout.strip() or f"status {exc.returncode}"
+        raise MeasurementError(f"command failed ({' '.join(args)}): {detail}") from exc
+    return result.stdout
+
+
+class TrafficTopology:
+    """One disposable bridge namespace with fixed VLAN-specific peer ports."""
+
+    def __init__(self, active_limit: int):
+        self.active_limit = active_limit
+        self.namespace = f"rbgp-raw-skew-{os.getpid()}"
+        self.bridge = "rbgpskbr0"
+        self.host_ports: dict[str, list[str]] = {"10": [], "20": []}
+        self.peer_ports: dict[str, list[str]] = {"10": [], "20": []}
+        self.before_netns = ""
+        self.before_links = ""
+        self.created_namespace = False
+        self.created_bridge = False
+        self.created_host_ports: list[str] = []
+        self._port_ifindexes: dict[str, list[int]] = {"10": [], "20": []}
+
+    def __enter__(self) -> "TrafficTopology":
+        try:
+            return self._setup()
+        except BaseException as exc:
+            try:
+                self.__exit__(type(exc), exc, exc.__traceback__)
+            except MeasurementError as cleanup:
+                raise MeasurementError(
+                    f"topology setup failed and cleanup was incomplete: {cleanup}"
+                ) from exc
+            raise
+
+    def _setup(self) -> "TrafficTopology":
+        if os.geteuid() != 0:
+            raise MeasurementError("raw bridge skew traffic must run as root")
+        for tool in ("bridge", "ip", "python3"):
+            if shutil.which(tool) is None:
+                raise MeasurementError(f"required traffic tool is missing: {tool}")
+        self.before_netns = _command(["ip", "netns", "list"])
+        self.before_links = _command(["ip", "-o", "link", "show"])
+        _command(["ip", "netns", "add", self.namespace])
+        self.created_namespace = True
+        _command(
+            [
+                "ip",
+                "link",
+                "add",
+                self.bridge,
+                "type",
+                "bridge",
+                "vlan_filtering",
+                "1",
+                "vlan_default_pvid",
+                "0",
+            ]
+        )
+        self.created_bridge = True
+        _command(["ip", "link", "set", self.bridge, "up"])
+        for vlan in (10, 20):
+            for slot in range(self.active_limit):
+                host = f"rh{vlan}{slot:02d}"
+                peer = f"rp{vlan}{slot:02d}"
+                self.host_ports[str(vlan)].append(host)
+                self.peer_ports[str(vlan)].append(peer)
+                _command(["ip", "link", "add", host, "type", "veth", "peer", "name", peer])
+                self.created_host_ports.append(host)
+                _command(["ip", "link", "set", host, "master", self.bridge])
+                _command(["ip", "link", "set", host, "up"])
+                _command(["ip", "link", "set", peer, "netns", self.namespace])
+                _command(
+                    [
+                        "ip",
+                        "-n",
+                        self.namespace,
+                        "link",
+                        "set",
+                        peer,
+                        "addrgenmode",
+                        "none",
+                    ]
+                )
+                _command(
+                    [
+                        "bridge",
+                        "vlan",
+                        "add",
+                        "dev",
+                        host,
+                        "vid",
+                        str(vlan),
+                        "pvid",
+                        "untagged",
+                    ]
+                )
+        for vlan in (10, 20):
+            _command(
+                [
+                    "bridge",
+                    "vlan",
+                    "add",
+                    "dev",
+                    self.bridge,
+                    "vid",
+                    str(vlan),
+                    "untagged",
+                    "self",
+                ]
+            )
+        for address in (
+            "10.10.255.254/16",
+            "10.20.255.254/16",
+            "2001:db8:a::ffff/64",
+            "2001:db8:14::ffff/64",
+        ):
+            args = ["ip", "addr", "add", address, "dev", self.bridge]
+            if ":" in address:
+                args.append("nodad")
+            _command(args)
+        self._port_ifindexes = {
+            vlan: [
+                int(_command(["cat", f"/sys/class/net/{name}/ifindex"]).strip())
+                for name in names
+            ]
+            for vlan, names in self.host_ports.items()
+        }
+        return self
+
+    def ifindexes(self) -> tuple[int, dict[str, list[int]]]:
+        bridge = int(_command(["cat", f"/sys/class/net/{self.bridge}/ifindex"]).strip())
+        return bridge, {key: list(value) for key, value in self._port_ifindexes.items()}
+
+    def prepare_rows(self, rows: list[dict[str, object]]) -> None:
+        commands = []
+        for row in rows:
+            vlan = str(row["vlan"])
+            port_ifindex = int(row["port_ifindex"])
+            slot = self._port_ifindexes[vlan].index(port_ifindex)
+            peer = self.peer_ports[vlan][slot]
+            prefix = 16 if row["family"] == AF_INET else 64
+            commands.extend(
+                [
+                    f"link set dev {peer} down",
+                    f"addr flush dev {peer}",
+                    f"link set dev {peer} address {row['mac']}",
+                    f"link set dev {peer} up",
+                    f"addr add {row['ip']}/{prefix} dev {peer}"
+                    + (" nodad" if row["family"] == AF_INET6 else ""),
+                ]
+            )
+        _command(
+            ["ip", "-n", self.namespace, "-batch", "-"],
+            input_text="\n".join(commands) + "\n",
+        )
+
+    def stimulus(self, rows: list[dict[str, object]]) -> subprocess.Popen[bytes]:
+        payload = []
+        for row in rows:
+            vlan = str(row["vlan"])
+            slot = self._port_ifindexes[vlan].index(int(row["port_ifindex"]))
+            payload.append(
+                {
+                    "family": row["family"],
+                    "source": row["ip"],
+                    "device": self.peer_ports[vlan][slot],
+                    "target": (
+                        f"10.{vlan}.255.254"
+                        if row["family"] == AF_INET
+                        else f"2001:db8:{int(vlan):x}::ffff"
+                    ),
+                }
+            )
+        code = (
+            "import json,socket,sys,threading\n"
+            "rows=json.loads(sys.argv[1])\n"
+            "sockets=[]\n"
+            "for row in rows:\n"
+            " s=socket.socket(row['family'],socket.SOCK_DGRAM)\n"
+            " s.setsockopt(socket.SOL_SOCKET,socket.SO_BINDTODEVICE,(row['device']+'\\0').encode())\n"
+            " s.bind((row['source'],0))\n"
+            " sockets.append(s)\n"
+            "barrier=threading.Barrier(len(rows)+1)\n"
+            "errors=[]\n"
+            "def send(index):\n"
+            " try:\n"
+            "  barrier.wait()\n"
+            "  sockets[index].sendto(b'x',(rows[index]['target'],9))\n"
+            " except BaseException as exc:\n"
+            "  errors.append(repr(exc))\n"
+            "threads=[threading.Thread(target=send,args=(i,)) for i in range(len(rows))]\n"
+            "[thread.start() for thread in threads]\n"
+            "barrier.wait()\n"
+            "[thread.join() for thread in threads]\n"
+            "[sock.close() for sock in sockets]\n"
+            "if errors: raise RuntimeError('; '.join(errors))\n"
+        )
+        return subprocess.Popen(
+            [
+                "ip",
+                "netns",
+                "exec",
+                self.namespace,
+                "python3",
+                "-c",
+                code,
+                json.dumps(payload, allow_nan=False, separators=(",", ":")),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+
+    def __exit__(self, _kind: object, _value: object, _traceback: object) -> None:
+        errors = []
+        for name in self.created_host_ports:
+            result = subprocess.run(
+                ["ip", "link", "del", name],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if result.returncode != 0 and self.created_bridge:
+                errors.append(result.stderr.strip() or f"port cleanup failed: {name}")
+        if self.created_namespace:
+            result = subprocess.run(
+                ["ip", "netns", "del", self.namespace],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if result.returncode != 0:
+                errors.append(result.stderr.strip() or "namespace cleanup failed")
+        if self.created_bridge:
+            result = subprocess.run(
+                ["ip", "link", "del", self.bridge],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if result.returncode != 0:
+                errors.append(result.stderr.strip() or "bridge cleanup failed")
+        try:
+            if _command(["ip", "netns", "list"]) != self.before_netns:
+                errors.append("network namespace inventory changed")
+            if _command(["ip", "-o", "link", "show"]) != self.before_links:
+                errors.append("link inventory changed")
+        except MeasurementError as exc:
+            errors.append(str(exc))
+        if errors:
+            raise MeasurementError("cleanup residue: " + "; ".join(errors))
+
+
+def _collect_batch(
+    observer: Observer,
+    pairer: Pairer,
+    sample_ids: list[str],
+    censor_deadline: float,
+) -> None:
+    while not pairer.is_complete(sample_ids):
+        remaining = censor_deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        for event in observer.receive(min(remaining, 0.25)):
+            pairer.add(event)
+
+
+def _drain_ready(observer: Observer, pairer: Pairer) -> None:
+    while True:
+        events = observer.receive(0)
+        if not events:
+            return
+        for event in events:
+            pairer.add(event)
+
+
+def _finish_process(process: subprocess.Popen[bytes]) -> None:
+    try:
+        _stdout, stderr = process.communicate(timeout=2)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        _stdout, stderr = process.communicate()
+        raise MeasurementError("traffic stimulus did not terminate")
+    if process.returncode != 0:
+        detail = stderr.decode(errors="replace").strip()
+        raise MeasurementError(f"traffic stimulus failed: {detail or process.returncode}")
+
+
+def _smoke_plan(
+    bridge_ifindex: int, port_ifindexes: dict[str, list[int]]
+) -> dict[str, object]:
+    planned = [
+        {
+            "sample_id": "smoke-vlan10-v4",
+            "profile": "current-kernel-smoke",
+            "phase": "vlan-10-ipv4",
+            "vlan": 10,
+            "family": AF_INET,
+            "ip": "10.10.254.1",
+            "mac": "02:10:04:ff:00:01",
+            "bridge_ifindex": bridge_ifindex,
+            "port_ifindex": port_ifindexes["10"][0],
+        },
+        {
+            "sample_id": "smoke-vlan20-v6",
+            "profile": "current-kernel-smoke",
+            "phase": "vlan-20-ipv6",
+            "vlan": 20,
+            "family": AF_INET6,
+            "ip": "2001:db8:14::fffe",
+            "mac": "02:20:06:ff:00:01",
+            "bridge_ifindex": bridge_ifindex,
+            "port_ifindex": port_ifindexes["20"][0],
+        },
+    ]
+    return {
+        "schema": 1,
+        "profile": "current-kernel-smoke",
+        "active_limit": 1,
+        "censor_seconds": 5,
+        "wall_seconds": 30,
+        "acceptance": None,
+        "topology": {
+            "bridge_ifindex": bridge_ifindex,
+            "port_ifindexes": port_ifindexes,
+        },
+        "planned": planned,
+    }
+
+
+def _execute(profile: str, *, smoke: bool) -> tuple[dict[str, object], Pairer]:
+    active_limit = 1 if smoke else CAMPAIGNS[profile]
+    wall_deadline = time.monotonic() + (30 if smoke else 1200)
+    with TrafficTopology(active_limit) as topology:
+        bridge_ifindex, port_ifindexes = topology.ifindexes()
+        run = (
+            _smoke_plan(bridge_ifindex, port_ifindexes)
+            if smoke
+            else deterministic_plan(profile, bridge_ifindex, port_ifindexes)
+        )
+        planned = cast(list[dict[str, object]], run["planned"])
+        pairer = Pairer(planned)
+        observer = Observer()
+        try:
+            phases = ["vlan-10-ipv4", "vlan-10-ipv6", "vlan-20-ipv4", "vlan-20-ipv6"]
+            for phase in phases:
+                phase_rows = [row for row in planned if row["phase"] == phase]
+                for start in range(0, len(phase_rows), active_limit):
+                    if time.monotonic() >= wall_deadline:
+                        break
+                    batch = phase_rows[start : start + active_limit]
+                    topology.prepare_rows(batch)
+                    process = topology.stimulus(batch)
+                    try:
+                        _collect_batch(
+                            observer,
+                            pairer,
+                            [str(row["sample_id"]) for row in batch],
+                            min(wall_deadline, time.monotonic() + 5),
+                        )
+                    finally:
+                        pairer.freeze([str(row["sample_id"]) for row in batch])
+                        _finish_process(process)
+                        _drain_ready(observer, pairer)
+        finally:
+            observer.close()
+    smoke_ids = ["smoke-vlan10-v4", "smoke-vlan20-v6"]
+    if smoke and not pairer.is_complete(smoke_ids):
+        raise MeasurementError("current-kernel ARP/ND smoke did not produce both pairs")
+    if pairer.wrong_tenant or pairer.ambiguous_tenant:
+        raise MeasurementError("wrong-tenant or ambiguous event invalidated the run")
+    return run, pairer
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--self-test", action="store_true")
+    modes.add_argument("--plan", choices=sorted(CAMPAIGNS))
+    modes.add_argument("--campaign", choices=sorted(CAMPAIGNS))
+    modes.add_argument("--current-kernel-smoke", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.self_test:
+        print("raw bridge skew parser ready")
+        return 0
+    if args.plan:
+        payload = deterministic_plan(args.plan)
+        text = json.dumps(payload, allow_nan=False, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.write_text(text, encoding="utf-8")
+        else:
+            print(text, end="")
+        return 0
+    if args.output is None:
+        parser.error("--campaign and --current-kernel-smoke require --output")
+    run, pairer = _execute(args.campaign or "serial-1", smoke=args.current_kernel_smoke)
+    write_pairer_receipt(run, pairer, args.output)
+    report = json.loads((args.output / "report.json").read_text(encoding="utf-8"))
+    print(json.dumps(report, allow_nan=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/netns-calibration/raw_bridge_skew.py
+++ b/bench/netns-calibration/raw_bridge_skew.py
@@ -182,11 +182,15 @@ class Observer:
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, receive_bytes)
         self.socket.bind((0, RTMGRP_NEIGH))
 
+    def ready(self, timeout_seconds: float = 0.0) -> bool:
+        readable, _, _ = select.select(
+            [self.socket], [], [], max(0.0, timeout_seconds)
+        )
+        return bool(readable)
+
     def receive(self, timeout_seconds: float | None = None) -> list[Event]:
-        if timeout_seconds is not None:
-            readable, _, _ = select.select([self.socket], [], [], max(0.0, timeout_seconds))
-            if not readable:
-                return []
+        if timeout_seconds is not None and not self.ready(timeout_seconds):
+            return []
         try:
             data, _ancillary, flags, address = self.socket.recvmsg(65536)
         except OSError as exc:
@@ -565,6 +569,14 @@ def _command(args: list[str], *, input_text: str | None = None) -> str:
     return result.stdout
 
 
+def _ifindex(name: str) -> int:
+    path = Path("/sys/class/net") / name / "ifindex"
+    try:
+        return int(path.read_text(encoding="ascii").strip())
+    except (OSError, ValueError) as exc:
+        raise MeasurementError(f"cannot read interface index for {name}: {exc}") from exc
+
+
 class TrafficTopology:
     """One disposable bridge namespace with fixed VLAN-specific peer ports."""
 
@@ -680,16 +692,13 @@ class TrafficTopology:
                 args.append("nodad")
             _command(args)
         self._port_ifindexes = {
-            vlan: [
-                int(_command(["cat", f"/sys/class/net/{name}/ifindex"]).strip())
-                for name in names
-            ]
+            vlan: [_ifindex(name) for name in names]
             for vlan, names in self.host_ports.items()
         }
         return self
 
     def ifindexes(self) -> tuple[int, dict[str, list[int]]]:
-        bridge = int(_command(["cat", f"/sys/class/net/{self.bridge}/ifindex"]).strip())
+        bridge = _ifindex(self.bridge)
         return bridge, {key: list(value) for key, value in self._port_ifindexes.items()}
 
     def prepare_rows(self, rows: list[dict[str, object]]) -> None:
@@ -826,11 +835,8 @@ def _collect_batch(
 
 
 def _drain_ready(observer: Observer, pairer: Pairer) -> None:
-    while True:
-        events = observer.receive(0)
-        if not events:
-            return
-        for event in events:
+    while observer.ready():
+        for event in observer.receive():
             pairer.add(event)
 
 

--- a/bench/netns-calibration/run-vm.sh
+++ b/bench/netns-calibration/run-vm.sh
@@ -16,15 +16,21 @@ REPO=$(cd -- "$SCRIPT_DIR/../.." && pwd)
 PROFILES="$SCRIPT_DIR/profiles.json"
 VERIFIER="$SCRIPT_DIR/verify-receipt.py"
 GUEST="$SCRIPT_DIR/guest-smoke.sh"
+SKEW="$SCRIPT_DIR/raw_bridge_skew.py"
 # shellcheck disable=SC1091 # REPO is resolved from this tracked script.
 source "$REPO/tests/soak/host-lock.sh"
 # shellcheck disable=SC1091 # REPO is resolved from this tracked script.
 source "$REPO/bench/scale/host-quiet.sh"
 
 usage() {
-    echo "usage: $0 PROFILE PINNED_CLOUD_IMAGE FRESH_RECEIPT_DIR" >&2
+    echo "usage: $0 [--raw-bridge-skew CAMPAIGN] PROFILE PINNED_CLOUD_IMAGE FRESH_RECEIPT_DIR" >&2
 }
 
+CAMPAIGN=''
+if [ "$#" -eq 5 ] && [ "$1" = --raw-bridge-skew ]; then
+    CAMPAIGN=$2
+    shift 2
+fi
 if [ "$#" -ne 3 ]; then
     usage
     exit 2
@@ -39,6 +45,10 @@ EXPECTED_IMAGE_SHA=${PROFILE_FIELDS[0]}
 EXPECTED_IMAGE_URL=${PROFILE_FIELDS[1]}
 QEMU_BIN=${PROFILE_FIELDS[2]}
 CLOUD_BIN=${PROFILE_FIELDS[3]}
+CAMPAIGN_TIMEOUT_SECONDS=''
+if [ -n "$CAMPAIGN" ]; then
+    CAMPAIGN_TIMEOUT_SECONDS=$(python3 "$VERIFIER" skew-select "$PROFILES" "$CAMPAIGN")
+fi
 
 if [ ! -f "$IMAGE" ] || [ -L "$IMAGE" ] || [ ! -r "$IMAGE" ]; then
     echo "pinned cloud image must be a readable regular file: $IMAGE" >&2
@@ -161,10 +171,11 @@ fi
 PAYLOAD_DIR="$TMP_DIR/payload"
 mkdir -m 700 -- "$PAYLOAD_DIR"
 python3 - "$REPO" "$PROFILE" "$EXPECTED_IMAGE_URL" "$EXPECTED_IMAGE_SHA" \
-    "$GIT_COMMIT" "$ORIGIN_MAIN" "$GIT_STATUS_SHA" "$OUTPUT/request.json" <<'PY'
+    "$GIT_COMMIT" "$ORIGIN_MAIN" "$GIT_STATUS_SHA" "$CAMPAIGN" \
+    "$OUTPUT/request.json" <<'PY'
 import hashlib, json, pathlib, sys
 repo = pathlib.Path(sys.argv[1])
-profile, image_url, image_sha, commit, origin_main, status_sha, output = sys.argv[2:]
+profile, image_url, image_sha, commit, origin_main, status_sha, campaign, output = sys.argv[2:]
 paths = {
     "guest": "bench/netns-calibration/guest-smoke.sh",
     "host_lock": "tests/soak/host-lock.sh",
@@ -173,6 +184,8 @@ paths = {
     "runner": "bench/netns-calibration/run-vm.sh",
     "verifier": "bench/netns-calibration/verify-receipt.py",
 }
+if campaign:
+    paths["raw_bridge_skew"] = "bench/netns-calibration/raw_bridge_skew.py"
 payload = {
     "git": {"commit": commit, "dirty": False, "origin_main": origin_main, "status_sha256": status_sha},
     "image": {"sha256": image_sha, "url": image_url},
@@ -180,9 +193,14 @@ payload = {
     "schema": 1,
     "sources": {name: hashlib.sha256((repo / path).read_bytes()).hexdigest() for name, path in paths.items()},
 }
+if campaign:
+    payload["raw_bridge_skew"] = {"profile": campaign}
 pathlib.Path(output).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 PY
 cp -- "$PROFILES" "$GUEST" "$OUTPUT/request.json" "$PAYLOAD_DIR/"
+if [ -n "$CAMPAIGN" ]; then
+    cp -- "$SKEW" "$PAYLOAD_DIR/"
+fi
 chmod 500 "$PAYLOAD_DIR/guest-smoke.sh"
 chmod 400 "$PAYLOAD_DIR/profiles.json" "$PAYLOAD_DIR/request.json"
 
@@ -267,6 +285,9 @@ mapfile -d '' -t QEMU_COMMAND <"$TMP_DIR/qemu-argv.nul"
     exit 1
 }
 TIMEOUT_SECONDS=300
+if [ -n "$CAMPAIGN" ]; then
+    TIMEOUT_SECONDS=$CAMPAIGN_TIMEOUT_SECONDS
+fi
 setsid timeout --signal=TERM --kill-after=10s "${TIMEOUT_SECONDS}s" \
     "${QEMU_COMMAND[@]}" >"$OUTPUT/console.log" 2>&1 &
 QEMU_GROUP_PID=$!

--- a/bench/netns-calibration/test_raw_bridge_skew.py
+++ b/bench/netns-calibration/test_raw_bridge_skew.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+import importlib.util
+import socket
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PATH = Path(__file__).with_name("raw_bridge_skew.py")
+SPEC = importlib.util.spec_from_file_location("raw_bridge_skew", PATH)
+MOD = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+BRIDGE = bytes.fromhex(
+    "380000001c00000000000000000000000700000016000000020000000a000200"
+    "02000000000100000800090063000000060005000a000000"
+)
+IPV4 = bytes.fromhex(
+    "4c0000001c000000000000000000000002000000630000000200000008000100"
+    "c000020a0a000200020000000001000008000400000000001400030000000000"
+    "000000000000000001000000"
+)
+IPV6 = bytes.fromhex(
+    "580000001c00000000000000000000000a000000630000000200000014000100"
+    "20010db80010000000000000000000020a000200020000000002000008000400"
+    "000000001400030000000000000000000000000001000000"
+)
+OVERRUN = bytes.fromhex("10000000040000000000000000000000")
+
+
+def message(kind, family, ifindex, attrs=b"", seq=0, pid=0):
+    body = struct.pack("=BBHiHBB", family, 0, 0, ifindex, 2, 0, 0) + attrs
+    raw = struct.pack("=IHHII", 16 + len(body), kind, 0, seq, pid) + body
+    return raw + bytes((-len(raw)) % 4)
+
+
+class ParserTests(unittest.TestCase):
+    def test_supplied_literal_bridge_ipv4_and_ipv6_vectors(self):
+        bridge, ipv4, ipv6 = MOD.parse_datagram(BRIDGE + IPV4 + IPV6, 0, 0, 44)
+        self.assertEqual(
+            (bridge.family, bridge.ifindex, bridge.vlan, bridge.master, bridge.lladdr),
+            (7, 22, 10, 99, "02:00:00:00:00:01"),
+        )
+        self.assertEqual(
+            (ipv4.family, ipv4.ifindex, ipv4.dst, ipv4.lladdr),
+            (2, 99, "192.0.2.10", "02:00:00:00:00:01"),
+        )
+        self.assertEqual(
+            (ipv6.family, ipv6.ifindex, ipv6.dst, ipv6.lladdr),
+            (10, 99, "2001:db8:10::2", "02:00:00:00:00:02"),
+        )
+        self.assertEqual({event.timestamp_ns for event in (bridge, ipv4, ipv6)}, {44})
+
+    def test_delete_is_retained_as_a_distinct_message(self):
+        deleted = bytearray(IPV6)
+        struct.pack_into("=H", deleted, 4, MOD.RTM_DELNEIGH)
+        event = MOD.parse_datagram(bytes(deleted), 0, 0, 7)[0]
+        self.assertEqual((event.message, event.dst), ("delete", "2001:db8:10::2"))
+
+    def test_fail_closed_framing_sender_sequence_overrun_and_truncation(self):
+        cases = [
+            (IPV4, 4, 0),
+            (IPV4, 0, MOD.MSG_TRUNC),
+            (message(MOD.RTM_NEWNEIGH, socket.AF_INET, 12, seq=1), 0, 0),
+            (OVERRUN, 0, 0),
+            (b"short", 0, 0),
+            (struct.pack("=IHHII", 999, MOD.RTM_NEWNEIGH, 0, 0, 0), 0, 0),
+            (IPV4[:-1], 0, 0),
+        ]
+        for vector, sender, flags in cases:
+            with self.subTest(sender=sender, flags=flags, length=len(vector)):
+                with self.assertRaises(MOD.MeasurementError):
+                    MOD.parse_datagram(vector, sender, flags, 1)
+
+
+class PairingTests(unittest.TestCase):
+    def setUp(self):
+        self.expected = [
+            {
+                "sample_id": "s1",
+                "profile": "fixture",
+                "phase": "vlan-10-ipv4",
+                "vlan": 10,
+                "port_ifindex": 12,
+                "bridge_ifindex": 4,
+                "family": socket.AF_INET,
+                "ip": "192.0.2.1",
+                "mac": "02:00:00:00:00:01",
+            }
+        ]
+
+    def event(self, family, timestamp, **kwargs):
+        fields = dict(
+            message="new",
+            family=family,
+            ifindex=4,
+            state=2,
+            flags=0,
+            dst=None,
+            lladdr=None,
+            vlan=None,
+            master=None,
+            nda_ifindex=None,
+            timestamp_ns=timestamp,
+        )
+        fields.update(kwargs)
+        return MOD.Event(**fields)
+
+    def test_first_new_pairs_duplicates_and_delete_are_explicit(self):
+        pairer = MOD.Pairer(self.expected)
+        pairer.add(
+            self.event(
+                MOD.AF_BRIDGE,
+                100,
+                ifindex=12,
+                master=4,
+                vlan=10,
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        pairer.add(
+            self.event(
+                socket.AF_INET,
+                120,
+                dst="192.0.2.1",
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        pairer.add(
+            self.event(
+                socket.AF_INET,
+                125,
+                dst="192.0.2.1",
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        pairer.add(
+            self.event(
+                socket.AF_INET,
+                130,
+                message="delete",
+                dst="192.0.2.1",
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        row = pairer.rows()[0]
+        self.assertEqual(
+            (row["skew_ns"], row["duplicate_neighbor"], row["delete_events"]),
+            (20, 1, 1),
+        )
+        self.assertEqual(row["missing_reason"], "")
+
+    def test_wrong_identity_clock_regression_and_invalid_nud(self):
+        pairer = MOD.Pairer(self.expected)
+        pairer.add(
+            self.event(
+                socket.AF_INET,
+                100,
+                state=MOD.INVALID_NUD,
+                dst="198.51.100.1",
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        self.assertEqual(pairer.wrong_tenant, 0)
+        pairer.add(
+            self.event(
+                socket.AF_INET,
+                101,
+                dst="198.51.100.1",
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        self.assertEqual(pairer.wrong_tenant, 1)
+        with self.assertRaises(MOD.MeasurementError):
+            pairer.add(
+                self.event(
+                    socket.AF_INET,
+                    99,
+                    dst="192.0.2.1",
+                    lladdr="02:00:00:00:00:01",
+                )
+            )
+
+    def test_duplicate_event_identity_is_rejected(self):
+        duplicate = {**self.expected[0], "sample_id": "s2"}
+        with self.assertRaises(MOD.MeasurementError):
+            MOD.Pairer([*self.expected, duplicate])
+
+    def test_censor_freezes_missing_sides_and_late_duplicates(self):
+        pairer = MOD.Pairer(self.expected)
+        pairer.add(
+            self.event(
+                MOD.AF_BRIDGE,
+                100,
+                ifindex=12,
+                master=4,
+                vlan=10,
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        pairer.freeze(["s1"])
+        pairer.add(
+            self.event(
+                socket.AF_INET,
+                120,
+                dst="192.0.2.1",
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        pairer.add(
+            self.event(
+                MOD.AF_BRIDGE,
+                125,
+                ifindex=12,
+                master=4,
+                vlan=10,
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        row = pairer.rows()[0]
+        self.assertFalse(row["complete"])
+        self.assertEqual(row["missing_reason"], "missing-neighbor")
+        self.assertEqual(row["duplicate_fdb"], 0)
+        self.assertEqual((row["late_neighbor"], row["late_fdb"]), (1, 1))
+
+    def test_report_is_descriptive_split_by_family_and_timestamp_zero_is_present(self):
+        pairer = MOD.Pairer(self.expected)
+        pairer.add(
+            self.event(
+                MOD.AF_BRIDGE,
+                0,
+                ifindex=12,
+                master=4,
+                vlan=10,
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        pairer.add(
+            self.event(
+                socket.AF_INET,
+                30,
+                dst="192.0.2.1",
+                lladdr="02:00:00:00:00:01",
+            )
+        )
+        report = MOD.build_report(pairer.rows(), 1, 0)
+        self.assertTrue(report["descriptive_only"])
+        self.assertEqual(report["missing_fdb"], 0)
+        self.assertEqual(report["absolute_skew"]["p99_9_ns"], 30)
+        self.assertEqual(report["by_family"]["ipv4"]["complete"], 1)
+        self.assertEqual(report["directions"]["fdb_first"]["count"], 1)
+        with self.assertRaises(MOD.MeasurementError):
+            MOD.build_report(pairer.rows(), 2, 0)
+        with self.assertRaises(MOD.MeasurementError):
+            MOD.build_report(pairer.rows(), 1, 1)
+        with self.assertRaises(MOD.MeasurementError):
+            MOD.build_report(pairer.rows(), 1, 0, 0, {"w_safe_ns": 50})
+
+
+class PlanAndArtifactTests(unittest.TestCase):
+    def test_plan_is_exactly_split_bounded_and_globally_unique(self):
+        plan = MOD.deterministic_plan("burst-32")
+        rows = plan["planned"]
+        self.assertEqual(len(rows), 4000)
+        self.assertEqual(plan["active_limit"], 32)
+        self.assertEqual(plan["censor_seconds"], 5)
+        self.assertEqual(plan["wall_seconds"], 1200)
+        self.assertIsNone(plan["acceptance"])
+        self.assertEqual(len({row["sample_id"] for row in rows}), 4000)
+        self.assertEqual(len({row["mac"] for row in rows}), 4000)
+        counts = {
+            (vlan, family): sum(
+                row["vlan"] == vlan and row["family"] == family for row in rows
+            )
+            for vlan in (10, 20)
+            for family in (socket.AF_INET, socket.AF_INET6)
+        }
+        self.assertEqual(set(counts.values()), {1000})
+        with self.assertRaises(MOD.MeasurementError):
+            MOD.deterministic_plan("burst-8", 100, {"10": [110], "20": [210]})
+
+    def test_receipt_has_closed_inventory_and_explicit_missing_row(self):
+        run = MOD.deterministic_plan("serial-1")
+        run["planned"] = run["planned"][:1]
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "receipt"
+            MOD.write_receipt(run, [], output)
+            MOD.check_artifacts(output)
+            sample = (output / "samples.csv").read_text().splitlines()[1]
+            self.assertIn("missing-fdb-and-neighbor", sample)
+            self.assertEqual(set(path.name for path in output.iterdir()), {
+                "run.json", "samples.csv", "report.json"
+            })
+
+
+class TopologyRollbackTests(unittest.TestCase):
+    def test_mid_setup_failure_deletes_only_created_objects_and_restores_inventory(self):
+        topology = MOD.TrafficTopology(1)
+        command_calls = []
+
+        def fake_command(args, **_kwargs):
+            command_calls.append(args)
+            if args == ["ip", "netns", "list"]:
+                return "base-netns\n"
+            if args == ["ip", "-o", "link", "show"]:
+                return "base-links\n"
+            if args == ["ip", "link", "set", "rh1000", "master", "rbgpskbr0"]:
+                raise MOD.MeasurementError("injected mid-setup failure")
+            return ""
+
+        completed = lambda args, **_kwargs: __import__("subprocess").CompletedProcess(
+            args, 0, "", ""
+        )
+        with mock.patch.object(MOD.os, "geteuid", return_value=0), mock.patch.object(
+            MOD.shutil, "which", return_value="/fixture/tool"
+        ), mock.patch.object(MOD, "_command", side_effect=fake_command), mock.patch.object(
+            MOD.subprocess, "run", side_effect=completed
+        ) as cleanup:
+            with self.assertRaisesRegex(MOD.MeasurementError, "injected mid-setup failure"):
+                topology.__enter__()
+
+        cleanup_commands = [call.args[0] for call in cleanup.call_args_list]
+        self.assertEqual(
+            cleanup_commands,
+            [
+                ["ip", "link", "del", "rh1000"],
+                ["ip", "netns", "del", topology.namespace],
+                ["ip", "link", "del", topology.bridge],
+            ],
+        )
+        self.assertEqual(topology.created_host_ports, ["rh1000"])
+        self.assertNotIn(["ip", "link", "del", "rh1001"], cleanup_commands)
+        self.assertGreaterEqual(command_calls.count(["ip", "netns", "list"]), 2)
+        self.assertGreaterEqual(command_calls.count(["ip", "-o", "link", "show"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/netns-calibration/test_raw_bridge_skew.py
+++ b/bench/netns-calibration/test_raw_bridge_skew.py
@@ -227,6 +227,30 @@ class PairingTests(unittest.TestCase):
         self.assertEqual(row["duplicate_fdb"], 0)
         self.assertEqual((row["late_neighbor"], row["late_fdb"]), (1, 1))
 
+    def test_ready_drain_continues_after_an_irrelevant_datagram(self):
+        pairer = MOD.Pairer(self.expected)
+        neighbor = self.event(
+            socket.AF_INET,
+            120,
+            dst="192.0.2.1",
+            lladdr="02:00:00:00:00:01",
+        )
+
+        class ObserverFixture:
+            def __init__(self):
+                self.batches = [[], [neighbor]]
+
+            def ready(self):
+                return bool(self.batches)
+
+            def receive(self):
+                return self.batches.pop(0)
+
+        observer = ObserverFixture()
+        MOD._drain_ready(observer, pairer)
+        self.assertEqual(len(pairer.sides["s1"]["neighbor"]), 1)
+        self.assertEqual(observer.batches, [])
+
     def test_report_is_descriptive_split_by_family_and_timestamp_zero_is_present(self):
         pairer = MOD.Pairer(self.expected)
         pairer.add(

--- a/bench/netns-calibration/verify-receipt.py
+++ b/bench/netns-calibration/verify-receipt.py
@@ -609,12 +609,13 @@ def verify_skew_receipt(root: Path) -> str:
     for name in files:
         path = root / name
         require(path.is_file() and not path.is_symlink(), f"bad skew artifact: {name}")
-        require(path.stat().st_size <= 10 * 1024 * 1024, f"oversized skew artifact: {name}")
+        limit = SKEW_RECEIPT_FILES[f"guest/skew/{name}"]
+        require(path.stat().st_size <= limit, f"oversized skew artifact: {name}")
     require(sum((root / name).stat().st_size for name in files) <= 10 * 1024 * 1024, "skew artifacts exceed 10 MiB total")
     module_path = Path(__file__).with_name("raw_bridge_skew.py")
     spec = importlib.util.spec_from_file_location("raw_bridge_skew_verify", module_path)
+    require(spec is not None and spec.loader is not None, "cannot load skew recomputer")
     module = importlib.util.module_from_spec(spec)
-    require(spec.loader is not None, "cannot load skew recomputer")
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     run = load_json(root / "run.json")

--- a/bench/netns-calibration/verify-receipt.py
+++ b/bench/netns-calibration/verify-receipt.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import csv
 import hashlib
+import importlib.util
 import json
 import re
 import sys
@@ -59,6 +60,13 @@ EXPECTED: dict[str, Any] = {
             },
         },
     ],
+    "raw_bridge_skew": {
+        "active_limits": {"burst-32": 32, "burst-8": 8, "serial-1": 1},
+        "censor_seconds": 5,
+        "pairs_per_profile": 4000,
+        "vm_timeout_seconds": 1500,
+        "wall_seconds": 1200,
+    },
     "schema": 1,
     "vm": {
         "machine": "pc-q35-8.2",
@@ -76,6 +84,11 @@ RECEIPT_FILES = {
     "plan.json": 64 * 1024,
     "quiet.tsv": 64 * 1024,
     "request.json": 64 * 1024,
+}
+SKEW_RECEIPT_FILES = {
+    "guest/skew/report.json": 1024 * 1024,
+    "guest/skew/run.json": 8 * 1024 * 1024,
+    "guest/skew/samples.csv": 8 * 1024 * 1024,
 }
 QUIET_FIELDS = [
     "sample",
@@ -99,6 +112,7 @@ SOURCE_PATHS = {
     "runner": "bench/netns-calibration/run-vm.sh",
     "verifier": "bench/netns-calibration/verify-receipt.py",
 }
+SKEW_SOURCE_PATH = "bench/netns-calibration/raw_bridge_skew.py"
 
 
 class VerificationError(ValueError):
@@ -113,7 +127,21 @@ def require(condition: bool, message: str) -> None:
 def load_json(path: Path) -> dict[str, Any]:
     require(path.is_file() and not path.is_symlink(), f"not a regular file: {path}")
     try:
-        value = json.loads(path.read_text())
+        def reject_constant(value: str) -> None:
+            raise VerificationError(f"non-finite JSON number: {value}")
+
+        def reject_duplicates(items: list[tuple[str, Any]]) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, value in items:
+                require(key not in result, f"duplicate JSON key: {key}")
+                result[key] = value
+            return result
+
+        value = json.loads(
+            path.read_text(),
+            parse_constant=reject_constant,
+            object_pairs_hook=reject_duplicates,
+        )
     except (OSError, json.JSONDecodeError) as exc:
         raise VerificationError(f"cannot parse {path}: {exc}") from exc
     require(isinstance(value, dict), f"{path} must contain one JSON object")
@@ -234,6 +262,7 @@ def verify_source_contract(repo: Path, runner: Path | None = None, guest: Path |
     guest = guest or repo / SOURCE_PATHS["guest"]
     runner_text = runner.read_text()
     guest_text = guest.read_text()
+    skew_text = (repo / SKEW_SOURCE_PATH).read_text()
     anchors = [
         "if [ \"$EUID\" -eq 0 ]; then",
         "SCRIPT_DIR=$(cd --",
@@ -293,6 +322,16 @@ def verify_source_contract(repo: Path, runner: Path | None = None, guest: Path |
         require(runner_text.count(anchor) == 1, f"runner tool-path anchor changed: {anchor}")
     for forbidden in ("command -v qemu-system-x86_64", "command -v cloud-localds"):
         require(forbidden not in runner_text, f"runner resolves a pinned tool through PATH: {forbidden}")
+    campaign_runner_anchors = [
+        "CAMPAIGN=''",
+        'if [ "$#" -eq 5 ] && [ "$1" = --raw-bridge-skew ]; then',
+        'CAMPAIGN_TIMEOUT_SECONDS=$(python3 "$VERIFIER" skew-select "$PROFILES" "$CAMPAIGN")',
+        'paths["raw_bridge_skew"] = "bench/netns-calibration/raw_bridge_skew.py"',
+        'cp -- "$SKEW" "$PAYLOAD_DIR/"',
+        'TIMEOUT_SECONDS=$CAMPAIGN_TIMEOUT_SECONDS',
+    ]
+    for anchor in campaign_runner_anchors:
+        require(runner_text.count(anchor) == 1, f"runner campaign anchor changed: {anchor}")
     cleanup_anchor = 'ip netns del "$NETNS" >/dev/null 2>&1 || rc=1'
     require(guest_text.count(cleanup_anchor) == 1, "guest failure cleanup is not unique")
     guest_anchors = [
@@ -307,6 +346,14 @@ def verify_source_contract(repo: Path, runner: Path | None = None, guest: Path |
         guest_positions.append(guest_text.index(anchor))
     require(guest_positions == sorted(guest_positions), "guest cleanup lifecycle changed")
     require(guest_text.index(cleanup_anchor) < guest_positions[0], "guest trap does not use the cleanup helper")
+    campaign_guest_anchors = [
+        'campaign=$(python3 -c',
+        "python3 /mnt/payload/raw_bridge_skew.py",
+        '--campaign "$campaign" --output "$output/skew"',
+        "raw bridge skew campaign left netns residue",
+    ]
+    for anchor in campaign_guest_anchors:
+        require(guest_text.count(anchor) == 1, f"guest campaign anchor changed: {anchor}")
     bootstrap_anchors = [
         "mount -t 9p -o trans=virtio,version=9p2000.L,ro payload",
         "mount -t 9p -o trans=virtio,version=9p2000.L receipt",
@@ -321,6 +368,9 @@ def verify_source_contract(repo: Path, runner: Path | None = None, guest: Path |
     command = re.compile(r"^\s*(sudo|docker|curl|wget)\b", re.MULTILINE)
     require(command.search(runner_text) is None, "runner gained a forbidden host command")
     require(command.search(guest_text) is None, "guest gained a forbidden command")
+    require(skew_text.count("self.socket.bind((0, RTMGRP_NEIGH))") == 1, "collector socket binding changed")
+    for forbidden in ("bridge fdb add", "bridge fdb replace", "ip neigh add", "ip neigh replace"):
+        require(forbidden not in skew_text, f"collector gained a synthetic measured stimulus: {forbidden}")
 
 
 def verify_quiet(path: Path) -> None:
@@ -361,27 +411,61 @@ def exact_keys(value: dict[str, Any], keys: set[str], label: str) -> None:
     require(set(value) == keys, f"{label} has missing or extra fields")
 
 
+def same_typed_value(actual: Any, expected: Any) -> bool:
+    if type(actual) is not type(expected):
+        return False
+    if isinstance(expected, dict):
+        return set(actual) == set(expected) and all(
+            same_typed_value(actual[key], expected[key]) for key in expected
+        )
+    if isinstance(expected, list):
+        return len(actual) == len(expected) and all(
+            same_typed_value(left, right) for left, right in zip(actual, expected, strict=True)
+        )
+    return actual == expected
+
+
 def verify_receipt(profiles_path: Path, root: Path, write_manifest: bool) -> None:
     profiles = verify_profiles(profiles_path)
     require(root.is_dir() and not root.is_symlink(), "receipt root must be a real directory")
+    request = load_json(root / "request.json")
+    campaign = request.get("raw_bridge_skew")
+    if campaign is None:
+        exact_keys(request, {"git", "image", "profile", "schema", "sources"}, "request")
+        receipt_files = dict(RECEIPT_FILES)
+        source_paths = dict(SOURCE_PATHS)
+        allowed_directories = {"guest"}
+    else:
+        exact_keys(
+            request,
+            {"git", "image", "profile", "raw_bridge_skew", "schema", "sources"},
+            "campaign request",
+        )
+        require(isinstance(campaign, dict), "raw bridge skew request must be an object")
+        exact_keys(campaign, {"profile"}, "raw bridge skew request")
+        require(
+            campaign["profile"] in profiles["raw_bridge_skew"]["active_limits"],
+            "unknown raw bridge skew profile",
+        )
+        receipt_files = {**RECEIPT_FILES, **SKEW_RECEIPT_FILES}
+        source_paths = {**SOURCE_PATHS, "raw_bridge_skew": SKEW_SOURCE_PATH}
+        allowed_directories = {"guest", "guest/skew"}
     found: set[str] = set()
     for path in root.rglob("*"):
         relative = path.relative_to(root).as_posix()
         require(not path.is_symlink(), f"receipt contains a symlink: {relative}")
         if path.is_dir():
-            require(relative == "guest", f"receipt contains an unexpected directory: {relative}")
+            require(relative in allowed_directories, f"receipt contains an unexpected directory: {relative}")
             continue
         require(path.is_file(), f"receipt contains a non-regular path: {relative}")
         found.add(relative)
-    allowed = set(RECEIPT_FILES)
+    allowed = set(receipt_files)
     if (root / "SHA256SUMS").exists():
         allowed.add("SHA256SUMS")
     require(found == allowed, f"receipt file set mismatch: got {sorted(found)}")
-    for relative, limit in RECEIPT_FILES.items():
+    for relative, limit in receipt_files.items():
         require((root / relative).stat().st_size <= limit, f"receipt artifact is oversized: {relative}")
 
-    request = load_json(root / "request.json")
-    exact_keys(request, {"git", "image", "profile", "schema", "sources"}, "request")
     require(request["schema"] == 1, "request schema mismatch")
     profile = selected_profile(profiles, request["profile"])
     require(request["image"] == profile["source"], "request mixed or changed its image tuple")
@@ -391,8 +475,8 @@ def verify_receipt(profiles_path: Path, root: Path, write_manifest: bool) -> Non
     require(git["commit"] == git["origin_main"], "request commit is not exact origin/main")
     require(git["dirty"] is False and git["status_sha256"] == EMPTY_SHA256, "dirty source is not publishable")
     repo = Path(__file__).resolve().parents[2]
-    require(set(request["sources"]) == set(SOURCE_PATHS), "request source inventory mismatch")
-    for name, relative in SOURCE_PATHS.items():
+    require(set(request["sources"]) == set(source_paths), "request source inventory mismatch")
+    for name, relative in source_paths.items():
         require(request["sources"][name] == sha256(repo / relative), f"source hash mismatch: {name}")
 
     plan = load_json(root / "plan.json")
@@ -491,14 +575,23 @@ def verify_receipt(profiles_path: Path, root: Path, write_manifest: bool) -> Non
         "guest smoke surface mismatch",
     )
 
-    for relative in RECEIPT_FILES:
-        if relative.endswith((".json", ".tsv", ".log")):
+    if campaign is not None:
+        measured_profile = verify_skew_receipt(root / "guest/skew")
+        require(
+            measured_profile == campaign["profile"],
+            "raw bridge skew request/result profile mismatch",
+        )
+
+    for relative in receipt_files:
+        if relative.endswith((".csv", ".json", ".tsv", ".log")):
             text = (root / relative).read_text(errors="replace")
             for forbidden in ("/home/", "github_pat_", "ghp_", "GITHUB_TOKEN", "AWS_SECRET", "Authorization:"):
                 require(forbidden not in text, f"unsanitized receipt content in {relative}")
 
     manifest_path = root / "SHA256SUMS"
-    expected_manifest = "".join(f"{sha256(root / relative)}  {relative}\n" for relative in sorted(RECEIPT_FILES))
+    expected_manifest = "".join(
+        f"{sha256(root / relative)}  {relative}\n" for relative in sorted(receipt_files)
+    )
     if manifest_path.exists():
         require(manifest_path.is_file() and not manifest_path.is_symlink(), "bad SHA256SUMS path")
         require(manifest_path.read_text() == expected_manifest, "SHA256SUMS does not seal the exact receipt")
@@ -506,6 +599,129 @@ def verify_receipt(profiles_path: Path, root: Path, write_manifest: bool) -> Non
         manifest_path.write_text(expected_manifest)
     else:
         raise VerificationError("receipt has no SHA256SUMS (pass --write-manifest only at finalization)")
+
+
+def verify_skew_receipt(root: Path) -> str:
+    """Recompute a raw-bridge skew report from its closed plan and rows."""
+    files = {"run.json", "samples.csv", "report.json"}
+    require(root.is_dir() and not root.is_symlink(), "skew receipt root is not a real directory")
+    require({path.name for path in root.iterdir()} == files, "skew receipt inventory mismatch")
+    for name in files:
+        path = root / name
+        require(path.is_file() and not path.is_symlink(), f"bad skew artifact: {name}")
+        require(path.stat().st_size <= 10 * 1024 * 1024, f"oversized skew artifact: {name}")
+    require(sum((root / name).stat().st_size for name in files) <= 10 * 1024 * 1024, "skew artifacts exceed 10 MiB total")
+    module_path = Path(__file__).with_name("raw_bridge_skew.py")
+    spec = importlib.util.spec_from_file_location("raw_bridge_skew_verify", module_path)
+    module = importlib.util.module_from_spec(spec)
+    require(spec.loader is not None, "cannot load skew recomputer")
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    run = load_json(root / "run.json")
+    require(
+        set(run)
+        == {
+            "acceptance",
+            "active_limit",
+            "censor_seconds",
+            "planned",
+            "profile",
+            "schema",
+            "topology",
+            "wall_seconds",
+        },
+        "run.json shape mismatch",
+    )
+    require(run["schema"] == 1 and run["profile"] in {"serial-1", "burst-8", "burst-32"}, "bad campaign identity")
+    require(run["active_limit"] == {"serial-1": 1, "burst-8": 8, "burst-32": 32}[run["profile"]], "profile concurrency mismatch")
+    require(run["active_limit"] <= 32 and run["censor_seconds"] == 5 and run["wall_seconds"] == 1200, "campaign bounds mismatch")
+    require(run["acceptance"] is None, "campaign must remain descriptive without external acceptance inputs")
+    topology = run["topology"]
+    require(isinstance(topology, dict), "campaign topology must be an object")
+    exact_keys(topology, {"bridge_ifindex", "port_ifindexes"}, "campaign topology")
+    bridge_ifindex = topology["bridge_ifindex"]
+    ports = topology["port_ifindexes"]
+    require(type(bridge_ifindex) is int and bridge_ifindex > 0, "bad bridge ifindex")
+    require(isinstance(ports, dict), "campaign port map must be an object")
+    try:
+        expected_run = module.deterministic_plan(run["profile"], bridge_ifindex, ports)
+    except (RuntimeError, TypeError, ValueError, KeyError) as exc:
+        raise VerificationError(f"invalid campaign topology: {exc}") from exc
+    require(
+        same_typed_value(run, expected_run),
+        "run.json is not the exact closed deterministic plan",
+    )
+    planned = run["planned"]
+    require(isinstance(planned, list) and len(planned) == 4000, "campaign denominator must be 4,000")
+    expected_header = module.SAMPLE_FIELDS
+    with (root / "samples.csv").open(newline="") as stream:
+        reader = csv.DictReader(stream)
+        require(reader.fieldnames == expected_header, "samples.csv header mismatch")
+        samples = list(reader)
+    require(len(samples) == 4000, "samples.csv denominator mismatch")
+    require(
+        [row["sample_id"] for row in samples] == [row["sample_id"] for row in planned],
+        "samples do not exactly follow plan",
+    )
+
+    def decimal(value: str, label: str, *, signed: bool = False) -> int:
+        pattern = r"-?(?:0|[1-9][0-9]*)" if signed else r"(?:0|[1-9][0-9]*)"
+        require(re.fullmatch(pattern, value) is not None, f"bad sample integer: {label}")
+        return int(value)
+
+    rows = []
+    for expected, sample in zip(planned, samples, strict=True):
+        for field in ("sample_id", "profile", "phase"):
+            require(sample[field] == str(expected[field]), f"sample metadata mismatch: {field}")
+        require(
+            decimal(sample["family"], "family") == expected["family"]
+            and decimal(sample["vlan"], "vlan") == expected["vlan"],
+            "sample family/VLAN mismatch",
+        )
+        complete = sample["complete"] == "true"
+        require(sample["complete"] in {"true", "false"}, "bad complete value")
+        neighbor = decimal(sample["neighbor_ns"], "neighbor_ns") if sample["neighbor_ns"] else None
+        fdb = decimal(sample["fdb_ns"], "fdb_ns") if sample["fdb_ns"] else None
+        skew = decimal(sample["skew_ns"], "skew_ns", signed=True) if sample["skew_ns"] else None
+        require(complete == (neighbor is not None and fdb is not None), "complete row mismatch")
+        require(skew == (neighbor - fdb if complete else None), "signed skew mismatch")
+        missing_reason = (
+            ""
+            if complete
+            else "missing-fdb-and-neighbor"
+            if neighbor is None and fdb is None
+            else "missing-neighbor"
+            if neighbor is None
+            else "missing-fdb"
+        )
+        require(sample["missing_reason"] == missing_reason, "missing reason mismatch")
+        rows.append(
+            {
+                **expected,
+                "complete": complete,
+                "missing_reason": missing_reason,
+                "neighbor_ns": neighbor,
+                "fdb_ns": fdb,
+                "skew_ns": skew,
+                "duplicate_neighbor": decimal(sample["duplicate_neighbor"], "duplicate_neighbor"),
+                "duplicate_fdb": decimal(sample["duplicate_fdb"], "duplicate_fdb"),
+                "delete_events": decimal(sample["delete_events"], "delete_events"),
+                "late_neighbor": decimal(sample["late_neighbor"], "late_neighbor"),
+                "late_fdb": decimal(sample["late_fdb"], "late_fdb"),
+                "late_delete": decimal(sample["late_delete"], "late_delete"),
+            }
+        )
+    report = load_json(root / "report.json")
+    require(
+        report.get("wrong_tenant") == 0 and report.get("ambiguous_tenant") == 0,
+        "wrong-tenant and ambiguity hard gates must be literal zero",
+    )
+    recomputed = module.build_report(rows, 4000, 0, 0, run["acceptance"])
+    require(
+        same_typed_value(report, recomputed),
+        "report.json does not recompute from planned samples",
+    )
+    return run["profile"]
 
 
 def main() -> int:
@@ -516,6 +732,9 @@ def main() -> int:
     select_parser = sub.add_parser("select")
     select_parser.add_argument("profiles", type=Path)
     select_parser.add_argument("name")
+    skew_select_parser = sub.add_parser("skew-select")
+    skew_select_parser.add_argument("profiles", type=Path)
+    skew_select_parser.add_argument("name")
     plan_parser = sub.add_parser("plan")
     plan_parser.add_argument("profiles", type=Path)
     plan_parser.add_argument("plan", type=Path)
@@ -534,6 +753,8 @@ def main() -> int:
     receipt_parser.add_argument("profiles", type=Path)
     receipt_parser.add_argument("root", type=Path)
     receipt_parser.add_argument("--write-manifest", action="store_true")
+    skew_parser = sub.add_parser("skew-receipt")
+    skew_parser.add_argument("root", type=Path)
     args = parser.parse_args()
     try:
         if args.command == "profiles":
@@ -545,6 +766,13 @@ def main() -> int:
             print(profile["source"]["url"])
             print(profiles["host_tools"]["qemu_system_x86"]["path"])
             print(profiles["host_tools"]["cloud_image_utils"]["path"])
+        elif args.command == "skew-select":
+            profiles = verify_profiles(args.profiles)
+            require(
+                args.name in profiles["raw_bridge_skew"]["active_limits"],
+                f"unknown raw bridge skew profile: {args.name}",
+            )
+            print(profiles["raw_bridge_skew"]["vm_timeout_seconds"])
         elif args.command == "plan":
             verify_plan(args.profiles, args.plan)
         elif args.command == "argv":
@@ -562,8 +790,10 @@ def main() -> int:
             sys.stdout.buffer.write(b"\0".join(item.encode() for item in argv) + b"\0")
         elif args.command == "source":
             verify_source_contract(args.repo.resolve(), args.runner, args.guest)
-        else:
+        elif args.command == "receipt":
             verify_receipt(args.profiles, args.root, args.write_manifest)
+        else:
+            verify_skew_receipt(args.root)
     except (OSError, VerificationError, ValueError, KeyError, TypeError) as exc:
         print(f"netns calibration receipt error: {exc}", file=sys.stderr)
         return 1

--- a/bench/tests/test-netns-calibration-vm.sh
+++ b/bench/tests/test-netns-calibration-vm.sh
@@ -212,6 +212,15 @@ assert "guest/skew/run.json" in manifest
 assert "guest/skew/samples.csv" in manifest
 assert "guest/skew/report.json" in manifest
 
+oversized_skew = tmp / "skew-oversized-report"
+shutil.copytree(campaign / "guest/skew", oversized_skew)
+report_path = oversized_skew / "report.json"
+padding = verify.SKEW_RECEIPT_FILES["guest/skew/report.json"] + 1 - report_path.stat().st_size
+assert padding > 0
+with report_path.open("a") as stream:
+    stream.write(" " * padding)
+expect(False, "skew-oversized-report", "skew-receipt", oversized_skew)
+
 def mutate_campaign_json(path, relative, mutate):
     value = json.loads((path / relative).read_text())
     mutate(value)

--- a/bench/tests/test-netns-calibration-vm.sh
+++ b/bench/tests/test-netns-calibration-vm.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 export PYTHONDONTWRITEBYTECODE=1
 
 repo=$(git rev-parse --show-toplevel)
+python3 -m unittest -v "$repo/bench/netns-calibration/test_raw_bridge_skew.py"
 profiles="$repo/bench/netns-calibration/profiles.json"
 verifier="$repo/bench/netns-calibration/verify-receipt.py"
 runner="$repo/bench/netns-calibration/run-vm.sh"
@@ -188,6 +189,51 @@ expect(True, "valid-sealed", "receipt", profiles_path, base)
 unsealed = tmp / "receipt-unsuccessful"; shutil.copytree(base, unsealed)
 (unsealed / "SHA256SUMS").unlink()
 expect(False, "unsuccessful-receipt-is-unsealed", "receipt", profiles_path, unsealed)
+
+# The explicit campaign path expands the otherwise byte-stable smoke receipt
+# by exactly one request/source field and three sealed nested artifacts.
+raw_path = repo / "bench/netns-calibration/raw_bridge_skew.py"
+raw_spec = importlib.util.spec_from_file_location("raw_bridge_skew_fixture", raw_path)
+raw = importlib.util.module_from_spec(raw_spec)
+assert raw_spec.loader is not None
+sys.modules[raw_spec.name] = raw
+raw_spec.loader.exec_module(raw)
+campaign = tmp / "receipt-campaign"; shutil.copytree(base, campaign)
+(campaign / "SHA256SUMS").unlink()
+campaign_request = json.loads((campaign / "request.json").read_text())
+campaign_request["raw_bridge_skew"] = {"profile": "burst-8"}
+campaign_request["sources"]["raw_bridge_skew"] = verify.sha256(raw_path)
+write_json(campaign / "request.json", campaign_request)
+raw.write_receipt(raw.deterministic_plan("burst-8"), [], campaign / "guest/skew")
+expect(True, "valid-campaign-finalize", "receipt", profiles_path, campaign, "--write-manifest")
+expect(True, "valid-campaign-sealed", "receipt", profiles_path, campaign)
+manifest = (campaign / "SHA256SUMS").read_text()
+assert "guest/skew/run.json" in manifest
+assert "guest/skew/samples.csv" in manifest
+assert "guest/skew/report.json" in manifest
+
+def mutate_campaign_json(path, relative, mutate):
+    value = json.loads((path / relative).read_text())
+    mutate(value)
+    write_json(path / relative, value)
+
+for name, mutate in {
+    "campaign-missing": lambda p: (p / "guest/skew/report.json").unlink(),
+    "campaign-extra": lambda p: (p / "guest/skew/extra.txt").write_text("extra\n"),
+    "campaign-tampered-plan": lambda p: mutate_campaign_json(
+        p, "guest/skew/run.json", lambda x: x["planned"][0].update(ip="192.0.2.99")
+    ),
+    "campaign-nonzero-wrong-tenant": lambda p: mutate_campaign_json(
+        p, "guest/skew/report.json", lambda x: x.update(wrong_tenant=1)
+    ),
+    "campaign-profile-mismatch": lambda p: mutate_campaign_json(
+        p, "request.json", lambda x: x["raw_bridge_skew"].update(profile="serial-1")
+    ),
+}.items():
+    candidate = tmp / f"receipt-{name}"; shutil.copytree(campaign, candidate)
+    (candidate / "SHA256SUMS").unlink()
+    mutate(candidate)
+    expect(False, name, "receipt", profiles_path, candidate, "--write-manifest")
 
 def receipt_mutation(name, mutate):
     path = tmp / f"receipt-{name}"; shutil.copytree(base, path)


### PR DESCRIPTION
## Summary

- observe bridge FDB and IP-neighbor notifications through one raw netlink socket and pair exact VLAN/family identities
- add an opt-in 4,000-sample serial/burst VM path while preserving the existing smoke default
- freeze censored samples and atomically seal recomputable descriptive artifacts with cleanup and identity checks

## Validation

- `bash bench/tests/test-netns-calibration-vm.sh`
- `python3 scripts/check_developer_tooling.py`
- `bash -n bench/netns-calibration/run-vm.sh bench/netns-calibration/guest-smoke.sh bench/tests/test-netns-calibration-vm.sh`
- `shellcheck -x bench/netns-calibration/run-vm.sh bench/netns-calibration/guest-smoke.sh bench/tests/test-netns-calibration-vm.sh`
- disposable current-kernel Docker smoke: 2/2 IPv4/IPv6 pairs complete with zero missing, duplicate, late, wrong-identity, ambiguity, or cleanup-residue counters

No pinned-image campaigns were run.