### PR TITLE
Add max_as_path_length ceiling for received AS_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `rbgp neighbor <addr>` detail row `Reconnect In`, and its JSON key
   `reconnect_in_seconds` report the remaining wait. Older daemons leave the
   API field absent; JSON omits the value when absent or zero.
+- Add `[global] max_as_path_length` (default `750`, `0` disables), a ceiling
+  on the number of AS numbers accepted in a received `AS_PATH`. A longer path
+  carrying reachable NLRI is handled as RFC 7606 treat-as-withdraw and counted
+  under `bgp_update_malformed_total{disposition="treat_as_withdraw"}`; without
+  reachable NLRI, RFC 7606 section 5.2 requires a session reset.
 
 ### Fixed
 
@@ -255,6 +260,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   memory results, exact-release FIB and Enhanced Route Refresh refreshes, and
   source-equivalent IXP, route-server-1000, RR1000, and twelve-root IRR reload
   receipts with compact checksummed artifacts and explicit claim boundaries.
+
+### Upgrade notes
+
+- Received `AS_PATH` attributes with more than 750 AS numbers and reachable
+  NLRI are now treated as withdraw by default; without reachable NLRI, the
+  session resets. Deployments that must relay arbitrarily long paths set
+  `[global] max_as_path_length = 0` to keep the previous behavior.
 
 ## [0.68.0] — 2026-08-30
 

