### PR TITLE
Install and scope local hooks correctly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@
 # cache and pushes paid a full workspace re-doc.
 #
 # Setup: see CONTRIBUTING.md "Pre-commit hooks".
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
   - repo: local
     hooks:
@@ -27,22 +29,24 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --workspace --all-targets -- -D warnings
+        entry: cargo clippy --locked --workspace --all-targets -- -D warnings
         language: system
-        types: [rust]
+        files: '(^|/)([^/]+\.rs|Cargo\.toml|Cargo\.lock)$'
+        types: [file]
         pass_filenames: false
 
       - id: cargo-test
         name: cargo test
-        entry: cargo test --workspace --lib
+        entry: cargo test --locked --workspace --lib
         language: system
-        types: [rust]
+        files: '(^|/)([^/]+\.rs|Cargo\.toml|Cargo\.lock)$'
+        types: [file]
         pass_filenames: false
         stages: [pre-push]
 
       - id: cargo-doc
         name: cargo doc
-        entry: cargo doc --workspace --lib --no-deps
+        entry: cargo doc --locked --workspace --lib --no-deps
         language: system
         always_run: true
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,8 +198,8 @@ remain responsible for shell scripts.
 ### Pre-commit hooks
 
 We ship a `.pre-commit-config.yaml` that runs `cargo fmt` and
-`cargo clippy --workspace --all-targets -- -D warnings` on every
-commit and `cargo test --workspace --lib` on every push. The
+`cargo clippy --locked --workspace --all-targets -- -D warnings` on every
+commit and `cargo test --locked --workspace --lib` on every push. The
 hooks are a fast local subset, not an exact CI mirror or a guarantee that a
 pull request is ready. `cargo test` is gated to pre-push (not pre-commit) so
 commits stay fast.
@@ -209,10 +209,12 @@ Set it up once:
 ```bash
 # Recommended: prek (fast Rust port, drop-in compatible)
 cargo install --locked prek
-prek install
 
 # Or via standalone installer (no Rust toolchain needed)
 curl -LsSf https://github.com/j178/prek/releases/latest/download/prek-installer.sh | sh
+
+# Both prek installation methods use the configured hook types
+prek install
 
 # Or with the original Python pre-commit
 pipx install pre-commit


### PR DESCRIPTION
## Summary

- install both pre-commit and pre-push stages with the recommended prek setup
- run Clippy and library tests for Rust sources and Cargo manifest or lockfile changes
- use locked Cargo resolution for all local Cargo hooks

## Verification

- `prek validate-config .pre-commit-config.yaml`
- file-selection matrix for Rust, Cargo.toml, Cargo.lock, and Markdown
- fresh-repository `prek install` creates executable pre-commit and pre-push hooks
- `just links`
- `just gate`
- `git diff --check`