### PR TITLE
Add terminal-aware paging for RIB listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rbgp --pager auto|always|never` now provides terminal-aware paging for
+  complete human best, received, and advertised unicast RIB listings.
+
 - `rbgp rib lookup <IP|CIDR>` now performs one atomic IPv4/IPv6
   longest-prefix match against the global Loc-RIB and renders the existing
   best-path explanation in human or JSON form. Invalid targets, no covering

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -158,6 +158,19 @@ rbgp fib-table list
 rbgp fib-table set edge --table-id 1000 --metric 200 --families ipv4_unicast,ipv6_unicast
 ```
 
+Complete human `rib`, `rib received`, and `rib advertised` unicast listings
+use `--pager auto` by default: a pager starts only when stdout is a terminal,
+the terminal height is known, and the complete rendered table plus any
+`--limit` footer is taller than the terminal. `--pager never` always writes
+directly. `--pager always` requires a terminal and one of those three human
+listings; JSON and all other commands are rejected before connecting.
+
+The pager command is the first non-empty value of `RBGP_PAGER`, then `PAGER`,
+split on ASCII whitespace without a shell. With neither set, auto mode uses
+`less -FRSX` and always mode uses `less -RSX`. If auto mode cannot find the
+pager executable, it writes the same rendered bytes directly; other pager
+startup failures and unsuccessful exits are errors.
+
 `rib received <addr> --rejected` reads a bounded per-peer retention buffer, not
 a guaranteed complete history of rejected routes. Plain-text output reports
 incomplete or unknown completeness with these warnings (using three evictions

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -5,6 +5,7 @@ use crate::output::{
     self, JsonExplainAdvertisedRoute, JsonExplainModifications, JsonExplainReason,
     JsonOrrExplainCandidate, JsonRouteSourceIdentity,
 };
+use crate::pager;
 use crate::proto::injection_service_client::InjectionServiceClient;
 use crate::proto::policy_service_client::PolicyServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
@@ -434,12 +435,16 @@ struct JsonBoundedRoutes<'a> {
     complete: bool,
 }
 
