### PR TITLE
Reject unsupported telemetry log formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Intentionally narrow `[global.telemetry].log_format` to JSON only. Other
+  strings were previously ignored but now fail configuration parsing; migrate
+  them to `log_format = "json"`.
+
 - `rbgp doctor` now describes config freshness as an mtime comparison with the
   daemon's last config-file marker rather than claiming effective runtime
   agreement. The Prometheus alert pack reports authoritative partial

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -601,7 +601,7 @@ Required. Configures observability and management endpoints.
 | Field             | Type   | Required | Default | Description                        |
 |-------------------|--------|----------|---------|------------------------------------|
 | `prometheus_addr` | string | no       | --      | `host:port` for Prometheus metrics and HTTP `/livez` / `/readyz` probes (omit to disable) |
-| `log_format`      | string | yes      | --      | Log output format (`"json"`)       |
+| `log_format`      | enum   | yes      | --      | Log output format; only `"json"` is supported |
 
 `prometheus_addr`, when present, must be a valid `ip:port` socket address. The
 same listener serves `/metrics`, `/livez`, and `/readyz`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -836,8 +836,8 @@ systemd's `Restart=on-failure`. If the config moves the socket, set
   default); if your config moves the socket, set `RUSTBGPD_ADDR` on
   the container to match.
 
