### PR TITLE
Clean up gRPC sockets after bounded shutdown

### DIFF
--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
-use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -70,6 +70,7 @@ use rustbgpd_telemetry::BgpMetrics;
 
 const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
 const GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+const GRPC_LISTENER_SHUTDOWN_GRACE: Duration = Duration::from_secs(1);
 const FULLY_COMPENSATED_STATUS_PREFIX: &str =
     "runtime effects were fully compensated; retry may repeat transient runtime changes:";
 const RUNTIME_CONFIG_OUTCOME_METADATA: &str = "rustbgpd-runtime-config-outcome";
@@ -1479,11 +1480,37 @@ pub async fn serve(
         }
     }
 
-    while let Some(result) = listener_tasks.join_next().await {
-        match result {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => error!(error = %err, "gRPC listener exit during shutdown"),
-            Err(err) => error!(error = %err, "gRPC listener task panicked during shutdown"),
+    // Tonic waits for active streaming RPCs during graceful shutdown. Give
+    // every listener one shared grace deadline, then cancel the stragglers.
+    let listener_shutdown_deadline = tokio::time::Instant::now() + GRPC_LISTENER_SHUTDOWN_GRACE;
+    let graceful_drain = async {
+        while let Some(result) = listener_tasks.join_next().await {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => error!(error = %err, "gRPC listener exit during shutdown"),
+                Err(err) => error!(error = %err, "gRPC listener task panicked during shutdown"),
+            }
+        }
+    };
+    if tokio::time::timeout_at(listener_shutdown_deadline, graceful_drain)
+        .await
+        .is_err()
+    {
+        warn!(
+            remaining_listeners = listener_tasks.len(),
+            grace_ms = GRPC_LISTENER_SHUTDOWN_GRACE.as_millis(),
+            "gRPC listener shutdown grace expired; aborting remaining listeners"
+        );
+        listener_tasks.abort_all();
+        while let Some(result) = listener_tasks.join_next().await {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => error!(error = %err, "gRPC listener exit after shutdown abort"),
+                Err(err) if err.is_cancelled() => {}
+                Err(err) => {
+                    error!(error = %err, "gRPC listener task panicked during shutdown abort");
+                }
+            }
         }
     }
 }
@@ -2033,7 +2060,7 @@ async fn run_uds_listener(
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
     stream_plan: Option<Arc<crate::config_service::stream::StreamPlanState>>,
 ) -> Result<(), String> {
-    let uds_listener = bind_uds_listener(&path, mode)?;
+    let (uds_listener, _socket_cleanup) = bind_uds_listener(&path, mode)?;
     let auth_enabled = credential_store
         .load()
         .listener(credential_index)
@@ -2192,7 +2219,7 @@ async fn run_uds_listener(
         interceptor,
     ));
 
-    let result = Server::builder()
+    Server::builder()
         .layer(GrpcAuthzLayer::new(audit_context, metrics.clone()))
         .add_routes(routes.routes())
         .serve_with_incoming_shutdown(
@@ -2200,16 +2227,10 @@ async fn run_uds_listener(
             await_shutdown(shutdown_rx),
         )
         .await
-        .map_err(|e| format!("UDS listener {} failed: {e}", path.display()));
-
-    if let Err(err) = cleanup_uds_socket(&path) {
-        warn!(path = %path.display(), error = %err, "failed to remove gRPC UDS socket");
-    }
-
-    result
+        .map_err(|e| format!("UDS listener {} failed: {e}", path.display()))
 }
 
