### PR TITLE
Bound rrtransport VmHWM accounting drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The rrtransport receipt verifier now tolerates at most 4 MiB of Linux
+  `/proc` `VmHWM` accounting drift between checkpoints while retaining raw
+  observations. `VmHWM` below `VmRSS`, larger regressions, and the 2 GiB RSS
+  ceiling remain fail-closed.
+
 - The hosted M43 TCP-AO rotation and crash-recovery proof now uses
   checksum-built BIRD 3.3.2. Before either mode starts BIRD, it verifies the
   exact container image, sleeping command, runtime version, and all four bound

--- a/bench/scale/rrtransport/README.md
+++ b/bench/scale/rrtransport/README.md
@@ -76,6 +76,12 @@ written only after all three attempts pass the semantic verifier. Results are
 not comparable to the historical unavailable scratch harness and must not be
 published as an A/B.
 
+Raw `VmHWM` checkpoints retain Linux's asynchronous `/proc` observations. The
+verifier always requires `VmHWM >= VmRSS`, permits at most a 4 MiB apparent
+high-water regression between checkpoints, and rejects any larger dip. The
+tolerance is 0.2% of the harness's 2 GiB RSS ceiling and matches the existing
+persisted-config receipt convention.
+
 A three-attempt full campaign on 2026-08-29 ran at repository commit
 `05a71687ff3f4787eb1eb90a180fa7bd817e36c5`. Its three staged-convergence
 times were 295, 300, and 307 ms; exact wire-convergence times were 330, 334,

--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -14,6 +14,10 @@ SOURCES = 4
 WORKERS = 12
 TOTAL_NLRI = PEERS * PREFIXES
 RSS_LIMIT_KIB = 2 * 1024 * 1024
+# Linux documents /proc RSS accounting as asynchronous and imprecise. Keep raw
+# checkpoint values, but tolerate only the same 4 MiB VmHWM dip already used by
+# the persisted-config receipt verifier: 0.2% of this harness's RSS ceiling.
+VMHWM_REGRESSION_TOLERANCE_KIB = 4 * 1024
 # Seeded from a three-attempt full campaign on 2026-08-29: staged
 # 295/300/307 ms and wire 330/334/329 ms. Each limit is ceil(1.15 * max).
 STAGED_MS_LIMIT = 354
@@ -196,8 +200,16 @@ def verify(directory, tiny=False):
         fail(f"RSS ceiling exceeded: process_tree_sampler_max_rss_kib={sampler_max} KiB")
     hwms = [observer[name]["direct_pid_vmhwm_kib"] for name in ("established", "staged", "wire")]
     values = [observer[name]["direct_pid_vmrss_kib"] for name in ("established", "staged", "wire")]
-    if hwms != sorted(hwms) or any(hwm < value for hwm, value in zip(hwms, values)):
-        fail("VmHWM is non-monotonic or below VmRSS")
+    if any(hwm < value for hwm, value in zip(hwms, values)):
+        fail("VmHWM is below VmRSS")
+    if any(
+        current + VMHWM_REGRESSION_TOLERANCE_KIB < previous
+        for previous, current in zip(hwms, hwms[1:])
+    ):
+        fail(
+            "VmHWM regression exceeds "
+            f"{VMHWM_REGRESSION_TOLERANCE_KIB} KiB accounting tolerance"
+        )
     with (directory / "rss.tsv").open(encoding="utf-8") as stream:
         lines = stream.read().splitlines()
     if not lines or lines[0] != "observer\trss_kib":

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -484,7 +484,13 @@ expect_red wrong-peer mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/
 expect_red wire-max mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["wire_ms"]=4;p.write_text(json.dumps(d))'
 expect_red phase-rss mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["staged"]["direct_pid_vmrss_kib"]=111;p.write_text(json.dumps(d))'
 expect_red hwm-below-rss mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);[(lambda f,d:(d["checkpoints" if f.name=="rss.json" else "resource_observer"]["wire"].__setitem__("direct_pid_vmhwm_kib",119),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]'
-expect_red hwm-nonmonotonic mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);[(lambda f,d:(d["checkpoints" if f.name=="rss.json" else "resource_observer"]["staged"].__setitem__("direct_pid_vmhwm_kib",126),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]'
+cp -a "$tmp/accepted" "$tmp/hwm-tolerance-boundary"
+mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);values={"established":5000,"staged":5000,"wire":904};[(lambda f,d:(d["checkpoints" if f.name=="rss.json" else "resource_observer"].update({name:{**d["checkpoints" if f.name=="rss.json" else "resource_observer"][name],"direct_pid_vmhwm_kib":value} for name,value in values.items()}),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]' \
+  "$tmp/hwm-tolerance-boundary"
+python3 "$verifier" "$tmp/hwm-tolerance-boundary"
+expect_red hwm-material-regression mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);[(lambda f,d:(d["checkpoints" if f.name=="rss.json" else "resource_observer"]["staged"].__setitem__("direct_pid_vmhwm_kib",4222),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]'
+grep -Fxq "FAIL: VmHWM regression exceeds 4096 KiB accounting tolerance" \
+  "$tmp/hwm-material-regression.result"
 expect_red no-external-sample mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";p.write_text("\n".join(x for x in p.read_text().splitlines() if not x.startswith("process_tree_target_rss_sample"))+"\n")'
 expect_red legacy-sample-name mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";s=p.read_text();p.write_text(s.replace("process_tree_target_rss_sample","sample",1))'
 expect_red sampler-max mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.json";d=json.loads(p.read_text());d["process_tree_sampler_max_rss_kib"]=124;p.write_text(json.dumps(d))'


### PR DESCRIPTION
## Summary

- retain raw rrtransport `VmRSS` and `VmHWM` checkpoint observations
- tolerate at most 4 MiB of documented asynchronous `/proc` high-water drift while keeping the 2 GiB ceiling
- keep `VmHWM < VmRSS` and regressions above 4 MiB fail-closed
- document the verifier boundary and add positive-boundary plus destructive over-boundary coverage

Closes LAN-1426.

## Evidence

Merged-main CI run 33465159882 failed when `VmHWM` dipped 4 KiB between staged and wire checkpoints while remaining equal to `VmRSS` at every point. The same failure reproduced once in 30 local real-smoke runs.

The retained failing receipt passes under this bounded rule. Sixty additional real-smoke repetitions passed 60/60.

## Verification

- `bash bench/tests/test-rrtransport-receipt.sh`
- `bench/scale/rrtransport/run-receipt.sh --real-smoke <tmp>`
- 60 repeated real-smoke runs
- `cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked`
- `cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml --locked --all-targets -- -D warnings`
- `cargo run --manifest-path bench/scale/rrtransport/Cargo.toml --locked -- smoke`
- `ruff check bench/scale/rrtransport/verify_receipt.py`
- `shellcheck bench/tests/test-rrtransport-receipt.sh`
- `git diff --check`
