### PR TITLE
Remove unused validator setup from core CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
           compression-level: 0
 
   core:
-    needs: v064_validator
     runs-on: ubuntu-latest
     # Bound any wedge (e.g. a rustdoc hang) so a stuck step fails fast
     # instead of running to GitHub's 6-hour default. The last serial run
@@ -110,17 +109,6 @@ jobs:
           bash -n .github/scripts/install-grpcurl.sh
           shellcheck .github/scripts/install-grpcurl.sh
           bash .github/scripts/install-grpcurl.sh --self-test
-      - name: Download verified v0.64 validator archive
-        uses: actions/download-artifact@v8
-        with:
-          name: rustbgpd-v0.64.0-linux-amd64
-          path: ${{ runner.temp }}/rustbgpd-v064-artifact
-      - name: Install exact v0.64 config migration validator offline
-        run: |
-          .github/scripts/install-rustbgpd-v064-validator.sh \
-            --install-archive \
-            "$RUNNER_TEMP/rustbgpd-v064-artifact/rustbgpd-linux-amd64.tar.gz" \
-            "$RUNNER_TEMP/rustbgpd-v064"
       - name: Prove CI image-primer contract
         run: |
           python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -163,7 +163,7 @@ PINS = collections.Counter(
         "docker/build-push-action@v7": 55,
         "actions/cache@v6": 7,
         "actions/upload-artifact@v7": 12,
-        "actions/download-artifact@v8": 6,
+        "actions/download-artifact@v8": 5,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
     }
@@ -466,33 +466,30 @@ def check(root: Path) -> list[str]:
     if producer.count("uses: actions/upload-artifact@v7") != 1:
         errors.append("ci.yml:v064_validator must upload one same-run artifact")
 
-    for job_name in ("core", "core_tests"):
-        consumer = ci_jobs.get(job_name, "")
-        for seam in (
-            "needs: v064_validator",
-            "uses: actions/download-artifact@v8",
-            f"name: {V064_ARTIFACT}",
-            "path: ${{ runner.temp }}/rustbgpd-v064-artifact",
-            "--install-archive",
-            f'"$RUNNER_TEMP/rustbgpd-v064-artifact/{V064_ARCHIVE}"',
-            '"$RUNNER_TEMP/rustbgpd-v064"',
-        ):
-            if seam not in consumer:
-                errors.append(f"ci.yml:{job_name} missing validator seam {seam}")
-        if consumer.count("uses: actions/download-artifact@v8") != 1:
-            errors.append(f"ci.yml:{job_name} must download one validator artifact")
-        for forbidden in (
-            "--prepare-archive",
-            "actions/cache@",
-            "actions/upload-artifact@",
-            "releases/download/v0.64.0",
-            "restore-keys:",
-            "continue-on-error:",
-        ):
-            if forbidden in consumer:
-                errors.append(
-                    f"ci.yml:{job_name} validator consumer permits {forbidden}"
-                )
+    consumer = ci_jobs.get("core_tests", "")
+    for seam in (
+        "needs: v064_validator",
+        "uses: actions/download-artifact@v8",
+        f"name: {V064_ARTIFACT}",
+        "path: ${{ runner.temp }}/rustbgpd-v064-artifact",
+        "--install-archive",
+        f'"$RUNNER_TEMP/rustbgpd-v064-artifact/{V064_ARCHIVE}"',
+        '"$RUNNER_TEMP/rustbgpd-v064"',
+    ):
+        if seam not in consumer:
+            errors.append(f"ci.yml:core_tests missing validator seam {seam}")
+    if consumer.count("uses: actions/download-artifact@v8") != 1:
+        errors.append("ci.yml:core_tests must download one validator artifact")
+    for forbidden in (
+        "--prepare-archive",
+        "actions/cache@",
+        "actions/upload-artifact@",
+        "releases/download/v0.64.0",
+        "restore-keys:",
+        "continue-on-error:",
+    ):
+        if forbidden in consumer:
+            errors.append(f"ci.yml:core_tests validator consumer permits {forbidden}")
 
     aggregate = ci_jobs.get("check", "")
     for seam in (

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -230,6 +230,19 @@ class PrimerContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(".github/workflows/ci.yml", old, new)
 
+    def test_v064_core_tests_consumer_is_load_bearing(self):
+        cases = (
+            ("    needs: v064_validator\n", "    needs: []\n"),
+            (
+                "uses: actions/download-artifact@v8",
+                "uses: actions/download-artifact@main",
+            ),
+            ("--install-archive", "--prepare-archive"),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(".github/workflows/ci.yml", old, new)
+
     def test_empty_flow_needs_is_empty(self):
         self.assertEqual([], _list_needs("    needs: []\n"))
         self.assertEqual(


### PR DESCRIPTION
## Summary

- let the core CI job run without waiting for the v0.64 migration validator it never uses
- retain the validator producer, real core-tests consumer, migration test, and aggregate enforcement
- keep the remaining consumer load-bearing in the existing contract checker

## Verification

- image-primer checker and 53 companion tests
- scale-split checker and companion tests
- `actionlint .github/workflows/ci.yml`
- `ruff check` on the changed Python files
- `git diff --check`