-fn print_route_listing(listing: &RouteListing, show_age: bool, json: bool) -> Result<(), CliError> {
-    let Some(limit) = listing.limit else {
-        return print_routes(&listing.routes, show_age, json);
-    };
-
+fn print_route_listing(
+    listing: &RouteListing,
+    show_age: bool,
+    json: bool,
+    pager_mode: pager::PagerMode,
+) -> Result<(), CliError> {
     if json {
+        if listing.limit.is_none() {
+            return print_routes(&listing.routes, show_age, true);
+        }
         return output::print_json_pretty(&JsonBoundedRoutes {
             routes: JsonRoutes(&listing.routes),
             returned_count: listing.routes.len() as u64,
@@ -448,23 +453,37 @@ fn print_route_listing(listing: &RouteListing, show_age: bool, json: bool) -> Re
         });
     }
 
+    pager::write_payload(pager_mode, &render_human_route_listing(listing, show_age))
+}
+
+fn render_human_route_listing(listing: &RouteListing, show_age: bool) -> String {
+    let Some(limit) = listing.limit else {
+        return if listing.routes.is_empty() {
+            "No routes\n".to_string()
+        } else {
+            output::render_route_table_text(&listing.routes, show_age)
+        };
+    };
+
     if listing.routes.is_empty() {
-        println!("No matching routes.");
-        return Ok(());
+        return "No matching routes.\n".to_string();
     }
 
-    print_routes(&listing.routes, show_age, false)?;
+    let mut payload = output::render_route_table_text(&listing.routes, show_age);
     if listing.complete {
-        println!("Showing all {} matching routes.", listing.total_count);
+        payload.push_str(&format!(
+            "Showing all {} matching routes.\n",
+            listing.total_count
+        ));
     } else {
-        println!(
-            "Showing first {} of {} matching routes (--limit {}).",
+        payload.push_str(&format!(
+            "Showing first {} of {} matching routes (--limit {}).\n",
             listing.routes.len(),
             listing.total_count,
             limit
-        );
+        ));
     }
-    Ok(())
+    payload
 }
 
 fn print_bgpls_routes(routes: &[BgpLsRouteEntry], json: bool) -> Result<(), CliError> {
@@ -1791,6 +1810,7 @@ pub async fn best(
     filters: &RouteFilterOpts,
     show_age: bool,
     json: bool,
+    pager_mode: pager::PagerMode,
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -1801,7 +1821,7 @@ pub async fn best(
         filters.limit,
     )
     .await?;
-    print_route_listing(&listing, show_age, json)
+    print_route_listing(&listing, show_age, json, pager_mode)
 }
 
 pub async fn count_best(
@@ -1918,6 +1938,7 @@ pub async fn received(
     filters: &RouteFilterOpts,
     show_age: bool,
     json: bool,
+    pager_mode: pager::PagerMode,
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -1931,7 +1952,7 @@ pub async fn received(
     for route in &mut listing.routes {
         restore_matching_scoped_address(Some(address), &mut route.peer_address);
     }
-    print_route_listing(&listing, show_age, json)
+    print_route_listing(&listing, show_age, json, pager_mode)
 }
 
 pub async fn count_received(
@@ -2109,6 +2130,7 @@ pub async fn advertised(
     filters: &RouteFilterOpts,
     show_age: bool,
     json: bool,
+    pager_mode: pager::PagerMode,
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -2122,7 +2144,7 @@ pub async fn advertised(
     for route in &mut listing.routes {
         restore_matching_scoped_address(Some(address), &mut route.peer_address);
     }
-    print_route_listing(&listing, show_age, json)
+    print_route_listing(&listing, show_age, json, pager_mode)
 }
 
 pub async fn count_advertised(
@@ -3975,6 +3997,7 @@ mod tests {
             &filters,
             false,
             true,
+            pager::PagerMode::Never,
         )
         .await
         .unwrap();
@@ -3985,6 +4008,7 @@ mod tests {
             &filters,
             false,
             true,
+            pager::PagerMode::Never,
         )
         .await
         .unwrap();
@@ -4030,6 +4054,7 @@ mod tests {
             &no_route_filters(),
             false,
             false,
+            pager::PagerMode::Never,
         )
         .await
         .unwrap();
@@ -4064,6 +4089,7 @@ mod tests {
             &filters,
             false,
             true,
+            pager::PagerMode::Never,
         )
         .await
         .unwrap();
@@ -4099,6 +4125,25 @@ mod tests {
         assert_eq!(value["routes"][0]["prefix"], "10.0.0.0/24");
     }
 
+    #[test]
+    fn bounded_human_listing_keeps_table_then_footer_bytes() {
+        let listing = RouteListing {
+            routes: vec![crate::proto::Route {
+                prefix: "10.0.0.0".to_string(),
+                prefix_length: 24,
+                ..Default::default()
+            }],
+            total_count: 42,
+            complete: false,
+            limit: Some(1),
+        };
+        let table = output::render_route_table_text(&listing.routes, false);
+        assert_eq!(
+            render_human_route_listing(&listing, false),
+            format!("{table}Showing first 1 of 42 matching routes (--limit 1).\n")
+        );
+    }
+
     /// `rbgp best` stops after a single page when the server reports
     /// the listing complete (empty `next_page_token`).
     #[tokio::test]
@@ -4110,9 +4155,16 @@ mod tests {
         }
 
         let connection = connect(&server.addr, None).await.unwrap();
-        best(connection, None, &no_route_filters(), false, false)
-            .await
-            .unwrap();
+        best(
+            connection,
+            None,
+            &no_route_filters(),
+            false,
+            false,
+            pager::PagerMode::Never,
+        )
+        .await
+        .unwrap();
 
         let requests = server.state.list_route_requests.lock().await;
         assert_eq!(requests.len(), 1);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,6 +4,7 @@ mod commands;
 mod connection;
 mod error;
 mod output;
+mod pager;
 #[cfg(test)]
 mod test_support;
 mod tui;
@@ -23,6 +24,8 @@ use crate::output::parse_family;
 use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::{Generator, Shell};
 use std::path::PathBuf;
+
+use pager::PagerMode;
 
 const BINARY_NAME: &str = "rbgp";
 
@@ -146,6 +149,10 @@ struct Cli {
     /// presence disables color without requiring a boolean value.
     #[arg(long, global = true)]
     no_color: bool,
+
+    /// Page complete human unicast RIB listings
+    #[arg(long, value_enum, default_value_t = PagerMode::Auto, global = true)]
+    pager: PagerMode,
 
     #[command(subcommand)]
     command: Command,
@@ -2507,7 +2514,35 @@ fn flush_stdout_result<W: std::io::Write + ?Sized>(
     result
 }
 
+fn pager_supported(command: &Command) -> bool {
+    let Command::Rib {
+        action,
+        explain,
+        count,
+        ..
+    } = command
+    else {
+        return false;
+    };
+    match action {
+        None => !explain && !count,
+        Some(RibAction::Received {
+            count: view_count,
+            rejected,
+            ..
+        }) => !explain && !count && !view_count && !rejected,
+        Some(RibAction::Advertised {
+            count: view_count,
+            explain: view_explain,
+            ..
+        }) => !explain && !count && !view_count && !view_explain,
+        _ => false,
+    }
+}
+
 async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
+    pager::validate_request(cli.pager, cli.json, pager_supported(&cli.command))?;
+
     // Shell completions don't need a gRPC connection.
     if let Command::Completions { shell } = cli.command {
         generate_completions(shell, binary_name, &mut std::io::stdout()).map_err(CliError::Io)?;
@@ -3152,7 +3187,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     } else if count {
                         commands::rib::count_best(connection, family_val, &filters, json).await
                     } else {
-                        commands::rib::best(connection, family_val, &filters, age, json).await
+                        commands::rib::best(connection, family_val, &filters, age, json, cli.pager)
+                            .await
                     }
                 }
                 Some(RibAction::Received {
@@ -3194,7 +3230,10 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     if count {
                         commands::rib::count_received(connection, &address, f, &filters, json).await
                     } else {
-                        commands::rib::received(connection, &address, f, &filters, age, json).await
+                        commands::rib::received(
+                            connection, &address, f, &filters, age, json, cli.pager,
+                        )
+                        .await
                     }
                 }
                 Some(RibAction::Advertised {
@@ -3267,8 +3306,10 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         commands::rib::count_advertised(connection, &address, f, &filters, json)
                             .await
                     } else {
-                        commands::rib::advertised(connection, &address, f, &filters, age, json)
-                            .await
+                        commands::rib::advertised(
+                            connection, &address, f, &filters, age, json, cli.pager,
+                        )
+                        .await
                     }
                 }
                 Some(
@@ -7224,5 +7265,44 @@ printf '%s\n' "${COMPREPLY[@]}"
                 },
             } if prefix == "192.0.2.0/24"
         ));
+    }
+
+    #[test]
+    fn pager_support_is_limited_to_human_unicast_route_lists() {
+        for args in [
+            "rbgp rib",
+            "rbgp rib received 192.0.2.1 --limit 10",
+            "rbgp rib advertised 192.0.2.1 --age",
+        ] {
+            let cli = Cli::try_parse_from(args.split_ascii_whitespace()).unwrap();
+            assert!(pager_supported(&cli.command), "{args}");
+        }
+        for args in [
+            "rbgp rib --count",
+            "rbgp rib received 192.0.2.1 --rejected",
+            "rbgp rib advertised 192.0.2.1 --count",
+            "rbgp rib blackholes",
+            "rbgp top",
+        ] {
+            let cli = Cli::try_parse_from(args.split_ascii_whitespace()).unwrap();
+            assert!(!pager_supported(&cli.command), "{args}");
+        }
+    }
+
+    #[test]
+    fn pager_modes_parse_and_invalid_spelling_is_rejected() {
+        for (value, expected) in [
+            ("auto", PagerMode::Auto),
+            ("always", PagerMode::Always),
+            ("never", PagerMode::Never),
+        ] {
+            let cli = Cli::try_parse_from(["rbgp", "--pager", value, "rib"]).unwrap();
+            assert_eq!(cli.pager, expected);
+        }
+        assert!(Cli::try_parse_from(["rbgp", "--pager", "sometimes", "rib"]).is_err());
+        assert_eq!(
+            Cli::try_parse_from(["rbgp", "rib"]).unwrap().pager,
+            PagerMode::Auto
+        );
     }
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -880,15 +880,16 @@ fn format_med(med_attr: Option<u32>) -> String {
 
 /// Print route table with dynamic column widths and colored best marker.
 pub fn print_route_table(routes: &[proto::Route], show_age: bool) {
-    print!(
-        "{}",
-        render_route_table_with_clock(routes, show_age, || {
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs()
-        })
-    );
+    print!("{}", render_route_table_text(routes, show_age));
+}
+
+pub(crate) fn render_route_table_text(routes: &[proto::Route], show_age: bool) -> String {
+    render_route_table_with_clock(routes, show_age, || {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    })
 }
 
 fn render_route_table_with_clock<F>(routes: &[proto::Route], show_age: bool, clock: F) -> String

--- a/crates/cli/src/pager.rs
+++ b/crates/cli/src/pager.rs
@@ -1,0 +1,233 @@
+use std::env;
+use std::io::{self, IsTerminal, Write};
+use std::process::{Command, Stdio};
+
+use crate::error::CliError;
+use crate::output;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum PagerMode {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+pub(crate) fn validate_request(
+    mode: PagerMode,
+    json: bool,
+    supported: bool,
+) -> Result<(), CliError> {
+    validate_request_with_tty(mode, json, supported, io::stdout().is_terminal())
+}
+
+fn validate_request_with_tty(
+    mode: PagerMode,
+    json: bool,
+    supported: bool,
+    stdout_is_tty: bool,
+) -> Result<(), CliError> {
+    if mode != PagerMode::Always {
+        return Ok(());
+    }
+    if json {
+        return Err(CliError::Argument(
+            "--pager always cannot be combined with --json".into(),
+        ));
+    }
+    if !stdout_is_tty {
+        return Err(CliError::Argument(
+            "--pager always requires stdout to be a terminal".into(),
+        ));
+    }
+    if !supported {
+        return Err(CliError::Argument(
+            "--pager always is supported only for human best, received, and advertised unicast RIB listings".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn write_payload(mode: PagerMode, payload: &str) -> Result<(), CliError> {
+    let stdout_is_tty = io::stdout().is_terminal();
+    let terminal_rows = stdout_is_tty
+        .then(crossterm::terminal::size)
+        .and_then(Result::ok)
+        .map(|(_, rows)| rows);
+    if !should_page(mode, stdout_is_tty, terminal_rows, payload.lines().count()) {
+        return output::write_bytes(&mut io::stdout().lock(), payload.as_bytes());
+    }
+
+    run_pager(&pager_argv(mode), payload, mode, &mut io::stdout().lock())
+}
+
+fn should_page(
+    mode: PagerMode,
+    stdout_is_tty: bool,
+    terminal_rows: Option<u16>,
+    payload_rows: usize,
+) -> bool {
+    match mode {
+        PagerMode::Never => false,
+        PagerMode::Always => stdout_is_tty,
+        PagerMode::Auto => {
+            stdout_is_tty && terminal_rows.is_some_and(|rows| payload_rows > usize::from(rows))
+        }
+    }
+}
+
+fn pager_argv(mode: PagerMode) -> Vec<String> {
+    let rbgp_pager = env::var("RBGP_PAGER").ok();
+    let pager = env::var("PAGER").ok();
+    pager_argv_from(mode, rbgp_pager.as_deref(), pager.as_deref())
+}
+
+fn pager_argv_from(mode: PagerMode, rbgp_pager: Option<&str>, pager: Option<&str>) -> Vec<String> {
+    rbgp_pager
+        .filter(|value| !value.trim_ascii().is_empty())
+        .or_else(|| pager.filter(|value| !value.trim_ascii().is_empty()))
+        .map(|value| value.split_ascii_whitespace().map(str::to_owned).collect())
+        .unwrap_or_else(|| match mode {
+            PagerMode::Auto => vec!["less".into(), "-FRSX".into()],
+            PagerMode::Always => vec!["less".into(), "-RSX".into()],
+            PagerMode::Never => unreachable!("never mode writes directly"),
+        })
+}
+
+fn run_pager(
+    argv: &[String],
+    payload: &str,
+    mode: PagerMode,
+    fallback: &mut dyn Write,
+) -> Result<(), CliError> {
+    let Some((program, args)) = argv.split_first() else {
+        return Err(CliError::Argument("pager command is empty".into()));
+    };
+    let mut child = match Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) if mode == PagerMode::Auto && error.kind() == io::ErrorKind::NotFound => {
+            return output::write_bytes(fallback, payload.as_bytes());
+        }
+        Err(error) => return Err(CliError::Io(error)),
+    };
+
+    let write_result = child
+        .stdin
+        .as_mut()
+        .expect("piped pager stdin")
+        .write_all(payload.as_bytes());
+    let status = child.wait()?;
+    classify_pager_result(write_result, status)
+}
+
+fn classify_pager_result(
+    write_result: io::Result<()>,
+    status: std::process::ExitStatus,
+) -> Result<(), CliError> {
+    if !status.success() {
+        return Err(CliError::Io(io::Error::other(match status.code() {
+            Some(code) => format!("pager exited with status {code}"),
+            None => "pager terminated by signal".to_string(),
+        })));
+    }
+    match write_result {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(CliError::Io(error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_rejects_invalid_surfaces_before_connect() {
+        assert!(validate_request_with_tty(PagerMode::Always, true, true, true).is_err());
+        assert!(validate_request_with_tty(PagerMode::Always, false, true, false).is_err());
+        assert!(validate_request_with_tty(PagerMode::Always, false, false, true).is_err());
+        assert!(validate_request_with_tty(PagerMode::Always, false, true, true).is_ok());
+        assert!(validate_request_with_tty(PagerMode::Auto, true, false, false).is_ok());
+    }
+
+    #[test]
+    fn process_failures_do_not_replay_payload() {
+        let argv = vec!["/definitely/missing/rbgp-pager".to_string()];
+        let mut fallback = Vec::new();
+        assert!(run_pager(&argv, "payload", PagerMode::Always, &mut fallback).is_err());
+        assert!(fallback.is_empty());
+        assert!(run_pager(&[], "payload", PagerMode::Always, &mut fallback).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_status_is_checked_after_payload_delivery() {
+        assert!(
+            run_pager(
+                &["/bin/true".into()],
+                "payload",
+                PagerMode::Always,
+                &mut Vec::new(),
+            )
+            .is_ok()
+        );
+        let error = run_pager(
+            &["/bin/false".into()],
+            "payload",
+            PagerMode::Always,
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "pager exited with status 1");
+
+        let status = Command::new("/bin/false").status().unwrap();
+        let error = classify_pager_result(
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed")),
+            status,
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "pager exited with status 1");
+    }
+
+    #[test]
+    fn pager_command_uses_first_nonempty_ascii_token_list() {
+        assert_eq!(
+            pager_argv_from(PagerMode::Auto, Some(" \t"), Some("more -f")),
+            ["more", "-f"]
+        );
+        assert_eq!(
+            pager_argv_from(PagerMode::Always, Some("cat -n"), Some("more")),
+            ["cat", "-n"]
+        );
+        assert_eq!(
+            pager_argv_from(PagerMode::Auto, None, None),
+            ["less", "-FRSX"]
+        );
+        assert_eq!(
+            pager_argv_from(PagerMode::Always, None, None),
+            ["less", "-RSX"]
+        );
+    }
+
+    #[test]
+    fn paging_decision_is_tty_height_aware_and_never_is_direct() {
+        assert!(should_page(PagerMode::Auto, true, Some(23), 24));
+        assert!(!should_page(PagerMode::Auto, true, Some(24), 24));
+        assert!(!should_page(PagerMode::Auto, true, None, 100));
+        assert!(!should_page(PagerMode::Auto, false, Some(1), 100));
+        assert!(!should_page(PagerMode::Never, true, Some(1), 100));
+        assert!(should_page(PagerMode::Always, true, None, 1));
+    }
+
+    #[test]
+    fn auto_missing_executable_falls_back_byte_identically() {
+        let argv = vec!["/definitely/missing/rbgp-pager".to_string()];
+        let mut fallback = Vec::new();
+        run_pager(&argv, "table\nfooter\n", PagerMode::Auto, &mut fallback).unwrap();
+        assert_eq!(fallback, b"table\nfooter\n");
+    }
+}

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -18,6 +18,7 @@ _rbgp() {
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -39,6 +40,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -51,6 +53,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -71,6 +74,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -85,6 +89,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -104,6 +109,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -117,6 +123,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -130,6 +137,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -143,6 +151,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -155,6 +164,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -172,6 +182,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -185,6 +196,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -199,6 +211,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -277,6 +290,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '()--wide[Append summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (\`!\` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -313,6 +327,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '(--no-route-server-client)--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
 '--no-route-server-client[Explicitly disable inherited transparent route-server client mode]' \
 '(--no-per-client-best --no-route-server-client)--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon]' \
@@ -334,6 +349,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -346,6 +362,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -359,6 +376,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -373,6 +391,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -385,6 +404,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -446,6 +466,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '()--wide[Append summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (\`!\` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -482,6 +503,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '(--no-route-server-client)--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
 '--no-route-server-client[Explicitly disable inherited transparent route-server client mode]' \
 '(--no-per-client-best --no-route-server-client)--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon]' \
@@ -503,6 +525,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -515,6 +538,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -528,6 +552,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -542,6 +567,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -554,6 +580,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -614,6 +641,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -634,6 +662,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -675,6 +704,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -695,6 +725,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -707,6 +738,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -766,6 +798,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-l[Show longer (more specific) prefixes matching --prefix]' \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
 '(--count)--explain[Show why the best route was selected (requires --prefix)]' \
@@ -791,6 +824,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -816,6 +850,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '(--age)--count[Print only the number of matching received routes]' \
 '(--rejected)--age[Append the original route receive age]' \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
@@ -846,6 +881,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '(--age)--count[Print only the number of matching received routes]' \
 '(--rejected)--age[Append the original route receive age]' \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
@@ -879,6 +915,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '(--age)--count[Print only the number of matching advertised routes]' \
 '(--explain)--age[Append the original route receive age]' \
 '(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
@@ -913,6 +950,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '(--age)--count[Print only the number of matching advertised routes]' \
 '(--explain)--age[Append the original route receive age]' \
 '(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
@@ -932,6 +970,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -952,6 +991,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -969,6 +1009,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -986,6 +1027,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1002,6 +1044,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1018,6 +1061,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1032,6 +1076,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1052,6 +1097,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1066,6 +1112,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1147,6 +1194,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1167,6 +1215,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1179,6 +1228,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1223,6 +1273,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1235,6 +1286,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1265,6 +1317,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1277,6 +1330,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1302,6 +1356,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1318,6 +1373,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1417,6 +1473,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1441,6 +1498,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1456,6 +1514,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1504,6 +1563,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1532,6 +1592,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--no-vxlan-encap[Disable the RFC 8365 VXLAN encapsulation ext community]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -1550,6 +1611,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--no-vxlan-encap[]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -1571,6 +1633,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--no-vxlan-encap[]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -1588,6 +1651,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1603,6 +1667,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1618,6 +1683,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1632,6 +1698,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1644,6 +1711,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1656,6 +1724,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1676,6 +1745,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1689,6 +1759,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1702,6 +1773,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1751,6 +1823,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1763,6 +1836,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1775,6 +1849,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1787,6 +1862,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1799,6 +1875,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1812,6 +1889,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1934,6 +2012,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1953,6 +2032,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1981,6 +2061,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -1997,6 +2078,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2013,6 +2095,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2031,6 +2114,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2083,6 +2167,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2097,6 +2182,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2109,6 +2195,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2122,6 +2209,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2134,6 +2222,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2148,6 +2237,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--clear[Clear instead of enabling]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -2163,6 +2253,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2175,6 +2266,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2195,6 +2287,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2210,6 +2303,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--list-deps[Print the resolved import graph — each module'\''s path, SHA-256 content hash, and imports — instead of running tests (audit/packaging aid)]' \
 '--coverage[Report which policy terms the in-language tests exercised (evaluated vs. matched, per term) plus static lints (unused sets/datasets/fns, unreachable terms, unreferenced policies). A report only — it never changes the exit code by itself]' \
 '-j[Output in JSON format]' \
@@ -2225,6 +2319,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--check[Rewrite nothing; print a diff and exit 1 when any file is not canonically formatted (CI mode)]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -2247,6 +2342,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2260,6 +2356,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2274,6 +2371,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2287,6 +2385,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2300,6 +2399,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2322,6 +2422,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2336,6 +2437,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2351,6 +2453,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2366,6 +2469,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2380,6 +2484,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2439,6 +2544,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2454,6 +2560,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2470,6 +2577,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2578,6 +2686,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2598,6 +2707,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2610,6 +2720,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2624,6 +2735,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2637,6 +2749,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2690,6 +2803,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2710,6 +2824,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2722,6 +2837,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2736,6 +2852,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2749,6 +2866,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2763,6 +2881,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2776,6 +2895,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2837,6 +2957,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2857,6 +2978,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2873,6 +2995,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2886,6 +3009,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2935,6 +3059,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2955,6 +3080,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2976,6 +3102,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -2989,6 +3116,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -3038,6 +3166,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -3051,6 +3180,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -1163,7 +1163,7 @@ _rbgp() {
 
     case "${cmd}" in
         rbgp)
-            opts="-s -j -h -V --addr --token-file --json --no-color --help --version global config neighbor summary bfd rpki rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help"
+            opts="-s -j -h -V --addr --token-file --json --no-color --pager --help --version global config neighbor summary bfd rpki rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1181,6 +1181,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1189,7 +1193,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__bfd)
-            opts="-s -j -h --addr --token-file --json --no-color --help show help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help show help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1205,6 +1209,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -1257,7 +1265,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__bfd__subcmd__show)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1273,6 +1281,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -1283,7 +1295,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__completions)
-            opts="-s -j -h --addr --token-file --json --no-color --help bash elvish fish powershell zsh"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help bash elvish fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1299,6 +1311,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -1309,7 +1325,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config)
-            opts="-s -j -h --addr --token-file --json --no-color --help diff plan apply confirm abort status history rollback effective import help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help diff plan apply confirm abort status history rollback effective import help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1327,6 +1343,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1335,7 +1355,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__abort)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1353,6 +1373,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1361,7 +1385,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__apply)
-            opts="-s -j -h --expected-runtime-snapshot-token --plan-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --plan-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1411,6 +1435,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1419,7 +1447,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__confirm)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1437,6 +1465,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1445,7 +1477,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__diff)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1471,6 +1503,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1479,7 +1515,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__effective)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1495,6 +1531,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -1673,7 +1713,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__history)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1691,6 +1731,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1699,7 +1743,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__import)
-            opts="-s -j -h --format --out --addr --token-file --json --no-color --help"
+            opts="-s -j -h --format --out --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1733,6 +1777,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1741,7 +1789,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__plan)
-            opts="-s -j -h --expected-runtime-snapshot-token --addr --token-file --json --no-color --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1771,6 +1819,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1779,7 +1831,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__rollback)
-            opts="-s -j -h --expected-runtime-snapshot-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1817,6 +1869,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1825,7 +1881,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__status)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1843,6 +1899,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1851,7 +1911,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff)
-            opts="-s -j -h --addr --token-file --json --no-color --help advertised snapshot help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help advertised snapshot help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1869,6 +1929,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1877,7 +1941,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__advertised)
-            opts="-a -s -j -h --peer --neighbor --against --family --max-routes --max-input-bytes --ignore-attribute --detail --deadline --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --peer --neighbor --against --family --max-routes --max-input-bytes --ignore-attribute --detail --deadline --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1933,6 +1997,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -2027,7 +2095,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__snapshot)
-            opts="-s -j -h --addr --token-file --json --no-color --help from-mrt from-bmp help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help from-mrt from-bmp help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2045,6 +2113,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2053,7 +2125,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__bmp)
-            opts="-s -j -h --peer --source --generation --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --source --generation --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2091,6 +2163,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2099,7 +2175,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__mrt)
-            opts="-s -j -h --view --peer --peer-asn --source --generation --addr --token-file --json --no-color --help"
+            opts="-s -j -h --view --peer --peer-asn --source --generation --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2143,6 +2219,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -2209,7 +2289,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__doctor)
-            opts="-s -j -h --output --log-file --addr --token-file --json --no-color --help"
+            opts="-s -j -h --output --log-file --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2235,6 +2315,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2243,7 +2327,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor)
-            opts="-s -j -h --addr --token-file --json --no-color --help list add delete help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help list add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2261,6 +2345,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2269,7 +2357,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --peer-group --asn --remote-asn --description --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer-group --asn --remote-asn --description --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2303,6 +2391,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2311,7 +2403,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2327,6 +2419,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -2407,7 +2503,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2425,6 +2521,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2433,7 +2533,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events)
-            opts="-a -l -s -j -h --address --family --prefix --limit --addr --token-file --json --no-color --help watch sessions policy evpn help"
+            opts="-a -l -s -j -h --address --family --prefix --limit --addr --token-file --json --no-color --pager --help watch sessions policy evpn help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2475,6 +2575,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2483,7 +2587,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__evpn)
-            opts="-l -s -j -h --address --route-type --rd --type --limit --addr --token-file --json --no-color --help"
+            opts="-l -s -j -h --address --route-type --rd --type --limit --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2523,6 +2627,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -2617,7 +2725,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__policy)
-            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --help"
+            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2649,6 +2757,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -2659,7 +2771,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__sessions)
-            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --help"
+            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2693,6 +2805,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2701,7 +2817,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__watch)
-            opts="-a -s -j -h --category --address --family --prefix --type --backfill --from-event-id --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --category --address --family --prefix --type --backfill --from-event-id --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2751,6 +2867,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2759,7 +2879,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn)
-            opts="-s -j -h --route-type --peer --neighbor --rd --addr --token-file --json --no-color --help add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help"
+            opts="-s -j -h --route-type --peer --neighbor --rd --addr --token-file --json --no-color --pager --help add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2793,6 +2913,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2801,7 +2925,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__add__subcmd__imet)
-            opts="-s -j -h --rd --ethernet-tag --ip --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --help"
+            opts="-s -j -h --rd --ethernet-tag --ip --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2839,6 +2963,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2847,7 +2975,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__add__subcmd__ip__subcmd__prefix)
-            opts="-s -j -h --rd --ethernet-tag --prefix --label --next-hop --gateway --router-mac --rt --no-vxlan-encap --addr --token-file --json --no-color --help"
+            opts="-s -j -h --rd --ethernet-tag --prefix --label --next-hop --gateway --router-mac --rt --no-vxlan-encap --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2897,6 +3025,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2905,7 +3037,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__add__subcmd__mac__subcmd__ip)
-            opts="-s -j -h --rd --ethernet-tag --mac --ip --label --label2 --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --help"
+            opts="-s -j -h --rd --ethernet-tag --mac --ip --label --label2 --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2955,6 +3087,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2963,7 +3099,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__clear__subcmd__duplicate__subcmd__mac)
-            opts="-s -j -h --vni --mac --addr --token-file --json --no-color --help"
+            opts="-s -j -h --vni --mac --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2989,6 +3125,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2997,7 +3137,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__delete__subcmd__imet)
-            opts="-s -j -h --rd --ethernet-tag --ip --addr --token-file --json --no-color --help"
+            opts="-s -j -h --rd --ethernet-tag --ip --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3027,6 +3167,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3035,7 +3179,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__delete__subcmd__ip__subcmd__prefix)
-            opts="-s -j -h --rd --ethernet-tag --prefix --addr --token-file --json --no-color --help"
+            opts="-s -j -h --rd --ethernet-tag --prefix --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3065,6 +3209,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3073,7 +3221,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__delete__subcmd__mac__subcmd__ip)
-            opts="-s -j -h --rd --ethernet-tag --mac --ip --addr --token-file --json --no-color --help"
+            opts="-s -j -h --rd --ethernet-tag --mac --ip --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3107,6 +3255,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3115,7 +3267,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__diagnose)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3131,6 +3283,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3141,7 +3297,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__duplicate__subcmd__mac__subcmd__quarantines)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3157,6 +3313,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3167,7 +3327,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es)
-            opts="-s -j -h --addr --token-file --json --no-color --help list drain undrain help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help list drain undrain help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3185,6 +3345,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3193,7 +3357,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__drain)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3209,6 +3373,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3289,7 +3457,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3305,6 +3473,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3315,7 +3487,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__undrain)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3331,6 +3503,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3621,7 +3797,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__instances)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3637,6 +3813,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3647,7 +3827,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__managed__subcmd__netdevs)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3663,6 +3843,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3673,7 +3857,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__nexthops)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3689,6 +3873,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3699,7 +3887,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__runtime)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3715,6 +3903,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3725,7 +3917,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__vrfs)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3743,6 +3935,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3751,7 +3947,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table)
-            opts="-s -j -h --addr --token-file --json --no-color --help list set delete help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help list set delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3769,6 +3965,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3777,7 +3977,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3793,6 +3993,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -3873,7 +4077,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3891,6 +4095,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3899,7 +4107,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__set)
-            opts="-s -j -h --table-id --metric --families --allowed-peer-group --allowed-neighbor --max-routes --maximum-paths --maximum-paths-ebgp --maximum-paths-ibgp --addr --token-file --json --no-color --help"
+            opts="-s -j -h --table-id --metric --families --allowed-peer-group --allowed-neighbor --max-routes --maximum-paths --maximum-paths-ebgp --maximum-paths-ibgp --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3953,6 +4161,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3961,7 +4173,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__flowspec)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --help add delete help"
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --pager --help add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3987,6 +4199,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -3995,7 +4211,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__flowspec__subcmd__add)
-            opts="-a -s -j -h --family --match --action --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --match --action --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4029,6 +4245,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -4037,7 +4257,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__flowspec__subcmd__delete)
-            opts="-a -s -j -h --family --match --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --match --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4065,6 +4285,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -4131,7 +4355,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__global)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4149,6 +4373,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -4157,7 +4385,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__gshut)
-            opts="-s -j -h --peer --neighbor --clear --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --clear --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4183,6 +4411,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -4191,7 +4423,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__health)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4207,6 +4439,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -5897,7 +6133,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__man)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5913,6 +6149,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -5923,7 +6163,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__metrics)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5939,6 +6179,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -5949,7 +6193,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__mrt__subcmd__dump)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5967,6 +6211,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -5975,7 +6223,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor)
-            opts="-s -j -h --wide --compare --addr --token-file --json --no-color --help add delete enable disable softreset refresh-out help"
+            opts="-s -j -h --wide --compare --addr --token-file --json --no-color --pager --help add delete enable disable softreset refresh-out help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5997,6 +6245,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6005,7 +6257,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set)
-            opts="-s -j -h --addr --token-file --json --no-color --help list get set delete help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help list get set delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6023,6 +6275,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6031,7 +6287,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6047,6 +6303,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6057,7 +6317,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6073,6 +6333,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6167,7 +6431,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6185,6 +6449,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6193,7 +6461,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6215,6 +6483,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6223,7 +6495,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --peer-group --max-prefix-restart-seconds --families --required-families --route-server-client --no-route-server-client --per-client-best --no-per-client-best --role --strict-role --no-strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --no-add-path --addr --token-file --json --no-color --help"
+            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --peer-group --max-prefix-restart-seconds --families --required-families --route-server-client --no-route-server-client --per-client-best --no-per-client-best --role --strict-role --no-strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --no-add-path --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6297,6 +6569,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6305,7 +6581,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6323,6 +6599,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6331,7 +6611,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__disable)
-            opts="-s -j -h --reason --addr --token-file --json --no-color --help"
+            opts="-s -j -h --reason --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6353,6 +6633,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6361,7 +6645,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__enable)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6377,6 +6661,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6499,7 +6787,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__refresh__subcmd__out)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6517,6 +6805,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6525,7 +6817,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__softreset)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6551,6 +6843,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6559,7 +6855,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__orr)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6575,6 +6871,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6585,7 +6885,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group)
-            opts="-s -j -h --addr --token-file --json --no-color --help list get set delete attach detach help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help list get set delete attach detach help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6603,6 +6903,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6611,7 +6915,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__attach)
-            opts="-s -j -h --group --addr --token-file --json --no-color --help"
+            opts="-s -j -h --group --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6633,6 +6937,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6641,7 +6949,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6657,6 +6965,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6667,7 +6979,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__detach)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6683,6 +6995,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6693,7 +7009,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6709,6 +7025,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6831,7 +7151,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6849,6 +7169,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6857,7 +7181,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6879,6 +7203,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6887,7 +7215,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy)
-            opts="-s -j -h --addr --token-file --json --no-color --help list check fmt test get set delete chain stats counters explain help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help list check fmt test get set delete chain stats counters explain help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6905,6 +7233,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6913,7 +7245,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain)
-            opts="-s -j -h --addr --token-file --json --no-color --help show set-import set-export clear-import clear-export help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help show set-import set-export clear-import clear-export help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6931,6 +7263,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -6939,7 +7275,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6963,6 +7299,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -6973,7 +7313,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__import)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6997,6 +7337,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -7105,7 +7449,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__export)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7129,6 +7473,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -7139,7 +7487,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__import)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7163,6 +7511,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -7173,7 +7525,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__show)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7199,6 +7551,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7207,7 +7563,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__check)
-            opts="-s -j -h --root --max-graph-bytes --list-deps --coverage --coverage-min --addr --token-file --json --no-color --help"
+            opts="-s -j -h --root --max-graph-bytes --list-deps --coverage --coverage-min --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7245,6 +7601,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7253,7 +7613,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7271,6 +7631,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7279,7 +7643,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__explain)
-            opts="-s -j -h --peer --neighbor --prefix --path-id --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --prefix --path-id --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7313,6 +7677,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7321,11 +7689,11 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__fmt)
-            opts="-s -j -h --check --addr --token-file --json --no-color --help"
+            opts="-s -j -h --check --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
-            elif [[ ${COMP_CWORD} -eq 3 || ( ${COMP_CWORD} -gt 3 && "${prev}" != "--addr" && "${prev}" != "--token-file" && "${prev}" != "-s" ) ]] ; then
+            elif [[ ${COMP_CWORD} -eq 3 || ( ${COMP_CWORD} -gt 3 && "${prev}" != "--addr" && "${prev}" != "--pager" && "${prev}" != "--token-file" && "${prev}" != "-s" ) ]] ; then
                 local rbgp_old_ifs rbgp_ifs_was_set
                 [ -n "${IFS+x}" ] && { rbgp_old_ifs="$IFS"; rbgp_ifs_was_set=1; }
                 IFS=$'\n'
@@ -7347,6 +7715,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7355,7 +7727,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7371,6 +7743,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -7619,7 +7995,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7637,6 +8013,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7645,7 +8025,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7667,6 +8047,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7675,7 +8059,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__stats)
-            opts="-s -j -h --peer --neighbor --direction --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --direction --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7705,6 +8089,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7713,7 +8101,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__test)
-            opts="-a -s -j -h --policy --direction --peer --neighbor --family --limit --show-changes --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --policy --direction --peer --neighbor --family --limit --show-changes --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7771,6 +8159,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7779,7 +8171,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib)
-            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --age --explain-peer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --limit --addr --token-file --json --no-color --help lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
+            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --age --explain-peer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --limit --addr --token-file --json --no-color --pager --help lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7849,6 +8241,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7857,7 +8253,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__add)
-            opts="-s -j -h --nexthop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --help"
+            opts="-s -j -h --nexthop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7907,6 +8303,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -7915,7 +8315,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -p -l -c -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --no-color --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7993,6 +8393,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8001,7 +8405,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__bgpls)
-            opts="-a -s -j -h --family --peer --neighbor --nlri-type --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --peer --neighbor --nlri-type --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8039,6 +8443,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8047,7 +8455,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__blackholes)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8065,6 +8473,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8073,7 +8485,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__delete)
-            opts="-s -j -h --path-id --addr --token-file --json --no-color --help"
+            opts="-s -j -h --path-id --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8095,6 +8507,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8103,7 +8519,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__fib)
-            opts="-s -j -h --table --state --reason --prefix --peer --neighbor --page-size --page-token --addr --token-file --json --no-color --help"
+            opts="-s -j -h --table --state --reason --prefix --peer --neighbor --page-size --page-token --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8151,6 +8567,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -8343,7 +8763,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__labeled)
-            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8377,6 +8797,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8385,7 +8809,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__lookup)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8403,6 +8827,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8411,7 +8839,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__received)
-            opts="-a -p -l -c -s -j -h --family --count --age --rejected --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --no-color --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --rejected --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8477,6 +8905,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8485,7 +8917,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__rtc)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8511,6 +8943,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8519,7 +8955,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__vpn)
-            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8553,6 +8989,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8561,7 +9001,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rpki)
-            opts="-s -j -h --addr --token-file --json --no-color --help caches validate help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help caches validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8579,6 +9019,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8587,7 +9031,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rpki__subcmd__caches)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8603,6 +9047,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -8669,7 +9117,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rpki__subcmd__validate)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8687,6 +9135,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8695,7 +9147,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__shutdown)
-            opts="-s -j -h --reason --addr --token-file --json --no-color --help"
+            opts="-s -j -h --reason --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8717,6 +9169,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8725,7 +9181,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__top)
-            opts="-i -s -j -h --interval --addr --token-file --json --no-color --help"
+            opts="-i -s -j -h --interval --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8751,6 +9207,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8759,7 +9219,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__topology)
-            opts="-s -j -h --addr --token-file --json --no-color --help nodes links help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help nodes links help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8775,6 +9235,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -8841,7 +9305,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__topology__subcmd__links)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8857,6 +9321,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)
@@ -8867,7 +9335,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__topology__subcmd__nodes)
-            opts="-s -j -h --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8885,6 +9353,10 @@ _rbgp() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -8893,7 +9365,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__watch)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8917,6 +9389,10 @@ _rbgp() {
                     ;;
                 --token-file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pager)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;
                 *)

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_rbgp_global_optspecs
-    string join \n s/addr= token-file= j/json no-color h/help V/version
+    string join \n s/addr= token-file= j/json no-color pager= h/help V/version
 end
 
 function __fish_rbgp_needs_command
