### PR TITLE
lab: prove EVPN underlay mark plumbing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1332,11 +1332,24 @@ an ADR "Deferred" section that points back here. Tightened, not dropped.
   ADR-0065's netns spike confirmed this is not achievable with stateless
   `tc-flower` on the standard bridged-VXLAN softswitch — the overlay source is
   not visible to `tc` at the VXLAN ingress hook (the FRR #15400 failure mode) —
-  so it is ASIC/offload-dependent. The only remaining softswitch avenue
-  (underlay-ingress eBPF with per-MAC state, or `collect_metadata` VXLAN) is a
-  separate ADR if demand appears. The shipped multi-homing enforcement is
-  role-based DF/non-DF BUM suppression + aliasing ECMP, not source-conditioned
-  local-bias.
+  so that stateless `tc-flower` approach remains ASIC/offload-dependent. A
+  bounded underlay-ingress TC-BPF lab on
+  Linux 6.17.0-35-generic proves that the softswitch plumbing is possible for
+  fixed fixture traffic: a bounds-checked IPv4/UDP/VXLAN parser can identify an
+  ES-peer source and VNI, OR a fixture-reserved `skb->mark` bit before
+  decapsulation, and drive a masked CE-egress drop. The tracked reproducer is
+  `crates/evpn-linux/tests/scripts/netns-localbias-underlay-mark-spike.sh`.
+  Exact mark/drop deltas were 8/8 for broadcast, 5/5 for multicast, and 5/5 for
+  the fixed unknown-unicast MAC; fixed known unicast, non-ES traffic, and
+  non-VXLAN traffic remained unmarked. An earlier removal probe showed ES-peer
+  and non-ES broadcast forwarding resume after removing the functional
+  BPF/mark/drop chain. This establishes no kernel-version floor and makes no
+  timing claim. More importantly, the hard-coded known/unknown fixture proves
+  only parser/mark/drop plumbing: arbitrary unknown-unicast classification
+  still requires dynamic MAC state. Production work remains a separate ADR
+  covering that state, lifecycle, mark ownership, and compatibility. The
+  shipped multi-homing enforcement is still role-based DF/non-DF BUM
+  suppression + aliasing ECMP, not source-conditioned local-bias.
 
 - **RFC 9234 (BGP Roles + OTC) follow-ups** *(ADR-0071 counterpart).* None
   blocking — v1 ships static eBGP Role config + IPv4/IPv6 unicast OTC, proven by

--- a/crates/evpn-linux/tests/scripts/netns-localbias-underlay-mark-spike.bpf.c
+++ b/crates/evpn-linux/tests/scripts/netns-localbias-underlay-mark-spike.bpf.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0
+// Bounded TC classifier for the disposable EVPN local-bias netns spike.
+//
+// This is deliberately not production packet parsing. It recognizes only the
+// spike's fixed Ethernet/IPv4/UDP/4789/VXLAN-100 shape, one ES-peer VTEP, and
+// one fixed unknown-unicast destination. Everything else passes unchanged.
+
+#define SEC(name) __attribute__((section(name), used))
+
+typedef unsigned char __u8;
+typedef unsigned short __u16;
+typedef unsigned int __u32;
+
+struct __sk_buff {
+    __u32 len;
+    __u32 pkt_type;
+    __u32 mark;
+    __u32 queue_mapping;
+    __u32 protocol;
+    __u32 vlan_present;
+    __u32 vlan_tci;
+    __u32 vlan_proto;
+    __u32 priority;
+    __u32 ingress_ifindex;
+    __u32 ifindex;
+    __u32 tc_index;
+    __u32 cb[5];
+    __u32 hash;
+    __u32 tc_classid;
+    __u32 data;
+    __u32 data_end;
+};
+
+struct eth_header {
+    __u8 destination[6];
+    __u8 source[6];
+    __u8 protocol[2];
+} __attribute__((packed));
+
+struct ipv4_header {
+    __u8 version_ihl;
+    __u8 tos;
+    __u16 total_length;
+    __u16 identification;
+    __u8 fragment_offset[2];
+    __u8 ttl;
+    __u8 protocol;
+    __u16 checksum;
+    __u8 source[4];
+    __u8 destination[4];
+} __attribute__((packed));
+
+struct udp_header {
+    __u8 source[2];
+    __u8 destination[2];
+    __u8 length[2];
+    __u8 checksum[2];
+} __attribute__((packed));
+
+#define TC_ACT_UNSPEC (-1)
+#define IPPROTO_UDP 17
+#define VXLAN_PORT 4789
+#define VXLAN_VNI 100
+#define LOCAL_BIAS_MARK_BIT 0x40000000
+#define PARSER_DIAGNOSTIC_MARK_BIT 0x20000000
+
+static __inline int is_fixed_unknown(const __u8 destination[6])
+{
+    return destination[0] == 0x02 && destination[1] == 0x00 &&
+           destination[2] == 0x00 && destination[3] == 0x00 &&
+           destination[4] == 0x00 && destination[5] == 0x50;
+}
+
+SEC("classifier")
+int classify_local_bias(struct __sk_buff *skb)
+{
+    void *data = (void *)(unsigned long)skb->data;
+    void *data_end = (void *)(unsigned long)skb->data_end;
+    struct eth_header *outer_eth = data;
+
+    // A second lab-only bit feeds the next TC filter's action counter and is
+    // cleared there immediately. It proves direct-action execution without a
+    // map; the local-bias bit remains independent and survives to CE egress.
+    skb->mark |= PARSER_DIAGNOSTIC_MARK_BIT;
+
+    if ((void *)(outer_eth + 1) > data_end)
+        return TC_ACT_UNSPEC;
+    if (outer_eth->protocol[0] != 0x08 || outer_eth->protocol[1] != 0x00)
+        return TC_ACT_UNSPEC;
+
+    struct ipv4_header *ipv4 = (void *)(outer_eth + 1);
+    if ((void *)(ipv4 + 1) > data_end)
+        return TC_ACT_UNSPEC;
+    if ((ipv4->version_ihl >> 4) != 4 || ipv4->protocol != IPPROTO_UDP)
+        return TC_ACT_UNSPEC;
+
+    __u32 ipv4_length = (ipv4->version_ihl & 0x0f) * 4;
+    if (ipv4_length < sizeof(*ipv4) || ipv4_length > 60)
+        return TC_ACT_UNSPEC;
+    __u16 fragment_offset = ((__u16)ipv4->fragment_offset[0] << 8) |
+                            ipv4->fragment_offset[1];
+    if ((fragment_offset & 0x3fff) != 0)
+        return TC_ACT_UNSPEC;
+
+    // 10.255.0.2, the fixed ES-peer address in the reused topology.
+    if (ipv4->source[0] != 10 || ipv4->source[1] != 255 ||
+        ipv4->source[2] != 0 || ipv4->source[3] != 2)
+        return TC_ACT_UNSPEC;
+
+    struct udp_header *udp = data + sizeof(*outer_eth) + ipv4_length;
+    if ((void *)(udp + 1) > data_end)
+        return TC_ACT_UNSPEC;
+    if (udp->destination[0] != (VXLAN_PORT >> 8) ||
+        udp->destination[1] != (VXLAN_PORT & 0xff))
+        return TC_ACT_UNSPEC;
+
+    __u8 *vxlan = (void *)(udp + 1);
+    if ((void *)(vxlan + 8) > data_end)
+        return TC_ACT_UNSPEC;
+    if ((vxlan[0] & 0x08) == 0)
+        return TC_ACT_UNSPEC;
+    if (vxlan[4] != 0 || vxlan[5] != 0 || vxlan[6] != VXLAN_VNI)
+        return TC_ACT_UNSPEC;
+
+    struct eth_header *inner_eth = (void *)(vxlan + 8);
+    if ((void *)(inner_eth + 1) > data_end)
+        return TC_ACT_UNSPEC;
+
+    // Mark only B/M or the fixed unknown-unicast case. The fixed known MAC,
+    // non-ES peers, and non-VXLAN traffic retain their incoming mark.
+    if ((inner_eth->destination[0] & 0x01) != 0 ||
+        is_fixed_unknown(inner_eth->destination))
+        skb->mark |= LOCAL_BIAS_MARK_BIT;
+
+    return TC_ACT_UNSPEC;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/crates/evpn-linux/tests/scripts/netns-localbias-underlay-mark-spike.sh
+++ b/crates/evpn-linux/tests/scripts/netns-localbias-underlay-mark-spike.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# Disposable proof for the remaining RFC 8365 local-bias softswitch seam.
+#
+# A tiny TC direct-action eBPF classifier runs on the local VTEP's underlay
+# ingress, before VXLAN decapsulation. It recognizes only this lab's fixed
+# IPv4/UDP/4789/VNI-100 packet shape, marks ES-peer BUM plus one fixed
+# unknown-unicast destination, and leaves all other traffic unchanged. A
+# post-decap fw counter proves mark survival; a CE-egress fw action drops the
+# same mark. This is a finding harness, not production packet parsing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPILER_IMAGE="docker.io/silkeh/clang:20-bookworm@sha256:203abb1df1563b3bd19cd596d67112e0c0ad380a428810dc9a61c85e555b1323"
+TEST_IMAGE="${TEST_IMAGE:-rustbgpd-netns-tests:latest}"
+
+outer_cleanup() {
+    local rc=$?
+    trap - EXIT INT TERM
+    if [ -n "${COMPILER_CONTAINER:-}" ]; then
+        docker rm -f "$COMPILER_CONTAINER" >/dev/null 2>&1 || true
+    fi
+    if [ -n "${TEST_CONTAINER:-}" ]; then
+        docker rm -f "$TEST_CONTAINER" >/dev/null 2>&1 || true
+    fi
+    if [ -n "${BUILD_DIR:-}" ]; then
+        rm -rf "$BUILD_DIR"
+    fi
+    exit "$rc"
+}
+
+run_outer() {
+    command -v docker >/dev/null 2>&1 || {
+        echo "SETUP-ERROR: docker is required" >&2
+        return 2
+    }
+    docker image inspect "$TEST_IMAGE" >/dev/null 2>&1 || {
+        echo "SETUP-ERROR: missing existing test image $TEST_IMAGE" >&2
+        return 2
+    }
+
+    BUILD_DIR="$(mktemp -d /tmp/rustbgpd-localbias-mark.XXXXXX)"
+    COMPILER_CONTAINER="rustbgpd-localbias-compile-$$"
+    TEST_CONTAINER="rustbgpd-localbias-test-$$"
+    trap outer_cleanup EXIT INT TERM
+
+    echo "source_sha=$(git -C "$SCRIPT_DIR/../../../.." rev-parse HEAD)"
+    echo "host_kernel=$(uname -r)"
+    echo "compiler_image=$COMPILER_IMAGE"
+    TEST_IMAGE_ID="$(docker image inspect "$TEST_IMAGE" --format '{{.Id}}')"
+    echo "test_image=$TEST_IMAGE"
+    echo "test_image_id=$TEST_IMAGE_ID"
+
+    docker run --rm --name "$COMPILER_CONTAINER" \
+        -v "$SCRIPT_DIR:/source:ro" \
+        -v "$BUILD_DIR:/output" \
+        -w /source \
+        "$COMPILER_IMAGE" \
+        sh -ceu '
+            printf "compiler_version="
+            clang --version | sed -n "1p"
+            clang -O2 -g -target bpf -Wall -Werror \
+                -c netns-localbias-underlay-mark-spike.bpf.c \
+                -o /output/localbias-underlay-mark.bpf.o
+        '
+    COMPILER_CONTAINER=""
+
+    echo "compiler_image_id=$(docker image inspect "$COMPILER_IMAGE" --format '{{.Id}}')"
+    echo "object_sha256=$(sha256sum "$BUILD_DIR/localbias-underlay-mark.bpf.o" | awk '{print $1}')"
+
+    local test_rc=0
+    docker run --rm --name "$TEST_CONTAINER" \
+        --cap-add=NET_ADMIN \
+        --cap-add=SYS_ADMIN \
+        --security-opt apparmor=unconfined \
+        -v "$SCRIPT_DIR:/lab:ro" \
+        -v "$BUILD_DIR:/object:ro" \
+        "$TEST_IMAGE_ID" \
+        bash /lab/netns-localbias-underlay-mark-spike.sh \
+            --inside /object/localbias-underlay-mark.bpf.o || test_rc=$?
+    TEST_CONTAINER=""
+
+    for name in "rustbgpd-localbias-compile-$$" "rustbgpd-localbias-test-$$"; do
+        if docker ps -a --format '{{.Names}}' | grep -Fxq "$name"; then
+            echo "CLEANUP-ERROR: container remains: $name" >&2
+            return 2
+        fi
+    done
+    echo "cleanup_containers=absent"
+
+    trap - EXIT INT TERM
+    rm -rf "$BUILD_DIR"
+    BUILD_DIR=""
+    return "$test_rc"
+}
+
+if [ "${1:-}" != "--inside" ]; then
+    run_outer
+    exit $?
+fi
+
+BPF_OBJECT="${2:-}"
+[ -r "$BPF_OBJECT" ] || {
+    echo "SETUP-ERROR: unreadable BPF object: $BPF_OBJECT" >&2
+    exit 2
+}
+
+SFX=$$
+ULNS="lbmark-ul-$SFX"
+LOC="lbmark-loc-$SFX"
+ESP="lbmark-esp-$SFX"
+NES="lbmark-nes-$SFX"
+VNI=100
+DPORT=4789
+MARK=0x40000000
+MARK_MASK=0x40000000
+PARSER_MARK=0x20000000
+PARSER_MARK_MASK=0x20000000
+LOC_UL=10.255.0.1
+ESP_UL=10.255.0.2
+NES_UL=10.255.0.3
+OV=10.200.0
+PINGS=5
+KNOWN_MAC=02:00:00:00:00:aa
+UNKNOWN_MAC=02:00:00:00:00:50
+MCAST_GRP=239.1.1.1
+PASS=0
+FAIL=0
+
+ulx() { ip netns exec "$ULNS" "$@"; }
+locx() { ip netns exec "$LOC" "$@"; }
+espx() { ip netns exec "$ESP" "$@"; }
+nesx() { ip netns exec "$NES" "$@"; }
+
+cleanup_namespaces() {
+    local namespace
+    for namespace in "$ULNS" "$LOC" "$ESP" "$NES"; do
+        ip netns delete "$namespace" >/dev/null 2>&1 || true
+    done
+}
+
+finish() {
+    local rc=$?
+    local leftovers
+    trap - EXIT INT TERM
+    cleanup_namespaces
+    leftovers="$(ip netns list | awk '{print $1}' | grep '^lbmark-' || true)"
+    if [ -n "$leftovers" ]; then
+        echo "CLEANUP-ERROR: matching namespaces remain: $leftovers" >&2
+        rc=2
+    else
+        echo "cleanup_namespaces=absent"
+    fi
+    exit "$rc"
+}
+trap finish EXIT INT TERM
+
+die() {
+    echo "SETUP-ERROR: $*" >&2
+    exit 2
+}
+pass() {
+    echo "PASS [$1]: ${2:-}"
+    PASS=$((PASS + 1))
+}
+fail() {
+    echo "FAIL [$1]: ${2:-}"
+    FAIL=$((FAIL + 1))
+}
+
+[ "$(id -u)" -eq 0 ] || die "requires container root"
+for tool in ip bridge tc ping sha256sum; do
+    command -v "$tool" >/dev/null 2>&1 || die "missing tool '$tool'"
+done
+
+echo "test_kernel=$(uname -r)"
+echo "test_iproute2=$(ip -Version 2>&1)"
+echo "bpf_object_sha256=$(sha256sum "$BPF_OBJECT" | awk '{print $1}')"
+
+rx() {
+    locx cat /sys/class/net/ce-tap/statistics/rx_packets
+}
+
+packet_counter() {
+    local namespace=$1
+    local device=$2
+    local direction=$3
+    local preference=$4
+    ip netns exec "$namespace" tc -s filter show dev "$device" "$direction" pref "$preference" 2>/dev/null |
+        awk '/Sent [0-9]+ bytes [0-9]+ pkt/ { for (i = 1; i <= NF; i++) if ($i == "pkt") value = $(i - 1) } END { print value + 0 }'
+}
+
+assert_forwarded() {
+    local label=$1
+    local delta=$2
+    if [ "$delta" -gt 0 ]; then
+        pass "$label" "CE rx delta=$delta"
+    else
+        fail "$label" "expected forwarding, CE rx delta=0"
+    fi
+}
+
+assert_dropped() {
+    local label=$1
+    local baseline=$2
+    local delta=$3
+    if [ "$((delta * 5))" -lt "$baseline" ]; then
+        pass "$label" "CE rx delta=$delta (baseline=$baseline)"
+    else
+        fail "$label" "expected drop, CE rx delta=$delta (baseline=$baseline)"
+    fi
+}
+
+assert_zero() {
+    local label=$1
+    local delta=$2
+    if [ "$delta" -eq 0 ]; then
+        pass "$label" "counter delta=0"
+    else
+        fail "$label" "expected counter delta=0, got $delta"
+    fi
+}
+
+add_leg() {
+    local child_namespace=$1
+    local leg=$2
+    local address=$3
+    ip -n "$ULNS" link add "ul-$leg" type veth peer name "$leg"
+    ip -n "$ULNS" link set "$leg" netns "$child_namespace"
+    ip -n "$ULNS" link set "ul-$leg" master ulbr
+    ip -n "$ULNS" link set "ul-$leg" up
+    ip -n "$child_namespace" link set "$leg" up
+    ip -n "$child_namespace" address add "$address/24" dev "$leg"
+}
+
+make_remote() {
+    local namespace=$1
+    local local_ip=$2
+    local overlay_ip=$3
+    local leg=$4
+    ip netns exec "$namespace" ip link add brm type bridge
+    ip netns exec "$namespace" ip link add vx type vxlan id "$VNI" \
+        dstport "$DPORT" local "$local_ip" dev "$leg" nolearning
+    ip netns exec "$namespace" ip link add inj type veth peer name injt
+    ip netns exec "$namespace" ip link set vx master brm
+    ip netns exec "$namespace" ip link set inj master brm
+    local device
+    for device in brm vx inj injt; do
+        ip netns exec "$namespace" ip link set "$device" up
+    done
+    ip netns exec "$namespace" ip address add "$overlay_ip/24" dev injt
+    ip netns exec "$namespace" bridge fdb append 00:00:00:00:00:00 \
+        dev vx dst "$LOC_UL"
+}
+
+gen_broadcast() {
+    ip netns exec "$1" ping -b -W1 -c"$PINGS" -I injt "$OV.255" \
+        >/dev/null 2>&1 || true
+}
+
+gen_multicast() {
+    ip netns exec "$1" ping -W1 -c"$PINGS" -I injt "$MCAST_GRP" \
+        >/dev/null 2>&1 || true
+}
+
+gen_unicast() {
+    local namespace=$1
+    local destination_mac=$2
+    local destination_ip=$3
+    ip netns exec "$namespace" ip neigh replace "$destination_ip" \
+        lladdr "$destination_mac" dev injt
+    ip netns exec "$namespace" bridge fdb append "$destination_mac" \
+        dev vx dst "$LOC_UL" >/dev/null 2>&1 || true
+    ip netns exec "$namespace" ping -W1 -c"$PINGS" -I injt "$destination_ip" \
+        >/dev/null 2>&1 || true
+}
+
+measure_rx() {
+    local generator=$1
+    shift
+    local before after
+    before="$(rx)"
+    "$generator" "$@"
+    sleep 0.3
+    after="$(rx)"
+    echo $((after - before))
+}
+
+run_candidate_probe() {
+    local label=$1
+    local expectation=$2
+    local baseline=$3
+    local generator=$4
+    shift 4
+    local parser_before mark_before drop_before ce_before
+    local parser_after mark_after drop_after ce_after
+    local parser_delta mark_delta drop_delta ce_delta
+
+    parser_before="$(packet_counter "$LOC" loc-leg ingress 2)"
+    mark_before="$(packet_counter "$LOC" vxlan100 ingress 1)"
+    drop_before="$(packet_counter "$LOC" ce-br egress 1)"
+    ce_before="$(rx)"
+    "$generator" "$@"
+    sleep 0.3
+    parser_after="$(packet_counter "$LOC" loc-leg ingress 2)"
+    mark_after="$(packet_counter "$LOC" vxlan100 ingress 1)"
+    drop_after="$(packet_counter "$LOC" ce-br egress 1)"
+    ce_after="$(rx)"
+
+    parser_delta=$((parser_after - parser_before))
+    mark_delta=$((mark_after - mark_before))
+    drop_delta=$((drop_after - drop_before))
+    ce_delta=$((ce_after - ce_before))
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$label" "$parser_delta" "$mark_delta" "$drop_delta" "$ce_delta"
+
+    if [ "$parser_delta" -gt 0 ]; then
+        pass "$label parser" "$parser_delta packet(s) traversed loc-leg ingress"
+    else
+        fail "$label parser" "classifier execution counter did not advance"
+    fi
+
+    if [ "$expectation" = drop ]; then
+        if [ "$mark_delta" -gt 0 ]; then
+            pass "$label mark" "$mark_delta packet(s) carried the reserved bit after decap"
+        else
+            fail "$label mark" "post-decap reserved-bit counter did not advance"
+        fi
+        if [ "$drop_delta" -gt 0 ]; then
+            pass "$label drop" "$drop_delta packet(s) reached the CE-egress drop"
+        else
+            fail "$label drop" "CE-egress drop counter did not advance"
+        fi
+        assert_dropped "$label delivery" "$baseline" "$ce_delta"
+    else
+        assert_zero "$label mark" "$mark_delta"
+        assert_zero "$label drop" "$drop_delta"
+        assert_forwarded "$label delivery" "$ce_delta"
+    fi
+}
+
+run_underlay_control() {
+    local parser_before mark_before drop_before
+    local parser_after mark_after drop_after
+    local parser_delta mark_delta drop_delta
+    parser_before="$(packet_counter "$LOC" loc-leg ingress 2)"
+    mark_before="$(packet_counter "$LOC" vxlan100 ingress 1)"
+    drop_before="$(packet_counter "$LOC" ce-br egress 1)"
+    if ! espx ping -q -W1 -c1 "$LOC_UL" >/dev/null 2>&1; then
+        fail "non-VXLAN underlay delivery" "ordinary underlay ping failed"
+    else
+        pass "non-VXLAN underlay delivery" "ES peer reached the local underlay address"
+    fi
+    sleep 0.1
+    parser_after="$(packet_counter "$LOC" loc-leg ingress 2)"
+    mark_after="$(packet_counter "$LOC" vxlan100 ingress 1)"
+    drop_after="$(packet_counter "$LOC" ce-br egress 1)"
+    parser_delta=$((parser_after - parser_before))
+    mark_delta=$((mark_after - mark_before))
+    drop_delta=$((drop_after - drop_before))
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        non_vxlan_underlay "$parser_delta" "$mark_delta" "$drop_delta" n/a
+    if [ "$parser_delta" -gt 0 ]; then
+        pass "non-VXLAN underlay parser" "$parser_delta packet(s) traversed loc-leg ingress"
+    else
+        fail "non-VXLAN underlay parser" "classifier execution counter did not advance"
+    fi
+    assert_zero "non-VXLAN underlay mark" "$mark_delta"
+    assert_zero "non-VXLAN underlay drop" "$drop_delta"
+}
+
+# Reuse the existing three-VTEP topology.
+for namespace in "$ULNS" "$LOC" "$ESP" "$NES"; do
+    ip netns add "$namespace"
+    ip netns exec "$namespace" ip link set lo up
+done
+ulx ip link add ulbr type bridge
+ulx ip link set ulbr up
+add_leg "$LOC" loc-leg "$LOC_UL"
+add_leg "$ESP" esp-leg "$ESP_UL"
+add_leg "$NES" nes-leg "$NES_UL"
+
+for namespace in "$LOC" "$ESP" "$NES"; do
+    ip netns exec "$namespace" sysctl -wq net.ipv4.icmp_echo_ignore_broadcasts=0 \
+        2>/dev/null || true
+    ip netns exec "$namespace" sysctl -wq net.ipv4.ping_group_range='0 65535' \
+        2>/dev/null || true
+done
+
+locx ip link add br100 type bridge
+locx ip link add vxlan100 type vxlan id "$VNI" dstport "$DPORT" \
+    local "$LOC_UL" dev loc-leg nolearning || die "kernel rejected VXLAN creation"
+if locx ip -d link show dev vxlan100 | grep -qw gbp; then
+    die "fixture unexpectedly enabled VXLAN GBP, which can overwrite skb marks"
+fi
+echo "vxlan_gbp=off"
+locx ip link add ce-br type veth peer name ce-tap
+locx ip link set vxlan100 master br100
+locx ip link set ce-br master br100
+for device in br100 vxlan100 ce-br ce-tap; do
+    locx ip link set "$device" up
+done
+locx ip address add "$OV.1/24" dev ce-tap
+
+make_remote "$ESP" "$ESP_UL" "$OV.2" esp-leg
+make_remote "$NES" "$NES_UL" "$OV.3" nes-leg
+locx bridge fdb replace "$KNOWN_MAC" dev ce-br master static
+sleep 0.4
+
+# Baseline: both source classes and both unicast classes reach the CE.
+BASE_ES_BROADCAST="$(measure_rx gen_broadcast "$ESP")"
+assert_forwarded "baseline ES-peer broadcast" "$BASE_ES_BROADCAST"
+BASE_ES_MULTICAST="$(measure_rx gen_multicast "$ESP")"
+assert_forwarded "baseline ES-peer multicast" "$BASE_ES_MULTICAST"
+BASE_NON_ES_BROADCAST="$(measure_rx gen_broadcast "$NES")"
+assert_forwarded "baseline non-ES broadcast" "$BASE_NON_ES_BROADCAST"
+BASE_ES_UNKNOWN="$(measure_rx gen_unicast "$ESP" "$UNKNOWN_MAC" "$OV.50")"
+assert_forwarded "baseline ES-peer fixed unknown unicast" "$BASE_ES_UNKNOWN"
+BASE_ES_KNOWN="$(measure_rx gen_unicast "$ESP" "$KNOWN_MAC" "$OV.60")"
+assert_forwarded "baseline ES-peer fixed known unicast" "$BASE_ES_KNOWN"
+# Candidate: classify before decap, observe the mark after decap, then drop it.
+locx tc qdisc add dev loc-leg clsact
+locx tc filter add dev loc-leg ingress pref 1 bpf da obj "$BPF_OBJECT" sec classifier \
+    || {
+        echo "FINDING=NEGATIVE_BOUNDED_LOADER"
+        echo "MECHANISM-ERROR: TC BPF classifier did not load with the bounded capability set" >&2
+        exit 1
+    }
+locx tc filter add dev loc-leg ingress pref 2 protocol all \
+    handle "$PARSER_MARK/$PARSER_MARK_MASK" fw \
+    action skbedit mark "0/$PARSER_MARK_MASK" pipe \
+    action pass \
+    || die "parser diagnostic observer did not install"
+locx tc qdisc add dev vxlan100 clsact
+locx tc filter add dev vxlan100 ingress pref 1 protocol all \
+    handle "$MARK/$MARK_MASK" fw \
+    action pass || die "post-decap mark observer did not install"
+locx tc qdisc add dev ce-br clsact
+locx tc filter add dev ce-br egress pref 1 protocol all \
+    handle "$MARK/$MARK_MASK" fw \
+    action drop || die "CE-egress mark drop did not install"
+
+echo $'probe\tparser_delta\tpost_decap_mark_delta\tce_drop_delta\tce_rx_delta'
+run_candidate_probe es_peer_broadcast drop "$BASE_ES_BROADCAST" gen_broadcast "$ESP"
+run_candidate_probe es_peer_multicast drop "$BASE_ES_MULTICAST" gen_multicast "$ESP"
+run_candidate_probe es_peer_fixed_unknown drop "$BASE_ES_UNKNOWN" \
+    gen_unicast "$ESP" "$UNKNOWN_MAC" "$OV.51"
+run_candidate_probe es_peer_fixed_known pass "$BASE_ES_KNOWN" \
+    gen_unicast "$ESP" "$KNOWN_MAC" "$OV.60"
+run_candidate_probe non_es_broadcast pass "$BASE_NON_ES_BROADCAST" \
+    gen_broadcast "$NES"
+run_candidate_probe non_es_fixed_unknown pass "$BASE_ES_UNKNOWN" \
+    gen_unicast "$NES" "$UNKNOWN_MAC" "$OV.52"
+run_underlay_control
+
+echo "--- underlay classifier stats ---"
+locx tc -s filter show dev loc-leg ingress pref 1
+echo "--- parser diagnostic stats ---"
+locx tc -s filter show dev loc-leg ingress pref 2
+echo "--- post-decap mark stats ---"
+locx tc -s filter show dev vxlan100 ingress pref 1
+echo "--- CE-egress drop stats ---"
+locx tc -s filter show dev ce-br egress pref 1
+
+# Removal is part of the finding: no filter state may be required for recovery.
+locx tc filter del dev loc-leg ingress pref 1
+locx tc filter del dev loc-leg ingress pref 2
+locx tc filter del dev vxlan100 ingress pref 1
+locx tc filter del dev ce-br egress pref 1
+RESTORED_ES="$(measure_rx gen_broadcast "$ESP")"
+assert_forwarded "classifier removal restores ES-peer baseline" "$RESTORED_ES"
+RESTORED_NON_ES="$(measure_rx gen_broadcast "$NES")"
+assert_forwarded "classifier removal restores non-ES baseline" "$RESTORED_NON_ES"
+
+echo
+echo "=== underlay-mark local-bias spike: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -ne 0 ]; then
+    echo "FINDING=NEGATIVE"
+    exit 1
+fi
+echo "FINDING=POSITIVE_CURRENT_KERNEL_ONLY"


### PR DESCRIPTION
## Summary

- add a disposable three-VTEP Linux lab with a pinned TC-BPF build
- prove a fixture-reserved mark survives same-namespace VXLAN decapsulation and drives masked CE-egress filtering
- document the exact current-kernel result and the remaining production boundary

## Evidence

- ES-peer broadcast mark/drop: 8/8
- ES-peer multicast mark/drop: 5/5
- fixed unknown-unicast mark/drop: 5/5
- fixed known unicast, non-ES traffic, and non-VXLAN traffic remained unmarked and forwarded
- matching namespaces and containers were absent after every retained run

## Validation

- bash syntax check
- ShellCheck
- diff check
- commit-hook formatting, workspace Clippy, tests, and docs
- two independent exact-commit reviews

This is fixed-fixture plumbing evidence on Linux 6.17.0-35-generic. It makes no kernel-version or timing claim and does not add production packet parsing, daemon wiring, dynamic MAC state, or mark ownership policy.