### PR TITLE
bench: harden raw bridge event observation

### DIFF
--- a/bench/netns-calibration/README.md
+++ b/bench/netns-calibration/README.md
@@ -87,18 +87,34 @@ IPv4/IPv6. The profiles release one, eight, or 32 UDP sends together; no more
 than 32 samples are active. Each batch freezes after completion or five
 seconds, and the campaign has a 1,200-second internal wall inside a separate
 1,500-second VM timeout. Late events remain diagnostics and cannot change a
-frozen sample. `raw_bridge_skew.py --plan PROFILE` prints a deterministic
-shape preview with placeholder ifindexes, not an executable receipt.
+frozen sample. After the sender exits, every planned IP in the frozen batch is
+idempotently retired, all resulting notifications are drained, and a `nud all`
+inventory must prove that zero planned neighbors remain before the next batch.
+`raw_bridge_skew.py --plan PROFILE` prints a schema-2 deterministic shape
+preview with placeholder ifindexes and null runtime receive-capacity fields,
+not an executable receipt.
 
 The campaign has no acceptance threshold. Until an external safe window and
 loss rule are predeclared, its output is descriptive and production behavior
 remains deferred. No pinned-image campaign is run by the offline suite.
 
-The decoder uses one `NETLINK_ROUTE` socket bound to the `RTMGRP_NEIGH` bitmask
-4 and rejects receive overflow, truncation, malformed framing, non-kernel
-events, clock regression, and ambiguous identity. IP-neighbor messages are
-paired only through the deterministic expected table; they never infer a VLAN.
-`RTM_DELNEIGH` observations and duplicate or missing sides remain explicit.
+The decoder uses one continuously drained `NETLINK_ROUTE` socket bound to the
+`RTMGRP_NEIGH` bitmask 4. A background receive owner timestamps and parses in
+socket order while only the foreground mutates pairing state. Before binding,
+the collector requests a 4 MiB `SO_RCVBUF`, falls back to
+`SO_RCVBUFFORCE` when the ordinary request is capped, and requires the reported
+Linux capacity to be at least 8 MiB. Requested/effective capacity, force use,
+and the zero planned-neighbor retirement bound are retained in `run.json`.
+Receive overflow, truncation, malformed framing, non-kernel events, clock
+regression, and ambiguous identity remain fatal, including errors observed
+after an apparently complete pair or during synchronized shutdown. IP-neighbor
+messages are paired only through the deterministic expected table; they never
+infer a VLAN. The `recvmsg` sender must always be the kernel and netlink
+sequence must remain zero; Linux's request-correlated `NUD_FAILED` invalidation
+may retain the administrator request's port ID in the message header only when
+it has no LLADDR. `RTM_DELNEIGH` observations with measured identity and
+duplicate or missing sides remain explicit; maintenance deletes without an
+LLADDR are strictly parsed but do not change a frozen sample's diagnostics.
 The three campaign artifacts are staged in a fresh sibling directory, checked
 against a 10 MiB aggregate limit, and atomically published. The outer VM
 receipt verifier recomputes the exact plan and report, hard-requires zero

--- a/bench/netns-calibration/raw_bridge_skew.py
+++ b/bench/netns-calibration/raw_bridge_skew.py
@@ -16,10 +16,12 @@ import socket
 import struct
 import subprocess
 import tempfile
+import threading
 import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Callable, cast
 
 NETLINK_ROUTE = 0
 RTMGRP_NEIGH = 4
@@ -35,11 +37,69 @@ MSG_TRUNC = getattr(socket, "MSG_TRUNC", 0x20)
 MAX_ARTIFACT_BYTES = 10 * 1024 * 1024
 VALID_NUD = 0x02 | 0x04 | 0x40 | 0x80
 INVALID_NUD = 0x01 | 0x08 | 0x10 | 0x20
+NUD_FAILED = 0x20
 CAMPAIGNS = {"serial-1": 1, "burst-8": 8, "burst-32": 32}
+REQUESTED_RECEIVE_BYTES = 4 * 1024 * 1024
+LINUX_RCVBUF_ACCOUNTING = 2
+SO_RCVBUFFORCE = 33
+POST_RETIRE_NEIGHBOR_LIMIT = 0
 
 
 class MeasurementError(RuntimeError):
     """The measurement lost data, identity, or its closed execution boundary."""
+
+
+def _combine_errors(
+    primary: BaseException | None,
+    secondary: BaseException,
+    context: str,
+) -> BaseException:
+    if primary is None:
+        return secondary
+    if str(secondary) in str(primary):
+        return primary
+    return MeasurementError(f"{primary}; additionally {context}: {secondary}")
+
+
+@dataclass(frozen=True)
+class ReceiveCapacity:
+    requested_bytes: int
+    effective_bytes: int
+    forced: bool
+
+
+def _admit_receive_capacity(sock: socket.socket, requested: int) -> ReceiveCapacity:
+    """Prove Linux's doubled receive-buffer accounting before subscribing."""
+    if type(requested) is not int or requested <= 0:
+        raise MeasurementError("receive-buffer request must be a positive integer")
+    required = requested * LINUX_RCVBUF_ACCOUNTING
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, requested)
+        effective = int(sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF))
+    except OSError as exc:
+        raise MeasurementError(f"cannot request NETLINK_ROUTE receive capacity: {exc}") from exc
+    forced = False
+    if effective < required:
+        forced = True
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, SO_RCVBUFFORCE, requested)
+            effective = int(sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF))
+        except OSError as exc:
+            try:
+                effective = int(sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF))
+            except OSError:
+                pass
+            raise MeasurementError(
+                "NETLINK_ROUTE receive capacity is capped "
+                f"at {effective} bytes; {required} bytes are required and "
+                f"SO_RCVBUFFORCE failed: {exc}"
+            ) from exc
+    if effective < required:
+        raise MeasurementError(
+            "NETLINK_ROUTE receive capacity is undersized: "
+            f"got {effective} bytes, require at least {required}"
+        )
+    return ReceiveCapacity(requested, effective, forced)
 
 
 def align4(value: int) -> int:
