### PR TITLE
Surface event-history storage interruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Durable event replay now reports a closed storage mailbox or dropped reply
+  as one terminal gRPC `UNAVAILABLE` status with resume guidance instead of a
+  clean end-of-stream. Allocator pass-through remains `FAILED_PRECONDITION`,
+  and post-admission producer loss remains `DATA_LOSS`.
+
 - `bgp_policy_routes_total` now retires stale policy/action label identities
   after successful settled policy replacement while preserving exact values
   for every identity the installed peer chains can still emit.

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -595,11 +595,11 @@ impl proto::event_service_server::EventService for EventService {
     /// the gap.
     ///
     /// When the daemon was started with `[event_history].enabled =
-    /// false`, when EHM failed to start with
-    /// `required = false`, or when EHM dropped into pass-through
-    /// mode at runtime, returns `Status::failed_precondition`. The
-    /// live `WatchEvents` / `List*Events` surfaces continue to work
-    /// in all those cases.
+    /// false` or EHM failed to start with `required = false`, returns
+    /// `Status::failed_precondition`. Replay storage interruption
+    /// returns `Status::unavailable` unless post-admission producer
+    /// loss takes `Status::data_loss` precedence. The live
+    /// `WatchEvents` / `List*Events` surfaces continue to work.
     async fn subscribe_from_event(
         &self,
         request: Request<proto::SubscribeFromEventRequest>,
@@ -607,10 +607,10 @@ impl proto::event_service_server::EventService for EventService {
         let req = request.into_inner();
         let handle = self.event_history.as_ref().ok_or_else(|| {
             Status::failed_precondition(
-                "durable event history is disabled; \
-                 set [event_history].enabled = true and restart the daemon \
-                 for restart-safe cursor replay (off by default since v0.32.0). \
-                 If enabled, check the bgp_event_outbox_degraded gauge",
+                "durable event history is not active; \
+                 set [event_history].enabled = true and restart the daemon if disabled. \
+                 If already enabled, inspect startup logs and the \
+                 bgp_event_outbox_degraded gauge",
             )
         })?;
         let stream = cursor::subscribe(handle, &req, self.metrics.clone())?;
@@ -2747,7 +2747,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subscribe_from_event_unavailable_returns_failed_precondition() {
+    async fn subscribe_from_event_without_history_returns_failed_precondition() {
         // EventService constructed without `with_event_history` ⇒
         // handle is None ⇒ the handler returns FAILED_PRECONDITION
         // and the legacy WatchEvents surface is unaffected.
@@ -2764,11 +2764,15 @@ mod tests {
             .await
         {
             Ok(_) => panic!("subscribe_from_event must error when EHM is None"),
-            Err(status) => assert_eq!(
-                status.code(),
-                tonic::Code::FailedPrecondition,
-                "expected FAILED_PRECONDITION when event_history handle is None"
-            ),
+            Err(status) => {
+                assert_eq!(
+                    status.code(),
+                    tonic::Code::FailedPrecondition,
+                    "expected FAILED_PRECONDITION when event_history handle is None"
+                );
+                assert!(status.message().contains("not active"));
+                assert!(status.message().contains("If already enabled"));
+            }
         }
 
         // Legacy WatchEvents is unaffected: it still returns a stream.

--- a/crates/api/src/event_service/cursor.rs
+++ b/crates/api/src/event_service/cursor.rs
@@ -389,6 +389,9 @@ pub(crate) fn map_ehm_err_to_status(err: EventHistoryError) -> Status {
             "event history in pass-through mode; durable cursor unavailable \
              — see [event_history].required + the bgp_event_outbox_degraded gauge",
         ),
+        EventHistoryError::StorageUnavailable => Status::unavailable(
+            "event-history storage unavailable; resume from the last received event_id",
+        ),
         other => Status::internal(format!("event history error: {other}")),
     }
 }
@@ -488,6 +491,11 @@ async fn run_drain(
             }
         };
         let event = match item {
+            EventSubscriptionItem::Error(err) => {
+                let _ =
+                    send_with_loss(Err(map_ehm_err_to_status(err)), &out_tx, &mut loss_rx).await;
+                return;
+            }
             EventSubscriptionItem::Event(committed) => {
                 if !filter.matches_committed(&committed) {
                     continue;
@@ -626,6 +634,61 @@ pub(crate) fn subscribe(
 mod tests {
     use super::*;
 
+    #[test]
+    fn event_history_availability_errors_keep_distinct_statuses() {
+        assert_eq!(
+            map_ehm_err_to_status(EventHistoryError::StorageUnavailable).code(),
+            tonic::Code::Unavailable
+        );
+        assert_eq!(
+            map_ehm_err_to_status(EventHistoryError::PassThrough).code(),
+            tonic::Code::FailedPrecondition
+        );
+    }
+
+    #[tokio::test]
+    async fn storage_failure_is_terminal_and_shutdown_is_clean() {
+        let filter = ProtoFilter::from_request(&proto::SubscribeFromEventRequest::default())
+            .expect("wildcard filter");
+        let (committed_tx, committed_rx) = mpsc::channel(1);
+        committed_tx
+            .send(EventSubscriptionItem::Error(
+                EventHistoryError::StorageUnavailable,
+            ))
+            .await
+            .unwrap();
+        let (out_tx, mut out_rx) = mpsc::channel(1);
+        let (_loss_tx, loss_rx) = watch::channel(0_u64);
+        run_drain(
+            filter.clone(),
+            Some(7),
+            committed_rx,
+            out_tx,
+            loss_rx,
+            BgpMetrics::new(),
+        )
+        .await;
+        let status = out_rx.recv().await.unwrap().unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert!(status.message().contains("last received event_id"));
+        assert!(out_rx.recv().await.is_none());
+
+        let (committed_tx, committed_rx) = mpsc::channel(1);
+        drop(committed_tx);
+        let (out_tx, mut out_rx) = mpsc::channel(1);
+        let (_loss_tx, loss_rx) = watch::channel(0_u64);
+        run_drain(
+            filter,
+            None,
+            committed_rx,
+            out_tx,
+            loss_rx,
+            BgpMetrics::new(),
+        )
+        .await;
+        assert!(out_rx.recv().await.is_none());
+    }
+
     #[tokio::test]
     async fn producer_loss_preempts_blocked_cursor_delivery() {
         // Load-bearing breaks: reversing baseline/admission hides the first loss;
@@ -645,7 +708,9 @@ mod tests {
             .expect("wildcard filter");
         let (committed_tx, committed_rx) = mpsc::channel(1);
         committed_tx
-            .try_send(EventSubscriptionItem::RetentionGap(1))
+            .try_send(EventSubscriptionItem::Error(
+                EventHistoryError::StorageUnavailable,
+            ))
             .unwrap();
         let (out_tx, mut out_rx) = mpsc::channel(1);
         out_tx.try_send(Ok(proto::BgpEvent::default())).unwrap();

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -46,7 +46,7 @@ one SQLite transaction, and serves cursor-based replay through the
   sidecar (`events.last_id`) atomic write, matching the
   `fib-owned.json` pattern in `src/fib_runtime.rs`.
 - `error.rs` — `EventHistoryError`. Single type covering SQL,
-  schema, allocator, I/O, and `PassThrough`.
+  schema, allocator, I/O, unavailable storage, and `PassThrough`.
 
 ## Invariants
 
@@ -70,6 +70,9 @@ one SQLite transaction, and serves cursor-based replay through the
   EHM commits a batch BEFORE broadcasting; live subscribers and
   cursor-replay subscribers observing the same `event_id` see the
   same envelope.
+- **Storage loss is not pass-through.** A closed storage mailbox or dropped
+  reply terminates cursor replay with `StorageUnavailable`; `PassThrough` is
+  reserved for an unrecoverable allocator anchor.
 - **Allocator recovery ladder.** Primary DB → quarantine fallback.
   `events.last_id` is a diagnostic hint only in v1 because it can lag
   committed events. If both authoritative sources fail AND prior

--- a/crates/event-history/src/cursor.rs
+++ b/crates/event-history/src/cursor.rs
@@ -154,6 +154,9 @@ impl SubscribeStats {
 /// Item produced by a durable cursor subscription.
 pub enum EventSubscriptionItem {
     Event(CommittedEvent),
+    /// Terminal replay failure. Consumers should surface the status
+    /// once, then stop reading the stream.
+    Error(EventHistoryError),
     /// The per-subscriber broadcast receiver fell behind the live
     /// stream. The producing path is EHM's broadcast; gRPC translates
     /// this to a `StreamLagEvent` payload.
@@ -307,6 +310,7 @@ async fn run_subscription(
                     Ok(o) => o,
                     Err(e) => {
                         warn!(error = %e, "replay first-chunk query failed; aborting subscription");
+                        let _ = out_tx.send(EventSubscriptionItem::Error(e)).await;
                         return;
                     }
                 };
@@ -324,6 +328,7 @@ async fn run_subscription(
                     Ok(r) => r,
                     Err(e) => {
                         warn!(error = %e, "replay chunk query failed; aborting subscription");
+                        let _ = out_tx.send(EventSubscriptionItem::Error(e)).await;
                         return;
                     }
                 }
@@ -457,6 +462,43 @@ async fn emit_retention_gap(out_tx: &mpsc::Sender<EventSubscriptionItem>, missed
 mod tests {
     use super::*;
     use crate::{Category, Severity};
+
+    #[tokio::test]
+    async fn replay_query_failures_emit_one_terminal_error() {
+        for failure in [
+            crate::storage::TestQueryFailure::FirstReply,
+            crate::storage::TestQueryFailure::LaterReply,
+        ] {
+            let (_live_tx, live_rx) = broadcast::channel(1);
+            let (out_tx, mut out_rx) = mpsc::channel(2);
+            run_subscription(
+                SubscribeRequest {
+                    from_event_id: Some(0),
+                    ..SubscribeRequest::default()
+                },
+                2,
+                crate::storage::StoreHandle::test_query_failure(failure),
+                live_rx,
+                out_tx,
+                Arc::new(SubscribeStats::default()),
+            )
+            .await;
+
+            if failure == crate::storage::TestQueryFailure::LaterReply {
+                assert!(matches!(
+                    out_rx.recv().await,
+                    Some(EventSubscriptionItem::Event(_))
+                ));
+            }
+            assert!(matches!(
+                out_rx.recv().await,
+                Some(EventSubscriptionItem::Error(
+                    EventHistoryError::StorageUnavailable
+                ))
+            ));
+            assert!(out_rx.recv().await.is_none());
+        }
+    }
 
     fn make_committed(event_id: u64, category: Category) -> CommittedEvent {
         make_committed_with_peers(event_id, category, crate::EnvelopePeers::default())

--- a/crates/event-history/src/error.rs
+++ b/crates/event-history/src/error.rs
@@ -43,6 +43,10 @@ pub enum EventHistoryError {
         source: std::io::Error,
     },
 
+    /// The storage actor stopped accepting work or dropped a reply.
+    #[error("event-history storage unavailable")]
+    StorageUnavailable,
+
     /// EHM has been driven into pass-through mode (allocator anchor
     /// unrecoverable) and refuses to issue new event_ids. Operator
     /// resolves explicitly via `rbgp event-history reset-allocator`

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -760,8 +760,9 @@ impl EventHistoryHandle {
     ///
     /// # Errors
     ///
-    /// Returns [`EventHistoryError::PassThrough`] when the storage
-    /// thread has exited or EHM is in pass-through mode.
+    /// Returns [`EventHistoryError::PassThrough`] when EHM is in
+    /// pass-through mode, or [`EventHistoryError::StorageUnavailable`]
+    /// when the storage thread has exited.
     pub async fn oldest_retained_event_id(&self) -> Result<Option<u64>, EventHistoryError> {
         if self.state.pass_through() {
             return Err(EventHistoryError::PassThrough);
@@ -996,8 +997,8 @@ impl EventHistoryManager {
     ///
     /// # Errors
     ///
-    /// Returns [`EventHistoryError::PassThrough`] when the storage
-    /// thread has exited.
+    /// Returns [`EventHistoryError::StorageUnavailable`] when the
+    /// storage thread has exited.
     pub async fn run_retention_pass(&self) -> Result<RetentionOutcome, EventHistoryError> {
         self.storage.retain(self.max_events, self.max_bytes).await
     }

--- a/crates/event-history/src/storage.rs
+++ b/crates/event-history/src/storage.rs
@@ -224,6 +224,13 @@ pub(crate) enum TestStoreOp {
 }
 
 #[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TestQueryFailure {
+    FirstReply,
+    LaterReply,
+}
+
+#[cfg(test)]
 impl PauseHook {
     async fn after_send(&self) {
         if self.armed.swap(false, Ordering::AcqRel) {
@@ -234,6 +241,48 @@ impl PauseHook {
 }
 
 impl StoreHandle {
+    #[cfg(test)]
+    pub(crate) fn test_query_failure(failure: TestQueryFailure) -> Self {
+        let (tx, mut rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            while let Some(op) = rx.recv().await {
+                match op {
+                    StoreOp::QueryWithFloor { reply, .. } => match failure {
+                        TestQueryFailure::FirstReply => drop(reply),
+                        TestQueryFailure::LaterReply => {
+                            let _ = reply.send(Ok(QueryWithFloorOutcome {
+                                rows: vec![PersistedEvent {
+                                    event_id: 1,
+                                    timestamp_ns: 0,
+                                    category: Category::Route,
+                                    event_type: "test".to_string(),
+                                    peer: None,
+                                    previous_peer: None,
+                                    target_peer: None,
+                                    afi_safi: None,
+                                    prefix: None,
+                                    rd: None,
+                                    evpn_route_type: None,
+                                    severity: Severity::Info,
+                                    daemon_boot_id: "test".to_string(),
+                                    payload_codec: "opaque".to_string(),
+                                    payload: Vec::new(),
+                                }],
+                                floor: Some(1),
+                            }));
+                        }
+                    },
+                    StoreOp::Query { reply, .. } => drop(reply),
+                    _ => unreachable!("query failure test received a non-query operation"),
+                }
+            }
+        });
+        Self {
+            tx,
+            test_hooks: Arc::new(StoreTestHooks::default()),
+        }
+    }
+
     pub(crate) async fn append(
         &self,
         envelopes: Vec<Arc<EventEnvelope>>,
@@ -244,10 +293,11 @@ impl StoreHandle {
         self.tx
             .send(StoreOp::Append { envelopes, reply })
             .await
-            .map_err(|_| EventHistoryError::PassThrough)?;
+            .map_err(|_| EventHistoryError::StorageUnavailable)?;
         #[cfg(test)]
         self.test_hooks.append.after_send().await;
-        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+        rx.await
+            .map_err(|_| EventHistoryError::StorageUnavailable)?
     }
 
     pub(crate) async fn query(
@@ -267,8 +317,9 @@ impl StoreHandle {
                 reply,
             })
             .await
-            .map_err(|_| EventHistoryError::PassThrough)?;
-        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+            .map_err(|_| EventHistoryError::StorageUnavailable)?;
+        rx.await
+            .map_err(|_| EventHistoryError::StorageUnavailable)?
     }
 
     /// `Query` plus the live `MIN(event_id)` evaluated under the same
@@ -293,8 +344,9 @@ impl StoreHandle {
                 reply,
             })
             .await
-            .map_err(|_| EventHistoryError::PassThrough)?;
-        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+            .map_err(|_| EventHistoryError::StorageUnavailable)?;
+        rx.await
+            .map_err(|_| EventHistoryError::StorageUnavailable)?
     }
 
     pub(crate) async fn retain(
@@ -310,8 +362,9 @@ impl StoreHandle {
                 reply,
             })
             .await
-            .map_err(|_| EventHistoryError::PassThrough)?;
-        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+            .map_err(|_| EventHistoryError::StorageUnavailable)?;
+        rx.await
+            .map_err(|_| EventHistoryError::StorageUnavailable)?
     }
 
     pub(crate) async fn flush_sidecar(&self) -> Result<u64, EventHistoryError> {
@@ -319,10 +372,11 @@ impl StoreHandle {
         self.tx
             .send(StoreOp::FlushSidecar { reply })
             .await
-            .map_err(|_| EventHistoryError::PassThrough)?;
+            .map_err(|_| EventHistoryError::StorageUnavailable)?;
         #[cfg(test)]
         self.test_hooks.flush.after_send().await;
-        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+        rx.await
+            .map_err(|_| EventHistoryError::StorageUnavailable)?
     }
 
     /// `MIN(event_id)` over the live table, or `None` when the table
@@ -333,8 +387,9 @@ impl StoreHandle {
         self.tx
             .send(StoreOp::OldestEventId { reply })
             .await
-            .map_err(|_| EventHistoryError::PassThrough)?;
-        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+            .map_err(|_| EventHistoryError::StorageUnavailable)?;
+        rx.await
+            .map_err(|_| EventHistoryError::StorageUnavailable)?
     }
 
     pub(crate) async fn shutdown(&self) {
@@ -1068,4 +1123,31 @@ fn oldest_event_id_blocking(conn: &Connection) -> Result<Option<u64>, EventHisto
     // SQLite's INTEGER column type is i64; the runtime invariant gives
     // us a safe `as u64` cast.
     Ok(row.map(|v| v as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn closed_store_and_dropped_reply_are_storage_unavailable() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        let closed = StoreHandle {
+            tx,
+            test_hooks: Arc::new(StoreTestHooks::default()),
+        };
+        assert!(matches!(
+            closed.oldest_event_id().await,
+            Err(EventHistoryError::StorageUnavailable)
+        ));
+
+        let dropped = StoreHandle::test_query_failure(TestQueryFailure::FirstReply);
+        assert!(matches!(
+            dropped
+                .query_with_floor(0, 1, 1, QueryFilter::default())
+                .await,
+            Err(EventHistoryError::StorageUnavailable)
+        ));
+    }
 }

--- a/crates/event-history/tests/cursor_handoff.rs
+++ b/crates/event-history/tests/cursor_handoff.rs
@@ -56,6 +56,9 @@ async fn drain_subscription(
             Ok(Some(EventSubscriptionItem::RetentionGap(missed))) => {
                 panic!("unexpected retention-gap signal while draining: missed={missed}")
             }
+            Ok(Some(EventSubscriptionItem::Error(err))) => {
+                panic!("unexpected subscription error while draining: {err}")
+            }
             Ok(None) => break,
             Err(_) => break,
         }
@@ -71,6 +74,9 @@ async fn drain_subscription(
                 }
                 Ok(Some(EventSubscriptionItem::RetentionGap(missed))) => {
                     panic!("unexpected retention-gap signal while draining: missed={missed}")
+                }
+                Ok(Some(EventSubscriptionItem::Error(err))) => {
+                    panic!("unexpected subscription error while draining: {err}")
                 }
                 Ok(None) | Err(_) => break,
             }
@@ -483,6 +489,9 @@ async fn retention_gap_emits_as_leading_subscription_item_race_free() {
         }
         EventSubscriptionItem::Lagged(n) => {
             panic!("expected leading RetentionGap, got Lagged({n})")
+        }
+        EventSubscriptionItem::Error(err) => {
+            panic!("expected leading RetentionGap, got subscription error: {err}")
         }
     };
     assert_eq!(

--- a/docs/API.md
+++ b/docs/API.md
@@ -1765,9 +1765,10 @@ category and type filters select every EHM-fed category on this RPC: route,
 EVPN, session lifecycle, session notifications, policy, dataplane, and BFD.
 Dataplane summary and per-route FIB apply events remain live on `WatchEvents`
 and are also replayable through `SubscribeFromEvent` when event history is
-enabled. When event history is disabled or unavailable, the RPC returns
-`FAILED_PRECONDITION`; legacy live and `List*Events` RPCs are unaffected.
-That availability result takes precedence over filter validation.
+enabled. When event history is disabled or startup fell back to live-only
+operation, the RPC returns `FAILED_PRECONDITION` at admission; legacy live and
+`List*Events` RPCs are unaffected. That admission result takes precedence over
+filter validation.
 
 Pre-admission loss is the baseline; later loss wins delivery races and ends with
 `DATA_LOSS`. Cursors cannot replay pre-commit loss, so reconcile state first.
@@ -1794,6 +1795,12 @@ Live `WatchEvents` compatibility:
 | BFD | `BGP_EVENT_TYPE_BFD_SESSION_UP`, `BGP_EVENT_TYPE_BFD_SESSION_DOWN`, `BGP_EVENT_TYPE_BFD_SESSION_STATE_CHANGED`, `BGP_EVENT_TYPE_STREAM_LAGGED` |
 
 Durable `SubscribeFromEvent` compatibility:
+
+If the storage actor becomes unavailable after admission and no producer loss
+has been observed, the stream ends with gRPC `UNAVAILABLE`. Resume from the
+last received top-level `event_id` after restoring the daemon. Allocator
+pass-through remains `FAILED_PRECONDITION`; post-admission producer loss retains
+`DATA_LOSS` precedence.
 
 | Category | Compatible event types |
 |----------|------------------------|

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4256,12 +4256,11 @@ NATS / Vector / journald sink, then persist
 durable receipt. See `OPERATIONS.md` "Durable Event Cursor"
 for the alert + sizing playbook.
 
-When `enabled = false`, when EHM failed to start with
-`required = false`, or when EHM dropped into pass-through
-mode at runtime, `SubscribeFromEvent` returns
+When `enabled = false` or EHM failed to start with
+`required = false`, `SubscribeFromEvent` returns
 `FAILED_PRECONDITION`. The live `WatchEvents`
 and `List*Events` surfaces are byte-identical
-to pre-ADR-0072 behavior in all three cases — they're
+to pre-ADR-0072 behavior in both cases — they're
 backed by the existing in-memory rings.
 
 **Producer set:** route, EVPN, session-lifecycle,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1336,10 +1336,16 @@ any `WatchEvents` subscriber is alive.
    reason; fix permissions / free disk / restore from backup, then
    restart. Pre-1.0, `required = true` is the strictest posture — the
    daemon refuses to start when the outbox cannot be opened.
-3. EHM dropped into pass-through mode at runtime because the
-   allocator anchor became unrecoverable (e.g. a moved
-   `.stale-<ts>` quarantine file with no sidecar fallback). Same
-   recovery: check log, fix the underlying I/O issue, restart.
+3. Event-history startup failed because the allocator anchor was unrecoverable
+   (for example, a moved `.stale-<ts>` quarantine file with no sidecar
+   fallback). With `required = false`, the daemon continues live-only without
+   EHM; with `required = true`, startup fails. Check the startup log, fix the
+   underlying I/O issue, and restart.
+
+**`UNAVAILABLE` during `SubscribeFromEvent` replay** means the storage actor
+stopped accepting work or failed to reply. Inspect daemon health and logs,
+restart if necessary, and resume from the last received top-level `event_id`.
+Events already delivered remain valid; the terminal status is emitted once.
 
 **Sizing retention** — `max_events` and `max_bytes` are retention targets
 evaluated during each scheduled pass. The count target is evaluated first and

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -210,7 +210,7 @@ shape itself does not raise the tier.
 | `ListSessionEvents` | `sensitive_read` | Bounded session lifecycle history per peer. |
 | `ListPolicyEvents` | `sensitive_read` | Bounded policy mutation history. |
 | `ListEvpnEvents` | `sensitive_read` | Bounded EVPN route add / withdraw / best-change history. |
-| `SubscribeFromEvent` (stream) | `sensitive_read` | ADR-0072 durable cursor replay + live. Same disclosure scope as `WatchEvents` plus historical events from the durable outbox. Returns `FAILED_PRECONDITION` when `[event_history].enabled = false` or EHM is in pass-through mode; the live `WatchEvents` and bounded `List*Events` surfaces are unaffected. |
+| `SubscribeFromEvent` (stream) | `sensitive_read` | ADR-0072 durable cursor replay + live. Same disclosure scope as `WatchEvents` plus historical events from the durable outbox. Returns `FAILED_PRECONDITION` when `[event_history].enabled = false` or startup fell back to live-only operation, and terminal `UNAVAILABLE` if storage fails during replay without observed producer loss; resume from the last received `event_id`. Post-admission producer loss retains `DATA_LOSS` precedence. The live `WatchEvents` and bounded `List*Events` surfaces are unaffected. |
 
 ### InjectionService (6 RPCs)
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -400,8 +400,8 @@ what's deferred.
 
 | Field | Class | Notes |
 |---|---|---|
-| `enabled` | restart-required | Off ⇒ EHM does not open `events.db`; live event broadcast paths remain possible, but no durable outbox/replay state is created. (See ADR-0072 for the pass-through contract on `required = false` recovery failures, which is a runtime degraded state distinct from `enabled = false`.) |
-| `required` | restart-required | If `true`, the daemon fails to start when the events DB cannot be opened or recovered. Default `false`: degrade to pass-through with `bgp_event_outbox_degraded = 1`. |
+| `enabled` | restart-required | Off ⇒ EHM does not open `events.db`; live event broadcast paths remain possible, but no durable outbox/replay state is created. (See ADR-0072 for the live-only startup fallback on `required = false` recovery failures, which is distinct from `enabled = false`.) |
+| `required` | restart-required | If `true`, the daemon fails to start when the events DB cannot be opened or recovered. Default `false`: continue in live-only mode with `bgp_event_outbox_degraded = 1`. |
 | `path` | restart-required | Relative to `runtime_state_dir`. Empty ⇒ `<runtime_state_dir>/events.db`. |
 | `max_events` | restart-required | Count retention target; default 100,000. Each 60s pass evaluates this first and evicts at most 5,000 oldest events above the target. |
 | `max_bytes` | restart-required | Byte retention target on `events.db` + WAL combined; default 256 MB. After the count phase, a pass removes up to ten additional 5,000-event batches while oversized. A busy or heavily oversized store can remain above either target after a bounded pass, and SQLite may reuse freed pages rather than shrink the main DB immediately. |

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -613,7 +613,7 @@
           "minimum": 0
         },
         "enabled": {
-          "description": "Enable the durable outbox. **Default `false` (opt-in as of\nv0.32.0).** When `false`, EHM runs in pass-through mode (live\nbroadcasts only, no persistence) and `SubscribeFromEvent`\nreturns `FAILED_PRECONDITION`. Set `true` for restart-safe event\nreplay — it costs memory / CPU / disk (see `docs/BENCHMARKS.md`).",
+          "description": "Enable the durable outbox. **Default `false` (opt-in as of\nv0.32.0).** When `false`, the daemon does not start EHM;\nlive broadcasts remain available without persistence, and\n`SubscribeFromEvent` returns `FAILED_PRECONDITION`. Set `true`\nfor restart-safe event replay — it costs memory / CPU / disk\n(see `docs/BENCHMARKS.md`).",
           "type": "boolean",
           "default": false
         },
@@ -649,7 +649,7 @@
           "minimum": 0
         },
         "required": {
-          "description": "Fail to start if the events DB cannot be opened or recovered.\nDefault `false` — degrade to pass-through with the\n`bgp_event_outbox_degraded` flag set.",
+          "description": "Fail to start if the events DB cannot be opened or recovered.\nDefault `false` — continue in live-only mode with the\n`bgp_event_outbox_degraded` flag set.",
           "type": "boolean",
           "default": false
         },

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2042,9 +2042,10 @@ service EventService {
   // SubscribeFromEvent semantics (all EHM-fed categories), not WatchEvents
   // live-stream defaults.
   //
-  // Returns FAILED_PRECONDITION when durable history is disabled, unavailable,
-  // or in pass-through mode. Availability is checked before category/type
-  // filter validation.
+  // Returns FAILED_PRECONDITION at admission when durable history is disabled
+  // or startup fell back to live-only operation. Replay storage interruption
+  // ends the stream with UNAVAILABLE unless post-admission producer loss takes
+  // DATA_LOSS precedence. Admission is checked before category/type validation.
   rpc SubscribeFromEvent(SubscribeFromEventRequest) returns (stream BgpEvent);
 }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -397,14 +397,15 @@ fn default_inbound_admission_table_capacity() -> usize {
 #[serde(deny_unknown_fields)]
 pub struct EventHistoryConfig {
     /// Enable the durable outbox. **Default `false` (opt-in as of
-    /// v0.32.0).** When `false`, EHM runs in pass-through mode (live
-    /// broadcasts only, no persistence) and `SubscribeFromEvent`
-    /// returns `FAILED_PRECONDITION`. Set `true` for restart-safe event
-    /// replay — it costs memory / CPU / disk (see `docs/BENCHMARKS.md`).
+    /// v0.32.0).** When `false`, the daemon does not start EHM;
+    /// live broadcasts remain available without persistence, and
+    /// `SubscribeFromEvent` returns `FAILED_PRECONDITION`. Set `true`
+    /// for restart-safe event replay — it costs memory / CPU / disk
+    /// (see `docs/BENCHMARKS.md`).
     #[serde(default = "default_event_history_enabled")]
     pub enabled: bool,
     /// Fail to start if the events DB cannot be opened or recovered.
-    /// Default `false` — degrade to pass-through with the
+    /// Default `false` — continue in live-only mode with the
     /// `bgp_event_outbox_degraded` flag set.
     #[serde(default)]
     pub required: bool,


### PR DESCRIPTION
## Summary

- distinguish a stopped event-history store or dropped reply from allocator pass-through
- terminate durable replay with retryable `UNAVAILABLE` guidance while preserving `DATA_LOSS` precedence and clean shutdown EOF
- align the proto, Rust API, configuration, and operator documentation with the three status cases

## Testing

- `cargo test --locked -p rustbgpd-event-history`
- `cargo test --locked -p rustbgpd-api --lib`
- `cargo clippy --locked -p rustbgpd-event-history -p rustbgpd-api --all-targets -- -D warnings`
- `python3 scripts/check-v1-stable-surface.py`
- `just links`
- `just gate`
- `just gate-rib`