### PR TITLE
docs: consolidate cutover procedure into migration checklist

### DIFF
--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -26,7 +26,7 @@ rbgp config import bird.conf --out config.toml
 #    explicit policy, by name and direction.
 rustbgpd --check config.toml
 
-# 3. Shadow trial (docs/cookbook/route-server.md), then compare the
+# 3. Shadow trial (the cutover checklist below), then compare the
 #    advertised view against the incumbent per member:
 rbgp diff advertised --neighbor 198.51.100.2 --against bird-member.ndjson
 ```
@@ -463,8 +463,12 @@ cutover blockers.
 
 1. Build the candidate config and run `rustbgpd --check --strict`.
 2. Run `rbgp policy check` for every `.rpol` file.
-3. Shadow-peer the same members with a non-production listener so no accidental
-   TCP/179 collision occurs.
+3. Shadow-peer the same members with a non-production listener (or
+   `listen_port = 0`) so no accidental TCP/179 collision occurs, peering to
+   safe member-session copies where possible. Keep
+   `route_server_client = true`, `role = "route_server"`, and the same
+   import/export chains you intend to use after cutover, so the trial
+   exercises the production policy.
 4. Compare received and advertised views:
 
    ```bash
@@ -491,13 +495,25 @@ cutover blockers.
    was refused (incomplete, stale, or over-limit input is never treated
    as equal). Gate each cutover batch on exit code 0 for its members.
 
-5. Confirm counters stay quiet after convergence:
+5. Validate the path-hiding mitigation per member: for Add-Path members,
+   verify multiple candidate paths are present; for non-Add-Path members,
+   verify `Distribution Mode: per-client-best` (`rbgp neighbor <member>`)
+   and inspect the candidate ladder with `--explain`.
+
+6. Confirm counters stay quiet after convergence:
 
    ```bash
+   rbgp policy counters
    rbgp metrics | grep -E 'route_refresh|session_state|update_group'
    ```
 
-6. Cut member sessions in small batches. Keep the incumbent read-only during the
+7. Generate a support bundle before and after the trial:
+
+   ```bash
+   rbgp doctor --output ./support-rs-shadow.tar.gz
+   ```
+
+8. Cut member sessions in small batches. Keep the incumbent read-only during the
    first batch so advertised-view diffs remain available.
 
 [openbgpd-bgpctl-out]: https://man.openbsd.org/OpenBSD-7.7/bgpctl.8#out

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -272,51 +272,20 @@ $ rbgp neighbor 198.51.100.4 add --remote-asn 64503 \
 
 ## Shadow trial
 
-Use the shadow trial before production cutover. The goal is to prove import
-hygiene and per-member export views without carrying member traffic yet.
+Run rustbgpd beside the incumbent to prove import hygiene and per-member
+export views before any member session moves. Whatever the goal, give the
+shadow a non-production listener or `listen_port = 0` so nothing can
+collide with the incumbent's TCP/179.
 
-1. Run rustbgpd beside the incumbent route server with a non-production listener
-   or `listen_port = 0`, and peer it to safe member-session copies where
-   possible.
-2. Keep `route_server_client = true`, `role = "route_server"`, and the same
-   import/export chains you intend to use after cutover.
-3. Compare the incumbent and rustbgpd views per member:
-
-   ```console
-   $ rbgp rib recv 198.51.100.2
-   $ rbgp rib sent 198.51.100.3
-   $ rbgp rib --prefix 203.0.113.0/24 advertised 198.51.100.3 --explain
-   ```
-
-   For the systematic version — every member, every prefix, every
-   attribute — export the incumbent's advertised view to an NDJSON
-   snapshot and diff it against the live Adj-RIB-Out
-   ([`docs/ribdiff.md`](../ribdiff.md) has the snapshot format and
-   producer snippets):
-
-   ```console
-   $ rbgp diff advertised --against incumbent.ndjson
-   $ echo $?   # 0 in sync, 1 divergent, 2 comparison refused
-   ```
-
-4. For Add-Path members, verify multiple candidate paths are present. For
-   non-Add-Path members, verify `Distribution Mode: per-client-best` and inspect
-   the candidate ladder with `--explain`.
-5. Keep the session counters flat after convergence:
-
-   ```console
-   $ rbgp policy counters
-   $ rbgp metrics | grep -E 'bgp_session_state_transitions_total|route_refresh'
-   ```
-
-6. Generate a support bundle before and after the trial:
-
-   ```console
-   $ rbgp doctor --output ./support-rs-shadow.tar.gz
-   ```
-
-Migration mapping for FRR, BIRD, and ARouteServer lives in
-[`route-server-migration.md`](route-server-migration.md).
+- **Replacing the incumbent:** follow the
+  [cutover checklist](route-server-migration.md#cutover-checklist) — the
+  step-by-step procedure, from shadow-peering through the
+  `rbgp diff advertised` gate to cutting sessions in batches. The same
+  page maps FRR, BIRD, OpenBGPD, and ARouteServer concepts to rustbgpd.
+- **Evaluating with no cutover planned or implied:** run the standing
+  [shadow pilot](route-server-shadow-pilot.md) instead — a receive-only,
+  non-authoritative deployment shaped for weeks-to-months comparison
+  against the incumbent.
 
 ## IRR-driven member filters (arouteserver data)
 


### PR DESCRIPTION
The cutover procedure was documented twice: as the shadow-trial steps in `cookbook/route-server.md` and as the cutover checklist in `cookbook/route-server-migration.md`. This makes the migration page's cutover checklist the single canonical procedure — folding in the shadow-trial detail it lacked (listener/`listen_port = 0` and config-parity setup, the Add-Path versus per-client-best validation, `rbgp policy counters`, and the before/after `rbgp doctor` support bundles) — and reduces the route-server page's shadow-trial section to a routing stub: planned replacements go to the cutover checklist, open-ended evaluations go to the standing shadow pilot, and the non-production-listener safety reminder stays in place. One extra navigation step for readers landing on the route-server page is the accepted cost.

## URL and mirror constraints

| Source document | rbgp.rs treatment | Constraint |
|-----------------|-------------------|------------|
| `cookbook/route-server.md` | Native page at `/docs/cookbook/route-server` | Path and `shadow-trial` anchor preserved |
| `cookbook/route-server-migration.md` | Native page at `/docs/cookbook/route-server-migration` | Path and `cutover-checklist` anchor preserved |
| `cookbook/route-server-shadow-pilot.md` | Native page at `/docs/cookbook/route-server-shadow-pilot` | Owns open-ended, non-authoritative evaluation |
| `cookbook/ixp-filter-pipeline.md` | Native page at `/docs/cookbook/ixp-filter-pipeline` | Owns the ARouteServer workflow |

## Checklist

- [x] Both anchors preserved (`#shadow-trial`, `#cutover-checklist`); no file renamed, moved, or deleted
- [x] Both route-server-only checks retained in the canonical procedure (Add-Path vs per-client-best validation; before/after `rbgp doctor` support bundles)
- [x] Non-production-listener safety boundary intact (stated in the stub and in checklist step 3)
- [x] Shadow pilot still reads as open-ended evaluation with no cutover planned or implied
