### PR TITLE
config: allow full-snapshot transactions when external policy inputs are unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Operator-visible:** config transactions no longer reject a full-snapshot
+  candidate merely because `[policy] rpol_files` / `[policy.datasets]` are
+  declared. The planner now captures every declared external file at plan and
+  apply time and admits the transaction when its byte identity matches the
+  accepted snapshot's recorded identity (ADR-0130) — restoring plan, apply,
+  commit-confirm, and rollback for `.rpol`/dataset deployments whose external
+  sources are unchanged on disk. Any drift (an edited dataset or `.rpol`
+  module, including comment-only rewrites), a missing/unreadable file, or a
+  rollback across an external-content change still rejects without mutation,
+  and gNMI Set full-snapshot candidates remain rejected whenever external
+  inputs are present.
+
 - `rbgp doctor` now describes config freshness as an mtime comparison with the
   daemon's last config-file marker rather than claiming effective runtime
   agreement. The Prometheus alert pack reports authoritative partial

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -253,6 +253,7 @@ impl proto::config_service_server::ConfigService for ConfigService {
             |reply| PeerManagerCommand::PlanConfigTransaction {
                 candidate_toml: request.candidate_toml,
                 expected_runtime_snapshot_token,
+                verify_external_inputs: true,
                 reply,
             },
             "peer manager dropped config transaction plan reply",
@@ -772,6 +773,7 @@ mod tests {
             let Some(PeerManagerCommand::PlanConfigTransaction {
                 candidate_toml,
                 expected_runtime_snapshot_token,
+                verify_external_inputs: true,
                 reply,
             }) = rx.recv().await
             else {

--- a/crates/api/src/config_service/stream.rs
+++ b/crates/api/src/config_service/stream.rs
@@ -633,6 +633,7 @@ async fn run_detached_plan(
             .send(PeerManagerCommand::PlanConfigTransaction {
                 candidate_toml,
                 expected_runtime_snapshot_token,
+                verify_external_inputs: true,
                 reply,
             })
             .await
@@ -1236,6 +1237,7 @@ mod tests {
         let PeerManagerCommand::PlanConfigTransaction {
             candidate_toml,
             expected_runtime_snapshot_token,
+            verify_external_inputs: true,
             reply,
         } = peer_rx.recv().await.unwrap()
         else {

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -781,6 +781,13 @@ pub enum PeerManagerCommand {
         /// Optional optimistic-concurrency token the caller expects to plan
         /// against.
         expected_runtime_snapshot_token: Option<String>,
+        /// Whether the planner may capture the candidate's declared external
+        /// policy sources and, on a byte-identical match with the accepted
+        /// snapshot, classify them as verified-unchanged. The
+        /// config-transaction plan/apply paths set this; the gNMI Set bridge
+        /// leaves it false so gNMI full-snapshot candidates keep the
+        /// external-input presence fence.
+        verify_external_inputs: bool,
         /// Reply channel returning the transaction plan.
         reply: oneshot::Sender<
             Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError>,

--- a/docs/API.md
+++ b/docs/API.md
@@ -586,14 +586,18 @@ at a time. Cross-family candidates, mixed policy/session effective impacts,
 and other valid-but-unsupported sections return `REJECTED` without mutation
 until their section executor lands.
 
-Native apply and rollback reject any supported family that would stage and
-adopt the full candidate snapshot when either side references external
-`.rpol` main/import files or `[policy.datasets]` snapshots. Those bytes are not
-covered by the transaction token and cannot be rolled back atomically with the
-TOML. Deploy the TOML, `.rpol` graph, and dataset snapshots together, then send
-SIGHUP. A true no-op remains `NOOP`; a pure `[[fib_tables]]` transaction with
-unchanged external inputs remains committable because that executor substitutes
-only the targeted table set rather than adopting the full candidate config.
+Native plan/apply/rollback admit a full-snapshot family with external
+`.rpol` main/import files or `[policy.datasets]` snapshots declared only when
+the planner's fresh capture of those files is byte-identical to the accepted
+snapshot's recorded identity (ADR-0130) — the bytes are not covered by the
+transaction token and cannot be rolled back atomically with the TOML, so any
+drift rejects the transaction without mutation. Deploy changed TOML, `.rpol`
+graphs, and dataset snapshots together, then send SIGHUP. gNMI Set never
+verifies external inputs: a gNMI full-snapshot candidate remains rejected
+whenever they are present. A true no-op remains `NOOP`; a pure
+`[[fib_tables]]` transaction with unchanged external inputs remains
+committable because that executor substitutes only the targeted table set
+rather than adopting the full candidate config.
 `diff_json.reload_applied.datasets_changed` reports dataset binding/path edits.
 
 ```bash

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3480,11 +3480,13 @@ is rejected and rolled back. Dynamic-range peer-group reassignments and mixed
 policy/session effective-impact candidates remain rejected until dedicated
 executors exist.
 When either the running or candidate config references external `.rpol` graphs
-or `[policy.datasets]` snapshots, every full-candidate transaction family is
-also rejected: the external bytes are not staged, tokened, or rollback-safe.
-Use coordinated file deployment plus SIGHUP. A no-op remains a no-op, and a
-pure `[[fib_tables]]` edit with unchanged external inputs remains committable
-because it does not adopt the rest of the candidate snapshot.
+or `[policy.datasets]` snapshots, full-candidate native transactions remain
+available only while those sources are byte-identical to the accepted snapshot
+(ADR-0130). Any drift rejects those transactions without mutation; deploy
+changed TOML and external inputs together with SIGHUP. A no-op remains a no-op,
+and a pure `[[fib_tables]]` transaction remains available because it does not
+adopt the rest of the candidate snapshot. gNMI full-candidate changes remain
+rejected whenever external inputs are present, even unchanged.
 Like SIGHUP and FIB CRUD, FIB transaction apply requires the FIB reconciler to
 already be running: a daemon that started with no `[[fib_tables]]` still needs a
 restart to enable the subsystem.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2595,14 +2595,18 @@ import_policy_chain = ["customer-in(200)", "bogon-filter", "toml-defined"]
   for materially changed import chains — same mechanism as
   `[policy.definitions]` edits). `rbgp config diff` reports the change
   under the policy section.
-- **Scope notes:** config transactions fail closed while either the running or
-  candidate config references external `.rpol` graphs or policy datasets if
-  the selected executor would adopt the full candidate snapshot. The files
-  live outside the candidate TOML, transaction token, and rollback payload.
-  This applies to native apply/rollback and gNMI Set. Deploy TOML, `.rpol`
-  graphs, and datasets together, then use SIGHUP. True no-ops and pure
-  `[[fib_tables]]` transactions with unchanged external inputs remain
-  available because the FIB executor substitutes only its targeted table set.
+- **Scope notes:** with external `.rpol` graphs or policy datasets declared,
+  native config transactions (plan/apply/rollback, commit-confirm included)
+  are admitted only when the planner's fresh capture of every declared
+  external file is byte-identical to the accepted snapshot's recorded
+  identity (ADR-0130). The files live outside the candidate TOML,
+  transaction token, and rollback payload, so any drift — including a
+  comment-only rewrite — fails closed without mutation; deploy changed TOML,
+  `.rpol` graphs, and datasets together, then use SIGHUP. gNMI Set never
+  verifies external inputs and stays fully fenced while they are present.
+  True no-ops and pure `[[fib_tables]]` transactions with unchanged external
+  inputs remain available because the FIB executor substitutes only its
+  targeted table set.
   `rbgp policy explain` statement
   traces cover `.rpol` chain members at term granularity, and
   `rbgp policy stats` reads the installed chains' live per-term hit

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -471,11 +471,6 @@ rollback, and live dynamic sessions accepted by an affected
 re-accept under the committed config on reconnect (ADR-0086). Mixed-family
 candidates, dynamic-range peer-group reassignments, mixed policy/session
 effective impact, and unsupported sections are rejected without mutation.
-The same rejection applies to every full-candidate family while the running or
-candidate config references external `.rpol` graphs or policy datasets; use a
-coordinated file deployment plus SIGHUP. Pure `[[fib_tables]]` edits with those
-inputs unchanged remain the targeted exception.
-
 Output is grouped into two actionable sections plus a per-neighbor
 effective-impact view:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -411,10 +411,12 @@ unreadable/mismatched rows fail closed before mutation. An eligible
 row is routed through the **same transaction path as
 `config apply`**: the same plan classification, the same reload-impact and
 update-group annotations, and the same receipts. Confirmed rollback remains
-subject to that planner: full-snapshot external-policy adoption is still
-fenced, while an unchanged-external-input pure-`[[fib_tables]]` rollback can
-carry the provenance-verified v2 history row's exact accepted prior snapshot
-through v3 authority.
+subject to that planner: a full-snapshot rollback with external policy inputs
+is admitted only when the verified history row's `.rpol`/dataset identity is
+byte-identical to the currently accepted one, and an unchanged-external-input
+pure-`[[fib_tables]]` rollback can carry the provenance-verified v2 history
+row's exact accepted prior snapshot through v3 authority. Rolling back across
+an external-content change stays rejected — reload the sources first.
 There is no second apply engine —
 a rollback whose entry contains sections the transaction executor cannot
 commit live (for example restart-required `[global]` fields) is rejected
@@ -428,13 +430,20 @@ detached load and requires the live sources to reproduce that identity exactly.
 Keep the operator-authored TOML, `.rpol` graph, and datasets under version control or
 another coordinated deployment system.
 
-Do not use native config apply/rollback or gNMI Set for a full-candidate change
-while either side references `.rpol` or `[policy.datasets]` files. Those bytes
-are outside the transaction token and rollback payload, so the planner rejects
-the change without mutation. Deploy the TOML and external inputs together and
-send SIGHUP instead. External-input no-ops still return `NOOP`; a pure
-`[[fib_tables]]` transaction with unchanged external inputs remains safe and
-committable because it stages only the FIB table set.
+With `.rpol` or `[policy.datasets]` files declared, native config
+plan/apply/rollback (commit-confirm included) work as long as the external
+sources on disk are byte-identical to the accepted ones: the planner captures
+every declared external file at plan and apply time and compares its identity
+(canonical path, length, content digest — ADR-0130) against the accepted
+snapshot before admitting any full-candidate change. Any drift — an edited
+dataset, a touched `.rpol` module, even a comment-only rewrite — rejects the
+transaction without mutation, and a missing or unreadable file fails the
+candidate load. Changed external content still deploys the old way: update the
+TOML and external inputs together and send SIGHUP. gNMI Set is stricter — it
+never verifies external inputs, so a gNMI full-candidate change is rejected
+whenever they are present, even unchanged. External-input no-ops still return
+`NOOP`; a pure `[[fib_tables]]` transaction with unchanged external inputs
+remains safe and committable because it stages only the FIB table set.
 
 For a static-neighbor edit, change the neighbor in the candidate file (for
 example `hold_time`, `max_prefixes`, policy-chain refs, or ORF receive), run

--- a/docs/adr/0130-identity-conditional-external-policy-fence.md
+++ b/docs/adr/0130-identity-conditional-external-policy-fence.md
@@ -1,0 +1,159 @@
+# ADR-0130: Identity-Conditional External-Policy Transaction Fence
+
+**Status:** Proposed
+**Date:** 2026-09-01
+
+## Context
+
+Since #1370, the v1 config-transaction classifier rejects any transaction
+whose selected executor would adopt the full candidate snapshot while either
+side of the diff declares external policy inputs (`[policy] rpol_files` or
+`[policy.datasets]`). The hazard that fence closes is real: external policy
+bytes live outside the candidate TOML, outside the optimistic
+`runtime_snapshot_token`, and outside the rollback payload. Every v1 executor
+except the targeted `[[fib_tables]]` path adopts the full candidate snapshot,
+so an unrelated neighbor or catalog mutation could silently adopt `.rpol` or
+dataset content that was never part of the transaction.
+
+The fence, however, is **presence**-conditional. Any deployment that uses
+`.rpol` at all — including the shipped IXP route-server profile
+(`examples/route-server/config.toml`, `rpol_files = ["hygiene.rpol"]`) —
+loses the entire transactional quartet (plan, apply, commit-confirm,
+rollback) for even a trivial neighbor-description edit, and is pushed to the
+file-edit-plus-SIGHUP workflow for every change.
+
+[ADR-0121](0121-config-history-external-policy-provenance.md) built the
+machinery this decision stands on: every accepted config carries a v2 source
+manifest (per-`.rpol`-module and per-dataset canonical path, byte length,
+SHA-256, and import edges) and a domain-separated `source_sha256`; capture
+happens during the same read that produces the running content and is never
+re-read afterwards. ADR-0121 §8 used that machinery for verified history
+rollback but explicitly kept the presence fence, deferring any
+external-policy adoption capability to "a separate design and production
+fence proofs". This ADR is that design.
+
+## Decision
+
+Make the full-snapshot clause of the external-input fence
+**identity**-conditional instead of presence-conditional.
+
+The classifier input gains an `ExternalInputsIdentity` verdict with two
+values: `Unverified` (the default everywhere) and `VerifiedUnchanged`. The
+full-snapshot rejection clause now fires when external inputs are present
+**and** the verdict is `Unverified`. The `rpol_changed` / `datasets_changed`
+clauses are untouched: an actual change to the declared external roster or
+compiled `.rpol` content rejects regardless of the verdict.
+
+Only the config-transaction plan path can produce `VerifiedUnchanged`, and
+only by an actual comparison:
+
+1. The candidate load on that path captures every external source it reads —
+   the same read that produces the compiled `.rpol` registry and parsed
+   dataset handles — and condenses the capture into a domain-separated
+   digest over the ADR-0121 v2 manifest's external frames (document hash
+   excluded). Two manifests share this digest exactly when substituting one
+   document hash into the other would reproduce the same `source_sha256`,
+   i.e. when the external inputs are byte-identical.
+2. The peer manager compares that digest against the accepted snapshot's
+   manifest (the ADR-0121 accepted authority watch). Equality means the
+   content the executor would adopt **is** the accepted content, so the
+   silent-adoption hazard cannot arise; the transaction is allowed.
+3. Anything else — no captured digest, no accepted authority, or any
+   mismatch — stays `Unverified` and rejects exactly as before. A missing or
+   unreadable external file at plan time fails the candidate load itself.
+
+### The verified candidate adopts no detached state
+
+On `VerifiedUnchanged`, the planner immediately re-attaches the running
+external state into the candidate before anything can adopt it: the
+candidate's freshly compiled `.rpol` units are replaced by the running
+registry's shared storage, and its freshly parsed dataset handles are
+replaced by the live handles. The fresh reads serve as verification evidence
+only — exactly the discipline ADR-0121 §8 required of verified rollback.
+The committed runtime therefore keeps the very dataset handles that future
+SIGHUP refreshes swap in place; no second policy or dataset generation
+enters the runtime, and dataset generations and statistics are preserved.
+
+This is why the change is **not** the "detached external-policy state
+adoption" ADR-0121 §8 warned about. That warning concerned adopting external
+content whose identity is not the accepted identity. Here the only content
+ever adopted is proven byte-identical to the accepted content, and the
+adopted in-memory state is the running state itself.
+
+### TOCTOU chain
+
+What is captured when, and what covers each side:
+
+- **Plan RPC** (`PlanConfigTransaction` / stream variant): the peer manager
+  parses the candidate TOML with capture, verifies, classifies. Advisory
+  only; nothing is adopted.
+- **Apply** runs under the runtime-config coordinator lock, which also
+  serializes SIGHUP reload and every other persisted runtime mutation — the
+  accepted authority cannot advance mid-apply, and a pending confirm window
+  additionally rejects SIGHUP outright. The apply executor never adopts the
+  plan RPC's capture. It performs its own captured parse of the candidate
+  TOML and plans twice through the real planner: the authoritative plan
+  re-parses the TOML (fresh capture, fresh verification), and the typed plan
+  verifies the exact `Config` object the executor will stage — the object
+  whose own captured digest rode in with it, and the object into which the
+  live handles are re-attached on success. The typed plan's committed
+  candidate must byte-match the authoritative plan's or apply fails with
+  `FAILED_PRECONDITION`. An external file edited between any two of these
+  reads produces a digest mismatch (rejected) or a candidate-changed
+  precondition failure — there is no verify-then-adopt gap.
+- **The optimistic token** covers what it always covered: the accepted
+  runtime config plus the RIB snapshot identity on the accepted side. It
+  never hashed external bytes and still does not; external bytes are covered
+  by the digest comparison performed at apply time under the coordinator
+  lock, against an accepted manifest that the same lock holds still.
+- **History rollback** keeps its ADR-0121 §8 chain unchanged
+  (`load_retained` + retained-manifest verification, failing closed with
+  `FAILED_PRECONDITION`) and then passes through this classifier like any
+  apply. Its verdict compares the retained row's external identity against
+  the **current** accepted identity, so rolling back across an
+  external-content change remains rejected — reload the sources first.
+
+### Mid-window edits
+
+- **Runtime auto-revert and abort** re-apply the in-memory
+  `prior_snapshot: Arc<AcceptedConfigSnapshot>` captured before the
+  candidate committed. Capture never re-reads external sources, and the
+  revert candidate's identity is seeded from that snapshot's own manifest —
+  so an external file edited between apply and auto-revert cannot inject
+  content into the revert, and because SIGHUP is fenced while the window is
+  pending, the accepted external identity is unchanged and the revert still
+  classifies committable.
+- **Boot revert** re-loads the journaled prior sources from disk and
+  verifies them against the retained manifest and `source_sha256`, failing
+  closed ("journaled prior sources are unavailable or changed") on any
+  drift. Unchanged.
+
+### Scope
+
+gNMI Set full-snapshot candidates remain **presence-fenced**. The gNMI
+bridge plans and applies without external-input verification (the plain,
+non-capturing candidate load), so external inputs present means rejected
+there even when the on-disk sources are unchanged — the #1370 posture,
+deliberately preserved. The two existing #1370 exceptions are also
+preserved: a true no-op remains `NOOP`, and a targeted pure-`[[fib_tables]]`
+transaction remains committable because it never adopts the full snapshot.
+
+Every non-verifying classifier caller defaults to `Unverified`, so a missed
+or future call site fails safe (presence-fenced), never open.
+
+## Consequences
+
+- Deployments with `.rpol` / dataset files regain plan, apply,
+  commit-confirm, and rollback for every supported transaction family, as
+  long as the external sources on disk are byte-identical to the accepted
+  ones. Any drift — including semantically-equal rewrites such as added
+  comments — rejects with the existing external-inputs reason; the deploy
+  path for changed external content remains files-plus-SIGHUP.
+- No external bytes are archived, no new executor family is added, and the
+  rejection reason string is unchanged.
+- A new domain string (`rustbgpd.config-external-sources.v2`) separates the
+  external-roster digest from the full `source_sha256`; both are derived
+  from the same v2 manifest frames.
+- The peer manager now holds a receiver of the accepted-config authority
+  watch. Daemons without a config file have no authority and keep the
+  presence fence everywhere.

--- a/docs/adr/0130-identity-conditional-external-policy-fence.md
+++ b/docs/adr/0130-identity-conditional-external-policy-fence.md
@@ -1,6 +1,6 @@
 # ADR-0130: Identity-Conditional External-Policy Transaction Fence
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-09-01
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -151,6 +151,7 @@ states that the whole decision is Superseded.
 | [0127](0127-config-transaction-settlement-watchdog.md) | Persisted runtime-config settlement watchdog | Accepted | 2026-08-11 | Active |
 | [0128](0128-route-server-next-hop-translation.md) | Route-server next-hop translation | Accepted (architecture GO if activated; implementation NO-GO, demand-gated) | 2026-08-29 | Active |
 | [0129](0129-prefix-sid-domain-boundary.md) | BGP Prefix-SID administrative-domain boundary | Proposed (no runtime behavior shipped) | 2026-08-29 | Unstated |
+| [0130](0130-identity-conditional-external-policy-fence.md) | Identity-conditional external-policy transaction fence | Proposed | 2026-09-01 | Unstated |
 
 ## Supporting records
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -151,7 +151,7 @@ states that the whole decision is Superseded.
 | [0127](0127-config-transaction-settlement-watchdog.md) | Persisted runtime-config settlement watchdog | Accepted | 2026-08-11 | Active |
 | [0128](0128-route-server-next-hop-translation.md) | Route-server next-hop translation | Accepted (architecture GO if activated; implementation NO-GO, demand-gated) | 2026-08-29 | Active |
 | [0129](0129-prefix-sid-domain-boundary.md) | BGP Prefix-SID administrative-domain boundary | Proposed (no runtime behavior shipped) | 2026-08-29 | Unstated |
-| [0130](0130-identity-conditional-external-policy-fence.md) | Identity-conditional external-policy transaction fence | Proposed | 2026-09-01 | Unstated |
+| [0130](0130-identity-conditional-external-policy-fence.md) | Identity-conditional external-policy transaction fence | Accepted | 2026-09-01 | Active |
 
 ## Supporting records
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -699,6 +699,38 @@ impl Config {
         Self::load_from_toml_source(content, source_name, None)
     }
 
+    /// [`Self::load_toml_with_diagnostics`] additionally capturing the
+    /// byte identity of every external policy source the load actually
+    /// read (`.rpol` module graphs and dataset files) into
+    /// `policy.external_sources_digest` (ADR-0121 v2 framing).
+    ///
+    /// Only the config-transaction plan and apply paths use this loader:
+    /// the captured digest lets the planner admit a full-snapshot
+    /// candidate whose external inputs are byte-identical to the
+    /// accepted snapshot's, and every other load path leaves the digest
+    /// empty so classification falls back to the presence fence.
+    pub(crate) fn load_toml_candidate_captured(
+        content: &str,
+        source_name: &str,
+    ) -> Result<Self, String> {
+        let mut capture = source_provenance::SourceCapture::default();
+        let mut config = Self::load_from_toml_source_with_capture(
+            content,
+            source_name,
+            None,
+            None,
+            DatasetBindMode::Apply,
+            Some(&mut capture),
+            None,
+            None,
+        )?;
+        // The document hash is irrelevant here: only the external-source
+        // frames feed the digest.
+        config.policy.external_sources_digest =
+            ExternalSourcesDigest(Some(capture.finish([0; 32]).external_sources_sha256()));
+        Ok(config)
+    }
+
     /// Load config and, on failure, render a diagnostic with source context.
     ///
     /// Returns the rendered diagnostic string on error (suitable for direct
@@ -1933,6 +1965,34 @@ pub struct PolicyDiff {
     #[serde(skip)]
     #[doc(hidden)]
     pub external_inputs_present: bool,
+    /// Whether a transaction planner verified the candidate's freshly
+    /// captured external policy sources as byte-identical to the accepted
+    /// snapshot's. `diff_config` always initializes this to
+    /// [`ExternalInputsIdentity::Unverified`]; only the config-transaction
+    /// plan path upgrades it after an actual digest comparison, so a
+    /// caller that never verifies keeps the presence fence. Kept out of
+    /// serialized diff output like `external_inputs_present`.
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub external_inputs_identity: ExternalInputsIdentity,
+}
+
+/// Identity verdict for a candidate's declared external policy inputs
+/// (`[policy] rpol_files` / `[policy.datasets]`), consumed by
+/// [`classify_config_transaction_v1`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExternalInputsIdentity {
+    /// No verification was performed (the safe default): the presence of
+    /// external inputs fences every transaction that would adopt the full
+    /// candidate snapshot (#1370). The gNMI Set bridge and every
+    /// non-transaction caller stay here.
+    #[default]
+    Unverified,
+    /// The candidate load's captured `.rpol` + dataset byte identity
+    /// equals the accepted snapshot's manifest identity (domain-separated
+    /// digest match), so adopting the candidate snapshot cannot change
+    /// external policy content.
+    VerifiedUnchanged,
 }
 
 impl PolicyDiff {
@@ -2962,6 +3022,7 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
         push_transaction_external_policy_inputs_reason(&mut class);
     }
     if diff.policy.external_inputs_present
+        && diff.policy.external_inputs_identity == ExternalInputsIdentity::Unverified
         && transaction_stages_full_candidate_snapshot(&class.supported_sections)
     {
         // Every v1 executor except the targeted FIB path adopts the full
@@ -2971,6 +3032,14 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
         // content that was never part of the transaction. A true no-op has no
         // supported family and remains a no-op; pure FIB substitutes only the
         // table set and is therefore safe with unchanged external inputs.
+        //
+        // ADR-0130 narrows the fence to identity: when the config-transaction
+        // plan path has captured the candidate's external sources and proven
+        // them byte-identical to the accepted snapshot's manifest
+        // (`VerifiedUnchanged`), the content the executor would adopt IS the
+        // accepted content and the silent-adoption hazard cannot arise. Every
+        // caller that does not verify — the gNMI Set bridge included — stays
+        // `Unverified` and keeps the presence fence (#1370).
         push_transaction_external_policy_inputs_reason(&mut class);
     }
     if diff.honor_graceful_shutdown_changed {
@@ -3107,6 +3176,7 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
 pub(crate) fn materialize_rfc8212_transaction_candidate(
     live: &Config,
     candidate: &mut Config,
+    external_inputs: ExternalInputsIdentity,
 ) -> Option<ConfigDiff> {
     let live_posture = live.rfc8212_posture();
     let candidate_posture = candidate.rfc8212_posture();
@@ -3136,7 +3206,8 @@ pub(crate) fn materialize_rfc8212_transaction_candidate(
     // this helper from using its own representation change as authorization.
     candidate.config_epoch = live_raw.0;
     candidate.global.ebgp_requires_policy = live_raw.1;
-    let operational_diff = diff_config(live, candidate);
+    let mut operational_diff = diff_config(live, candidate);
+    operational_diff.policy.external_inputs_identity = external_inputs;
     let mutation = classify_config_transaction_v1(&operational_diff);
     candidate.config_epoch = candidate_raw.0;
     candidate.global.ebgp_requires_policy = candidate_raw.1;
@@ -5014,6 +5085,7 @@ pub fn diff_policy(old: &PolicyConfig, new: &PolicyConfig) -> PolicyDiff {
             || !new.rpol_files.is_empty()
             || !old.datasets.is_empty()
             || !new.datasets.is_empty(),
+        external_inputs_identity: ExternalInputsIdentity::Unverified,
     }
 }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2186,6 +2186,16 @@ pub struct PolicyConfig {
     /// the dependency-scoped peer refresh and `failed` into metrics.
     #[serde(skip)]
     pub dataset_events: DatasetLoadEvents,
+    /// Domain-separated digest of the external policy sources this load
+    /// actually read (`.rpol` module graphs and dataset files, in the
+    /// ADR-0121 v2 manifest framing). Populated only by capturing
+    /// candidate loads on the config-transaction path; every other load
+    /// leaves it empty, which the transaction planner treats as
+    /// unverified. Not serialized and excluded from equality like
+    /// `dataset_events`: it records what one load observed, not
+    /// configuration identity.
+    #[serde(skip)]
+    pub external_sources_digest: ExternalSourcesDigest,
 }
 
 fn default_rpol_max_graph_bytes() -> usize {
@@ -2208,6 +2218,7 @@ impl Default for PolicyConfig {
             datasets: HashMap::new(),
             dataset_bindings: rustbgpd_policy::datasets::DatasetBindings::default(),
             dataset_events: DatasetLoadEvents::default(),
+            external_sources_digest: ExternalSourcesDigest::default(),
         }
     }
 }
@@ -2244,6 +2255,23 @@ impl PartialEq for DatasetLoadEvents {
 }
 
 impl Eq for DatasetLoadEvents {}
+
+/// Captured external-source byte identity of one config load: the
+/// domain-separated SHA-256 over the load's `.rpol` module fingerprints
+/// and dataset file fingerprints in ADR-0121 v2 manifest framing (the
+/// document hash excluded). `None` when the load did not capture.
+/// Excluded from config equality like [`DatasetLoadEvents`] — it is a
+/// load observation, not configuration identity.
+#[derive(Debug, Clone, Default)]
+pub struct ExternalSourcesDigest(pub Option<[u8; 32]>);
+
+impl PartialEq for ExternalSourcesDigest {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for ExternalSourcesDigest {}
 
 /// Tuning for the per-session import-decision cache that backs
 /// `rbgp policy explain` / `PolicyService.ExplainImportPolicy`

--- a/src/config/source_provenance.rs
+++ b/src/config/source_provenance.rs
@@ -19,6 +19,7 @@ use sha2::{Digest, Sha256};
 use super::{Config, DatasetBindMode, persisted_config_document_bounded};
 
 const SOURCE_DIGEST_DOMAIN: &[u8] = b"rustbgpd.config-source.v2\0";
+const EXTERNAL_SOURCES_DIGEST_DOMAIN: &[u8] = b"rustbgpd.config-external-sources.v2\0";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SourceManifest {
@@ -120,7 +121,7 @@ impl SourceCapture {
         Ok(())
     }
 
-    fn finish(mut self, toml_sha256: [u8; 32]) -> SourceManifest {
+    pub(super) fn finish(mut self, toml_sha256: [u8; 32]) -> SourceManifest {
         self.datasets
             .sort_by(|left, right| left.name.as_bytes().cmp(right.name.as_bytes()));
         SourceManifest {
@@ -142,28 +143,45 @@ impl SourceManifest {
         let mut digest = Sha256::new();
         digest.update(SOURCE_DIGEST_DOMAIN);
         frame(&mut digest, &self.toml_sha256);
-        frame_u64(&mut digest, self.rpol_units.len());
+        self.frame_external_sources(&mut digest);
+        digest.finalize().into()
+    }
+
+    /// Domain-separated digest over the external-source rosters alone
+    /// (the `.rpol` module fingerprints and dataset fingerprints, in the
+    /// exact `source_sha256` framing with the document hash excluded).
+    /// Two manifests produce the same value exactly when substituting one
+    /// document hash into the other yields the same `source_sha256` —
+    /// i.e. when their captured external inputs are byte-identical.
+    pub(crate) fn external_sources_sha256(&self) -> [u8; 32] {
+        let mut digest = Sha256::new();
+        digest.update(EXTERNAL_SOURCES_DIGEST_DOMAIN);
+        self.frame_external_sources(&mut digest);
+        digest.finalize().into()
+    }
+
+    fn frame_external_sources(&self, digest: &mut Sha256) {
+        frame_u64(digest, self.rpol_units.len());
         for unit in &self.rpol_units {
-            frame_u64(&mut digest, unit.modules.len());
+            frame_u64(digest, unit.modules.len());
             for module in &unit.modules {
-                frame_path(&mut digest, &module.path);
-                frame_u64_value(&mut digest, module.length);
-                frame(&mut digest, &module.sha256);
-                frame_u64(&mut digest, module.imports.len());
+                frame_path(digest, &module.path);
+                frame_u64_value(digest, module.length);
+                frame(digest, &module.sha256);
+                frame_u64(digest, module.imports.len());
                 for &import in &module.imports {
-                    frame(&mut digest, &import.to_be_bytes());
+                    frame(digest, &import.to_be_bytes());
                 }
             }
         }
-        frame_u64(&mut digest, self.datasets.len());
+        frame_u64(digest, self.datasets.len());
         for dataset in &self.datasets {
-            frame(&mut digest, dataset.name.as_bytes());
-            frame(&mut digest, dataset.kind.as_str().as_bytes());
-            frame_path(&mut digest, &dataset.path);
-            frame_u64_value(&mut digest, dataset.length);
-            frame(&mut digest, &dataset.sha256);
+            frame(digest, dataset.name.as_bytes());
+            frame(digest, dataset.kind.as_str().as_bytes());
+            frame_path(digest, &dataset.path);
+            frame_u64_value(digest, dataset.length);
+            frame(digest, &dataset.sha256);
         }
-        digest.finalize().into()
     }
 }
 
@@ -1189,6 +1207,52 @@ log_format = "json"
                 0x4c, 0x7e, 0x60, 0x09,
             ]
         );
+    }
+
+    #[test]
+    fn external_sources_digest_ignores_document_but_not_source_bytes() {
+        let manifest = SourceManifest {
+            toml_sha256: [0x11; 32],
+            rpol_units: vec![RpolUnitSource {
+                modules: vec![RpolModuleSource {
+                    path: PathBuf::from("/policy"),
+                    length: 3,
+                    sha256: [0x22; 32],
+                    imports: vec![0, 1],
+                }],
+            }],
+            datasets: vec![DatasetSource {
+                name: "customers".to_string(),
+                kind: DatasetKind::Asn,
+                path: PathBuf::from("/dataset"),
+                length: 4,
+                sha256: [0x33; 32],
+            }],
+        };
+        let mut document_only = manifest.clone();
+        document_only.toml_sha256 = [0x44; 32];
+        assert_eq!(
+            manifest.external_sources_sha256(),
+            document_only.external_sources_sha256(),
+            "a document-only edit is not an external-source change"
+        );
+        assert_ne!(manifest.source_sha256(), document_only.source_sha256());
+
+        let mut dataset_edit = manifest.clone();
+        dataset_edit.datasets[0].sha256 = [0x55; 32];
+        assert_ne!(
+            manifest.external_sources_sha256(),
+            dataset_edit.external_sources_sha256()
+        );
+        let mut rpol_edit = manifest.clone();
+        rpol_edit.rpol_units[0].modules[0].sha256 = [0x66; 32];
+        assert_ne!(
+            manifest.external_sources_sha256(),
+            rpol_edit.external_sources_sha256()
+        );
+        // Distinct domain separation from the full source digest even for
+        // identical rosters.
+        assert_ne!(manifest.external_sources_sha256(), manifest.source_sha256());
     }
 
     #[test]

--- a/src/config/tests/persistence.rs
+++ b/src/config/tests/persistence.rs
@@ -579,8 +579,12 @@ fn rfc8212_transaction_materialization_requires_real_mutation_and_exact_posture(
     ] {
         let live = rfc8212_transaction_fixture(live_epoch, live_policy, false);
         let mut candidate = rfc8212_transaction_fixture(candidate_epoch, candidate_policy, true);
-        let operational = materialize_rfc8212_transaction_candidate(&live, &mut candidate)
-            .unwrap_or_else(|| panic!("{label} must materialize"));
+        let operational = materialize_rfc8212_transaction_candidate(
+            &live,
+            &mut candidate,
+            crate::config::ExternalInputsIdentity::Unverified,
+        )
+        .unwrap_or_else(|| panic!("{label} must materialize"));
         assert_eq!(
             classify_config_transaction_v1(&operational).supported_sections,
             vec!["[[neighbors]] add"],
@@ -643,7 +647,12 @@ fn rfc8212_transaction_materialization_requires_real_mutation_and_exact_posture(
         let mut candidate = rfc8212_transaction_fixture(candidate_epoch, candidate_policy, mutate);
         let before = candidate.rfc8212_posture();
         assert!(
-            materialize_rfc8212_transaction_candidate(&live, &mut candidate).is_none(),
+            materialize_rfc8212_transaction_candidate(
+                &live,
+                &mut candidate,
+                crate::config::ExternalInputsIdentity::Unverified,
+            )
+            .is_none(),
             "{label}"
         );
         assert_eq!(candidate.rfc8212_posture(), before, "{label}");

--- a/src/config/tests/transaction.rs
+++ b/src/config/tests/transaction.rs
@@ -1,6 +1,68 @@
 use super::*;
 
 #[test]
+fn external_inputs_identity_gates_full_snapshot_families() {
+    let with_description = |description: &str| {
+        format!(
+            r#"
+{}
+
+[[neighbors]]
+address = "10.0.0.99"
+remote_asn = 65099
+description = "{description}"
+"#,
+            valid_toml()
+        )
+    };
+    let old = parse(&with_description("before")).unwrap();
+    let new = parse(&with_description("after")).unwrap();
+    let mut diff = diff_config(&old, &new);
+    assert_eq!(
+        diff.policy.external_inputs_identity,
+        ExternalInputsIdentity::Unverified,
+        "diff_config must always start unverified"
+    );
+
+    // Presence-fenced: external inputs present and no identity verification
+    // rejects every full-snapshot family. This is the #1370 behavior every
+    // non-verifying caller keeps — the gNMI Set bridge included.
+    diff.policy.external_inputs_present = true;
+    let fenced = classify_config_transaction_v1(&diff);
+    assert_eq!(fenced.supported_sections, vec!["[[neighbors]] modify"]);
+    assert!(
+        fenced
+            .unsupported_sections
+            .iter()
+            .any(|section| section.contains("external inputs")),
+        "{fenced:?}"
+    );
+    assert!(!fenced.is_committable());
+
+    // Identity-verified (ADR-0130): the same diff becomes committable once
+    // the plan path has proven the candidate's external sources
+    // byte-identical to the accepted snapshot's.
+    diff.policy.external_inputs_identity = ExternalInputsIdentity::VerifiedUnchanged;
+    let verified = classify_config_transaction_v1(&diff);
+    assert_eq!(verified.supported_sections, vec!["[[neighbors]] modify"]);
+    assert!(verified.unsupported_sections.is_empty(), "{verified:?}");
+    assert!(verified.is_committable());
+
+    // A declared-roster change stays rejected regardless of the verdict:
+    // identity only lifts the presence clause, never the rpol/datasets
+    // change clauses.
+    diff.policy.rpol_changed = true;
+    let changed = classify_config_transaction_v1(&diff);
+    assert!(
+        changed
+            .unsupported_sections
+            .iter()
+            .any(|section| section.contains("external inputs")),
+        "{changed:?}"
+    );
+}
+
+#[test]
 fn transaction_v1_classifies_noop_candidate() {
     let config = parse(valid_toml()).unwrap();
     let diff = diff_config(&config, &config);

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -466,7 +466,7 @@ impl ConfigTransactionController {
         if let Some(confirmed) = confirmed {
             self.begin_confirmed_apply(&confirmed.confirm_id).await?;
             let result = self
-                .apply_confirmed_locked(request, confirmed.clone(), preloaded, progress)
+                .apply_confirmed_locked(request, confirmed.clone(), preloaded, progress, true)
                 .await;
             if !matches!(
                 result,
@@ -492,11 +492,12 @@ impl ConfigTransactionController {
                 Some(preloaded),
                 Some(peer_mgr_internal_tx),
                 progress,
+                true,
             )
             .await
             .map_err(ApplyFailure::into_apply_error)
         } else {
-            self.apply_locked(request, None, progress).await
+            self.apply_locked(request, None, progress, true).await
         }
     }
 
@@ -669,6 +670,7 @@ impl ConfigTransactionController {
                         request,
                         confirmed,
                         &RuntimeConfigMutationProgress::default(),
+                        true,
                     )
                     .await;
                 drop(context);
@@ -704,7 +706,7 @@ impl ConfigTransactionController {
                 ));
             }
             let progress = RuntimeConfigMutationProgress::owned(&operation);
-            let result = self.apply_locked(request, confirmed, &progress).await;
+            let result = self.apply_locked(request, confirmed, &progress, true).await;
             if let Err(ConfigTransactionApplyError::RecoveryRequired { reason, .. }) = &result {
                 let _ = operation.fence_recovery(*reason);
                 std::future::pending::<()>().await;
@@ -797,7 +799,11 @@ impl ConfigTransactionController {
                                 .map_err(apply_error_to_owned_gnmi_set_error)?;
                             // A confirmed gNMI candidate is derived from the live
                             // config. The ordinary planner must still fence external
-                            // declarations after constructing the full snapshot.
+                            // declarations after constructing the full snapshot:
+                            // gNMI applies below run without external-input
+                            // verification, so gNMI full-snapshot candidates stay
+                            // presence-fenced (#1370) even when the sources are
+                            // unchanged on disk (ADR-0130 scope).
                         }
                         None => {
                             self_
@@ -844,7 +850,7 @@ impl ConfigTransactionController {
                         .map_err(apply_error_to_owned_gnmi_set_error)?;
                     let response = if confirmed.is_some() {
                         self_
-                            .apply_locked(request, confirmed, &progress)
+                            .apply_locked(request, confirmed, &progress, false)
                             .await
                             .map_err(apply_error_to_owned_gnmi_set_error)?
                     } else {
@@ -863,6 +869,7 @@ impl ConfigTransactionController {
                             request,
                             Some(peer_mgr_internal_tx),
                             &progress,
+                            false,
                         )
                         .await
                         .map_err(|failure| match failure.fence_reason {
@@ -894,11 +901,18 @@ impl ConfigTransactionController {
         request: proto::ApplyConfigTransactionRequest,
         confirmed: Option<ConfirmedApplyMode>,
         progress: &RuntimeConfigMutationProgress,
+        verify_external_inputs: bool,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         if let Some(confirmed) = confirmed {
             self.begin_confirmed_apply(&confirmed.confirm_id).await?;
             let result = self
-                .apply_confirmed_locked(request, confirmed.clone(), None, progress)
+                .apply_confirmed_locked(
+                    request,
+                    confirmed.clone(),
+                    None,
+                    progress,
+                    verify_external_inputs,
+                )
                 .await;
             if !matches!(
                 result,
@@ -918,6 +932,7 @@ impl ConfigTransactionController {
                 request,
                 self.peer_mgr_internal_tx.as_ref(),
                 progress,
+                verify_external_inputs,
             )
             .await
             .map_err(ApplyFailure::into_apply_error)
@@ -934,6 +949,7 @@ impl ConfigTransactionController {
         confirmed: ConfirmedApplyMode,
         preloaded: Option<PlannedTransactionConfig>,
         progress: &RuntimeConfigMutationProgress,
+        verify_external_inputs: bool,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         let prior_snapshot = self
             .accepted_prior_snapshot()
@@ -1042,6 +1058,7 @@ impl ConfigTransactionController {
             preloaded,
             self.peer_mgr_internal_tx.as_ref(),
             progress,
+            verify_external_inputs,
         )
         .await
         {
@@ -1793,6 +1810,7 @@ impl ConfigTransactionController {
             Some(plan),
             Some(peer_mgr_internal_tx),
             progress,
+            true,
         )
         .await;
         let response = result.map_err(ApplyFailure::into_apply_error)?;
@@ -2185,6 +2203,7 @@ async fn apply_config_transaction(
             request,
             None,
             &RuntimeConfigMutationProgress::default(),
+            true,
         )
         .await
         .map_err(ApplyFailure::into_apply_error)
@@ -2211,6 +2230,7 @@ async fn apply_config_transaction_with_internal(
             request,
             Some(&peer_mgr_internal_tx),
             &RuntimeConfigMutationProgress::default(),
+            true,
         )
         .await
         .map_err(ApplyFailure::into_apply_error)
@@ -2227,6 +2247,7 @@ async fn apply_config_transaction_locked(
     request: proto::ApplyConfigTransactionRequest,
     peer_mgr_internal_tx: Option<&mpsc::Sender<InternalCommand>>,
     progress: &RuntimeConfigMutationProgress,
+    verify_external_inputs: bool,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     apply_config_transaction_locked_with_preloaded(
         deps,
@@ -2234,6 +2255,7 @@ async fn apply_config_transaction_locked(
         None,
         peer_mgr_internal_tx,
         progress,
+        verify_external_inputs,
     )
     .await
 }
@@ -2248,19 +2270,32 @@ async fn apply_config_transaction_locked_with_preloaded(
     preloaded: Option<PlannedTransactionConfig>,
     peer_mgr_internal_tx: Option<&mpsc::Sender<InternalCommand>>,
     progress: &RuntimeConfigMutationProgress,
+    verify_external_inputs: bool,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     let (plan, candidate, typed_plan) = if let Some(planned) = preloaded {
         (planned.plan, planned.candidate, true)
     } else {
-        let candidate = Config::load_toml_with_diagnostics(
-            &request.candidate_toml,
-            "candidate runtime config transaction",
-        )
+        // The config-transaction path loads the candidate with external-source
+        // capture so the typed plan below can verify identity against the
+        // accepted snapshot (ADR-0130); the gNMI Set bridge loads plain and
+        // stays behind the presence fence.
+        let candidate = if verify_external_inputs {
+            Config::load_toml_candidate_captured(
+                &request.candidate_toml,
+                "candidate runtime config transaction",
+            )
+        } else {
+            Config::load_toml_with_diagnostics(
+                &request.candidate_toml,
+                "candidate runtime config transaction",
+            )
+        }
         .map_err(ConfigTransactionApplyError::InvalidArgument)?;
         let plan = plan_candidate(
             &deps.peer_mgr_tx,
             request.candidate_toml.clone(),
             request.expected_runtime_snapshot_token.clone(),
+            verify_external_inputs,
         )
         .await?;
         (plan, Box::new(candidate), false)
@@ -2893,12 +2928,14 @@ async fn plan_candidate(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     candidate_toml: String,
     expected_runtime_snapshot_token: String,
+    verify_external_inputs: bool,
 ) -> Result<rustbgpd_api::peer_types::RuntimeConfigTransactionPlan, ConfigTransactionApplyError> {
     let (reply_tx, reply_rx) = oneshot::channel();
     peer_mgr_tx
         .send(PeerManagerCommand::PlanConfigTransaction {
             candidate_toml,
             expected_runtime_snapshot_token: Some(expected_runtime_snapshot_token),
+            verify_external_inputs,
             reply: reply_tx,
         })
         .await

--- a/src/config_transaction_control/tests.rs
+++ b/src/config_transaction_control/tests.rs
@@ -2135,6 +2135,7 @@ async fn fake_live_policy_peer_manager(
             PeerManagerCommand::PlanConfigTransaction {
                 candidate_toml,
                 expected_runtime_snapshot_token,
+                verify_external_inputs: _,
                 reply,
             } => {
                 let mut response = attach_committed_candidate(plan.clone(), &candidate_toml);
@@ -5149,6 +5150,7 @@ async fn apply_commits_live_policy_impact_after_persist_ack() {
         &peer_tx,
         candidate_toml.clone(),
         response.runtime_snapshot_token.clone(),
+        true,
     )
     .await
     .expect("returned post-commit token must chain into a second plan");
@@ -7575,7 +7577,7 @@ async fn config_transaction_plan_matches_real_post_apply_update_groups() {
     let before = query_real_update_group_snapshot(&rib_tx).await;
     assert_eq!(before.peers.len(), 5, "all real PeerUp rows are visible");
 
-    let planned = plan_candidate(&peer_tx, candidate_toml.clone(), String::new())
+    let planned = plan_candidate(&peer_tx, candidate_toml.clone(), String::new(), true)
         .await
         .expect("real PlanConfigTransaction flow must succeed");
     assert_eq!(planned.status, RuntimeConfigTransactionStatus::Committable);
@@ -7793,7 +7795,7 @@ async fn config_transaction_plan_matches_real_post_apply_update_groups() {
         assert_eq!(acks.route_refreshes(), 0, "export-only peer {peer}");
     }
 
-    let replanned = plan_candidate(&peer_tx, committed_candidate_toml, String::new())
+    let replanned = plan_candidate(&peer_tx, committed_candidate_toml, String::new(), true)
         .await
         .expect("re-plan of the committed candidate must succeed");
     assert_eq!(replanned.status, RuntimeConfigTransactionStatus::Noop);
@@ -7929,7 +7931,7 @@ async fn config_transaction_plan_matches_real_post_apply_heterogeneous_update_gr
     let before = query_real_update_group_snapshot(&rib_tx).await;
     assert_eq!(before.peers.len(), 5, "all heterogeneous peers are live");
     while outbound_rx.try_recv().is_ok() {}
-    let planned = plan_candidate(&peer_tx, candidate_toml.clone(), String::new())
+    let planned = plan_candidate(&peer_tx, candidate_toml.clone(), String::new(), true)
         .await
         .expect("heterogeneous plan must succeed");
     assert_eq!(planned.status, RuntimeConfigTransactionStatus::Committable);
@@ -8051,7 +8053,7 @@ async fn config_transaction_plan_matches_real_post_apply_heterogeneous_update_gr
         assert_eq!((acks.import_updates(), acks.route_refreshes()), (0, 0));
     }
 
-    let replanned = plan_candidate(&peer_tx, committed_candidate_toml, String::new())
+    let replanned = plan_candidate(&peer_tx, committed_candidate_toml, String::new(), true)
         .await
         .expect("re-plan of the committed candidate must succeed");
     assert_eq!(replanned.status, RuntimeConfigTransactionStatus::Noop);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4250,6 +4250,17 @@ async fn run<T>(
     let (bfd_desired_tx, bfd_desired_rx) = tokio::sync::watch::channel(bfd_initial.clone());
     let (bfd_state_change_tx, bfd_state_change_rx) = bfd_runtime::state_change_channel();
 
+    // Accepted-config authority watch (ADR-0121), created before the peer
+    // manager so the config-transaction planner can verify a candidate's
+    // captured external-input identity against the accepted snapshot
+    // (ADR-0130). The sender is handed to the config bridge below; without a
+    // config file there is no accepted authority and every candidate stays
+    // unverified (presence-fenced).
+    let mut accepted_watch = config
+        .file_path
+        .is_some()
+        .then(|| watch::channel(Arc::clone(&accepted)));
+
     let peer_mgr = PeerManager::new_with_config(
         peer_mgr_rx,
         peer_mgr_internal_rx,
@@ -4268,6 +4279,11 @@ async fn run<T>(
     .with_transport_event_sink(event_history_handle.clone().map(|handle| {
         rustbgpd_api::event_history_sinks::make_transport_event_sink(handle, metrics.clone())
     }));
+    let peer_mgr = if let Some((_, accepted_identity_rx)) = &accepted_watch {
+        peer_mgr.with_accepted_identity(accepted_identity_rx.clone())
+    } else {
+        peer_mgr
+    };
     // Wire BFD coupling only when BFD is configured; otherwise the unused ends
     // are dropped (the actor won't spawn either). PeerManager holds the desired
     // sender for life and never recreates it (the actor treats sender drop as
@@ -4314,7 +4330,9 @@ async fn run<T>(
         let (event_tx, event_rx) = mpsc::channel::<rustbgpd_api::peer_types::ConfigEvent>(64);
         let (mutation_tx, mutation_rx) = mpsc::channel::<ConfigMutation>(64);
         let (bridge_replace_tx, bridge_replace_rx) = mpsc::channel(1);
-        let (accepted_tx, accepted_rx) = watch::channel(Arc::clone(&accepted));
+        let (accepted_tx, accepted_rx) = accepted_watch
+            .take()
+            .expect("accepted watch is created whenever a config file path exists");
         let persister = ConfigPersister::new_accepted(
             mutation_rx,
             path.clone(),

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -445,6 +445,11 @@ pub struct PeerManager {
     /// from acting as an offline oracle for config secrets. See
     /// [`crate::config::RuntimeSnapshotKey`].
     snapshot_key: crate::config::RuntimeSnapshotKey,
+    /// Accepted-config authority (ADR-0121) for external-input identity
+    /// verification on the config-transaction plan path. `None` (no config
+    /// file, tests) keeps every candidate `Unverified`, i.e. the presence
+    /// fence.
+    accepted_rx: Option<watch::Receiver<Arc<crate::config::AcceptedConfigSnapshot>>>,
     /// Test-only deterministic fault injection: `reconfigure_peer` against
     /// a mapped key fails up front, before the delete/re-add cycle, once the
     /// key's budget of remaining successful calls reaches zero (a value of 0
@@ -550,6 +555,17 @@ impl PeerManager {
                 inbound_admission: crate::config::InboundAdmissionConfig::default(),
             },
         )
+    }
+
+    /// Install the accepted-config authority used to verify a transaction
+    /// candidate's captured external-input identity (ADR-0130).
+    #[must_use]
+    pub fn with_accepted_identity(
+        mut self,
+        accepted_rx: watch::Receiver<Arc<crate::config::AcceptedConfigSnapshot>>,
+    ) -> Self {
+        self.accepted_rx = Some(accepted_rx);
+        self
     }
 
     /// Install the dedicated read-only readiness-query receiver.
@@ -763,6 +779,7 @@ impl PeerManager {
             event_history: None,
             transport_event_sink: None,
             snapshot_key: crate::config::RuntimeSnapshotKey::random(),
+            accepted_rx: None,
             #[cfg(test)]
             inject_reconfigure_failures: std::collections::BTreeMap::new(),
             #[cfg(test)]
@@ -1240,11 +1257,13 @@ impl PeerManager {
                         PeerManagerCommand::PlanConfigTransaction {
                             candidate_toml,
                             expected_runtime_snapshot_token,
+                            verify_external_inputs,
                             mut reply,
                         } => {
                             let planning = self.plan_config_transaction(
                                 &candidate_toml,
                                 expected_runtime_snapshot_token.as_deref(),
+                                verify_external_inputs,
                             );
                             tokio::pin!(planning);
                             let result = tokio::select! {
@@ -1838,6 +1857,15 @@ impl PeerManager {
                             reply,
                         }) => {
                             let mut candidate = snapshot.config();
+                            // A retained/prior snapshot carries its own
+                            // captured external-source manifest; seed the
+                            // candidate's identity from it so the ADR-0130
+                            // verification compares that capture against the
+                            // current accepted authority.
+                            candidate.policy.external_sources_digest =
+                                crate::config::ExternalSourcesDigest(Some(
+                                    snapshot.source_manifest().external_sources_sha256(),
+                                ));
                             let result = self
                                 .plan_preloaded_config_transaction(
                                     &mut candidate,

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -157,20 +157,31 @@ impl PeerManager {
         &mut self,
         candidate_toml: &str,
         expected_runtime_snapshot_token: Option<&str>,
+        verify_external_inputs: bool,
     ) -> Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError> {
         let (live_snapshot, live_snapshot_identity, runtime_snapshot_token) = self
             .config_transaction_plan_context(expected_runtime_snapshot_token)
             .await?;
-        let mut candidate =
+        // Only the config-transaction path captures the candidate's external
+        // sources for identity verification (ADR-0130). The gNMI Set bridge
+        // plans with the plain loader, so its candidates classify as
+        // `Unverified` and keep the #1370 presence fence.
+        let mut candidate = if verify_external_inputs {
+            Config::load_toml_candidate_captured(candidate_toml, "candidate runtime config")
+        } else {
             Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
-                .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
+        }
+        .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
+        let external_inputs = self.verified_external_inputs(&mut candidate);
         let materialization = crate::config::materialize_rfc8212_transaction_candidate(
             &self.current_config,
             &mut candidate,
+            external_inputs,
         );
         self.finish_config_transaction_plan(
             &mut candidate,
             materialization.as_ref(),
+            external_inputs,
             live_snapshot,
             live_snapshot_identity,
             runtime_snapshot_token,
@@ -185,6 +196,7 @@ impl PeerManager {
         let (live_snapshot, live_snapshot_identity, runtime_snapshot_token) = self
             .config_transaction_plan_context(expected_runtime_snapshot_token)
             .await?;
+        let external_inputs = self.verified_external_inputs(candidate);
         // A retained snapshot is trusted rollback authority. Preserve every
         // non-tuple field, but carry forward an unchanged live tuple.
         let live_posture = self.current_config.rfc8212_posture();
@@ -198,14 +210,50 @@ impl PeerManager {
         let materialization = crate::config::materialize_rfc8212_transaction_candidate(
             &self.current_config,
             candidate,
+            external_inputs,
         );
         self.finish_config_transaction_plan(
             candidate,
             materialization.as_ref(),
+            external_inputs,
             live_snapshot,
             live_snapshot_identity,
             runtime_snapshot_token,
         )
+    }
+
+    /// Compare the candidate's captured external-source digest against the
+    /// accepted snapshot's manifest (ADR-0130). On a byte-identical match the
+    /// candidate's freshly loaded external state is verification evidence
+    /// only: the running compiled `.rpol` storage and live dataset handles
+    /// are re-attached in its place, so an adopted candidate cannot detach
+    /// live policy state (the ADR-0121 §8 concern). Any missing digest,
+    /// missing authority, or mismatch stays `Unverified` — the presence
+    /// fence.
+    fn verified_external_inputs(
+        &self,
+        candidate: &mut Config,
+    ) -> crate::config::ExternalInputsIdentity {
+        let Some(candidate_digest) = candidate.policy.external_sources_digest.0 else {
+            return crate::config::ExternalInputsIdentity::Unverified;
+        };
+        let Some(accepted_rx) = &self.accepted_rx else {
+            return crate::config::ExternalInputsIdentity::Unverified;
+        };
+        let accepted = accepted_rx.borrow().clone();
+        if accepted.source_manifest().external_sources_sha256() != candidate_digest {
+            return crate::config::ExternalInputsIdentity::Unverified;
+        }
+        // Re-attach the running external state. A candidate whose declared
+        // roster diverges from the running config is rejected by the
+        // rpol/dataset diff clauses before any executor adopts it, so a
+        // rebind on such a candidate is discarded with the plan.
+        candidate
+            .policy
+            .rpol
+            .reuse_unchanged_files_from(&self.current_config.policy.rpol);
+        candidate.policy.dataset_bindings = self.current_config.policy.dataset_bindings.clone();
+        crate::config::ExternalInputsIdentity::VerifiedUnchanged
     }
 
     async fn config_transaction_plan_context(
@@ -247,6 +295,7 @@ impl PeerManager {
         &mut self,
         candidate: &mut Config,
         materialization: Option<&crate::config::ConfigDiff>,
+        external_inputs: crate::config::ExternalInputsIdentity,
         live_snapshot: rustbgpd_rib::UpdateGroupSnapshot,
         live_snapshot_identity: [u8; 8],
         runtime_snapshot_token: String,
@@ -261,7 +310,8 @@ impl PeerManager {
                     RuntimeConfigTransactionPlanError::Internal(message)
                 }
             })?;
-        let committed_diff = crate::config::diff_config(&self.current_config, candidate);
+        let mut committed_diff = crate::config::diff_config(&self.current_config, candidate);
+        committed_diff.policy.external_inputs_identity = external_inputs;
         let operational_diff = materialization.unwrap_or(&committed_diff);
         let classification = crate::config::classify_config_transaction_v1(operational_diff);
         let status = if classification.is_noop() {

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -234,7 +234,7 @@ impl PeerManager {
         &self,
         candidate: &mut Config,
     ) -> crate::config::ExternalInputsIdentity {
-        let Some(candidate_digest) = candidate.policy.external_sources_digest.0 else {
+        let Some(candidate_digest) = candidate.policy.external_sources_digest.0.take() else {
             return crate::config::ExternalInputsIdentity::Unverified;
         };
         let Some(accepted_rx) = &self.accepted_rx else {

--- a/src/peer_manager/tests/config_transaction.rs
+++ b/src/peer_manager/tests/config_transaction.rs
@@ -81,11 +81,15 @@ log_format = "json"
             })
             .unwrap();
     });
-    let planned = mgr.plan_config_transaction(&candidate, None).await.unwrap();
+    let planned = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap();
     let error = mgr
         .plan_config_transaction(
             "this is not valid TOML =",
             Some(&planned.runtime_snapshot_token),
+            true,
         )
         .await
         .unwrap_err();
@@ -145,7 +149,7 @@ remote_asn = 65002
     });
 
     let error = mgr
-        .plan_config_transaction(&candidate, None)
+        .plan_config_transaction(&candidate, None, true)
         .await
         .unwrap_err();
 
@@ -237,7 +241,10 @@ import_policy_chain = ["edge-in"]
             .unwrap();
     });
 
-    let plan = mgr.plan_config_transaction(&candidate, None).await.unwrap();
+    let plan = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap();
 
     assert_eq!(
         plan.status,
@@ -252,6 +259,287 @@ import_policy_chain = ["edge-in"]
     );
     assert_eq!(live_dataset.status(), live_status);
     assert_eq!(live_dataset.pin().data.records(), 1);
+    responder.await.unwrap();
+}
+
+/// Write an rpol + dataset + config-file fixture and return the paths as
+/// `(config, rpol, dataset)`. All references in the TOML are absolute so a
+/// candidate serialized from the loaded config re-resolves the same files.
+fn external_inputs_fixture(
+    dir: &std::path::Path,
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    let rpol_path = dir.join("edge.rpol");
+    let dataset_path = dir.join("customers.list");
+    std::fs::write(
+        &rpol_path,
+        r"
+dataset asn-set customers
+
+policy edge-in {
+    term customer { if route.origin-as in customers { accept } }
+    term rest { reject }
+}
+",
+    )
+    .unwrap();
+    std::fs::write(&dataset_path, "64500\n").unwrap();
+    let config_toml = crate::test_support::tier_authorized_uds_test_config(&format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[policy]
+rpol_files = [{rpol_path:?}]
+
+[policy.datasets.customers]
+path = {dataset_path:?}
+
+[[neighbors]]
+address = "192.0.2.1"
+remote_asn = 65002
+description = "before"
+import_policy_chain = ["edge-in"]
+"#,
+        rpol_path = rpol_path.display().to_string(),
+        dataset_path = dataset_path.display().to_string()
+    ));
+    let config_path = dir.join("config.toml");
+    std::fs::write(&config_path, config_toml).unwrap();
+    (config_path, rpol_path, dataset_path)
+}
+
+/// A manager whose running config came from an accepted snapshot load and
+/// that holds the accepted-identity watch (ADR-0130), plus the RIB channel
+/// and the sender halves the manager must keep alive.
+#[expect(
+    clippy::type_complexity,
+    reason = "test fixture returns every channel half the scenario must keep alive"
+)]
+fn accepted_identity_manager(
+    config_path: &std::path::Path,
+) -> (
+    PeerManager,
+    Arc<crate::config::AcceptedConfigSnapshot>,
+    mpsc::Receiver<RibUpdate>,
+    (
+        mpsc::Sender<PeerManagerCommand>,
+        mpsc::Sender<InternalCommand>,
+        watch::Sender<Arc<crate::config::AcceptedConfigSnapshot>>,
+    ),
+) {
+    let accepted = Arc::new(
+        crate::config::AcceptedConfigSnapshot::load(config_path, None).expect("accepted load"),
+    );
+    let (accepted_tx, accepted_rx) = watch::channel(Arc::clone(&accepted));
+    let (tx, rx) = mpsc::channel(4);
+    let (internal_tx, internal_rx) = mpsc::channel(1);
+    let (rib_tx, rib_rx) = mpsc::channel(4);
+    let mgr = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        accepted.config(),
+    )
+    .with_accepted_identity(accepted_rx);
+    (mgr, accepted, rib_rx, (tx, internal_tx, accepted_tx))
+}
+
+fn answer_snapshot_queries(
+    mut rib_rx: mpsc::Receiver<RibUpdate>,
+    count: usize,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        for _ in 0..count {
+            let Some(RibUpdate::QueryUpdateGroupSnapshot { reply }) = rib_rx.recv().await else {
+                panic!("plan snapshot query missing");
+            };
+            reply
+                .send(rustbgpd_rib::UpdateGroupSnapshot::default())
+                .unwrap();
+        }
+    })
+}
+
+#[tokio::test]
+async fn transaction_plan_supports_full_snapshot_family_with_unchanged_external_inputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let (config_path, _rpol_path, _dataset_path) = external_inputs_fixture(dir.path());
+    let (mut mgr, _accepted, rib_rx, _keepalive) = accepted_identity_manager(&config_path);
+    let responder = answer_snapshot_queries(rib_rx, 1);
+
+    let mut candidate = mgr.current_config.clone();
+    candidate.neighbors[0].description = Some("after".to_string());
+    let candidate = toml::to_string_pretty(&candidate).unwrap();
+
+    let plan = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        plan.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Committable,
+        "{:?}",
+        plan.unsupported_sections
+    );
+    assert_eq!(plan.supported_sections, vec!["[[neighbors]] modify"]);
+    assert!(plan.unsupported_sections.is_empty());
+    responder.await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_plan_rejects_dataset_byte_drift_against_accepted_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let (config_path, _rpol_path, dataset_path) = external_inputs_fixture(dir.path());
+    let (mut mgr, _accepted, rib_rx, _keepalive) = accepted_identity_manager(&config_path);
+    let responder = answer_snapshot_queries(rib_rx, 2);
+
+    let mut candidate = mgr.current_config.clone();
+    candidate.neighbors[0].description = Some("after".to_string());
+    let candidate = toml::to_string_pretty(&candidate).unwrap();
+
+    // A real content edit between the accepted load and the candidate plan.
+    // The dataset binding declaration is unchanged, so only the ADR-0130
+    // identity comparison can catch this.
+    std::fs::write(&dataset_path, "64500\n64999\n").unwrap();
+    let plan = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap();
+    assert_eq!(
+        plan.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Rejected
+    );
+    assert_eq!(plan.supported_sections, vec!["[[neighbors]] modify"]);
+    assert!(plan.unsupported_sections[0].contains("external inputs"));
+
+    // Byte identity, not parse identity: a semantically equal rewrite is
+    // still drift and still rejected.
+    std::fs::write(&dataset_path, "# same set\n64500\n").unwrap();
+    let plan = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap();
+    assert_eq!(
+        plan.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Rejected
+    );
+    assert!(plan.unsupported_sections[0].contains("external inputs"));
+    responder.await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_plan_rejects_rpol_byte_drift_against_accepted_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let (config_path, rpol_path, _dataset_path) = external_inputs_fixture(dir.path());
+    let (mut mgr, _accepted, rib_rx, _keepalive) = accepted_identity_manager(&config_path);
+    let responder = answer_snapshot_queries(rib_rx, 1);
+
+    let mut candidate = mgr.current_config.clone();
+    candidate.neighbors[0].description = Some("after".to_string());
+    let candidate = toml::to_string_pretty(&candidate).unwrap();
+
+    // Comment-only edit: compiled policy content is unchanged, but the
+    // source bytes are not the accepted bytes.
+    let source = std::fs::read_to_string(&rpol_path).unwrap();
+    std::fs::write(&rpol_path, format!("# touched\n{source}")).unwrap();
+    let plan = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap();
+    assert_eq!(
+        plan.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Rejected
+    );
+    assert!(
+        plan.unsupported_sections
+            .iter()
+            .any(|section| section.contains("external inputs")),
+        "{:?}",
+        plan.unsupported_sections
+    );
+    responder.await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_plan_fails_closed_when_external_source_is_unreadable() {
+    let dir = tempfile::tempdir().unwrap();
+    let (config_path, _rpol_path, dataset_path) = external_inputs_fixture(dir.path());
+    let (mut mgr, _accepted, rib_rx, _keepalive) = accepted_identity_manager(&config_path);
+    let responder = answer_snapshot_queries(rib_rx, 1);
+
+    let mut candidate = mgr.current_config.clone();
+    candidate.neighbors[0].description = Some("after".to_string());
+    let candidate = toml::to_string_pretty(&candidate).unwrap();
+
+    std::fs::remove_file(&dataset_path).unwrap();
+    let error = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionPlanError::InvalidCandidate(_)
+    ));
+    responder.await.unwrap();
+}
+
+#[tokio::test]
+async fn verified_plan_reattaches_live_external_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let (config_path, _rpol_path, _dataset_path) = external_inputs_fixture(dir.path());
+    let (mut mgr, _accepted, rib_rx, _keepalive) = accepted_identity_manager(&config_path);
+    let responder = answer_snapshot_queries(rib_rx, 1);
+
+    let mut candidate_source = mgr.current_config.clone();
+    candidate_source.neighbors[0].description = Some("after".to_string());
+    let candidate_toml = toml::to_string_pretty(&candidate_source).unwrap();
+    // A captured load builds detached rpol storage and fresh dataset handles.
+    let mut candidate = Config::load_toml_candidate_captured(&candidate_toml, "candidate").unwrap();
+    let fresh_handle = Arc::clone(candidate.policy.dataset_bindings.get("customers").unwrap());
+    let live_handle = Arc::clone(
+        mgr.current_config
+            .policy
+            .dataset_bindings
+            .get("customers")
+            .unwrap(),
+    );
+    assert!(!Arc::ptr_eq(&fresh_handle, &live_handle));
+
+    let plan = mgr
+        .plan_preloaded_config_transaction(&mut candidate, None)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        plan.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Committable
+    );
+    // The verified candidate's freshly loaded external state is verification
+    // evidence only: the plan re-attached the live dataset handle and shared
+    // rpol storage, so adopting the candidate cannot detach live policy
+    // state (ADR-0121 §8 / ADR-0130).
+    assert!(Arc::ptr_eq(
+        candidate.policy.dataset_bindings.get("customers").unwrap(),
+        &live_handle
+    ));
+    assert!(Arc::ptr_eq(
+        &candidate.policy.rpol.policies["edge-in"].file,
+        &mgr.current_config.policy.rpol.policies["edge-in"].file
+    ));
     responder.await.unwrap();
 }
 
@@ -332,7 +620,10 @@ route_server_client = true
             .unwrap();
     });
 
-    let plan = mgr.plan_config_transaction(&candidate, None).await.unwrap();
+    let plan = mgr
+        .plan_config_transaction(&candidate, None, true)
+        .await
+        .unwrap();
 
     assert_eq!(
         plan.status,
@@ -482,11 +773,11 @@ export_policy_chain = ["dataset-export"]
     });
 
     let noop = mgr
-        .plan_config_transaction(&noop_candidate, None)
+        .plan_config_transaction(&noop_candidate, None, true)
         .await
         .unwrap();
     let fib = mgr
-        .plan_config_transaction(&fib_candidate, None)
+        .plan_config_transaction(&fib_candidate, None, true)
         .await
         .unwrap();
 
@@ -540,7 +831,10 @@ export_policy_chain = ["dataset-export"]
         committed.contains("ebgp_requires_policy = false"),
         "{committed}"
     );
-    let chained = mgr.plan_config_transaction(committed, None).await.unwrap();
+    let chained = mgr
+        .plan_config_transaction(committed, None, true)
+        .await
+        .unwrap();
     assert_eq!(
         chained.post_commit_runtime_snapshot_token,
         fib.post_commit_runtime_snapshot_token
@@ -1270,7 +1564,7 @@ log_format = "json"
 
     // Unary Apply seam: the epoch-cell tuple materializes canonically.
     let plan = mgr
-        .plan_config_transaction(&fib_candidate_toml, None)
+        .plan_config_transaction(&fib_candidate_toml, None, true)
         .await
         .unwrap();
     assert_eq!(
@@ -1312,7 +1606,7 @@ log_format = "json"
 
     // Effective drift out of the activated cell stays restart-required.
     let rejected = mgr
-        .plan_config_transaction(&drift_candidate_toml, None)
+        .plan_config_transaction(&drift_candidate_toml, None, true)
         .await
         .unwrap();
     assert_eq!(

--- a/src/peer_manager/tests/config_transaction.rs
+++ b/src/peer_manager/tests/config_transaction.rs
@@ -405,7 +405,7 @@ async fn transaction_plan_rejects_dataset_byte_drift_against_accepted_identity()
     let dir = tempfile::tempdir().unwrap();
     let (config_path, _rpol_path, dataset_path) = external_inputs_fixture(dir.path());
     let (mut mgr, _accepted, rib_rx, _keepalive) = accepted_identity_manager(&config_path);
-    let responder = answer_snapshot_queries(rib_rx, 2);
+    let responder = answer_snapshot_queries(rib_rx, 1);
 
     let mut candidate = mgr.current_config.clone();
     candidate.neighbors[0].description = Some("after".to_string());
@@ -502,7 +502,7 @@ async fn verified_plan_reattaches_live_external_state() {
     let dir = tempfile::tempdir().unwrap();
     let (config_path, _rpol_path, _dataset_path) = external_inputs_fixture(dir.path());
     let (mut mgr, _accepted, rib_rx, _keepalive) = accepted_identity_manager(&config_path);
-    let responder = answer_snapshot_queries(rib_rx, 1);
+    let responder = answer_snapshot_queries(rib_rx, 3);
 
     let mut candidate_source = mgr.current_config.clone();
     candidate_source.neighbors[0].description = Some("after".to_string());
@@ -540,6 +540,30 @@ async fn verified_plan_reattaches_live_external_state() {
         &candidate.policy.rpol.policies["edge-in"].file,
         &mgr.current_config.policy.rpol.policies["edge-in"].file
     ));
+    assert!(candidate.policy.external_sources_digest.0.is_none());
+
+    // The live-policy apply path replans the staged snapshot once to return
+    // its post-commit token. That no-op must succeed without reusing the
+    // consumed one-load identity evidence.
+    mgr.current_config = candidate.clone();
+    let post_commit = mgr
+        .plan_preloaded_config_transaction(&mut candidate, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        post_commit.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Noop
+    );
+
+    candidate.neighbors[0].description = Some("later".to_string());
+    let replay = mgr
+        .plan_preloaded_config_transaction(&mut candidate, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        replay.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Rejected
+    );
     responder.await.unwrap();
 }
 

--- a/src/peer_manager/tests/queries.rs
+++ b/src/peer_manager/tests/queries.rs
@@ -601,6 +601,7 @@ log_format = "json"
     tx.send(PeerManagerCommand::PlanConfigTransaction {
         candidate_toml: candidate,
         expected_runtime_snapshot_token: None,
+        verify_external_inputs: true,
         reply: plan_reply,
     })
     .await


### PR DESCRIPTION
## Summary

Narrows the external-policy-inputs transaction fence from
presence-conditional to identity-conditional (ADR-0130, Accepted). Since
#1370, any config using `[policy] rpol_files` / `[policy.datasets]` — the
shipped route-server profile included — lost the entire transactional
quartet (plan, apply, commit-confirm, rollback) for even a trivial
neighbor-description edit, because every v1 executor except the targeted
FIB path adopts the full candidate snapshot and external bytes are outside
the candidate TOML, the optimistic token, and the rollback payload.

The config-transaction plan and apply paths now capture every declared
external source during the candidate load (the same read that produces the
compiled `.rpol` registry and parsed dataset handles) and compare a
domain-separated digest of the ADR-0121 v2 manifest's external frames
against the accepted snapshot's manifest. Byte-identical means the content
the executor would adopt IS the accepted content, so the transaction is
admitted; on success the planner re-attaches the running compiled rpol
storage and live dataset handles into the candidate, so the fresh reads
are verification evidence only and no detached policy state enters the
runtime (the ADR-0121 §8 concern, pinned by test).

## Behavior change

- **Now supported (previously rejected):** full-snapshot transaction
  families (neighbor add/delete/modify, catalog, live policy impact,
  session reshape) with external inputs declared, when the on-disk
  `.rpol`/dataset bytes are identical to the accepted snapshot's recorded
  identity — across plan, apply, commit-confirm, and history rollback.
- **Still rejected, unchanged:** any rpol/dataset roster or content change
  in the diff; any byte drift of an external file (comment-only rewrites
  included); missing/unreadable external files at plan or apply time
  (candidate load fails); rollback to a history row whose external
  identity differs from the currently accepted one; and **every gNMI Set
  full-snapshot candidate while external inputs are present** — the gNMI
  bridge deliberately plans and applies without verification, preserving
  the #1370 fence there. Callers that never verify default to unverified,
  so a missed path fails safe (fenced), never open.

## Compatibility impact

- The rejection reason string, proto surfaces, and CLI output are
  unchanged; no external bytes are archived and no new executor family is
  added. `PeerManagerCommand::PlanConfigTransaction` (workspace-internal
  Rust API) gains a `verify_external_inputs` field.
- Docs updated to the new boundary: `docs/OPERATIONS.md`,
  `docs/CONFIGURATION.md`, `docs/API.md`, CHANGELOG (`Unreleased` /
  Changed, operator-visible), plus ADR-0130 and its index row.

## TOCTOU and mid-window analysis (brief)

Apply never adopts plan-RPC state: under the runtime-config coordinator
lock (which also serializes SIGHUP, so the accepted authority cannot move
mid-apply) the executor re-parses the candidate with capture and plans
twice — the authoritative TOML re-plan and the typed plan of the exact
`Config` object that is staged, each independently verified, with the
existing byte-equality check between their committed candidates. A file
edited between reads yields a digest mismatch or a candidate-changed
`FAILED_PRECONDITION`. The optimistic token continues to cover the
accepted/runtime side only; external bytes are covered by the apply-time
digest comparison. Mid-confirm-window edits cannot reach the runtime
auto-revert: it re-applies the in-memory prior `AcceptedConfigSnapshot`
(capture never re-reads), with identity seeded from that snapshot's own
manifest, and SIGHUP is rejected while the window is pending. Boot revert
keeps its fail-closed re-read ("journaled prior sources are unavailable or
changed"). Full chain in `docs/adr/0130-identity-conditional-external-policy-fence.md`.

## Checks run

- `cargo fmt --all -- --check` — passed.
- `just gate` (developer-tooling checks, clippy-reasons / stable-surface /
  tracker-id checkers, `cargo clippy --workspace --all-targets`, workspace
  tests, doc build; all `--locked`) — passed.
- Focused batteries: peer-manager `config_transaction`, config
  `source_provenance` + `tests::transaction`, and the
  `config_transaction_control` suite — passed, including the unchanged
  #1370 rejection test and the golden source-digest framing test.
- Not run: `gate-rib`, `gate-deps`, `gate-contract` (no feature-gated
  RIB/bench or scale-harness surfaces touched), containerlab interop, and
  the hosted CI matrix. No end-to-end commit-confirm integration test with
  a live rpol config was added: that requires the full
  real-peer-manager + v3-journal + persister-ack harness; plan-level
  verification, the apply re-plan path, and the gNMI/v3 fence are covered
  by the listed tests instead.
