### PR TITLE
docs: route readers by intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ explain, opt-in import-decision explain, retained rejected routes with
 reasons, BMP/MRT/metrics — with receipt-backed interop behind each claimed
 behavior.
 
+## Choose your path
+
+| I want to… | Start here |
+|------------|------------|
+| Run a local demo | [Try it in 60 seconds](#try-it-60-seconds) |
+| Evaluate rustbgpd for an IXP route server | [IXP evaluation](docs/ixp-evaluation.md) |
+| Deploy a proven topology | [Scenario cookbook](docs/cookbook/README.md) |
+| Operate or troubleshoot a daemon | [Operations reference](docs/OPERATIONS.md) |
+| Build against the gRPC API | [API reference](docs/API.md) |
+| Check current boundaries and non-goals | [Limitations](docs/LIMITATIONS.md) |
+| Audit a behavior or performance claim | [Evidence and receipts](docs/RECEIPTS.md) |
+
+<details>
+<summary>Performance evidence and current headline results</summary>
+
 **Measured, not marketed** — every number below links to its published,
 reproducible receipt:
 
@@ -66,6 +81,8 @@ The rustbgpd figures above are current v0.68.0 source-equivalent rows measured
 2026-08-30. BIRD remains the v0.64.0 same-host refresh measured 2026-08-08;
 OpenBGPD 9.2 is a supplemental comparator amendment measured 2026-08-30.
 The mixed-date boundary and earlier bands are preserved in the receipt.
+
+</details>
 
 **Status: public alpha.** Feature-complete for the initial programmable
 control-plane target and expanding toward cloud / AI-scale data-center

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,18 @@ guides** to get a task done, **reference** to look something up, and
 **explanation** to understand why. Every file in `docs/` is indexed
 below under its primary bucket.
 
+## Start with your task
+
+| I want to… | Read this first |
+|------------|-----------------|
+| Run rustbgpd for the first time | [Quickstart](QUICKSTART.md) |
+| Choose and deploy a complete topology | [Scenario cookbook](cookbook/README.md) |
+| Operate, reload, upgrade, or debug a daemon | [Operations](OPERATIONS.md) |
+| Explain why a route was selected, rejected, or advertised | [Route explainability](explain.md) |
+| Automate rustbgpd through gRPC | [API reference](API.md) |
+| Evaluate support boundaries and non-goals | [Limitations](LIMITATIONS.md) |
+| Audit the evidence behind a claim | [Receipts index](RECEIPTS.md) |
+
 ## Document classes
 
 The label immediately below a page title distinguishes maintained guidance

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -10,6 +10,36 @@ The configs are derived from the interop fixtures under
 M-series receipts run against real peer stacks — every recipe cites the
 receipts that prove its scenario ([`RECEIPTS.md`](../RECEIPTS.md)).
 
+## Find the route-server path
+
+| I want to… | Read this |
+|------------|-----------|
+| Decide whether rustbgpd fits an IXP route-server deployment | [IXP evaluation](../ixp-evaluation.md) |
+| Build a route server from hand-maintained member and policy configuration | [IXP route server](route-server.md) |
+| Keep an existing ARouteServer `general.yml` / `clients.yml` workflow | [IXP filter pipeline](ixp-filter-pipeline.md) |
+| Provision from an IXP Manager v7.4 database | [IXP Manager route server](ixp-manager-route-server.md) |
+| Run a non-authoritative comparison beside the incumbent, without planning a cutover yet | [Route-server shadow pilot](route-server-shadow-pilot.md) |
+| Replace an incumbent through a planned shadow trial and cutover | [Route-server migration](route-server-migration.md) |
+| Verify or troubleshoot a hand-maintained route server after deployment | [IXP route server](route-server.md) |
+
+### How the six route-server documents divide the work
+
+| Document | Scope it owns | Scope it does not own |
+|----------|---------------|-----------------------|
+| [IXP evaluation](../ixp-evaluation.md) | Fit assessment: capability, evidence, and product-boundary checks before choosing a deployment | Configuration generation, a running pilot, or cutover procedure |
+| [IXP route server](route-server.md) | Hand-maintained member and policy configuration, validation, startup, and day-2 verification | ARouteServer or IXP Manager generation, standing incumbent comparison, or migration planning |
+| [IXP filter pipeline](ixp-filter-pipeline.md) | ARouteServer input, generated datasets and configuration, validated activation, and Alice-LG integration | Hand-maintained inventories, IXP Manager lifecycle, or incumbent cutover |
+| [IXP Manager route server](ixp-manager-route-server.md) | IXP Manager export, render, receipt, activation, rollback, lock, fetch, and callback lifecycle | ARouteServer inputs or a generic incumbent-replacement plan |
+| [Route-server shadow pilot](route-server-shadow-pilot.md) | A standing, receive-only comparison beside production, including its mode-specific safety boundary, comparison loop, data return, and teardown | Authoritative service or a decision to cut over |
+| [Route-server migration](route-server-migration.md) | Incumbent concept mapping, a cutover-oriented shadow trial, readiness gates, cutover, and rollback | A long-running evaluation with no planned authority transfer |
+
+The only genuine overlap is the comparison interval shared by the shadow-pilot
+and migration guides. The shadow-pilot guide owns an ongoing non-authoritative
+evaluation; the migration guide repeats the comparison only as a gate on a
+planned cutover. The three provisioning guides can look similar because each
+produces a route-server configuration, but their input authority is mutually
+exclusive: hand-maintained files, ARouteServer, or IXP Manager.
+
 ## IXP provisioning: three modes
 
 An exchange provisions a rustbgpd route server in exactly one of three


### PR DESCRIPTION
## Summary

- put a seven-way intent chooser before the root README's long-form material
- collapse the unchanged headline measurement block behind a native disclosure while preserving every claim and the complete later performance section
- add a task-first chooser above the complete Diataxis inventory
- add an exact route-server decision tree and six-document scope map to the cookbook

## Files and line counts

- `README.md`: +17 lines
- `docs/README.md`: +12 lines
- `docs/cookbook/README.md`: +30 lines

The diff is addition-only.

## Navigation references

The intent-first front doors follow patterns used by the official Kubernetes, Envoy, PostgreSQL, and Ansible documentation: lead with reader goals, distinguish current/reference/history, and retain a complete reference inventory behind the short path chooser.

## Route-server overlap findings

- the six pages have distinct primary jobs: fit assessment, hand-maintained deployment, ARouteServer generation, IXP Manager lifecycle, standing shadow evaluation, and planned migration
- the only genuine overlap is the comparison interval shared by the standing shadow pilot and the cutover-oriented migration guide
- the three provisioning pages only appear to overlap: their input authorities are mutually exclusive
- no source page was merged, rewritten, renamed, or moved

## Verification

- eight companion suites: 146 tests passed
- all nine required documentation checkers passed; performance freshness retained the same five pre-existing advisories
- Lychee: 239 links checked, 0 errors
- `cargo test --workspace --no-fail-fast`
- all six destination paths exist
- `git diff --check`

## Deliberately unchanged

- no benchmark claim, date, loss, limitation, evidence link, or destination page changed
- the full documentation inventory and all cookbook recipe tables remain present
- no performance number was re-derived and no stale claim was identified in the added navigation copy
