### PR TITLE
Report absent session writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Session enqueue attempts without an active writer now report `WriterClosed`
+  instead of falsely reporting success.
+
 - Durable event replay now reports a closed storage mailbox or dropped reply
   as one terminal gRPC `UNAVAILABLE` status with resume guidance instead of a
   clean end-of-stream. Allocator pass-through remains `FAILED_PRECONDITION`,

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -212,7 +212,7 @@ impl PeerSession {
                 msg_type = %msg.message_type(),
                 "cannot send — not connected (priority)"
             );
-            return Ok(());
+            return Err(TransportError::WriterClosed);
         };
         tx.send(Bytes::from(encoded))
             .map_err(|_| TransportError::WriterClosed)
@@ -233,7 +233,7 @@ impl PeerSession {
                 msg_type = %msg.message_type(),
                 "cannot send — not connected (bulk)"
             );
-            return Ok(());
+            return Err(TransportError::WriterClosed);
         }
         self.enqueue_bulk_encoded(Bytes::from(encoded), matches!(msg, Message::Update(_)))
     }
@@ -254,7 +254,7 @@ impl PeerSession {
                 peer = %self.peer_label,
                 "cannot send — not connected (bulk)"
             );
-            return Ok(());
+            return Err(TransportError::WriterClosed);
         };
         // RFC 8671 post-policy Adj-RIB-Out tap: every outbound UPDATE
         // (announcements, withdraws, EoR markers — all families) funnels

--- a/crates/transport/src/session/shared_group.rs
+++ b/crates/transport/src/session/shared_group.rs
@@ -433,8 +433,8 @@ impl PeerSession {
     }
 
     /// Returns `true` when this envelope was fully handled through the
-    /// shared bytes (including an enqueue failure, whose saturation/teardown
-    /// policy already ran — re-encoding locally would duplicate the stream).
+    /// shared bytes (including an enqueue failure: saturation tears down
+    /// inside enqueue, while a missing or closed writer is already exiting).
     /// `false` = fall back to the ordinary path, which re-runs the snapshot
     /// trust checks and owns their teardown. Mid-stream `false` (truncated
     /// stream) is safe: every prefix sent so far carries exactly the
@@ -514,9 +514,9 @@ impl PeerSession {
         let mut order: Vec<usize> = (0..update.announce.len()).collect();
         order.sort_unstable_by_key(|&i| update.announce[i].peer);
         // Keep publishing for the group even after this session's own writer
-        // saturates: the group's stream must not depend on one member's
-        // channel health. The saturation/teardown policy for this session
-        // already ran inside the failed enqueue.
+        // fails: the group's stream must not depend on one member's channel
+        // health. Saturation tears down inside enqueue; a missing or closed
+        // writer is already driving session teardown.
         let mut own_send_healthy = true;
         let mut sent: u64 = 0;
         let mut idx = 0;
@@ -586,8 +586,9 @@ impl PeerSession {
                     continue;
                 }
                 if self.enqueue_bulk_encoded(chunk.bytes, true).is_err() {
-                    // Saturation teardown / writer-closed policy already ran
-                    // inside; abort like the ordinary chunked senders.
+                    // Saturation tears down inside enqueue; a missing or
+                    // closed writer is already driving session teardown.
+                    // Abort like the ordinary chunked senders.
                     return true;
                 }
                 self.updates_sent += 1;

--- a/crates/transport/src/session/tests/run_loop.rs
+++ b/crates/transport/src/session/tests/run_loop.rs
@@ -896,6 +896,8 @@ async fn inbound_extended_message_accepted_from_peer_without_capability() {
 #[tokio::test]
 async fn outbound_extended_message_gated_on_peer_capability() {
     let mut session = make_test_session(65001, 65002);
+    let (priority_tx, _priority_rx) = mpsc::unbounded_channel();
+    session.writer_priority_tx = Some(priority_tx);
     session.negotiated = Some(Arc::new(negotiated_session(65002, false)));
     assert_eq!(
         session.outbound_max_message_len(),
@@ -921,6 +923,36 @@ async fn outbound_extended_message_gated_on_peer_capability() {
         session.enqueue_priority(&big).is_ok(),
         "the peer advertised Extended Messages — the extended limit applies"
     );
+}
+
+#[test]
+fn enqueue_priority_without_writer_returns_writer_closed() {
+    let mut session = make_test_session(65001, 65002);
+    assert!(matches!(
+        session.enqueue_priority(&Message::Keepalive),
+        Err(TransportError::WriterClosed)
+    ));
+}
+
+#[test]
+fn enqueue_bulk_without_writer_returns_writer_closed() {
+    let mut session = make_test_session(65001, 65002);
+    assert!(matches!(
+        session.enqueue_bulk(&Message::RouteRefresh(RouteRefreshMessage::new(
+            Afi::Ipv4,
+            Safi::Unicast,
+        ))),
+        Err(TransportError::WriterClosed)
+    ));
+}
+
+#[test]
+fn enqueue_bulk_encoded_without_writer_returns_writer_closed() {
+    let mut session = make_test_session(65001, 65002);
+    assert!(matches!(
+        session.enqueue_bulk_encoded(Bytes::new(), false),
+        Err(TransportError::WriterClosed)
+    ));
 }
 
 // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- return the existing `WriterClosed` error when priority, bulk, or pre-encoded bulk writer senders are absent
- preserve encoding precedence, saturation teardown, BMP ordering, and best-effort session teardown behavior
- pin all three seams directly and make the RFC 8654 test use the live writer its success case assumes

## Testing

- `cargo test --locked -p rustbgpd-transport --lib`
- `cargo clippy --locked -p rustbgpd-transport --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `just gate`
- `just gate-rib`