### PR TITLE
Export bgp_peer_info and join it in the dashboard and alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   configured. Enabling the bound on an Established session requests a route
   refresh so existing rejections are recounted (ADR-0108 amendment).
 
+- **Operator-visible:** export one
+  `bgp_peer_info{peer,interface,remote_asn,description,peer_group}` identity
+  gauge per configured and dynamic peer so dashboards and alerts can name a
+  member instead of its bare address. The row is published on install,
+  replaced in place on a description, peer-group, or learned-ASN change, and
+  reaped with the other per-peer series on delete; `description` and
+  `peer_group` are scrubbed of control characters and bounded to 128
+  characters. The shipped overview dashboard adds a **Peer identity** row
+  with a `group_left(remote_asn, description)` join, and
+  `BgpSessionNotEstablished` now carries `remote_asn`, `description`, and
+  `peer_group` labels with a fallback that still fires for peers without an
+  identity row. No existing metric family or label changes.
+
 ### Changed
 
 - Reject AS 0 in received and locally encoded AS paths and aggregators per RFC

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -133,6 +133,25 @@ impl Collector for EventOutboxQueueDepthCollector {
     }
 }
 
+/// Longest `description` or `peer_group` label value `bgp_peer_info`
+/// exports, in characters; longer configured values are truncated.
+pub const PEER_INFO_LABEL_MAX_CHARS: usize = 128;
+
+/// Scrub one free-text `bgp_peer_info` label value: drop control
+/// characters (newlines, tabs, escapes), trim surrounding whitespace, and
+/// bound the result to [`PEER_INFO_LABEL_MAX_CHARS`] characters.
+#[must_use]
+pub fn scrub_info_label(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
+        .trim()
+        .chars()
+        .take(PEER_INFO_LABEL_MAX_CHARS)
+        .collect()
+}
+
 /// Canonical `peer` label value: the neighbor's bare IP address.
 ///
 /// **Every** `peer`-labeled series exported by this crate uses this one
@@ -409,6 +428,7 @@ struct BgpMetricsInner {
     peer_admin_enabled: IntGaugeVec,
     peer_session_established: IntGaugeVec,
     peer_session_state: IntGaugeVec,
+    peer_info: IntGaugeVec,
     session_down: IntCounterVec,
     stale_timer_events: IntCounterVec,
     session_notification_outstanding_value: Arc<AtomicI64>,
@@ -762,6 +782,21 @@ impl BgpMetrics {
                 "Active-primary BGP FSM state as an exact six-row one-hot gauge",
             ),
             &["peer", "interface", "state"],
+        )
+        .expect("valid metric definition");
+
+        let peer_info = IntGaugeVec::new(
+            Opts::new(
+                "bgp_peer_info",
+                "Configured peer identity for dashboard and alert joins (always 1)",
+            ),
+            &[
+                "peer",
+                "interface",
+                "remote_asn",
+                "description",
+                "peer_group",
+            ],
         )
         .expect("valid metric definition");
 
