### PR TITLE
Preserve unavailable RPC reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The CLI now preserves actionable daemon reasons on mid-RPC gRPC
+  `UNAVAILABLE` responses instead of replacing them with a generic diagnostic.
+
 - Session enqueue attempts without an active writer now report `WriterClosed`
   instead of falsely reporting success.
 

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -44,11 +44,14 @@ impl From<tonic::Status> for CliError {
         // message reads as the sentence.
         let prefix = match s.code() {
             // Connect-time unreachability is handled by `CliError::Connect`
-            // (with address + failure class); an UNAVAILABLE that surfaces
-            // mid-RPC means the daemon went away, and the raw transport
-            // detail is intentionally suppressed.
+            // (with address + failure class). Mid-RPC UNAVAILABLE statuses
+            // retain an actionable daemon message when one is present.
             tonic::Code::Unavailable => {
-                return CliError::Rpc("daemon is not running or unreachable".into());
+                return CliError::Rpc(if s.message().trim().is_empty() {
+                    "temporarily unavailable".into()
+                } else {
+                    format!("temporarily unavailable: {}", s.message())
+                });
             }
             tonic::Code::NotFound => "not found",
             tonic::Code::InvalidArgument => "invalid argument",
@@ -116,13 +119,24 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_is_reported_as_generic_unreachable() {
-        // The raw transport detail is intentionally suppressed: an
-        // operator seeing UNAVAILABLE almost always just means the daemon
-        // is down, so we never leak the noisy inner message.
-        let err = CliError::from(Status::unavailable("connection reset by peer"));
+    fn unavailable_preserves_nonempty_server_reason() {
+        let err = CliError::from(Status::unavailable(
+            "config persistence queue busy — refusing mutation to avoid drift",
+        ));
         assert!(matches!(err, CliError::Rpc(_)));
-        assert_eq!(err.to_string(), "daemon is not running or unreachable");
+        assert_eq!(
+            err.to_string(),
+            "temporarily unavailable: config persistence queue busy — refusing mutation to avoid drift"
+        );
+    }
+
+    #[test]
+    fn unavailable_without_reason_uses_bounded_fallback() {
+        for message in ["", " \t\n"] {
+            let err = CliError::from(Status::unavailable(message));
+            assert!(matches!(err, CliError::Rpc(_)));
+            assert_eq!(err.to_string(), "temporarily unavailable");
+        }
     }
 
     #[test]

--- a/tools/rs-config-render/tests/activation.rs
+++ b/tools/rs-config-render/tests/activation.rs
@@ -110,6 +110,7 @@ case "$*" in
     case "$(cat "$root/health-mode")" in
       malformed) printf 'not-json\n'; exit 0 ;;
       auth) printf 'Error: permission denied\n' >&2; exit 1 ;;
+      rpc-unavailable) printf 'Error: temporarily unavailable: config persistence unavailable\n' >&2; exit 1 ;;
     esac
     if [ ! -f "$root/runtime" ]; then
       printf 'Error: cannot reach rustbgpd at test (connection refused)\n' >&2
@@ -370,6 +371,21 @@ fn initial_activation_and_noop_are_private_exact_and_secret_free() {
     });
     assert_refused(result);
     assert!(!second_state.join("current").exists());
+}
+
+#[test]
+fn initial_rpc_unavailable_is_invalid_not_unreachable() {
+    let _serial = activation_test_guard();
+    let rig = Rig::new();
+    let candidate = rig.candidate("candidate-rpc-unavailable", 101);
+    rig.set("health-mode", "rpc-unavailable");
+
+    assert!(matches!(
+        rig.run(&candidate, true, &rig.activation),
+        Err(Error::Refused(message)) if message == "--initial requires no reachable daemon"
+    ));
+    assert!(!rig.state.join("current").exists());
+    assert!(!rig.root.join("activation.log").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve actionable daemon messages on mid-RPC `UNAVAILABLE` responses
- keep a bounded fallback for empty messages
- leave connect-time diagnostics and all other status mappings unchanged

## Compatibility

`rs-config-render` compatibility was checked explicitly. Its health probe intentionally continues to classify only connect-time `cannot reach rustbgpd at ...` failures as unreachable. The new `temporarily unavailable...` wording represents an ambiguous mid-RPC failure and remains invalid and fail-closed, particularly for `activate --initial`. The legacy generic phrase remains recognized for older `rbgp` binaries.

## Verification

- focused unavailable and connect-diagnostic tests
- `rs-config-render` initial-activation fail-closed regression
- complete `rustbgpctl` test suite
- strict `rustbgpctl` Clippy and formatting
- full local gate