-fn bind_uds_listener(path: &Path, mode: u32) -> Result<UnixListener, String> {
+fn bind_uds_listener(path: &Path, mode: u32) -> Result<(UnixListener, UdsSocketCleanup), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("failed to create UDS parent {}: {e}", parent.display()))?;
@@ -2232,13 +2253,22 @@ fn bind_uds_listener(path: &Path, mode: u32) -> Result<UnixListener, String> {
 
     let listener = UnixListener::bind(path)
         .map_err(|e| format!("failed to bind UDS listener {}: {e}", path.display()))?;
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|e| format!("failed to stat bound UDS listener {}: {e}", path.display()))?;
+    if !metadata.file_type().is_socket() {
+        return Err(format!(
+            "bound UDS listener path {} is not a socket",
+            path.display()
+        ));
+    }
+    let cleanup = UdsSocketCleanup::new(path.to_path_buf(), metadata.dev(), metadata.ino());
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| {
         format!(
             "failed to set permissions on UDS listener {}: {e}",
             path.display()
         )
     })?;
-    Ok(listener)
+    Ok((listener, cleanup))
 }
 
 fn cleanup_uds_socket(path: &Path) -> Result<(), String> {
@@ -2249,6 +2279,65 @@ fn cleanup_uds_socket(path: &Path) -> Result<(), String> {
             "failed to remove UDS socket {}: {e}",
             path.display()
         )),
+    }
+}
+
+/// Removes a bound UDS path whether its listener completes or is cancelled.
+struct UdsSocketCleanup {
+    path: PathBuf,
+    dev: u64,
+    ino: u64,
+}
+
+impl UdsSocketCleanup {
+    fn new(path: PathBuf, dev: u64, ino: u64) -> Self {
+        Self { path, dev, ino }
+    }
+}
+
+impl Drop for UdsSocketCleanup {
+    fn drop(&mut self) {
+        let metadata = match std::fs::symlink_metadata(&self.path) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+            Err(err) => {
+                warn!(
+                    path = %self.path.display(),
+                    error = %err,
+                    "failed to stat gRPC UDS socket during cleanup; retaining path"
+                );
+                return;
+            }
+        };
+        if !metadata.file_type().is_socket() {
+            warn!(
+                path = %self.path.display(),
+                expected_dev = self.dev,
+                expected_ino = self.ino,
+                current_dev = metadata.dev(),
+                current_ino = metadata.ino(),
+                "gRPC UDS path is no longer a socket; retaining replacement"
+            );
+            return;
+        }
+        if metadata.dev() != self.dev || metadata.ino() != self.ino {
+            warn!(
+                path = %self.path.display(),
+                expected_dev = self.dev,
+                expected_ino = self.ino,
+                current_dev = metadata.dev(),
+                current_ino = metadata.ino(),
+                "gRPC UDS socket identity changed; retaining replacement"
+            );
+            return;
+        }
+        if let Err(err) = cleanup_uds_socket(&self.path) {
+            warn!(
+                path = %self.path.display(),
+                error = %err,
+                "failed to remove gRPC UDS socket"
+            );
+        }
     }
 }
 
