### PR TITLE
docs: index performance evidence and ADR lifecycles

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,143 +1,178 @@
 # Architecture Decision Records
 
+> **Document class: CURRENT.** This maintained index describes the current
+> decision inventory; each linked ADR remains a historical record of its
+> stated decision and lifecycle.
+
 Records of significant architectural decisions made during rustbgpd
 development. Each record captures the context, decision, and
 consequences so future contributors understand *why*, not just *what*.
+Measured implementation evidence is indexed separately in the
+[performance evidence index](../perf/README.md).
 
 ## Index
 
-| ADR | Title | Status | Date |
-|-----|-------|--------|------|
-| [0001](0001-typed-raw-hybrid-path-attributes.md) | Typed + raw hybrid model for path attributes | Accepted | 2026-02-27 |
-| [0002](0002-inherent-methods-not-traits-for-codec.md) | Inherent methods, not traits, for codec API | Accepted | 2026-02-27 |
-| [0003](0003-subcodes-as-constants-not-enums.md) | NOTIFICATION subcodes as constants, not enums | Accepted | 2026-02-27 |
-| [0004](0004-proptest-for-property-testing.md) | Proptest for property-based testing | Accepted | 2026-02-27 |
-| [0005](0005-fsm-pure-state-machine.md) | Pure state machine FSM with no Result return | Accepted | 2026-02-27 |
-| [0006](0006-validate-open-returns-notification.md) | validate_open returns Result\<NegotiatedSession, NotificationMessage\> | Accepted | 2026-02-27 |
-| [0007](0007-explicit-prometheus-registry.md) | Explicit Prometheus registry, not global default | Accepted | 2026-02-27 |
-| [0008](0008-single-task-per-peer.md) | Single tokio task per peer for M0 | Accepted | 2026-02-27 |
-| [0009](0009-iterative-action-loop.md) | Iterative action loop to avoid async recursion | Accepted | 2026-02-27 |
-| [0010](0010-minimal-metrics-server.md) | Minimal TCP metrics server, no HTTP framework | Accepted | 2026-02-27 |
-| [0011](0011-unknown-notification-code-variant.md) | Unknown variant for NOTIFICATION error codes | Accepted | 2026-02-27 |
-| [0012](0012-separate-decode-from-validation.md) | Separate structural decode from semantic validation for UPDATEs | Accepted | 2026-02-27 |
-| [0013](0013-single-task-rib-manager.md) | Single-task RIB manager with channel-based ownership | Accepted | 2026-02-27 |
-| [0014](0014-best-path-standalone-function-deterministic-med.md) | Best-path comparison as standalone function with deterministic MED | Accepted | 2026-02-27 |
-| [0015](0015-adj-rib-out-inside-rib-manager.md) | Adj-RIB-Out inside RibManager with per-peer outbound channels | Accepted | 2026-02-27 |
-| [0016](0016-socket2-for-md5-gtsm.md) | socket2 for TCP MD5 and GTSM socket options | Accepted | 2026-02-27 |
-| [0017](0017-peer-manager-channel-based-ownership.md) | PeerManager — channel-based single-task ownership | Accepted | 2026-02-27 |
-| [0018](0018-broadcast-channel-for-watch-routes.md) | Broadcast channel for WatchRoutes streaming | Accepted | 2026-02-27 |
-| [0019](0019-inbound-tcp-listener.md) | Inbound TCP listener for passive peering | Accepted | 2026-02-27 |
-| [0020](0020-global-control-services-coordinated-shutdown.md) | GlobalService, ControlService, and coordinated shutdown | Accepted | 2026-02-27 |
-| [0021](0021-tcp-collision-detection.md) | TCP collision detection via PeerManager coordination | Accepted | 2026-02-28 |
-| [0022](0022-grpc-server-supervision.md) | gRPC server supervision — unexpected exit triggers shutdown | Accepted | 2026-02-28 |
-| [0023](0023-prefix-enum-afi-agnostic-rib.md) | Prefix enum and AFI-agnostic RIB for MP-BGP | Accepted | 2026-02-28 |
-| [0024](0024-graceful-restart.md) | Graceful Restart — Receiving Speaker (RFC 4724) | Accepted | 2026-03-01 |
-| [0025](0025-extended-communities.md) | Extended Communities (RFC 4360) | Accepted | 2026-03-01 |
-| [0026](0026-extended-community-policy.md) | Extended Community Policy Matching | Accepted | 2026-03-01 |
-| [0027](0027-route-refresh.md) | Route Refresh (RFC 2918) | Accepted | 2026-03-02 |
-| [0028](0028-standard-community-policy.md) | Standard Community Policy Matching (RFC 1997) | Accepted | 2026-03-02 |
-| [0029](0029-route-reflector.md) | Route Reflector (RFC 4456) | Accepted | 2026-03-02 |
-| [0030](0030-policy-actions.md) | Policy Actions and AS_PATH Regex | Accepted | 2026-03-02 |
-| [0031](0031-large-communities.md) | Large Communities (RFC 8092) | Accepted | 2026-03-02 |
-| [0032](0032-extended-messages.md) | Extended Messages (RFC 8654) | Accepted | 2026-03-02 |
-| [0033](0033-add-path.md) | Add-Path (RFC 7911) | Accepted | 2026-03-02 |
-| [0034](0034-rpki-origin-validation.md) | RPKI Origin Validation (RFC 6811 + RFC 8210) | Accepted | 2026-03-03 |
-| [0035](0035-flowspec.md) | FlowSpec (RFC 8955 / RFC 8956) | Accepted | 2026-03-03 |
-| [0036](0036-policy-chaining.md) | Policy Chaining + Named Policies | Accepted | 2026-03-04 |
-| [0037](0037-extended-nexthop.md) | Extended Next Hop Encoding (RFC 8950) | Accepted | 2026-03-04 |
-| [0038](0038-enhanced-route-refresh.md) | Enhanced Route Refresh (RFC 7313) | Accepted | 2026-03-04 |
-| [0039](0039-transparent-route-server.md) | Transparent Route Server Mode | Accepted | 2026-03-04 |
-| [0040](0040-gr-restarting-speaker.md) | Graceful Restart — Minimal Restarting Speaker Mode | Accepted | 2026-03-04 |
-| [0041](0041-bmp-exporter.md) | BMP Exporter (RFC 7854) | Accepted | 2026-03-04 |
-| [0042](0042-llgr.md) | Long-Lived Graceful Restart (RFC 9494) | Accepted | 2026-03-05 |
-| [0043](0043-config-persistence.md) | Config Persistence and SIGHUP Reload | Accepted | 2026-03-05 |
-| [0044](0044-mrt-dump-export.md) | MRT Dump Export (RFC 6396) | Accepted | 2026-03-05 |
-| [0045](0045-private-as-removal.md) | Private AS Removal | Accepted | 2026-03-05 |
-| [0046](0046-notification-gr.md) | Notification GR (RFC 8538) | Accepted | 2026-03-05 |
-| [0047](0047-grpc-security-hardening.md) | gRPC Security Hardening | Accepted | 2026-03-06 |
-| [0048](0048-rib-memory-optimizations.md) | RIB Memory Optimizations | Accepted | 2026-03-08 |
-| [0049](0049-aspa-verification.md) | ASPA Path Verification | Accepted | 2026-03-13 |
-| [0050](0050-evpn-route-reflector.md) | EVPN Route Reflector (RFC 7432 Phase 1) | Accepted | 2026-04-23 |
-| [0051](0051-per-peer-outbound-writer-task.md) | Per-peer outbound writer task | Accepted | 2026-04-27 |
-| [0052](0052-evpn-vtep-foundation.md) | EVPN VTEP Foundation — Local EVI/VNI Domain Model | Accepted | 2026-05-01 |
-| [0053](0053-rfc-8326-graceful-shutdown.md) | RFC 8326 BGP Graceful Shutdown | Accepted | 2026-05-04 |
-| [0054](0054-evpn-linux-dataplane-boundary.md) | EVPN Linux Dataplane Boundary | Accepted | 2026-05-04 |
-| [0055](0055-evpn-local-mac-origination.md) | EVPN Local-MAC Origination Boundary | Accepted | 2026-05-06 |
-| [0056](0056-evpn-sticky-macs.md) | EVPN sticky-MAC operator config | Accepted | 2026-05-08 |
-| [0057](0057-evpn-gate-8-observable-df-election.md) | EVPN Gate 8 — observable DF election without forwarding enforcement | Accepted | 2026-05-09 |
-| [0058](0058-evpn-gate-9-irb-l3vni.md) | EVPN Gate 9 — symmetric IRB, L3VNI, Type 5 dataplane | Accepted | 2026-05-10 |
-| [0059](0059-evpn-aliasing-fdb-nexthop-groups.md) | EVPN aliasing dataplane via FDB nexthop groups | Accepted | 2026-05-12 |
-| [0060](0060-rfc-7999-blackhole.md) | RFC 7999 BLACKHOLE receiver scoping and opt-in FIB discard | Accepted | 2026-05-13 |
-| [0061](0061-opt-in-unicast-linux-fib-integration.md) | Opt-in unicast Linux FIB integration | Accepted | 2026-05-14 |
-| [0062](0062-tcp-ao-foundation.md) | TCP-AO foundation | Accepted | 2026-05-16 |
-| [0063](0063-evpn-runtime-instance-mutation.md) | EVPN runtime instance mutation semantics | Accepted | 2026-05-17 |
-| [0064](0064-grpc-authorization.md) | gRPC per-method authorization | Accepted | 2026-05-18 |
-| [0064-annex](0064-threat-model.md) | gRPC authorization threat model (ADR-0064 annex) | Current | 2026-07-26 |
-| [0065](0065-evpn-localbias-split-horizon.md) | EVPN VXLAN local-bias split-horizon (spike-gated) | Accepted | 2026-05-22 |
-| [0066](0066-unicast-multipath-ecmp-fib.md) | Unicast multipath / ECMP FIB install | Accepted | 2026-05-24 |
-| [0067](0067-bfd-single-hop.md) | Single-hop asynchronous BFD for BGP | Accepted | 2026-05-24 |
-| [0068](0068-weighted-multipath.md) | Weighted (unequal-cost) multipath via Link Bandwidth | Accepted | 2026-05-24 |
-| [0069](0069-bgp-unnumbered.md) | BGP unnumbered and IPv6 link-local peering | Accepted | 2026-05-25 |
-| [0070](0070-gnmi-openconfig-telemetry.md) | gNMI / OpenConfig telemetry and Set adapter | Accepted | 2026-05-25 |
-| [0071](0071-bgp-roles-otc.md) | BGP Roles and Only-to-Customer (RFC 9234) | Accepted | 2026-05-26 |
-| [0072](0072-durable-event-history.md) | Durable event history (local outbox) | Accepted | 2026-05-26 |
-| [0073](0073-import-policy-explain.md) | Import policy explain via per-session decision cache | Accepted | 2026-05-28 |
-| [0074](0074-fib-table-crud-authz-tier.md) | Runtime FIB-table CRUD authorization tier | Accepted | 2026-06-01 |
-| [0075](0075-outbound-route-filtering.md) | Receive-side Address-Prefix Outbound Route Filtering (ORF) | Accepted | 2026-06-03 |
-| [0076](0076-config-transaction-model.md) | Config transaction model foundation | Accepted | 2026-06-03 |
-| [0077](0077-mpls-vpn-bgpls-address-family-boundary.md) | MPLS, VPN, and BGP-LS address-family boundary | Accepted | 2026-06-08 |
-| [0078](0078-inbound-rib-backpressure.md) | Inbound transport→RIB backpressure — block, never drop | Accepted | 2026-06-10 |
-| [0079](0079-kernel-state-crash-restart-reconciliation.md) | Kernel-state crash-restart reconciliation via adoption sweeps | Accepted | 2026-06-10 |
-| [0080](0080-cancellation-shielded-runtime-applies.md) | Cancellation-shielded runtime mutation applies | Accepted | 2026-06-10 |
-| [0081](0081-atomic-peer-group-reshape.md) | Atomic peer-group session reshapes on the targeted RPC path | Accepted | 2026-06-10 |
-| [0082](0082-nda-protocol-ownership-stamp.md) | NDA_PROTOCOL ownership stamping for EVPN FDB/neighbor state | Accepted | 2026-06-10 |
-| [0083](0083-evpn-single-active-backup-path.md) | EVPN single-active backup-path pre-install | Accepted | 2026-06-11 |
-| [0084](0084-evpn-ethernet-segment-drain.md) | Runtime Ethernet Segment drain | Accepted | 2026-06-12 |
-| [0085](0085-evpn-es-interface-binding.md) | Ethernet Segment interface binding — link-driven drain and same-ESI local bias | Accepted | 2026-06-12 |
-| [0086](0086-dynamic-peer-group-reconfigure.md) | Peer-group field edits reach live dynamic sessions via post-persist graceful reset | Accepted | 2026-06-12 |
-| [0087](0087-evpn-type5-gateway-ip-overlay-index-origination.md) | Native GW-IP overlay-index Type 5 origination (RFC 9136) | Accepted | 2026-06-12 |
-| [0088](0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md) | EVPN VLAN-aware bridge and managed netdev boundary | Accepted | 2026-06-15 |
-| [0089](0089-evpn-vni-per-bd-vlan-aware-bridge-support.md) | EVPN VNI-per-BD VLAN-aware bridge support | Accepted | 2026-06-15 |
-| [0090](0090-evpn-all-active-esi-overlay-index-type5-receive.md) | All-active ESI overlay-index Type 5 receive | Accepted | 2026-06-17 |
-| [0091](0091-evpn-managed-netdev-creation.md) | rustbgpd-managed netdev creation | Accepted | 2026-06-19 |
-| [0092](0092-evpn-vlan-aware-bundle-service.md) | EVPN VLAN-Aware Bundle service (non-zero Ethernet Tag) | Accepted | 2026-06-19 |
-| [0093](0093-evpn-vlan-macip-fdb-correlation.md) | VLAN MAC+IP attribution via FDB correlation on raw bridge ifindexes | Proposed | 2026-06-19 |
-| [0094](0094-evpn-vxlan-nondf-filtering-l2miss.md) | EVPN VXLAN all-active BUM filtering via kernel l2_miss (revisits ADR-0065) | Accepted (negative result) | 2026-06-29 |
-| [0095](0095-optimal-route-reflection.md) | Optimal Route Reflection via BGP-LS-sourced SPF (RFC 9107) | Accepted | 2026-07-02 |
-| [0096](0096-policy-language.md) | A typed, compiled policy language (`.rpol`) | Accepted | 2026-07-02 |
-| [0097](0097-bmp-monitoring.md) | BMP monitoring — the trio, BMPv4 framing, and path marking | Accepted | 2026-07-03 |
-| [0098](0098-update-groups.md) | RIB-level update groups — shared outbound staging | Accepted | 2026-07-03 |
-| [0099](0099-update-groups-v2.md) | Update groups v2 — per-family keying and RT-aware VPN emit | Accepted | 2026-07-03 |
-| [0100](0100-parallel-rib-manager.md) | Parallelizing the RibManager (research blueprint) | Proposed | 2026-07-03 |
-| [0101](0101-route-server-profile.md) | IXP route-server profile — per-client best-path (RFC 7947 §2.3.2) | Accepted | 2026-07-03 |
-| [0102](0102-evpn-origination-acknowledgement.md) | EVPN origination acknowledgement-awareness (Type 1/2/4) | Accepted | 2026-07-09 |
-| [0103](0103-rpol-execution-model.md) | rpol execution model, purity contract, and evaluation budgets | Accepted | 2026-07-09 |
-| [0104](0104-shutdown-warm-checkpoint-publication.md) | Shutdown warm-checkpoint publication without boot restore | Accepted | 2026-07-13 |
-| [0105](0105-grouped-export-policy-transition.md) | Grouped export-policy transition transaction | Accepted | 2026-07-14 |
-| [0106](0106-warm-checkpoint-restore-decision.md) | Warm checkpoint restore under planned-restart GR | Proposed | 2026-07-14 |
-| [0107](0107-route-server-next-hop-ownership.md) | Route-server NEXT_HOP ownership | Accepted | 2026-07-15 |
-| [0108](0108-per-family-max-prefix-limits.md) | Independent per-family maximum-prefix limits | Accepted | 2026-07-16 |
-| [0109](0109-update-group-shared-encode.md) | Encode-once wire sharing for update-group fanout | Accepted | 2026-07-16 |
-| [0110](0110-irr-peeringdb-filtering-pipeline.md) | IRR/PeeringDB-driven filtering pipeline — ride arouteserver, defer native ingestion | Accepted | 2026-07-17 |
-| [0111](0111-authoritative-policy-replacement-continuation.md) | Actor-owned authoritative export-policy replacement continuation | Rejected (borrow-free Gate 1 NO-GO) | 2026-07-20 |
-| [0112](0112-rfc-8212-ebgp-requires-policy.md) | Opt-in RFC 8212 explicit-policy enforcement for eBGP | Accepted — fully shipped | 2026-07-21 |
-| [0113](0113-outbound-prefix-limits.md) | Per-peer outbound unicast prefix limits | Accepted — released in v0.61.0 | 2026-07-21 |
-| [0114](0114-as4-path-migration.md) | RFC 6793 AS4 path migration across legacy peers | Accepted | 2026-07-21 |
-| [0115](0115-lean-daemon-build-flavors.md) | Lean daemon build flavors | Accepted (no additional flavor) | 2026-07-22 |
-| [0116](0116-rfc-9857-sr-policy-state.md) | RFC 9857 SR Policy state in BGP-LS | Accepted (feature implementation demand-gated) | 2026-07-22 |
-| [0117](0117-authenticated-single-hop-bfd-decision.md) | Authenticated single-hop BFD | Accepted (implementation NO-GO; evidence-gated) | 2026-07-22 |
-| [0118](0118-presence-preserving-runtime-neighbor-create.md) | Presence-preserving runtime neighbor creation | Accepted — fully shipped | 2026-07-29 |
-| [0119](0119-rfc-8212-secure-default-config-epoch.md) | RFC 8212 secure-default config epoch | Accepted (implemented; activation shipped) | 2026-07-29 |
-| [0120](0120-inbound-connection-admission.md) | Inbound connection admission rate limiting | Accepted | 2026-07-30 |
-| [0121](0121-config-history-external-policy-provenance.md) | Config-history external-policy provenance | Accepted — v2 history restore and provenance-bearing commit-confirm v2 shipped | 2026-08-01 |
-| [0122](0122-compatibility-debt-inventory.md) | Compatibility-debt inventory and removal schedule | Accepted | 2026-08-03 |
-| [0123](0123-aspa-v27-mitigation-and-retention.md) | ASPA draft-v27 mitigation requires lossless retention | Proposed (behavior activation NO-GO until retention gates pass) | 2026-08-03 |
-| [0124](0124-bounded-config-history-retention.md) | Bounded config-history retention for oversized snapshots | Proposed (owner decisions recorded; implementation pending) | 2026-08-04 |
-| [0125](0125-v1-stability-contract.md) | v1.0 stability contract | Accepted (tagging remains evidence-gated; no tag is scheduled) | 2026-08-04 |
-| [0126](0126-shared-group-per-client-best.md) | Shared-group per-client best-path — path-hiding mitigation inside update groups | Accepted | 2026-08-05 |
-| [0127](0127-config-transaction-settlement-watchdog.md) | Persisted runtime-config settlement watchdog | Accepted | 2026-08-11 |
-| [0128](0128-route-server-next-hop-translation.md) | Route-server next-hop translation | Accepted (architecture GO if activated; implementation NO-GO, demand-gated) | 2026-08-29 |
-| [0129](0129-prefix-sid-domain-boundary.md) | BGP Prefix-SID administrative-domain boundary | Proposed (no runtime behavior shipped) | 2026-08-29 |
+`Lifecycle` is a navigation aid, not a replacement for the decision's source
+status. Accepted and Current records are Active; rejected records are Rejected.
+A Proposed record is Unstated unless its own text says it is Parked. The
+current proposed records do not, and [ROADMAP's deferred follow-ups](../../ROADMAP.md#deferred-with-rationale)
+do not establish the lifecycle of their associated ADRs. No record currently
+states that the whole decision is Superseded.
+
+| ADR | Title | Status | Date | Lifecycle |
+|-----|-------|--------|------|-----------|
+| [0001](0001-typed-raw-hybrid-path-attributes.md) | Typed + raw hybrid model for path attributes | Accepted | 2026-02-27 | Active |
+| [0002](0002-inherent-methods-not-traits-for-codec.md) | Inherent methods, not traits, for codec API | Accepted | 2026-02-27 | Active |
+| [0003](0003-subcodes-as-constants-not-enums.md) | NOTIFICATION subcodes as constants, not enums | Accepted | 2026-02-27 | Active |
+| [0004](0004-proptest-for-property-testing.md) | Proptest for property-based testing | Accepted | 2026-02-27 | Active |
+| [0005](0005-fsm-pure-state-machine.md) | Pure state machine FSM with no Result return | Accepted | 2026-02-27 | Active |
+| [0006](0006-validate-open-returns-notification.md) | validate_open returns Result\<NegotiatedSession, NotificationMessage\> | Accepted | 2026-02-27 | Active |
+| [0007](0007-explicit-prometheus-registry.md) | Explicit Prometheus registry, not global default | Accepted | 2026-02-27 | Active |
+| [0008](0008-single-task-per-peer.md) | Single tokio task per peer for M0 | Accepted | 2026-02-27 | Active |
+| [0009](0009-iterative-action-loop.md) | Iterative action loop to avoid async recursion | Accepted | 2026-02-27 | Active |
+| [0010](0010-minimal-metrics-server.md) | Minimal TCP metrics server, no HTTP framework | Accepted | 2026-02-27 | Active |
+| [0011](0011-unknown-notification-code-variant.md) | Unknown variant for NOTIFICATION error codes | Accepted | 2026-02-27 | Active |
+| [0012](0012-separate-decode-from-validation.md) | Separate structural decode from semantic validation for UPDATEs | Accepted | 2026-02-27 | Active |
+| [0013](0013-single-task-rib-manager.md) | Single-task RIB manager with channel-based ownership | Accepted | 2026-02-27 | Active |
+| [0014](0014-best-path-standalone-function-deterministic-med.md) | Best-path comparison as standalone function with deterministic MED | Accepted | 2026-02-27 | Active |
+| [0015](0015-adj-rib-out-inside-rib-manager.md) | Adj-RIB-Out inside RibManager with per-peer outbound channels | Accepted | 2026-02-27 | Active |
+| [0016](0016-socket2-for-md5-gtsm.md) | socket2 for TCP MD5 and GTSM socket options | Accepted | 2026-02-27 | Active |
+| [0017](0017-peer-manager-channel-based-ownership.md) | PeerManager — channel-based single-task ownership | Accepted | 2026-02-27 | Active |
+| [0018](0018-broadcast-channel-for-watch-routes.md) | Broadcast channel for WatchRoutes streaming | Accepted | 2026-02-27 | Active |
+| [0019](0019-inbound-tcp-listener.md) | Inbound TCP listener for passive peering | Accepted | 2026-02-27 | Active |
+| [0020](0020-global-control-services-coordinated-shutdown.md) | GlobalService, ControlService, and coordinated shutdown | Accepted | 2026-02-27 | Active |
+| [0021](0021-tcp-collision-detection.md) | TCP collision detection via PeerManager coordination | Accepted | 2026-02-28 | Active |
+| [0022](0022-grpc-server-supervision.md) | gRPC server supervision — unexpected exit triggers shutdown | Accepted | 2026-02-28 | Active |
+| [0023](0023-prefix-enum-afi-agnostic-rib.md) | Prefix enum and AFI-agnostic RIB for MP-BGP | Accepted | 2026-02-28 | Active |
+| [0024](0024-graceful-restart.md) | Graceful Restart — Receiving Speaker (RFC 4724) | Accepted | 2026-03-01 | Active |
+| [0025](0025-extended-communities.md) | Extended Communities (RFC 4360) | Accepted | 2026-03-01 | Active |
+| [0026](0026-extended-community-policy.md) | Extended Community Policy Matching | Accepted | 2026-03-01 | Active |
+| [0027](0027-route-refresh.md) | Route Refresh (RFC 2918) | Accepted | 2026-03-02 | Active |
+| [0028](0028-standard-community-policy.md) | Standard Community Policy Matching (RFC 1997) | Accepted | 2026-03-02 | Active |
+| [0029](0029-route-reflector.md) | Route Reflector (RFC 4456) | Accepted | 2026-03-02 | Active |
+| [0030](0030-policy-actions.md) | Policy Actions and AS_PATH Regex | Accepted | 2026-03-02 | Active |
+| [0031](0031-large-communities.md) | Large Communities (RFC 8092) | Accepted | 2026-03-02 | Active |
+| [0032](0032-extended-messages.md) | Extended Messages (RFC 8654) | Accepted | 2026-03-02 | Active |
+| [0033](0033-add-path.md) | Add-Path (RFC 7911) | Accepted | 2026-03-02 | Active |
+| [0034](0034-rpki-origin-validation.md) | RPKI Origin Validation (RFC 6811 + RFC 8210) | Accepted | 2026-03-03 | Active |
+| [0035](0035-flowspec.md) | FlowSpec (RFC 8955 / RFC 8956) | Accepted | 2026-03-03 | Active |
+| [0036](0036-policy-chaining.md) | Policy Chaining + Named Policies | Accepted | 2026-03-04 | Active |
+| [0037](0037-extended-nexthop.md) | Extended Next Hop Encoding (RFC 8950) | Accepted | 2026-03-04 | Active |
+| [0038](0038-enhanced-route-refresh.md) | Enhanced Route Refresh (RFC 7313) | Accepted | 2026-03-04 | Active |
+| [0039](0039-transparent-route-server.md) | Transparent Route Server Mode | Accepted | 2026-03-04 | Active |
+| [0040](0040-gr-restarting-speaker.md) | Graceful Restart — Minimal Restarting Speaker Mode | Accepted | 2026-03-04 | Active |
+| [0041](0041-bmp-exporter.md) | BMP Exporter (RFC 7854) | Accepted | 2026-03-04 | Active |
+| [0042](0042-llgr.md) | Long-Lived Graceful Restart (RFC 9494) | Accepted | 2026-03-05 | Active |
+| [0043](0043-config-persistence.md) | Config Persistence and SIGHUP Reload | Accepted | 2026-03-05 | Active |
+| [0044](0044-mrt-dump-export.md) | MRT Dump Export (RFC 6396) | Accepted | 2026-03-05 | Active |
+| [0045](0045-private-as-removal.md) | Private AS Removal | Accepted | 2026-03-05 | Active |
+| [0046](0046-notification-gr.md) | Notification GR (RFC 8538) | Accepted | 2026-03-05 | Active |
+| [0047](0047-grpc-security-hardening.md) | gRPC Security Hardening | Accepted | 2026-03-06 | Active |
+| [0048](0048-rib-memory-optimizations.md) | RIB Memory Optimizations | Accepted | 2026-03-08 | Active |
+| [0049](0049-aspa-verification.md) | ASPA Path Verification | Accepted | 2026-03-13 | Active |
+| [0050](0050-evpn-route-reflector.md) | EVPN Route Reflector (RFC 7432 Phase 1) | Accepted | 2026-04-23 | Active |
+| [0051](0051-per-peer-outbound-writer-task.md) | Per-peer outbound writer task | Accepted | 2026-04-27 | Active |
+| [0052](0052-evpn-vtep-foundation.md) | EVPN VTEP Foundation — Local EVI/VNI Domain Model | Accepted | 2026-05-01 | Active |
+| [0053](0053-rfc-8326-graceful-shutdown.md) | RFC 8326 BGP Graceful Shutdown | Accepted | 2026-05-04 | Active |
+| [0054](0054-evpn-linux-dataplane-boundary.md) | EVPN Linux Dataplane Boundary | Accepted | 2026-05-04 | Active |
+| [0055](0055-evpn-local-mac-origination.md) | EVPN Local-MAC Origination Boundary | Accepted | 2026-05-06 | Active |
+| [0056](0056-evpn-sticky-macs.md) | EVPN sticky-MAC operator config | Accepted | 2026-05-08 | Active |
+| [0057](0057-evpn-gate-8-observable-df-election.md) | EVPN Gate 8 — observable DF election without forwarding enforcement | Accepted | 2026-05-09 | Active |
+| [0058](0058-evpn-gate-9-irb-l3vni.md) | EVPN Gate 9 — symmetric IRB, L3VNI, Type 5 dataplane | Accepted | 2026-05-10 | Active |
+| [0059](0059-evpn-aliasing-fdb-nexthop-groups.md) | EVPN aliasing dataplane via FDB nexthop groups | Accepted | 2026-05-12 | Active |
+| [0060](0060-rfc-7999-blackhole.md) | RFC 7999 BLACKHOLE receiver scoping and opt-in FIB discard | Accepted | 2026-05-13 | Active |
+| [0061](0061-opt-in-unicast-linux-fib-integration.md) | Opt-in unicast Linux FIB integration | Accepted | 2026-05-14 | Active |
+| [0062](0062-tcp-ao-foundation.md) | TCP-AO foundation | Accepted | 2026-05-16 | Active |
+| [0063](0063-evpn-runtime-instance-mutation.md) | EVPN runtime instance mutation semantics | Accepted | 2026-05-17 | Active |
+| [0064](0064-grpc-authorization.md) | gRPC per-method authorization | Accepted | 2026-05-18 | Active |
+| [0064-annex](0064-threat-model.md) | gRPC authorization threat model (ADR-0064 annex) | Current | 2026-07-26 | Active |
+| [0065](0065-evpn-localbias-split-horizon.md) | EVPN VXLAN local-bias split-horizon (spike-gated) | Accepted | 2026-05-22 | Active |
+| [0066](0066-unicast-multipath-ecmp-fib.md) | Unicast multipath / ECMP FIB install | Accepted | 2026-05-24 | Active |
+| [0067](0067-bfd-single-hop.md) | Single-hop asynchronous BFD for BGP | Accepted | 2026-05-24 | Active |
+| [0068](0068-weighted-multipath.md) | Weighted (unequal-cost) multipath via Link Bandwidth | Accepted | 2026-05-24 | Active |
+| [0069](0069-bgp-unnumbered.md) | BGP unnumbered and IPv6 link-local peering | Accepted | 2026-05-25 | Active |
+| [0070](0070-gnmi-openconfig-telemetry.md) | gNMI / OpenConfig telemetry and Set adapter | Accepted | 2026-05-25 | Active |
+| [0071](0071-bgp-roles-otc.md) | BGP Roles and Only-to-Customer (RFC 9234) | Accepted | 2026-05-26 | Active |
+| [0072](0072-durable-event-history.md) | Durable event history (local outbox) | Accepted | 2026-05-26 | Active |
+| [0073](0073-import-policy-explain.md) | Import policy explain via per-session decision cache | Accepted | 2026-05-28 | Active |
+| [0074](0074-fib-table-crud-authz-tier.md) | Runtime FIB-table CRUD authorization tier | Accepted | 2026-06-01 | Active |
+| [0075](0075-outbound-route-filtering.md) | Receive-side Address-Prefix Outbound Route Filtering (ORF) | Accepted | 2026-06-03 | Active |
+| [0076](0076-config-transaction-model.md) | Config transaction model foundation | Accepted | 2026-06-03 | Active |
+| [0077](0077-mpls-vpn-bgpls-address-family-boundary.md) | MPLS, VPN, and BGP-LS address-family boundary | Accepted | 2026-06-08 | Active |
+| [0078](0078-inbound-rib-backpressure.md) | Inbound transport→RIB backpressure — block, never drop | Accepted | 2026-06-10 | Active |
+| [0079](0079-kernel-state-crash-restart-reconciliation.md) | Kernel-state crash-restart reconciliation via adoption sweeps | Accepted | 2026-06-10 | Active |
+| [0080](0080-cancellation-shielded-runtime-applies.md) | Cancellation-shielded runtime mutation applies | Accepted | 2026-06-10 | Active |
+| [0081](0081-atomic-peer-group-reshape.md) | Atomic peer-group session reshapes on the targeted RPC path | Accepted | 2026-06-10 | Active |
+| [0082](0082-nda-protocol-ownership-stamp.md) | NDA_PROTOCOL ownership stamping for EVPN FDB/neighbor state | Accepted | 2026-06-10 | Active |
+| [0083](0083-evpn-single-active-backup-path.md) | EVPN single-active backup-path pre-install | Accepted | 2026-06-11 | Active |
+| [0084](0084-evpn-ethernet-segment-drain.md) | Runtime Ethernet Segment drain | Accepted | 2026-06-12 | Active |
+| [0085](0085-evpn-es-interface-binding.md) | Ethernet Segment interface binding — link-driven drain and same-ESI local bias | Accepted | 2026-06-12 | Active |
+| [0086](0086-dynamic-peer-group-reconfigure.md) | Peer-group field edits reach live dynamic sessions via post-persist graceful reset | Accepted | 2026-06-12 | Active |
+| [0087](0087-evpn-type5-gateway-ip-overlay-index-origination.md) | Native GW-IP overlay-index Type 5 origination (RFC 9136) | Accepted | 2026-06-12 | Active |
+| [0088](0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md) | EVPN VLAN-aware bridge and managed netdev boundary | Accepted | 2026-06-15 | Active |
+| [0089](0089-evpn-vni-per-bd-vlan-aware-bridge-support.md) | EVPN VNI-per-BD VLAN-aware bridge support | Accepted | 2026-06-15 | Active |
+| [0090](0090-evpn-all-active-esi-overlay-index-type5-receive.md) | All-active ESI overlay-index Type 5 receive | Accepted | 2026-06-17 | Active |
+| [0091](0091-evpn-managed-netdev-creation.md) | rustbgpd-managed netdev creation | Accepted | 2026-06-19 | Active |
+| [0092](0092-evpn-vlan-aware-bundle-service.md) | EVPN VLAN-Aware Bundle service (non-zero Ethernet Tag) | Accepted | 2026-06-19 | Active |
+| [0093](0093-evpn-vlan-macip-fdb-correlation.md) | VLAN MAC+IP attribution via FDB correlation on raw bridge ifindexes | Proposed | 2026-06-19 | Unstated |
+| [0094](0094-evpn-vxlan-nondf-filtering-l2miss.md) | EVPN VXLAN all-active BUM filtering via kernel l2_miss (revisits ADR-0065) | Accepted (negative result) | 2026-06-29 | Active |
+| [0095](0095-optimal-route-reflection.md) | Optimal Route Reflection via BGP-LS-sourced SPF (RFC 9107) | Accepted | 2026-07-02 | Active |
+| [0096](0096-policy-language.md) | A typed, compiled policy language (`.rpol`) | Accepted | 2026-07-02 | Active |
+| [0097](0097-bmp-monitoring.md) | BMP monitoring — the trio, BMPv4 framing, and path marking | Accepted | 2026-07-03 | Active |
+| [0098](0098-update-groups.md) | RIB-level update groups — shared outbound staging | Accepted | 2026-07-03 | Active |
+| [0099](0099-update-groups-v2.md) | Update groups v2 — per-family keying and RT-aware VPN emit | Accepted | 2026-07-03 | Active |
+| [0100](0100-parallel-rib-manager.md) | Parallelizing the RibManager (research blueprint) | Proposed | 2026-07-03 | Unstated |
+| [0101](0101-route-server-profile.md) | IXP route-server profile — per-client best-path (RFC 7947 §2.3.2) | Accepted | 2026-07-03 | Active |
+| [0102](0102-evpn-origination-acknowledgement.md) | EVPN origination acknowledgement-awareness (Type 1/2/4) | Accepted | 2026-07-09 | Active |
+| [0103](0103-rpol-execution-model.md) | rpol execution model, purity contract, and evaluation budgets | Accepted | 2026-07-09 | Active |
+| [0104](0104-shutdown-warm-checkpoint-publication.md) | Shutdown warm-checkpoint publication without boot restore | Accepted | 2026-07-13 | Active |
+| [0105](0105-grouped-export-policy-transition.md) | Grouped export-policy transition transaction | Accepted | 2026-07-14 | Active |
+| [0106](0106-warm-checkpoint-restore-decision.md) | Warm checkpoint restore under planned-restart GR | Proposed | 2026-07-14 | Unstated |
+| [0107](0107-route-server-next-hop-ownership.md) | Route-server NEXT_HOP ownership | Accepted | 2026-07-15 | Active |
+| [0108](0108-per-family-max-prefix-limits.md) | Independent per-family maximum-prefix limits | Accepted | 2026-07-16 | Active |
+| [0109](0109-update-group-shared-encode.md) | Encode-once wire sharing for update-group fanout | Accepted | 2026-07-16 | Active |
+| [0110](0110-irr-peeringdb-filtering-pipeline.md) | IRR/PeeringDB-driven filtering pipeline — ride arouteserver, defer native ingestion | Accepted | 2026-07-17 | Active |
+| [0111](0111-authoritative-policy-replacement-continuation.md) | Actor-owned authoritative export-policy replacement continuation | Rejected (borrow-free Gate 1 NO-GO) | 2026-07-20 | Rejected |
+| [0112](0112-rfc-8212-ebgp-requires-policy.md) | Opt-in RFC 8212 explicit-policy enforcement for eBGP | Accepted — fully shipped | 2026-07-21 | Active |
+| [0113](0113-outbound-prefix-limits.md) | Per-peer outbound unicast prefix limits | Accepted — released in v0.61.0 | 2026-07-21 | Active |
+| [0114](0114-as4-path-migration.md) | RFC 6793 AS4 path migration across legacy peers | Accepted | 2026-07-21 | Active |
+| [0115](0115-lean-daemon-build-flavors.md) | Lean daemon build flavors | Accepted (no additional flavor) | 2026-07-22 | Active |
+| [0116](0116-rfc-9857-sr-policy-state.md) | RFC 9857 SR Policy state in BGP-LS | Accepted (feature implementation demand-gated) | 2026-07-22 | Active |
+| [0117](0117-authenticated-single-hop-bfd-decision.md) | Authenticated single-hop BFD | Accepted (implementation NO-GO; evidence-gated) | 2026-07-22 | Active |
+| [0118](0118-presence-preserving-runtime-neighbor-create.md) | Presence-preserving runtime neighbor creation | Accepted — fully shipped | 2026-07-29 | Active |
+| [0119](0119-rfc-8212-secure-default-config-epoch.md) | RFC 8212 secure-default config epoch | Accepted (implemented; activation shipped) | 2026-07-29 | Active |
+| [0120](0120-inbound-connection-admission.md) | Inbound connection admission rate limiting | Accepted | 2026-07-30 | Active |
+| [0121](0121-config-history-external-policy-provenance.md) | Config-history external-policy provenance | Accepted — v2 history restore and provenance-bearing commit-confirm v2 shipped | 2026-08-01 | Active |
+| [0122](0122-compatibility-debt-inventory.md) | Compatibility-debt inventory and removal schedule | Accepted | 2026-08-03 | Active |
+| [0123](0123-aspa-v27-mitigation-and-retention.md) | ASPA draft-v27 mitigation requires lossless retention | Proposed (behavior activation NO-GO until retention gates pass) | 2026-08-03 | Unstated |
+| [0124](0124-bounded-config-history-retention.md) | Bounded config-history retention for oversized snapshots | Proposed (owner decisions recorded; implementation pending) | 2026-08-04 | Unstated |
+| [0125](0125-v1-stability-contract.md) | v1.0 stability contract | Accepted (tagging remains evidence-gated; no tag is scheduled) | 2026-08-04 | Active |
+| [0126](0126-shared-group-per-client-best.md) | Shared-group per-client best-path — path-hiding mitigation inside update groups | Accepted | 2026-08-05 | Active |
+| [0127](0127-config-transaction-settlement-watchdog.md) | Persisted runtime-config settlement watchdog | Accepted | 2026-08-11 | Active |
+| [0128](0128-route-server-next-hop-translation.md) | Route-server next-hop translation | Accepted (architecture GO if activated; implementation NO-GO, demand-gated) | 2026-08-29 | Active |
+| [0129](0129-prefix-sid-domain-boundary.md) | BGP Prefix-SID administrative-domain boundary | Proposed (no runtime behavior shipped) | 2026-08-29 | Unstated |
+
+## Supporting records
+
+Supporting records are evidence for an ADR, not separate decisions. Their own
+metadata is indexed independently; `Unstated` is not inferred from the parent
+ADR or from repository history.
+
+| Record | Date stated | Status stated | Workload or shape | Establishes | Does not establish |
+|--------|-------------|---------------|-------------------|-------------|--------------------|
+| [ADR-0103 benchmark spike](0103-rpol-execution-model-spike/README.md) | Unstated | Unstated | Two measurements: the in-tree policy-chain, predicate, and set-heavy Criterion groups; and one 15-term program evaluated as tree-walk, bytecode, and bytecode with fuel over the same deterministic one-million-route stream. | With the counter live, per-instruction fuel cost roughly 0–20% over bare bytecode dispatch; fueled bytecode evaluated at 0.84–0.99 times tree-walk. | Absolute nanoseconds are machine-specific; the ratios are the signal. |
+
+## Lifecycle metadata gaps
+
+The six Proposed records do not state one of the navigation lifecycles above.
+They remain **Unstated** rather than being inferred as Parked:
+
+- [ADR-0093](0093-evpn-vlan-macip-fdb-correlation.md)
+- [ADR-0100](0100-parallel-rib-manager.md)
+- [ADR-0106](0106-warm-checkpoint-restore-decision.md)
+- [ADR-0123](0123-aspa-v27-mitigation-and-retention.md)
+- [ADR-0124](0124-bounded-config-history-retention.md)
+- [ADR-0129](0129-prefix-sid-domain-boundary.md)
 
 ## Template
 

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,243 @@
+# Performance evidence index
+
+> **Document class: CURRENT.** This maintained index describes the current
+> evidence inventory; linked receipts remain historical and bounded to their
+> stated date and shape.
+
+This directory is a historical evidence archive. Each row reports only the
+workload and metadata stated by its linked file; it is not a claim about every
+deployment or the current tip. Follow the linked record before reusing a
+result. `Unstated` means that the linked file does not state the field; this
+index does not infer metadata from filenames, parent directories, or related
+records.
+
+## Primary records
+
+| Document | Date stated | Workload or shape | Establishes | Does not establish |
+|---|---|---|---|---|
+| [`actor-ceiling-1m-2026-07.md`][actor-ceiling-1m-2026-07.md] | 2026-07 | 500 clients, 1M routes, 300 policy changes, three SIGHUP reloads | Transition polls stayed at or below 200 ms, but the post-commit flush blocked readiness for 1.64–2.40 s on all three reloads | A high-percentile bound from a large reload sample |
+| [`adj-rib-out-family-gauge-2026-07.md`][adj-rib-out-family-gauge-2026-07.md] | July 2026 | Family-gauge refresh at 8, 64, 256, and 1,000 peers | 256-peer and 1,000-peer rows improved 11.69% and 14.98% | A sevenfold whole-daemon or every-shape gain |
+| [`attr-intern-hashing-2026-08.md`][attr-intern-hashing-2026-08.md] | August 2026 | Typical and rich attributes at 10k and 100k entries | NO-GO: the isolated hash control exceeded its stability limit | A production change or speedup |
+| [`attr-intern-hashing-recheck-2026-08.md`][attr-intern-hashing-recheck-2026-08.md] | August 2026 | A 35-row same-source control matrix | Not evaluated: six controls exceeded their limits | A performance or regression claim |
+| [`attribute-layout-2026-08.md`][attribute-layout-2026-08.md] | August 2026 | 900k prefixes with 2.7M and 4.5M route-copy models | Slice-backed attributes increased modeled memory by 17.7 and 31.4 MiB | Allocator, locality, conversion-cost, or nested-payload effects |
+| [`authoritative-policy-replacement-cursor-feasibility-2026-07.md`][authoritative-policy-replacement-cursor-feasibility-2026-07.md] | 2026-07 | Borrow-free, exact-once bounded-continuation feasibility gate | Gate 1 NO-GO | Gate 2 or a behavior change |
+| [`competitive-bgperf2-2026-07.md`][competitive-bgperf2-2026-07.md] | Initial campaign 2026-07-26; latest refresh 2026-07-27 | Four daemons, five fleet shapes, three runs per shape | Historical observations whose cross-daemon ranking was later retracted | Any projection beyond 100 peers |
+| [`competitive-bgperf2-v0670-2026-08.md`][competitive-bgperf2-v0670-2026-08.md] | 2026-08-29 | Four daemons, five import shapes, four repetitions | 79 of 80 cells reached the exact expected table | Export, reload, churn, IPv6, Add-Path, OpenBGPD, or another host |
+| [`competitive-bgperf2-v0680-2026-08.md`][competitive-bgperf2-v0680-2026-08.md] | 2026-08-30 | Four daemons, five import shapes, four counterbalanced repetitions | All 80 cells reached the exact expected table | Universal throughput, memory, or CPU ranking |
+| [`config-persistence-2026-07.md`][config-persistence-2026-07.md] | 2026-07-25 | Pinned persistence, history, rollback, and commit-confirm lifecycle harness | Behavioral assertions preserved by the workspace integration test | Timing or performance |
+| [`enhanced-route-refresh-2026-07.md`][enhanced-route-refresh-2026-07.md] | Initial campaign 2026-07; latest refresh 2026-08-30 | 100k-route Enhanced Route Refresh inventory lifecycle | Completion dominated snapshot creation in the all-withdraw shape | Fleet-wide convergence or generic throughput |
+| [`event-history-producer-2026-07.md`][event-history-producer-2026-07.md] | 2026-07 | Three event-history producer shapes at 1.3–3.3 µs per event | The offload proceed gate passed and bounded delivery completed | Independent BIRD timeout evidence |
+| [`exact-export-fanout-2026-07.md`][exact-export-fanout-2026-07.md] | 2026-07 | Four exact-export fanout campaigns with production probes | PASS for the measured grouped fanout optimization | Resync or full-table convergence |
+| [`explain-cache-opt-in-2026-07.md`][explain-cache-opt-in-2026-07.md] | 2026-07 | Same-host route-server memory runs with explain cache on and off | Resident-memory cost of the opt-in import-decision cache | Throughput or competitor ranking |
+| [`fanout-metrics-handle-2026-07.md`][fanout-metrics-handle-2026-07.md] | July 2026 | Homogeneous groups of 1–1,000 peers distributing 64 changed routes | Clone-once metrics handling reduced the measured distribution interval | Whole-daemon convergence |
+| [`fib-kernel-dump-2026-08.md`][fib-kernel-dump-2026-08.md] | 2026-08-30 | 64 managed tables with 0, 1k, 5k, and 20k unrelated routes | Strict-table dump crossover and scaling on Linux 6.17 | Whole-reconcile latency, IPv6, realistic nexthops, or a shipped-code speedup |
+| [`grouped-private-adj-rib-out-late-join-2026-07.md`][grouped-private-adj-rib-out-late-join-2026-07.md] | Unstated | Late join after a preloaded Loc-RIB, measured across client counts | Fresh grouped-join virtual-allocation reduction | A retained-RSS headline |
+| [`grouped-withdrawal-fanout-2026-07.md`][grouped-withdrawal-fanout-2026-07.md] | July 2026 | Grouped withdrawal fanout across the disclosed member fleet | Absolute measurement-only baseline | Writer, socket, network, or end-to-end latency |
+| [`grouped-withdrawal-probe-skip-2026-07.md`][grouped-withdrawal-probe-skip-2026-07.md] | July 2026 | Fixed 64-route withdrawal at 64, 256, and 1,000 members | Exact-probe skip improved measured medians by 6.80–9.33% | A result outside the fixed withdrawal shape |
+| [`high-n-route-server-v0680-2026-08.md`][high-n-route-server-v0680-2026-08.md] | 2026-08-30 | Exact-source 2,500- and 5,000-peer route-server runs | Both high-N runs completed their session and route-count gates | A scaling law, interpolation, or extrapolation |
+| [`irr-reload-comparison-2026-08.md`][irr-reload-comparison-2026-08.md] | 2026-08 | 320 members, 183,040 routes, 3.2M filter entries, eight reload roots | Same-host rustbgpd, BIRD, and OpenBGPD reload observations | A cause for later-reload growth or exact allocator comparison |
+| [`irr-reload-grouped-per-client-best-2026-08.md`][irr-reload-grouped-per-client-best-2026-08.md] | 2026-08 | 320 members, 183,040 prefixes, four reloads per cell | Historical grouped per-client-best acceptance result | A speedup or the internal mechanism behind later-reload growth |
+| [`irr-reload-realistic-mix-2026-08.md`][irr-reload-realistic-mix-2026-08.md] | 2026-08 | Canonical IRR scenario with controlled received-route overlap | Historical realistic-mix reload result | A same-commit A/B or the operational value of a hidden path |
+| [`irr-reload-v0680-2026-08.md`][irr-reload-v0680-2026-08.md] | 2026-08-30 | 320 IPv4 members, 183,040 prefixes, three overlap levels | All 12 roots and 96 verifier rows passed exact route-count gates | IPv6, larger fleets, or other policy distributions |
+| [`irr-transactional-apply-2026-08.md`][irr-transactional-apply-2026-08.md] | 2026-08 | 320-member, 183,040-route, 295.6 MB streamed candidate | Eight full transactional reload cycles completed and were confirmed | A memory optimization claim |
+| [`ixp-matrix-2026-07.md`][ixp-matrix-2026-07.md] | Initial campaign 2026-07; latest refresh 2026-08-30 | 700-session route-server matrix for reload, churn, convergence, and memory | Dated same-host observations for rustbgpd, BIRD, and OpenBGPD | A universal memory win or cross-host ranking |
+| [`known-path-accounting-2026-07.md`][known-path-accounting-2026-07.md] | July 2026 | Two BIRD peers, 100k prefixes each, one GoBGP monitor | Compact plain-unicast accounting reduced the measured common-case memory | An Add-Path memory win |
+| [`lean-daemon-build-flavors-2026-07.md`][lean-daemon-build-flavors-2026-07.md] | July 2026 | Four release build flavors and their dependency inventories | Dependency and binary-size observations for the disclosed builds | Shipped prototype features or every production config ingress |
+| [`memory-attribution-2026-08.md`][memory-attribution-2026-08.md] | 2026-08 | 100 peers × 1,000 routes, three fresh-build arms, five runs each | Attribution of the July memory step across the measured arms | Portable process-RSS or cross-host conclusions |
+| [`mrt-snapshot-allocation-2026-07.md`][mrt-snapshot-allocation-2026-07.md] | July 2026 | Public snapshot encoder with ordinary and warm-checkpoint outputs | Bounded ordinary-output growth passed and was implemented | A completed warm-checkpoint preallocation result |
+| [`otc-pristine-reconcile-2026-07.md`][otc-pristine-reconcile-2026-07.md] | July 2026 | Pristine OTC path, 64 routes, 1–1,000 homogeneous peers | Early return improved the exact pristine reconciliation case | Whole-daemon convergence or active OTC-blocked state |
+| [`outbound-prefix-limit-admission-compaction-2026-07.md`][outbound-prefix-limit-admission-compaction-2026-07.md] | 2026-07 | Homogeneous IPv4 group, one run per revision and fleet size | Admission-compaction result for the archived harness shape | IPv6, Add-Path, heterogeneous groups, or mixed capabilities |
+| [`outbound-prefix-limit-recovery-slicing-2026-07.md`][outbound-prefix-limit-recovery-slicing-2026-07.md] | 2026-07 | 400k IPv4 routes recovered across bounded member slices | Recovery became bounded actor turns at the measured fleet sizes | A short total recovery time |
+| [`outbound-prefix-limit-scale-2026-07.md`][outbound-prefix-limit-scale-2026-07.md] | 2026-07 | Real daemon and TCP driver across grouped prefix-limit fleet sizes | Archived scale observations for admission, suppression, and recovery | Run-to-run variance or extrapolation past 100 members and 400k routes |
+| [`outbound-prefix-limits-2026-07.md`][outbound-prefix-limits-2026-07.md] | 2026-07-24 | Pinned outbound-prefix-limit behavior harness | Limit, warning, teardown, and recovery behavior | Timing or performance |
+| [`per-peer-rss-attribution-2026-07.md`][per-peer-rss-attribution-2026-07.md] | 2026-07 | 10/100 peers and 10k/100k BASE-route matrix | Both peer and route dimensions materially affect memory | “Memory tracks peers, not routes” |
+| [`persisted-config-serialization-2026-08.md`][persisted-config-serialization-2026-08.md] | August 2026 | Legacy and bounded serialization over the same 342,422,071-byte config | Phase attribution and byte-identical serialization output | Portable conclusions from small `/proc` RSS movement |
+| [`policy-attribution-criterion-2026-07.md`][policy-attribution-criterion-2026-07.md] | Unstated | Four Criterion policy-evaluation shapes with same-SHA and isolated controls | The measured deltas do not support CPU-gain attribution | Convergence, reload latency, throughput, or end-to-end gain |
+| [`policy-fallback-per-peer-handoff-2026-07.md`][policy-fallback-per-peer-handoff-2026-07.md] | July 2026 | Clean policy transition with typed grouped and fallback outcomes | Per-member fallback work moved out of the clean actor poll | Total-work improvement or wall-clock scheduler latency |
+| [`policy-regroup-shared-plan-2026-07.md`][policy-regroup-shared-plan-2026-07.md] | July 2026 | Four alternating reloads between pinned base and candidate revisions | Shared regroup-plan transition result for the disclosed fleet | General RIB-query latency during the transition |
+| [`private-single-best-fanout-2026-07.md`][private-single-best-fanout-2026-07.md] | 2026-07-30 | Manager-path fanout at 1, 8, 64, and 256 peers | Improvement at 8, 64, and 256 peers with linear absolute scaling there | A one-peer improvement |
+| [`probe-mp-reach-borrowed-attrs-2026-08.md`][probe-mp-reach-borrowed-attrs-2026-08.md] | August 2026 | IPv6 MP_REACH exact-export probe with paired allocation campaigns | Removed a temporary attribute-vector clone in the measured path | RSS, live heap, convergence, or whole-daemon memory |
+| [`rebaseline-2026-07.md`][rebaseline-2026-07.md] | 2026-07 | Manager-direct RR fanout reconstruction and memory attribution | Post-update-group manager-phase and allocation breakdown | Transport, encode, writer, network, or backpressure cost |
+| [`reload-authoritative-batch-discriminator-2026-08.md`][reload-authoritative-batch-discriminator-2026-08.md] | August 2026 | Two identical 320-member, 183,040-prefix roots on one candidate | Localized later-reload growth to registration/membership, with a negative adjudicator result | A mechanism, improvement, or authorization to optimize |
+| [`reload-flush-envelope-2026-07.md`][reload-flush-envelope-2026-07.md] | 2026-07 | 100-peer fleets with 100k, 300k, and 500k tables | Reload-flush depooling tracked fleet shape more than route volume | A fitted coefficient or fully orthogonalized peer-axis result |
+| [`reload-generation-phase-attribution-2026-08.md`][reload-generation-phase-attribution-2026-08.md] | August 2026 | Two 320-member, 183,040-prefix roots with four SIGHUP reloads | Localized later-reload latency inside the synchronous authoritative RIB transition | A mechanism, latency improvement, or sufficient basis for a fix |
+| [`reload-stall-2026-07.md`][reload-stall-2026-07.md] | Initial campaign 2026-07-11; latest campaign 2026-07-16 | 700 clients, 400,400 routes, live churn, four reloads | Dated reload stall and completion observations | A settled RSS plateau from four cycles |
+| [`revised-update-duplicate-table-2026-07.md`][revised-update-duplicate-table-2026-07.md] | 2026-07 | One clean UPDATE through the eBGP disposition branch | Fixed-table duplicate detection improved the measured parser fixture | A causal 21.73% speedup after the biased control |
+| [`rib-criterion-noise-floor-2026-07.md`][rib-criterion-noise-floor-2026-07.md] | 2026-07 | Same-SHA controls plus isolated LLGR tag-lookup row | Establishes the host noise floor and one scoped CPU improvement | Convergence, pipeline, other sizes, or other hosts |
+| [`rib-memory-v0680-2026-08.md`][rib-memory-v0680-2026-08.md] | 2026-08-30 | Twelve shared v0.67/v0.68 RIB memory shapes | Shared rows were byte-identical between releases | Whole-daemon RSS or live-table footprint |
+| [`rib-ops-prefix-fixture-audit-2026-08.md`][rib-ops-prefix-fixture-audit-2026-08.md] | 2026-08 | Audit of the pre-fix prefix generator above 65,536 entries | Historical rows remain valid only for their duplicate-shaped workload | Unique-table throughput or high-N extrapolation |
+| [`rib-rebaseline-2026-07-13.md`][rib-rebaseline-2026-07-13.md] | 2026-07-13 | Flood and churn shapes plus a two-peer 100k-route run | Production-encoder CPU attribution and a one-capture 210,338,877-byte live-heap component breakdown | Independently measured BIRD tester timeouts |
+| [`rib-route-paging-2026-07.md`][rib-route-paging-2026-07.md] | Initial campaign 2026-07; ordered-index follow-up 2026-07-18 | Bounded unicast pages and grouped advertised-route materialization | Identified full-scope scans and removed grouped full-view cloning | Performance for the later ordered-index method without a receipt |
+| [`route-server-1000-2026-07.md`][route-server-1000-2026-07.md] | Initial campaign 2026-07-20; latest refresh 2026-08-30 | 1,000 eBGP clients, 400k routes, uniform export policy | The real daemon completed the disclosed capacity and reload gates | Competitor comparison or universal forecast |
+| [`scale-receipt-2026-07.md`][scale-receipt-2026-07.md] | Initial campaign 2026-07-03; latest refresh 2026-08-30 | 1,000 RR clients × 100k routes in the rrharness | Absolute route-reflector fanout and memory baseline | Larger-fleet scaling or real-NIC behavior |
+| [`shared-source-ordering-2026-07.md`][shared-source-ordering-2026-07.md] | 2026-07 | Multi-source speedup target with retained one-source guards | NO-GO because the 400k/1-source row regressed 5.298% | A shipped performance change |
+| [`unicast-prefix-announcer-index-2026-08.md`][unicast-prefix-announcer-index-2026-08.md] | 2026-08 | Three admitted campaigns and six pairs per rung | Announcer-index compaction passed the bounded no-regression gate | Universal throughput speedup |
+| [`v0.61.0-final-performance-2026-07.md`][v0.61.0-final-performance-2026-07.md] | 2026-07 | Three 1,000-client, 400k-route daemon runs plus Criterion rows | Absolute v0.61.0 release-candidate baseline | An A/B optimization or CPU-delta claim |
+| [`vpn-rib-query-occupancy-method.md`][vpn-rib-query-occupancy-method.md] | Unstated | Existing `ListVpnRoutes` path with a 48-cell campaign method | The required campaign and verifier protocol | A committed result or API redesign |
+| [`wire-codec-allocation-2026-07.md`][wire-codec-allocation-2026-07.md] | July 2026 | Rich 11-attribute encode and six-attribute UPDATE validation fixtures | Measured fixture improvements of 28.34% and 90.57% | Framing, policy, RIB, fanout, sockets, or convergence |
+
+[actor-ceiling-1m-2026-07.md]: actor-ceiling-1m-2026-07.md
+[adj-rib-out-family-gauge-2026-07.md]: adj-rib-out-family-gauge-2026-07.md
+[attr-intern-hashing-2026-08.md]: attr-intern-hashing-2026-08.md
+[attr-intern-hashing-recheck-2026-08.md]: attr-intern-hashing-recheck-2026-08.md
+[attribute-layout-2026-08.md]: attribute-layout-2026-08.md
+[authoritative-policy-replacement-cursor-feasibility-2026-07.md]: authoritative-policy-replacement-cursor-feasibility-2026-07.md
+[competitive-bgperf2-2026-07.md]: competitive-bgperf2-2026-07.md
+[competitive-bgperf2-v0670-2026-08.md]: competitive-bgperf2-v0670-2026-08.md
+[competitive-bgperf2-v0680-2026-08.md]: competitive-bgperf2-v0680-2026-08.md
+[config-persistence-2026-07.md]: config-persistence-2026-07.md
+[enhanced-route-refresh-2026-07.md]: enhanced-route-refresh-2026-07.md
+[event-history-producer-2026-07.md]: event-history-producer-2026-07.md
+[exact-export-fanout-2026-07.md]: exact-export-fanout-2026-07.md
+[explain-cache-opt-in-2026-07.md]: explain-cache-opt-in-2026-07.md
+[fanout-metrics-handle-2026-07.md]: fanout-metrics-handle-2026-07.md
+[fib-kernel-dump-2026-08.md]: fib-kernel-dump-2026-08.md
+[grouped-private-adj-rib-out-late-join-2026-07.md]: grouped-private-adj-rib-out-late-join-2026-07.md
+[grouped-withdrawal-fanout-2026-07.md]: grouped-withdrawal-fanout-2026-07.md
+[grouped-withdrawal-probe-skip-2026-07.md]: grouped-withdrawal-probe-skip-2026-07.md
+[high-n-route-server-v0680-2026-08.md]: high-n-route-server-v0680-2026-08.md
+[irr-reload-comparison-2026-08.md]: irr-reload-comparison-2026-08.md
+[irr-reload-grouped-per-client-best-2026-08.md]: irr-reload-grouped-per-client-best-2026-08.md
+[irr-reload-realistic-mix-2026-08.md]: irr-reload-realistic-mix-2026-08.md
+[irr-reload-v0680-2026-08.md]: irr-reload-v0680-2026-08.md
+[irr-transactional-apply-2026-08.md]: irr-transactional-apply-2026-08.md
+[ixp-matrix-2026-07.md]: ixp-matrix-2026-07.md
+[known-path-accounting-2026-07.md]: known-path-accounting-2026-07.md
+[lean-daemon-build-flavors-2026-07.md]: lean-daemon-build-flavors-2026-07.md
+[memory-attribution-2026-08.md]: memory-attribution-2026-08.md
+[mrt-snapshot-allocation-2026-07.md]: mrt-snapshot-allocation-2026-07.md
+[otc-pristine-reconcile-2026-07.md]: otc-pristine-reconcile-2026-07.md
+[outbound-prefix-limit-admission-compaction-2026-07.md]: outbound-prefix-limit-admission-compaction-2026-07.md
+[outbound-prefix-limit-recovery-slicing-2026-07.md]: outbound-prefix-limit-recovery-slicing-2026-07.md
+[outbound-prefix-limit-scale-2026-07.md]: outbound-prefix-limit-scale-2026-07.md
+[outbound-prefix-limits-2026-07.md]: outbound-prefix-limits-2026-07.md
+[per-peer-rss-attribution-2026-07.md]: per-peer-rss-attribution-2026-07.md
+[persisted-config-serialization-2026-08.md]: persisted-config-serialization-2026-08.md
+[policy-attribution-criterion-2026-07.md]: policy-attribution-criterion-2026-07.md
+[policy-fallback-per-peer-handoff-2026-07.md]: policy-fallback-per-peer-handoff-2026-07.md
+[policy-regroup-shared-plan-2026-07.md]: policy-regroup-shared-plan-2026-07.md
+[private-single-best-fanout-2026-07.md]: private-single-best-fanout-2026-07.md
+[probe-mp-reach-borrowed-attrs-2026-08.md]: probe-mp-reach-borrowed-attrs-2026-08.md
+[rebaseline-2026-07.md]: rebaseline-2026-07.md
+[reload-authoritative-batch-discriminator-2026-08.md]: reload-authoritative-batch-discriminator-2026-08.md
+[reload-flush-envelope-2026-07.md]: reload-flush-envelope-2026-07.md
+[reload-generation-phase-attribution-2026-08.md]: reload-generation-phase-attribution-2026-08.md
+[reload-stall-2026-07.md]: reload-stall-2026-07.md
+[revised-update-duplicate-table-2026-07.md]: revised-update-duplicate-table-2026-07.md
+[rib-criterion-noise-floor-2026-07.md]: rib-criterion-noise-floor-2026-07.md
+[rib-memory-v0680-2026-08.md]: rib-memory-v0680-2026-08.md
+[rib-ops-prefix-fixture-audit-2026-08.md]: rib-ops-prefix-fixture-audit-2026-08.md
+[rib-rebaseline-2026-07-13.md]: rib-rebaseline-2026-07-13.md
+[rib-route-paging-2026-07.md]: rib-route-paging-2026-07.md
+[route-server-1000-2026-07.md]: route-server-1000-2026-07.md
+[scale-receipt-2026-07.md]: scale-receipt-2026-07.md
+[shared-source-ordering-2026-07.md]: shared-source-ordering-2026-07.md
+[unicast-prefix-announcer-index-2026-08.md]: unicast-prefix-announcer-index-2026-08.md
+[v0.61.0-final-performance-2026-07.md]: v0.61.0-final-performance-2026-07.md
+[vpn-rib-query-occupancy-method.md]: vpn-rib-query-occupancy-method.md
+[wire-codec-allocation-2026-07.md]: wire-codec-allocation-2026-07.md
+
+## Supporting records
+
+These files retain manifests, raw-output indexes, comparisons, verifier
+summaries, and reproduction instructions. Their title and date are taken only
+from that file; a directory name does not fill a missing date.
+
+| Document | Date stated | Workload, shape, or role | Establishes | Does not establish |
+|---|---|---|---|---|
+| [`artifacts/adj-rib-out-family-gauge-2026-07/README.md`](artifacts/adj-rib-out-family-gauge-2026-07/README.md) | Unstated | Exact unrounded estimates and controls for the linked family-gauge receipt | Unstated | Unstated |
+| [`artifacts/adj-rib-out-family-gauge-2026-07/rejected-attempts.md`](artifacts/adj-rib-out-family-gauge-2026-07/rejected-attempts.md) | Unstated | Preflight-invalid and threshold-crossing attempts | Why those attempts were excluded | A retained result |
+| [`artifacts/attribute-layout-2026-08/README.md`](artifacts/attribute-layout-2026-08/README.md) | Unstated | 100k, 500k, and 900k structural rows plus a 200k-route bgperf2 result | The container-layout migration was rejected before a prototype | A live-byte A/B or throughput result |
+| [`artifacts/competitive-bgperf2-2026-07/README.md`](artifacts/competitive-bgperf2-2026-07/README.md) | 2026-07 | Four daemons, five fleet shapes, and three runs per shape | The retained inputs can recompute the linked receipt | Unstated |
+| [`artifacts/competitive-bgperf2-v0680-2026-08/README.md`](artifacts/competitive-bgperf2-v0680-2026-08/README.md) | Unstated | Eighty rows across five fixed import shapes | The retained row and image inventory | A full-table campaign |
+| [`artifacts/current-scale-v0680-2026-08/README.md`](artifacts/current-scale-v0680-2026-08/README.md) | Unstated | IXP-700 S2/S3, route-server-1000, and three RR1000 runs | Compact source-equivalent v0.68.0 evidence | Unstated |
+| [`artifacts/enhanced-route-refresh-2026-07/README.md`](artifacts/enhanced-route-refresh-2026-07/README.md) | Unstated | One Enhanced Route Refresh peer with 100,000 IPv4 unicast routes | Retained phase, actor-duration, and memory boundaries | A 1M-route result |
+| [`artifacts/enhanced-route-refresh-v0680-2026-08/README.md`](artifacts/enhanced-route-refresh-v0680-2026-08/README.md) | Unstated | Exact-release phase, correctness, actor-duration, and memory observations | The compact summary and provenance inventory | Unstated |
+| [`artifacts/event-history-producer-2026-07/README.md`](artifacts/event-history-producer-2026-07/README.md) | 2026-07 | Criterion phases and four enabled/disabled full-daemon profiles | The machine-artifact and verdict inventory | Unstated |
+| [`artifacts/explain-cache-opt-in-2026-07/README.md`](artifacts/explain-cache-opt-in-2026-07/README.md) | Unstated | Real-daemon explain-cache memory campaign across two source trees | The bounded retained artifact inventory | Unstated |
+| [`artifacts/fanout-source-stack-2026-07/README.md`](artifacts/fanout-source-stack-2026-07/README.md) | Unstated | Four six-attempt, five-shape Criterion comparisons | Exact aggregate statistics and retained inputs | Unstated |
+| [`artifacts/fanout-source-stack-2026-07/metrics-before-after-summary.md`](artifacts/fanout-source-stack-2026-07/metrics-before-after-summary.md) | Unstated | Criterion before/after comparison summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/fanout-source-stack-2026-07/metrics-same-sha-summary.md`](artifacts/fanout-source-stack-2026-07/metrics-same-sha-summary.md) | Unstated | Criterion same-SHA comparison summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/fanout-source-stack-2026-07/otc-before-after-summary.md`](artifacts/fanout-source-stack-2026-07/otc-before-after-summary.md) | Unstated | OTC before/after Criterion comparison summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/fanout-source-stack-2026-07/otc-same-sha-summary.md`](artifacts/fanout-source-stack-2026-07/otc-same-sha-summary.md) | Unstated | OTC same-SHA Criterion comparison summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/grouped-exact-precommit-2026-07/README.md`](artifacts/grouped-exact-precommit-2026-07/README.md) | 2026-07 | Campaign 3 of the grouped exact-export fanout receipt | Retained result rows, hashes, gate decisions, and completion marker | Unstated |
+| [`artifacts/grouped-private-adj-rib-out-late-join-2026-07/README.md`](artifacts/grouped-private-adj-rib-out-late-join-2026-07/README.md) | Unstated | Same-host A/B/B/A late-join campaign | The complete retained inputs for the linked receipt | Unstated |
+| [`artifacts/grouped-withdrawal-fanout-2026-07/README.md`](artifacts/grouped-withdrawal-fanout-2026-07/README.md) | Unstated | Exact-commit grouped-withdrawal baseline campaign | Retained estimates, workload, and claim boundary | Unstated |
+| [`artifacts/grouped-withdrawal-probe-skip-2026-07/README.md`](artifacts/grouped-withdrawal-probe-skip-2026-07/README.md) | Unstated | A/B/B/A grouped-withdrawal exact-probe campaign at 8, 64, 256, and 1,000 members | A manager-path improvement at 64, 256, and 1,000 members | An 8-member, full-daemon, convergence, or network-throughput result |
+| [`artifacts/high-n-route-server-v0680-2026-08/README.md`](artifacts/high-n-route-server-v0680-2026-08/README.md) | Unstated | Exact-source 2,500- and 5,000-peer runs | Status, timing, settled RSS, and provenance rows | A replayable binary package |
+| [`artifacts/irr-reload-comparison-2026-08/README.md`](artifacts/irr-reload-comparison-2026-08/README.md) | 2026-08 | Four verified sealed comparison roots | Verifier output and sealed-root identity digests | Unstated |
+| [`artifacts/irr-reload-grouped-per-client-best-2026-08/README.md`](artifacts/irr-reload-grouped-per-client-best-2026-08/README.md) | 2026-08 | Eight roots across announcement overlap points 0.1 and 0.5 | Verifier output, received-view identities, and root digests | Unstated |
+| [`artifacts/irr-reload-realistic-mix-2026-08/README.md`](artifacts/irr-reload-realistic-mix-2026-08/README.md) | 2026-08 | Eight roots across announcement overlap points 0.1 and 0.5 | Verifier output and sealed-root identity digests | Unstated |
+| [`artifacts/irr-reload-v0680-2026-08/README.md`](artifacts/irr-reload-v0680-2026-08/README.md) | 2026-08-30 | Twenty-four comparison and eight grouped-control rows per overlap point | Every verifier-approved row and derived RSS peak | An exact-tag run |
+| [`artifacts/irr-transactional-apply-2026-08/README.md`](artifacts/irr-transactional-apply-2026-08/README.md) | 2026-08 | Two verified sealed transactional-apply roots | Verifier output, transaction lifecycle, and identity digests | Unstated |
+| [`artifacts/ixp-exact-export-cohorts-2026-07/README.md`](artifacts/ixp-exact-export-cohorts-2026-07/README.md) | Unstated | IXP exact-export cohort summaries and production state-machine counters | Aggregate estimates and first-invocation counters | Raw samples |
+| [`artifacts/ixp-matrix-2026-07/README.md`](artifacts/ixp-matrix-2026-07/README.md) | 2026-07 | Seven hundred peers and 400,400 prefixes across three daemons | Raw data behind the linked route-server matrix | Unstated |
+| [`artifacts/known-path-accounting-2026-07/README.md`](artifacts/known-path-accounting-2026-07/README.md) | July 2026 | Eight admitted bgperf2 rows with sixteen BIRD logs | The manifest, route-count rows, and zero `RMT` log scan | Independent timeout evidence from bgperf2's structural field |
+| [`artifacts/memory-attribution-2026-08/README.md`](artifacts/memory-attribution-2026-08/README.md) | 2026-08 | Seven sealed coarse-to-single-commit campaigns | Preregistered manifests, result tables, verdicts, and identity seals | Unstated |
+| [`artifacts/mrt-snapshot-allocation-2026-07/README.md`](artifacts/mrt-snapshot-allocation-2026-07/README.md) | Unstated | Two-shape ordinary and warm-checkpoint allocation control | Feasibility evidence for a separately measured candidate | A future candidate's speedup or timing comparator |
+| [`artifacts/outbound-prefix-limit-admission-compaction-2026-07/README.md`](artifacts/outbound-prefix-limit-admission-compaction-2026-07/README.md) | Unstated | One cell per revision and fleet size through 100 members and 400,000 IPv4 routes | The acceptance allocator delta and behavior summary | Exact retained-heap ownership, run variance, or larger-shape extrapolation |
+| [`artifacts/outbound-prefix-limit-recovery-slicing-2026-07/README.md`](artifacts/outbound-prefix-limit-recovery-slicing-2026-07/README.md) | Unstated | One source, 400,000 IPv4 routes, and 1, 10, or 100 recovering members | The six-cell recovery summary | Run variance or reduced total replay work |
+| [`artifacts/outbound-prefix-limit-scale-2026-07/README.md`](artifacts/outbound-prefix-limit-scale-2026-07/README.md) | Unstated | One source and 400,000 IPv4 routes across the retained fleet sizes | Scale rows and adjacent same-SHA control subtraction | Run-to-run variance |
+| [`artifacts/per-peer-rss-attribution-2026-07/README.md`](artifacts/per-peer-rss-attribution-2026-07/README.md) | Unstated | Real-daemon peer and BASE-route RSS attribution campaign | The exact 6,150,300-byte eager-reserve allocation stack | An attributable RSS improvement |
+| [`artifacts/persisted-config-serialization-2026-08/README.md`](artifacts/persisted-config-serialization-2026-08/README.md) | Unstated | AB/BA/AB serialization of 320 policy definitions with 10,000 statements each | Byte identity and the retained memory and latency gates | Unstated |
+| [`artifacts/policy-attribution-criterion-2026-07/README.md`](artifacts/policy-attribution-criterion-2026-07/README.md) | Unstated | Six-attempt policy-attribution Criterion package | The retained row classifications and verifier inputs | Unstated |
+| [`artifacts/policy-attribution-criterion-2026-07/control-summary.md`](artifacts/policy-attribution-criterion-2026-07/control-summary.md) | Unstated | Same-SHA Criterion comparison summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/policy-attribution-criterion-2026-07/isolated-summary.md`](artifacts/policy-attribution-criterion-2026-07/isolated-summary.md) | Unstated | Isolated Criterion comparison summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/policy-attribution-criterion-2026-07/red-proofs.md`](artifacts/policy-attribution-criterion-2026-07/red-proofs.md) | Unstated | Independent verifier mutations | The named mutations make their verifier paths fail | Unstated |
+| [`artifacts/policy-reload-cohort-partition-2026-07/README.md`](artifacts/policy-reload-cohort-partition-2026-07/README.md) | Unstated | Seven hundred sessions, 400,400 routes, 600 changed peers, 100 stable peers, and four reloads | Completion p50 improved 116.185 times while delivery-gap p50 worsened 2.070 times | An unconditional performance acceptance or sub-second delivery stall |
+| [`artifacts/policy-reload-cohort-partition-2026-07/REPRODUCE.md`](artifacts/policy-reload-cohort-partition-2026-07/REPRODUCE.md) | Unstated | Reproduction instructions for the mixed export-policy reload campaign | Unstated | Unstated |
+| [`artifacts/policy-set-store-2026-07/README.md`](artifacts/policy-set-store-2026-07/README.md) | 2026-07 | Common sets at 1, 10, 100, and 1,000 peers plus unique sets around 32-peer chunk boundaries | Bounded chunk sharing passed its common-set and unique-set gates | Arbitrarily many distinct sets per peer or a shipped CPU-regression claim |
+| [`artifacts/private-single-best-fanout-2026-07/README.md`](artifacts/private-single-best-fanout-2026-07/README.md) | Unstated | Sanitized control and A/B summaries with exact Criterion estimates | The retained artifact inventory | Unstated |
+| [`artifacts/private-single-best-fanout-2026-07/ab-summary.md`](artifacts/private-single-best-fanout-2026-07/ab-summary.md) | Unstated | Private single-best A/B Criterion summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/private-single-best-fanout-2026-07/control-summary.md`](artifacts/private-single-best-fanout-2026-07/control-summary.md) | Unstated | Private single-best same-SHA Criterion summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/raw-bridge-event-skew-2026-08/README.md`](artifacts/raw-bridge-event-skew-2026-08/README.md) | 2026-08-31 | One 4,000-pair run for each of six kernel and traffic-profile tuples | Every measured pair was FDB-first, with descriptive inter-arrival observations | Variance, a worst-case bound, freshness window, kernel regression, or production behavior |
+| [`artifacts/reload-generation-phase-attribution-2026-08/README.md`](artifacts/reload-generation-phase-attribution-2026-08/README.md) | Unstated | Two four-row campaigns with 320 sessions | Later-reload growth is inside the synchronous batched authoritative RIB transition | The internal mechanism, an improvement, or authorization to optimize |
+| [`artifacts/reload-stall-2026-07-16/README.md`](artifacts/reload-stall-2026-07-16/README.md) | 2026-07-16 | Accepted 700-member, 400,400-route reload-stall campaign outputs | The raw outputs behind the linked receipt's current numbers | Unstated |
+| [`artifacts/revised-update-duplicate-table-2026-07/README.md`](artifacts/revised-update-duplicate-table-2026-07/README.md) | Unstated | Six same-revision and six immediate-baseline/candidate pairs plus allocation diagnostics | One allocation and 48 requested bytes removed per call, plus a narrower fixture-scoped timing separation | A formal bias correction, daemon, fleet, full-table, network, convergence, or RSS result |
+| [`artifacts/revised-update-duplicate-table-2026-07/REPRODUCE.md`](artifacts/revised-update-duplicate-table-2026-07/REPRODUCE.md) | Unstated | Reproduction instructions for the duplicate-table comparisons | Unstated | Unstated |
+| [`artifacts/revised-update-duplicate-table-2026-07/control-summary.md`](artifacts/revised-update-duplicate-table-2026-07/control-summary.md) | Unstated | Same-revision Criterion comparison summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/revised-update-duplicate-table-2026-07/target-summary.md`](artifacts/revised-update-duplicate-table-2026-07/target-summary.md) | Unstated | Immediate-baseline/candidate Criterion summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/rib-criterion-noise-floor-2026-07/README.md`](artifacts/rib-criterion-noise-floor-2026-07/README.md) | Unstated | Four six-attempt Criterion comparisons | The retained noise-floor and isolated-row evidence | Unstated |
+| [`artifacts/rib-criterion-noise-floor-2026-07/runs/control-adj-rib-in-same-sha/summary.md`](artifacts/rib-criterion-noise-floor-2026-07/runs/control-adj-rib-in-same-sha/summary.md) | Unstated | Adj-RIB-In same-SHA Criterion summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/rib-criterion-noise-floor-2026-07/runs/control-pipeline-bulk-same-sha/summary.md`](artifacts/rib-criterion-noise-floor-2026-07/runs/control-pipeline-bulk-same-sha/summary.md) | Unstated | Pipeline and bulk same-SHA Criterion summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/rib-criterion-noise-floor-2026-07/runs/llgr-tag-guard-isolated/summary.md`](artifacts/rib-criterion-noise-floor-2026-07/runs/llgr-tag-guard-isolated/summary.md) | Unstated | Isolated LLGR tag-guard Criterion summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/rib-criterion-noise-floor-2026-07/runs/v0.60.0-to-head/summary.md`](artifacts/rib-criterion-noise-floor-2026-07/runs/v0.60.0-to-head/summary.md) | Unstated | v0.60.0-to-head Criterion summary | No confident regressions under the configured rule | Unstated |
+| [`artifacts/rib-memory-v0680-2026-08/README.md`](artifacts/rib-memory-v0680-2026-08/README.md) | Unstated | Twelve shared v0.67/v0.68 shapes and six v0.68-only shapes | The complete compact comparison output | A/B deltas for the six v0.68-only rows |
+| [`artifacts/rib-rebaseline-2026-07-13/README.md`](artifacts/rib-rebaseline-2026-07-13/README.md) | 2026-07-13 | Eight CPU profiles and the full-daemon memory-attribution run | The revision-pinned artifact and classifier inventory | Unstated |
+| [`artifacts/rib-route-paging-2026-07/README.md`](artifacts/rib-route-paging-2026-07/README.md) | 2026-07-13 | Four-repetition route-paging matrix | The retained matrix and manifest inventory | Unstated |
+| [`artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-final-post-fix.md`](artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-final-post-fix.md) | Unstated | Three-group ordered-index post-fix A/B | Confident recompute regressions remained at sizes 1, 2, 4, and 8 | Unstated |
+| [`artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-initial-repro.md`](artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-initial-repro.md) | Unstated | Two-attempt initial ordered-index reproduction | No confident regressions under the configured rule | A conclusion beyond the insufficient attempt count |
+| [`artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-noop-discriminator.md`](artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-noop-discriminator.md) | Unstated | Three-attempt no-op-body discriminator | Confident recompute regressions at sizes 1, 4, and 8 | Unstated |
+| [`artifacts/rib-route-paging-2026-07-route-churn-control.md`](artifacts/rib-route-paging-2026-07-route-churn-control.md) | 2026-07-13 | Four counterbalanced route-churn comparisons | No confident regression | Unstated |
+| [`artifacts/route-server-1000-2026-07/README.md`](artifacts/route-server-1000-2026-07/README.md) | Unstated | Real-daemon 1,000-peer route-server campaign artifacts | The bounded retained artifact inventory | Unstated |
+| [`artifacts/selection-deferral-release-v0680-2026-08/README.md`](artifacts/selection-deferral-release-v0680-2026-08/README.md) | Unstated | Three timer-release modes at 700 peers and 400,400 routes, five runs per variant | Fully reusable homogeneous-wire cohorts improved 35.83 to 66.09 times | Whole-daemon convergence, policy reload timing, mixed-capability fleets, or fallback paths |
+| [`artifacts/session-notification-flapstorm-2026-08/README.md`](artifacts/session-notification-flapstorm-2026-08/README.md) | 2026-08-25 | One 700-session, 400,400-prefix run with three 50-session flap rounds | All ten checkpoints drained notification accounting to zero | Handling completion, queue capacity, latency, memory, or an optimization bound |
+| [`artifacts/unicast-prefix-announcer-index-2026-08/README.md`](artifacts/unicast-prefix-announcer-index-2026-08/README.md) | Unstated | Isolated allocator rows and 24 accepted A/B pairs from three campaigns | The verifier-bound memory and paired-result inventory | Unstated |
+| [`artifacts/v0.61.0-final-performance-2026-07/README.md`](artifacts/v0.61.0-final-performance-2026-07/README.md) | Unstated | Three real-daemon route-server runs and one Criterion archive | The absolute release-tip baseline artifact inventory | An A/B optimization or CPU-delta claim |
+| [`artifacts/v0.61.0-final-performance-2026-07/commands.md`](artifacts/v0.61.0-final-performance-2026-07/commands.md) | Unstated | Reproduction commands for the release-tip baseline | Unstated | Unstated |
+| [`artifacts/wire-codec-allocation-2026-07/README.md`](artifacts/wire-codec-allocation-2026-07/README.md) | Unstated | Rich attribute-encode and six-attribute validation artifacts | The retained estimates, diagnostics, controls, and hashes | Unstated |
+| [`artifacts/wire-codec-allocation-2026-07/red-proofs.md`](artifacts/wire-codec-allocation-2026-07/red-proofs.md) | Unstated | Six mutation-sensitive allocation-receipt gates | Exact output, error semantics, and diagnostic sensitivity | RSS, jemalloc, retained or peak heap, deallocation, or whole-daemon evidence |
+| [`artifacts/wire-codec-production-parser-2026-07/README.md`](artifacts/wire-codec-production-parser-2026-07/README.md) | Unstated | Production parser, IPv6 MP Add-Path, and attribute encode/decode rows | Production-path coverage and sensitivity to each named path | An optimization or before/after performance gain |
+
+## Metadata gaps
+
+The index covers all 133 pre-existing Markdown files: 60 primary records and
+73 supporting records. Supporting artifacts often rely on their parent receipt
+for context; this index deliberately leaves their own missing metadata as
+`Unstated` instead of copying it down.
+
+Among primary records, every file states a workload or shape. Three do not
+state a date:
+
+- [`grouped-private-adj-rib-out-late-join-2026-07.md`][grouped-private-adj-rib-out-late-join-2026-07.md]
+- [`policy-attribution-criterion-2026-07.md`][policy-attribution-criterion-2026-07.md]
+- [`vpn-rib-query-occupancy-method.md`][vpn-rib-query-occupancy-method.md]
+
+Every primary record states a claim and claim boundary. In the supporting
+table, 55 files do not state their own date, four do not state an independent
+claim, and 47 do not state an independent claim boundary. Those gaps appear as
+`Unstated` in the affected row; every supporting file states at least its role
+or workload.
+
+Both tables derive every field from the linked record rather than treating a
+filename, parent directory, or neighboring receipt as evidence.


### PR DESCRIPTION
## Summary

- index all 133 performance Markdown records by stated date, shape, claim, and boundary
- add ADR lifecycle navigation while preserving each record's source status and date
- report missing metadata as `Unstated` instead of inferring it
- mark both maintained indexes as CURRENT while leaving every receipt and ADR body untouched

## Verification

- eight checker companion suites: 146 tests passed
- all required documentation checkers passed; the performance checker retained its five pre-existing advisories
- Lychee: 2,087 links checked, 0 errors
- `cargo test --workspace --no-fail-fast`
- exact coverage audits: 60 primary + 73 supporting performance records; 130 ADRs + 1 supporting spike
- historical-path guard: only `docs/adr/README.md` changed and `docs/perf/README.md` was added

## Files

- `docs/adr/README.md`: 198 lines after adding lifecycle navigation
- `docs/perf/README.md`: 243-line new performance evidence index

## Deliberately unchanged

- no performance receipt, artifact, ADR body, or soak postmortem was edited
- no performance number was re-derived
- six Proposed ADRs remain `Unstated` rather than being inferred as Parked
- the five existing freshness advisories retain their checker semantics
