### PR TITLE
cli: make live RIB queries first-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `rbgp rib received` and `rbgp rib advertised` now expose their prefix,
+  longer-prefix, origin-ASN, standard-community, and large-community filters
+  after the route view where operators naturally look for them. A single-page
+  `--limit 1..1000` query reports explicit completeness and remains usable
+  against a churning full table; unbounded walks still fail closed rather than
+  emit a torn snapshot.
+
 - RPKI fail-stop receipts now retain the task class behind a panic even when a
   dependent forwarder returns first. The daemon still performs coordinated
   shutdown and exits 1; ordinary RTR reconnect and expiry remain non-fatal.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -196,6 +196,14 @@ This is the bounded inspection path for a live full table. Without `--limit`,
 the CLI still follows every page and fails closed if the table changes; it
 never labels a torn multi-page walk complete.
 
+In JSON route rows, `validation_state` is the route's recorded RPKI
+origin-validation verdict, not an indicator that `[rpki]` is enabled.
+`not_found` means no covering VRP was present when that route was evaluated. A
+daemon with no `[rpki]` sources therefore reports `not_found` for every route;
+with configured and ready sources, the same value is a real uncovered-route
+verdict. Use `rbgp rpki caches` or `rbgp doctor` for validator readiness—the
+route field alone cannot prove it.
+
 The full unary listings (`rib bgpls|vpn|labeled|rtc|blackholes|fib`,
 `flowspec`, `evpn|evpn diagnose`, `topology nodes|links`, `orr`) return the
 whole table in one response and decode up to a finite 64 MiB ceiling (roughly

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -109,11 +109,14 @@ rbgp rib
 rbgp rib --age                              # append original receive age
 rbgp rib --count                            # best-route count only
 rbgp rib received <addr>
+rbgp rib received <addr> --prefix 203.0.113.0/24
+rbgp rib received <addr> --origin-asn 64496 --limit 100
 rbgp rib received <addr> --age
 rbgp rib received <addr> --count
 rbgp rib received <addr> --rejected         # retained rejected routes with reject reasons
 rbgp rib recv <addr>                        # alias
 rbgp rib advertised <addr>
+rbgp rib advertised <addr> --prefix 203.0.113.0/24 --longer
 rbgp rib advertised <addr> --age
 rbgp rib advertised <addr> --count
 rbgp rib sent <addr>                        # alias
@@ -178,6 +181,20 @@ route row, rendering `Total matching routes: N` or `{"total_count":N}` with
 `--json`. A filtered count still scans the matching backend view to compute the
 exact total; `--count` bounds response transfer, not server-side query work. It
 cannot be combined with the rejected-route or explain views.
+
+The accepted-route filters can be placed after `received PEER` or
+`advertised PEER`, where their `--help` pages list them. The older parent form
+(`rbgp rib --prefix CIDR received PEER`) remains accepted for compatibility.
+Filters compose with AND semantics; repeated community filters require every
+specified value.
+
+`--limit N` returns one server-fenced page, with `N` from 1 through the
+server's 1000-row page cap. Human output says whether it is showing the first
+N of the exact matching total. JSON uses
+`{"routes": [...], "returned_count": N, "total_count": T, "complete": false}`.
+This is the bounded inspection path for a live full table. Without `--limit`,
+the CLI still follows every page and fails closed if the table changes; it
+never labels a torn multi-page walk complete.
 
 The full unary listings (`rib bgpls|vpn|labeled|rtc|blackholes|fib`,
 `flowspec`, `evpn|evpn diagnose`, `topology nodes|links`, `orr`) return the

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -29,6 +29,8 @@ pub struct RouteFilterOpts {
     pub origin_asn: Option<u32>,
     pub community: Vec<u32>,
     pub large_community: Vec<String>,
+    /// Maximum rows returned by a bounded single-page query.
+    pub limit: Option<u32>,
 }
 
 /// Parsed general FIB status filter options from CLI flags.
@@ -132,15 +134,26 @@ enum RouteListRpc {
 /// server's per-page cap so the loop takes the fewest round trips.
 const ROUTE_PAGE_SIZE: u32 = 1000;
 
-/// Fetch every page of a route listing. The server bounds each page;
-/// the CLI follows `next_page_token` until the listing completes, so
-/// output is never silently truncated.
-async fn fetch_all_route_pages(
+struct RouteListing {
+    routes: Vec<Route>,
+    total_count: u64,
+    complete: bool,
+    limit: Option<u32>,
+}
+
+/// Fetch a route listing.
+///
+/// Without `limit`, the CLI follows every continuation and preserves the
+/// daemon's fail-closed mutation fence. A bounded query deliberately issues
+/// exactly one RPC: the server caps the requested page at 1000, so the result
+/// can be useful on a churning full table without presenting a torn snapshot.
+async fn fetch_route_listing(
     client: &mut RibClient,
     rpc: &RouteListRpc,
     mut req: ListRoutesRequest,
-) -> Result<Vec<Route>, CliError> {
-    req.page_size = ROUTE_PAGE_SIZE;
+    limit: Option<u32>,
+) -> Result<RouteListing, CliError> {
+    req.page_size = limit.unwrap_or(ROUTE_PAGE_SIZE);
     let mut routes = Vec::new();
     loop {
         let resp = match rpc {
@@ -149,9 +162,16 @@ async fn fetch_all_route_pages(
             RouteListRpc::Advertised => client.list_advertised_routes(req.clone()).await?,
         }
         .into_inner();
+        let total_count = resp.total_count;
         routes.extend(resp.routes);
-        if resp.next_page_token.is_empty() {
-            return Ok(routes);
+        let complete = resp.next_page_token.is_empty();
+        if limit.is_some() || complete {
+            return Ok(RouteListing {
+                routes,
+                total_count,
+                complete,
+                limit,
+            });
         }
         req.page_token = resp.next_page_token;
     }
@@ -378,6 +398,47 @@ fn print_routes(
         println!("No routes");
     } else {
         output::print_route_table(routes, show_age);
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct JsonBoundedRoutes<'a> {
+    routes: JsonRoutes<'a>,
+    returned_count: u64,
+    total_count: u64,
+    complete: bool,
+}
+
+fn print_route_listing(listing: &RouteListing, show_age: bool, json: bool) -> Result<(), CliError> {
+    let Some(limit) = listing.limit else {
+        return print_routes(&listing.routes, show_age, json);
+    };
+
+    if json {
+        return output::print_json_pretty(&JsonBoundedRoutes {
+            routes: JsonRoutes(&listing.routes),
+            returned_count: listing.routes.len() as u64,
+            total_count: listing.total_count,
+            complete: listing.complete,
+        });
+    }
+
+    if listing.routes.is_empty() {
+        println!("No matching routes.");
+        return Ok(());
+    }
+
+    print_routes(&listing.routes, show_age, false)?;
+    if listing.complete {
+        println!("Showing all {} matching routes.", listing.total_count);
+    } else {
+        println!(
+            "Showing first {} of {} matching routes (--limit {}).",
+            listing.routes.len(),
+            listing.total_count,
+            limit
+        );
     }
     Ok(())
 }
@@ -1686,13 +1747,14 @@ pub async fn best(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let routes = fetch_all_route_pages(
+    let listing = fetch_route_listing(
         &mut client,
         &RouteListRpc::Best,
         make_route_request(None, family, filters)?,
+        filters.limit,
     )
     .await?;
-    print_routes(&routes, show_age, json)
+    print_route_listing(&listing, show_age, json)
 }
 
 pub async fn count_best(
@@ -1812,16 +1874,17 @@ pub async fn received(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut routes = fetch_all_route_pages(
+    let mut listing = fetch_route_listing(
         &mut client,
         &RouteListRpc::Received,
         make_route_request(Some(address), family, filters)?,
+        filters.limit,
     )
     .await?;
-    for route in &mut routes {
+    for route in &mut listing.routes {
         restore_matching_scoped_address(Some(address), &mut route.peer_address);
     }
-    print_routes(&routes, show_age, json)
+    print_route_listing(&listing, show_age, json)
 }
 
 pub async fn count_received(
@@ -2002,16 +2065,17 @@ pub async fn advertised(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut routes = fetch_all_route_pages(
+    let mut listing = fetch_route_listing(
         &mut client,
         &RouteListRpc::Advertised,
         make_route_request(Some(address), family, filters)?,
+        filters.limit,
     )
     .await?;
-    for route in &mut routes {
+    for route in &mut listing.routes {
         restore_matching_scoped_address(Some(address), &mut route.peer_address);
     }
-    print_routes(&routes, show_age, json)
+    print_route_listing(&listing, show_age, json)
 }
 
 pub async fn count_advertised(
@@ -3403,6 +3467,7 @@ mod tests {
             origin_asn: None,
             community: vec![],
             large_community: vec![],
+            limit: None,
         }
     }
 
@@ -3429,6 +3494,7 @@ mod tests {
             origin_asn: Some(64512),
             community: vec![(64512_u32 << 16) | 100],
             large_community: vec!["64512:1:100".to_string()],
+            limit: None,
         }
     }
 
@@ -3668,6 +3734,63 @@ mod tests {
         assert_eq!(requests[0].neighbor_address, "fe80::1");
         assert!(requests[0].page_size > 0, "CLI requests bounded pages");
         assert_eq!(requests[1].page_token, "10.0.0.0/24|192.0.2.1|0");
+    }
+
+    /// A bounded listing never follows a continuation token. This is the
+    /// live-table escape hatch: one server-fenced page with explicit
+    /// completeness, rather than a torn multi-page snapshot.
+    #[tokio::test]
+    async fn received_limit_stops_after_one_page() {
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .list_route_pages
+            .lock()
+            .await
+            .push(mock_route_page("10.0.0.0", "poison-if-followed"));
+        let mut filters = no_route_filters();
+        filters.limit = Some(1);
+
+        received(
+            connect(&server.addr, None).await.unwrap(),
+            "192.0.2.1",
+            None,
+            &filters,
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let requests = server.state.list_route_requests.lock().await;
+        assert_eq!(requests.len(), 1, "bounded query must issue one RPC");
+        assert_eq!(requests[0].page_size, 1);
+        assert!(requests[0].page_token.is_empty());
+    }
+
+    #[test]
+    fn bounded_route_json_exposes_completeness() {
+        let listing = RouteListing {
+            routes: vec![crate::proto::Route {
+                prefix: "10.0.0.0".to_string(),
+                prefix_length: 24,
+                ..Default::default()
+            }],
+            total_count: 42,
+            complete: false,
+            limit: Some(1),
+        };
+        let value = serde_json::to_value(JsonBoundedRoutes {
+            routes: JsonRoutes(&listing.routes),
+            returned_count: listing.routes.len() as u64,
+            total_count: listing.total_count,
+            complete: listing.complete,
+        })
+        .unwrap();
+        assert_eq!(value["returned_count"], 1);
+        assert_eq!(value["total_count"], 42);
+        assert_eq!(value["complete"], false);
+        assert_eq!(value["routes"][0]["prefix"], "10.0.0.0/24");
     }
 
     /// `rbgp best` stops after a single page when the server reports

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1191,7 +1191,7 @@ struct RouteViewArgs {
     prefix: Option<String>,
 
     /// Show longer (more specific) prefixes matching --prefix
-    #[arg(short = 'l', long, requires = "prefix")]
+    #[arg(short = 'l', long)]
     longer: bool,
 
     /// Filter by origin ASN (last ASN in AS_PATH)
@@ -1861,6 +1861,10 @@ fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
             reject_duplicate_route_view_option("--origin-asn", origin_asn, &filters.origin_asn)?;
             reject_duplicate_route_view_option("--limit", limit, &filters.limit)?;
 
+            if filters.longer && prefix.is_none() && filters.prefix.is_none() {
+                return Err(CliError::Argument("--longer requires --prefix".into()));
+            }
+
             let any_limit = limit.is_some() || filters.limit.is_some();
             if route_count_requested(*parent_count, *view_count) && any_limit {
                 return Err(CliError::Argument(
@@ -1900,6 +1904,10 @@ fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
             reject_duplicate_route_view_option("--prefix", prefix, &filters.prefix)?;
             reject_duplicate_route_view_option("--origin-asn", origin_asn, &filters.origin_asn)?;
             reject_duplicate_route_view_option("--limit", limit, &filters.limit)?;
+
+            if filters.longer && prefix.is_none() && filters.prefix.is_none() {
+                return Err(CliError::Argument("--longer requires --prefix".into()));
+            }
 
             let any_limit = limit.is_some() || filters.limit.is_some();
             if route_count_requested(*parent_count, *view_count) && any_limit {
@@ -2760,16 +2768,6 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             large_community,
             limit,
         } => {
-            if limit.is_some()
-                && !matches!(
-                    &action,
-                    None | Some(RibAction::Received { .. } | RibAction::Advertised { .. })
-                )
-            {
-                return Err(CliError::Argument(
-                    "--limit is only valid for best, received, or advertised routes".into(),
-                ));
-            }
             match action {
                 Some(RibAction::Fib {
                     table,
@@ -4946,6 +4944,18 @@ printf '%s\n' "${COMPREPLY[@]}"
                 ..
             } if prefix == "198.51.100.0/24"
         ));
+
+        let compatible_mixed_form = Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "--prefix",
+            "198.51.100.0/24",
+            "received",
+            "192.0.2.1",
+            "--longer",
+        ])
+        .unwrap();
+        validate_rib_route_view_action(&compatible_mixed_form.command).unwrap();
     }
 
     #[test]
@@ -5029,6 +5039,10 @@ printf '%s\n' "${COMPREPLY[@]}"
                 "--count cannot be combined with --limit",
             ),
             (
+                "rbgp rib received 192.0.2.1 --longer",
+                "--longer requires --prefix",
+            ),
+            (
                 "rbgp rib --limit 10 advertised 192.0.2.1 --count",
                 "--count cannot be combined with --limit",
             ),
@@ -5057,6 +5071,8 @@ printf '%s\n' "${COMPREPLY[@]}"
 
         for args in [
             "rbgp rib --prefix 203.0.113.0/24 received 192.0.2.1",
+            "rbgp rib --prefix 203.0.113.0/24 received 192.0.2.1 --longer",
+            "rbgp rib --prefix 203.0.113.0/24 advertised 192.0.2.1 --longer",
             "rbgp rib received 192.0.2.1 --prefix 203.0.113.0/24 --limit 10",
             "rbgp rib advertised 192.0.2.1 --origin-asn 64496 --limit 10",
         ] {
@@ -5072,6 +5088,10 @@ printf '%s\n' "${COMPREPLY[@]}"
             (
                 "rib --count received 192.0.2.1 --limit 10",
                 "--count cannot be combined with --limit",
+            ),
+            (
+                "rib received 192.0.2.1 --longer",
+                "--longer requires --prefix",
             ),
             (
                 "rib received 192.0.2.1 --rejected --prefix 203.0.113.0/24",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -20,11 +20,21 @@ pub mod proto {
 use crate::connection::connect;
 use crate::error::CliError;
 use crate::output::parse_family;
-use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::{Generator, Shell};
 use std::path::PathBuf;
 
 const BINARY_NAME: &str = "rbgp";
+
+fn parse_route_limit(value: &str) -> Result<u32, String> {
+    let limit = value
+        .parse::<u32>()
+        .map_err(|_| "route limit must be an integer from 1 through 1000".to_string())?;
+    if !(1..=1000).contains(&limit) {
+        return Err("route limit must be from 1 through 1000".to_string());
+    }
+    Ok(limit)
+}
 
 // ======================= CLI conventions =======================
 // New commands and flags must follow these rules (LAN-329):
@@ -206,6 +216,14 @@ enum Command {
         /// Filter by large community (e.g., 65001:100:200); may be repeated
         #[arg(long, value_delimiter = ',')]
         large_community: Vec<String>,
+
+        /// Return at most this many routes without walking the full table (1-1000)
+        #[arg(
+            long,
+            value_parser = parse_route_limit,
+            conflicts_with_all = ["count", "explain"]
+        )]
+        limit: Option<u32>,
     },
 
     /// Show the RFC 9107 ORR topology graph derived from BGP-LS
@@ -1166,6 +1184,33 @@ enum RpkiAction {
     },
 }
 
+#[derive(Args, Default)]
+struct RouteViewArgs {
+    /// Prefix filter (e.g., 10.0.0.0/24)
+    #[arg(short = 'p', long)]
+    prefix: Option<String>,
+
+    /// Show longer (more specific) prefixes matching --prefix
+    #[arg(short = 'l', long, requires = "prefix")]
+    longer: bool,
+
+    /// Filter by origin ASN (last ASN in AS_PATH)
+    #[arg(long)]
+    origin_asn: Option<u32>,
+
+    /// Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated
+    #[arg(short = 'c', long, value_delimiter = ',')]
+    community: Vec<String>,
+
+    /// Filter by large community (e.g., 65001:100:200); may be repeated
+    #[arg(long, value_delimiter = ',')]
+    large_community: Vec<String>,
+
+    /// Return at most this many routes without walking the full table (1-1000)
+    #[arg(long, value_parser = parse_route_limit, conflicts_with = "count")]
+    limit: Option<u32>,
+}
+
 #[derive(Subcommand)]
 enum RibAction {
     /// Show received routes from a neighbor
@@ -1187,6 +1232,8 @@ enum RibAction {
         /// filtered-route view; [policy.reject_retention])
         #[arg(long, conflicts_with = "count")]
         rejected: bool,
+        #[command(flatten)]
+        filters: RouteViewArgs,
     },
     /// Show advertised routes to a neighbor
     #[command(visible_alias = "sent")]
@@ -1232,6 +1279,8 @@ enum RibAction {
             conflicts_with_all = ["rd", "labeled"]
         )]
         source_path_id: Option<u32>,
+        #[command(flatten)]
+        filters: RouteViewArgs,
     },
     /// Show RFC 7999 BLACKHOLE discard install status
     Blackholes,
@@ -1706,6 +1755,177 @@ fn route_count_requested(parent_count: bool, view_count: bool) -> bool {
 
 fn route_age_requested(parent_age: bool, view_age: bool) -> bool {
     parent_age || view_age
+}
+
+fn merge_scoped_option<T>(
+    flag: &str,
+    parent: Option<T>,
+    view: Option<T>,
+) -> Result<Option<T>, CliError> {
+    if parent.is_some() && view.is_some() {
+        return Err(CliError::Argument(format!(
+            "{flag} may be specified either before or after the route view, not both"
+        )));
+    }
+    Ok(parent.or(view))
+}
+
+fn merge_route_view_filters(
+    mut parent: commands::rib::RouteFilterOpts,
+    view: RouteViewArgs,
+) -> Result<commands::rib::RouteFilterOpts, CliError> {
+    parent.prefix = merge_scoped_option("--prefix", parent.prefix, view.prefix)?;
+    parent.origin_asn = merge_scoped_option("--origin-asn", parent.origin_asn, view.origin_asn)?;
+    parent.limit = merge_scoped_option("--limit", parent.limit, view.limit)?;
+    parent.longer |= view.longer;
+    parent.community.extend(
+        view.community
+            .iter()
+            .map(|value| parse_community_str(value))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(CliError::Argument)?,
+    );
+    parent.large_community.extend(view.large_community);
+    Ok(parent)
+}
+
+fn accepted_route_filters_requested(filters: &commands::rib::RouteFilterOpts) -> bool {
+    filters.prefix.is_some()
+        || filters.longer
+        || filters.origin_asn.is_some()
+        || !filters.community.is_empty()
+        || !filters.large_community.is_empty()
+}
+
+fn route_view_filters_requested(filters: &RouteViewArgs) -> bool {
+    filters.prefix.is_some()
+        || filters.longer
+        || filters.origin_asn.is_some()
+        || !filters.community.is_empty()
+        || !filters.large_community.is_empty()
+}
+
+fn reject_duplicate_route_view_option<T>(
+    flag: &str,
+    parent: &Option<T>,
+    view: &Option<T>,
+) -> Result<(), CliError> {
+    if parent.is_some() && view.is_some() {
+        return Err(CliError::Argument(format!(
+            "{flag} may be specified either before or after the route view, not both"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject route-view combinations before opening the gRPC transport.
+///
+/// Clap catches conflicts within one argument scope, but parent-compatible
+/// flags and their natural post-subcommand forms occupy separate scopes. Keep
+/// those cross-scope checks just as immediate as native Clap diagnostics.
+fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
+    let Command::Rib {
+        action,
+        family,
+        prefix,
+        longer,
+        explain: parent_explain,
+        count: parent_count,
+        origin_asn,
+        community,
+        large_community,
+        limit,
+        ..
+    } = command
+    else {
+        return Ok(());
+    };
+
+    match action {
+        None => {
+            if limit.is_some() && *parent_explain {
+                return Err(CliError::Argument(
+                    "--explain cannot be combined with --limit".into(),
+                ));
+            }
+        }
+        Some(RibAction::Received {
+            family: view_family,
+            count: view_count,
+            rejected,
+            filters,
+            ..
+        }) => {
+            reject_duplicate_route_view_option("--family", family, view_family)?;
+            reject_duplicate_route_view_option("--prefix", prefix, &filters.prefix)?;
+            reject_duplicate_route_view_option("--origin-asn", origin_asn, &filters.origin_asn)?;
+            reject_duplicate_route_view_option("--limit", limit, &filters.limit)?;
+
+            let any_limit = limit.is_some() || filters.limit.is_some();
+            if route_count_requested(*parent_count, *view_count) && any_limit {
+                return Err(CliError::Argument(
+                    "--count cannot be combined with --limit".into(),
+                ));
+            }
+            if *parent_explain {
+                return Err(CliError::Argument(
+                    "--explain is only valid for the default best-routes view (rib --prefix X --explain)".into(),
+                ));
+            }
+            if *rejected
+                && (family.is_some()
+                    || view_family.is_some()
+                    || prefix.is_some()
+                    || *longer
+                    || origin_asn.is_some()
+                    || !community.is_empty()
+                    || !large_community.is_empty()
+                    || limit.is_some()
+                    || route_view_filters_requested(filters)
+                    || filters.limit.is_some())
+            {
+                return Err(CliError::Argument(
+                    "--rejected does not support accepted-route family, prefix, path-attribute, or limit filters".into(),
+                ));
+            }
+        }
+        Some(RibAction::Advertised {
+            family: view_family,
+            count: view_count,
+            explain,
+            filters,
+            ..
+        }) => {
+            reject_duplicate_route_view_option("--family", family, view_family)?;
+            reject_duplicate_route_view_option("--prefix", prefix, &filters.prefix)?;
+            reject_duplicate_route_view_option("--origin-asn", origin_asn, &filters.origin_asn)?;
+            reject_duplicate_route_view_option("--limit", limit, &filters.limit)?;
+
+            let any_limit = limit.is_some() || filters.limit.is_some();
+            if route_count_requested(*parent_count, *view_count) && any_limit {
+                return Err(CliError::Argument(
+                    "--count cannot be combined with --limit".into(),
+                ));
+            }
+            if *parent_explain {
+                return Err(CliError::Argument(
+                    "--explain is only valid for the default best-routes view (rib --prefix X --explain)".into(),
+                ));
+            }
+            if *explain && any_limit {
+                return Err(CliError::Argument(
+                    "--explain cannot be combined with --limit".into(),
+                ));
+            }
+        }
+        Some(_) if limit.is_some() => {
+            return Err(CliError::Argument(
+                "--limit is only valid for best, received, or advertised routes".into(),
+            ));
+        }
+        Some(_) => {}
+    }
+    Ok(())
 }
 
 fn validate_rib_count_action(command: &Command) -> Result<(), CliError> {
@@ -2316,6 +2536,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
     validate_neighbor_compare_action(&cli.command)?;
     validate_rib_count_action(&cli.command)?;
     validate_rib_age_action(&cli.command)?;
+    validate_rib_route_view_action(&cli.command)?;
     if let Command::Events {
         action:
             Some(EventsAction::Watch {
@@ -2537,7 +2758,18 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             origin_asn,
             community,
             large_community,
+            limit,
         } => {
+            if limit.is_some()
+                && !matches!(
+                    &action,
+                    None | Some(RibAction::Received { .. } | RibAction::Advertised { .. })
+                )
+            {
+                return Err(CliError::Argument(
+                    "--limit is only valid for best, received, or advertised routes".into(),
+                ));
+            }
             match action {
                 Some(RibAction::Fib {
                     table,
@@ -2697,10 +2929,16 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 origin_asn,
                 community: parsed_filter_communities,
                 large_community,
+                limit,
             };
             match action {
                 None => {
                     if explain {
+                        if filters.limit.is_some() {
+                            return Err(CliError::Argument(
+                                "--explain cannot be combined with --limit".into(),
+                            ));
+                        }
                         if filters.longer {
                             return Err(CliError::Argument(
                                 "--explain does not support --longer".into(),
@@ -2739,7 +2977,9 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     count: count_received,
                     age: age_received,
                     rejected,
+                    filters: view_filters,
                 }) => {
+                    let filters = merge_route_view_filters(filters, view_filters)?;
                     let count = route_count_requested(count, count_received);
                     let age = route_age_requested(age, age_received);
                     if explain {
@@ -2748,7 +2988,22 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         ));
                     }
                     if rejected {
+                        if fam.is_some()
+                            || family.is_some()
+                            || accepted_route_filters_requested(&filters)
+                            || filters.limit.is_some()
+                        {
+                            return Err(CliError::Argument(
+                                "--rejected does not support accepted-route family, prefix, path-attribute, or limit filters"
+                                    .into(),
+                            ));
+                        }
                         return commands::rib::rejected(connection, &address, json).await;
+                    }
+                    if count && filters.limit.is_some() {
+                        return Err(CliError::Argument(
+                            "--count cannot be combined with --limit".into(),
+                        ));
                     }
                     let f = resolve_family(&fam.or(family))?;
                     if count {
@@ -2767,7 +3022,9 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     labeled,
                     source_peer,
                     source_path_id,
+                    filters: view_filters,
                 }) => {
+                    let filters = merge_route_view_filters(filters, view_filters)?;
                     let count = route_count_requested(count, count_advertised);
                     let age = route_age_requested(age, age_advertised);
                     if explain {
@@ -2777,6 +3034,11 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     }
                     let f = resolve_family(&fam.or(family))?;
                     if explain_advertised {
+                        if filters.limit.is_some() {
+                            return Err(CliError::Argument(
+                                "--explain cannot be combined with --limit".into(),
+                            ));
+                        }
                         if filters.longer {
                             return Err(CliError::Argument(
                                 "--explain does not support --longer".into(),
@@ -2808,6 +3070,11 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         )
                         .await
                     } else if count {
+                        if filters.limit.is_some() {
+                            return Err(CliError::Argument(
+                                "--count cannot be combined with --limit".into(),
+                            ));
+                        }
                         commands::rib::count_advertised(connection, &address, f, &filters, json)
                             .await
                     } else {
@@ -4601,6 +4868,227 @@ printf '%s\n' "${COMPREPLY[@]}"
             assert_eq!(address, "10.0.0.1");
         } else {
             panic!("expected Rib Received command");
+        }
+    }
+
+    #[test]
+    fn rib_received_and_advertised_expose_natural_scoped_filters() {
+        let received = Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "received",
+            "23.111.167.227",
+            "--prefix",
+            "1.1.1.0/24",
+            "--longer",
+            "--origin-asn",
+            "13335",
+            "--community",
+            "13335:100,13335:200",
+            "--large-community",
+            "13335:1:100",
+            "--limit",
+            "50",
+        ])
+        .unwrap();
+        let Command::Rib {
+            action: Some(RibAction::Received {
+                address, filters, ..
+            }),
+            ..
+        } = received.command
+        else {
+            panic!("expected received route view");
+        };
+        assert_eq!(address, "23.111.167.227");
+        assert_eq!(filters.prefix.as_deref(), Some("1.1.1.0/24"));
+        assert!(filters.longer);
+        assert_eq!(filters.origin_asn, Some(13335));
+        assert_eq!(filters.community, ["13335:100", "13335:200"]);
+        assert_eq!(filters.large_community, ["13335:1:100"]);
+        assert_eq!(filters.limit, Some(50));
+
+        let advertised = Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "advertised",
+            "192.0.2.1",
+            "--prefix",
+            "203.0.113.0/24",
+            "--limit",
+            "25",
+        ])
+        .unwrap();
+        let Command::Rib {
+            action: Some(RibAction::Advertised { filters, .. }),
+            ..
+        } = advertised.command
+        else {
+            panic!("expected advertised route view");
+        };
+        assert_eq!(filters.prefix.as_deref(), Some("203.0.113.0/24"));
+        assert_eq!(filters.limit, Some(25));
+
+        let compatible_parent_form = Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "--prefix",
+            "198.51.100.0/24",
+            "received",
+            "192.0.2.1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            compatible_parent_form.command,
+            Command::Rib {
+                prefix: Some(prefix),
+                action: Some(RibAction::Received { .. }),
+                ..
+            } if prefix == "198.51.100.0/24"
+        ));
+    }
+
+    #[test]
+    fn rib_route_view_help_lists_operator_filters_and_limit() {
+        let mut command = Cli::command();
+        let rib = command.find_subcommand_mut("rib").unwrap();
+        for view in ["received", "advertised"] {
+            let help = rib
+                .find_subcommand_mut(view)
+                .unwrap()
+                .render_long_help()
+                .to_string();
+            for flag in [
+                "--prefix",
+                "--longer",
+                "--origin-asn",
+                "--community",
+                "--large-community",
+                "--limit",
+            ] {
+                assert!(help.contains(flag), "{view} help omitted {flag}");
+            }
+        }
+    }
+
+    #[test]
+    fn route_view_filters_merge_parent_compatibility_with_natural_flags() {
+        let parent = commands::rib::RouteFilterOpts {
+            prefix: Some("203.0.113.0/24".to_string()),
+            longer: false,
+            origin_asn: None,
+            community: vec![(64496_u32 << 16) | 100],
+            large_community: vec![],
+            limit: None,
+        };
+        let view = RouteViewArgs {
+            longer: true,
+            origin_asn: Some(64496),
+            community: vec!["64496:200".to_string()],
+            large_community: vec!["64496:1:100".to_string()],
+            limit: Some(100),
+            ..Default::default()
+        };
+        let merged = merge_route_view_filters(parent, view).unwrap();
+        assert_eq!(merged.prefix.as_deref(), Some("203.0.113.0/24"));
+        assert!(merged.longer);
+        assert_eq!(merged.origin_asn, Some(64496));
+        assert_eq!(
+            merged.community,
+            [(64496_u32 << 16) | 100, (64496_u32 << 16) | 200]
+        );
+        assert_eq!(merged.large_community, ["64496:1:100"]);
+        assert_eq!(merged.limit, Some(100));
+    }
+
+    #[test]
+    fn rib_route_limit_is_one_server_page() {
+        for value in ["0", "1001", "not-a-number"] {
+            assert!(
+                Cli::try_parse_from(["rbgp", "rib", "received", "192.0.2.1", "--limit", value,])
+                    .is_err(),
+                "invalid route limit unexpectedly parsed: {value}"
+            );
+        }
+        Cli::try_parse_from(["rbgp", "rib", "received", "192.0.2.1", "--limit", "1000"]).unwrap();
+    }
+
+    #[test]
+    fn rib_route_view_cross_scope_conflicts_are_explicit() {
+        for (args, expected) in [
+            (
+                "rbgp rib --family ipv4_unicast received 192.0.2.1 --family ipv6_unicast",
+                "--family may be specified either before or after the route view, not both",
+            ),
+            (
+                "rbgp rib --prefix 203.0.113.0/24 received 192.0.2.1 --prefix 198.51.100.0/24",
+                "--prefix may be specified either before or after the route view, not both",
+            ),
+            (
+                "rbgp rib --count received 192.0.2.1 --limit 10",
+                "--count cannot be combined with --limit",
+            ),
+            (
+                "rbgp rib --limit 10 advertised 192.0.2.1 --count",
+                "--count cannot be combined with --limit",
+            ),
+            (
+                "rbgp rib --limit 10 advertised 192.0.2.1 --explain --prefix 203.0.113.0/24",
+                "--explain cannot be combined with --limit",
+            ),
+            (
+                "rbgp rib received 192.0.2.1 --rejected --prefix 203.0.113.0/24",
+                "--rejected does not support accepted-route family, prefix, path-attribute, or limit filters",
+            ),
+            (
+                "rbgp rib --limit 10 blackholes",
+                "--limit is only valid for best, received, or advertised routes",
+            ),
+        ] {
+            let cli = Cli::try_parse_from(args.split_whitespace()).unwrap();
+            assert_eq!(
+                validate_rib_route_view_action(&cli.command)
+                    .unwrap_err()
+                    .to_string(),
+                expected,
+                "unexpected validation result for {args}"
+            );
+        }
+
+        for args in [
+            "rbgp rib --prefix 203.0.113.0/24 received 192.0.2.1",
+            "rbgp rib received 192.0.2.1 --prefix 203.0.113.0/24 --limit 10",
+            "rbgp rib advertised 192.0.2.1 --origin-asn 64496 --limit 10",
+        ] {
+            let cli = Cli::try_parse_from(args.split_whitespace()).unwrap();
+            validate_rib_route_view_action(&cli.command)
+                .unwrap_or_else(|error| panic!("valid route view rejected for {args}: {error}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn rib_route_view_conflicts_fail_before_transport() {
+        for (args, expected) in [
+            (
+                "rib --count received 192.0.2.1 --limit 10",
+                "--count cannot be combined with --limit",
+            ),
+            (
+                "rib received 192.0.2.1 --rejected --prefix 203.0.113.0/24",
+                "--rejected does not support accepted-route family, prefix, path-attribute, or limit filters",
+            ),
+            (
+                "rib --limit 10 blackholes",
+                "--limit is only valid for best, received, or advertised routes",
+            ),
+        ] {
+            let command = format!("rbgp --addr http://127.0.0.1:1 {args}");
+            let cli = Cli::try_parse_from(command.split_whitespace()).unwrap();
+            assert_eq!(
+                run(cli, BINARY_NAME).await.unwrap_err().to_string(),
+                expected,
+                "{args} reached transport instead of preflight validation"
+            );
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1205,10 +1205,6 @@ struct RouteViewArgs {
     /// Filter by large community (e.g., 65001:100:200); may be repeated
     #[arg(long, value_delimiter = ',')]
     large_community: Vec<String>,
-
-    /// Return at most this many routes without walking the full table (1-1000)
-    #[arg(long, value_parser = parse_route_limit, conflicts_with = "count")]
-    limit: Option<u32>,
 }
 
 #[derive(Subcommand)]
@@ -1232,6 +1228,9 @@ enum RibAction {
         /// filtered-route view; [policy.reject_retention])
         #[arg(long, conflicts_with = "count")]
         rejected: bool,
+        /// Return at most this many routes without walking the full table (1-1000)
+        #[arg(long, value_parser = parse_route_limit, conflicts_with = "count")]
+        limit: Option<u32>,
         #[command(flatten)]
         filters: RouteViewArgs,
     },
@@ -1279,6 +1278,13 @@ enum RibAction {
             conflicts_with_all = ["rd", "labeled"]
         )]
         source_path_id: Option<u32>,
+        /// Return at most this many routes without walking the full table (1-1000)
+        #[arg(
+            long,
+            value_parser = parse_route_limit,
+            conflicts_with_all = ["count", "explain"]
+        )]
+        limit: Option<u32>,
         #[command(flatten)]
         filters: RouteViewArgs,
     },
@@ -1773,10 +1779,11 @@ fn merge_scoped_option<T>(
 fn merge_route_view_filters(
     mut parent: commands::rib::RouteFilterOpts,
     view: RouteViewArgs,
+    view_limit: Option<u32>,
 ) -> Result<commands::rib::RouteFilterOpts, CliError> {
     parent.prefix = merge_scoped_option("--prefix", parent.prefix, view.prefix)?;
     parent.origin_asn = merge_scoped_option("--origin-asn", parent.origin_asn, view.origin_asn)?;
-    parent.limit = merge_scoped_option("--limit", parent.limit, view.limit)?;
+    parent.limit = merge_scoped_option("--limit", parent.limit, view_limit)?;
     parent.longer |= view.longer;
     parent.community.extend(
         view.community
@@ -1853,19 +1860,20 @@ fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
             family: view_family,
             count: view_count,
             rejected,
+            limit: view_limit,
             filters,
             ..
         }) => {
             reject_duplicate_route_view_option("--family", family, view_family)?;
             reject_duplicate_route_view_option("--prefix", prefix, &filters.prefix)?;
             reject_duplicate_route_view_option("--origin-asn", origin_asn, &filters.origin_asn)?;
-            reject_duplicate_route_view_option("--limit", limit, &filters.limit)?;
+            reject_duplicate_route_view_option("--limit", limit, view_limit)?;
 
             if filters.longer && prefix.is_none() && filters.prefix.is_none() {
                 return Err(CliError::Argument("--longer requires --prefix".into()));
             }
 
-            let any_limit = limit.is_some() || filters.limit.is_some();
+            let any_limit = limit.is_some() || view_limit.is_some();
             if route_count_requested(*parent_count, *view_count) && any_limit {
                 return Err(CliError::Argument(
                     "--count cannot be combined with --limit".into(),
@@ -1886,7 +1894,7 @@ fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
                     || !large_community.is_empty()
                     || limit.is_some()
                     || route_view_filters_requested(filters)
-                    || filters.limit.is_some())
+                    || view_limit.is_some())
             {
                 return Err(CliError::Argument(
                     "--rejected does not support accepted-route family, prefix, path-attribute, or limit filters".into(),
@@ -1897,19 +1905,20 @@ fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
             family: view_family,
             count: view_count,
             explain,
+            limit: view_limit,
             filters,
             ..
         }) => {
             reject_duplicate_route_view_option("--family", family, view_family)?;
             reject_duplicate_route_view_option("--prefix", prefix, &filters.prefix)?;
             reject_duplicate_route_view_option("--origin-asn", origin_asn, &filters.origin_asn)?;
-            reject_duplicate_route_view_option("--limit", limit, &filters.limit)?;
+            reject_duplicate_route_view_option("--limit", limit, view_limit)?;
 
             if filters.longer && prefix.is_none() && filters.prefix.is_none() {
                 return Err(CliError::Argument("--longer requires --prefix".into()));
             }
 
-            let any_limit = limit.is_some() || filters.limit.is_some();
+            let any_limit = limit.is_some() || view_limit.is_some();
             if route_count_requested(*parent_count, *view_count) && any_limit {
                 return Err(CliError::Argument(
                     "--count cannot be combined with --limit".into(),
@@ -2975,9 +2984,10 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     count: count_received,
                     age: age_received,
                     rejected,
+                    limit: view_limit,
                     filters: view_filters,
                 }) => {
-                    let filters = merge_route_view_filters(filters, view_filters)?;
+                    let filters = merge_route_view_filters(filters, view_filters, view_limit)?;
                     let count = route_count_requested(count, count_received);
                     let age = route_age_requested(age, age_received);
                     if explain {
@@ -3020,9 +3030,10 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     labeled,
                     source_peer,
                     source_path_id,
+                    limit: view_limit,
                     filters: view_filters,
                 }) => {
-                    let filters = merge_route_view_filters(filters, view_filters)?;
+                    let filters = merge_route_view_filters(filters, view_filters, view_limit)?;
                     let count = route_count_requested(count, count_advertised);
                     let age = route_age_requested(age, age_advertised);
                     if explain {
@@ -4140,6 +4151,20 @@ printf '%s\n' "${COMPREPLY[@]}"
     }
 
     #[test]
+    fn zsh_advertised_limit_completion_excludes_explain() {
+        let mut generated = Vec::new();
+        generate_completions(Shell::Zsh, BINARY_NAME, &mut generated).unwrap();
+        let generated = String::from_utf8(generated).unwrap();
+        let guarded_limit = "'(--count --explain)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default'";
+
+        assert_eq!(
+            generated.matches(guarded_limit).count(),
+            3,
+            "best, advertised, and sent completions must hide --limit after --explain"
+        );
+    }
+
+    #[test]
     fn test_man_page_is_roff_and_covers_nested_subcommands() {
         let mut output = Vec::new();
         generate_man(BINARY_NAME, &mut output).unwrap();
@@ -4890,9 +4915,13 @@ printf '%s\n' "${COMPREPLY[@]}"
         ])
         .unwrap();
         let Command::Rib {
-            action: Some(RibAction::Received {
-                address, filters, ..
-            }),
+            action:
+                Some(RibAction::Received {
+                    address,
+                    limit,
+                    filters,
+                    ..
+                }),
             ..
         } = received.command
         else {
@@ -4904,7 +4933,7 @@ printf '%s\n' "${COMPREPLY[@]}"
         assert_eq!(filters.origin_asn, Some(13335));
         assert_eq!(filters.community, ["13335:100", "13335:200"]);
         assert_eq!(filters.large_community, ["13335:1:100"]);
-        assert_eq!(filters.limit, Some(50));
+        assert_eq!(limit, Some(50));
 
         let advertised = Cli::try_parse_from([
             "rbgp",
@@ -4918,14 +4947,14 @@ printf '%s\n' "${COMPREPLY[@]}"
         ])
         .unwrap();
         let Command::Rib {
-            action: Some(RibAction::Advertised { filters, .. }),
+            action: Some(RibAction::Advertised { limit, filters, .. }),
             ..
         } = advertised.command
         else {
             panic!("expected advertised route view");
         };
         assert_eq!(filters.prefix.as_deref(), Some("203.0.113.0/24"));
-        assert_eq!(filters.limit, Some(25));
+        assert_eq!(limit, Some(25));
 
         let compatible_parent_form = Cli::try_parse_from([
             "rbgp",
@@ -4996,10 +5025,9 @@ printf '%s\n' "${COMPREPLY[@]}"
             origin_asn: Some(64496),
             community: vec!["64496:200".to_string()],
             large_community: vec!["64496:1:100".to_string()],
-            limit: Some(100),
             ..Default::default()
         };
-        let merged = merge_route_view_filters(parent, view).unwrap();
+        let merged = merge_route_view_filters(parent, view, Some(100)).unwrap();
         assert_eq!(merged.prefix.as_deref(), Some("203.0.113.0/24"));
         assert!(merged.longer);
         assert_eq!(merged.origin_asn, Some(64496));
@@ -5025,6 +5053,26 @@ printf '%s\n' "${COMPREPLY[@]}"
 
     #[test]
     fn rib_route_view_cross_scope_conflicts_are_explicit() {
+        let local_conflict = match Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "advertised",
+            "192.0.2.1",
+            "--prefix",
+            "203.0.113.0/24",
+            "--explain",
+            "--limit",
+            "10",
+        ]) {
+            Ok(_) => panic!("view-local --explain and --limit unexpectedly parsed"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            local_conflict.kind(),
+            clap::error::ErrorKind::ArgumentConflict,
+            "view-local --explain and --limit must conflict in Clap and generated completions"
+        );
+
         for (args, expected) in [
             (
                 "rbgp rib --family ipv4_unicast received 192.0.2.1 --family ipv6_unicast",

--- a/docs/API.md
+++ b/docs/API.md
@@ -1395,6 +1395,14 @@ whole selected view, regardless of page size. This is the contract behind
 `rbgp rib received|advertised <PEER> --count`, which request a single-row
 page and read only `total_count`.
 
+The same contract backs `rbgp rib --limit N`,
+`rbgp rib received PEER --limit N`, and
+`rbgp rib advertised PEER --limit N` for `N` from 1 through 1000. A limited
+query issues one RPC and exposes the exact `total_count` plus whether the
+returned page is complete; it never follows a continuation into a potentially
+changing table. Unbounded CLI listings retain the version-fenced full-walk
+behavior described above.
+
 ### Watch route changes (streaming)
 
 Live route deltas stream through `EventService.WatchEvents` with

--- a/docs/API.md
+++ b/docs/API.md
@@ -1403,6 +1403,14 @@ returned page is complete; it never follows a continuation into a potentially
 changing table. Unbounded CLI listings retain the version-fenced full-walk
 behavior described above.
 
+`Route.validation_state` is the route's recorded RPKI origin-validation
+verdict, not a configuration/readiness sentinel. `not_found` means the
+validation table applied to that route had no covering VRP. It is therefore
+the natural value for every route when no `[rpki]` sources are configured, but
+on a configured and ready deployment it is a real per-route uncovered-origin
+result. Consumers must use the RPKI cache/readiness surfaces when they need to
+distinguish those deployment states; this route field cannot do so by itself.
+
 ### Watch route changes (streaming)
 
 Live route deltas stream through `EventService.WatchEvents` with

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2514,6 +2514,8 @@ their effective send value is explicitly `inactive`, `unlimited`, or finite.
 
 ```bash
 rbgp rib received 10.0.0.2
+rbgp rib received 10.0.0.2 --prefix 203.0.113.0/24
+rbgp rib received 10.0.0.2 --origin-asn 64496 --limit 100
 rbgp rib received 10.0.0.2 --age
 rbgp rib received 10.0.0.2 --count
 ```
@@ -2530,6 +2532,22 @@ rbgp rib --count
 filters as the full view and renders only the total:
 `Total matching routes: N` in human output, `{"total_count": N}` with
 `--json`.
+
+Received and advertised route filters belong after the view and peer:
+
+```bash
+rbgp rib received PEER --prefix 203.0.113.0/24 --longer
+rbgp rib received PEER --origin-asn 64496
+rbgp rib advertised PEER --community 64496:100
+rbgp rib advertised PEER --large-community 64496:1:100
+```
+
+The parent spelling (`rbgp rib --prefix CIDR received PEER`) remains accepted
+for compatibility. On a continuously changing full table, use a selective
+filter or `--limit 1..1000`. A limited query is exactly one mutation-fenced
+RPC and reports whether the exact matching total was truncated. An unbounded
+query continues to require a version-consistent walk of every page and returns
+an error if the table changes; the CLI does not emit a torn snapshot.
 
 `--age` appends the time since the route was originally received into the RIB.
 It also works on `rbgp rib advertised PEER --age`, where it remains the

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -787,13 +787,13 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-a+[Address family filter]:FAMILY:_default' \
 '--family=[Address family filter]:FAMILY:_default' \
+'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
 '*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
-'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -814,13 +814,13 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-a+[Address family filter]:FAMILY:_default' \
 '--family=[Address family filter]:FAMILY:_default' \
+'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
 '*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
-'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -844,13 +844,13 @@ _arguments "${_arguments_options[@]}" : \
 '--rd=[Route Distinguisher ("asn\:nn" or "ip\:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate]:RD:_default' \
 '(--rd --labeled)--source-peer=[Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id]:PEER:_default' \
 '(--rd --labeled)--source-path-id=[Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector]:ID:_default' \
+'(--count --explain)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
 '*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
-'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -875,13 +875,13 @@ _arguments "${_arguments_options[@]}" : \
 '--rd=[Route Distinguisher ("asn\:nn" or "ip\:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate]:RD:_default' \
 '(--rd --labeled)--source-peer=[Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id]:PEER:_default' \
 '(--rd --labeled)--source-path-id=[Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector]:ID:_default' \
+'(--count --explain)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
 '--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
 '*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
-'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -759,6 +759,7 @@ _arguments "${_arguments_options[@]}" : \
 '*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
 '*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
+'(--count --explain)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -786,12 +787,21 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-a+[Address family filter]:FAMILY:_default' \
 '--family=[Address family filter]:FAMILY:_default' \
+'-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
+'*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
+'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '(--age)--count[Print only the number of matching received routes]' \
 '(--rejected)--age[Append the original route receive age]' \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
+'-l[Show longer (more specific) prefixes matching --prefix]' \
+'--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -804,12 +814,21 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-a+[Address family filter]:FAMILY:_default' \
 '--family=[Address family filter]:FAMILY:_default' \
+'-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
+'*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
+'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '(--age)--count[Print only the number of matching received routes]' \
 '(--rejected)--age[Append the original route receive age]' \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
+'-l[Show longer (more specific) prefixes matching --prefix]' \
+'--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -825,6 +844,13 @@ _arguments "${_arguments_options[@]}" : \
 '--rd=[Route Distinguisher ("asn\:nn" or "ip\:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate]:RD:_default' \
 '(--rd --labeled)--source-peer=[Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id]:PEER:_default' \
 '(--rd --labeled)--source-path-id=[Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector]:ID:_default' \
+'-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
+'*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
+'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -832,6 +858,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--explain)--age[Append the original route receive age]' \
 '(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
+'-l[Show longer (more specific) prefixes matching --prefix]' \
+'--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -847,6 +875,13 @@ _arguments "${_arguments_options[@]}" : \
 '--rd=[Route Distinguisher ("asn\:nn" or "ip\:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate]:RD:_default' \
 '(--rd --labeled)--source-peer=[Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id]:PEER:_default' \
 '(--rd --labeled)--source-path-id=[Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector]:ID:_default' \
+'-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
+'*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
+'(--count)--limit=[Return at most this many routes without walking the full table (1-1000)]:LIMIT:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -854,6 +889,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--explain)--age[Append the original route receive age]' \
 '(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
+'-l[Show longer (more specific) prefixes matching --prefix]' \
+'--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -7756,7 +7756,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib)
-            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --age --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
+            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --age --explain-peer --origin-asn --community --large-community --limit --addr --token-file --json --no-color --help received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7795,6 +7795,10 @@ _rbgp() {
                     return 0
                     ;;
                 --large-community)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -7876,7 +7880,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --addr --token-file --json --no-color --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --prefix --longer --origin-asn --community --large-community --limit --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7899,6 +7903,34 @@ _rbgp() {
                     return 0
                     ;;
                 --source-path-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --origin-asn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --community)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --large-community)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -8292,7 +8324,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__received)
-            opts="-a -s -j -h --family --count --age --rejected --addr --token-file --json --no-color --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --rejected --prefix --longer --origin-asn --community --large-community --limit --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8303,6 +8335,34 @@ _rbgp() {
                     return 0
                     ;;
                 -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --origin-asn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --community)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --large-community)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -7880,7 +7880,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -p -l -c -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --prefix --longer --origin-asn --community --large-community --limit --addr --token-file --json --no-color --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --limit --prefix --longer --origin-asn --community --large-community --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7906,6 +7906,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --prefix)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -7927,10 +7931,6 @@ _rbgp() {
                     return 0
                     ;;
                 --large-community)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --limit)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -8324,7 +8324,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__received)
-            opts="-a -p -l -c -s -j -h --family --count --age --rejected --prefix --longer --origin-asn --community --large-community --limit --addr --token-file --json --no-color --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --rejected --limit --prefix --longer --origin-asn --community --large-community --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8335,6 +8335,10 @@ _rbgp() {
                     return 0
                     ;;
                 -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -8359,10 +8363,6 @@ _rbgp() {
                     return 0
                     ;;
                 --large-community)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --limit)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -373,11 +373,11 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "delete" -d 'Withdraw a route'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l count -d 'Print only the number of matching received routes'
@@ -388,11 +388,11 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l count -d 'Print only the number of matching received routes'
@@ -406,11 +406,11 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l rd -d 'Route Distinguisher ("asn:nn" or "ip:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l source-peer -d 'Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l source-path-id -d 'Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l count -d 'Print only the number of matching advertised routes'
@@ -425,11 +425,11 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l rd -d 'Route Distinguisher ("asn:nn" or "ip:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l source-peer -d 'Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l source-path-id -d 'Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l count -d 'Print only the number of matching advertised routes'

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -348,6 +348,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
@@ -372,20 +373,32 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "delete" -d 'Withdraw a route'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l count -d 'Print only the number of matching received routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l count -d 'Print only the number of matching received routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -393,12 +406,18 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l rd -d 'Route Distinguisher ("asn:nn" or "ip:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l source-peer -d 'Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l source-path-id -d 'Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l count -d 'Print only the number of matching advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -406,12 +425,18 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l rd -d 'Route Distinguisher ("asn:nn" or "ip:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l source-peer -d 'Adj-RIB-In peer that supplied the exact Add-Path candidate to explain; must be paired with --source-path-id' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l source-path-id -d 'Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l count -d 'Print only the number of matching advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s h -l help -d 'Print help (see more with \'--help\')'


### PR DESCRIPTION
## Summary

- expose prefix, longer-prefix, origin-ASN, standard-community, and large-community filters directly on `rib received PEER` and `rib advertised PEER`
- add `--limit 1..1000` as a true bounded query: one server-fenced RPC with explicit completeness and exact total metadata
- keep the established parent flag spelling compatible while rejecting ambiguous cross-scope combinations before connecting
- preserve unlimited listing behavior and its mutation-fenced fail-closed semantics
- refresh CLI docs, operator/API guidance, changelog, and checked-in completions

`--limit` is intentionally the user-facing control rather than `--page-size`. The unlimited CLI already uses the server's maximum page size; changing that would alter round trips without bounding output. `--limit` bounds both the returned rows and the RPC count.

## Validation

- `cargo test -p rustbgpctl` (716 passed, 1 release-scale test ignored)
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- commit and pre-push hooks, including workspace library tests
- release-mode candidate smoke-tested against the live v0.68.0 daemon over its Unix socket:
  - exact IPv4 and IPv6 prefix lookups
  - repeated bounded IPv4 and IPv6 full-table queries
  - origin-ASN and longer-prefix filters
  - count and empty-result rendering
  - human and JSON completeness output
  - pre-connection diagnostics for conflicting flag placements

The live daemon held approximately 1.08 million accepted IPv4 routes and 248 thousand accepted IPv6 routes during the checks. It and its configuration were not modified.