--- a/bench/scale/rrtransport/src/main.rs
+++ b/bench/scale/rrtransport/src/main.rs
@@ -169,6 +169,7 @@ fn transport_config(remote: SocketAddr) -> TransportConfig {
         rs_control_communities: false,
         remove_private_as: RemovePrivateAs::Disabled,
         discard_path_attributes: Arc::from([]),
+        max_as_path_length: rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH,
         cluster_id: Some(Ipv4Addr::new(127, 255, 0, 1)),
         explain_enabled: false,
         explain_cache_size: 0,

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -496,6 +496,12 @@ pub struct TransportConfig {
     pub remove_private_as: RemovePrivateAs,
     /// Canonical inbound attribute type codes discarded after safety checks.
     pub discard_path_attributes: std::sync::Arc<[u8]>,
+    /// Maximum number of AS numbers accepted in a received `AS_PATH`;
+    /// prepends and individual `AS_SET` members each count. An over-ceiling
+    /// path carrying reachable NLRI is RFC 7606 treat-as-withdraw; without
+    /// reachable NLRI, RFC 7606 section 5.2 requires a session reset. `0`
+    /// disables the ceiling.
+    pub max_as_path_length: u16,
     /// Local cluster ID for route reflection. `Some` means this speaker is a
     /// route reflector; used for `CLUSTER_LIST` prepend and loop detection.
     pub cluster_id: Option<Ipv4Addr>,
@@ -551,6 +557,9 @@ pub const DEFAULT_SLOW_PEER_THRESHOLD_PCT: u8 = 50;
 /// Default slow-peer persistence duration (seconds) before the flag is
 /// raised.
 pub const DEFAULT_SLOW_PEER_DURATION_SECS: u32 = 30;
+/// Default ceiling on the number of AS numbers accepted in a received
+/// `AS_PATH`.
+pub const DEFAULT_MAX_AS_PATH_LENGTH: u16 = 750;
 
 impl TransportConfig {
     /// Default TCP connect timeout (30 seconds).
@@ -590,6 +599,7 @@ impl TransportConfig {
             rs_control_communities: false,
             remove_private_as: RemovePrivateAs::Disabled,
             discard_path_attributes: std::sync::Arc::from([]),
+            max_as_path_length: DEFAULT_MAX_AS_PATH_LENGTH,
             cluster_id: None,
             explain_enabled: false,
             explain_cache_size: crate::session::import_decision_cache::DEFAULT_EXPLAIN_CACHE_SIZE,

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -51,11 +51,11 @@ impl ExplainSnapshotBenchCache {
 }
 
 pub use config::{
-    DEFAULT_SLOW_PEER_DURATION_SECS, DEFAULT_SLOW_PEER_THRESHOLD_PCT, RemovePrivateAs,
-    TCP_AO_MAX_INSPECT_KEYS, TcpAoAlgorithm, TcpAoConfig, TcpAoKeyring, TcpAoRotationGeneration,
-    TcpAoRotationOperation, TcpAoRotationOwner, TcpAoRotationPhase, TcpAoRotationStatus,
-    TcpAoSessionDeletion, TcpAoSessionGeneration, TcpAoSessionSelection, TransportAuthSecret,
-    TransportConfig,
+    DEFAULT_MAX_AS_PATH_LENGTH, DEFAULT_SLOW_PEER_DURATION_SECS, DEFAULT_SLOW_PEER_THRESHOLD_PCT,
+    RemovePrivateAs, TCP_AO_MAX_INSPECT_KEYS, TcpAoAlgorithm, TcpAoConfig, TcpAoKeyring,
+    TcpAoRotationGeneration, TcpAoRotationOperation, TcpAoRotationOwner, TcpAoRotationPhase,
+    TcpAoRotationStatus, TcpAoSessionDeletion, TcpAoSessionGeneration, TcpAoSessionSelection,
+    TransportAuthSecret, TransportConfig,
 };
 pub use error::TransportError;
 pub use event_sink::{

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1385,17 +1385,25 @@ impl PeerSession {
                 && self.use_extended_nexthop_ipv4(),
         };
         let mut validation_payload: Option<(u8, Vec<u8>)> = None;
-        if let Err(update_err) = rustbgpd_wire::validate::validate_update_attributes_with_options(
+        let validation = rustbgpd_wire::validate::validate_update_attributes_with_options(
             &parsed.attributes,
             has_nlri,
             has_body_nlri,
             is_ebgp,
             validation_options,
-        ) {
+        )
+        .and_then(|()| {
+            rustbgpd_wire::validate::validate_as_path_ceiling(
+                &parsed.attributes,
+                self.config.max_as_path_length,
+            )
+        });
+        if let Err(update_err) = validation {
             warn!(
                 peer = %self.peer_label,
                 subcode = update_err.subcode,
                 disposition = update_err.disposition.as_str(),
+                max_as_path_length = self.config.max_as_path_length,
                 "UPDATE validation error"
             );
             self.debug_dump_malformed_update(&update, &parsed);

--- a/crates/transport/src/session/tests/rfc7606.rs
+++ b/crates/transport/src/session/tests/rfc7606.rs
@@ -1665,3 +1665,62 @@ fn malformed_update_dump_is_untruncated_and_enumerates_nlri() {
         "MP family withdrawal enumerated: {listed}"
     );
 }
+
+/// ORIGIN, an `AS_SEQUENCE` of `hops` copies of AS 65002 (four-octet), and
+/// `NEXT_HOP`, for exercising the `max_as_path_length` ceiling.
+fn as_path_attr_bytes(hops: u8) -> Vec<u8> {
+    let mut attrs = vec![0x40, 1, 1, 0]; // ORIGIN = IGP
+    attrs.extend([0x40, 2, 2 + 4 * hops, 2, hops]);
+    for _ in 0..hops {
+        attrs.extend([0, 0, 0xFD, 0xEA]);
+    }
+    attrs.extend([0x40, 3, 4, 10, 0, 0, 2]); // NEXT_HOP 10.0.0.2
+    attrs
+}
+
+/// `max_as_path_length`: a path exactly at the ceiling is accepted; one
+/// element over takes the RFC 7606 treat-as-withdraw path — the replacement
+/// is withdrawn, the session stays Established, and the disposition metric
+/// records exactly one `treat_as_withdraw` row.
+#[tokio::test]
+async fn as_path_ceiling_withdraws_route_and_keeps_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.max_as_path_length = 3;
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    session
+        .process_update(rfc7606_update(as_path_attr_bytes(3), &[prefix]))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected the at-ceiling path to be accepted");
+    };
+    assert_eq!(announced.len(), 1);
+    assert_single_malformed_disposition(&session, "none");
+
+    session
+        .process_update(rfc7606_update(as_path_attr_bytes(4), &[prefix]))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx.try_recv().unwrap()
+    else {
+        panic!("expected treat-as-withdraw RoutesReceived");
+    };
+    assert!(
+        announced.is_empty(),
+        "a path over the ceiling must not admit any announcement"
+    );
+    assert_eq!(withdrawn, vec![(Prefix::V4(prefix), 0)]);
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(
+        session.fsm.state(),
+        SessionState::Established,
+        "the ceiling must keep the session Established"
+    );
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
+}

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -107,6 +107,7 @@ fn transport_config(addr: SocketAddr) -> TransportConfig {
         rs_control_communities: false,
         remove_private_as: rustbgpd_transport::RemovePrivateAs::Disabled,
         discard_path_attributes: std::sync::Arc::from([]),
+        max_as_path_length: rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH,
         cluster_id: None,
         explain_enabled: true,
         explain_cache_size: 4096,

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -9,6 +9,9 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
   `AS4_AGGREGATOR`. Revised decoding treats an ordinary path containing AS 0
   as withdraw and discards affected compatibility and aggregator attributes;
   canonical encoding rejects AS 0 before compatibility sidecars are derived.
+- Add `validate_as_path_ceiling`, an optional bounded ceiling on the number of
+  AS numbers in `AS_PATH`, enforced as treat-as-withdraw (subcode 11). `0`
+  leaves validation unchanged.
 
 ## 0.19.0 - 2026-08-30
 

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -341,6 +341,40 @@ fn check_as_path(path: &AsPath) -> Result<(), UpdateError> {
     }
     Ok(())
 }
+
+/// Enforce an operational ceiling on received `AS_PATH` elements.
+///
+/// Every sequence occurrence is counted, including prepends, and every
+/// `AS_SET` member counts individually. `0` disables the ceiling. Call this
+/// after [`validate_update_attributes`] or
+/// [`validate_update_attributes_with_options`] so ordinary RFC validation
+/// takes precedence.
+///
+/// # Errors
+///
+/// Returns malformed-AS_PATH with treat-as-withdraw when the path exceeds
+/// `max_as_path_length`.
+pub fn validate_as_path_ceiling(
+    attrs: &[PathAttribute],
+    max_as_path_length: u16,
+) -> Result<(), UpdateError> {
+    if max_as_path_length == 0 {
+        return Ok(());
+    }
+    let limit = usize::from(max_as_path_length);
+    let exceeds_limit = attrs.iter().any(|attr| match attr {
+        PathAttribute::AsPath(path) => path.asns().nth(limit).is_some(),
+        _ => false,
+    });
+    if exceeds_limit {
+        return Err(UpdateError {
+            subcode: update_subcode::MALFORMED_AS_PATH,
+            data: vec![],
+            disposition: ErrorDisposition::TreatAsWithdraw,
+        });
+    }
+    Ok(())
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -988,5 +1022,42 @@ mod tests {
         ];
         let err = validate_update_attributes(&attrs, false, false, true).unwrap_err();
         assert_eq!(err.disposition, ErrorDisposition::SessionReset);
+    }
+    fn as_path_attrs(segments: Vec<AsPathSegment>) -> Vec<PathAttribute> {
+        vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath { segments }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)),
+        ]
+    }
+    #[test]
+    fn as_path_ceiling_accepts_at_limit_and_withdraws_one_over() {
+        let at_limit = as_path_attrs(vec![AsPathSegment::AsSequence(vec![65001; 3])]);
+        assert!(validate_as_path_ceiling(&at_limit, 3).is_ok());
+        let one_over = as_path_attrs(vec![AsPathSegment::AsSequence(vec![65001; 4])]);
+        let err = validate_as_path_ceiling(&one_over, 3).unwrap_err();
+        assert_eq!(err.subcode, update_subcode::MALFORMED_AS_PATH);
+        assert_eq!(err.disposition, ErrorDisposition::TreatAsWithdraw);
+        assert!(err.data.is_empty(), "the diagnostic never carries the path");
+    }
+    #[test]
+    fn as_path_ceiling_zero_disables_and_ordinary_validation_is_unchanged() {
+        let long = as_path_attrs(vec![AsPathSegment::AsSequence(vec![65001; 2000])]);
+        assert!(validate_as_path_ceiling(&long, 0).is_ok());
+        assert!(validate_update_attributes(&long, true, true, true).is_ok());
+    }
+    #[test]
+    fn as_path_ceiling_counts_prepends_and_set_members() {
+        // Two prepended sequence members plus two set members are four wire
+        // elements even though RFC 4271 section 9.1.2.2 scores the set as one
+        // hop for best-path selection.
+        let attrs = as_path_attrs(vec![
+            AsPathSegment::AsSequence(vec![65001, 65001]),
+            AsPathSegment::AsSet(vec![65002, 65003]),
+        ]);
+        assert!(validate_as_path_ceiling(&attrs, 4).is_ok());
+        let err = validate_as_path_ceiling(&attrs, 3).unwrap_err();
+        assert_eq!(err.subcode, update_subcode::MALFORMED_AS_PATH);
+        assert_eq!(err.disposition, ErrorDisposition::TreatAsWithdraw);
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -193,6 +193,7 @@ Required. Defines the local BGP speaker identity.
 | `listen_port`       | u16    | yes      | --                   | TCP port to listen on (typically 179). When `listen_addresses` is absent, the daemon uses `0.0.0.0` and `[::]`; an unavailable family is skipped while the other keeps serving, and startup fails only when neither binds. Explicit endpoints instead bind atomically |
 | `listen_addresses`  | array of IP strings | no | -- | Exact local BGP endpoints and active-open source addresses. Omission preserves the tolerant dual-wildcard listener. When present, the list must be nonempty with at most one address per family; every listed address must be a usable unicast endpoint (unspecified, multicast, IPv4 broadcast, IPv4-mapped IPv6, and IPv6 link-local are rejected); every configured peer and dynamic range must use a listed family; and every bind is atomic. Scoped IPv6 link-local `[[neighbors]]` and `[[dynamic_neighbors]]` entries are not supported alongside an explicit list — keep those deployments on the default dual-wildcard listener. **Restart-required.** |
 | `dynamic_neighbor_limit` | u32 | no     | `100`                | Maximum number of auto-accepted dynamic peers (must be > 0) |
+| `max_as_path_length` | u16 | no       | `750`                | Maximum number of AS numbers accepted in a received `AS_PATH`, counted across every segment with prepends and `AS_SET` members included. A longer path carrying reachable NLRI is handled as RFC 7606 treat-as-withdraw (subcode 11): its routes are withdrawn, the session stays Established, and `bgp_update_malformed_total{disposition="treat_as_withdraw"}` increments. Without reachable NLRI, RFC 7606 section 5.2 requires a session reset. `0` disables the ceiling. Distinct from the `as_path_length` policy match, which filters without withdrawing. **Restart-required.** |
 | `worker_threads`    | usize  | no       | `min(cores, 8)`      | Tokio runtime worker threads. Unset caps to `min(CPU parallelism, 8)` to avoid over-provisioning the async runtime (one worker + stack reservation per core) on a high-core host for this I/O-bound daemon — reduces virtual-address reservation and scheduler footprint (RSS-neutral in benchmarks). `0` means unset. `RUSTBGPD_WORKER_THREADS` overrides. **Restart-required** (runtime built once at startup). |
 | `runtime_state_dir` | string | no       | `"/var/lib/rustbgpd"` | Directory for daemon-owned runtime state (GR restart marker, optional warm checkpoint, FIB and BLACKHOLE ownership receipts, and gRPC socket) |
 | `warm_cache_checkpoint_on_shutdown` | bool | no | `false`             | Publish a bounded daemon-private routing checkpoint during coordinated shutdown. **Restart-required.** Publication only; startup does not restore routes. |
@@ -224,6 +225,7 @@ listen_port = 179
 # listen_addresses = ["192.0.2.10", "2001:db8::10"]
 runtime_state_dir = "/var/lib/rustbgpd"
 warm_cache_checkpoint_on_shutdown = false
+max_as_path_length = 750
 honor_graceful_shutdown = true
 honor_blackhole = true
 install_blackhole_discard = false

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -407,6 +407,20 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   state. Canonical encoding rejects it before deriving type 17/18
   compatibility attributes.
 
+## AS_PATH Element Ceiling (`max_as_path_length`)
+
+- `[global] max_as_path_length` (default 750, `0` disables) bounds the
+  number of AS numbers accepted in a received `AS_PATH`, counted across every
+  segment with prepends and `AS_SET` members included. A longer path carrying
+  reachable NLRI is treat-as-withdraw through the RFC 7606 validation path
+  (subcode 11): its routes are withdrawn, the session stays Established, and
+  `bgp_update_malformed_total{disposition="treat_as_withdraw"}` increments.
+  Without reachable NLRI, RFC 7606 section 5.2 requires a session reset. The
+  log line carries the ceiling, never the path.
+- The ceiling is an operational guard (draft-ietf-grow-bgpopsecupd), not an
+  RFC requirement; OpenBGPD applies the same 750-element limit. The wire
+  crate exposes `validate_as_path_ceiling`; `0` leaves it off.
+
 ## RFC 9774 — AS_SET / AS_CONFED_SET Deprecation
 
 - The revised inbound attribute decoder inspects raw AS_PATH and AS4_PATH

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -268,6 +268,7 @@ that are stood up once at startup. Two flags are hot-pluggable.
 | `blackhole_discard_install_burst` | restart-required | The reconciler captures the install-attempt burst at startup; SIGHUP pins the running value. |
 | `multipath_relax` | restart-required | RIB best-path tie-break behavior; reconciling mid-flight would require an Adj-RIB-Out rebuild. |
 | `link_bandwidth_weighted` | restart-required | Weighted-multipath behavior (ADR-0068). |
+| `max_as_path_length` | restart-required | Threaded into each session's transport config when the peer is built; running sessions keep the ceiling they started with. |
 | `dynamic_neighbor_limit` | restart-required | Admission cap compared live against the dynamic-peer counter (inbound admission and LRU eviction bound); nothing is pre-allocated. SIGHUP pins the runtime snapshot to the startup value while retaining the edited desired value for restart. |
 | `worker_threads` | restart-required | Tokio runtime worker-thread count; the runtime is built once at startup. Unset caps to `min(CPU parallelism, 8)`; `RUSTBGPD_WORKER_THREADS` overrides. |
 | `warm_cache_checkpoint_on_shutdown` | restart-required | The shutdown checkpoint writer and its pinned runtime-state directory are selected at startup. |

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1097,6 +1097,14 @@
           "maximum": 65535,
           "minimum": 0
         },
+        "max_as_path_length": {
+          "description": "Maximum number of AS numbers accepted in a received `AS_PATH`,\ncounted across every segment with prepends and `AS_SET` members\nincluded. An over-ceiling path carrying reachable NLRI is RFC 7606\ntreat-as-withdraw; without reachable NLRI, RFC 7606 section 5.2\nrequires a session reset. `0` disables the ceiling.",
+          "type": "integer",
+          "format": "uint16",
+          "default": 750,
+          "maximum": 65535,
+          "minimum": 0
+        },
         "multipath_relax": {
           "description": "ADR-0066 multipath-relax (FRR's `bgp bestpath as-path multipath-relax`).\nWhen `true`, unicast ECMP groups equal-cost candidates by `AS_PATH`\n*length* instead of an exact `AS_PATH` match, so equal-length paths through\ndifferent ASes co-install as multipath. Off by default (exact match). It\nis a best-path-wide knob, so it lives here rather than per\n`[[fib_tables]]`; it is inert unless a table sets `maximum_paths`,\n`maximum_paths_ebgp`, or `maximum_paths_ibgp` above 1.",
           "type": "boolean",

--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -908,6 +908,7 @@ impl Config {
         // reflects routes with no CLUSTER_LIST prepend and skips inbound
         // cluster-loop detection until the daemon restarts.
         transport.cluster_id = self.cluster_id();
+        transport.max_as_path_length = self.global.max_as_path_length;
         // ADR-0073: this is the second transport-construction path (the
         // resolved-neighbor one used by snapshot-sync gRPC peer adds);
         // it must thread the explain knobs just like

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -927,6 +927,13 @@ pub struct Global {
     /// changing it requires a daemon restart.
     #[serde(default)]
     pub warm_cache_checkpoint_on_shutdown: bool,
+    /// Maximum number of AS numbers accepted in a received `AS_PATH`,
+    /// counted across every segment with prepends and `AS_SET` members
+    /// included. An over-ceiling path carrying reachable NLRI is RFC 7606
+    /// treat-as-withdraw; without reachable NLRI, RFC 7606 section 5.2
+    /// requires a session reset. `0` disables the ceiling.
+    #[serde(default = "default_max_as_path_length")]
+    pub max_as_path_length: u16,
     /// Directory for daemon-owned runtime state files.
     #[serde(default = "default_runtime_state_dir")]
     pub runtime_state_dir: String,
@@ -937,6 +944,10 @@ pub struct Global {
 
 fn default_runtime_state_dir() -> String {
     "/var/lib/rustbgpd".to_string()
+}
+
+fn default_max_as_path_length() -> u16 {
+    rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -516,6 +516,34 @@ remote_asn = 65001
 peer_group = "rr"
 "#;
 
+#[test]
+fn global_max_as_path_length_defaults_and_zero_disables_the_ceiling_per_session() {
+    let default = parse_strict(V1_EFFECTIVE_DEFAULTS_TOML).expect("default fixture must load");
+    assert_eq!(
+        default.global.max_as_path_length,
+        rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH
+    );
+    assert_eq!(
+        default
+            .resolve_neighbor(&default.neighbors[0])
+            .expect("bare neighbor must resolve")
+            .transport_config
+            .max_as_path_length,
+        rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH
+    );
+    let toml = V1_EFFECTIVE_DEFAULTS_TOML.replacen(
+        "listen_port = 179",
+        "listen_port = 179\nmax_as_path_length = 0",
+        1,
+    );
+    let config = parse_strict(&toml).expect("explicit ceiling fixture must load");
+    assert_eq!(config.global.max_as_path_length, 0);
+    let bare = config
+        .resolve_neighbor(&config.neighbors[0])
+        .expect("bare neighbor must resolve");
+    assert_eq!(bare.transport_config.max_as_path_length, 0);
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "the v1 inventory checker requires all contextual-default proofs in one named test"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8493,6 +8493,7 @@ peer_group = "plain"
                 blackhole_discard_install_burst: None,
                 ebgp_requires_policy: None,
                 warm_cache_checkpoint_on_shutdown: false,
+                max_as_path_length: rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH,
             },
             security: crate::config::SecurityConfig::default(),
             neighbors: vec![

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -524,6 +524,7 @@ impl PeerManager {
                     blackhole_discard_install_burst: None,
                     ebgp_requires_policy: None,
                     warm_cache_checkpoint_on_shutdown: false,
+                    max_as_path_length: rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH,
                 },
                 // PeerManager::new constructs an in-memory baseline
                 // Config before the operator's TOML is applied. The
@@ -932,6 +933,7 @@ impl PeerManager {
         transport.remove_private_as = config.remove_private_as;
         transport.discard_path_attributes = config.discard_path_attributes.clone();
         transport.cluster_id = self.cluster_id;
+        transport.max_as_path_length = self.current_config.global.max_as_path_length;
         // ADR-0073: per-session import-decision explain cache wiring.
         // Both the enable flag and the capacity must be threaded — a
         // missing `explain_enabled` here would silently leave the

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -228,6 +228,7 @@ fn make_dynamic_manager_config() -> Config {
             blackhole_discard_install_burst: None,
             ebgp_requires_policy: None,
             warm_cache_checkpoint_on_shutdown: false,
+            max_as_path_length: rustbgpd_transport::DEFAULT_MAX_AS_PATH_LENGTH,
         },
         security: crate::config::SecurityConfig {
             grpc: crate::config::GrpcSecurityConfig {

--- a/src/peer_manager/tests/transport_config.rs
+++ b/src/peer_manager/tests/transport_config.rs
@@ -56,6 +56,34 @@ fn build_transport_config_threads_policy_explain_settings() {
 }
 
 #[test]
+fn build_transport_config_threads_max_as_path_length() {
+    // Same field-threading hazard as the explain knobs: a missed line
+    // would leave every session at the TransportConfig::new default and
+    // silently ignore an operator's `0` (off) or tighter ceiling.
+    let (_, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    mgr.current_config.global.max_as_path_length = 0;
+
+    let config = make_config(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 65002);
+    let transport = mgr.build_transport_config(&config);
+    assert_eq!(
+        transport.max_as_path_length, 0,
+        "max_as_path_length must propagate"
+    );
+}
+
+#[test]
 fn build_transport_config_threads_reject_retention_settings() {
     // LAN-472: both [policy.reject_retention] knobs must propagate from
     // the daemon config snapshot into the per-session TransportConfig —

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1850,6 +1850,7 @@ fn pin_unreconciled_daemon_runtime_fields(new_config: &mut Config, current: &Con
     new_config.global.link_bandwidth_weighted = current.global.link_bandwidth_weighted;
     new_config.global.warm_cache_checkpoint_on_shutdown =
         current.global.warm_cache_checkpoint_on_shutdown;
+    new_config.global.max_as_path_length = current.global.max_as_path_length;
     new_config
         .global
         .runtime_state_dir
@@ -7645,6 +7646,7 @@ honor_blackhole = true
 multipath_relax = true
 link_bandwidth_weighted = true
 warm_cache_checkpoint_on_shutdown = true
+max_as_path_length = 901
 runtime_state_dir = "/tmp/rustbgpd-reload-edited"
 
 [global.telemetry]
@@ -7702,6 +7704,7 @@ hold_time = 90
                 runtime.global.warm_cache_checkpoint_on_shutdown,
                 startup.global.warm_cache_checkpoint_on_shutdown
             );
+            assert_eq!(runtime.global.max_as_path_length, 750);
             assert_eq!(
                 runtime.global.runtime_state_dir,
                 startup.global.runtime_state_dir


### PR DESCRIPTION
## Summary

- Adds `[global] max_as_path_length` (`u16`, default `750`, `0` disables), a ceiling on the number of AS numbers accepted in a received `AS_PATH`. Sequence prepends and individual `AS_SET` members each count.
- Keeps the existing `UpdateValidationOptions` API unchanged. `rustbgpd-wire` exposes an additive `validate_as_path_ceiling` helper, and the daemon invokes it after ordinary RFC validation so existing validation errors retain precedence.
- Stops scanning as soon as the element at `limit + 1` is observed; paths at the limit are accepted.

## Operator-visible behavior

- A path over the ceiling that carries reachable NLRI follows RFC 7606 treat-as-withdraw (subcode 11): affected routes are withdrawn, the session stays Established, and `bgp_update_malformed_total{disposition="treat_as_withdraw"}` increments.
- When the malformed UPDATE carries no reachable NLRI, the existing RFC 7606 section 5.2 escalation resets the session.
- The existing validation warning records the configured ceiling, never the path itself.
- The knob is restart-required. SIGHUP keeps the running value pinned while retaining an edited value in the desired snapshot for the next restart.
- `0` preserves the previous unbounded behavior. The policy-language `as_path_length` match remains a separate filtering control.

## Compatibility

- `rustbgpd-wire`: additive public function only; no field was added to the exhaustively constructible `UpdateValidationOptions`, and ordinary validation entry points are unchanged. Recorded in `crates/wire/CHANGELOG.md` under Unreleased.
- `rustbgpd-transport`: internal, unpublished `TransportConfig` carries the per-session ceiling and exports the default constant. Both daemon construction paths and the standalone scale consumer set it.
- Configuration schema: one optional global field with a serde default. The v1 stable RPC surface, wire encoding, and metric names are unchanged.
- The root changelog includes the default behavior change and an upgrade note for deployments that need an unbounded path.

## Tests

- Wire tests cover at-limit acceptance, one-over rejection, `0` disabling, unchanged ordinary validation, prepends, and individual `AS_SET` members.
- A transport session test admits the at-limit route, treats the one-over replacement as withdraw, removes the prior route, preserves Established state, and records one malformed disposition.
- Config tests cover the default, explicit `0`, per-session resolution, both transport construction paths, schema freshness, and repeated SIGHUP pinning with desired drift retained.
- The scale-harness transport literal uses the shared default.

## Checks run

- Focused wire, transport, config, reload, schema, and transport-threading tests
- `python3 scripts/check-v1-stable-surface.py`
- `cargo semver-checks check-release -p rustbgpd-wire` — 196 checks passed
- `cargo fmt --all -- --check`
- `just gate`
- `just gate-rib`
- `just gate-deps`
- `just gate-contract`
- Commit and push hooks

No new dependency, crate-version change, interoperability harness, RPC, or metric was added.
