### PR TITLE
Reject noncanonical RTR v2 prefix PDUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- RTR v2 now rejects IPv4 and IPv6 Prefix PDUs with nonzero host bits as
+  corrupt data, sends Error Report code 0 with the offending frame, and avoids
+  publishing the incomplete transaction while flushing that cache's previously
+  learned data as required for a fatal error. RTR v1 decoding remains unchanged.
+
 - `rbgp rib received` and `rbgp rib advertised` now expose their prefix,
   longer-prefix, origin-ASN, standard-community, and large-community filters
   after the route view where operators naturally look for them. A single-page

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -13,7 +13,9 @@ newer. Release-by-release crate changes are recorded in the
   validation plus a deterministic, 256-row-bounded covering-VRP diagnostic.
 - **RTR client** — an asynchronous client that prefers the ASPA-capable
   protocol v2 shape and falls back to RFC 8210 version 1 when the cache
-  explicitly rejects v2. `RtrClientConfig::max_expire_interval` adds an
+  explicitly rejects v2. Version 2 rejects IPv4 and IPv6 Prefix PDUs with
+  nonzero host bits as corrupt data; RFC 8210 v1 compatibility is unchanged.
+  `RtrClientConfig::max_expire_interval` adds an
   optional operator freshness ceiling: it clamps both the configured
   `expire_interval` and a cache-advertised End of Data expire down, never raises
   a lower value, and when unset leaves the configured interval unchanged while

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -1462,11 +1462,12 @@ impl RtrError {
     /// ends the session. See [`SessionEndDisposition`].
     fn disposition(&self) -> SessionEndDisposition {
         match self {
-            // §6: "The router MUST NOT retain the data past the time
-            // indicated by this parameter." The expire interval is the
-            // deadline that bounds staleness, and the only clock that
-            // drops validated data on its own.
-            RtrError::Expired => SessionEndDisposition::FlushAndDrop,
+            // §6 expiry and §12 fatal corrupt Prefix PDUs (reported as
+            // code 0) both flush the cache's data and clear the epoch
+            // before the next Reset Query.
+            RtrError::Expired | RtrError::Decode(RtrDecodeError::NonCanonicalPrefix) => {
+                SessionEndDisposition::FlushAndDrop
+            }
             // A session-identity failure voids the epoch, not the data.
             // §5.3 names the cache's signal for a Serial Query bearing
             // "a session ID [that] designates a session that is no
@@ -1495,9 +1496,8 @@ impl RtrError {
                 2 | 4 | 12 => SessionEndDisposition::RetainAndRetry,
                 _ => SessionEndDisposition::FlushAndDrop,
             },
-            // Transport loss, budgets, and locally detected garbage:
-            // the held data is still the most recent validated cache
-            // state; keep it until the expire interval says otherwise.
+            // Other local decode/transport guards retain the most recent
+            // validated cache state under their existing dispositions.
             RtrError::Io(_)
             | RtrError::Decode(_)
             | RtrError::Encode(_)
@@ -2305,6 +2305,87 @@ mod tests {
         )
         .await;
         let _ = vrp_rx.recv().await.unwrap();
+    }
+
+    /// 8210bis v2 requires Prefix PDUs to carry the canonical network
+    /// address. A host bit is fatal corrupt data: code 0 embeds the exact
+    /// frame, the session closes, held data is flushed, and the incomplete
+    /// transaction is never published.
+    #[tokio::test]
+    async fn v2_noncanonical_prefix_sends_error_report_flushes_and_is_not_published() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (vrp_tx, mut vrp_rx) = mpsc::channel(8);
+        let client = RtrClient::new(test_config(addr, 60, 0, 3600), vrp_tx);
+        let client_handle = tokio::spawn(client.run());
+
+        let (mut stream, _) = listener.accept().await.unwrap();
+        establish_epoch_with_timers(&mut stream, &mut vrp_rx, 0, 3600).await;
+        write_pdu(
+            &mut stream,
+            RtrPdu::SerialNotify {
+                session_id: 7,
+                serial: 101,
+            },
+        )
+        .await;
+        assert_eq!(
+            read_pdu(&mut stream).await,
+            RtrPdu::SerialQuery {
+                session_id: 7,
+                serial: 100,
+            }
+        );
+        write_pdu(&mut stream, RtrPdu::CacheResponse { session_id: 7 }).await;
+
+        let malformed = RtrPdu::Ipv4Prefix {
+            flags: 1,
+            prefix_len: 24,
+            max_len: 24,
+            prefix: Ipv4Addr::new(203, 0, 113, 1),
+            asn: 65001,
+        };
+        let mut offending = Vec::new();
+        malformed
+            .encode_with_version(&mut offending, crate::rtr_codec::RTR_VERSION_2)
+            .unwrap();
+        stream.write_all(&offending).await.unwrap();
+
+        assert_eq!(
+            read_pdu(&mut stream).await,
+            RtrPdu::ErrorReport {
+                code: 0,
+                pdu: offending,
+                text: "corrupt PDU".to_string(),
+            }
+        );
+        let mut buf = [0u8; 1];
+        assert_eq!(
+            timeout(Duration::from_secs(2), stream.read(&mut buf))
+                .await
+                .unwrap()
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            timeout(Duration::from_secs(2), vrp_rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            VrpUpdate::ServerDown { server: addr },
+            "fatal corrupt data must flush the cache's previously learned data"
+        );
+        assert!(
+            vrp_rx.try_recv().is_err(),
+            "incomplete malformed transaction was published"
+        );
+        assert_eq!(
+            RtrError::Decode(RtrDecodeError::NonCanonicalPrefix).disposition(),
+            SessionEndDisposition::FlushAndDrop
+        );
+
+        client_handle.abort();
+        let _ = client_handle.await;
     }
 
     /// 8210bis §5.1: a Serial Query answered from a DIFFERENT session is
@@ -3596,7 +3677,7 @@ mod tests {
     /// invalid-Error-Report rule — is fatal (flush). Code 0 is the one
     /// code whose two consequences differ: §5.3 makes it a report of a
     /// stale session, so the epoch goes but the data stays. Data expiry
-    /// flushes; transport loss and locally detected garbage retain.
+    /// flushes; transport loss and other local guards retain.
     #[test]
     fn error_code_disposition_table() {
         use SessionEndDisposition::{FlushAndDrop, ResyncAndRetain, RetainAndRetry};
@@ -3645,6 +3726,15 @@ mod tests {
         );
         // Transport loss and local guards retain until expiry.
         assert_eq!(RtrError::ConnectionClosed.disposition(), RetainAndRetry);
+        assert_eq!(
+            RtrError::Decode(RtrDecodeError::NonCanonicalPrefix).disposition(),
+            FlushAndDrop
+        );
+        assert_eq!(
+            RtrError::Decode(RtrDecodeError::InvalidPrefix).disposition(),
+            RetainAndRetry,
+            "legacy invalid-length disposition remains unchanged"
+        );
         assert_eq!(RtrError::TransactionTimeout.disposition(), RetainAndRetry);
         assert_eq!(
             RtrError::TransactionLimit("record budget exceeded").disposition(),

--- a/crates/rpki/src/rtr_codec.rs
+++ b/crates/rpki/src/rtr_codec.rs
@@ -115,6 +115,9 @@ pub enum RtrDecodeError {
     /// Prefix length or max-length out of range.
     #[error("invalid prefix")]
     InvalidPrefix,
+    /// RTR v2 Prefix PDU contains nonzero bits beyond Prefix Length.
+    #[error("noncanonical prefix")]
+    NonCanonicalPrefix,
     /// Error report text is not valid UTF-8.
     #[error("invalid UTF-8 in error text")]
     Utf8Error,
@@ -181,6 +184,21 @@ fn checked_counted_len(
             len: usize::MAX,
         })?;
     checked_total_len(field, base, &[body_len])
+}
+
+fn prefix_host_bits_are_zero(octets: &[u8], prefix_len: u8) -> bool {
+    let whole_octets = usize::from(prefix_len / 8);
+    let partial_bits = prefix_len % 8;
+    let host_start = whole_octets + usize::from(partial_bits != 0);
+
+    if partial_bits != 0 {
+        let host_mask = (1u8 << (8 - partial_bits)) - 1;
+        if octets[whole_octets] & host_mask != 0 {
+            return false;
+        }
+    }
+
+    octets[host_start..].iter().all(|octet| *octet == 0)
 }
 
 impl RtrPdu {
@@ -265,6 +283,11 @@ impl RtrPdu {
                 if prefix_len > 32 || max_len > 32 || max_len < prefix_len {
                     return Err(RtrDecodeError::InvalidPrefix);
                 }
+                if version == RTR_VERSION_2
+                    && !prefix_host_bits_are_zero(&prefix.octets(), prefix_len)
+                {
+                    return Err(RtrDecodeError::NonCanonicalPrefix);
+                }
                 RtrPdu::Ipv4Prefix {
                     flags,
                     prefix_len,
@@ -287,6 +310,11 @@ impl RtrPdu {
                 let asn = u32::from_be_bytes([buf[28], buf[29], buf[30], buf[31]]);
                 if prefix_len > 128 || max_len > 128 || max_len < prefix_len {
                     return Err(RtrDecodeError::InvalidPrefix);
+                }
+                if version == RTR_VERSION_2
+                    && !prefix_host_bits_are_zero(&prefix.octets(), prefix_len)
+                {
+                    return Err(RtrDecodeError::NonCanonicalPrefix);
                 }
                 RtrPdu::Ipv6Prefix {
                     flags,
@@ -794,6 +822,102 @@ mod tests {
             RtrPdu::decode(&buf).unwrap_err(),
             RtrDecodeError::InvalidPrefix
         );
+    }
+
+    #[test]
+    fn v2_rejects_noncanonical_ipv4_host_bits_but_v1_accepts_them() {
+        let cases = [
+            (0, Ipv4Addr::new(0, 0, 0, 1)),
+            (8, Ipv4Addr::new(10, 0, 0, 1)),
+            (9, Ipv4Addr::new(10, 64, 0, 0)),
+            (31, Ipv4Addr::new(192, 0, 2, 1)),
+        ];
+
+        for (prefix_len, prefix) in cases {
+            let pdu = RtrPdu::Ipv4Prefix {
+                flags: 1,
+                prefix_len,
+                max_len: 32,
+                prefix,
+                asn: 65001,
+            };
+            let mut v2 = Vec::new();
+            pdu.encode_with_version(&mut v2, RTR_VERSION_2).unwrap();
+            assert_eq!(RtrPdu::decode(&v2), Err(RtrDecodeError::NonCanonicalPrefix));
+
+            let mut v1 = Vec::new();
+            pdu.encode_with_version(&mut v1, RTR_VERSION).unwrap();
+            assert!(RtrPdu::decode(&v1).is_ok());
+        }
+    }
+
+    #[test]
+    fn v2_accepts_canonical_ipv4_prefix_boundaries() {
+        for (prefix_len, prefix) in [
+            (0, Ipv4Addr::UNSPECIFIED),
+            (8, Ipv4Addr::new(10, 0, 0, 0)),
+            (9, Ipv4Addr::new(10, 128, 0, 0)),
+            (32, Ipv4Addr::new(192, 0, 2, 1)),
+        ] {
+            let pdu = RtrPdu::Ipv4Prefix {
+                flags: 1,
+                prefix_len,
+                max_len: 32,
+                prefix,
+                asn: 65001,
+            };
+            let mut buf = Vec::new();
+            pdu.encode_with_version(&mut buf, RTR_VERSION_2).unwrap();
+            assert!(RtrPdu::decode(&buf).is_ok());
+        }
+    }
+
+    #[test]
+    fn v2_rejects_noncanonical_ipv6_host_bits_but_v1_accepts_them() {
+        let cases = [
+            (0, "::1"),
+            (32, "2001:db8::1"),
+            (33, "2001:db8:4000::"),
+            (127, "2001:db8::1"),
+        ];
+
+        for (prefix_len, prefix) in cases {
+            let pdu = RtrPdu::Ipv6Prefix {
+                flags: 1,
+                prefix_len,
+                max_len: 128,
+                prefix: prefix.parse().unwrap(),
+                asn: 65002,
+            };
+            let mut v2 = Vec::new();
+            pdu.encode_with_version(&mut v2, RTR_VERSION_2).unwrap();
+            assert_eq!(RtrPdu::decode(&v2), Err(RtrDecodeError::NonCanonicalPrefix));
+
+            let mut v1 = Vec::new();
+            pdu.encode_with_version(&mut v1, RTR_VERSION).unwrap();
+            assert!(RtrPdu::decode(&v1).is_ok());
+        }
+    }
+
+    #[test]
+    fn v2_accepts_canonical_ipv6_prefix_boundaries() {
+        for (prefix_len, prefix) in [
+            (0, "::"),
+            (32, "2001:db8::"),
+            (33, "2001:db8:8000::"),
+            (128, "2001:db8::1"),
+        ] {
+            let pdu = RtrPdu::Ipv6Prefix {
+                flags: 1,
+                prefix_len,
+                max_len: 128,
+                prefix: prefix.parse().unwrap(),
+                asn: 65002,
+            };
+            let mut buf = Vec::new();
+            pdu.encode_with_version(&mut buf, RTR_VERSION_2).unwrap();
+            assert!(RtrPdu::decode(&buf).is_ok());
+        }
     }
 
     #[test]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -1054,9 +1054,13 @@ carries inactive (absent), unlimited (zero), or finite.
   record/byte budgets.
 - ASPA over RTR v2 uses 8210bis replacement semantics: announce replaces
   the customer's provider set; withdraw removes the customer ASN.
-- Strict acceptance limits (8210bis-26): per-PDU length is capped at
+- Strict acceptance limits (8210bis-27): per-PDU length is capped at
   65,535 octets (§5 — an over-limit length field is corrupt framing,
-  Error Report code 0); End of Data timers are bounded to the §6 legal
+  Error Report code 0); negotiated-v2 IPv4 and IPv6 Prefix PDUs must carry
+  canonical network addresses (nonzero host bits draw code 0 with the
+  offending frame, close the session, flush that cache's held data, and publish
+  none of the incomplete transaction; v1 decoding is unchanged); End of
+  Data timers are bounded to the §6 legal
   ranges (zeros mean "not provided"; above-maximum values clamp down
   with a warning; an expire below the 600 s minimum is honored as-is,
   since expiring early is safe; a refresh/retry not below the expire is

--- a/docs/aspa-conformance.md
+++ b/docs/aspa-conformance.md
@@ -22,16 +22,15 @@ enforcement or lossless Adj-RIB-In retention.
   editorial; the meaningful -25→-26 clarifications
   (consecutive-duplicate compression, semantic-invalid first-AS
   handling) are implemented and covered below.
-- **draft-ietf-sidrops-8210bis-26** — the RTR client's ASPA transport
-  (PDU shape enforcement, timers, error dispositions) was implemented
-  and drift-checked against revision 26. Revision 27 (13 August 2026)
-  was diff-reviewed against 26: PDU type assignments are unchanged
-  (End of Data 7, Cache Reset 8, ASPA 11), and the two
-  router-affecting tightenings — treating sessions that differ in
-  protocol version as distinct sessions, and mandatory Error Report
-  code 9 for malformed ASPA PDUs — were already implemented under
-  26. No code change was required; the transport table below cites 26
-  as the implemented revision.
+- **draft-ietf-sidrops-8210bis-27** (13 August 2026) — the RTR client's
+  ASPA transport is drift-checked against revision 27. PDU type assignments
+  remain unchanged (End of Data 7, Cache Reset 8, ASPA 11), and the prior
+  session-version and malformed-ASPA tightenings remain implemented. Revision
+  27 also requires a router client to reject noncanonical host bits in IPv4
+  and IPv6 Prefix PDUs; that negotiated-v2 boundary is implemented below.
+  The new paragraph labels Error Code 1 as "Corrupt Data" even though the
+  draft's registry assigns Corrupt Data to code 0, so rustbgpd follows the
+  internally consistent registry value.
 
 **Refresh trigger:** re-verify this page when either draft is
 published as an RFC, and review the revision delta whenever either
@@ -109,7 +108,7 @@ together behind that gate or not at all, because an intermediate
 ranking would create a behavior epoch without satisfying the draft's
 complete mitigation.
 
-## ASPA transport over RTR v2 (draft-ietf-sidrops-8210bis-26)
+## ASPA transport over RTR v2 (draft-ietf-sidrops-8210bis-27)
 
 | # | Requirement | Status | What exists | Evidence |
 |---|-------------|--------|-------------|----------|
@@ -117,6 +116,7 @@ complete mitigation.
 | 2 | §5.12 replacement semantics | Implemented | Within one cache an announcement replaces the customer's provider set (never merges) and a withdrawal removes the customer ASN; proven live, including a valid→invalid REPLACE that a merge would have left valid. | `crates/rpki/src/aspa.rs` · M84 row in [INTEROP.md](INTEROP.md) |
 | 3 | §7 version negotiation with v1 fallback | Implemented | Each fresh connection probes v2; an Unsupported Protocol Version error lands v1 for that attempt. At v1 no ASPA PDUs arrive and routes stay Unknown. Proven against StayRTR (v1-only) alongside Routinator (v2) and a deterministic v2 ASPA source. | M84 row in [INTEROP.md](INTEROP.md) |
 | 4 | Per-cache session/serial epoch with retention across resync | Implemented | Cache state is one per-cache `(version, session ID, serial)` epoch advanced only at validated End of Data; identity mismatches force a Reset Query resync while validated data (including ASPA) is retained until replaced or expired. | M84 row in [INTEROP.md](INTEROP.md) · [RTR notes in RFC_NOTES.md](RFC_NOTES.md#rfc-6811--rpki-origin-validation--rfc-8210--rtr) |
+| 5 | §5.9/§5.10 canonical Prefix PDU network addresses | Implemented | Under negotiated v2, IPv4 and IPv6 Prefix PDUs with nonzero host bits are fatal corrupt data: the client sends Error Report code 0 with the offending frame, closes, flushes that cache's previously learned data, and publishes none of the incomplete transaction. RTR v1 decoding remains compatible. | Codec boundary tables and end-to-end client test in `crates/rpki/src/rtr_codec.rs` and `crates/rpki/src/rtr_client.rs` |
 
 The full RTR conformance notes — timer bounds, error-code
 dispositions, and the two documented deviations (Error Codes 6 and 7


### PR DESCRIPTION
## Summary

- reject RTR v2 IPv4 and IPv6 Prefix PDUs whose host bits are not zero
- preserve RTR v1 acceptance while routing malformed v2 frames through the fatal corrupt-data disposition
- verify that rejection returns the exact offending frame, flushes that cache's prior data, and publishes none of the incomplete transaction

## Compatibility

This applies the canonical-prefix requirement only to negotiated RTR v2 sessions. Existing RTR v1 behavior is unchanged.

## Verification

- `cargo test -p rustbgpd-rpki` (179 tests)
- `cargo clippy -p rustbgpd-rpki --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## Documentation

Updates the current RTR capability and conformance references without altering historical evidence.

Linear: https://linear.app/lance0/issue/LAN-1419
