### PR TITLE
Retire stale policy metric series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `bgp_policy_routes_total` now retires stale policy/action label identities
+  after successful settled policy replacement while preserving exact values
+  for every identity the installed peer chains can still emit.
+
 - RTR v2 now rejects IPv4 and IPv6 Prefix PDUs with nonzero host bits as
   corrupt data, sends Error Report code 0 with the offending frame, and avoids
   publishing the incomplete transaction while flushing that cache's previously

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -681,8 +681,10 @@ impl RibManager {
         // counters reset on session-down (they live on PeerSessionState),
         // and the export-side aggregates do too — same per-session
         // contract in both directions. Operators that need across-flap
-        // totals can subtract Prometheus snapshots
-        // (`bgp_policy_routes_total` is monotonic per process).
+        // totals can use `rate()` / `increase()` over
+        // `bgp_policy_routes_total`: each installed label identity is
+        // monotonic, while a successfully retired identity goes stale and
+        // restarts from zero if that exact identity is later installed again.
         self.export_policy_stats.remove(&peer);
         self.pending_regroup_baseline.remove(&peer);
         self.pending_extra_withdraws.remove(&peer);

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1,6 +1,7 @@
 //! Prometheus metrics for session, RIB, policy, EVPN, GR, and RPKI counters/gauges.
 
 use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -184,12 +185,20 @@ pub fn non_canonical_peer_labels(registry: &Registry) -> Vec<(String, String)> {
 /// across clones.
 static NEXT_METRICS_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
 
-/// Bumped whenever peer series are reaped ([`BgpMetrics::reap_peer_series`]),
+/// Bumped once after a reap batch actually removes policy-route children,
 /// invalidating every thread's [`POLICY_ROUTES_MEMO`]. Without this, a
 /// memoized handle would keep incrementing a child detached from the
 /// vec — invisible to scrapes — instead of re-resolving (and thereby
 /// recreating, from zero) the series like `with_label_values` does.
 static POLICY_ROUTES_REAP_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+/// Installed policy/action identities reachable for selected
+/// `(peer, direction)` metric scopes.
+///
+/// This is deliberately specific to `bgp_policy_routes_total`: the outer key
+/// selects exact scopes eligible for retirement and the inner set preserves
+/// every policy/action tuple that the installed chains can still emit.
+pub type PolicyRoutesReachability = BTreeMap<(String, String), BTreeSet<(String, String)>>;
 
 /// Current unix time in whole seconds, saturating at the `i64` gauge
 /// range (0 if the clock reads before the epoch).
@@ -3301,7 +3310,7 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.0.update_malformed, peer);
         Self::reap_peer_series_from_vec(&self.0.otc_routes_blocked, peer);
         Self::reap_peer_series_from_vec(&self.0.role_mismatch, peer);
-        Self::reap_peer_series_from_vec(&self.0.policy_routes, peer);
+        let policy_routes_removed = Self::reap_peer_series_from_vec(&self.0.policy_routes, peer);
         Self::reap_peer_series_from_vec(&self.0.gr_active_peers, peer);
         Self::reap_peer_series_from_vec(&self.0.gr_stale_routes, peer);
         Self::reap_peer_series_from_vec(&self.0.gr_timer_expired, peer);
@@ -3316,7 +3325,65 @@ impl BgpMetrics {
         // vec. An increment racing the removal itself can still be
         // lost, exactly as a bare `with_label_values` racing
         // `remove_label_values` could before the memo existed.
-        POLICY_ROUTES_REAP_EPOCH.fetch_add(1, Ordering::Release);
+        if policy_routes_removed > 0 {
+            POLICY_ROUTES_REAP_EPOCH.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    /// Retire policy-route counter identities that selected installed scopes
+    /// can no longer emit.
+    ///
+    /// The metric family is collected once, surviving children are untouched,
+    /// and memoized handles are invalidated exactly once after a batch that
+    /// actually removed at least one child. Returning to a retired identity
+    /// therefore creates a fresh counter starting at zero.
+    pub fn reap_unreachable_policy_routes(&self, reachable: &PolicyRoutesReachability) -> usize {
+        use prometheus::core::Collector;
+
+        let mut retired = Vec::new();
+        for family in self.0.policy_routes.collect() {
+            for metric in family.get_metric() {
+                let labels = metric.get_label();
+                let value = |name: &str| {
+                    labels
+                        .iter()
+                        .find(|label| label.name() == name)
+                        .map(prometheus::proto::LabelPair::value)
+                };
+                let (Some(peer), Some(policy), Some(direction), Some(action)) = (
+                    value("peer"),
+                    value("policy"),
+                    value("direction"),
+                    value("action"),
+                ) else {
+                    continue;
+                };
+                let scope = (peer.to_owned(), direction.to_owned());
+                let Some(scope_reachable) = reachable.get(&scope) else {
+                    continue;
+                };
+                if !scope_reachable.contains(&(policy.to_owned(), action.to_owned())) {
+                    retired.push([
+                        peer.to_owned(),
+                        policy.to_owned(),
+                        direction.to_owned(),
+                        action.to_owned(),
+                    ]);
+                }
+            }
+        }
+
+        let mut removed = 0;
+        for labels in retired {
+            let labels = labels.iter().map(String::as_str).collect::<Vec<_>>();
+            if self.0.policy_routes.remove_label_values(&labels).is_ok() {
+                removed += 1;
+            }
+        }
+        if removed > 0 {
+            POLICY_ROUTES_REAP_EPOCH.fetch_add(1, Ordering::Release);
+        }
+        removed
     }
 
     /// Remove the exact configured-peer gauge identity.
@@ -3344,8 +3411,8 @@ impl BgpMetrics {
     fn reap_peer_series_from_vec<T: prometheus::core::MetricVecBuilder>(
         vec: &prometheus::core::MetricVec<T>,
         peer: &str,
-    ) {
-        Self::reap_label_series_from_vec(vec, "peer", peer);
+    ) -> usize {
+        Self::reap_label_series_from_vec(vec, "peer", peer)
     }
 
     /// Remove every series of one Vec metric whose `label` label equals
@@ -3362,13 +3429,14 @@ impl BgpMetrics {
         vec: &prometheus::core::MetricVec<T>,
         label: &str,
         value: &str,
-    ) {
+    ) -> usize {
         use prometheus::core::Collector;
 
         let descs = vec.desc();
         let Some(desc) = descs.first() else {
-            return;
+            return 0;
         };
+        let mut removed = 0;
         for family in vec.collect() {
             for metric in family.get_metric() {
                 let labels = metric.get_label();
@@ -3397,9 +3465,12 @@ impl BgpMetrics {
                 };
                 // Removal can only fail for a tuple that no longer
                 // exists (e.g. removed concurrently) — ignore.
-                let _ = vec.remove_label_values(&values);
+                if vec.remove_label_values(&values).is_ok() {
+                    removed += 1;
+                }
             }
         }
+        removed
     }
 
     // ── Recording methods ──────────────────────────────────────────
@@ -5690,8 +5761,13 @@ mod jemalloc_stats {
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
+    use std::sync::Mutex;
 
     use prometheus::{Encoder, core::Collector};
+
+    /// Epoch assertions and peer reaps share one process-global memo epoch.
+    /// Serialize only tests that can advance it; production remains lock-free.
+    static POLICY_ROUTES_REAP_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn unlabeled_gauge(metrics: &BgpMetrics, name: &str) -> f64 {
         metrics
@@ -6687,6 +6763,7 @@ mod tests {
     /// recreated from zero), never increments the detached child.
     #[test]
     fn policy_routes_memo_invalidated_by_reap() {
+        let _reap_guard = POLICY_ROUTES_REAP_TEST_LOCK.lock().unwrap();
         let m = BgpMetrics::new();
         m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
         m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
@@ -6706,6 +6783,92 @@ mod tests {
                 .get(),
             1,
             "post-reap series restarts from zero and receives the increment"
+        );
+    }
+
+    #[test]
+    fn policy_routes_batch_reap_is_exact_and_invalidates_memo_once() {
+        let _reap_guard = POLICY_ROUTES_REAP_TEST_LOCK.lock().unwrap();
+        let m = BgpMetrics::new();
+        let peer = "10.0.0.2";
+        let other = "10.0.0.3";
+
+        for _ in 0..2 {
+            m.record_policy_routes(peer, "renamed-v1", "import", "deny");
+            m.record_policy_routes(peer, "renamed-v2", "import", "deny");
+        }
+        for _ in 0..5 {
+            m.record_policy_routes(peer, "keep", "import", "deny");
+        }
+        m.record_policy_routes(peer, "keep", "import", "permit");
+        m.record_policy_routes(peer, "renamed-v1", "export", "deny");
+        m.record_policy_routes(other, "renamed-v1", "import", "deny");
+        m.record_policy_routes(peer, "bulk-old", "import", "deny");
+        // Keep this identity in the single-slot memo when the batch removes it.
+        m.record_policy_routes(peer, "memo-old", "import", "deny");
+        m.record_policy_routes(peer, "memo-old", "import", "deny");
+
+        let reachable = PolicyRoutesReachability::from([(
+            (peer.to_string(), "import".to_string()),
+            BTreeSet::from([("keep".to_string(), "deny".to_string())]),
+        )]);
+        let before_epoch = POLICY_ROUTES_REAP_EPOCH.load(Ordering::Acquire);
+        assert_eq!(m.reap_unreachable_policy_routes(&reachable), 5);
+        assert_eq!(
+            POLICY_ROUTES_REAP_EPOCH.load(Ordering::Acquire),
+            before_epoch + 1,
+            "one batch with removals advances the memo epoch exactly once"
+        );
+        assert_eq!(m.reap_unreachable_policy_routes(&reachable), 0);
+        assert_eq!(
+            POLICY_ROUTES_REAP_EPOCH.load(Ordering::Acquire),
+            before_epoch + 1,
+            "a no-op batch must not advance the epoch"
+        );
+
+        assert_eq!(
+            m.0.policy_routes
+                .with_label_values(&[peer, "keep", "import", "deny"])
+                .get(),
+            5,
+            "a surviving child keeps its exact monotonic value"
+        );
+        assert_eq!(
+            m.0.policy_routes
+                .with_label_values(&[peer, "renamed-v1", "export", "deny"])
+                .get(),
+            1,
+            "an unselected direction is isolated"
+        );
+        assert_eq!(
+            m.0.policy_routes
+                .with_label_values(&[other, "renamed-v1", "import", "deny"])
+                .get(),
+            1,
+            "an unselected peer is isolated"
+        );
+        assert!(
+            !gather_text(&m).contains(
+                "bgp_policy_routes_total{action=\"permit\",direction=\"import\",peer=\"10.0.0.2\",policy=\"keep\"}"
+            ),
+            "policy identity alone is insufficient: action is part of reachability"
+        );
+
+        m.record_policy_routes(peer, "memo-old", "import", "deny");
+        assert_eq!(
+            m.0.policy_routes
+                .with_label_values(&[peer, "memo-old", "import", "deny"])
+                .get(),
+            1,
+            "a memoized retired identity returns on a fresh child"
+        );
+        m.record_policy_routes_by(peer, "bulk-old", "import", "deny", 7);
+        assert_eq!(
+            m.0.policy_routes
+                .with_label_values(&[peer, "bulk-old", "import", "deny"])
+                .get(),
+            7,
+            "a bulk-recorded retired identity returns at the requested increment"
         );
     }
 
@@ -7987,6 +8150,7 @@ mod tests {
 
     #[test]
     fn reap_peer_series_removes_every_peer_labeled_family() {
+        let _reap_guard = POLICY_ROUTES_REAP_TEST_LOCK.lock().unwrap();
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1063,8 +1063,11 @@ completes without rejection uses the bounded
 label for an inline Deny or a Permit from an absent / genuinely empty chain.
 Initial table dumps, route refreshes, dirty resyncs, and forced outbound
 refreshes can increment export counters because they re-evaluate export
-policy. The Prometheus counter is **monotonic for the lifetime of the
-daemon process** — use Prometheus `rate()` / `increase()` to read it.
+policy. Each label identity remains monotonic while its policy/action is
+reachable from the installed chain. After a successful policy replacement,
+an unreachable identity is retired and goes stale; reinstalling that exact
+identity creates a fresh counter starting from zero. Prometheus `rate()` and
+`increase()` handle the resulting counter reset.
 
 ```promql
 # Routes denied by a named filter on each peer's import side:

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -6,9 +6,10 @@ use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicNeighborInfo, OwnedCatalogMutation, OwnedNeighborMutation,
-    OwnedNeighborMutationError, OwnedNeighborMutationOutcome, PeerKey, PeerManagerCommand,
-    PeerManagerNeighborConfig, PeerManagerReadinessQuery, PolicyDatasetStatusRow, PolicyEvent,
+    ConfigEvent, DynamicNeighborInfo, OwnedCatalogMutation, OwnedCatalogMutationOutcome,
+    OwnedHotUpdatePeerOutcome, OwnedNeighborMutation, OwnedNeighborMutationError,
+    OwnedNeighborMutationOutcome, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
+    PeerManagerReadinessQuery, PeerReconcileAuthority, PolicyDatasetStatusRow, PolicyEvent,
     RuntimeConfigTransactionPlanError, SessionEvent, SessionLifecycleEvent,
 };
 use rustbgpd_bmp::BmpEvent;
@@ -387,6 +388,10 @@ pub struct PeerManager {
     /// in this window so candidate-only ranges cannot create live peers before
     /// the candidate is durable.
     config_snapshot_staged: bool,
+    /// Installed policy-route metric reachability before a successful staged
+    /// config transaction. Consumed only by commit; restore/replacement clear
+    /// it without retiring series.
+    staged_policy_routes_prior: Option<policy::InstalledPolicyRoutesReachability>,
     /// Resolved dynamic neighbor ranges for prefix-based auto-accept.
     dynamic_ranges: Vec<DynamicRange>,
     /// Current number of active dynamic peers (for limit enforcement).
@@ -740,6 +745,7 @@ impl PeerManager {
             policy_events_tx,
             policy_event_history: VecDeque::new(),
             config_snapshot_staged: false,
+            staged_policy_routes_prior: None,
             dynamic_ranges: Self::parse_dynamic_ranges(&current_config),
             dynamic_peer_count: 0,
             dynamic_neighbor_limit: current_config.effective_dynamic_neighbor_limit(),
@@ -1067,6 +1073,8 @@ impl PeerManager {
                             let _ = reply.send(outcome);
                         }
                         PeerManagerCommand::OwnedCatalogMutation { mutation, reply } => {
+                            let policy_routes_prior =
+                                self.installed_policy_routes_reachability();
                             let outcome = match mutation {
                                 OwnedCatalogMutation::SetPeerGroup { name, definition } => {
                                     let event = ConfigEvent::SetPeerGroup {
@@ -1188,6 +1196,9 @@ impl PeerManager {
                                     ).await
                                 }
                             };
+                            if matches!(&outcome, OwnedCatalogMutationOutcome::Success) {
+                                self.reap_retired_policy_routes(&policy_routes_prior);
+                            }
                             let _ = reply.send(outcome);
                         }
                         PeerManagerCommand::ReconfigurePeer { config, reply } => {
@@ -1244,6 +1255,9 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::CommitConfigSnapshotStage { reply } => {
+                            if let Some(prior) = self.staged_policy_routes_prior.take() {
+                                self.reap_retired_policy_routes(&prior);
+                            }
                             self.config_snapshot_staged = false;
                             let _ = reply.send(());
                         }
@@ -1361,11 +1375,24 @@ impl PeerManager {
                             let _ = reply.send(Ok(()));
                         }
                         PeerManagerCommand::ReconcilePeers { added, removed, changed, reply } => {
+                            let policy_routes_prior =
+                                self.installed_policy_routes_reachability();
                             let result = self.reconcile_peers(added, removed, changed).await;
+                            if result.authority == PeerReconcileAuthority::Known
+                                && result.failures.is_empty()
+                            {
+                                self.reap_retired_policy_routes(&policy_routes_prior);
+                            }
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::HotUpdatePeer { config, reply } => {
-                            let _ = reply.send(self.hot_update_peer_owned(config).await);
+                            let policy_routes_prior =
+                                self.installed_policy_routes_reachability();
+                            let outcome = self.hot_update_peer_owned(config).await;
+                            if matches!(&outcome, OwnedHotUpdatePeerOutcome::Success) {
+                                self.reap_retired_policy_routes(&policy_routes_prior);
+                            }
+                            let _ = reply.send(outcome);
                         }
                         PeerManagerCommand::SyncExplainConfig {
                             enabled,
@@ -1614,11 +1641,21 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::SetHonorGracefulShutdown { enabled, reply } => {
+                            let policy_routes_prior =
+                                self.installed_policy_routes_reachability();
                             let result = self.set_honor_graceful_shutdown(enabled).await;
+                            if result.is_ok() {
+                                self.reap_retired_policy_routes(&policy_routes_prior);
+                            }
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::SetHonorBlackhole { enabled, reply } => {
+                            let policy_routes_prior =
+                                self.installed_policy_routes_reachability();
                             let result = self.set_honor_blackhole(enabled).await;
+                            if result.is_ok() {
+                                self.reap_retired_policy_routes(&policy_routes_prior);
+                            }
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::GetNeighborPolicyChains { address, reply } => {
@@ -1776,6 +1813,7 @@ impl PeerManager {
                         Some(InternalCommand::ReplaceConfigSnapshot { config, ack }) => {
                             self.current_config = *config;
                             self.config_snapshot_staged = false;
+                            self.staged_policy_routes_prior = None;
                         // #338: rebuild the live dynamic-neighbor accept-matcher so
                         // [[dynamic_neighbors]] edits applied via SIGHUP take effect
                         // (previously only `current_config` was swapped). The shared
@@ -1831,6 +1869,9 @@ impl PeerManager {
                             scope,
                             reply,
                         }) => {
+                            self.staged_policy_routes_prior = None;
+                            let policy_routes_prior =
+                                self.installed_policy_routes_reachability();
                             let result = match scope {
                                 TransactionConfigScope::Full => Ok(*candidate),
                                 TransactionConfigScope::FibTablesOnly => {
@@ -1854,6 +1895,7 @@ impl PeerManager {
                                         Self::parse_dynamic_ranges(&self.current_config);
                                     self.reconcile_stale_dynamic_max_prefix_restarts();
                                     self.config_snapshot_staged = true;
+                                    self.staged_policy_routes_prior = Some(policy_routes_prior);
                                     self.metrics.record_policy_generation_loaded();
                                     TransactionConfigRollbackToken::capture(
                                         Box::new(previous),
@@ -1870,6 +1912,7 @@ impl PeerManager {
                             self.dynamic_ranges = Self::parse_dynamic_ranges(&self.current_config);
                             self.reconcile_stale_dynamic_max_prefix_restarts();
                             self.config_snapshot_staged = false;
+                            self.staged_policy_routes_prior = None;
                             self.metrics.record_policy_generation_loaded();
                             if rollback.scope == TransactionConfigScope::Full {
                                 self.reap_dynamic_peers_not_allowed_by_current_ranges()

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::net::IpAddr;
 use std::time::Instant;
@@ -38,6 +38,35 @@ use super::{
 /// route-server-scale fleet (hundreds of members) logs a handful of `info!`
 /// lines instead of either silence or one line per peer.
 const COHORT_SETUP_PROGRESS_INTERVAL: usize = 64;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct InstalledPolicyRoutesReachability {
+    scopes: BTreeMap<(String, String), InstalledPolicyRoutesScope>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct InstalledPolicyRoutesScope {
+    reachable: BTreeSet<(String, String)>,
+    clean: bool,
+}
+
+pub(super) fn policy_routes_reachable_labels(
+    chain: Option<&PolicyChain>,
+) -> BTreeSet<(String, String)> {
+    let Some(chain) = chain.filter(|chain| !chain.policies.is_empty()) else {
+        return BTreeSet::from([("inline".to_string(), "permit".to_string())]);
+    };
+
+    let mut reachable =
+        BTreeSet::from([("chain_default_permit".to_string(), "permit".to_string())]);
+    for policy in &chain.policies {
+        reachable.insert((
+            policy.name.as_deref().unwrap_or("inline").to_string(),
+            "deny".to_string(),
+        ));
+    }
+    reachable
+}
 
 #[derive(Default)]
 struct PolicySnapshotPhaseTimings {
@@ -351,6 +380,55 @@ fn record_import_validation_refresh_metrics(
 }
 
 impl PeerManager {
+    pub(super) fn installed_policy_routes_reachability(&self) -> InstalledPolicyRoutesReachability {
+        let mut snapshot = InstalledPolicyRoutesReachability::default();
+        for (peer, managed) in &self.peers {
+            let peer_label = rustbgpd_telemetry::peer_label(peer.address);
+            for (direction, chain, clean) in [
+                (
+                    "import",
+                    managed.import_policy.as_ref(),
+                    !managed.pending_refresh,
+                ),
+                (
+                    "export",
+                    managed.export_policy.as_ref(),
+                    !managed.pending_export_apply,
+                ),
+            ] {
+                let scope = snapshot
+                    .scopes
+                    .entry((peer_label.clone(), direction.to_string()))
+                    .or_insert_with(|| InstalledPolicyRoutesScope {
+                        reachable: BTreeSet::new(),
+                        clean: true,
+                    });
+                scope
+                    .reachable
+                    .extend(policy_routes_reachable_labels(chain));
+                scope.clean &= clean;
+            }
+        }
+        snapshot
+    }
+
+    pub(super) fn reap_retired_policy_routes(
+        &self,
+        before: &InstalledPolicyRoutesReachability,
+    ) -> usize {
+        let current = self.installed_policy_routes_reachability();
+        let mut selected = rustbgpd_telemetry::metrics::PolicyRoutesReachability::new();
+        for (key, prior) in &before.scopes {
+            let Some(installed) = current.scopes.get(key) else {
+                continue;
+            };
+            if installed.clean && prior.reachable != installed.reachable {
+                selected.insert(key.clone(), installed.reachable.clone());
+            }
+        }
+        self.metrics.reap_unreachable_policy_routes(&selected)
+    }
+
     /// ADR-0112: would installing `candidate_import` flip this peer's RFC 8212
     /// import-presence verdict?
     ///

--- a/src/peer_manager/tests/config_transaction.rs
+++ b/src/peer_manager/tests/config_transaction.rs
@@ -978,6 +978,143 @@ async fn runtime_config_snapshot_returns_current_staged_config() {
     handle.await.unwrap();
 }
 
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one actor test contrasts staged restore and commit retirement boundaries"
+)]
+async fn policy_route_series_retire_only_when_a_staged_snapshot_commits() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let (tx, rx) = mpsc::channel(16);
+    let (internal_tx, internal_rx) = mpsc::channel(2);
+    let (rib_tx, _rib_rx) = mpsc::channel(16);
+    let config = make_dynamic_manager_config();
+    let candidate = config.clone();
+    let metrics = BgpMetrics::new();
+    let address: IpAddr = "192.0.2.142".parse().unwrap();
+    let mut manager = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics.clone(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    insert_test_managed_peer(
+        &mut manager,
+        address,
+        acking_policy_handle(address, SessionState::Established),
+        false,
+    );
+    manager.peers.get_mut(&key(address)).unwrap().import_policy =
+        Some(named_deny_policy_chain(&[Some("staged-old")]));
+    metrics.record_policy_routes("192.0.2.142", "staged-old", "import", "deny");
+    let handle = tokio::spawn(manager.run());
+
+    let (stage_tx, stage_rx) = oneshot::channel();
+    internal_tx
+        .send(InternalCommand::StageTransactionConfig {
+            candidate: Box::new(candidate.clone()),
+            scope: TransactionConfigScope::Full,
+            reply: stage_tx,
+        })
+        .await
+        .unwrap();
+    let rollback = stage_rx.await.unwrap().unwrap();
+
+    let (apply_tx, apply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
+        targets: vec![ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: Some(named_deny_policy_chain(&[Some("staged-new")])),
+            export_policy: None,
+        }],
+        reply: apply_tx,
+    })
+    .await
+    .unwrap();
+    apply_rx.await.unwrap().unwrap();
+    assert_eq!(
+        policy_route_counter(&metrics, "192.0.2.142", "staged-old", "import", "deny"),
+        Some(1.0),
+        "staged installation is not yet a durable retirement boundary"
+    );
+
+    let (restore_tx, restore_rx) = oneshot::channel();
+    internal_tx
+        .send(InternalCommand::RestoreTransactionConfig {
+            rollback,
+            reply: restore_tx,
+        })
+        .await
+        .unwrap();
+    restore_rx.await.unwrap();
+    assert_eq!(
+        policy_route_counter(&metrics, "192.0.2.142", "staged-old", "import", "deny"),
+        Some(1.0),
+        "restore discards the staged snapshot without retiring history"
+    );
+
+    let (reset_tx, reset_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
+        targets: vec![ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: Some(named_deny_policy_chain(&[Some("staged-old")])),
+            export_policy: None,
+        }],
+        reply: reset_tx,
+    })
+    .await
+    .unwrap();
+    reset_rx.await.unwrap().unwrap();
+
+    let (stage_tx, stage_rx) = oneshot::channel();
+    internal_tx
+        .send(InternalCommand::StageTransactionConfig {
+            candidate: Box::new(candidate),
+            scope: TransactionConfigScope::Full,
+            reply: stage_tx,
+        })
+        .await
+        .unwrap();
+    stage_rx.await.unwrap().unwrap();
+    let (apply_tx, apply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
+        targets: vec![ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: Some(named_deny_policy_chain(&[Some("staged-new")])),
+            export_policy: None,
+        }],
+        reply: apply_tx,
+    })
+    .await
+    .unwrap();
+    apply_rx.await.unwrap().unwrap();
+
+    let (commit_tx, commit_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::CommitConfigSnapshotStage { reply: commit_tx })
+        .await
+        .unwrap();
+    commit_rx.await.unwrap();
+    assert_eq!(
+        policy_route_counter(&metrics, "192.0.2.142", "staged-old", "import", "deny"),
+        None,
+        "commit consumes the prior installed snapshot and retires stale labels"
+    );
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
 #[test]
 fn runtime_config_diff_compares_candidate_against_live_snapshot_and_redacts_secret() {
     let (_tx, rx) = mpsc::channel(16);

--- a/src/peer_manager/tests/metrics.rs
+++ b/src/peer_manager/tests/metrics.rs
@@ -1130,3 +1130,199 @@ async fn periodic_bmp_stats_channel_full_records_the_source_drop() {
         Some(1.0)
     );
 }
+
+#[tokio::test]
+async fn policy_route_reaper_unions_scoped_siblings_and_waits_for_current_settlement() {
+    let mut mgr = test_peer_manager();
+    let metrics = mgr.metrics.clone();
+    let address: IpAddr = "fe80::1425".parse().unwrap();
+    let eth0 = scoped_key(address, "eth0");
+    let eth1 = scoped_key(address, "eth1");
+    for peer in [&eth0, &eth1] {
+        insert_test_managed_peer_for_key(
+            &mut mgr,
+            peer,
+            65002,
+            acking_policy_handle(address, SessionState::Idle),
+            false,
+        );
+        mgr.peers.get_mut(peer).unwrap().import_policy =
+            Some(named_deny_policy_chain(&[Some("old-import")]));
+    }
+    metrics.record_policy_routes("fe80::1425", "old-import", "import", "deny");
+    let prior = mgr.installed_policy_routes_reachability();
+
+    mgr.peers.get_mut(&eth0).unwrap().import_policy =
+        Some(named_deny_policy_chain(&[Some("new-import")]));
+    assert_eq!(mgr.reap_retired_policy_routes(&prior), 0);
+    assert_eq!(
+        policy_route_counter(&metrics, "fe80::1425", "old-import", "import", "deny"),
+        Some(1.0),
+        "one sibling can still emit the bare-IP metric identity"
+    );
+
+    let sibling_prior = mgr.installed_policy_routes_reachability();
+    let sibling = mgr.peers.get_mut(&eth1).unwrap();
+    sibling.import_policy = Some(named_deny_policy_chain(&[Some("new-import")]));
+    sibling.pending_refresh = true;
+    assert_eq!(mgr.reap_retired_policy_routes(&sibling_prior), 0);
+    assert_eq!(
+        policy_route_counter(&metrics, "fe80::1425", "old-import", "import", "deny"),
+        Some(1.0),
+        "any pending current sibling fences the whole aliased scope"
+    );
+
+    mgr.peers.get_mut(&eth1).unwrap().pending_refresh = false;
+    assert_eq!(mgr.reap_retired_policy_routes(&sibling_prior), 1);
+    assert_eq!(
+        policy_route_counter(&metrics, "fe80::1425", "old-import", "import", "deny"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn policy_route_reaper_heals_prior_pending_and_tracks_bare_scope_across_interface_move() {
+    let mut mgr = test_peer_manager();
+    let metrics = mgr.metrics.clone();
+    let address: IpAddr = "fe80::1425".parse().unwrap();
+    let eth0 = scoped_key(address, "eth0");
+    insert_test_managed_peer_for_key(
+        &mut mgr,
+        &eth0,
+        65002,
+        acking_policy_handle(address, SessionState::Idle),
+        true,
+    );
+    mgr.peers.get_mut(&eth0).unwrap().import_policy =
+        Some(named_deny_policy_chain(&[Some("pending-old")]));
+    metrics.record_policy_routes("fe80::1425", "pending-old", "import", "deny");
+    let pending_prior = mgr.installed_policy_routes_reachability();
+
+    let peer = mgr.peers.get_mut(&eth0).unwrap();
+    peer.import_policy = Some(named_deny_policy_chain(&[Some("settled-new")]));
+    peer.pending_refresh = false;
+    assert_eq!(mgr.reap_retired_policy_routes(&pending_prior), 1);
+    assert_eq!(
+        policy_route_counter(&metrics, "fe80::1425", "pending-old", "import", "deny"),
+        None,
+        "a successful clean state can retire history captured while pending"
+    );
+
+    metrics.record_policy_routes("fe80::1425", "settled-new", "import", "deny");
+    let interface_prior = mgr.installed_policy_routes_reachability();
+    mgr.peers.remove(&eth0);
+    let eth9 = scoped_key(address, "eth9");
+    insert_test_managed_peer_for_key(
+        &mut mgr,
+        &eth9,
+        65002,
+        acking_policy_handle(address, SessionState::Idle),
+        false,
+    );
+    mgr.peers.get_mut(&eth9).unwrap().import_policy =
+        Some(named_deny_policy_chain(&[Some("moved-new")]));
+    assert_eq!(mgr.reap_retired_policy_routes(&interface_prior), 1);
+    assert_eq!(
+        policy_route_counter(&metrics, "fe80::1425", "settled-new", "import", "deny"),
+        None,
+        "metric identity follows the bare-IP scope across interface replacement"
+    );
+}
+
+#[test]
+fn policy_route_reachability_uses_exact_bounded_policy_action_pairs() {
+    use crate::peer_manager::policy::policy_routes_reachable_labels;
+
+    let inline_permit = BTreeSet::from([("inline".to_string(), "permit".to_string())]);
+    assert_eq!(policy_routes_reachable_labels(None), inline_permit);
+    assert_eq!(
+        policy_routes_reachable_labels(Some(&PolicyChain::new(Vec::new()))),
+        inline_permit
+    );
+
+    let chain = named_deny_policy_chain(&[Some("named-deny"), None]);
+    assert_eq!(
+        policy_routes_reachable_labels(Some(&chain)),
+        BTreeSet::from([
+            ("chain_default_permit".to_string(), "permit".to_string()),
+            ("inline".to_string(), "deny".to_string()),
+            ("named-deny".to_string(), "deny".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn policy_route_retirement_actor_fences_are_definitive_and_staged() {
+    let source = include_str!("../mod.rs");
+    let arm = |start: &str, end: &str| {
+        source
+            .split_once(start)
+            .unwrap_or_else(|| panic!("missing actor arm {start}"))
+            .1
+            .split_once(end)
+            .unwrap_or_else(|| panic!("missing actor boundary after {start}"))
+            .0
+    };
+
+    let catalog = arm(
+        "PeerManagerCommand::OwnedCatalogMutation { mutation, reply } => {",
+        "PeerManagerCommand::ReconfigurePeer",
+    );
+    assert!(catalog.contains("OwnedCatalogMutationOutcome::Success"));
+    assert_eq!(catalog.matches("reap_retired_policy_routes").count(), 1);
+
+    let reconcile = arm(
+        "PeerManagerCommand::ReconcilePeers { added, removed, changed, reply } => {",
+        "PeerManagerCommand::HotUpdatePeer",
+    );
+    assert!(reconcile.contains("result.authority == PeerReconcileAuthority::Known"));
+    assert!(reconcile.contains("result.failures.is_empty()"));
+    assert_eq!(reconcile.matches("reap_retired_policy_routes").count(), 1);
+
+    let hot = arm(
+        "PeerManagerCommand::HotUpdatePeer { config, reply } => {",
+        "PeerManagerCommand::SyncExplainConfig",
+    );
+    assert!(hot.contains("OwnedHotUpdatePeerOutcome::Success"));
+    assert_eq!(hot.matches("reap_retired_policy_routes").count(), 1);
+
+    for (start, end) in [
+        (
+            "PeerManagerCommand::SetHonorGracefulShutdown { enabled, reply } => {",
+            "PeerManagerCommand::SetHonorBlackhole",
+        ),
+        (
+            "PeerManagerCommand::SetHonorBlackhole { enabled, reply } => {",
+            "PeerManagerCommand::GetNeighborPolicyChains",
+        ),
+    ] {
+        let honor = arm(start, end);
+        assert!(honor.contains("if result.is_ok()"));
+        assert_eq!(honor.matches("reap_retired_policy_routes").count(), 1);
+    }
+
+    let commit = arm(
+        "PeerManagerCommand::CommitConfigSnapshotStage { reply } => {",
+        "PeerManagerCommand::RuntimeConfigSnapshot",
+    );
+    assert!(commit.contains("staged_policy_routes_prior.take()"));
+    assert_eq!(commit.matches("reap_retired_policy_routes").count(), 1);
+    let stage = arm(
+        "Some(InternalCommand::StageTransactionConfig {",
+        "Some(InternalCommand::RestoreTransactionConfig",
+    );
+    assert!(stage.contains("self.staged_policy_routes_prior = None"));
+    assert!(stage.contains("self.staged_policy_routes_prior = Some(policy_routes_prior)"));
+    let restore = arm(
+        "Some(InternalCommand::RestoreTransactionConfig {",
+        "None => {}",
+    );
+    assert!(restore.contains("self.staged_policy_routes_prior = None"));
+    assert!(!restore.contains("reap_retired_policy_routes"));
+    let replace = arm(
+        "Some(InternalCommand::ReplaceConfigSnapshot { config, ack }) => {",
+        "Some(InternalCommand::PlanAcceptedTransactionConfig",
+    );
+    assert!(replace.contains("self.staged_policy_routes_prior = None"));
+    assert!(!replace.contains("reap_retired_policy_routes"));
+}

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -308,6 +308,56 @@ fn deny_policy_chain() -> PolicyChain {
     }])
 }
 
+fn named_deny_policy_chain(names: &[Option<&str>]) -> PolicyChain {
+    use rustbgpd_policy::{NamedPolicy, Policy, PolicyAction};
+
+    PolicyChain::from_named(
+        names
+            .iter()
+            .map(|name| NamedPolicy {
+                name: name.map(str::to_string),
+                policy: Policy {
+                    entries: Vec::new(),
+                    default_action: PolicyAction::Deny,
+                },
+                rpol: None,
+            })
+            .collect(),
+    )
+}
+
+fn policy_route_counter(
+    metrics: &BgpMetrics,
+    peer: &str,
+    policy: &str,
+    direction: &str,
+    action: &str,
+) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == "bgp_policy_routes_total")
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                let labels = metric.get_label();
+                [
+                    ("peer", peer),
+                    ("policy", policy),
+                    ("direction", direction),
+                    ("action", action),
+                ]
+                .iter()
+                .all(|(name, value)| {
+                    labels
+                        .iter()
+                        .any(|label| label.name() == *name && label.value() == *value)
+                })
+                .then(|| metric.get_counter().value())
+            })
+        })
+}
+
 /// A deny chain padded to `depth + 1` copies of the deny policy —
 /// content-distinct per depth. Per-peer distinct export targets keep a
 /// snapshot off the import-tolerant export cohort (LAN-462 relaxed its
@@ -372,7 +422,7 @@ fn insert_test_managed_peer(
     handle: PeerHandle,
     pending_refresh: bool,
 ) {
-    insert_test_managed_peer_with_asn(mgr, addr, 65002, handle, pending_refresh);
+    insert_test_managed_peer_for_key(mgr, &key(addr), 65002, handle, pending_refresh);
 }
 
 fn insert_test_managed_peer_with_asn(
@@ -382,15 +432,26 @@ fn insert_test_managed_peer_with_asn(
     handle: PeerHandle,
     pending_refresh: bool,
 ) {
-    let peer_config = make_config(addr, remote_asn);
+    insert_test_managed_peer_for_key(mgr, &key(addr), remote_asn, handle, pending_refresh);
+}
+
+fn insert_test_managed_peer_for_key(
+    mgr: &mut PeerManager,
+    peer_key: &PeerKey,
+    remote_asn: u32,
+    handle: PeerHandle,
+    pending_refresh: bool,
+) {
+    let mut peer_config = make_config(peer_key.address, remote_asn);
+    peer_config.interface.clone_from(&peer_key.interface);
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
-    let peer_key = key(addr);
+    let session_id = u64::try_from(mgr.peers.len()).unwrap_or(u64::MAX - 1) + 1;
     mgr.peers.insert(
         peer_key.clone(),
         ManagedPeer {
             handle,
-            session_id: 1,
+            session_id,
             remote_asn,
             description: "test".to_string(),
             peer_group: None,
@@ -412,7 +473,7 @@ fn insert_test_managed_peer_with_asn(
             advertise_graceful_shutdown: false,
         },
     );
-    mgr.register_session(1, &peer_key);
+    mgr.register_session(session_id, peer_key);
 }
 
 fn stalled_policy_query_handle() -> PeerHandle {

--- a/src/peer_manager/tests/policy_apply.rs
+++ b/src/peer_manager/tests/policy_apply.rs
@@ -886,6 +886,160 @@ async fn apply_resolved_policy_snapshot_skips_non_live_targets() {
 }
 
 #[tokio::test]
+async fn actor_hot_update_reaps_only_successful_policy_identity_changes() {
+    use rustbgpd_api::peer_types::OwnedHotUpdatePeerOutcome;
+
+    let (tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(16);
+    let metrics = BgpMetrics::new();
+    let successful: IpAddr = "192.0.2.143".parse().unwrap();
+    let divergent: IpAddr = "192.0.2.144".parse().unwrap();
+    let mut manager = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics.clone(),
+        rib_tx,
+        None,
+    );
+    for address in [successful, divergent] {
+        insert_test_managed_peer(
+            &mut manager,
+            address,
+            acking_policy_handle(address, SessionState::Established),
+            false,
+        );
+        manager.peers.get_mut(&key(address)).unwrap().import_policy =
+            Some(named_deny_policy_chain(&[Some("hot-old")]));
+        metrics.record_policy_routes(&address.to_string(), "hot-old", "import", "deny");
+    }
+    manager.inject_hot_update_failures.insert(key(divergent), 0);
+    let handle = tokio::spawn(manager.run());
+
+    for (address, expect_success) in [(successful, true), (divergent, false)] {
+        let mut config = make_config(address, 65002);
+        config.import_policy = Some(named_deny_policy_chain(&[Some("hot-new")]));
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(PeerManagerCommand::HotUpdatePeer {
+            config,
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        let outcome = reply_rx.await.unwrap();
+        assert_eq!(
+            matches!(outcome, OwnedHotUpdatePeerOutcome::Success),
+            expect_success,
+            "unexpected owned hot-update outcome: {outcome:?}"
+        );
+    }
+
+    assert_eq!(
+        policy_route_counter(
+            &metrics,
+            &successful.to_string(),
+            "hot-old",
+            "import",
+            "deny"
+        ),
+        None,
+        "a successful actor outcome retires the old installed identity"
+    );
+    assert_eq!(
+        policy_route_counter(
+            &metrics,
+            &divergent.to_string(),
+            "hot-old",
+            "import",
+            "deny"
+        ),
+        Some(1.0),
+        "KnownDivergence is not a definitive retirement boundary"
+    );
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn actor_honor_toggle_reaps_clean_success_but_retains_partial_batch_history() {
+    async fn run_case(partial: bool) -> (Result<(), String>, BgpMetrics, IpAddr) {
+        let (tx, rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let metrics = BgpMetrics::new();
+        let successful: IpAddr = if partial {
+            "192.0.2.145".parse().unwrap()
+        } else {
+            "192.0.2.146".parse().unwrap()
+        };
+        let failing: IpAddr = "192.0.2.147".parse().unwrap();
+        let mut manager = PeerManager::new(
+            rx,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            None,
+            None,
+            metrics.clone(),
+            rib_tx,
+            None,
+        );
+        let mut addresses = vec![successful];
+        if partial {
+            addresses.push(failing);
+        }
+        manager.current_config.neighbors = addresses
+            .iter()
+            .copied()
+            .map(|address| config_neighbor(address, 65002))
+            .collect();
+        for address in addresses {
+            let peer_handle = if partial && address == failing {
+                route_refresh_failing_handle(address, SessionState::Established)
+            } else {
+                acking_policy_handle(address, SessionState::Established)
+            };
+            insert_test_managed_peer(&mut manager, address, peer_handle, false);
+            manager.peers.get_mut(&key(address)).unwrap().import_policy =
+                Some(named_deny_policy_chain(&[Some("honor-old")]));
+            metrics.record_policy_routes(&address.to_string(), "honor-old", "import", "deny");
+        }
+        let handle = tokio::spawn(manager.run());
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(PeerManagerCommand::SetHonorGracefulShutdown {
+            enabled: true,
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        let result = reply_rx.await.unwrap();
+        tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+        handle.await.unwrap();
+        (result, metrics, successful)
+    }
+
+    let (result, metrics, peer) = run_case(false).await;
+    assert!(result.is_ok(), "clean toggle failed: {result:?}");
+    assert_eq!(
+        policy_route_counter(&metrics, &peer.to_string(), "honor-old", "import", "deny"),
+        None,
+        "a clean honor toggle retires the superseded identity"
+    );
+
+    let (result, metrics, peer) = run_case(true).await;
+    assert!(
+        result.is_err(),
+        "injected partial toggle unexpectedly succeeded"
+    );
+    assert_eq!(
+        policy_route_counter(&metrics, &peer.to_string(), "honor-old", "import", "deny"),
+        Some(1.0),
+        "a partial batch is not a definitive retirement boundary"
+    );
+}
+
+#[tokio::test]
 async fn apply_policy_impact_snapshot_expands_dynamic_range_targets() {
     let mut mgr = live_policy_test_manager();
     let candidate_toml = tier_authorized_uds_test_config(


### PR DESCRIPTION
## Summary

- retire unreachable `bgp_policy_routes_total` label identities after definitive settled policy changes
- preserve every surviving counter value and invalidate the memo once per batch that removes children
- defer staged transaction cleanup until commit and retain history on rollback, partial, divergent, or pending outcomes
- evaluate reachability at the bare-IP metric scope, including scoped sibling and interface-replacement cases

## Compatibility

The metric name, type, label order, and help text are unchanged. An installed exact label identity remains monotonic; once retired it goes stale and starts from zero if later installed again.

## Verification

- focused telemetry, actor, policy-apply, and config-transaction suites
- 100/100 parallel telemetry stress repetitions at 32 test threads
- Grafana, metric-consumer, and metric-release-note checker suites
- scoped clippy, formatting, and diff checks
- pre-push workspace format, clippy, test, and doc gates

Linear: https://linear.app/lance0/issue/LAN-1425
