### PR TITLE
api: report catalog persistence admission as unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Policy and peer-group mutations now report unavailable when configuration
+  persistence admission is closed or temporarily full.
+
 - Redirected daemon diffs no longer contain terminal color escapes, and the
   interactive CLI restores normal terminal mode if alternate-screen entry fails.
 

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -301,9 +301,9 @@ async fn reserve_config_event_slot(
     let permit = tokio::time::timeout(CONFIG_PERSIST_RESERVE_TIMEOUT, tx.reserve_owned())
         .await
         .map_err(|_| {
-            Status::internal("config persistence queue busy — refusing mutation to avoid drift")
+            Status::unavailable("config persistence queue busy — refusing mutation to avoid drift")
         })?
-        .map_err(|_| Status::internal("config persistence unavailable"))?;
+        .map_err(|_| Status::unavailable("config persistence unavailable"))?;
 
     Ok(Some(permit))
 }
@@ -783,6 +783,23 @@ mod tests {
     use crate::proto::peer_group_service_server::PeerGroupService as PeerGroupServiceRpc;
     use tokio::sync::mpsc::error::TryRecvError;
 
+    #[tokio::test(start_paused = true)]
+    async fn config_persistence_admission_failures_are_unavailable() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        let error = reserve_config_event_slot(Some(tx)).await.unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(error.message(), "config persistence unavailable");
+
+        let (tx, _rx) = mpsc::channel(1);
+        let _permit = tx.clone().reserve_owned().await.unwrap();
+        let error = reserve_config_event_slot(Some(tx)).await.unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(
+            error.message(),
+            "config persistence queue busy — refusing mutation to avoid drift"
+        );
+    }
     fn sample_definition() -> proto::PeerGroupDefinition {
         proto::PeerGroupDefinition {
             families: vec!["ipv4_unicast".into()],

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -294,9 +294,9 @@ async fn reserve_config_event_slot(
     let permit = tokio::time::timeout(CONFIG_PERSIST_RESERVE_TIMEOUT, tx.reserve_owned())
         .await
         .map_err(|_| {
-            Status::internal("config persistence queue busy — refusing mutation to avoid drift")
+            Status::unavailable("config persistence queue busy — refusing mutation to avoid drift")
         })?
-        .map_err(|_| Status::internal("config persistence unavailable"))?;
+        .map_err(|_| Status::unavailable("config persistence unavailable"))?;
 
     Ok(Some(permit))
 }
@@ -1746,6 +1746,23 @@ mod tests {
     use tokio::sync::mpsc::error::TryRecvError;
     use tokio::sync::oneshot;
 
+    #[tokio::test(start_paused = true)]
+    async fn config_persistence_admission_failures_are_unavailable() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        let error = reserve_config_event_slot(Some(tx)).await.unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(error.message(), "config persistence unavailable");
+
+        let (tx, _rx) = mpsc::channel(1);
+        let _permit = tx.clone().reserve_owned().await.unwrap();
+        let error = reserve_config_event_slot(Some(tx)).await.unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(
+            error.message(),
+            "config persistence queue busy — refusing mutation to avoid drift"
+        );
+    }
     fn sample_proto_definition() -> proto::PolicyDefinition {
         proto::PolicyDefinition {
             default_action: "permit".into(),


### PR DESCRIPTION
## Summary

- classify closed or saturated catalog persistence admission as gRPC `UNAVAILABLE`
- retain the existing timeout, messages, ordering, and no-effect failure boundary
- pin both closed and saturated behavior in the policy and peer-group helpers

## Validation

- `cargo test --locked -p rustbgpd-api`
- `cargo clippy --locked -p rustbgpd-api --all-targets -- -D warnings`
- `python3 scripts/check-v1-stable-surface.py`
- `cargo fmt --all -- --check`
- `just gate-rib`
- `just gate`
- `git diff --check`
