### PR TITLE
Report SIGHUP reload outcomes honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `rbgp doctor` now describes config freshness as an mtime comparison with the
+  daemon's last config-file marker rather than claiming effective runtime
+  agreement. The Prometheus alert pack reports authoritative partial
+  SIGHUP reloads and failed retained reload tasks over a reset-safe ten-minute
+  window.
+
 - The rrtransport receipt verifier now tolerates at most 4 MiB of Linux
   `/proc` `VmHWM` accounting drift between checkpoints while retaining raw
   observations. `VmHWM` below `VmRSS`, larger regressions, and the 2 GiB RSS

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1778,8 +1778,8 @@ fn config_freshness_reference(state_dir: &Path, pid: u32) -> Option<u64> {
     last_persist_unix(state_dir).or_else(|| proc_start_unix(pid))
 }
 
-/// Pure freshness verdict: the config file was modified after the daemon last
-/// read or wrote it, so on-disk edits are pending until a reload.
+/// Pure freshness verdict: warn when the config mtime is newer than the
+/// daemon's marker without claiming that the file contents diverge.
 fn config_freshness_check(
     pid: u32,
     config_path: &str,
@@ -1790,15 +1790,18 @@ fn config_freshness_check(
         (
             CheckStatus::Warn,
             format!(
-                "config {config_path} was modified after daemon pid {pid} last applied it — \
-                 on-disk changes are not applied; validate with `rustbgpd --check \
+                "config {config_path} is newer than daemon pid {pid}'s last config-file marker — \
+                 on-disk changes may be pending; validate with `rustbgpd --check \
                  {config_path}` and reload with SIGHUP (systemctl reload rustbgpd)"
             ),
         )
     } else {
         (
             CheckStatus::Ok,
-            format!("config {config_path} matches what daemon pid {pid} last applied"),
+            format!(
+                "config {config_path} is not newer than daemon pid {pid}'s last config-file \
+                 marker; this does not prove effective runtime agreement"
+            ),
         )
     };
     Check {
@@ -4099,6 +4102,19 @@ paths = ["x"]
         assert!(stale.detail.contains("--check"), "{}", stale.detail);
         let fresh = config_freshness_check(7, "/etc/rustbgpd/config.toml", 1_000, 1_000);
         assert_eq!(fresh.status, CheckStatus::Ok);
+        assert!(
+            fresh.detail.contains("config-file marker"),
+            "{}",
+            fresh.detail
+        );
+        assert!(
+            fresh
+                .detail
+                .contains("does not prove effective runtime agreement"),
+            "{}",
+            fresh.detail
+        );
+        assert!(!fresh.detail.contains("last applied"), "{}", fresh.detail);
     }
 
     /// The regression: the daemon rewrites its own config file on every

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -93,6 +93,7 @@ A ready-to-load Prometheus alert-rule pack (session down/flapping,
 empty Adj-RIB-In, max-prefix near-limit and breach, empty RPKI VRP table, event-outbox
 degradation, update-group residue growth, stalled policy transition, a slow
 peer, RFC 8212 missing import/export policy, sustained outbound-prefix blocking,
+authoritative partial SIGHUP reloads and failed retained reload tasks,
 dynamic-neighbor admission near-limit and rejection,
 actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
 selection-deferral timeout and ledger overflow, outbound route loss, RFC 9687

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1923,7 +1923,7 @@ First-deploy checks (network probes are bounded to a 2s timeout; all are read-on
 | `gnmi_dialout.<name>.reachable_from_cli` | TCP connect from the `rbgp` process to each `[gnmi_dialout] targets` entry | yellow on failure because the daemon may have a different network vantage; inspect `gnmi_dialout_connected` and daemon logs for actual dial-out state |
 | `state_dir.writable` / `state_dir.disk` | `runtime_state_dir` writability and free space (yellow < 1 GiB, red < 100 MiB) | journal, MRT dumps, crash reports, and the event-history DB write there |
 | `host.run_context` | systemd / container / unknown from pid-1 facts | tailors remediation lines (e.g. `LimitNOFILE=` vs container ulimits) |
-| `daemon.config_freshness.<pid>` | config file mtime vs. local daemon start time | yellow when on-disk edits are pending; validate with `rustbgpd --check` then reload with SIGHUP |
+| `daemon.config_freshness.<pid>` | whether config file mtime is newer than the daemon's last config-file marker (process start fallback) | yellow means on-disk changes may be pending; green does not prove effective runtime agreement |
 
 Probe targets come from the daemon's effective config when it is up; when
 it is down, from the local config file (the path a local daemon process

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -96,6 +96,32 @@ groups:
             daemon exits independently when the 30-minute budget plus
             five-second grace expires.
 
+      - alert: BgpSighupReloadKnownPartial
+        expr: >-
+          increase(bgp_sighup_reload_outcomes_total{outcome="known_partial"}[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SIGHUP reload completed with partial runtime authority"
+          description: >-
+            A SIGHUP reload on {{ $labels.instance }} reached an authoritative
+            partial result in the last 10 minutes. Inspect the reload logs,
+            correct the reported cause, and reload again to converge.
+
+      - alert: BgpSighupReloadTaskFailed
+        expr: >-
+          increase(bgp_sighup_reload_outcomes_total{outcome="task_failed"}[10m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SIGHUP reload task failed"
+          description: >-
+            The retained SIGHUP reload task on {{ $labels.instance }} failed in
+            the last 10 minutes. Inspect daemon health and reload logs before
+            attempting another configuration change.
+
       - alert: BgpSessionNotEstablished
         # Exact configured identity join: catches enabled peers that have never
         # Established as well as peers that established previously and went

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -172,7 +172,62 @@ tests:
                 the daemon exits independently when the 30-minute budget plus
                 five-second grace expires.
 
-  # ── Session rules ─────────────────────────────────────────────
+  # SIGHUP reload outcomes use bounded, reset-safe counter windows.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_sighup_reload_outcomes_total{outcome="known_partial", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_sighup_reload_outcomes_total{outcome="task_failed", instance="edge2:9179"}'
+        values: "10 10 10 10 10 10 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_sighup_reload_outcomes_total{outcome="complete", instance="edge3:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_sighup_reload_outcomes_total{outcome="known_partial", instance="edge4:9179"}'
+        values: "7x22"
+      - series: 'bgp_sighup_reload_outcomes_total{outcome="rejected_no_effect", instance="edge5:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_sighup_reload_outcomes_total{outcome="ignored_in_flight", instance="edge6:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpSighupReloadKnownPartial
+        exp_alerts: []
+      - eval_time: 2m
+        alertname: BgpSighupReloadTaskFailed
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpSighupReloadKnownPartial
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              outcome: known_partial
+              instance: edge1:9179
+            exp_annotations:
+              summary: "SIGHUP reload completed with partial runtime authority"
+              description: >-
+                A SIGHUP reload on edge1:9179 reached an authoritative partial
+                result in the last 10 minutes. Inspect the reload logs, correct
+                the reported cause, and reload again to converge.
+      - eval_time: 10m
+        alertname: BgpSighupReloadTaskFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              outcome: task_failed
+              instance: edge2:9179
+            exp_annotations:
+              summary: "SIGHUP reload task failed"
+              description: >-
+                The retained SIGHUP reload task on edge2:9179 failed in the
+                last 10 minutes. Inspect daemon health and reload logs before
+                attempting another configuration change.
+      - eval_time: 21m
+        alertname: BgpSighupReloadKnownPartial
+        exp_alerts: []
+      - eval_time: 21m
+        alertname: BgpSighupReloadTaskFailed
+        exp_alerts: []
+
+  # Session rules.
   # Every series carries the bare neighbor address in `peer`, matching
   # the daemon's real export, so the session/RIB join needs no rewrite.
   # 192.0.2.1 — flapped down and stayed down (stale counters say up)

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -57,7 +57,7 @@ class MetricConsumerContractTests(unittest.TestCase):
         )
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 97)
-        self.assertEqual(len(self.rule_refs), 42)
+        self.assertEqual(len(self.rule_refs), 43)
         self.assertEqual(len(self.public_doc_refs), 193)
         self.assertEqual(len(self.doc_refs), 193)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs


### PR DESCRIPTION
## Summary

- make `rbgp doctor` report the config mtime-versus-marker observation without claiming effective runtime agreement
- alert on known-partial and failed SIGHUP reload outcomes with reset-safe ten-minute windows
- pin counter reset, non-firing outcomes, and expiry while updating the operator-facing alert inventory

## Testing

- `cargo test --locked -p rustbgpctl config_modified_after_daemon_start_is_yellow_with_reload_advice`
- `cargo test --locked -p rustbgpctl freshness_reference_prefers_the_daemon_last_persist_marker`
- `promtool check rules examples/prometheus/rustbgpd-alerts.yml`
- `promtool test rules rustbgpd-alerts_test.yml`
- `python3 -m unittest -v scripts/test_check_metric_consumers.py`
- `python3 scripts/check-metric-consumers.py`
- `just gate`