@@ -2429,6 +2464,9 @@ impl BgpMetrics {
             .register(Box::new(peer_session_state.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(peer_info.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(session_down.clone()))
             .expect("metric not already registered");
         registry
@@ -2998,6 +3036,7 @@ impl BgpMetrics {
             peer_admin_enabled,
             peer_session_established,
             peer_session_state,
+            peer_info,
             session_down,
             stale_timer_events,
             dynamic_neighbor_slots_used,
@@ -3268,6 +3307,7 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.0.peer_admin_enabled, peer);
         Self::reap_peer_series_from_vec(&self.0.peer_session_established, peer);
         Self::reap_peer_series_from_vec(&self.0.peer_session_state, peer);
+        Self::reap_peer_series_from_vec(&self.0.peer_info, peer);
         Self::reap_peer_series_from_vec(&self.0.session_down, peer);
         Self::reap_peer_series_from_vec(&self.0.stale_timer_events, peer);
         Self::reap_peer_series_from_vec(&self.0.bfd_session_up, peer);
@@ -3396,6 +3436,10 @@ impl BgpMetrics {
         let labels = &[peer, interface];
         let _ = self.0.peer_admin_enabled.remove_label_values(labels);
         let _ = self.0.peer_session_established.remove_label_values(labels);
+        Self::reap_label_series_from_vec(
+            &self.0.peer_info,
+            &[("peer", peer), ("interface", interface)],
+        );
         for state in SESSION_STATES {
             let _ = self
                 .0
@@ -3414,11 +3458,11 @@ impl BgpMetrics {
         vec: &prometheus::core::MetricVec<T>,
         peer: &str,
     ) -> usize {
-        Self::reap_label_series_from_vec(vec, "peer", peer)
+        Self::reap_label_series_from_vec(vec, &[("peer", peer)])
     }
 
-    /// Remove every series of one Vec metric whose `label` label equals
-    /// `value`.
+    /// Remove every series of one Vec metric whose labels equal every
+    /// `(label, value)` pair in `matches`.
     ///
     /// The prometheus crate has no wildcard removal —
     /// `remove_label_values` needs the exact, complete label-value
@@ -3429,8 +3473,7 @@ impl BgpMetrics {
     /// remove them one by one.
     fn reap_label_series_from_vec<T: prometheus::core::MetricVecBuilder>(
         vec: &prometheus::core::MetricVec<T>,
-        label: &str,
-        value: &str,
+        matches: &[(&str, &str)],
     ) -> usize {
         use prometheus::core::Collector;
 
@@ -3442,10 +3485,11 @@ impl BgpMetrics {
         for family in vec.collect() {
             for metric in family.get_metric() {
                 let labels = metric.get_label();
-                if !labels
-                    .iter()
-                    .any(|pair| pair.name() == label && pair.value() == value)
-                {
+                if !matches.iter().all(|(label, value)| {
+                    labels
+                        .iter()
+                        .any(|pair| pair.name() == *label && pair.value() == *value)
+                }) {
                     continue;
                 }
                 // Every declared variable label must be present on the
@@ -3501,6 +3545,38 @@ impl BgpMetrics {
             .peer_admin_enabled
             .with_label_values(&[peer, interface])
             .set(i64::from(enabled));
+    }
+
+    /// Publish the configured identity of one exact `(peer, interface)` peer
+    /// for `group_left` joins from dashboards and alert rules.
+    ///
+    /// Any prior `bgp_peer_info` series for that identity is removed first,
+    /// so a reconfigured description or peer group, or an ASN learned from
+    /// OPEN on an accept-any dynamic range, never leaves a stale identity
+    /// beside the current one. `description` and `peer_group` are scrubbed
+    /// by [`scrub_info_label`].
+    pub fn set_peer_info(
+        &self,
+        peer: &str,
+        interface: &str,
+        remote_asn: u32,
+        description: &str,
+        peer_group: &str,
+    ) {
+        Self::reap_label_series_from_vec(
+            &self.0.peer_info,
+            &[("peer", peer), ("interface", interface)],
+        );
+        self.0
+            .peer_info
+            .with_label_values(&[
+                peer,
+                interface,
+                &remote_asn.to_string(),
+                &scrub_info_label(description),
+                &scrub_info_label(peer_group),
+            ])
+            .set(1);
     }
 
     /// Publish whether the active-primary session is Established.
@@ -5565,9 +5641,12 @@ impl BgpMetrics {
     /// (`BmpManager`'s `Drop`) so a collector that leaves the config does
     /// not keep its series alive in a long-lived registry.
     pub fn reap_bmp_collector_series(&self, collector: &str) {
-        Self::reap_label_series_from_vec(&self.0.bmp_collector_drops, "collector", collector);
-        Self::reap_label_series_from_vec(&self.0.bmp_replay_attempts, "collector", collector);
-        Self::reap_label_series_from_vec(&self.0.bmp_control_event_drops, "collector", collector);
+        Self::reap_label_series_from_vec(&self.0.bmp_collector_drops, &[("collector", collector)]);
+        Self::reap_label_series_from_vec(&self.0.bmp_replay_attempts, &[("collector", collector)]);
+        Self::reap_label_series_from_vec(
+            &self.0.bmp_control_event_drops,
+            &[("collector", collector)],
+        );
     }
 
     // ── Event history outbox (ADR-0072) ─────────────────────────
@@ -6259,6 +6338,63 @@ mod tests {
                 .count(),
             6
         );
+    }
+
+    #[test]
+    fn peer_info_replaces_prior_identity_and_reaps_exactly() {
+        let m = BgpMetrics::new();
+        m.set_peer_info("192.0.2.1", "", 64496, "Example Member", "members");
+        m.set_peer_info("fe80::1", "eth0", 64497, "Scoped A", "");
+        m.set_peer_info("fe80::1", "eth1", 64498, "Scoped B", "");
+
+        let text = gather_text(&m);
+        assert!(text.contains(
+            r#"bgp_peer_info{description="Example Member",interface="",peer="192.0.2.1",peer_group="members",remote_asn="64496"} 1"#
+        ));
+
+        // A reconfigured description and a learned ASN replace the series
+        // for that exact identity instead of accumulating beside it.
+        m.set_peer_info("192.0.2.1", "", 64499, "Renamed Member", "members");
+        let text = gather_text(&m);
+        assert!(!text.contains(r#"description="Example Member""#));
+        assert!(text.contains(
+            r#"bgp_peer_info{description="Renamed Member",interface="",peer="192.0.2.1",peer_group="members",remote_asn="64499"} 1"#
+        ));
+        assert_eq!(text.matches(r"bgp_peer_info{").count(), 3);
+
+        // The exact identity reap spares the scoped sibling; the bare
+        // address reap removes whatever remains for the address.
+        m.reap_peer_identity_series("fe80::1", "eth0");
+        let text = gather_text(&m);
+        assert!(!text.contains(r#"description="Scoped A""#));
+        assert!(text.contains(r#"description="Scoped B""#));
+        m.reap_peer_series("fe80::1");
+        let text = gather_text(&m);
+        assert!(!text.contains(r#"peer="fe80::1""#));
+        assert!(text.contains(r#"description="Renamed Member""#));
+    }
+
+    #[test]
+    fn peer_info_scrubs_control_characters_and_bounds_free_text_labels() {
+        assert_eq!(
+            scrub_info_label("  Example\tMember\n\u{7f} "),
+            "ExampleMember"
+        );
+        assert_eq!(scrub_info_label("\u{1b}[31mred\u{1b}[0m"), "[31mred[0m");
+        assert_eq!(scrub_info_label(""), "");
+        let long = "é".repeat(PEER_INFO_LABEL_MAX_CHARS + 1);
+        let bounded = scrub_info_label(&long);
+        assert_eq!(bounded.chars().count(), PEER_INFO_LABEL_MAX_CHARS);
+        assert_eq!(bounded, "é".repeat(PEER_INFO_LABEL_MAX_CHARS));
+        let exact = "x".repeat(PEER_INFO_LABEL_MAX_CHARS);
+        assert_eq!(scrub_info_label(&exact), exact);
+
+        let m = BgpMetrics::new();
+        m.set_peer_info("192.0.2.1", "", 0, "line one\nline two", "grp\u{0}");
+        let text = gather_text(&m);
+        assert!(text.contains(
+            r#"bgp_peer_info{description="line oneline two",interface="",peer="192.0.2.1",peer_group="grp",remote_asn="0"} 1"#
+        ));
     }
 
     #[test]
@@ -8126,6 +8262,7 @@ mod tests {
         m.set_peer_admin_enabled(peer, "", true);
         m.set_peer_session_established(peer, "", false);
         m.set_peer_session_state(peer, "", "established");
+        m.set_peer_info(peer, "", 64496, "Example Member", "members");
         m.record_session_down(
             peer,
             "",
@@ -8217,9 +8354,9 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 68 peer-labeled series; state transitions hold two, while exact
+        // 69 peer-labeled series; state transitions hold two, while exact
         // state and down-reason vocabularies materialize six rows each.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 68);
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 69);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -8229,7 +8366,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 68);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 69);
     }
 
     /// Load-bearing finite/unlimited proof: removing either finite gauge
@@ -8473,7 +8610,7 @@ mod tests {
     // `gather()`, so no runtime check can catch one that is added and
     // left unpopulated; this list plus the struct doc comment is the
     // practical ceiling.
-    const PEER_LABELED_FAMILIES: [&str; 57] = [
+    const PEER_LABELED_FAMILIES: [&str; 58] = [
         "bfd_session_flaps_total",
         "bfd_session_up",
         "bgp_as_path_loop_detected_total",
@@ -8503,6 +8640,7 @@ mod tests {
         "bgp_outbound_route_drops_total",
         "bgp_path_attribute_discarded_total",
         "bgp_peer_admin_enabled",
+        "bgp_peer_info",
         "bgp_peer_outbound_queue_depth",
         "bgp_peer_session_established",
         "bgp_peer_session_state",

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -74,7 +74,13 @@ Template variables:
   identifies a peer the same way, by its bare neighbor address
   (`192.0.2.1`, `2001:db8::1`), so one selector drives every per-peer panel
   and `by (peer)` joins across families match. Supports multiple values
-  and All.
+  and All. The selector value stays the bare address; the member's ASN,
+  description, and peer group live on the
+  `bgp_peer_info{peer,interface,remote_asn,description,peer_group}` identity
+  metric, and the **Peer identity** row joins it onto session truth with
+  `* on (instance, peer, interface) group_left(remote_asn, description)` so a
+  legend can read `Example Member AS64496 192.0.2.1` instead of the address
+  alone. Copy that join onto any other per-peer panel that needs a name.
 
 Per-peer series are reaped when a peer is deleted, so stale values age out after
 the next scrape.
@@ -106,6 +112,12 @@ with per-rule unit tests in
 [`rustbgpd-alerts_test.yml`](../examples/prometheus/rustbgpd-alerts_test.yml)
 (`promtool test rules`). It assumes the scrape config above
 (`job_name: rustbgpd`).
+
+`BgpSessionNotEstablished` joins `bgp_peer_info` with
+`group_left(remote_asn, description, peer_group)`, so its alert labels carry
+the member identity for routing and notification templates. A peer with no
+identity row still fires through an `or ignoring(...)` fallback without those
+labels; the join can add labels but never suppress the alert.
 
 The loss alerts use a 10-minute counter-increase window and clear after
 the last increment ages out:
@@ -172,6 +184,13 @@ inside the bounded window does.
   defensive `unknown`. Local initiation remains the cause when best-effort
   NOTIFICATION delivery fails; neither query adds an alert or overview-dashboard
   panel.
+- **Peer identity** lists every selected `bgp_peer_info` row as an instant
+  table, and **Session truth by member identity** repeats the Established
+  state from the session-truth panel with the joined legend. A peer whose
+  identity row is absent stays visible on the session-truth panel and is
+  simply missing from the joined one. `description` falls back to the
+  neighbor address when none is configured; free-text labels are scrubbed of
+  control characters and bounded to 128 characters.
 - Exact-export rejection and malformed-UPDATE disposition rates share the
   `$peer` selector, like every other per-peer panel.
   Outbound route-drop and RFC 9687 send-hold alerts preserve that same `peer`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -985,12 +985,18 @@ families keyed by other identities (AFI/SAFI, VRF, VNI, BMP collector) are
 never removed.
 
 The exact `bgp_peer_admin_enabled{peer,interface}`,
-`bgp_peer_session_established{peer,interface}`, and
-`bgp_peer_session_state{peer,interface,state}` identity is removed after its
-session actor terminates, including abort-on-timeout teardown. Its matching
-`bgp_session_down_total{peer,interface,reason}` history is reaped at the same
-identity boundary. If a scoped sibling shares the bare address, its exact rows
-and the shared bare-address history remain.
+`bgp_peer_session_established{peer,interface}`,
+`bgp_peer_session_state{peer,interface,state}`, and
+`bgp_peer_info{peer,interface,remote_asn,description,peer_group}` identity is
+removed after its session actor terminates, including abort-on-timeout
+teardown. Its matching `bgp_session_down_total{peer,interface,reason}` history
+is reaped at the same identity boundary. If a scoped sibling shares the bare
+address, its exact rows and the shared bare-address history remain.
+
+`bgp_peer_info` holds exactly one row per exact `(peer, interface)` identity.
+Editing a neighbor's description or peer group, or learning the ASN from OPEN
+on an accept-any dynamic range, replaces that row rather than adding a second
+one beside it, so `group_left` joins never match two identities for one peer.
 
 ### Health
 
@@ -999,6 +1005,7 @@ and the shared bare-address history remain.
 | `bgp_peer_admin_enabled{peer,interface}` | Authoritative configured administrative intent: 1 enabled, 0 disabled |
 | `bgp_peer_session_established{peer,interface}` | Current active-primary session truth: 1 Established, 0 otherwise |
 | `bgp_peer_session_state{peer,interface,state}` | Exact active-primary one-hot FSM state; `state` is `idle`, `connect`, `active`, `open_sent`, `open_confirm`, or `established` |
+| `bgp_peer_info{peer,interface,remote_asn,description,peer_group}` | Configured identity of each exact peer, always `1`. Join it onto any per-peer family with `* on (instance, peer, interface) group_left(remote_asn, description, peer_group) bgp_peer_info` so dashboards and alerts name the member instead of the bare address. `remote_asn` is the configured ASN, or the ASN learned from OPEN for an accept-any dynamic range (`0` until then); `description` falls back to the neighbor address when none is configured, and dynamic peers without a range description carry `dynamic:<peer_group>`; `peer_group` is empty for ungrouped neighbors. `description` and `peer_group` are scrubbed — control characters dropped, surrounding whitespace trimmed, and bounded to 128 characters |
 | `bgp_session_established_total` | Cumulative sessions that reached Established (per-process counter; resets on restart) |
 | `bgp_session_flaps_total` | Cumulative session flaps |
 | `bgp_session_down_total{peer,interface,reason}` | Established active-primary sessions that ended. `local_notification` means a locally initiated NOTIFICATION teardown even if best-effort delivery failed; `remote_notification` means a received NOTIFICATION; `local_no_notification` includes forced local close such as send-hold expiry; `remote_no_notification` means remote TCP close without a NOTIFICATION; the remaining bounded values are `transport_error` and defensive `unknown`. |

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -3036,6 +3036,81 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 75,
+      "type": "row",
+      "title": "Peer identity",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 200 },
+      "panels": []
+    },
+    {
+      "id": 76,
+      "type": "table",
+      "title": "Peer identity",
+      "description": "Configured identity of every selected peer from bgp_peer_info: remote ASN, description, and peer group. The description falls back to the neighbor address when none is configured; free-text labels are scrubbed and bounded to 128 characters.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 201 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0 },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [ { "id": "custom.hidden", "value": true } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Time" },
+            "properties": [ { "id": "custom.hidden", "value": true } ]
+          }
+        ]
+      },
+      "options": { "showHeader": true },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_peer_info{instance=~\"$instance\",peer=~\"$peer\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 77,
+      "type": "timeseries",
+      "title": "Session truth by member identity",
+      "description": "The exact active-primary Established state from the session-truth panel, joined to bgp_peer_info so the legend names the member instead of the bare address. A peer with no bgp_peer_info row is absent here and still visible on the session-truth panel.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 201 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_peer_session_established{instance=~\"$instance\",peer=~\"$peer\"} * on (instance, peer, interface) group_left(remote_asn, description) bgp_peer_info{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{description}} AS{{remote_asn}} {{peer}} {{interface}}",
+          "refId": "A"
+        }
+      ]
     }
   ]
 }

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -18,6 +18,9 @@
 # Every `peer` label is the bare neighbor address ("192.0.2.1",
 # "2001:db8::1") in every metric family, so `by (peer)` aggregations and
 # joins across families work without rewriting the label.
+# `bgp_peer_info{peer,interface,remote_asn,description,peer_group}` is the
+# configured identity of each exact peer; BgpSessionNotEstablished joins it
+# so the alert labels carry the member ASN, description, and peer group.
 #
 # Unit tests: rustbgpd-alerts_test.yml (`promtool test rules`).
 
@@ -126,10 +129,24 @@ groups:
         # Exact configured identity join: catches enabled peers that have never
         # Established as well as peers that established previously and went
         # down. Disabled peers and a healthy scoped sibling do not match.
+        # The `bgp_peer_info` join carries the member identity into the alert
+        # labels; a peer without an identity row still fires through the
+        # `or ignoring` fallback, so a missing row can never suppress the alert.
         expr: >-
-          bgp_peer_admin_enabled == 1
-          and on (instance, peer, interface)
-          bgp_peer_session_established == 0
+          (
+            bgp_peer_admin_enabled == 1
+            and on (instance, peer, interface)
+            bgp_peer_session_established == 0
+          )
+          * on (instance, peer, interface)
+            group_left(remote_asn, description, peer_group)
+            bgp_peer_info
+          or ignoring(remote_asn, description, peer_group)
+          (
+            bgp_peer_admin_enabled == 1
+            and on (instance, peer, interface)
+            bgp_peer_session_established == 0
+          )
         for: 2m
         labels:
           severity: critical

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -364,7 +364,9 @@ tests:
 
   # Current-truth matrix for BgpSessionNotEstablished. Historical counters
   # cannot suppress or fabricate the level alert, and interface identity keeps
-  # scoped siblings independent.
+  # scoped siblings independent. Only 192.0.2.10 carries a `bgp_peer_info`
+  # row: its alert must carry the identity labels exactly once, while the
+  # peers without a row must still fire without them.
   - interval: 1m
     input_series:
       # Enabled and never Established.
@@ -372,6 +374,8 @@ tests:
         values: "1x6"
       - series: 'bgp_peer_session_established{peer="192.0.2.10", interface="", instance="edge1:9179"}'
         values: "0x6"
+      - series: 'bgp_peer_info{peer="192.0.2.10", interface="", remote_asn="64496", description="Example Member", peer_group="members", instance="edge1:9179"}'
+        values: "1x6"
       # Established previously, now down.
       - series: 'bgp_peer_admin_enabled{peer="192.0.2.11", interface="", instance="edge1:9179"}'
         values: "1x6"
@@ -416,6 +420,9 @@ tests:
               severity: critical
               peer: 192.0.2.10
               instance: edge1:9179
+              remote_asn: "64496"
+              description: Example Member
+              peer_group: members
             exp_annotations:
               summary: "BGP session to 192.0.2.10 not Established"
               description: >-

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -470,6 +470,14 @@ TARGETS = {
     ("BLACKHOLE active rows", "A"): (
         'bgp_blackhole_discard_active{instance=~"$instance"}'
     ),
+    ("Peer identity", "A"): (
+        'bgp_peer_info{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Session truth by member identity", "A"): (
+        'bgp_peer_session_established{instance=~"$instance",peer=~"$peer"} '
+        "* on (instance, peer, interface) group_left(remote_asn, description) "
+        'bgp_peer_info{instance=~"$instance",peer=~"$peer"}'
+    ),
 }
 
 REQUIRED_LEGENDS = {
@@ -508,6 +516,9 @@ REQUIRED_LEGENDS = {
     ("BLACKHOLE discard activity", "A"): "{{instance}} installed/s",
     ("BLACKHOLE discard activity", "B"): "{{instance}} withdrawn/s",
     ("BLACKHOLE active rows", "A"): "{{instance}} active",
+    ("Session truth by member identity", "A"): (
+        "{{description}} AS{{remote_asn}} {{peer}} {{interface}}"
+    ),
 }
 
 ROUTE_SAFETY_PANELS = {
@@ -1311,6 +1322,34 @@ def main() -> None:
     }
     if active_options != expected_active_options:
         fail("BLACKHOLE active rows must retain its exact stat reduction options")
+
+    identity_panel = next(
+        (panel for panel in panels if panel.get("title") == "Peer identity"
+         and panel.get("type") != "row"),
+        None,
+    )
+    if identity_panel is None or identity_panel.get("type") != "table":
+        fail("peer identity must be a discrete table panel")
+    identity_target = identity_panel["targets"][0]
+    if identity_target.get("format") != "table" or identity_target.get("instant") is not True:
+        fail("peer identity target must be an instant table query")
+
+    member_panel = next(
+        (panel for panel in panels
+         if panel.get("title") == "Session truth by member identity"),
+        None,
+    )
+    if member_panel is None or member_panel.get("type") != "timeseries":
+        fail("session truth by member identity must be a timeseries panel")
+    member_defaults = member_panel.get("fieldConfig", {}).get("defaults", {})
+    if (
+        member_defaults.get("decimals") != 0
+        or member_defaults.get("min") != 0
+        or member_defaults.get("max") != 1
+    ):
+        fail("session truth by member identity must be pinned to whole 0..1 values")
+    if member_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
+        fail("session truth by member identity must use step interpolation")
 
     try:
         references = dashboard_metric_references(dashboard)

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -640,8 +640,8 @@ def workspace_metric_inventory(
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 204:
-        raise ValueError(f"emitted metric roster changed: expected 204, got {len(inventory)}")
+    if len(inventory) != 205:
+        raise ValueError(f"emitted metric roster changed: expected 205, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -417,6 +417,57 @@ let families = self.allocated.collect();'''
         with self.assertRaisesRegex(ValueError, "exactly one.*counts=.*Active DF"):
             self.check_evpn(dashboard)
 
+    def test_peer_identity_join_mutations_fail_closed(self):
+        dashboard = json.loads(CHECK.DASHBOARD.read_text(encoding="utf-8"))
+        panels = CHECK.all_panels(dashboard["panels"])
+        member = next(
+            panel for panel in panels
+            if panel["title"] == "Session truth by member identity"
+        )
+        identity = next(
+            panel for panel in panels
+            if panel["title"] == "Peer identity" and panel["type"] != "row"
+        )
+        join = member["targets"][0]["expr"]
+        self.assertIn("group_left(remote_asn, description)", join)
+        self.assertEqual(
+            CHECK.expression_metric_names(join),
+            {"bgp_peer_session_established", "bgp_peer_info"},
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            copy = Path(directory) / "dashboard.json"
+            original, CHECK.DASHBOARD = CHECK.DASHBOARD, copy
+            try:
+                copy.write_text(json.dumps(dashboard), encoding="utf-8")
+                with redirect_stdout(io.StringIO()):
+                    CHECK.main()
+                mutations = (
+                    (member["targets"][0], "expr",
+                     join.replace(" * on (instance, peer, interface) group_left(remote_asn, description) bgp_peer_info{instance=~\"$instance\",peer=~\"$peer\"}", "")),
+                    (member["targets"][0], "expr",
+                     join.replace("group_left(remote_asn, description)", "group_left(remote_asn)")),
+                    (member["targets"][0], "legendFormat", "{{peer}}"),
+                    (member["fieldConfig"]["defaults"], "max", 2),
+                    (identity, "type", "timeseries"),
+                    (identity["targets"][0], "instant", False),
+                    (identity["targets"][0], "expr", 'bgp_peer_admin_enabled{instance=~"$instance",peer=~"$peer"}'),
+                )
+                for subject, field, replacement in mutations:
+                    saved = subject[field]
+                    subject[field] = replacement
+                    copy.write_text(json.dumps(dashboard), encoding="utf-8")
+                    with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+                        CHECK.main()
+                    subject[field] = saved
+                for panel_id in (member["id"], identity["id"]):
+                    self.assertTrue(self.remove_panel(dashboard["panels"], panel_id))
+                    copy.write_text(json.dumps(dashboard), encoding="utf-8")
+                    with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+                        CHECK.main()
+                    dashboard = json.loads(original.read_text(encoding="utf-8"))
+            finally:
+                CHECK.DASHBOARD = original
+
     def test_live_dashboard_presentation_mutations_pass_full_check(self):
         dashboard = json.loads(CHECK.DASHBOARD.read_text(encoding="utf-8"))
         for index, panel in enumerate(CHECK.all_panels(dashboard["panels"])):

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,21 +47,21 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 204)
+        self.assertEqual(len(self.inventory), 205)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
-            191,
+            192,
         )
         self.assertEqual(
             len(CHECK.settlement_metric_inventory(self.sources[CHECK.SETTLEMENT])), 4
         )
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
-        self.assertEqual(len(self.dashboard_refs), 97)
-        self.assertEqual(len(self.rule_refs), 43)
-        self.assertEqual(len(self.public_doc_refs), 193)
-        self.assertEqual(len(self.doc_refs), 193)
+        self.assertEqual(len(self.dashboard_refs), 98)
+        self.assertEqual(len(self.rule_refs), 44)
+        self.assertEqual(len(self.public_doc_refs), 194)
+        self.assertEqual(len(self.doc_refs), 194)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 198)
+        self.assertEqual(len(consumers), 199)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("204 emitted families", stdout.getvalue())
-        self.assertIn("193 normative-doc families", stdout.getvalue())
-        self.assertIn("198 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("205 emitted families", stdout.getvalue())
+        self.assertIn("194 normative-doc families", stdout.getvalue())
+        self.assertIn("199 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -26,7 +26,9 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
         added, removed = check.validate_release_notes(baseline, current, section)
 
         self.assertEqual(len(baseline), 204)
-        self.assertEqual(added, {"bgp_session_event_source_dropped_total"})
+        self.assertEqual(
+            added, {"bgp_session_event_source_dropped_total", "bgp_peer_info"}
+        )
         self.assertEqual(removed, {"bgp_session_lifecycle_source_dropped_total"})
 
     def test_consumed_new_family_without_release_note_fails(self):

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -562,6 +562,7 @@ impl PeerManager {
                 self.peers.insert(peer_key.clone(), managed);
                 self.register_session(session_id, &peer_key);
                 self.sync_owned_session_metrics(&peer_key).await;
+                self.publish_peer_info_metric(&peer_key);
                 self.dynamic_peer_count += 1;
                 self.refresh_dynamic_neighbor_capacity_metrics();
                 // ADR-0112: the accepted child carries the range's pinned

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -62,6 +62,22 @@ impl PeerManager {
         );
     }
 
+    /// Publish the `bgp_peer_info` identity join series from the installed
+    /// [`ManagedPeer`]. A peer that has gone away is skipped; its series are
+    /// dropped by the identity and bare-address reaps on removal.
+    pub(super) fn publish_peer_info_metric(&self, peer: &PeerKey) {
+        let Some(managed) = self.peers.get(peer) else {
+            return;
+        };
+        self.metrics.set_peer_info(
+            &rustbgpd_telemetry::peer_label(peer.address),
+            peer.interface.as_deref().unwrap_or(""),
+            managed.remote_asn,
+            &managed.description,
+            managed.peer_group.as_deref().unwrap_or(""),
+        );
+    }
+
     pub(super) fn seed_peer_truth_metrics(&self, peer: &PeerKey, enabled: bool) {
         let peer_label = rustbgpd_telemetry::peer_label(peer.address);
         let interface = peer.interface.as_deref().unwrap_or("");
@@ -749,6 +765,7 @@ impl PeerManager {
         );
         self.register_session(session_id, &peer_key);
         self.sync_owned_session_metrics(&peer_key).await;
+        self.publish_peer_info_metric(&peer_key);
 
         if let Some(next_config) = next_config {
             self.current_config = next_config;

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -1221,6 +1221,7 @@ impl PeerManager {
         managed.transport_config.gr_peer_restart_time_max = config.gr_peer_restart_time_max;
         managed.transport_config.local_ipv6_nexthop = config.local_ipv6_nexthop;
         managed.transport_config.remove_private_as = config.remove_private_as;
+        self.publish_peer_info_metric(&peer);
         info!(%peer, "hot-applied neighbor config change in place (no session rebuild)");
         Ok(())
     }

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -235,6 +235,7 @@ impl PeerManager {
                             self.peers.insert(peer_key.clone(), managed);
                             self.register_session(session_id, &peer_key);
                             self.seed_peer_truth_metrics(&peer_key, false);
+                            self.publish_peer_info_metric(&peer_key);
                             info!(%peer_addr, "retained dynamic peer disabled after terminal max-prefix signal during retirement");
                         } else {
                             // Auto-removal is authoritative when no terminal
@@ -445,6 +446,9 @@ impl PeerManager {
         {
             managed.remote_asn = peer_asn;
             managed.transport_config.peer.remote_asn = peer_asn;
+            // The learned ASN replaces the accept-any `remote_asn="0"`
+            // identity row.
+            self.publish_peer_info_metric(&peer_key);
         }
         self.publish_state_lifecycle_event(&peer_key, role, old, new);
     }

--- a/src/peer_manager/tests/metrics.rs
+++ b/src/peer_manager/tests/metrics.rs
@@ -565,16 +565,23 @@ async fn peer_presence_reconfigure_keeps_admin_event_but_stays_presence_silent()
         false,
     );
     seed_peer_metric_series(&metrics_view, "10.0.0.2");
+    // A peer installed through the real path also carries its identity row.
+    mgr.publish_peer_info_metric(&key(peer_addr));
     let before = peer_metric_series_count(&metrics_view, "10.0.0.2");
 
     // Reconfigure routes through the same delete primitive, but the
-    // peer continues to exist — its series and history must survive.
+    // peer continues to exist — its series and history must survive, and
+    // the edited description replaces the identity row in place.
     let mut new_config = make_config(peer_addr, 65002);
     new_config.description = "reshaped".to_string();
     mgr.reconfigure_peer(new_config).await.unwrap();
 
     assert!(mgr.peers.contains_key(&key(peer_addr)));
     assert_eq!(peer_metric_series_count(&metrics_view, "10.0.0.2"), before);
+    assert_eq!(
+        peer_info_series(&metrics_view, "10.0.0.2"),
+        vec![peer_info_labels("65002", "reshaped", "")]
+    );
     assert!(
         rib_rx.try_recv().is_err(),
         "no PeerDeleted on a reconfigure"
@@ -602,6 +609,95 @@ async fn peer_presence_reconfigure_keeps_admin_event_but_stays_presence_silent()
     )
     .await;
     assert_eq!(admin.len(), 1, "reconfigure keeps its incarnation fence");
+}
+
+/// Every `bgp_peer_info` label set carrying `peer`, in label-sorted form.
+fn peer_info_series(metrics: &BgpMetrics, peer: &str) -> Vec<Vec<(String, String)>> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .filter(|family| family.name() == "bgp_peer_info")
+        .flat_map(|family| {
+            family
+                .get_metric()
+                .iter()
+                .filter(|metric| {
+                    metric
+                        .get_label()
+                        .iter()
+                        .any(|label| label.name() == "peer" && label.value() == peer)
+                })
+                .map(|metric| {
+                    assert!((metric.get_gauge().value() - 1.0).abs() < f64::EPSILON);
+                    metric
+                        .get_label()
+                        .iter()
+                        .map(|label| (label.name().to_owned(), label.value().to_owned()))
+                        .collect()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn peer_info_labels(
+    remote_asn: &str,
+    description: &str,
+    peer_group: &str,
+) -> Vec<(String, String)> {
+    [
+        ("description", description),
+        ("interface", ""),
+        ("peer", "10.0.0.2"),
+        ("peer_group", peer_group),
+        ("remote_asn", remote_asn),
+    ]
+    .into_iter()
+    .map(|(name, value)| (name.to_owned(), value.to_owned()))
+    .collect()
+}
+
+#[tokio::test(start_paused = true)]
+async fn peer_info_follows_install_reconfigure_and_delete() {
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let metrics_view = metrics.clone();
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut config = make_config(peer_addr, 65002);
+    config.description = "Example Member".to_string();
+    mgr.add_peer(config, false).await.unwrap();
+
+    assert_eq!(
+        peer_info_series(&metrics_view, "10.0.0.2"),
+        vec![peer_info_labels("65002", "Example Member", "")]
+    );
+
+    // A description edit routes through reconfigure (delete without reap,
+    // then re-add): the new identity replaces the old row instead of
+    // accumulating beside it.
+    let mut renamed = make_config(peer_addr, 65002);
+    renamed.description = "Renamed Member".to_string();
+    mgr.reconfigure_peer(renamed).await.unwrap();
+    assert_eq!(
+        peer_info_series(&metrics_view, "10.0.0.2"),
+        vec![peer_info_labels("65002", "Renamed Member", "")]
+    );
+
+    mgr.delete_peer(key(peer_addr), false).await.unwrap();
+    assert!(peer_info_series(&metrics_view, "10.0.0.2").is_empty());
+    assert_eq!(peer_metric_series_count(&metrics_view, "10.0.0.2"), 0);
 }
 
 #[test]

--- a/src/peer_manager/tests/metrics.rs
+++ b/src/peer_manager/tests/metrics.rs
@@ -630,11 +630,13 @@ fn peer_info_series(metrics: &BgpMetrics, peer: &str) -> Vec<Vec<(String, String
                 })
                 .map(|metric| {
                     assert!((metric.get_gauge().value() - 1.0).abs() < f64::EPSILON);
-                    metric
+                    let mut labels = metric
                         .get_label()
                         .iter()
                         .map(|label| (label.name().to_owned(), label.value().to_owned()))
-                        .collect()
+                        .collect::<Vec<_>>();
+                    labels.sort();
+                    labels
                 })
                 .collect::<Vec<_>>()
         })
@@ -659,7 +661,7 @@ fn peer_info_labels(
 }
 
 #[tokio::test(start_paused = true)]
-async fn peer_info_follows_install_reconfigure_and_delete() {
+async fn peer_info_follows_install_hot_update_and_delete() {
     let (_cmd_tx, cmd_rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let metrics = BgpMetrics::new();
@@ -683,13 +685,14 @@ async fn peer_info_follows_install_reconfigure_and_delete() {
         peer_info_series(&metrics_view, "10.0.0.2"),
         vec![peer_info_labels("65002", "Example Member", "")]
     );
+    let session_id = mgr.peers[&key(peer_addr)].session_id;
 
-    // A description edit routes through reconfigure (delete without reap,
-    // then re-add): the new identity replaces the old row instead of
-    // accumulating beside it.
+    // A hot-applied description edit replaces the old identity row without
+    // rebuilding the session.
     let mut renamed = make_config(peer_addr, 65002);
     renamed.description = "Renamed Member".to_string();
-    mgr.reconfigure_peer(renamed).await.unwrap();
+    mgr.hot_update_peer(renamed).await.unwrap();
+    assert_eq!(mgr.peers[&key(peer_addr)].session_id, session_id);
     assert_eq!(
         peer_info_series(&metrics_view, "10.0.0.2"),
         vec![peer_info_labels("65002", "Renamed Member", "")]


### PR DESCRIPTION
## Summary

Export one `bgp_peer_info{peer,interface,remote_asn,description,peer_group} 1` identity gauge per configured and dynamic peer, and join it into the shipped dashboard and alert pack so a route server's NOC sees "Example Member AS64496" instead of a bare address. The info-metric join is the whole design: no identity labels are added to any existing per-peer family.

- **Telemetry** (`crates/telemetry/src/metrics.rs`): new `bgp_peer_info` family, `set_peer_info()` setter, `scrub_info_label()` (drops control characters, trims surrounding whitespace, bounds to `PEER_INFO_LABEL_MAX_CHARS = 128` characters). The setter removes any prior row for the exact `(peer, interface)` identity before publishing, so a description/peer-group edit or an ASN learned from OPEN replaces the row instead of leaving a stale sibling. The family is added to the `reap_peer_series` bare-address reap list, to the exact-identity `reap_peer_identity_series`, and to the pinned `PEER_LABELED_FAMILIES` inventory (57 → 58). `reap_label_series_from_vec` now matches a slice of `(label, value)` pairs so the identity reap can key on both `peer` and `interface`; the three BMP `collector` callers pass a one-pair slice.
- **Peer manager** (`src/peer_manager/`): `publish_peer_info_metric(&PeerKey)` reads `remote_asn`, `description`, and `peer_group` from the installed `ManagedPeer` (same shape as `refresh_rfc8212_policy_metrics`). Called after every `self.peers.insert` (static add, dynamic accept, retained dynamic peer), after an accept-any dynamic range learns its ASN from OPEN, and after a successful in-place hot update commits manager bookkeeping. Reconfigure (delete-without-reap + re-add) therefore also refreshes the row in place.
- **Dashboard** (`docs/grafana/rustbgpd-overview.json`): new **Peer identity** row (panel ids 75–77) with an instant `bgp_peer_info` table and a **Session truth by member identity** timeseries using `* on (instance, peer, interface) group_left(remote_asn, description) bgp_peer_info{…}` with legend `{{description}} AS{{remote_asn}} {{peer}} {{interface}}`. Existing panel ids, queries, legends, and layout are untouched; the row is appended at the end of the grid.
- **Alert pack** (`examples/prometheus/rustbgpd-alerts.yml`): `BgpSessionNotEstablished` joins `bgp_peer_info` with `group_left(remote_asn, description, peer_group)` so the alert labels carry the member identity, with an `or ignoring(remote_asn, description, peer_group)` fallback so a peer with no identity row still fires. Annotations are unchanged.
- **Checkers**: `check-grafana-dashboard.py` pins the two new targets and the join legend, requires the identity panel to be an instant table, and pins the joined panel to a stepped whole 0..1 timeseries. `check-metric-consumers.py` roster ratchet 204 → 205.
- **Docs**: metrics reference (`docs/OPERATIONS.md` Health table + per-peer series lifecycle), `docs/GRAFANA.md` (`$peer` selector text, alert-rule note, reading notes), CHANGELOG `[Unreleased]` entry.

## Behavior change

- `/metrics` gains one `bgp_peer_info` series per exact `(peer, interface)` identity, value always `1`. `remote_asn` is the configured ASN, or `0` on an accept-any dynamic range until the OPEN-learned ASN replaces the row. `description` is the configured description, falling back to the neighbor address (static) or `dynamic:<peer_group>` (dynamic), matching the neighbor-detail surface. `peer_group` is empty for ungrouped neighbors.
- Rows are published on install, replaced on reconfigure, successful in-place hot update, or learned-ASN, and reaped with the other per-peer series on delete (exact-identity reap at the identity boundary, bare-address reap when the last user of the address goes).
- `BgpSessionNotEstablished` alerts carry `remote_asn`, `description`, and `peer_group` labels when a `bgp_peer_info` row exists for the peer. Alert identity therefore changes on a description edit (the `for: 2m` timer restarts for that peer), which is the expected cost of an info-metric join.

## Compatibility impact

Additive. No existing metric family, label set, help text, dashboard query, panel id, or alert expression other than `BgpSessionNotEstablished`'s is changed; that alert's firing conditions are unchanged (the fallback branch reproduces the original expression exactly), only its label set grows when identity is available. Alert-pack consumers that route on an exact label set should note the three new labels. `BgpSessionFlapping` and the other `peer`-only rules are deliberately not joined: `bgp_session_flaps_total` carries no `interface`, so a scoped link-local sibling pair would make the join many-to-one.

## Tests

New:
- `crates/telemetry`: `peer_info_replaces_prior_identity_and_reaps_exactly`, `peer_info_scrubs_control_characters_and_bounds_free_text_labels`
- `src/peer_manager/tests/metrics.rs`: `peer_info_follows_install_hot_update_and_delete` (install labels → actual hot update replaces the description row without rebuilding the session → delete reaps it)
- `scripts/test_check_grafana_dashboard.py`: `test_peer_identity_join_mutations_fail_closed` (dropping the join, narrowing `group_left`, changing the legend, un-pinning the 0..1 axis, turning the identity table into a timeseries or a range query, pointing it at another family, or deleting either panel all fail the checker)
- `examples/prometheus/rustbgpd-alerts_test.yml`: the `BgpSessionNotEstablished` current-truth matrix gives `192.0.2.10` a `bgp_peer_info` row and expects the identity labels exactly once, while `192.0.2.11` and `fe80::1/eth0` still fire without a row (fallback proof, no duplicate alerts)

Updated:
- `crates/telemetry`: `populate_all_peer_families` emits the new family; `reap_peer_series_removes_every_peer_labeled_family` (68 → 69 series), `PEER_LABELED_FAMILIES` (57 → 58)
- `src/peer_manager/tests/metrics.rs`: `peer_presence_reconfigure_keeps_admin_event_but_stays_presence_silent` seeds the identity row the real install path would have published and asserts the edited description replaces it in place
- `scripts/test_check_metric_consumers.py`: roster count 204 → 205

Not covered by a dedicated test: the learned-ASN republish on an accept-any dynamic range (exercised only through the `StateChanged` notification path); the setter-level replacement it relies on is covered by the telemetry test.

## Checks run

All run at exact PR head `14aa8ca1`, rebased on `origin/main` (`6358e7d9`), exit codes only:

- `cargo fmt --all -- --check` — exit 0
- `cargo test -p rustbgpd-telemetry --lib` — exit 0 (111 passed, including the two new tests and the pinned-inventory/reap-list tests)
- `cargo test -p rustbgpd --bin rustbgpd peer_manager::tests::metrics` — exit 0 (22 passed)
- `cargo clippy --locked -p rustbgpd-telemetry --all-targets -- -D warnings` — exit 0
- `python3 -m unittest -v scripts/test_check_grafana_dashboard.py` — exit 0 (28 tests); `python3 scripts/check-grafana-dashboard.py` — exit 0 (77 panels, 43 operator targets, 99 linked metrics)
- `python3 -m unittest -v scripts/test_check_metric_consumers.py` — exit 0; `python3 scripts/check-metric-consumers.py` — exit 0 (205 emitted families; 98 dashboard, 44 rules, 194 normative-doc; 199 consumed)
- `python3 -m unittest -v scripts/test_check_metric_release_notes.py` — exit 0; `python3 scripts/check_metric_release_notes.py` — exit 0 (v0.68.0 → Unreleased: 2 added, 1 removed, all documented)
- `python3 scripts/check_public_tracker_ids.py` — exit 0
- `promtool check rules examples/prometheus/rustbgpd-alerts.yml` — exit 0 (40 rules); `promtool test rules rustbgpd-alerts_test.yml` — exit 0 (promtool 3.4.1)
- `just gate` — exit 0 (links, developer tooling, fmt, clippy reasons, stable surface, release-notes reflow, tracker IDs, IXP Manager docs, release checklist paths, metric consumers, strict workspace clippy, full workspace tests, library docs)

Not run locally: `just gate-rib`, `just gate-deps`, `just gate-contract` (no feature-gated RIB/transport/API, scale-harness, or Criterion surface is touched). Exact-head Observability assets passed; broader hosted lanes were still running with no failures at the time of this update.

