### PR TITLE
Expose renderer operational modes in help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rs-config-render --help` now lists its rendering, activation, status,
+  pruning, recovery, and IXP Manager lifecycle command paths.
+
 - `rbgp --pager auto|always|never` now provides terminal-aware paging for
   complete human best, received, and advertised unicast RIB listings.
 

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -24,6 +24,7 @@ enum InputFormat {
 #[derive(Parser)]
 #[command(
     name = "rs-config-render activate",
+    bin_name = "rs-config-render activate",
     about = "Atomically publish and settle a validated local candidate"
 )]
 struct ActivateArgs {
@@ -55,6 +56,7 @@ struct ActivateArgs {
 #[derive(Parser)]
 #[command(
     name = "rs-config-render prune",
+    bin_name = "rs-config-render prune",
     about = "Remove activation generations no retention rule keeps (dry run unless --apply)"
 )]
 struct PruneArgs {
@@ -72,6 +74,7 @@ struct PruneArgs {
 #[derive(Parser)]
 #[command(
     name = "rs-config-render status",
+    bin_name = "rs-config-render status",
     about = "Report activation and lifecycle state for one handle without changing it"
 )]
 struct StatusArgs {
@@ -86,6 +89,7 @@ struct StatusArgs {
 #[derive(Parser)]
 #[command(
     name = "rs-config-render recover",
+    bin_name = "rs-config-render recover",
     about = "Resolve manual-recovery (exit 5) state; every verb is a dry run unless --apply"
 )]
 struct RecoverArgs {
@@ -218,6 +222,7 @@ impl HostBindingArgs {
 #[derive(Parser)]
 #[command(
     name = "rs-config-render ixp-manager-lifecycle",
+    bin_name = "rs-config-render ixp-manager-lifecycle",
     about = "Run the authenticated IXP Manager v7.4 router lifecycle"
 )]
 struct LifecycleArgs {
@@ -291,7 +296,8 @@ struct LifecycleResumeArgs {
 #[command(
     name = "rs-config-render",
     version,
-    about = "Render rustbgpd route-server configuration from supported upstream exports"
+    about = "Render rustbgpd route-server configuration from supported upstream exports",
+    after_help = "Operational modes:\n  rs-config-render --context <CONTEXT> --out-dir <OUT_DIR>\n  rs-config-render activate --help\n  rs-config-render status --help\n  rs-config-render prune --help\n  rs-config-render recover keep-current --help\n  rs-config-render recover rollback --help\n  rs-config-render recover release-lock --help\n  rs-config-render recover clear --help\n  rs-config-render ixp-manager-lifecycle run --help\n  rs-config-render ixp-manager-lifecycle resume --help"
 )]
 struct Cli {
     /// Input document format

--- a/tools/rs-config-render/tests/help.rs
+++ b/tools/rs-config-render/tests/help.rs
@@ -1,0 +1,65 @@
+use std::process::Command;
+
+fn run_help(args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn cli_help_names_operational_modes_and_truthful_paths() {
+    let help = run_help(&["--help"]);
+    for path in [
+        "rs-config-render --context <CONTEXT> --out-dir <OUT_DIR>",
+        "rs-config-render activate --help",
+        "rs-config-render status --help",
+        "rs-config-render prune --help",
+        "rs-config-render recover keep-current --help",
+        "rs-config-render recover rollback --help",
+        "rs-config-render recover release-lock --help",
+        "rs-config-render recover clear --help",
+        "rs-config-render ixp-manager-lifecycle run --help",
+        "rs-config-render ixp-manager-lifecycle resume --help",
+    ] {
+        assert!(help.contains(path), "missing {path}: {help}");
+    }
+
+    for (args, usage) in [
+        (
+            &["activate", "--help"][..],
+            "Usage: rs-config-render activate",
+        ),
+        (&["status", "--help"][..], "Usage: rs-config-render status"),
+        (&["prune", "--help"][..], "Usage: rs-config-render prune"),
+        (
+            &["recover", "keep-current", "--help"][..],
+            "Usage: rs-config-render recover keep-current",
+        ),
+        (
+            &["recover", "rollback", "--help"][..],
+            "Usage: rs-config-render recover rollback",
+        ),
+        (
+            &["recover", "release-lock", "--help"][..],
+            "Usage: rs-config-render recover release-lock",
+        ),
+        (
+            &["recover", "clear", "--help"][..],
+            "Usage: rs-config-render recover clear",
+        ),
+        (
+            &["ixp-manager-lifecycle", "run", "--help"][..],
+            "Usage: rs-config-render ixp-manager-lifecycle run",
+        ),
+        (
+            &["ixp-manager-lifecycle", "resume", "--help"][..],
+            "Usage: rs-config-render ixp-manager-lifecycle resume",
+        ),
+    ] {
+        let help = run_help(args);
+        assert!(help.contains(usage), "missing {usage}: {help}");
+    }
+}


### PR DESCRIPTION
## Summary

- list every existing render, activation, status, pruning, recovery, and IXP Manager lifecycle path in root help
- give each existing parser its literal displayed command path so mode-specific Usage lines are copyable
- pin root discovery and all nine operational Usage paths through the real binary

No accepted arguments, dispatch, exit codes, dependencies, or runtime behavior change.

## Checks

- focused root and nested help contracts
- full `rs-config-render` package tests
- strict package Clippy and formatting
- `just gate`
- push hooks: workspace tests and docs