@@ -26,6 +26,9 @@ end
 
 complete -c rbgp -n "__fish_rbgp_needs_command" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_needs_command" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_needs_command" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_needs_command" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_needs_command" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_needs_command" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -61,11 +64,17 @@ complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "man" -d 'Print the rbgp m
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -82,12 +91,18 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_su
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l expected-runtime-snapshot-token -d 'Optional runtime snapshot token to check while planning' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -99,26 +114,41 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l confirm-timeout -d 'Confirmed-commit timeout in seconds; daemon default is 600, max is 86400' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -129,11 +159,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -l confirm-timeout -d 'Confirmed-commit timeout in seconds; daemon default is 600, max is 86400' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -143,6 +179,9 @@ gobgp\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -l out -d 'Write the translated config here (default: stdout; required with --json)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -160,6 +199,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l compare -d 'Compare this peer\'s live update-group membership with another configured peer without exposing internal group identifiers' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l wide -d 'Append summary columns to the list: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (`!` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l no-color -d 'Disable colored output'
@@ -186,6 +228,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l paths-limit-receive-max -d 'Experimental Paths-Limit preference for Add-Path receive families' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-route-server-client -d 'Explicitly disable inherited transparent route-server client mode'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon'
@@ -200,28 +245,43 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l reason -d 'Disable reason' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s a -l family -d 'Address family to refresh' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -235,6 +295,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l compare -d 'Compare this peer\'s live update-group membership with another configured peer without exposing internal group identifiers' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l wide -d 'Append summary columns to the list: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (`!` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l no-color -d 'Disable colored output'
@@ -261,6 +324,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l paths-limit-receive-max -d 'Experimental Paths-Limit preference for Add-Path receive families' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-route-server-client -d 'Explicitly disable inherited transparent route-server client mode'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon'
@@ -275,28 +341,43 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l reason -d 'Disable reason' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s a -l family -d 'Address family to refresh' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -309,6 +390,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -316,6 +400,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -323,6 +410,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -331,11 +421,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -358,6 +454,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l limit -d 'Return at most this many routes without walking the full table (1-1000)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l explain -d 'Show why the best route was selected (requires --prefix)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l count -d 'Print only the number of matching best, received, or advertised routes'
@@ -382,6 +481,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -400,6 +502,9 @@ unknown\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l as-path-contains -d 'Filter by exact ASN membership in the represented AS path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l count -d 'Print only the number of matching received routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
@@ -422,6 +527,9 @@ unknown\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l as-path-contains -d 'Filter by exact ASN membership in the represented AS path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l count -d 'Print only the number of matching received routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
@@ -447,6 +555,9 @@ unknown\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l as-path-contains -d 'Filter by exact ASN membership in the represented AS path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l count -d 'Print only the number of matching advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
@@ -473,6 +584,9 @@ unknown\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l as-path-contains -d 'Filter by exact ASN membership in the represented AS path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l count -d 'Print only the number of matching advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
@@ -483,6 +597,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -495,6 +612,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l page-token -d 'Page token returned by a previous paginated FIB status query' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -503,6 +623,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l nlri-type -d 'NLRI type filter (1=node, 2=link, 3=IPv4 prefix, 4=IPv6 prefix)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -511,6 +634,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l nlri-type -d 'NLRI type filter (1=node, 2=link, 3=IPv4 prefix, 4=IPv6 prefix)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -518,6 +644,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l neighbor -l peer -d 'Neighbor IP address filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -525,12 +654,18 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l neighbor -l peer -d 'Neighbor IP address filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l neighbor -l peer -d 'Neighbor IP address filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -544,12 +679,18 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l path-id -d 'Path ID for Add-Path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l path-id -d 'Path ID for Add-Path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -567,6 +708,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -575,11 +719,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -588,11 +738,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -609,11 +765,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l deadline -d 'Aggregate wall-clock budget for the live query phase, starting after bounded local snapshot parsing and shared by neighbor discovery and every advertised-route page; expiry refuses the comparison (exit 2)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -626,6 +788,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s a -l family -d 'Address family (ipv4_flowspec, ipv6_flowspec)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -637,6 +802,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l action -d 'Actions (e.g., drop, rate=1000, redirect=65001:100)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -644,6 +812,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l match -d 'Match components identifying the rule' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -655,6 +826,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -l rd -d 'Route Distinguisher filter (list mode only), e.g. "65000:100"' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -684,6 +858,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l rt -d 'Optional route targets, each "asn:value"' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l no-vxlan-encap -d 'Disable the RFC 8365 VXLAN encapsulation ext community'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l no-color -d 'Disable colored output'
@@ -695,6 +872,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l rt -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l no-vxlan-encap
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l no-color -d 'Disable colored output'
@@ -709,6 +889,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l rt -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l no-vxlan-encap
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l no-color -d 'Disable colored output'
@@ -719,6 +902,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l ip -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -727,6 +913,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l ip -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -735,6 +924,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l prefix -d 'IP prefix, e.g. "10.0.0.0/24" or "2001:db8::/48"' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -742,16 +934,25 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l mac -d 'MAC address "aa:bb:cc:dd:ee:ff"' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -761,31 +962,49 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -808,6 +1027,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s a -l family -d 'Address family filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -817,6 +1039,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_su
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s l -l limit -d 'Maximum recent route events to return (default 100; route history only)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -834,6 +1059,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l from-event-id -d 'ADR-0072 durable cursor: replay committed events with `event_id > N` from the daemon\'s local event outbox, then tail the live stream. `0` replays everything retained. Survives daemon restart. Returns `FAILED_PRECONDITION` when the daemon was started with `[event_history].enabled = false` or EHM is unavailable' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -842,6 +1070,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s l -l limit -d 'Maximum recent session events to return (default 100; explicit 0 requests the daemon\'s full bounded window)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -850,6 +1081,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s l -l limit -d 'Maximum recent policy events to return (default 100; explicit 0 requests the daemon\'s full bounded window)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -860,6 +1094,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s l -l limit -d 'Maximum recent EVPN events to return (default 100; explicit 0 requests the daemon\'s full bounded window)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -870,6 +1107,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -877,28 +1117,43 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l output -d 'Output t
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l log-file -d 'Daemon log file to tail (last 1000 lines) into the bundle. Without it the manifest records that the daemon logs to stdout/journald' -r -F
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l reason -d 'Shutdown reason' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l neighbor -l peer -d 'Neighbor address; omit to toggle for all peers' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l clear -d 'Clear instead of enabling'
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l no-color -d 'Disable colored output'
@@ -906,11 +1161,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s h -l help -d 'Print 
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s i -l interval -d 'Poll interval in seconds (1-60)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -928,6 +1189,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_su
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -936,6 +1200,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l coverage-min -d 'Minimum acceptable exercised-term percentage (implies --coverage): exit 3 when coverage falls below PCT (CI gate). Diagnostics (1) and test failures (2) take precedence' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l list-deps -d 'Print the resolved import graph — each module\'s path, SHA-256 content hash, and imports — instead of running tests (audit/packaging aid)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l coverage -d 'Report which policy terms the in-language tests exercised (evaluated vs. matched, per term) plus static lints (unused sets/datasets/fns, unreachable terms, unreferenced policies). A report only — it never changes the exit code by itself'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s j -l json -d 'Output in JSON format'
@@ -943,6 +1210,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l check -d 'Rewrite nothing; print a diff and exit 1 when any file is not canonically formatted (CI mode)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l no-color -d 'Disable colored output'
@@ -955,27 +1225,42 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l show-changes -d 'Maximum before/after attribute diffs to show' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l from-file -d 'JSON file containing the PolicyDefinition shape' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -991,6 +1276,9 @@ export\t''
 both\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1000,6 +1288,9 @@ export\t''
 both\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1008,6 +1299,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l path-id -d 'Add-Path identifier; omit to show every matching path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1024,6 +1318,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1034,22 +1331,34 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_s
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l from-file -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1060,6 +1369,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1072,33 +1384,51 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_see
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l from-file -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l group -d 'Peer-group name' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1111,6 +1441,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_su
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1120,6 +1453,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fi
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1128,11 +1464,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_s
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l description -d 'Optional description' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1142,6 +1484,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_s
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1151,6 +1496,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1165,11 +1513,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_sub
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l maximum-paths-ibgp -d 'Per-class iBGP ECMP cap (overrides maximum_paths for iBGP)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -1179,11 +1533,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_sub
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
+always\t''
+never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s h -l help -d 'Print help (see more with \'--help\')'


### PR DESCRIPTION
## Summary

- add global `--pager auto|always|never` modes with TTY- and height-aware auto behavior
- page only complete human best, received, and advertised unicast RIB listings
- use `RBGP_PAGER`, then `PAGER`, without a shell; preserve direct output when auto cannot find the pager
- keep JSON, redirected output, streams, other RIB families, and RPC behavior unchanged
- regenerate the checked-in Bash, Zsh, and Fish completions

## Verification

- `cargo test --locked -p rustbgpctl`
- `cargo clippy --locked -p rustbgpctl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `just links`
- `just gate`
- `git diff --check`