### PR TITLE
telemetry: report dropped session event sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Replace `bgp_session_lifecycle_source_dropped_total{reason}` with
+  `bgp_session_event_source_dropped_total{kind,reason}` so dropped state changes
+  and notifications are counted separately before peer-manager publication.
+
 - **Operator-visible:** config transactions no longer reject a full-snapshot
   candidate merely because `[policy] rpol_files` / `[policy.datasets]` are
   declared. The planner now captures every declared external file at plan and

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -466,7 +466,7 @@ struct BgpMetricsInner {
     // ── Event streams ───────────────────────────────────────────
     event_stream_lagged: IntCounterVec,
     event_stream_subscribers: IntGaugeVec,
-    session_lifecycle_source_dropped: IntCounterVec,
+    session_event_source_dropped: IntCounterVec,
     grpc_authz_decisions: IntCounterVec,
     grpc_credential_reloads: IntCounterVec,
     sighup_reload_outcomes: IntCounterVec,
@@ -1090,18 +1090,20 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
-        let session_lifecycle_source_dropped = IntCounterVec::new(
+        let session_event_source_dropped = IntCounterVec::new(
             Opts::new(
-                "bgp_session_lifecycle_source_dropped_total",
-                "Session lifecycle events dropped before process-local, live, and durable event history, by bounded reason.",
+                "bgp_session_event_source_dropped_total",
+                "Session events dropped before peer-manager publication, by bounded kind and reason.",
             ),
-            &["reason"],
+            &["kind", "reason"],
         )
         .expect("valid metric definition");
-        for reason in ["channel_full", "channel_closed"] {
-            session_lifecycle_source_dropped
-                .with_label_values(&[reason])
-                .inc_by(0);
+        for kind in ["state_change", "notification"] {
+            for reason in ["channel_full", "channel_closed"] {
+                session_event_source_dropped
+                    .with_label_values(&[kind, reason])
+                    .inc_by(0);
+            }
         }
 
         let grpc_authz_decisions = IntCounterVec::new(
@@ -2538,7 +2540,7 @@ impl BgpMetrics {
             .register(Box::new(event_stream_subscribers.clone()))
             .expect("metric not already registered");
         registry
-            .register(Box::new(session_lifecycle_source_dropped.clone()))
+            .register(Box::new(session_event_source_dropped.clone()))
             .expect("metric not already registered");
         registry
             .register(Box::new(grpc_authz_decisions.clone()))
@@ -3033,7 +3035,7 @@ impl BgpMetrics {
             orr_input_objects,
             event_stream_lagged,
             event_stream_subscribers,
-            session_lifecycle_source_dropped,
+            session_event_source_dropped,
             grpc_authz_decisions,
             grpc_credential_reloads,
             sighup_reload_outcomes,
@@ -3925,19 +3927,35 @@ impl BgpMetrics {
             .inc_by(missed);
     }
 
-    /// Record one session lifecycle event dropped because its source channel was full.
-    pub fn record_session_lifecycle_source_channel_full(&self) {
+    /// Record one session state change dropped because its source channel was full.
+    pub fn record_session_state_change_source_channel_full(&self) {
         self.0
-            .session_lifecycle_source_dropped
-            .with_label_values(&["channel_full"])
+            .session_event_source_dropped
+            .with_label_values(&["state_change", "channel_full"])
             .inc();
     }
 
-    /// Record one session lifecycle event dropped because its source channel was closed.
-    pub fn record_session_lifecycle_source_channel_closed(&self) {
+    /// Record one session state change dropped because its source channel was closed.
+    pub fn record_session_state_change_source_channel_closed(&self) {
         self.0
-            .session_lifecycle_source_dropped
-            .with_label_values(&["channel_closed"])
+            .session_event_source_dropped
+            .with_label_values(&["state_change", "channel_closed"])
+            .inc();
+    }
+
+    /// Record one session notification dropped because its source channel was full.
+    pub fn record_session_notification_source_channel_full(&self) {
+        self.0
+            .session_event_source_dropped
+            .with_label_values(&["notification", "channel_full"])
+            .inc();
+    }
+
+    /// Record one session notification dropped because its source channel was closed.
+    pub fn record_session_notification_source_channel_closed(&self) {
+        self.0
+            .session_event_source_dropped
+            .with_label_values(&["notification", "channel_closed"])
             .inc();
     }
 
@@ -6472,21 +6490,24 @@ mod tests {
     }
 
     #[test]
-    fn session_lifecycle_source_drop_series_are_bounded_and_accumulate_independently() {
+    fn session_event_source_drop_series_are_bounded_and_accumulate_independently() {
         let m = BgpMetrics::new();
 
         let samples = m
             .registry()
             .gather()
             .into_iter()
-            .find(|family| family.name() == "bgp_session_lifecycle_source_dropped_total")
-            .expect("session lifecycle source-drop metric registered")
+            .find(|family| family.name() == "bgp_session_event_source_dropped_total")
+            .expect("session event source-drop metric registered")
             .metric
             .into_iter()
             .map(|metric| {
-                assert_eq!(metric.get_label().len(), 1, "only reason label");
+                assert_eq!(metric.get_label().len(), 2, "kind and reason labels");
                 (
-                    metric.get_label()[0].value().to_owned(),
+                    (
+                        metric.get_label()[0].value().to_owned(),
+                        metric.get_label()[1].value().to_owned(),
+                    ),
                     metric.get_counter().value(),
                 )
             })
@@ -6494,23 +6515,51 @@ mod tests {
         assert_eq!(
             samples,
             std::collections::BTreeMap::from([
-                ("channel_closed".to_string(), 0.0),
-                ("channel_full".to_string(), 0.0),
+                (
+                    ("notification".to_string(), "channel_closed".to_string()),
+                    0.0
+                ),
+                (
+                    ("notification".to_string(), "channel_full".to_string()),
+                    0.0
+                ),
+                (
+                    ("state_change".to_string(), "channel_closed".to_string()),
+                    0.0
+                ),
+                (
+                    ("state_change".to_string(), "channel_full".to_string()),
+                    0.0
+                ),
             ])
         );
 
-        m.record_session_lifecycle_source_channel_full();
-        m.record_session_lifecycle_source_channel_full();
-        m.record_session_lifecycle_source_channel_closed();
+        m.record_session_state_change_source_channel_full();
+        m.record_session_state_change_source_channel_full();
+        m.record_session_state_change_source_channel_closed();
+        m.record_session_notification_source_channel_full();
+        m.record_session_notification_source_channel_closed();
         assert_eq!(
-            m.0.session_lifecycle_source_dropped
-                .with_label_values(&["channel_full"])
+            m.0.session_event_source_dropped
+                .with_label_values(&["state_change", "channel_full"])
                 .get(),
             2
         );
         assert_eq!(
-            m.0.session_lifecycle_source_dropped
-                .with_label_values(&["channel_closed"])
+            m.0.session_event_source_dropped
+                .with_label_values(&["state_change", "channel_closed"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.0.session_event_source_dropped
+                .with_label_values(&["notification", "channel_full"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.0.session_event_source_dropped
+                .with_label_values(&["notification", "channel_closed"])
                 .get(),
             1
         );

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -934,7 +934,8 @@ impl PeerSession {
             }) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {
-                    self.metrics.record_session_lifecycle_source_channel_full();
+                    self.metrics
+                        .record_session_state_change_source_channel_full();
                     debug!(
                         peer = %self.peer_label,
                         "dropped StateChanged lifecycle event because channel is full"
@@ -942,7 +943,7 @@ impl PeerSession {
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {
                     self.metrics
-                        .record_session_lifecycle_source_channel_closed();
+                        .record_session_state_change_source_channel_closed();
                     debug!(
                         peer = %self.peer_label,
                         "dropped StateChanged lifecycle event because channel is closed"

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -1665,8 +1665,16 @@ impl PeerSession {
 
         if let Err(e) = tx.try_send(event) {
             let reason = match e {
-                tokio::sync::mpsc::error::TrySendError::Full(_) => "channel_full",
-                tokio::sync::mpsc::error::TrySendError::Closed(_) => "channel_closed",
+                tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                    self.metrics
+                        .record_session_notification_source_channel_full();
+                    "channel_full"
+                }
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    self.metrics
+                        .record_session_notification_source_channel_closed();
+                    "channel_closed"
+                }
             };
             debug!(
                 peer = %self.peer_label,

--- a/crates/transport/src/session/tests/mod.rs
+++ b/crates/transport/src/session/tests/mod.rs
@@ -239,25 +239,58 @@ fn make_test_session_with_lifecycle(
     )
 }
 
-fn lifecycle_source_drop_value(metrics: &BgpMetrics, reason: &str) -> f64 {
-    counter_samples(metrics, "bgp_session_lifecycle_source_dropped_total")
-        .into_iter()
-        .find_map(|(labels, value)| {
-            (labels.get("reason").map(String::as_str) == Some(reason)).then_some(value)
-        })
-        .expect("preinitialized lifecycle source-drop series")
+fn make_test_session_with_event_source(
+    metrics: BgpMetrics,
+    event_tx: mpsc::Sender<SessionNotificationEvent>,
+) -> PeerSession {
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    PeerSession::new_with_identity_and_lifecycle(
+        config,
+        metrics,
+        cmd_rx,
+        rib_tx,
+        None,
+        None,
+        None,
+        Some(event_tx),
+        None,
+        None,
+        None,
+        false,
+        SessionIdentity::default(),
+    )
 }
 
-fn assert_lifecycle_source_drop_value(metrics: &BgpMetrics, reason: &str, expected: f64) {
-    let actual = lifecycle_source_drop_value(metrics, reason);
+fn session_event_source_drop_value(metrics: &BgpMetrics, kind: &str, reason: &str) -> f64 {
+    counter_samples(metrics, "bgp_session_event_source_dropped_total")
+        .into_iter()
+        .find_map(|(labels, value)| {
+            (labels.get("kind").map(String::as_str) == Some(kind)
+                && labels.get("reason").map(String::as_str) == Some(reason))
+            .then_some(value)
+        })
+        .expect("preinitialized session event source-drop series")
+}
+
+fn assert_session_event_source_drop_value(
+    metrics: &BgpMetrics,
+    kind: &str,
+    reason: &str,
+    expected: f64,
+) {
+    let actual = session_event_source_drop_value(metrics, kind, reason);
     assert!(
         (actual - expected).abs() < f64::EPSILON,
-        "expected lifecycle source-drop reason {reason} to equal {expected}, got {actual}"
+        "expected session event source-drop {kind}/{reason} to equal {expected}, got {actual}"
     );
 }
 
 #[tokio::test]
-async fn lifecycle_source_channel_full_records_one_drop() {
+async fn session_event_source_state_change_channel_full_records_one_drop() {
     let metrics = BgpMetrics::new();
     let (tx, _rx) = mpsc::channel(1);
     tx.try_send(SessionLifecycleNotification::StateChanged {
@@ -273,12 +306,12 @@ async fn lifecycle_source_channel_full_records_one_drop() {
 
     session.try_send_lifecycle_state_changed(SessionState::Idle, SessionState::Connect);
 
-    assert_lifecycle_source_drop_value(&metrics, "channel_full", 1.0);
-    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 0.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_full", 1.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_closed", 0.0);
 }
 
 #[tokio::test]
-async fn lifecycle_source_channel_closed_records_one_drop() {
+async fn session_event_source_state_change_channel_closed_records_one_drop() {
     let metrics = BgpMetrics::new();
     let (tx, rx) = mpsc::channel(1);
     drop(rx);
@@ -286,12 +319,12 @@ async fn lifecycle_source_channel_closed_records_one_drop() {
 
     session.try_send_lifecycle_state_changed(SessionState::Idle, SessionState::Connect);
 
-    assert_lifecycle_source_drop_value(&metrics, "channel_full", 0.0);
-    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 1.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_full", 0.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_closed", 1.0);
 }
 
 #[tokio::test]
-async fn lifecycle_source_success_delivers_exact_event_without_drop() {
+async fn session_event_source_state_change_success_delivers_exact_event_without_drop() {
     let metrics = BgpMetrics::new();
     let (tx, mut rx) = mpsc::channel(1);
     let session = make_test_session_with_lifecycle(metrics.clone(), Some(tx));
@@ -313,19 +346,89 @@ async fn lifecycle_source_success_delivers_exact_event_without_drop() {
     assert_eq!(peer_asn, None);
     assert_eq!(old, SessionState::Idle);
     assert_eq!(new, SessionState::Connect);
-    assert_lifecycle_source_drop_value(&metrics, "channel_full", 0.0);
-    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 0.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_full", 0.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_closed", 0.0);
 }
 
 #[test]
-fn absent_lifecycle_source_records_no_drop() {
+fn absent_session_event_source_records_no_drop() {
     let metrics = BgpMetrics::new();
     let session = make_test_session_with_lifecycle(metrics.clone(), None);
 
     session.try_send_lifecycle_state_changed(SessionState::Idle, SessionState::Connect);
 
-    assert_lifecycle_source_drop_value(&metrics, "channel_full", 0.0);
-    assert_lifecycle_source_drop_value(&metrics, "channel_closed", 0.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_full", 0.0);
+    assert_session_event_source_drop_value(&metrics, "state_change", "channel_closed", 0.0);
+}
+
+fn test_notification() -> NotificationMessage {
+    NotificationMessage {
+        code: NotificationCode::Cease,
+        subcode: 0,
+        data: Bytes::new(),
+    }
+}
+
+#[test]
+fn session_event_source_notification_channel_full_records_one_drop() {
+    let metrics = BgpMetrics::new();
+    let (tx, _rx) = mpsc::channel(1);
+    tx.try_send(SessionNotificationEvent {
+        session_id: 1,
+        role: SessionRole::Primary,
+        peer_addr: "192.0.2.1".parse().unwrap(),
+        direction: SessionNotificationDirection::Received,
+        code: 6,
+        subcode: 0,
+        description: "test".to_string(),
+        shutdown_reason: None,
+        failure_cause: None,
+    })
+    .unwrap();
+    let session = make_test_session_with_event_source(metrics.clone(), tx);
+
+    session.emit_notification_event(
+        SessionNotificationDirection::Received,
+        &test_notification(),
+        None,
+    );
+
+    assert_session_event_source_drop_value(&metrics, "notification", "channel_full", 1.0);
+    assert_session_event_source_drop_value(&metrics, "notification", "channel_closed", 0.0);
+}
+
+#[test]
+fn session_event_source_notification_channel_closed_records_one_drop() {
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(1);
+    drop(rx);
+    let session = make_test_session_with_event_source(metrics.clone(), tx);
+
+    session.emit_notification_event(
+        SessionNotificationDirection::Received,
+        &test_notification(),
+        None,
+    );
+
+    assert_session_event_source_drop_value(&metrics, "notification", "channel_full", 0.0);
+    assert_session_event_source_drop_value(&metrics, "notification", "channel_closed", 1.0);
+}
+
+#[tokio::test]
+async fn session_event_source_notification_success_delivers_without_drop() {
+    let metrics = BgpMetrics::new();
+    let (tx, mut rx) = mpsc::channel(1);
+    let session = make_test_session_with_event_source(metrics.clone(), tx);
+
+    session.emit_notification_event(
+        SessionNotificationDirection::Received,
+        &test_notification(),
+        None,
+    );
+
+    assert!(rx.recv().await.is_some());
+    assert_session_event_source_drop_value(&metrics, "notification", "channel_full", 0.0);
+    assert_session_event_source_drop_value(&metrics, "notification", "channel_closed", 0.0);
 }
 
 fn make_test_session_with_channels(

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -97,7 +97,7 @@ authoritative partial SIGHUP reloads and failed retained reload tasks,
 dynamic-neighbor admission near-limit and rejection,
 actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
 selection-deferral timeout and ledger overflow, outbound route loss, RFC 9687
-send-hold teardown, session lifecycle source loss, live event-stream
+send-hold teardown, session event source loss, live event-stream
 lag/desynchronization, BMP feed loss,
 stale MRT dumps, and daemon down)
 ships at
@@ -125,12 +125,13 @@ the last increment ages out:
   incremental events. Treat that consumer's local view as desynchronized:
   take a fresh authoritative snapshot for the named service and source, then
   restart the live watch. Use a durable cursor only when that API supports one.
-- `BgpSessionLifecycleSourceDrops` is warning severity because a session state
-  change was lost before process-local, live, and durable event history. The
-  `reason` label distinguishes a full source channel from a closed receiver.
-  Treat all incremental session history as potentially incomplete and
-  resnapshot current neighbor state. The alert clears after the last source
-  drop ages out of its 10-minute window; a flat historical counter stays quiet.
+- `BgpSessionEventSourceDrops` is warning severity because a session event was
+  lost before peer-manager publication. The `kind` label distinguishes
+  `state_change` from `notification`; `reason` distinguishes a full source
+  channel from a closed receiver. For state-change loss, take a fresh neighbor
+  snapshot. For notification loss, consult the structured daemon logs. The
+  alert clears after the last source drop ages out of its 10-minute window; a
+  flat historical counter stays quiet.
 - `BmpSourceDrops`, `BmpLocRibSourceDrops`, and `BmpCollectorDrops` are warning
   severity because routing is unaffected. For `BmpSourceDrops`,
   `channel_full` and `channel_closed` mean a source-channel event or report was

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1196,16 +1196,18 @@ signal.
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `bgp_session_lifecycle_source_dropped_total{reason}` | Session state changes dropped before process-local, live, or durable event history because the bounded source channel was `channel_full` or `channel_closed`. Both reason series exist at zero from startup. |
+| `bgp_session_event_source_dropped_total{kind,reason}` | Session `state_change` or `notification` events dropped before peer-manager publication because the bounded source channel was `channel_full` or `channel_closed`. All four bounded series exist at zero from startup. |
 | `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`; `source` is `route`, `session`, `policy`, `evpn`, `dataplane`, `dataplane_route`, or `bfd` where applicable |
 | `bgp_event_stream_subscribers{service,source}` | Current live stream subscriber count by service/source |
 | `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rbgp events` history queries |
 | `bgp_route_event_history_capacity` | Fixed capacity of the bounded unicast route-event history ring |
 
 These counters identify distinct loss boundaries. A non-zero
-`bgp_session_lifecycle_source_dropped_total` means the peer manager never
-received a state change, so process-local event history, live delivery, and
-durable history may all be incomplete; resnapshot current neighbor state.
+`bgp_session_event_source_dropped_total` means the peer manager never received
+the named event kind. For `state_change`, take a fresh neighbor snapshot before
+consuming further incremental state events. For `notification`, consult the
+structured daemon logs for the corresponding BGP NOTIFICATION or local
+teardown cause.
 `WatchEvents` is a live tail, not a durable queue. Non-zero
 `bgp_event_stream_lagged_total` means at least one live subscriber fell behind
 after the event reached the peer manager; combine a fresh snapshot or `ListRouteEvents`

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -491,22 +491,23 @@ groups:
             socket, so rustbgpd tore down the session without a NOTIFICATION;
             inspect the writer and peer before allowing the session to recover.
 
-      - alert: BgpSessionLifecycleSourceDrops
-        # Source loss happens before process-local, live, and durable session-event history.
-        expr: increase(bgp_session_lifecycle_source_dropped_total[10m]) > 0
+      - alert: BgpSessionEventSourceDrops
+        # Source loss happens before peer-manager publication.
+        expr: increase(bgp_session_event_source_dropped_total[10m]) > 0
         for: 0m
         labels:
           severity: warning
         annotations:
           summary: >-
-            Session lifecycle source dropped events ({{ $labels.reason }})
+            Session event source dropped {{ $labels.kind }} events ({{ $labels.reason }})
           description: >-
-            bgp_session_lifecycle_source_dropped_total for reason
-            {{ $labels.reason }} on {{ $labels.instance }} increased by
-            {{ $value | printf "%.0f" }} in the last 10 minutes. Session event
-            history, live delivery, and durable history may be incomplete;
-            resnapshot current neighbor state before consuming further
-            incremental session events.
+            bgp_session_event_source_dropped_total for kind {{ $labels.kind }}
+            and reason {{ $labels.reason }} on {{ $labels.instance }} increased
+            by {{ $value | printf "%.0f" }} in the last 10 minutes. For
+            state_change loss, take a fresh neighbor snapshot before consuming
+            further incremental state events. For notification loss, consult
+            the structured daemon logs for the corresponding BGP NOTIFICATION
+            or local teardown cause.
 
       - alert: BgpEventStreamLagged
         # A live subscriber that falls behind misses events and can no longer

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -1499,50 +1499,54 @@ tests:
         alertname: BgpSendHoldExpired
         exp_alerts: []
 
-  # ── BgpSessionLifecycleSourceDrops ────────────────────────
+  # ── BgpSessionEventSourceDrops ────────────────────────────
   - interval: 1m
     input_series:
-      - series: 'bgp_session_lifecycle_source_dropped_total{reason="channel_full", instance="edge1:9179"}'
+      - series: 'bgp_session_event_source_dropped_total{kind="state_change", reason="channel_full", instance="edge1:9179"}'
         values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
-      - series: 'bgp_session_lifecycle_source_dropped_total{reason="channel_closed", instance="edge2:9179"}'
+      - series: 'bgp_session_event_source_dropped_total{kind="notification", reason="channel_closed", instance="edge2:9179"}'
         values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
-      - series: 'bgp_session_lifecycle_source_dropped_total{reason="channel_full", instance="edge3:9179"}'
+      - series: 'bgp_session_event_source_dropped_total{kind="state_change", reason="channel_full", instance="edge3:9179"}'
         values: "7x22"
       - series: 'bgp_event_stream_lagged_total{service="watch_events", source="session", instance="edge4:9179"}'
         values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
     alert_rule_test:
       - eval_time: 2m
-        alertname: BgpSessionLifecycleSourceDrops
+        alertname: BgpSessionEventSourceDrops
         exp_alerts: []
       - eval_time: 10m
-        alertname: BgpSessionLifecycleSourceDrops
+        alertname: BgpSessionEventSourceDrops
         exp_alerts:
           - exp_labels:
               severity: warning
+              kind: state_change
               reason: channel_full
               instance: edge1:9179
             exp_annotations:
-              summary: "Session lifecycle source dropped events (channel_full)"
+              summary: "Session event source dropped state_change events (channel_full)"
               description: >-
-                bgp_session_lifecycle_source_dropped_total for reason
-                channel_full on edge1:9179 increased by 1 in the last 10
-                minutes. Session event history, live delivery, and durable
-                history may be incomplete; resnapshot current neighbor state
-                before consuming further incremental session events.
+                bgp_session_event_source_dropped_total for kind state_change
+                and reason channel_full on edge1:9179 increased by 1 in the
+                last 10 minutes. For state_change loss, take a fresh neighbor
+                snapshot before consuming further incremental state events.
+                For notification loss, consult the structured daemon logs for
+                the corresponding BGP NOTIFICATION or local teardown cause.
           - exp_labels:
               severity: warning
+              kind: notification
               reason: channel_closed
               instance: edge2:9179
             exp_annotations:
-              summary: "Session lifecycle source dropped events (channel_closed)"
+              summary: "Session event source dropped notification events (channel_closed)"
               description: >-
-                bgp_session_lifecycle_source_dropped_total for reason
-                channel_closed on edge2:9179 increased by 1 in the last 10
-                minutes. Session event history, live delivery, and durable
-                history may be incomplete; resnapshot current neighbor state
-                before consuming further incremental session events.
+                bgp_session_event_source_dropped_total for kind notification
+                and reason channel_closed on edge2:9179 increased by 1 in the
+                last 10 minutes. For state_change loss, take a fresh neighbor
+                snapshot before consuming further incremental state events.
+                For notification loss, consult the structured daemon logs for
+                the corresponding BGP NOTIFICATION or local teardown cause.
       - eval_time: 21m
-        alertname: BgpSessionLifecycleSourceDrops
+        alertname: BgpSessionEventSourceDrops
         exp_alerts: []
 
   # ── BgpEventStreamLagged ──────────────────────────────────

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -26,8 +26,8 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
         added, removed = check.validate_release_notes(baseline, current, section)
 
         self.assertEqual(len(baseline), 204)
-        self.assertEqual(added, set())
-        self.assertEqual(removed, set())
+        self.assertEqual(added, {"bgp_session_event_source_dropped_total"})
+        self.assertEqual(removed, {"bgp_session_lifecycle_source_dropped_total"})
 
     def test_consumed_new_family_without_release_note_fails(self):
         baseline = {"bgp_existing_total"}


### PR DESCRIPTION
## Summary

- replace the pre-stable lifecycle source-drop family with one bounded session-event metric
- distinguish state-change and notification loss across full and closed source channels
- update the single alert, recovery guidance, and release-note contract without dual emission

## Validation

- focused telemetry and transport tests
- strict telemetry and transport Clippy
- metric consumer and release-note checker suites plus live checks
- Prometheus 3.4.1 rule validation and alert tests
- `cargo fmt --all -- --check`
- `just gate-rib`
- `just gate`
- `git diff --check`