-- **Logs**: structured JSON when `[global.telemetry] log_format =
-  "json"` is set; pipe to your log aggregator.
+- **Logs**: `[global.telemetry] log_format = "json"` is required and emits
+  structured JSON; pipe it to your log aggregator.
 
 - **Networking**: Linux FIB integration and BFD require access to the network
   namespace they operate on. For host addresses, use the [root host-network
@@ -1412,8 +1412,9 @@ short version for first deployment:
 
 For deeper investigation, raise the daemon log level globally with the
 `RUST_LOG` environment variable — there is no log-level key in
-`[global.telemetry]`; `log_format` selects the output format, not the
-verbosity. Under systemd, set it in the unit's `[Service]` section:
+`[global.telemetry]`; `log_format` does not select among formats: `"json"` is
+the only accepted value. It does not control verbosity. Under systemd, set the
+log level in the unit's `[Service]` section:
 
 ```ini
 [Service]

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -277,7 +277,7 @@ pinned per ADR-0057.
 | Field | Class | Notes |
 |---|---|---|
 | `prometheus_addr` | restart-required | The exporter listener binds at startup. |
-| `log_format` | restart-required | The `tracing` subscriber is initialized at startup. |
+| `log_format` | rejected-before-mutation | Only `"json"` is accepted; other values fail config parsing before reload mutation. |
 
 ### `[global.telemetry.grpc_tcp]` and `[global.telemetry.grpc_uds]`
 

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1487,6 +1487,12 @@
       },
       "additionalProperties": false
     },
+    "LogFormatConfig": {
+      "type": "string",
+      "enum": [
+        "json"
+      ]
+    },
     "ManagedBridgeNetdevConfig": {
       "description": "One managed Linux bridge row (ADR-0091 bridge-first tranche).",
       "type": "object",
@@ -3117,7 +3123,7 @@
         },
         "log_format": {
           "description": "Log output format (`\"json\"`).",
-          "type": "string"
+          "$ref": "#/$defs/LogFormatConfig"
         },
         "prometheus_addr": {
           "description": "Prometheus metrics HTTP listener address (e.g., \"0.0.0.0:9179\").\nIf absent, no metrics HTTP server is started. Metrics are still\ncollected for gRPC health and internal counters.",

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -63,7 +63,7 @@
     "stable_fields": [
       {"definition": "Config", "fields": ["bmp", "dynamic_neighbors", "event_history", "global", "mrt", "neighbors", "peer_groups", "policy", "rpki", "security"], "schema_sha256": "f18e9cf437e78c8fb48be7a51de93f9142fdf26c229ef040b2b44c5655015b3e"},
       {"definition": "Global", "fields": ["asn", "cluster_id", "dynamic_neighbor_limit", "honor_graceful_shutdown", "listen_port", "multipath_relax", "router_id", "runtime_state_dir", "telemetry"], "schema_sha256": "0c466a203cb6519f865d6fe3fc9a81921cef27942240e38125738259aa73eb5d"},
-      {"definition": "TelemetryConfig", "fields": ["grpc_tcp", "grpc_uds", "log_format", "prometheus_addr"], "schema_sha256": "95ed5115adecb2c4fda72873482c6fee1d8b7df7a0844712a5408f04505e793d"},
+      {"definition": "TelemetryConfig", "fields": ["grpc_tcp", "grpc_uds", "log_format", "prometheus_addr"], "schema_sha256": "57dd4b53da31e8ee50be7491812f1bff0e813651635480084678a9e4017319ea"},
       {"definition": "GrpcTcpListenerConfig", "fields": ["access_mode", "address", "enabled", "max_tier", "principal", "tls_cert_file", "tls_client_ca_file", "tls_key_file", "token_file"], "schema_sha256": "2c5304b180fea247a211160087b6eed583e2834558faa02efc3473410a8695b2"},
       {"definition": "GrpcUdsListenerConfig", "fields": ["access_mode", "enabled", "max_tier", "mode", "path", "principal", "token_file"], "schema_sha256": "1616e6489f89848d729f1e0cc11f5150539bc22d6f548a09b4519735ebf1b6c0"},
       {"definition": "SecurityConfig", "fields": ["grpc"], "schema_sha256": "c0bb19eb23bdf4b585a75cb193f37490b52233aefb263c1d451d635db8f27847"},
@@ -92,7 +92,8 @@
       {"definition": "GrpcAccessModeConfig", "schema_sha256": "83c96eb88d57e5c0b689443bb415086df4ed403fae8e5ccc77a5dd0fe7b7c577"},
       {"definition": "GrpcEnforcementConfig", "schema_sha256": "191a2c9e85eefb3a60509df99e81edc496c422170b0bbd24961d9030de42f588"},
       {"definition": "GrpcMaxTierConfig", "schema_sha256": "244b9b776ca119f3c7af0e3fcfafac568318e3d830a9086e5de9646b923b83c8"},
-      {"definition": "GrpcRoleConfig", "schema_sha256": "46719dcd128578a3754ea0bfcce98b7cbfb1c361aa941edacaf7fc4d2ac528a5"}
+      {"definition": "GrpcRoleConfig", "schema_sha256": "46719dcd128578a3754ea0bfcce98b7cbfb1c361aa941edacaf7fc4d2ac528a5"},
+      {"definition": "LogFormatConfig", "schema_sha256": "2ffe2bc41781cd4765f757cf5a495bb37b338a57b3b6bbad802deffb1d5c213b"}
     ],
     "effective_defaults": {
       "paths": [

--- a/src/config/diagnostic.rs
+++ b/src/config/diagnostic.rs
@@ -472,7 +472,7 @@ router_id = \"1.2.3.4\"
 listen_port = 179
 [global.telemetry]
 prometheus_addr = \"0.0.0.0:9090\"
-log_format = \"text\"
+log_format = \"json\"
 
 [[neighbors]]
 address = \"10.0.0.1\"
@@ -495,7 +495,7 @@ router_id = \"not-an-ip\"
 listen_port = 179
 [global.telemetry]
 prometheus_addr = \"0.0.0.0:9090\"
-log_format = \"text\"
+log_format = \"json\"
 ";
         let error = ConfigError::InvalidRouterId {
             value: "not-an-ip".to_string(),
@@ -720,7 +720,7 @@ listen_port = 179
 
 [global.telemetry]
 prometheus_addr = \"0.0.0.0:9090\"
-log_format = \"text\"
+log_format = \"json\"
 
 [[neighbors]]
 address = \"10.0.0.1\"
@@ -753,7 +753,7 @@ listen_port = 179
 
 [global.telemetry]
 prometheus_addr = \"0.0.0.0:9090\"
-log_format = \"text\"
+log_format = \"json\"
 
 [[neighbours]]
 address = \"10.0.0.1\"
@@ -805,7 +805,7 @@ listen_port = 179
 
 [global.telemetry]
 prometheus_addr = \"0.0.0.0:9090\"
-log_format = \"text\"
+log_format = \"json\"
 
 [[neighbors]]
 address = \"10.0.0.1\"
@@ -831,7 +831,7 @@ listen_port = 179
 
 [global.telemetry]
 prometheus_addr = \"0.0.0.0:9090\"
-log_format = \"text\"
+log_format = \"json\"
 
 [[neighbors]]
 address = \"10.0.0.1\"
@@ -871,7 +871,7 @@ router_id = \"1.2.3.4\"
 listen_port = 179
 [global.telemetry]
 prometheus_addr = \"0.0.0.0:9090\"
-log_format = \"text\"
+log_format = \"json\"
 
 [[neighbors]]
 address = \"10.0.0.1\"

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -948,13 +948,19 @@ pub struct TelemetryConfig {
     #[serde(default)]
     pub prometheus_addr: Option<String>,
     /// Log output format (`"json"`).
-    pub log_format: String,
+    pub log_format: LogFormatConfig,
     /// gRPC TCP listener.
     #[serde(default)]
     pub grpc_tcp: Option<GrpcTcpListenerConfig>,
     /// gRPC Unix-domain-socket listener.
     #[serde(default)]
     pub grpc_uds: Option<GrpcUdsListenerConfig>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LogFormatConfig {
+    Json,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/src/config/tests/telemetry.rs
+++ b/src/config/tests/telemetry.rs
@@ -1,6 +1,31 @@
 use super::*;
 
 #[test]
+fn log_format_is_json_only() {
+    let source = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+"#;
+    let invalid = source.replace("log_format = \"json\"", "log_format = \"plain\"");
+    let error = parse(&invalid).unwrap_err().to_string();
+    assert!(error.contains("unknown variant"), "{error}");
+    assert!(error.contains("json"), "{error}");
+
+    let telemetry = parse(source).unwrap().global.telemetry;
+    let encoded = toml::to_string(&telemetry).unwrap();
+    assert!(encoded.contains("log_format = \"json\""));
+    assert_eq!(
+        toml::from_str::<TelemetryConfig>(&encoded).unwrap(),
+        telemetry
+    );
+}
+
+#[test]
 fn bmp_valid_config_accepted() {
     let config = parse(&bmp_toml("")).unwrap();
     let bmp = config.bmp.as_ref().unwrap();

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -1041,7 +1041,7 @@ router_id = "10.0.0.1"
 listen_port = 1179
 
 [global.telemetry]
-log_format = "plain"
+log_format = "json"
 
 [[neighbors]]
 address = "192.0.2.1"
@@ -1196,7 +1196,7 @@ router_id = "10.0.0.1"
 listen_port = 1179
 
 [global.telemetry]
-log_format = "plain"
+log_format = "json"
 
 [[neighbors]]
 address = "192.0.2.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8396,7 +8396,7 @@ peer_group = "plain"
                 runtime_state_dir: "/tmp".to_string(),
                 telemetry: crate::config::TelemetryConfig {
                     prometheus_addr: Some("127.0.0.1:9179".to_string()),
-                    log_format: "json".to_string(),
+                    log_format: crate::config::LogFormatConfig::Json,
                     grpc_tcp: None,
                     grpc_uds: None,
                 },

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -502,7 +502,7 @@ impl PeerManager {
                     runtime_state_dir: "/tmp/rustbgpd-tests".to_string(),
                     telemetry: crate::config::TelemetryConfig {
                         prometheus_addr: Some("127.0.0.1:9179".to_string()),
-                        log_format: "json".to_string(),
+                        log_format: crate::config::LogFormatConfig::Json,
                         grpc_tcp: None,
                         grpc_uds: None,
                     },

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -201,7 +201,7 @@ fn make_dynamic_manager_config() -> Config {
             runtime_state_dir: "/tmp/rustbgpd-tests".to_string(),
             telemetry: crate::config::TelemetryConfig {
                 prometheus_addr: Some("127.0.0.1:9179".to_string()),
-                log_format: "json".to_string(),
+                log_format: crate::config::LogFormatConfig::Json,
                 grpc_tcp: None,
                 grpc_uds: Some(crate::config::GrpcUdsListenerConfig {
                     enabled: true,

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1857,11 +1857,6 @@ fn pin_unreconciled_daemon_runtime_fields(new_config: &mut Config, current: &Con
         .telemetry
         .prometheus_addr
         .clone_from(&current.global.telemetry.prometheus_addr);
-    new_config
-        .global
-        .telemetry
-        .log_format
-        .clone_from(&current.global.telemetry.log_format);
     new_config.rpki.clone_from(&current.rpki);
     new_config.bmp.clone_from(&current.bmp);
     new_config.mrt.clone_from(&current.mrt);
@@ -7652,7 +7647,7 @@ runtime_state_dir = "/tmp/rustbgpd-reload-edited"
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:19179"
-log_format = "plain"
+log_format = "json"
 
 [rpki]
 [[rpki.cache_servers]]
@@ -7712,10 +7707,6 @@ hold_time = 90
             assert_eq!(
                 runtime.global.telemetry.prometheus_addr,
                 startup.global.telemetry.prometheus_addr
-            );
-            assert_eq!(
-                runtime.global.telemetry.log_format,
-                startup.global.telemetry.log_format
             );
             assert_eq!(runtime.rpki, startup.rpki);
             assert_eq!(runtime.bmp, startup.bmp);


### PR DESCRIPTION
## Summary

- reject unsupported telemetry log formats during configuration parsing
- model the only supported value as `LogFormatConfig::Json`
- keep the stable field inventoried and pin the enum schema
- document the intentional narrowing and migration to `log_format = "json"`

## Checks

- `cargo test --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `python3 scripts/check-v1-stable-surface.py`
- `just gate`
- `cargo fmt --all -- --check`
- `git diff --check`