@@ -2275,6 +2364,42 @@ mod tests {
     use crate::proto::global_service_client::GlobalServiceClient;
     use crate::proto::{EventCategory, WatchEventsRequest};
     use crate::test_support::{session_event, spawn_fake_peer_manager, spawn_fake_rib};
+
+    #[tokio::test]
+    async fn uds_cleanup_retains_replacement_socket() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("grpc.sock");
+        let moved = temp.path().join("original.sock");
+        let (listener, cleanup) = bind_uds_listener(&path, 0o600).unwrap();
+        std::fs::rename(&path, &moved).unwrap();
+
+        let replacement = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        let replacement_metadata = std::fs::symlink_metadata(&path).unwrap();
+        let replacement_identity = (replacement_metadata.dev(), replacement_metadata.ino());
+
+        drop(listener);
+        drop(cleanup);
+
+        let current = std::fs::symlink_metadata(&path).unwrap();
+        assert!(current.file_type().is_socket());
+        assert_eq!((current.dev(), current.ino()), replacement_identity);
+        drop(replacement);
+    }
+
+    #[tokio::test]
+    async fn uds_cleanup_retains_replacement_regular_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("grpc.sock");
+        let moved = temp.path().join("original.sock");
+        let (listener, cleanup) = bind_uds_listener(&path, 0o600).unwrap();
+        std::fs::rename(&path, &moved).unwrap();
+        std::fs::write(&path, b"replacement").unwrap();
+
+        drop(listener);
+        drop(cleanup);
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"replacement");
+    }
 
     #[test]
     fn config_transaction_deadline_maps_exactly_to_grpc() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5542,6 +5542,9 @@ async fn run<T>(
     // bounded attribution report before emitting the single fatal receipt.
     let mut rpki_failure_notice: Option<RpkiFailureNotice> = None;
     let mut rpki_failure_triggered = false;
+    // Set only by the gRPC supervision arm for the same reason: polling a
+    // completed JoinHandle again during coordinated teardown would panic.
+    let mut grpc_exited = false;
     loop {
         if initial_peer_boot_failed {
             break;
@@ -5565,6 +5568,7 @@ async fn run<T>(
             result = &mut grpc_handle => {
                 error!(?result, "gRPC server exited unexpectedly");
                 info!("initiating shutdown due to gRPC server failure");
+                grpc_exited = true;
                 component_failed = true;
                 break;
             }
@@ -6160,6 +6164,12 @@ async fn run<T>(
 
     // 4. Stop the gRPC server
     let _ = grpc_shutdown_tx.send(());
+    // The server owns its bounded listener drain and UDS cleanup. Join it
+    // before closing EHM so active streams cannot outlive their dependencies.
+    if !grpc_exited && let Err(error) = grpc_handle.await {
+        error!(%error, "gRPC server task panicked during shutdown");
+        component_failed = true;
+    }
 
     // 5. Shut down the durable event outbox (ADR-0072) after the
     // producers and gRPC have drained. The RIB-event conversion stage

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -324,20 +324,81 @@ fn establish_bgp_and_observe_shutdown(port: u16) {
     }
 }
 
-fn rbgp(grpc_addr: &str, args: &[&str]) -> std::process::Output {
+fn rbgp_command(grpc_addr: &str) -> Command {
     if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
         let mut cmd = Command::new(path);
-        cmd.arg("--addr").arg(grpc_addr).args(args).output()
+        cmd.arg("--addr").arg(grpc_addr);
+        cmd
     } else {
         let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
         let mut cmd = Command::new(cargo);
         cmd.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
             .arg("--addr")
-            .arg(grpc_addr)
-            .args(args)
-            .output()
+            .arg(grpc_addr);
+        cmd
     }
-    .expect("failed to spawn rbgp subprocess")
+}
+
+fn rbgp(grpc_addr: &str, args: &[&str]) -> std::process::Output {
+    rbgp_command(grpc_addr)
+        .args(args)
+        .output()
+        .expect("failed to spawn rbgp subprocess")
+}
+
+fn spawn_rbgp_watch(dir: &Path, grpc_addr: &str) -> Daemon {
+    let stdout_path = dir.join("rbgp-watch.stdout.log");
+    let stderr_path = dir.join("rbgp-watch.stderr.log");
+    Daemon {
+        child: rbgp_command(grpc_addr)
+            .arg("watch")
+            .stdout(Stdio::from(
+                std::fs::File::create(&stdout_path).expect("watcher stdout log"),
+            ))
+            .stderr(Stdio::from(
+                std::fs::File::create(&stderr_path).expect("watcher stderr log"),
+            ))
+            .spawn()
+            .expect("spawn rbgp watch"),
+        stdout_path,
+        stderr_path,
+    }
+}
+
+fn wait_for_route_watcher_subscriber(daemon: &mut Daemon, watcher: &mut Daemon, grpc_addr: &str) {
+    let expected = "bgp_event_stream_subscribers{service=\"watch_events\",source=\"route\"} 1";
+    let deadline = Instant::now() + Duration::from_secs(120);
+    let mut last_metrics = String::new();
+    while Instant::now() < deadline {
+        let output = rbgp(grpc_addr, &["metrics"]);
+        last_metrics = format!(
+            "status: {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if output.status.success() && String::from_utf8_lossy(&output.stdout).contains(expected) {
+            return;
+        }
+        if let Ok(Some(status)) = daemon.child.try_wait() {
+            panic!(
+                "rustbgpd exited before the route watcher subscribed: {status}\n{}",
+                daemon.logs()
+            );
+        }
+        if let Ok(Some(status)) = watcher.child.try_wait() {
+            panic!(
+                "rbgp watch exited before its route subscription became visible: {status}\n{}",
+                watcher.logs()
+            );
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "route watcher subscription never became visible\nlast metrics:\n{last_metrics}\n{}\n{}",
+        daemon.logs(),
+        watcher.logs()
+    );
 }
 
 fn run_bgp_ingress_fault(mode: &str, connect: bool) -> (ExitStatus, String, Vec<String>) {
@@ -765,6 +826,60 @@ fn shutdown_rpc_exits_zero_with_peer_manager_supervised() {
     assert!(
         !logs.contains(hidden),
         "unknown environment value leaked: {logs}"
+    );
+}
+
+#[test]
+fn shutdown_rpc_with_active_watch_cleans_up_uds() {
+    let temp = private_tempdir();
+    let config_path = write_config(temp.path(), DAEMON_CHOOSES, DAEMON_CHOOSES);
+    let mut daemon = spawn_daemon(temp.path(), &config_path);
+    wait_for_bound_grpc_port(&mut daemon);
+
+    let socket_path = temp.path().join("runtime/grpc.sock");
+    let socket_deadline = Instant::now() + Duration::from_secs(120);
+    while !socket_path.exists() {
+        if let Ok(Some(status)) = daemon.child.try_wait() {
+            panic!(
+                "rustbgpd exited before binding its UDS listener: {status}\n{}",
+                daemon.logs()
+            );
+        }
+        assert!(
+            Instant::now() < socket_deadline,
+            "gRPC UDS listener never appeared\n{}",
+            daemon.logs()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+    let grpc_addr = format!("unix://{}", socket_path.display());
+    let mut watcher = spawn_rbgp_watch(temp.path(), &grpc_addr);
+    wait_for_route_watcher_subscriber(&mut daemon, &mut watcher, &grpc_addr);
+
+    let output = rbgp(
+        &grpc_addr,
+        &["shutdown", "--reason", "active watch cleanup test"],
+    );
+    assert!(
+        output.status.success(),
+        "Shutdown RPC failed\nstdout:\n{}\nstderr:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        daemon.logs()
+    );
+
+    let status = daemon.wait_within(Duration::from_secs(120));
+    let logs = daemon.logs();
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "Shutdown RPC with an active watcher must exit 0, got {status}\n{logs}"
+    );
+    let _watcher_status = watcher.wait_within(Duration::from_secs(30));
+    assert!(
+        !socket_path.exists(),
+        "gRPC UDS socket survived coordinated shutdown with an active watcher\n{logs}\n{}",
+        watcher.logs()
     );
 }
 


### PR DESCRIPTION
## Summary

- give all gRPC listeners one shared one-second graceful shutdown deadline, then abort and drain any stragglers
- make Unix-socket cleanup cancellation-safe and retain replacement paths owned by overlapping restarts
- join the gRPC server before event-history teardown without polling a consumed task twice
- prove clean exit and socket removal with a real admitted WatchEvents stream

## Verification

- `cargo test --locked --test grpc_failure_exit_code -- --nocapture` — 20 passed
- `cargo test --locked -p rustbgpd-api server::tests -- --nocapture` — 27 passed
- active-watch shutdown regression — passed
- `cargo clippy --locked -p rustbgpd-api --lib --tests -- -D warnings`
- formatting, diff check, commit hooks, and push hooks — passed