### PR TITLE
Preserve terminal state and clean redirected diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Redirected daemon diffs no longer contain terminal color escapes, and the
+  interactive CLI restores normal terminal mode if alternate-screen entry fails.
+
 - Invalid TUI intervals and empty policy-chain replacements now fail locally
   before the CLI attempts to connect to the daemon.
 

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -31,8 +31,8 @@ impl Drop for TerminalGuard {
 
 pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> {
     enable_raw_mode()?;
-    io::stdout().execute(EnterAlternateScreen)?;
     let _guard = TerminalGuard;
+    io::stdout().execute(EnterAlternateScreen)?;
 
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2004,14 +2004,24 @@ fn warn_unpoliced_ebgp(config: &Config) -> usize {
 }
 
 fn write_config_diff(writer: &mut dyn io::Write, diff: &config::ConfigDiff) -> io::Result<()> {
-    use owo_colors::OwoColorize;
+    use owo_colors::{OwoColorize, Stream::Stdout};
 
-    let reload_header = "Reload-applied changes:".green().to_string();
-    let restart_header = "Restart-required changes:".yellow().to_string();
-    let add_marker = "+".green().to_string();
-    let remove_marker = "-".red().to_string();
-    let change_marker = "~".yellow().to_string();
-    let restart_marker = "!".yellow().to_string();
+    let reload_header = "Reload-applied changes:"
+        .if_supports_color(Stdout, OwoColorize::green)
+        .to_string();
+    let restart_header = "Restart-required changes:"
+        .if_supports_color(Stdout, OwoColorize::yellow)
+        .to_string();
+    let add_marker = "+"
+        .if_supports_color(Stdout, OwoColorize::green)
+        .to_string();
+    let remove_marker = "-".if_supports_color(Stdout, OwoColorize::red).to_string();
+    let change_marker = "~"
+        .if_supports_color(Stdout, OwoColorize::yellow)
+        .to_string();
+    let restart_marker = "!"
+        .if_supports_color(Stdout, OwoColorize::yellow)
+        .to_string();
     let style = config::ConfigDiffTextStyle {
         reload_header: reload_header.into(),
         restart_header: restart_header.into(),

--- a/tests/daemon_stdout_closed.rs
+++ b/tests/daemon_stdout_closed.rs
@@ -147,7 +147,7 @@ fn healthy_check_and_diff_bytes_streams_and_statuses_are_exact() {
     assert!(text.stderr.is_empty());
     assert_eq!(
         text.stdout,
-        b"\x1b[33mRestart-required changes:\x1b[39m\n  \x1b[33m!\x1b[39m [global] changed\n\n\
+        b"Restart-required changes:\n  ! [global] changed\n\n\
           Plan: no neighbor changes \xc2\xb7 daemon restart required for some changes\n"
     );
 


### PR DESCRIPTION
## Summary

- honor terminal color capability for daemon config diffs so redirected and `NO_COLOR` output stays ANSI-free
- arm the existing TUI cleanup guard immediately after raw mode starts
- preserve TTY color, text ordering, statuses, stdout errors, and successful TUI behavior

## Verification

- focused and full `daemon_stdout_closed` tests
- 55 focused TUI tests and full rustbgpctl package tests
- strict Clippy for rustbgpd and rustbgpctl
- `cargo fmt --all -- --check`
- `just gate`
- `git diff --check`