@@ -117,8 +177,8 @@ def parse_datagram(
         if kind in (NLMSG_OVERRUN, NLMSG_ERROR):
             raise MeasurementError("NLMSG_OVERRUN/ERROR")
         if kind in (RTM_NEWNEIGH, RTM_DELNEIGH):
-            if seq != 0 or pid != 0:
-                raise MeasurementError("relevant event has non-kernel pid/sequence")
+            if seq != 0:
+                raise MeasurementError("relevant event has nonzero sequence")
             if length < 28:
                 raise MeasurementError("short ndmsg")
             family, _pad1, _pad2, ifindex, state, ndflags, _ndtype = struct.unpack_from(
@@ -134,6 +194,15 @@ def parse_datagram(
                 lladdr = attrs.get(NDA_LLADDR)
                 if lladdr is not None and len(lladdr) != 6:
                     raise MeasurementError("bad NDA_LLADDR length")
+                request_correlated_invalidation = (
+                    kind == RTM_NEWNEIGH
+                    and family in (AF_INET, AF_INET6)
+                    and state == NUD_FAILED
+                    and NDA_DST in attrs
+                    and lladdr is None
+                )
+                if pid != 0 and not request_correlated_invalidation:
+                    raise MeasurementError("relevant event has unexpected header pid")
                 events.append(
                     Event(
                         message="new" if kind == RTM_NEWNEIGH else "delete",
@@ -174,23 +243,106 @@ def parse_datagram(
     return events
 
 
+class _Sync:
+    pass
+
+
+class _Closed:
+    pass
+
+
 class Observer:
-    """Exactly one standard-library NETLINK_ROUTE multicast socket."""
+    """One NETLINK_ROUTE socket with a continuously draining receive owner."""
 
-    def __init__(self, receive_bytes: int = 4 * 1024 * 1024):
-        self.socket = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_ROUTE)
-        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, receive_bytes)
-        self.socket.bind((0, RTMGRP_NEIGH))
+    def __init__(self, receive_bytes: int = REQUESTED_RECEIVE_BYTES):
+        netlink = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_ROUTE)
+        try:
+            capacity = _admit_receive_capacity(netlink, receive_bytes)
+            netlink.bind((0, RTMGRP_NEIGH))
+            self._start(netlink, capacity, parse_datagram)
+        except BaseException:
+            netlink.close()
+            raise
 
-    def ready(self, timeout_seconds: float = 0.0) -> bool:
-        readable, _, _ = select.select(
-            [self.socket], [], [], max(0.0, timeout_seconds)
+    @classmethod
+    def _for_test(
+        cls,
+        source: socket.socket,
+        decoder: Callable[[bytes, int, int, int], list[Event]],
+    ) -> "Observer":
+        observer = cls.__new__(cls)
+        observer._start(source, ReceiveCapacity(1, 2, False), decoder)
+        return observer
+
+    def _start(
+        self,
+        netlink: socket.socket,
+        capacity: ReceiveCapacity,
+        decoder: Callable[[bytes, int, int, int], list[Event]],
+    ) -> None:
+        self.socket = netlink
+        self.capacity = capacity
+        self._decoder = decoder
+        self._control_tx, self._control_rx = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._condition = threading.Condition()
+        self._items: deque[object] = deque()
+        self._failure: BaseException | None = None
+        self._started = False
+        self._closed = False
+        self._thread = threading.Thread(
+            target=self._receive_owner,
+            name="raw-bridge-skew-netlink-receiver",
+            daemon=False,
         )
-        return bool(readable)
+        deadline = time.monotonic() + 5
+        started = False
+        try:
+            self._thread.start()
+            started = True
+            with self._condition:
+                while not self._started and self._failure is None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise MeasurementError("observer receive owner did not start")
+                    self._condition.wait(remaining)
+                if self._failure is not None:
+                    raise self._failure
+        except BaseException as exc:
+            if started:
+                teardown_error = self._stop_failed_start()
+            else:
+                self._close_fds()
+                teardown_error = None
+            if teardown_error is not None:
+                raise _combine_errors(exc, teardown_error, "observer start teardown")
+            raise
 
-    def receive(self, timeout_seconds: float | None = None) -> list[Event]:
-        if timeout_seconds is not None and not self.ready(timeout_seconds):
-            return []
+    def _close_fds(self) -> None:
+        self.socket.close()
+        self._control_tx.close()
+        self._control_rx.close()
+
+    def _stop_failed_start(self) -> BaseException | None:
+        try:
+            self._control_tx.sendall(b"X")
+        except OSError:
+            pass
+        self._thread.join(timeout=1)
+        if self._thread.is_alive():
+            self._close_fds()
+            self._thread.join(timeout=5)
+        else:
+            self._close_fds()
+        if self._thread.is_alive():
+            return MeasurementError("observer receive owner survived failed start teardown")
+        return None
+
+    def _publish(self, item: object) -> None:
+        with self._condition:
+            self._items.append(item)
+            self._condition.notify_all()
+
+    def _receive_once(self) -> None:
         try:
             data, _ancillary, flags, address = self.socket.recvmsg(65536)
         except OSError as exc:
@@ -198,10 +350,123 @@ class Observer:
                 raise MeasurementError("NETLINK_ROUTE ENOBUFS") from exc
             raise
         timestamp_ns = time.clock_gettime_ns(time.CLOCK_MONOTONIC_RAW)
-        return parse_datagram(data, address[0], flags, timestamp_ns)
+        sender_pid = address[0] if isinstance(address, tuple) and address else 0
+        events = self._decoder(data, sender_pid, flags, timestamp_ns)
+        if events:
+            self._publish(events)
 
-    def close(self) -> None:
-        self.socket.close()
+    def _drain_source(self) -> None:
+        while select.select([self.socket], [], [], 0.0)[0]:
+            self._receive_once()
+
+    def _receive_owner(self) -> None:
+        try:
+            select.select([self.socket, self._control_rx], [], [], 0.0)
+            with self._condition:
+                self._started = True
+                self._condition.notify_all()
+            while True:
+                readable, _, _ = select.select([self.socket, self._control_rx], [], [])
+                if self.socket in readable:
+                    self._receive_once()
+                if self._control_rx in readable:
+                    command = self._control_rx.recv(1)
+                    if command not in (b"S", b"X"):
+                        raise MeasurementError("observer control channel failed")
+                    self._drain_source()
+                    self._publish(_Closed() if command == b"X" else _Sync())
+                    if command == b"X":
+                        return
+        except BaseException as exc:
+            with self._condition:
+                self._failure = exc
+                self._condition.notify_all()
+
+    def _take(self, deadline: float | None) -> object | None:
+        with self._condition:
+            while True:
+                if self._failure is not None:
+                    raise self._failure
+                if self._items:
+                    return self._items.popleft()
+                if deadline is None:
+                    self._condition.wait()
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._condition.wait(remaining)
+
+    def receive(self, timeout_seconds: float | None = None) -> list[Event]:
+        if self._closed:
+            raise MeasurementError("observer is closed")
+        deadline = None if timeout_seconds is None else time.monotonic() + max(0.0, timeout_seconds)
+        item = self._take(deadline)
+        if item is None:
+            return []
+        if isinstance(item, list):
+            return cast(list[Event], item)
+        raise MeasurementError("observer synchronization marker arrived out of order")
+
+    def _barrier(self, command: bytes) -> list[Event]:
+        if self._closed:
+            raise MeasurementError("observer is closed")
+        try:
+            self._control_tx.sendall(command)
+        except OSError as exc:
+            raise MeasurementError(f"observer control channel failed: {exc}") from exc
+        events: list[Event] = []
+        expected = _Closed if command == b"X" else _Sync
+        deadline = time.monotonic() + 5
+        while True:
+            item = self._take(deadline)
+            if item is None:
+                raise MeasurementError("observer synchronization timed out")
+            if isinstance(item, list):
+                events.extend(cast(list[Event], item))
+            elif isinstance(item, expected):
+                return events
+            elif command == b"X" and isinstance(item, _Sync):
+                continue
+            else:
+                raise MeasurementError("observer synchronization marker arrived out of order")
+
+    def synchronize(self) -> list[Event]:
+        """Return every decoded event queued before a receive-owner barrier."""
+        return self._barrier(b"S")
+
+    def close(self) -> list[Event]:
+        """Drain, join, and return the final ordered event suffix."""
+        if self._closed:
+            return []
+        events: list[Event] = []
+        error: BaseException | None = None
+        try:
+            events = self._barrier(b"X")
+        except BaseException as exc:
+            error = exc
+        self._closed = True
+        self._thread.join(timeout=5)
+        if self._thread.is_alive():
+            try:
+                self._control_tx.sendall(b"X")
+            except OSError:
+                pass
+            self._thread.join(timeout=5)
+        if self._thread.is_alive():
+            self._close_fds()
+            self._thread.join(timeout=5)
+        else:
+            self._close_fds()
+        if self._thread.is_alive():
+            error = _combine_errors(
+                error,
+                MeasurementError("observer receive owner did not terminate"),
+                "observer termination",
+            )
+        if error is not None:
+            raise error
+        return events
 
 
 class Pairer:
@@ -418,6 +683,7 @@ def deterministic_plan(
     profile: str,
     bridge_ifindex: int = 100,
     port_ifindexes: dict[str, list[int]] | None = None,
+    receive_capacity: ReceiveCapacity | None = None,
 ) -> dict[str, object]:
     if profile not in CAMPAIGNS:
         raise MeasurementError("unknown campaign profile")
@@ -463,12 +729,24 @@ def deterministic_plan(
                     }
                 )
     return {
-        "schema": 1,
+        "schema": 2,
         "profile": profile,
         "active_limit": active_limit,
         "censor_seconds": 5,
         "wall_seconds": 1200,
         "acceptance": None,
+        "observer": {
+            "so_rcvbuf_requested_bytes": (
+                receive_capacity.requested_bytes
+                if receive_capacity is not None
+                else REQUESTED_RECEIVE_BYTES
+            ),
+            "so_rcvbuf_effective_bytes": (
+                receive_capacity.effective_bytes if receive_capacity is not None else None
+            ),
+            "so_rcvbuf_forced": (receive_capacity.forced if receive_capacity is not None else None),
+            "post_freeze_retired_neighbors_max": POST_RETIRE_NEIGHBOR_LIMIT,
+        },
         "topology": {
             "bridge_ifindex": bridge_ifindex,
             "port_ifindexes": ports,
@@ -504,12 +782,37 @@ SAMPLE_FIELDS = [
 ]
 
 
+def _validate_runtime_observer(run: dict[str, object]) -> None:
+    if run.get("schema") != 2:
+        raise MeasurementError("runtime receipt requires raw bridge schema 2")
+    observer = run.get("observer")
+    if not isinstance(observer, dict) or set(observer) != {
+        "post_freeze_retired_neighbors_max",
+        "so_rcvbuf_effective_bytes",
+        "so_rcvbuf_forced",
+        "so_rcvbuf_requested_bytes",
+    }:
+        raise MeasurementError("runtime observer provenance shape mismatch")
+    requested = observer["so_rcvbuf_requested_bytes"]
+    effective = observer["so_rcvbuf_effective_bytes"]
+    if type(requested) is not int or requested != REQUESTED_RECEIVE_BYTES:
+        raise MeasurementError("runtime receive-buffer request mismatch")
+    if type(effective) is not int or effective < requested * LINUX_RCVBUF_ACCOUNTING:
+        raise MeasurementError("runtime effective receive capacity is undersized")
+    if type(observer["so_rcvbuf_forced"]) is not bool:
+        raise MeasurementError("runtime receive-buffer force provenance is not boolean")
+    retired_max = observer["post_freeze_retired_neighbors_max"]
+    if type(retired_max) is not int or retired_max != POST_RETIRE_NEIGHBOR_LIMIT:
+        raise MeasurementError("runtime neighbor-retirement bound mismatch")
+
+
 def write_pairer_receipt(run: dict[str, object], pairer: Pairer, output: Path) -> None:
     if output.exists() or output.is_symlink():
         raise MeasurementError("receipt output must be fresh")
     parent = output.parent
     if not parent.is_dir() or parent.is_symlink():
         raise MeasurementError("receipt parent must be a real directory")
+    _validate_runtime_observer(run)
     rows = pairer.rows()
     planned = cast(list[dict[str, object]], run["planned"])
     report = build_report(
@@ -724,6 +1027,63 @@ class TrafficTopology:
             input_text="\n".join(commands) + "\n",
         )
 
+    def _neighbor_inventory(self) -> set[str]:
+        text = _command(["ip", "-j", "neigh", "show", "dev", self.bridge, "nud", "all"])
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise MeasurementError(f"cannot parse bridge neighbor inventory: {exc}") from exc
+        if not isinstance(value, list):
+            raise MeasurementError("bridge neighbor inventory is not a JSON array")
+        destinations: set[str] = set()
+        for row in value:
+            if not isinstance(row, dict) or not isinstance(row.get("dst"), str):
+                raise MeasurementError("bridge neighbor inventory has a malformed row")
+            destination = str(row["dst"])
+            if destination in destinations:
+                raise MeasurementError("bridge neighbor inventory repeats a destination")
+            destinations.add(destination)
+        return destinations
+
+    def _retire_neighbor(self, destination: str) -> None:
+        family = "-6" if ipaddress.ip_address(destination).version == 6 else "-4"
+        result = subprocess.run(
+            [
+                "ip",
+                family,
+                "neigh",
+                "flush",
+                "to",
+                destination,
+                "dev",
+                self.bridge,
+                "nud",
+                "all",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+        if result.returncode == 0 and not result.stdout and not result.stderr:
+            return
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise MeasurementError(
+            f"neighbor retirement failed for {destination}: {detail or result.returncode}"
+        )
+
+    def retire_rows(self, rows: list[dict[str, object]]) -> None:
+        planned = {str(row["ip"]) for row in rows}
+        if len(planned) != len(rows):
+            raise MeasurementError("retirement batch repeats a planned IP")
+        for destination in sorted(planned):
+            self._retire_neighbor(destination)
+        live_planned = planned & self._neighbor_inventory()
+        if len(live_planned) > POST_RETIRE_NEIGHBOR_LIMIT:
+            raise MeasurementError(
+                "planned bridge neighbors survived retirement: " + ", ".join(sorted(live_planned))
+            )
+
     def stimulus(self, rows: list[dict[str, object]]) -> subprocess.Popen[bytes]:
         payload = []
         for row in rows:
@@ -834,10 +1194,13 @@ def _collect_batch(
             pairer.add(event)
 
 
-def _drain_ready(observer: Observer, pairer: Pairer) -> None:
-    while observer.ready():
-        for event in observer.receive():
-            pairer.add(event)
+def _apply_events(pairer: Pairer, events: list[Event]) -> None:
+    for event in events:
+        pairer.add(event)
+
+
+def _synchronize_observer(observer: Observer, pairer: Pairer) -> None:
+    _apply_events(pairer, observer.synchronize())
 
 
 def _finish_process(process: subprocess.Popen[bytes]) -> None:
@@ -853,7 +1216,9 @@ def _finish_process(process: subprocess.Popen[bytes]) -> None:
 
 
 def _smoke_plan(
-    bridge_ifindex: int, port_ifindexes: dict[str, list[int]]
+    bridge_ifindex: int,
+    port_ifindexes: dict[str, list[int]],
+    receive_capacity: ReceiveCapacity,
 ) -> dict[str, object]:
     planned = [
         {
@@ -880,12 +1245,18 @@ def _smoke_plan(
         },
     ]
     return {
-        "schema": 1,
+        "schema": 2,
         "profile": "current-kernel-smoke",
         "active_limit": 1,
         "censor_seconds": 5,
         "wall_seconds": 30,
         "acceptance": None,
+        "observer": {
+            "so_rcvbuf_requested_bytes": receive_capacity.requested_bytes,
+            "so_rcvbuf_effective_bytes": receive_capacity.effective_bytes,
+            "so_rcvbuf_forced": receive_capacity.forced,
+            "post_freeze_retired_neighbors_max": POST_RETIRE_NEIGHBOR_LIMIT,
+        },
         "topology": {
             "bridge_ifindex": bridge_ifindex,
             "port_ifindexes": port_ifindexes,
@@ -899,15 +1270,18 @@ def _execute(profile: str, *, smoke: bool) -> tuple[dict[str, object], Pairer]:
     wall_deadline = time.monotonic() + (30 if smoke else 1200)
     with TrafficTopology(active_limit) as topology:
         bridge_ifindex, port_ifindexes = topology.ifindexes()
-        run = (
-            _smoke_plan(bridge_ifindex, port_ifindexes)
-            if smoke
-            else deterministic_plan(profile, bridge_ifindex, port_ifindexes)
-        )
-        planned = cast(list[dict[str, object]], run["planned"])
-        pairer = Pairer(planned)
         observer = Observer()
+        run: dict[str, object] | None = None
+        pairer: Pairer | None = None
+        run_error: BaseException | None = None
         try:
+            run = (
+                _smoke_plan(bridge_ifindex, port_ifindexes, observer.capacity)
+                if smoke
+                else deterministic_plan(profile, bridge_ifindex, port_ifindexes, observer.capacity)
+            )
+            planned = cast(list[dict[str, object]], run["planned"])
+            pairer = Pairer(planned)
             phases = ["vlan-10-ipv4", "vlan-10-ipv6", "vlan-20-ipv4", "vlan-20-ipv6"]
             for phase in phases:
                 phase_rows = [row for row in planned if row["phase"] == phase]
@@ -915,21 +1289,63 @@ def _execute(profile: str, *, smoke: bool) -> tuple[dict[str, object], Pairer]:
                     if time.monotonic() >= wall_deadline:
                         break
                     batch = phase_rows[start : start + active_limit]
-                    topology.prepare_rows(batch)
-                    process = topology.stimulus(batch)
+                    batch_error: BaseException | None = None
+                    process: subprocess.Popen[bytes] | None = None
                     try:
+                        topology.prepare_rows(batch)
+                        process = topology.stimulus(batch)
                         _collect_batch(
                             observer,
                             pairer,
                             [str(row["sample_id"]) for row in batch],
                             min(wall_deadline, time.monotonic() + 5),
                         )
+                    except BaseException as exc:
+                        batch_error = exc
                     finally:
                         pairer.freeze([str(row["sample_id"]) for row in batch])
-                        _finish_process(process)
-                        _drain_ready(observer, pairer)
+                        if process is not None:
+                            try:
+                                _finish_process(process)
+                            except BaseException as exc:
+                                batch_error = _combine_errors(
+                                    batch_error, exc, "traffic stimulus shutdown"
+                                )
+                        try:
+                            _synchronize_observer(observer, pairer)
+                        except BaseException as exc:
+                            batch_error = _combine_errors(
+                                batch_error, exc, "observer post-stimulus barrier"
+                            )
+                        try:
+                            topology.retire_rows(batch)
+                        except BaseException as exc:
+                            batch_error = _combine_errors(
+                                batch_error, exc, "planned-neighbor retirement"
+                            )
+                        try:
+                            _synchronize_observer(observer, pairer)
+                        except BaseException as exc:
+                            batch_error = _combine_errors(
+                                batch_error, exc, "observer post-retirement barrier"
+                            )
+                    if batch_error is not None:
+                        raise batch_error
+        except BaseException as exc:
+            run_error = exc
         finally:
-            observer.close()
+            try:
+                final_events = observer.close()
+                if pairer is not None:
+                    _apply_events(pairer, final_events)
+                elif final_events:
+                    raise MeasurementError("observer emitted events before plan construction")
+            except BaseException as exc:
+                run_error = _combine_errors(run_error, exc, "observer shutdown")
+        if run_error is not None:
+            raise run_error
+        if run is None or pairer is None:
+            raise MeasurementError("campaign plan was not constructed")
     smoke_ids = ["smoke-vlan10-v4", "smoke-vlan20-v6"]
     if smoke and not pairer.is_complete(smoke_ids):
         raise MeasurementError("current-kernel ARP/ND smoke did not produce both pairs")

--- a/bench/netns-calibration/test_raw_bridge_skew.py
+++ b/bench/netns-calibration/test_raw_bridge_skew.py
@@ -4,6 +4,7 @@ import socket
 import struct
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -30,10 +31,15 @@ IPV6 = bytes.fromhex(
     "000000001400030000000000000000000000000001000000"
 )
 OVERRUN = bytes.fromhex("10000000040000000000000000000000")
+REQUEST_CORRELATED_FAILED = bytes.fromhex(
+    "400000001c0000000000000018000000020000000200000020000000"
+    "08000100c0000202080004000000000014000300000000000000000000000000"
+    "00000000"
+)
 
 
-def message(kind, family, ifindex, attrs=b"", seq=0, pid=0):
-    body = struct.pack("=BBHiHBB", family, 0, 0, ifindex, 2, 0, 0) + attrs
+def message(kind, family, ifindex, attrs=b"", seq=0, pid=0, state=2):
+    body = struct.pack("=BBHiHBB", family, 0, 0, ifindex, state, 0, 0) + attrs
     raw = struct.pack("=IHHII", 16 + len(body), kind, 0, seq, pid) + body
     return raw + bytes((-len(raw)) % 4)
 
@@ -75,6 +81,324 @@ class ParserTests(unittest.TestCase):
             with self.subTest(sender=sender, flags=flags, length=len(vector)):
                 with self.assertRaises(MOD.MeasurementError):
                     MOD.parse_datagram(vector, sender, flags, 1)
+
+    def test_relevant_header_pid_and_sequence_are_strict(self):
+        for seq, pid in ((1, 0), (0, 7)):
+            with self.subTest(seq=seq, pid=pid):
+                with self.assertRaisesRegex(
+                    MOD.MeasurementError, "nonzero sequence|unexpected header pid"
+                ):
+                    MOD.parse_datagram(
+                        message(
+                            MOD.RTM_NEWNEIGH,
+                            socket.AF_INET,
+                            12,
+                            seq=seq,
+                            pid=pid,
+                        ),
+                        0,
+                        0,
+                        1,
+                    )
+
+    def test_kernel_request_correlated_failed_invalidation_is_narrow(self):
+        event = MOD.parse_datagram(REQUEST_CORRELATED_FAILED, 0, 0, 9)[0]
+        self.assertEqual(
+            (event.message, event.family, event.ifindex, event.state, event.dst),
+            ("new", socket.AF_INET, 2, MOD.NUD_FAILED, "192.0.2.2"),
+        )
+        self.assertIsNone(event.lladdr)
+
+        valid_state = bytearray(REQUEST_CORRELATED_FAILED)
+        struct.pack_into("=H", valid_state, 24, 2)
+        deleted = bytearray(REQUEST_CORRELATED_FAILED)
+        struct.pack_into("=H", deleted, 4, MOD.RTM_DELNEIGH)
+        sequenced = bytearray(REQUEST_CORRELATED_FAILED)
+        struct.pack_into("=I", sequenced, 8, 1)
+        dst = struct.pack("=HH", 8, MOD.NDA_DST) + socket.inet_aton("192.0.2.2")
+        lladdr = struct.pack("=HH", 10, MOD.NDA_LLADDR) + bytes.fromhex("020000000001") + b"\0\0"
+        with_lladdr = message(
+            MOD.RTM_NEWNEIGH,
+            socket.AF_INET,
+            2,
+            attrs=dst + lladdr,
+            pid=24,
+            state=MOD.NUD_FAILED,
+        )
+        without_dst = message(
+            MOD.RTM_NEWNEIGH,
+            socket.AF_INET,
+            2,
+            pid=24,
+            state=MOD.NUD_FAILED,
+        )
+        bridge_dst = (
+            struct.pack("=HH", 10, MOD.NDA_DST)
+            + bytes.fromhex("020000000001")
+            + b"\0\0"
+        )
+        bridge_family = message(
+            MOD.RTM_NEWNEIGH,
+            MOD.AF_BRIDGE,
+            2,
+            attrs=bridge_dst,
+            pid=24,
+            state=MOD.NUD_FAILED,
+        )
+        for vector in (
+            bytes(valid_state),
+            bytes(deleted),
+            bytes(sequenced),
+            with_lladdr,
+            without_dst,
+            bridge_family,
+        ):
+            with self.subTest(vector=vector.hex()[:32]):
+                with self.assertRaises(MOD.MeasurementError):
+                    MOD.parse_datagram(vector, 0, 0, 10)
+
+
+class BufferSocketFixture:
+    def __init__(self, ordinary, forced=None, force_error=None):
+        self.ordinary = ordinary
+        self.forced = forced
+        self.force_error = force_error
+        self.effective = 0
+        self.options = []
+
+    def setsockopt(self, level, option, value):
+        self.options.append((level, option, value))
+        if option == socket.SO_RCVBUF:
+            self.effective = self.ordinary
+        elif option == MOD.SO_RCVBUFFORCE:
+            if self.force_error is not None:
+                raise self.force_error
+            self.effective = self.forced
+
+    def getsockopt(self, _level, _option):
+        return self.effective
+
+
+class ReceiveCapacityTests(unittest.TestCase):
+    def test_ordinary_receive_capacity_is_admitted_without_force(self):
+        requested = 4096
+        sock = BufferSocketFixture(ordinary=8192)
+        capacity = MOD._admit_receive_capacity(sock, requested)
+        self.assertEqual(capacity, MOD.ReceiveCapacity(requested, 8192, False))
+        self.assertEqual(
+            [option for _level, option, _value in sock.options],
+            [socket.SO_RCVBUF],
+        )
+
+    def test_force_denial_is_fatal_before_capacity_admission(self):
+        sock = BufferSocketFixture(
+            ordinary=4096,
+            force_error=PermissionError(1, "not permitted"),
+        )
+        with self.assertRaisesRegex(MOD.MeasurementError, "SO_RCVBUFFORCE failed"):
+            MOD._admit_receive_capacity(sock, 4096)
+        self.assertEqual(
+            [option for _level, option, _value in sock.options],
+            [socket.SO_RCVBUF, MOD.SO_RCVBUFFORCE],
+        )
+
+    def test_undersized_capacity_after_force_is_fatal(self):
+        sock = BufferSocketFixture(ordinary=4096, forced=8191)
+        with self.assertRaisesRegex(MOD.MeasurementError, "undersized"):
+            MOD._admit_receive_capacity(sock, 4096)
+
+    def test_force_success_records_effective_capacity(self):
+        sock = BufferSocketFixture(ordinary=4096, forced=8192)
+        capacity = MOD._admit_receive_capacity(sock, 4096)
+        self.assertEqual(capacity, MOD.ReceiveCapacity(4096, 8192, True))
+
+
+def fixture_event(token, timestamp):
+    return MOD.Event(
+        message="new",
+        family=socket.AF_INET,
+        ifindex=4,
+        state=2,
+        flags=0,
+        dst=token,
+        lladdr=None,
+        vlan=None,
+        master=None,
+        nda_ifindex=None,
+        timestamp_ns=timestamp,
+    )
+
+
+class BackgroundObserverTests(unittest.TestCase):
+    def make_observer(self, decoder):
+        source, sender = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        return MOD.Observer._for_test(source, decoder), sender
+
+    def test_receive_owner_continues_while_foreground_is_blocked(self):
+        decoded = threading.Event()
+
+        def decoder(data, _sender, _flags, timestamp):
+            decoded.set()
+            return [fixture_event(data.decode(), timestamp)]
+
+        observer, sender = self.make_observer(decoder)
+        try:
+            sender.send(b"queued-during-foreground-work")
+            self.assertTrue(decoded.wait(1))
+            events = observer.synchronize()
+            self.assertEqual([event.dst for event in events], ["queued-during-foreground-work"])
+        finally:
+            observer.close()
+            sender.close()
+
+    def test_delivery_order_is_receive_order(self):
+        observer, sender = self.make_observer(
+            lambda data, _sender, _flags, timestamp: [fixture_event(data.decode(), timestamp)]
+        )
+        try:
+            sender.send(b"first")
+            sender.send(b"second")
+            events = observer.synchronize()
+            self.assertEqual([event.dst for event in events], ["first", "second"])
+            self.assertLessEqual(events[0].timestamp_ns, events[1].timestamp_ns)
+        finally:
+            observer.close()
+            sender.close()
+
+    def test_async_enobufs_after_apparent_completion_is_sticky(self):
+        failed = threading.Event()
+
+        def decoder(data, _sender, _flags, timestamp):
+            if data == b"overflow":
+                failed.set()
+                raise MOD.MeasurementError("NETLINK_ROUTE ENOBUFS")
+            return [fixture_event(data.decode(), timestamp)]
+
+        observer, sender = self.make_observer(decoder)
+        try:
+            sender.send(b"complete")
+            self.assertEqual(observer.receive(1)[0].dst, "complete")
+            sender.send(b"overflow")
+            self.assertTrue(failed.wait(1))
+            with self.assertRaisesRegex(MOD.MeasurementError, "ENOBUFS"):
+                observer.synchronize()
+            with self.assertRaisesRegex(MOD.MeasurementError, "ENOBUFS") as caught:
+                observer.close()
+            combined = MOD._combine_errors(
+                MOD.MeasurementError("foreground failed"),
+                caught.exception,
+                "observer shutdown",
+            )
+            self.assertIn("foreground failed", str(combined))
+            self.assertIn("ENOBUFS", str(combined))
+        finally:
+            sender.close()
+
+    def test_close_drains_and_joins_receive_owner(self):
+        decoded = threading.Event()
+
+        def decoder(data, _sender, _flags, timestamp):
+            decoded.set()
+            return [fixture_event(data.decode(), timestamp)]
+
+        observer, sender = self.make_observer(decoder)
+        sender.send(b"final")
+        self.assertTrue(decoded.wait(1))
+        events = observer.close()
+        sender.close()
+        self.assertEqual([event.dst for event in events], ["final"])
+        self.assertFalse(observer._thread.is_alive())
+        self.assertEqual(observer.socket.fileno(), -1)
+
+    def test_simultaneous_source_and_control_readiness_drains_before_marker(self):
+        real_select = MOD.select.select
+        receiver_waiting = threading.Event()
+        release_receiver = threading.Event()
+        gated = False
+
+        def gated_select(readable, writable, exceptional, timeout=None):
+            nonlocal gated
+            if (
+                timeout is None
+                and threading.current_thread().name == "raw-bridge-skew-netlink-receiver"
+                and not gated
+            ):
+                gated = True
+                receiver_waiting.set()
+                if not release_receiver.wait(1):
+                    raise RuntimeError("test receiver gate timed out")
+            return real_select(readable, writable, exceptional, timeout)
+
+        with mock.patch.object(MOD.select, "select", side_effect=gated_select):
+            observer, sender = self.make_observer(
+                lambda data, _sender, _flags, timestamp: [fixture_event(data.decode(), timestamp)]
+            )
+            self.assertTrue(receiver_waiting.wait(1))
+            sender.send(b"before-marker")
+            result = []
+            errors = []
+
+            def synchronize():
+                try:
+                    result.extend(observer.synchronize())
+                except BaseException as exc:
+                    errors.append(exc)
+
+            foreground = threading.Thread(target=synchronize)
+            foreground.start()
+            self.assertTrue(real_select([observer._control_rx], [], [], 1)[0])
+            release_receiver.set()
+            foreground.join(1)
+            self.assertFalse(foreground.is_alive())
+            self.assertEqual(errors, [])
+            self.assertEqual([event.dst for event in result], ["before-marker"])
+            observer.close()
+            sender.close()
+        self.assertFalse(
+            any(
+                thread.name == "raw-bridge-skew-netlink-receiver"
+                for thread in threading.enumerate()
+            )
+        )
+
+    def test_failed_reader_start_closes_control_fds_and_leaves_no_thread(self):
+        source, sender = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        source.close()
+        control_tx, control_rx = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        with mock.patch.object(MOD.socket, "socketpair", return_value=(control_tx, control_rx)):
+            with self.assertRaises((OSError, ValueError)):
+                MOD.Observer._for_test(source, lambda *_args: [])
+        sender.close()
+        self.assertEqual(control_tx.fileno(), -1)
+        self.assertEqual(control_rx.fileno(), -1)
+        self.assertFalse(
+            any(
+                thread.name == "raw-bridge-skew-netlink-receiver"
+                for thread in threading.enumerate()
+            )
+        )
+
+    def test_thread_start_failure_closes_every_owned_fd(self):
+        source, sender = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        control_tx, control_rx = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        with (
+            mock.patch.object(MOD.socket, "socketpair", return_value=(control_tx, control_rx)),
+            mock.patch.object(
+                MOD.threading.Thread, "start", side_effect=RuntimeError("cannot start")
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "cannot start"):
+                MOD.Observer._for_test(source, lambda *_args: [])
+        sender.close()
+        self.assertEqual(source.fileno(), -1)
+        self.assertEqual(control_tx.fileno(), -1)
+        self.assertEqual(control_rx.fileno(), -1)
+        self.assertFalse(
+            any(
+                thread.name == "raw-bridge-skew-netlink-receiver"
+                for thread in threading.enumerate()
+            )
+        )
 
 
 class PairingTests(unittest.TestCase):
@@ -227,30 +551,6 @@ class PairingTests(unittest.TestCase):
         self.assertEqual(row["duplicate_fdb"], 0)
         self.assertEqual((row["late_neighbor"], row["late_fdb"]), (1, 1))
 
-    def test_ready_drain_continues_after_an_irrelevant_datagram(self):
-        pairer = MOD.Pairer(self.expected)
-        neighbor = self.event(
-            socket.AF_INET,
-            120,
-            dst="192.0.2.1",
-            lladdr="02:00:00:00:00:01",
-        )
-
-        class ObserverFixture:
-            def __init__(self):
-                self.batches = [[], [neighbor]]
-
-            def ready(self):
-                return bool(self.batches)
-
-            def receive(self):
-                return self.batches.pop(0)
-
-        observer = ObserverFixture()
-        MOD._drain_ready(observer, pairer)
-        self.assertEqual(len(pairer.sides["s1"]["neighbor"]), 1)
-        self.assertEqual(observer.batches, [])
-
     def test_report_is_descriptive_split_by_family_and_timestamp_zero_is_present(self):
         pairer = MOD.Pairer(self.expected)
         pairer.add(
@@ -293,7 +593,17 @@ class PlanAndArtifactTests(unittest.TestCase):
         self.assertEqual(plan["active_limit"], 32)
         self.assertEqual(plan["censor_seconds"], 5)
         self.assertEqual(plan["wall_seconds"], 1200)
+        self.assertEqual(plan["schema"], 2)
         self.assertIsNone(plan["acceptance"])
+        self.assertEqual(
+            plan["observer"],
+            {
+                "post_freeze_retired_neighbors_max": 0,
+                "so_rcvbuf_effective_bytes": None,
+                "so_rcvbuf_forced": None,
+                "so_rcvbuf_requested_bytes": 4 * 1024 * 1024,
+            },
+        )
         self.assertEqual(len({row["sample_id"] for row in rows}), 4000)
         self.assertEqual(len({row["mac"] for row in rows}), 4000)
         counts = {
@@ -308,7 +618,10 @@ class PlanAndArtifactTests(unittest.TestCase):
             MOD.deterministic_plan("burst-8", 100, {"10": [110], "20": [210]})
 
     def test_receipt_has_closed_inventory_and_explicit_missing_row(self):
-        run = MOD.deterministic_plan("serial-1")
+        run = MOD.deterministic_plan(
+            "serial-1",
+            receive_capacity=MOD.ReceiveCapacity(4 * 1024 * 1024, 8 * 1024 * 1024, False),
+        )
         run["planned"] = run["planned"][:1]
         with tempfile.TemporaryDirectory() as temporary:
             output = Path(temporary) / "receipt"
@@ -319,6 +632,95 @@ class PlanAndArtifactTests(unittest.TestCase):
             self.assertEqual(set(path.name for path in output.iterdir()), {
                 "run.json", "samples.csv", "report.json"
             })
+
+    def test_preview_capacity_cannot_be_published_as_a_runtime_receipt(self):
+        run = MOD.deterministic_plan("serial-1")
+        run["planned"] = run["planned"][:1]
+        pairer = MOD.Pairer(run["planned"])
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "receipt"
+            with self.assertRaisesRegex(MOD.MeasurementError, "undersized"):
+                MOD.write_pairer_receipt(run, pairer, output)
+            self.assertFalse(output.exists())
+
+
+class NeighborRetirementTests(unittest.TestCase):
+    def setUp(self):
+        self.topology = MOD.TrafficTopology(1)
+        self.rows = [
+            {"ip": "192.0.2.1"},
+            {"ip": "2001:db8::1"},
+        ]
+
+    def test_every_planned_ip_is_idempotently_retired_after_freeze(self):
+        completed = lambda args, **_kwargs: __import__("subprocess").CompletedProcess(
+            args, 0, "", ""
+        )
+        with (
+            mock.patch.object(MOD.subprocess, "run", side_effect=completed) as runner,
+            mock.patch.object(self.topology, "_neighbor_inventory", return_value=set()),
+        ):
+            self.topology.retire_rows(self.rows)
+        commands = [call.args[0] for call in runner.call_args_list]
+        self.assertEqual(
+            commands,
+            [
+                [
+                    "ip",
+                    "-4",
+                    "neigh",
+                    "flush",
+                    "to",
+                    "192.0.2.1",
+                    "dev",
+                    self.topology.bridge,
+                    "nud",
+                    "all",
+                ],
+                [
+                    "ip",
+                    "-6",
+                    "neigh",
+                    "flush",
+                    "to",
+                    "2001:db8::1",
+                    "dev",
+                    self.topology.bridge,
+                    "nud",
+                    "all",
+                ],
+            ],
+        )
+
+    def test_post_freeze_planned_neighbor_bound_is_exact_zero(self):
+        completed = lambda args, **_kwargs: __import__("subprocess").CompletedProcess(
+            args, 0, "", ""
+        )
+        with (
+            mock.patch.object(MOD.subprocess, "run", side_effect=completed),
+            mock.patch.object(self.topology, "_neighbor_inventory", return_value={"192.0.2.1"}),
+        ):
+            with self.assertRaisesRegex(MOD.MeasurementError, "survived retirement"):
+                self.topology.retire_rows(self.rows)
+
+    def test_inventory_includes_every_nud_state_and_rejects_bad_json(self):
+        with mock.patch.object(MOD, "_command", return_value='[{"dst":"192.0.2.1"}]\n') as command:
+            self.assertEqual(self.topology._neighbor_inventory(), {"192.0.2.1"})
+        command.assert_called_once_with(
+            [
+                "ip",
+                "-j",
+                "neigh",
+                "show",
+                "dev",
+                self.topology.bridge,
+                "nud",
+                "all",
+            ]
+        )
+        with mock.patch.object(MOD, "_command", return_value="not-json"):
+            with self.assertRaisesRegex(MOD.MeasurementError, "cannot parse"):
+                self.topology._neighbor_inventory()
 
 
 class TopologyRollbackTests(unittest.TestCase):

--- a/bench/netns-calibration/verify-receipt.py
+++ b/bench/netns-calibration/verify-receipt.py
@@ -368,8 +368,8 @@ def verify_source_contract(repo: Path, runner: Path | None = None, guest: Path |
     command = re.compile(r"^\s*(sudo|docker|curl|wget)\b", re.MULTILINE)
     require(command.search(runner_text) is None, "runner gained a forbidden host command")
     require(command.search(guest_text) is None, "guest gained a forbidden command")
-    require(skew_text.count("self.socket.bind((0, RTMGRP_NEIGH))") == 1, "collector socket binding changed")
-    for forbidden in ("bridge fdb add", "bridge fdb replace", "ip neigh add", "ip neigh replace"):
+    require(skew_text.count("netlink.bind((0, RTMGRP_NEIGH))") == 1, "collector socket binding changed")
+    for forbidden in ("NETLINK_NO_ENOBUFS", "bridge fdb add", "bridge fdb replace", "ip neigh add", "ip neigh replace"):
         require(forbidden not in skew_text, f"collector gained a synthetic measured stimulus: {forbidden}")
 
 
@@ -625,6 +625,7 @@ def verify_skew_receipt(root: Path) -> str:
             "acceptance",
             "active_limit",
             "censor_seconds",
+            "observer",
             "planned",
             "profile",
             "schema",
@@ -633,10 +634,53 @@ def verify_skew_receipt(root: Path) -> str:
         },
         "run.json shape mismatch",
     )
-    require(run["schema"] == 1 and run["profile"] in {"serial-1", "burst-8", "burst-32"}, "bad campaign identity")
-    require(run["active_limit"] == {"serial-1": 1, "burst-8": 8, "burst-32": 32}[run["profile"]], "profile concurrency mismatch")
-    require(run["active_limit"] <= 32 and run["censor_seconds"] == 5 and run["wall_seconds"] == 1200, "campaign bounds mismatch")
-    require(run["acceptance"] is None, "campaign must remain descriptive without external acceptance inputs")
+    require(
+        run["schema"] == 2 and run["profile"] in {"serial-1", "burst-8", "burst-32"},
+        "bad campaign identity",
+    )
+    require(
+        run["active_limit"] == {"serial-1": 1, "burst-8": 8, "burst-32": 32}[run["profile"]],
+        "profile concurrency mismatch",
+    )
+    require(
+        run["active_limit"] <= 32 and run["censor_seconds"] == 5 and run["wall_seconds"] == 1200,
+        "campaign bounds mismatch",
+    )
+    require(
+        run["acceptance"] is None,
+        "campaign must remain descriptive without external acceptance inputs",
+    )
+    observer = run["observer"]
+    require(isinstance(observer, dict), "campaign observer provenance must be an object")
+    exact_keys(
+        observer,
+        {
+            "post_freeze_retired_neighbors_max",
+            "so_rcvbuf_effective_bytes",
+            "so_rcvbuf_forced",
+            "so_rcvbuf_requested_bytes",
+        },
+        "campaign observer provenance",
+    )
+    requested = observer["so_rcvbuf_requested_bytes"]
+    effective = observer["so_rcvbuf_effective_bytes"]
+    require(
+        type(requested) is int and requested == module.REQUESTED_RECEIVE_BYTES,
+        "campaign receive-buffer request mismatch",
+    )
+    require(
+        type(effective) is int and effective >= requested * module.LINUX_RCVBUF_ACCOUNTING,
+        "campaign effective receive capacity is undersized",
+    )
+    require(
+        type(observer["so_rcvbuf_forced"]) is bool,
+        "campaign receive-buffer force provenance is not boolean",
+    )
+    retired_max = observer["post_freeze_retired_neighbors_max"]
+    require(
+        type(retired_max) is int and retired_max == module.POST_RETIRE_NEIGHBOR_LIMIT == 0,
+        "campaign neighbor-retirement bound mismatch",
+    )
     topology = run["topology"]
     require(isinstance(topology, dict), "campaign topology must be an object")
     exact_keys(topology, {"bridge_ifindex", "port_ifindexes"}, "campaign topology")
@@ -648,8 +692,16 @@ def verify_skew_receipt(root: Path) -> str:
         expected_run = module.deterministic_plan(run["profile"], bridge_ifindex, ports)
     except (RuntimeError, TypeError, ValueError, KeyError) as exc:
         raise VerificationError(f"invalid campaign topology: {exc}") from exc
+    normalized_run = {
+        **run,
+        "observer": {
+            **observer,
+            "so_rcvbuf_effective_bytes": None,
+            "so_rcvbuf_forced": None,
+        },
+    }
     require(
-        same_typed_value(run, expected_run),
+        same_typed_value(normalized_run, expected_run),
         "run.json is not the exact closed deterministic plan",
     )
     planned = run["planned"]

--- a/bench/tests/test-netns-calibration-vm.sh
+++ b/bench/tests/test-netns-calibration-vm.sh
@@ -204,7 +204,12 @@ campaign_request = json.loads((campaign / "request.json").read_text())
 campaign_request["raw_bridge_skew"] = {"profile": "burst-8"}
 campaign_request["sources"]["raw_bridge_skew"] = verify.sha256(raw_path)
 write_json(campaign / "request.json", campaign_request)
-raw.write_receipt(raw.deterministic_plan("burst-8"), [], campaign / "guest/skew")
+raw_capacity = raw.ReceiveCapacity(4 * 1024 * 1024, 8 * 1024 * 1024, False)
+raw.write_receipt(
+    raw.deterministic_plan("burst-8", receive_capacity=raw_capacity),
+    [],
+    campaign / "guest/skew",
+)
 expect(True, "valid-campaign-finalize", "receipt", profiles_path, campaign, "--write-manifest")
 expect(True, "valid-campaign-sealed", "receipt", profiles_path, campaign)
 manifest = (campaign / "SHA256SUMS").read_text()
@@ -231,6 +236,49 @@ for name, mutate in {
     "campaign-extra": lambda p: (p / "guest/skew/extra.txt").write_text("extra\n"),
     "campaign-tampered-plan": lambda p: mutate_campaign_json(
         p, "guest/skew/run.json", lambda x: x["planned"][0].update(ip="192.0.2.99")
+    ),
+    "campaign-run-schema": lambda p: mutate_campaign_json(
+        p, "guest/skew/run.json", lambda x: x.update(schema=1)
+    ),
+    "campaign-rcvbuf-request": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(so_rcvbuf_requested_bytes=4 * 1024 * 1024 - 1),
+    ),
+    "campaign-rcvbuf-effective-null": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(so_rcvbuf_effective_bytes=None),
+    ),
+    "campaign-rcvbuf-effective-string": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(so_rcvbuf_effective_bytes="8388608"),
+    ),
+    "campaign-rcvbuf-effective-bool": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(so_rcvbuf_effective_bytes=True),
+    ),
+    "campaign-rcvbuf-effective-small": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(so_rcvbuf_effective_bytes=8 * 1024 * 1024 - 1),
+    ),
+    "campaign-rcvbuf-forced-type": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(so_rcvbuf_forced=1),
+    ),
+    "campaign-retirement-bool": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(post_freeze_retired_neighbors_max=False),
+    ),
+    "campaign-retirement-nonzero": lambda p: mutate_campaign_json(
+        p,
+        "guest/skew/run.json",
+        lambda x: x["observer"].update(post_freeze_retired_neighbors_max=1),
     ),
     "campaign-nonzero-wrong-tenant": lambda p: mutate_campaign_json(
         p, "guest/skew/report.json", lambda x: x.update(wrong_tenant=1)


### PR DESCRIPTION
## Summary

- continuously drain the raw bridge netlink socket through one receive owner while keeping pairing-state mutation in the foreground
- require and record sufficient receive-buffer capacity, with a scoped `SO_RCVBUFFORCE` fallback when the ordinary request is capped
- retire every planned neighbor after each frozen batch and require zero planned residue before port reuse
- narrowly recognize Linux request-correlated failed-neighbor invalidations while retaining strict sender, sequence, family, state, destination, and LLADDR checks
- move raw campaign receipts to schema 2 and extend the verifier, harness contracts, and calibration documentation

## Validation

- `python3 bench/netns-calibration/test_raw_bridge_skew.py` — 28 tests
- `bash bench/tests/test-netns-calibration-vm.sh`
- `python3 scripts/check_developer_tooling.py`
- Python compile and Ruff checks
- shell syntax and ShellCheck
- `git diff --check`

Two descriptive runs on Linux `6.17.0-35-generic` exercised the frozen commit:

- `serial-1`: 4,000/4,000 complete samples
- `burst-32`: 4,000/4,000 complete samples
- both runs recorded zero missing FDB events, missing neighbor events, duplicate observations, wrong-tenant matches, ambiguous matches, and post-retirement planned neighbors
- both runs recorded a 4 MiB request, 8 MiB effective receive capacity, and use of the forced-buffer fallback

Post-freeze retirement and reused-port lifecycle notifications remain explicit late diagnostics and do not alter frozen samples. These runs are descriptive current-kernel evidence only; no pinned-image campaign is included.

## Docs / release notes

- the calibration README documents the observer, receive-capacity, retirement, and schema-2 boundaries
- CHANGELOG and ROADMAP updates are intentionally not needed because this changes benchmark tooling only