### PR TITLE
Authenticate RTR cache sessions with TCP MD5 or TCP-AO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sends KEEPALIVEs on the negotiated timer, and prints each successfully
   parsed UPDATE. Its loopback tests exercise the library-embedding shape in
   `docs/EMBEDDING.md`.
+- `[[rpki.cache_servers]]` accepts `md5_password` (RFC 2385) or a
+  neighbor-shaped `tcp_ao` keyring (RFC 5925); the key is installed on the
+  RTR socket before connect. **Operator-visible:** key material the kernel
+  refuses is a startup error, a cache holding a different key never completes
+  the handshake and is logged as `RTR connection failed` after a 10 s bound,
+  and there is no plaintext fallback. Both fields are redacted by
+  `rbgp config effective`, rejected when the `<redacted>` placeholder is
+  loaded back, and restart-required like the rest of `[rpki]`. RTR over TLS
+  or SSH remains unimplemented. `rustbgpd-rpki` gains
+  `RtrClient::with_dialer` for embedders that open the connection themselves.
 
 - `rs-config-render --help` now lists its rendering, activation, status,
   pruning, recovery, and IXP Manager lifecycle command paths.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -390,13 +390,14 @@ byte counts.
 - **Route Refresh is unconditional.** The ROUTE-REFRESH capability
   (code 2) is always advertised. Inbound route refresh requests check
   peer capability, but there is no config option to disable the feature.
-- **TCP-AO not supported for RTR connections.** RPKI cache (RTR) server
-  connections use plain TCP; TCP-AO (RFC 5925) is not available for the
-  RTR transport. Use network-level access controls or SSH tunnels for RTR
-  transport security. (TCP-AO *is* supported for BGP static-neighbor and
-  dynamic-prefix keys on Linux, including live successor installation,
-  selection, and deprecated-key deletion on SIGHUP — see SECURITY.md and
-  ADR-0062.)
+- **RTR over TLS or SSH is not supported.** RPKI cache (RTR) sessions are
+  authenticated at the TCP layer only: per-cache `md5_password` (RFC 2385)
+  or `tcp_ao` (RFC 5925) installed before connect. TCP-AO on RTR sockets is
+  startup-only — the live successor installation, selection, and
+  deprecated-key deletion that BGP neighbor keyrings get on SIGHUP does not
+  apply; `[rpki]` changes require a restart. Encrypted RTR transports
+  (RFC 8210 §3 TLS/SSH) are not implemented; tunnel the session for
+  confidentiality.
 - **Non-negotiated Add-Path NLRI is not detected.** If a peer violates
   negotiation and sends Add-Path-encoded NLRI for a family where Add-Path
   was not negotiated, the wire format is ambiguous — the 4-byte path ID

--- a/crates/rpki/CHANGELOG.md
+++ b/crates/rpki/CHANGELOG.md
@@ -5,6 +5,8 @@ Daemon and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- Added `RtrClient::with_dialer` so embedders can supply custom cache connection setup.
+
 ## 0.1.0 - 2026-08-30
 
 - Added an optional cache-inventory attachment with separate enhanced-update

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -103,7 +103,9 @@ runs inside the task the application supplies.
 | `draft-ietf-sidrops-8210bis` | Scoped RTR version 2 support for ASPA records, with v1 fallback. Router Key PDUs are not implemented. |
 | `draft-ietf-sidrops-aspa-verification-28` | Role-aware upstream/downstream ASPA path verification for IPv4 and IPv6 unicast. |
 
-RTR cache connections use plain TCP. TLS and SSH transports are not implemented.
+RTR cache connections use plain TCP by default; an embedding daemon can open them
+through its own dialer (`RtrClient::with_dialer`) to install TCP MD5 or TCP-AO
+before connect. TLS and SSH transports are not implemented.
 Transactions are bounded by time, record count, and byte count; validated data
 is retained across reconnects until replacement or expiry.
 

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -40,9 +40,12 @@
 //! - **Transaction bounds** — each transaction is bounded by a wall-clock
 //!   deadline and record/byte budgets, so a broken or malicious cache
 //!   cannot wedge the client or exhaust memory.
+//! - **Transport** — connections are plain TCP by default. An embedding
+//!   daemon can open them through its own dialer
+//!   ([`RtrClient::with_dialer`]) to install TCP MD5 or TCP-AO before
+//!   connect. RTR over TLS or SSH is not implemented.
 //! - **Not implemented** — Router Key PDUs (`BGPsec`, type 9) are rejected
-//!   as unknown and end the session; transport security (RTR over
-//!   TLS/SSH) — connections are plain TCP.
+//!   as unknown and end the session.
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -19,7 +19,9 @@
 //! deadline and record/byte budgets. See the crate-level docs for the
 //! supported RFC 8210 / 8210bis subset.
 
+use std::future::Future;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -227,7 +229,17 @@ pub struct RtrClient {
     /// Told the effective expire interval (seconds) at start and after
     /// every End of Data; see [`Self::with_expire_observer`].
     expire_observer: Option<Box<dyn Fn(u64) + Send + Sync>>,
+    /// Opens every transport connection to the cache; see
+    /// [`Self::with_dialer`]. `None` is a plain `TcpStream::connect`.
+    dialer: Option<RtrDialer>,
 }
+
+/// Boxed connection opener installed by [`RtrClient::with_dialer`].
+type RtrDialer = Box<
+    dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Output = std::io::Result<TcpStream>> + Send>>
+        + Send
+        + Sync,
+>;
 
 impl RtrClient {
     /// Create a new RTR client.
@@ -255,6 +267,7 @@ impl RtrClient {
             max_transaction_records: MAX_TRANSACTION_RECORDS,
             max_transaction_bytes: MAX_TRANSACTION_BYTES,
             expire_observer: None,
+            dialer: None,
         }
     }
 
@@ -284,6 +297,28 @@ impl RtrClient {
     fn observe_expire(&self) {
         if let Some(observer) = &self.expire_observer {
             observer(self.expire_interval.as_secs());
+        }
+    }
+
+    /// Open every transport connection through `dial` instead of a plain
+    /// `TcpStream::connect`. The embedding daemon uses this to install
+    /// socket options such as TCP MD5 or TCP-AO before connect; a dial
+    /// error is a failed connection attempt that is retried after the
+    /// retry interval, never a plaintext fallback.
+    #[must_use]
+    pub fn with_dialer<F, Fut>(mut self, dial: F) -> Self
+    where
+        F: Fn(SocketAddr) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = std::io::Result<TcpStream>> + Send + 'static,
+    {
+        self.dialer = Some(Box::new(move |addr| Box::pin(dial(addr))));
+        self
+    }
+
+    async fn dial(&self) -> std::io::Result<TcpStream> {
+        match &self.dialer {
+            Some(dial) => dial(self.config.server_addr).await,
+            None => TcpStream::connect(self.config.server_addr).await,
         }
     }
 
@@ -327,7 +362,7 @@ impl RtrClient {
     }
 
     async fn connect_and_run(&mut self) -> Result<(), std::io::Error> {
-        let mut stream = TcpStream::connect(self.config.server_addr).await?;
+        let mut stream = self.dial().await?;
         let mut disconnect_sent = false;
         self.send_enhanced(EnhancedVrpUpdate::Connected {
             server: self.config.server_addr,
@@ -430,7 +465,7 @@ impl RtrClient {
         // the v1 full table replaces them or the expire interval passes.
         self.epoch = None;
 
-        match TcpStream::connect(self.config.server_addr).await {
+        match self.dial().await {
             Ok(mut stream) => {
                 let mut disconnect_sent = false;
                 self.send_enhanced(EnhancedVrpUpdate::Connected {
@@ -1590,6 +1625,38 @@ mod tests {
             pdu.encode_with_version(&mut buf, version).unwrap();
         }
         stream.write_all(&buf).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn with_dialer_opens_every_connection_through_the_dialer() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // The configured address is deliberately not the listener: only the
+        // dialer knows where the cache is, so an accepted connection proves
+        // the client never fell back to a plain connect.
+        let configured: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let dials = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&dials);
+        let (vrp_tx, _vrp_rx) = mpsc::channel(8);
+        let client = RtrClient::new(test_config(configured, 60, 5, 120), vrp_tx).with_dialer(
+            move |requested| {
+                assert_eq!(requested, configured);
+                counter.fetch_add(1, Ordering::SeqCst);
+                TcpStream::connect(addr)
+            },
+        );
+        let client_handle = tokio::spawn(client.run());
+
+        let (mut stream, _) = timeout(Duration::from_secs(5), listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(read_pdu(&mut stream).await, RtrPdu::ResetQuery);
+        assert_eq!(dials.load(Ordering::SeqCst), 1);
+        client_handle.abort();
     }
 
     #[tokio::test]

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -84,6 +84,7 @@ pub use session::import_decision_cache::{
 // LAN-472: rejected-route retention types crossing into the api +
 // binary layers (PeerManagerCommand reply, PolicyService mapping).
 pub use session::rejected_routes::{RejectedRouteEntry, RejectedRoutesReply};
+pub use session::{connect_authenticated, preflight_authenticated_dial};
 pub use socket_opts::{
     TcpAoInfoSnapshot, TcpAoKeyState, TcpAoSupport, probe_tcp_ao_support, set_gtsm, set_tcp_md5sig,
 };

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -941,7 +941,8 @@ pub(super) async fn poll_connect(
 
 fn install_active_tcp_ao_with<F>(
     socket: &socket2::Socket,
-    config: &TransportConfig,
+    remote_addr: SocketAddr,
+    tcp_ao: Option<&crate::TcpAoKeyring>,
     peer_label: &str,
     mut install_key: F,
 ) -> std::io::Result<Option<crate::socket_opts::TcpAoMktReceipt>>
@@ -954,7 +955,7 @@ where
         crate::socket_opts::TcpAoSocketRole,
     ) -> std::io::Result<()>,
 {
-    let Some(tcp_ao) = config.tcp_ao.as_ref() else {
+    let Some(tcp_ao) = tcp_ao else {
         return Ok(None);
     };
     tcp_ao.selected().ok_or_else(|| {
@@ -963,11 +964,7 @@ where
             "TCP-AO keyring has no selectable non-deprecated key",
         )
     })?;
-    let prefix_len = if config.remote_addr.is_ipv4() {
-        32
-    } else {
-        128
-    };
+    let prefix_len = if remote_addr.is_ipv4() { 32 } else { 128 };
     for (index, key) in tcp_ao.startup_order().into_iter().enumerate() {
         let role = if index == 0 {
             crate::socket_opts::TcpAoSocketRole::ActiveOpen
@@ -976,7 +973,7 @@ where
         };
         install_key(
             socket,
-            config.remote_addr.ip(),
+            remote_addr.ip(),
             prefix_len,
             key,
             role,
@@ -984,7 +981,7 @@ where
         .map_err(|err| {
             warn!(
                 peer = %peer_label,
-                addr = %config.remote_addr,
+                addr = %remote_addr,
                 send_id = key.send_id,
                 recv_id = key.recv_id,
                 algorithm = key.algorithm.linux_name(),
@@ -996,7 +993,7 @@ where
                 format!(
                     "failed to install TCP-AO key for peer {peer_label} at {} \
                      (send_id={}, recv_id={}, algorithm={}): {err}",
-                    config.remote_addr,
+                    remote_addr,
                     key.send_id,
                     key.recv_id,
                     key.algorithm.linux_name()
@@ -1006,7 +1003,7 @@ where
     }
     let receipt = crate::socket_opts::capture_tcp_ao_keyring_receipt(
         socket,
-        config.remote_addr.ip(),
+        remote_addr.ip(),
         prefix_len,
         tcp_ao,
         true,
@@ -1014,7 +1011,7 @@ where
     .map_err(|err| {
         warn!(
             peer = %peer_label,
-            addr = %config.remote_addr,
+            addr = %remote_addr,
             error = %err,
             "failed to capture TCP-AO pre-connect kernel receipt; protected session will retry without unauthenticated fallback"
         );
@@ -1060,7 +1057,13 @@ where
     // key in declaration order before connect. This helper owns the fresh
     // socket, so any partial installation failure closes it before returning
     // and cannot reach the connect operation or fall back to plaintext.
-    let tcp_ao_receipt = install_active_tcp_ao_with(&socket, config, peer_label, install_key)?;
+    let tcp_ao_receipt = install_active_tcp_ao_with(
+        &socket,
+        config.remote_addr,
+        config.tcp_ao.as_ref(),
+        peer_label,
+        install_key,
+    )?;
 
     if let Some(hops) = config.ttl_security_hops {
         crate::socket_opts::set_gtsm(&socket, config.remote_addr, hops)?;
@@ -1092,6 +1095,102 @@ where
     C: FnOnce(&socket2::Socket, &socket2::SockAddr) -> std::io::Result<()>,
 {
     prepare_active_socket_with(socket, config, peer_label, install_key, connect_socket)
+}
+
+/// Build an unconnected socket for `remote` with `md5_password` (RFC 2385)
+/// and/or `tcp_ao` (RFC 5925) installed. Any option the kernel refuses is
+/// returned as the error; the socket never reaches the caller half-armed.
+fn prepare_authenticated_socket(
+    remote: SocketAddr,
+    md5_password: Option<&crate::TransportAuthSecret>,
+    tcp_ao: Option<&crate::TcpAoKeyring>,
+    label: &str,
+) -> std::io::Result<socket2::Socket> {
+    use socket2::{Domain, Protocol, Type};
+
+    let domain = if remote.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let socket = socket2::Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    if let Some(password) = md5_password {
+        crate::socket_opts::set_tcp_md5sig(&socket, remote, password.as_ref())?;
+        debug!(peer = %label, "TCP MD5 authentication configured");
+    }
+    install_active_tcp_ao_with(
+        &socket,
+        remote,
+        tcp_ao,
+        label,
+        crate::socket_opts::set_tcp_ao_config,
+    )?;
+    Ok(socket)
+}
+
+/// Prove the kernel accepts `md5_password` / `tcp_ao` for `remote` without
+/// connecting: the options are installed on a throwaway socket exactly as
+/// [`connect_authenticated`] would install them. Lets a daemon turn a refused
+/// key into a startup error instead of an endless reconnect loop.
+///
+/// # Errors
+///
+/// Returns the socket creation or `setsockopt` error.
+pub fn preflight_authenticated_dial(
+    remote: SocketAddr,
+    md5_password: Option<&crate::TransportAuthSecret>,
+    tcp_ao: Option<&crate::TcpAoKeyring>,
+    label: &str,
+) -> std::io::Result<()> {
+    prepare_authenticated_socket(remote, md5_password, tcp_ao, label).map(drop)
+}
+
+/// Connect to `remote` with `md5_password` and/or `tcp_ao` installed before
+/// the SYN leaves, for authenticated non-BGP clients such as RTR. A refused
+/// option or a failed handshake is the error; there is no plaintext fallback.
+///
+/// A peer holding a different key drops the signed SYN silently, which is
+/// indistinguishable from a black hole, so the handshake is bounded by
+/// `handshake_timeout` and the timeout error names the key mismatch.
+///
+/// # Errors
+///
+/// Returns the socket option, connect, or handshake error; `TimedOut` when
+/// the handshake does not complete within `handshake_timeout`.
+pub async fn connect_authenticated(
+    remote: SocketAddr,
+    md5_password: Option<&crate::TransportAuthSecret>,
+    tcp_ao: Option<&crate::TcpAoKeyring>,
+    label: &str,
+    handshake_timeout: Duration,
+) -> std::io::Result<TcpStream> {
+    let socket = prepare_authenticated_socket(remote, md5_password, tcp_ao, label)?;
+    socket.set_nonblocking(true)?;
+    match socket.connect(&socket2::SockAddr::from(remote)) {
+        Ok(()) => {}
+        Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+        Err(e) => return Err(e),
+    }
+    let stream = TcpStream::from_std(socket.into())?;
+    let Ok(ready) = tokio::time::timeout(handshake_timeout, stream.writable()).await else {
+        let hint = if md5_password.is_some() || tcp_ao.is_some() {
+            "; the peer is unreachable or does not hold the same TCP MD5 / TCP-AO key"
+        } else {
+            ""
+        };
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!(
+                "TCP handshake with {remote} did not complete within {}s{hint}",
+                handshake_timeout.as_secs_f64()
+            ),
+        ));
+    };
+    ready?;
+    if let Some(err) = stream.take_error()? {
+        return Err(err);
+    }
+    Ok(stream)
 }
 
 async fn create_and_connect(

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -10,6 +10,8 @@ pub mod rejected_routes;
 mod shared_group;
 mod writer;
 
+pub use io::{connect_authenticated, preflight_authenticated_dial};
+
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ops::ControlFlow;

--- a/crates/transport/src/session/tests/authenticated_dial.rs
+++ b/crates/transport/src/session/tests/authenticated_dial.rs
@@ -1,0 +1,159 @@
+//! Loopback proofs for the authenticated non-BGP dial used by RTR clients:
+//! the kernel enforces the installed TCP MD5 / TCP-AO material on both ends,
+//! so a matching key completes the handshake and a mismatched or absent key
+//! never yields an accepted connection.
+
+use super::*;
+use crate::socket_opts::{
+    TcpAoSocketRole, TcpAoSupport, probe_tcp_ao_support, set_tcp_ao_config, set_tcp_md5sig,
+};
+use crate::{
+    TcpAoAlgorithm, TcpAoConfig, TcpAoKeyring, TransportAuthSecret, connect_authenticated,
+    preflight_authenticated_dial,
+};
+use socket2::{Domain, Protocol, Socket, Type};
+use std::net::SocketAddr;
+
+fn loopback_listener() -> Socket {
+    Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap()
+}
+
+fn bind_listen(socket: &Socket) -> SocketAddr {
+    let any: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    socket.bind(&any.into()).unwrap();
+    socket.listen(4).unwrap();
+    socket.set_nonblocking(true).unwrap();
+    socket.local_addr().unwrap().as_socket().unwrap()
+}
+
+fn try_accept(listener: &Socket) -> bool {
+    match listener.accept() {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => false,
+        Err(e) => panic!("accept failed: {e}"),
+    }
+}
+
+async fn wait_accepted(listener: &Socket) -> bool {
+    for _ in 0..40 {
+        if try_accept(listener) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+const HANDSHAKE: Duration = Duration::from_secs(5);
+const SHORT: Duration = Duration::from_millis(500);
+
+/// The listener drops a mis-signed or unsigned SYN silently, so the dial can
+/// only time out; prove the bounded dial reports that and that no child was
+/// ever queued for accept.
+async fn assert_no_session(
+    listener: &Socket,
+    dial: impl std::future::Future<Output = std::io::Result<TcpStream>>,
+    expect_key_hint: bool,
+) {
+    let err = dial
+        .await
+        .expect_err("handshake must not complete without the listener's key");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut, "{err}");
+    assert_eq!(
+        err.to_string().contains("TCP MD5 / TCP-AO key"),
+        expect_key_hint,
+        "{err}"
+    );
+    assert!(!try_accept(listener), "listener must not accept a session");
+}
+
+#[tokio::test]
+async fn md5_dial_completes_with_matching_key_and_never_without_it() {
+    let listener = loopback_listener();
+    set_tcp_md5sig(&listener, "127.0.0.1:0".parse().unwrap(), "rtr-md5-secret").unwrap();
+    let addr = bind_listen(&listener);
+
+    let key = TransportAuthSecret::from("rtr-md5-secret");
+    let stream = connect_authenticated(addr, Some(&key), None, "rtr-test", HANDSHAKE)
+        .await
+        .unwrap();
+    assert!(wait_accepted(&listener).await);
+    drop(stream);
+
+    let wrong = TransportAuthSecret::from("not-the-key");
+    assert_no_session(
+        &listener,
+        connect_authenticated(addr, Some(&wrong), None, "rtr-test", SHORT),
+        true,
+    )
+    .await;
+    assert_no_session(
+        &listener,
+        connect_authenticated(addr, None, None, "rtr-test", SHORT),
+        false,
+    )
+    .await;
+}
+
+#[test]
+fn preflight_reports_refused_md5_material_without_connecting() {
+    let remote: SocketAddr = "127.0.0.1:3323".parse().unwrap();
+    let ok = TransportAuthSecret::from("rtr-md5-secret");
+    preflight_authenticated_dial(remote, Some(&ok), None, "rtr-test").unwrap();
+
+    let too_long = TransportAuthSecret::from("k".repeat(81));
+    let err = preflight_authenticated_dial(remote, Some(&too_long), None, "rtr-test").unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+fn ao_key(secret: &str, send_id: u8, recv_id: u8) -> TcpAoConfig {
+    TcpAoConfig {
+        key: TransportAuthSecret::from(secret),
+        send_id,
+        recv_id,
+        algorithm: TcpAoAlgorithm::HmacSha256,
+        preferred: false,
+        deprecated: false,
+    }
+}
+
+#[tokio::test]
+async fn tcp_ao_dial_completes_with_matching_mkt_and_never_without_it() {
+    if probe_tcp_ao_support() != TcpAoSupport::Supported {
+        eprintln!("skipping: kernel does not support TCP-AO");
+        return;
+    }
+    let listener = loopback_listener();
+    // The listener's MKT mirrors the client's KeyIDs: the client sends with
+    // KeyID 1 and expects 2, so the listener receives 1 and sends 2.
+    set_tcp_ao_config(
+        &listener,
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        32,
+        &ao_key("rtr-ao-secret", 2, 1),
+        TcpAoSocketRole::Listener,
+    )
+    .unwrap();
+    let addr = bind_listen(&listener);
+
+    let ring = TcpAoKeyring(vec![ao_key("rtr-ao-secret", 1, 2)]);
+    let stream = connect_authenticated(addr, None, Some(&ring), "rtr-test", HANDSHAKE)
+        .await
+        .unwrap();
+    assert!(wait_accepted(&listener).await);
+    drop(stream);
+
+    let wrong = TcpAoKeyring(vec![ao_key("not-the-key", 1, 2)]);
+    assert_no_session(
+        &listener,
+        connect_authenticated(addr, None, Some(&wrong), "rtr-test", SHORT),
+        true,
+    )
+    .await;
+    assert_no_session(
+        &listener,
+        connect_authenticated(addr, None, None, "rtr-test", SHORT),
+        false,
+    )
+    .await;
+}

--- a/crates/transport/src/session/tests/mod.rs
+++ b/crates/transport/src/session/tests/mod.rs
@@ -2057,6 +2057,7 @@ async fn direct_action_fallback_rebuilds_fresh_arc_and_add_path_projection() {
     );
 }
 
+mod authenticated_dial;
 mod bmp;
 mod denied_replacements;
 mod exact_export;

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -26,6 +26,16 @@ use zeroize::{Zeroize, Zeroizing};
 #[cfg(target_os = "linux")]
 const TCP_MD5SIG_MAXKEYLEN: usize = 80;
 
+fn validate_tcp_md5sig_key(password: &str) -> io::Result<()> {
+    if password.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "MD5 password must not be empty",
+        ));
+    }
+    Ok(())
+}
+
 /// Linux `tcp_md5sig`. The key buffer is populated only for the duration of
 /// one `setsockopt` call and is scrubbed, together with its length, on drop.
 #[cfg(target_os = "linux")]
@@ -147,9 +157,10 @@ fn tcp_md5sig_setsockopt(
 /// # Errors
 ///
 /// Returns the kernel `setsockopt` error, or `InvalidInput` when the
-/// password exceeds the 80-byte kernel key limit.
+/// password is empty or exceeds the 80-byte kernel key limit.
 #[cfg(target_os = "linux")]
 pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::Result<()> {
+    validate_tcp_md5sig_key(password)?;
     tcp_md5sig_setsockopt(socket, peer, None, password.as_bytes())
 }
 
@@ -162,7 +173,7 @@ pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::
 /// # Errors
 ///
 /// Returns the kernel `setsockopt` error (`ENOPROTOOPT` on kernels without
-/// `TCP_MD5SIG_EXT`), or `InvalidInput` for an oversized password.
+/// `TCP_MD5SIG_EXT`), or `InvalidInput` for an empty or oversized password.
 #[cfg(target_os = "linux")]
 pub fn set_tcp_md5sig_prefix(
     socket: &Socket,
@@ -170,6 +181,7 @@ pub fn set_tcp_md5sig_prefix(
     prefix_len: u8,
     password: &str,
 ) -> io::Result<()> {
+    validate_tcp_md5sig_key(password)?;
     tcp_md5sig_setsockopt(
         socket,
         SocketAddr::new(peer, 0),
@@ -199,6 +211,7 @@ pub fn remove_tcp_md5sig(socket: &Socket, peer: IpAddr, prefix_len: u8) -> io::R
 /// Stub for non-Linux platforms.
 #[cfg(not(target_os = "linux"))]
 pub fn set_tcp_md5sig(_socket: &Socket, _peer: SocketAddr, _password: &str) -> io::Result<()> {
+    validate_tcp_md5sig_key(_password)?;
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "TCP MD5 authentication is only supported on Linux",
@@ -213,6 +226,7 @@ pub fn set_tcp_md5sig_prefix(
     _prefix_len: u8,
     _password: &str,
 ) -> io::Result<()> {
+    validate_tcp_md5sig_key(_password)?;
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "TCP MD5 authentication is only supported on Linux",
@@ -3314,6 +3328,7 @@ pub fn set_gtsm(_socket: &Socket, _remote: SocketAddr, _hops: NonZeroU8) -> io::
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
+    use socket2::{Domain, Protocol, Type};
     use std::mem;
 
     // Stable, dependency-free negative trait assertion. If `$ty` implements
@@ -3385,6 +3400,19 @@ mod tests {
         assert_eq!(sig.tcpm_keylen, 0);
         assert!(sig.tcpm_key.iter().all(|byte| *byte == 0));
         assert!(mem::needs_drop::<TcpMd5Sig>());
+    }
+
+    #[test]
+    fn public_tcp_md5_setters_reject_empty_keys() {
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
+        let peer: SocketAddr = "127.0.0.1:179".parse().unwrap();
+
+        for result in [
+            set_tcp_md5sig(&socket, peer, ""),
+            set_tcp_md5sig_prefix(&socket, peer.ip(), 32, ""),
+        ] {
+            assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidInput);
+        }
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2322,9 +2322,12 @@ You need a running RPKI validator that speaks RTR:
 | [FORT](https://fortproject.net/) | 8323 | C, lightweight |
 | [OctoRPKI](https://github.com/cloudflare/cfrpki) | 8282 | Go, Cloudflare |
 
-RTR runs over plain TCP with no authentication or encryption. Keep caches on
+RTR runs over TCP. Per cache server, `md5_password` (RFC 2385) or `tcp_ao`
+(RFC 5925) authenticates the session at the TCP layer on Linux; the cache must
+hold the same key. Without either the session is plain TCP: keep such caches on
 loopback or a trusted segment, or tunnel the session; see the
 [security checklist](deployment.md#security-checklist) in the deployment guide.
+RTR over TLS or SSH is not implemented.
 
 ### Basic setup
 
@@ -2358,6 +2361,29 @@ address = "[2001:db8::10]:3323"
 | `retry_interval` | u64 | no | 600 | Seconds before reconnect on failure |
 | `expire_interval` | u64 | no | 7200 | Seconds before discarding stale VRPs, until the cache's End of Data supplies its own expire |
 | `max_expire_interval` | u64 | no | unset | Ceiling on the effective expire, in seconds: the cache-advertised expire (and `expire_interval`) is clamped down to it, so this cache's VRPs are discarded once older than this no matter what the cache advertises. Must be <= 172800 and > both `refresh_interval` and `retry_interval`. Unset: only the two-day maximum applies |
+| `md5_password` | string | no | unset | TCP MD5 key (RFC 2385, 1..=80 bytes) installed on the RTR socket before connect. Mutually exclusive with `tcp_ao` |
+| `tcp_ao` | table or array of tables | no | unset | TCP-AO keyring (RFC 5925) installed on the RTR socket before connect, in the same shape and with the same validation as a neighbor `tcp_ao`. Mutually exclusive with `md5_password` |
+
+### Transport authentication
+
+```toml
+[[rpki.cache_servers]]
+address = "192.0.2.10:3323"
+md5_password = "shared-with-the-cache"
+
+[[rpki.cache_servers]]
+address = "[2001:db8::10]:3323"
+tcp_ao = { key = "shared-with-the-cache", send_id = 1, recv_id = 2, algorithm = "hmac(sha256)" }
+```
+
+The key is installed on the socket before the SYN leaves. Key material the
+kernel refuses (an oversized password, TCP-AO on a kernel without
+`CONFIG_TCP_AO`) is a startup error; a cache that holds a different key never
+completes the TCP handshake, which the client logs as an `RTR connection failed`
+after a 10 s handshake bound and retries after `retry_interval`. There is no
+plaintext fallback. Both fields are redacted by `rbgp config effective` and
+never appear in logs; like the rest of `[rpki]`, changing them requires a
+restart.
 
 ### Validation states
 

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -495,6 +495,30 @@ three-key inventory. Only after BIRD selects the successor may the proof require
 `healthy` Current `3` / RNext `13`. M43 does not claim container- or host-reboot
 persistence.
 
+### RTR transport authentication (local loopback lab)
+
+No public RTR cache (Routinator, StayRTR, rpki-client, FORT) offers a TCP MD5
+or TCP-AO listener, so the daemon-level receipt runs the in-repo RTR v2 server
+with `TCP_MD5SIG` installed on its listener (`RTR_TCP_MD5_KEY`) on loopback —
+no containers, but the kernel enforces the key on both ends exactly as it
+would across a wire:
+
+```sh
+cargo build --bin rustbgpd
+bash tests/interop/scripts/test-rtr-tcp-md5.sh
+```
+
+The driver proves three outcomes for `[[rpki.cache_servers]] md5_password`:
+a matching key syncs (`bgp_rpki_cache_end_of_data_ready` = 1 and
+`bgp_rpki_vrp_count` > 0), a mismatched key never completes the handshake and
+is logged as `RTR connection failed` with the key-mismatch hint, and a keyed
+client against an unsigned cache also stays down — the client never falls
+back to plaintext. TCP-AO on RTR sockets is proven at the socket seam by the
+transport crate's loopback tests
+(`crates/transport/src/session/tests/authenticated_dial.rs`), which install
+the mirrored MKT on a listener and require the same three outcomes; they skip
+on kernels without `CONFIG_TCP_AO`.
+
 ### Network Layouts
 
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1421,9 +1421,11 @@ short version for first deployment:
   both supported. TCP-AO is preferred and needs mainline Linux 6.7 or newer,
   or a downstream kernel with TCP-AO backported, built with
   `CONFIG_TCP_AO=y`; see ADR-0062.
-- **RPKI cache transport.** RTR (RFC 8210) sessions are plain TCP:
-  unauthenticated and unencrypted. Run caches on loopback or a trusted
-  segment, or tunnel the session (WireGuard, an SSH or stunnel forward).
+- **RPKI cache transport.** RTR (RFC 8210) sessions are TCP with optional
+  per-cache `md5_password` or `tcp_ao` authentication; they are never
+  encrypted. Set a key when the cache supports one; otherwise run caches on
+  loopback or a trusted segment, or tunnel the session (WireGuard, an SSH or
+  stunnel forward).
   A remote cache reached over an untrusted path is a validation-integrity
   problem: anything on the path can rewrite the VRPs the daemon validates
   against.

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -440,6 +440,13 @@
           "format": "uint64",
           "minimum": 0
         },
+        "md5_password": {
+          "description": "TCP MD5 password (RFC 2385) installed on the RTR socket before\nconnect; the cache must hold the same key. Mutually exclusive with\n`tcp_ao`. Restart-required like the rest of `[rpki]`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "refresh_interval": {
           "description": "RTR refresh interval in seconds. Default 3600.",
           "type": "integer",
@@ -453,6 +460,17 @@
           "format": "uint64",
           "default": 600,
           "minimum": 0
+        },
+        "tcp_ao": {
+          "description": "TCP-AO keyring (RFC 5925) installed on the RTR socket before connect,\nin the neighbor `tcp_ao` shape. Mutually exclusive with\n`md5_password`. Restart-required like the rest of `[rpki]`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TcpAoKeyringConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod diagnostic;
 mod parse;
 pub mod profiles;
 mod resolution;
+pub(crate) use resolution::transport_tcp_ao_keyring;
 mod schema;
 pub(crate) mod source_provenance;
 pub(crate) use source_provenance::AcceptedConfigSnapshot;
@@ -2885,8 +2886,9 @@ impl Config {
         }
 
         // Redact secret material everywhere it appears in the schema:
-        // neighbor/dynamic-range tcp_ao.key, neighbor md5_password, and
-        // peer-group md5_password.
+        // neighbor/dynamic-range tcp_ao.key, neighbor md5_password,
+        // peer-group md5_password, and RPKI cache-server md5_password /
+        // tcp_ao.key.
         for neighbor in &mut effective.neighbors {
             if neighbor.md5_password.is_some() {
                 neighbor.md5_password = Some(REDACTED_SECRET.to_string());
@@ -2904,6 +2906,20 @@ impl Config {
         }
         for range in &mut effective.dynamic_neighbors {
             if let Some(tcp_ao) = &mut range.tcp_ao {
+                for key in &mut tcp_ao.0 {
+                    key.key = REDACTED_SECRET.to_string();
+                }
+            }
+        }
+        for server in effective
+            .rpki
+            .iter_mut()
+            .flat_map(|rpki| rpki.cache_servers.iter_mut())
+        {
+            if server.md5_password.is_some() {
+                server.md5_password = Some(REDACTED_SECRET.to_string());
+            }
+            if let Some(tcp_ao) = &mut server.tcp_ao {
                 for key in &mut tcp_ao.0 {
                     key.key = REDACTED_SECRET.to_string();
                 }

--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -770,22 +770,7 @@ impl Config {
             .clone()
             .or_else(|| group.and_then(|g| g.md5_password.clone()))
             .map(Into::into);
-        transport.tcp_ao = neighbor.tcp_ao.as_ref().map(|tcp_ao| {
-            TcpAoKeyring(
-                tcp_ao
-                    .iter()
-                    .map(|key| TransportTcpAoConfig {
-                        key: key.key.clone().into(),
-                        send_id: key.send_id,
-                        recv_id: key.recv_id,
-                        algorithm: TcpAoAlgorithm::from_linux_name(&key.algorithm)
-                            .expect("validated in Config::load"),
-                        preferred: key.preferred,
-                        deprecated: key.deprecated,
-                    })
-                    .collect(),
-            )
-        });
+        transport.tcp_ao = neighbor.tcp_ao.as_ref().map(transport_tcp_ao_keyring);
         let ttl_security = neighbor
             .ttl_security
             .or_else(|| group.and_then(|g| g.ttl_security))
@@ -1374,4 +1359,23 @@ pub struct EffectivePolicyChains {
     pub export_explicit: bool,
     /// RFC 8212 external (eBGP) classification for this resolution.
     pub external: bool,
+}
+
+/// Convert a validated schema keyring into the transport keyring installed
+/// on sockets, preserving declaration order and metadata.
+pub(crate) fn transport_tcp_ao_keyring(tcp_ao: &super::TcpAoKeyringConfig) -> TcpAoKeyring {
+    TcpAoKeyring(
+        tcp_ao
+            .iter()
+            .map(|key| TransportTcpAoConfig {
+                key: key.key.clone().into(),
+                send_id: key.send_id,
+                recv_id: key.recv_id,
+                algorithm: TcpAoAlgorithm::from_linux_name(&key.algorithm)
+                    .expect("validated in Config::load"),
+                preferred: key.preferred,
+                deprecated: key.deprecated,
+            })
+            .collect(),
+    )
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -568,11 +568,21 @@ pub struct RpkiConfig {
     pub cache_servers: Vec<CacheServer>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CacheServer {
     /// Numeric RTR cache endpoint as IPv4 `address:port` or bracketed IPv6 `[address]:port`.
     pub address: String,
+    /// TCP MD5 password (RFC 2385) installed on the RTR socket before
+    /// connect; the cache must hold the same key. Mutually exclusive with
+    /// `tcp_ao`. Restart-required like the rest of `[rpki]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub md5_password: Option<String>,
+    /// TCP-AO keyring (RFC 5925) installed on the RTR socket before connect,
+    /// in the neighbor `tcp_ao` shape. Mutually exclusive with
+    /// `md5_password`. Restart-required like the rest of `[rpki]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tcp_ao: Option<TcpAoKeyringConfig>,
     /// RTR refresh interval in seconds. Default 3600.
     #[serde(default = "default_rpki_refresh")]
     pub refresh_interval: u64,
@@ -590,6 +600,25 @@ pub struct CacheServer {
     /// `retry_interval`. Unset: only the two-day maximum applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_expire_interval: Option<u64>,
+}
+
+// Manual Debug: never render `md5_password` (mirrors `NeighborConfig`;
+// `TcpAoConfig` redacts its own key).
+impl fmt::Debug for CacheServer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CacheServer")
+            .field("address", &self.address)
+            .field(
+                "md5_password",
+                &self.md5_password.as_ref().map(|_| "<redacted>"),
+            )
+            .field("tcp_ao", &self.tcp_ao)
+            .field("refresh_interval", &self.refresh_interval)
+            .field("retry_interval", &self.retry_interval)
+            .field("expire_interval", &self.expire_interval)
+            .field("max_expire_interval", &self.max_expire_interval)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/src/config/tests/persistence.rs
+++ b/src/config/tests/persistence.rs
@@ -1211,6 +1211,14 @@ fn redacted_placeholder_fails_validation_loudly() {
             "dynamic tcp_ao key",
             "[peer_groups.g]\nhold_time = 90\n[[dynamic_neighbors]]\nprefix = \"192.0.2.0/24\"\npeer_group = \"g\"\ntcp_ao = { key = \"<redacted>\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }\n",
         ),
+        (
+            "rpki cache md5",
+            "[rpki]\n[[rpki.cache_servers]]\naddress = \"127.0.0.1:3323\"\nmd5_password = \"<redacted>\"\n",
+        ),
+        (
+            "rpki cache tcp_ao key",
+            "[rpki]\n[[rpki.cache_servers]]\naddress = \"127.0.0.1:3323\"\ntcp_ao = { key = \"<redacted>\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }\n",
+        ),
     ] {
         let toml_str = format!(
             "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n[global.telemetry]\nlog_format = \"json\"\n\n{snippet}"

--- a/src/config/tests/rpki.rs
+++ b/src/config/tests/rpki.rs
@@ -313,3 +313,75 @@ fn rpki_max_expire_interval_not_above_retry_rejected() {
         "{err}"
     );
 }
+
+#[test]
+fn rpki_cache_server_md5_password_parses_and_never_debug_prints() {
+    let config = parse(&rpki_toml("md5_password = \"rtr-md5-hunter2\"")).unwrap();
+    let server = &config.rpki.as_ref().unwrap().cache_servers[0];
+    assert_eq!(server.md5_password.as_deref(), Some("rtr-md5-hunter2"));
+    assert!(server.tcp_ao.is_none());
+    let debug = format!("{server:?}");
+    assert!(!debug.contains("hunter2"), "{debug}");
+    assert!(debug.contains("<redacted>"), "{debug}");
+}
+
+#[test]
+fn rpki_cache_server_tcp_ao_parses_in_neighbor_shape() {
+    let config = parse(&rpki_toml(
+        "tcp_ao = { key = \"rtr-ao-hunter2\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }",
+    ))
+    .unwrap();
+    let server = &config.rpki.as_ref().unwrap().cache_servers[0];
+    let ring = server.tcp_ao.as_ref().unwrap();
+    assert_eq!(ring.len(), 1);
+    assert_eq!((ring.0[0].send_id, ring.0[0].recv_id), (1, 2));
+    let transport = transport_tcp_ao_keyring(ring);
+    assert_eq!(transport.0.len(), 1);
+    assert_eq!(transport.selected().unwrap().send_id, 1);
+    assert!(!format!("{server:?}").contains("hunter2"));
+}
+
+#[test]
+fn rpki_cache_server_rejects_md5_with_tcp_ao_and_invalid_tcp_ao() {
+    let err = parse(&rpki_toml(
+        "md5_password = \"x\"\ntcp_ao = { key = \"k\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("cache_servers[0]"), "{err}");
+    assert!(err.contains("mutually exclusive"), "{err}");
+
+    let err = parse(&rpki_toml(
+        "tcp_ao = { key = \"k\", send_id = 1, recv_id = 2, algorithm = \"md5\" }",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("cache_servers[0]"), "{err}");
+    assert!(err.contains("tcp_ao.algorithm"), "{err}");
+
+    let err = parse(&rpki_toml(
+        "tcp_ao = { key = \"\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("tcp_ao.key"), "{err}");
+}
+
+#[test]
+fn rpki_cache_server_secrets_are_redacted_in_effective_dump() {
+    for fields in [
+        "md5_password = \"rtr-md5-hunter2\"",
+        "tcp_ao = { key = \"rtr-ao-hunter2\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }",
+    ] {
+        let mut config = parse(&rpki_toml(fields)).unwrap();
+        let rendered = config.effective_redacted_toml().unwrap();
+        assert!(!rendered.contains("hunter2"), "{rendered}");
+        assert!(rendered.contains(REDACTED_SECRET), "{rendered}");
+        let err = Config::load_toml_with_diagnostics(&rendered, "effective.toml").unwrap_err();
+        assert!(err.contains("rbgp config effective"), "{err}");
+        assert!(
+            err.contains("invalid RPKI config: cache_servers[0]"),
+            "{err}"
+        );
+    }
+}

--- a/src/config/tests/rpki.rs
+++ b/src/config/tests/rpki.rs
@@ -326,6 +326,19 @@ fn rpki_cache_server_md5_password_parses_and_never_debug_prints() {
 }
 
 #[test]
+fn rpki_cache_server_rejects_empty_and_oversized_md5_passwords() {
+    for password in [String::new(), "k".repeat(81), "é".repeat(41)] {
+        let err = parse(&rpki_toml(&format!("md5_password = {password:?}")))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("cache_servers[0]: md5_password must be 1..=80 bytes"),
+            "{err}"
+        );
+    }
+}
+
+#[test]
 fn rpki_cache_server_tcp_ao_parses_in_neighbor_shape() {
     let config = parse(&rpki_toml(
         "tcp_ao = { key = \"rtr-ao-hunter2\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }",

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -987,6 +987,13 @@ impl Config {
                         reason: format!("cache_servers[{i}]: expire_interval must be > 0"),
                     });
                 }
+                if let Some(password) = &server.md5_password
+                    && (password.is_empty() || password.len() > 80)
+                {
+                    return Err(ConfigError::InvalidRpkiConfig {
+                        reason: format!("cache_servers[{i}]: md5_password must be 1..=80 bytes"),
+                    });
+                }
                 if let Some(tcp_ao) = &server.tcp_ao {
                     if server.md5_password.is_some() {
                         return Err(ConfigError::InvalidRpkiConfig {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -987,6 +987,20 @@ impl Config {
                         reason: format!("cache_servers[{i}]: expire_interval must be > 0"),
                     });
                 }
+                if let Some(tcp_ao) = &server.tcp_ao {
+                    if server.md5_password.is_some() {
+                        return Err(ConfigError::InvalidRpkiConfig {
+                            reason: format!(
+                                "cache_servers[{i}]: tcp_ao is mutually exclusive with md5_password"
+                            ),
+                        });
+                    }
+                    validate_tcp_ao_config(&format!("rpki.cache_servers[{i}]"), tcp_ao).map_err(
+                        |e| ConfigError::InvalidRpkiConfig {
+                            reason: format!("cache_servers[{i}]: {e}"),
+                        },
+                    )?;
+                }
                 if server.expire_interval < server.refresh_interval {
                     return Err(ConfigError::InvalidRpkiConfig {
                         reason: format!(
@@ -1660,14 +1674,17 @@ impl Config {
     /// still carries the placeholder must fail loudly at load instead of
     /// silently booting with `<redacted>` as a live credential.
     fn validate_no_redacted_secrets(&self) -> Result<(), ConfigError> {
-        let placeholder_error = |address: &str, field: &str| ConfigError::InvalidNeighborConfig {
-            address: address.to_string(),
-            field: field.to_string(),
-            reason: format!(
+        let placeholder_reason = || {
+            format!(
                 "is the literal {:?} placeholder emitted by `rbgp config effective`; \
                  restore the real secret before loading this config",
                 super::REDACTED_SECRET
-            ),
+            )
+        };
+        let placeholder_error = |address: &str, field: &str| ConfigError::InvalidNeighborConfig {
+            address: address.to_string(),
+            field: field.to_string(),
+            reason: placeholder_reason(),
         };
         for neighbor in &self.neighbors {
             if neighbor.md5_password.as_deref() == Some(super::REDACTED_SECRET) {
@@ -1699,6 +1716,26 @@ impl Config {
                     &format!("peer_groups.{name}"),
                     "md5_password",
                 ));
+            }
+        }
+        for (i, server) in self
+            .rpki
+            .iter()
+            .flat_map(|rpki| rpki.cache_servers.iter().enumerate())
+        {
+            if server.md5_password.as_deref() == Some(super::REDACTED_SECRET) {
+                return Err(ConfigError::InvalidRpkiConfig {
+                    reason: format!("cache_servers[{i}]: md5_password {}", placeholder_reason()),
+                });
+            }
+            if server
+                .tcp_ao
+                .as_ref()
+                .is_some_and(|tcp_ao| tcp_ao.iter().any(|key| key.key == super::REDACTED_SECRET))
+            {
+                return Err(ConfigError::InvalidRpkiConfig {
+                    reason: format!("cache_servers[{i}]: tcp_ao.key {}", placeholder_reason()),
+                });
             }
         }
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -3007,6 +3007,10 @@ const TEST_RPKI_TASK_EXIT_ENV: &str = "RUSTBGPD_TEST_RPKI_TASK_EXIT";
 /// first unexpected exit. This is observability work before the ordinary
 /// fail-stop teardown, not a grace period for live tasks.
 const RPKI_FAILURE_RESOLUTION_DEADLINE: Duration = Duration::from_secs(1);
+/// Bound on an authenticated RTR TCP handshake. A cache holding a different
+/// TCP MD5 / TCP-AO key drops the signed SYN, so the mismatch surfaces as a
+/// logged connection failure instead of a kernel-length SYN retry.
+const RTR_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn resolve_test_peer_manager_panic() -> bool {
     match std::env::var(TEST_PEER_MANAGER_PANIC_ENV) {
@@ -3751,6 +3755,43 @@ async fn run<T>(
         );
     });
 
+    // Prove the kernel accepts every RPKI cache server's TCP MD5 / TCP-AO
+    // material before any teardown-owned actor starts. The RTR clients
+    // spawned later dial with the same options and never fall back to
+    // plaintext, so a refused key is a startup error rather than an endless
+    // reconnect loop.
+    for server in config
+        .rpki
+        .iter()
+        .flat_map(|rpki| rpki.cache_servers.iter())
+        .filter(|server| server.md5_password.is_some() || server.tcp_ao.is_some())
+    {
+        // Validation already requires a numeric endpoint; the spawn site
+        // reports anything that still fails to parse.
+        let Ok(addr) = server.address.parse::<std::net::SocketAddr>() else {
+            continue;
+        };
+        let md5_password = server
+            .md5_password
+            .clone()
+            .map(rustbgpd_transport::TransportAuthSecret::from);
+        let tcp_ao = server
+            .tcp_ao
+            .as_ref()
+            .map(crate::config::transport_tcp_ao_keyring);
+        if let Err(error) = rustbgpd_transport::preflight_authenticated_dial(
+            addr,
+            md5_password.as_ref(),
+            tcp_ao.as_ref(),
+            &addr.to_string(),
+        ) {
+            fatal_startup_error(
+                "RPKI cache server transport authentication rejected by the kernel",
+                format!("cache {addr}: {error}"),
+            );
+        }
+    }
+
     // Acquire every later-activated data-plane listener/socket now. Retaining
     // these resources reserves the operator's configured addresses, but no
     // BFD actor, BGP accept loop, or metrics HTTP server runs before its
@@ -4201,6 +4242,43 @@ async fn run<T>(
                 .with_expire_observer(move |secs| {
                     expire_metrics.set_rpki_cache_effective_expire_seconds(&cache_label, secs);
                 });
+            // Authenticated caches dial through the transport crate so TCP MD5
+            // or TCP-AO is installed before the SYN leaves; the material was
+            // preflighted against the kernel before the ownership boundary.
+            let md5_password = server
+                .md5_password
+                .clone()
+                .map(rustbgpd_transport::TransportAuthSecret::from);
+            let tcp_ao = server
+                .tcp_ao
+                .as_ref()
+                .map(crate::config::transport_tcp_ao_keyring);
+            let client = if md5_password.is_some() || tcp_ao.is_some() {
+                let auth_label = addr.to_string();
+                info!(
+                    server = %addr,
+                    md5 = md5_password.is_some(),
+                    tcp_ao = tcp_ao.is_some(),
+                    "RTR transport authentication configured"
+                );
+                client.with_dialer(move |remote| {
+                    let md5_password = md5_password.clone();
+                    let tcp_ao = tcp_ao.clone();
+                    let label = auth_label.clone();
+                    async move {
+                        rustbgpd_transport::connect_authenticated(
+                            remote,
+                            md5_password.as_ref(),
+                            tcp_ao.as_ref(),
+                            &label,
+                            RTR_HANDSHAKE_TIMEOUT,
+                        )
+                        .await
+                    }
+                })
+            } else {
+                client
+            };
             info!(server = %addr, "spawning RTR client for RPKI cache");
             let handle = rpki_tasks.spawn(async move {
                 assert!(

--- a/tests/interop/scripts/rtr-v2-server.py
+++ b/tests/interop/scripts/rtr-v2-server.py
@@ -9,11 +9,16 @@ ASPA PDU type 11 is v2-only.
 """
 
 import json
+import os
 import socket
 import struct
 import time
 
-LISTEN_PORT = 3323
+LISTEN_PORT = int(os.environ.get("RTR_LISTEN_PORT", "3323"))
+# Optional listener-side TCP MD5 (RFC 2385) key, applied to every IPv4 peer
+# via TCP_MD5SIG_EXT with a 0.0.0.0/0 prefix. Used by the RTR transport
+# authentication receipt; unset means plain TCP as before.
+TCP_MD5_KEY = os.environ.get("RTR_TCP_MD5_KEY", "").encode()
 SESSION_ID = 1
 SERIAL = 1
 REFRESH = 30
@@ -200,9 +205,31 @@ def write_status(queries_served):
         json.dump(status, f)
 
 
+def install_tcp_md5(sock, key):
+    """setsockopt(TCP_MD5SIG_EXT) with a prefix-scoped 0.0.0.0/0 key.
+
+    Linux ``struct tcp_md5sig``: sockaddr_storage (128), tcpm_flags (u8),
+    tcpm_prefixlen (u8), tcpm_keylen (u16), tcpm_ifindex (i32), key[80].
+    """
+    tcp_md5sig_ext = 32
+    tcp_md5sig_flag_prefix = 1
+    if not 1 <= len(key) <= 80:
+        raise SystemExit("RTR_TCP_MD5_KEY must be 1..=80 bytes")
+    addr = struct.pack("=HH4s", socket.AF_INET, 0, socket.inet_aton("0.0.0.0"))
+    opt = (
+        addr.ljust(128, b"\0")
+        + struct.pack("=BBHi", tcp_md5sig_flag_prefix, 0, len(key), 0)
+        + key.ljust(80, b"\0")
+    )
+    sock.setsockopt(socket.IPPROTO_TCP, tcp_md5sig_ext, opt)
+
+
 def main():
     srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if TCP_MD5_KEY:
+        install_tcp_md5(srv, TCP_MD5_KEY)
+        print("RTR: TCP MD5 required from every peer", flush=True)
     srv.bind(("0.0.0.0", LISTEN_PORT))
     srv.listen(2)
     srv.settimeout(300)

--- a/tests/interop/scripts/test-rtr-tcp-md5.sh
+++ b/tests/interop/scripts/test-rtr-tcp-md5.sh
@@ -30,7 +30,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-fail() { echo "FAIL: $*" >&2; echo "--- daemon log"; cat "$WORK/daemon.log"; exit 1; }
+fail() { echo "FAIL: $*" >&2; echo "--- daemon log"; cat "$WORK/daemon.log" 2>/dev/null || true; exit 1; }
 
 start_server() { # $1 = listener MD5 key ("" = plain TCP)
     RTR_LISTEN_PORT="$RTR_PORT" RTR_TCP_MD5_KEY="$1" \

--- a/tests/interop/scripts/test-rtr-tcp-md5.sh
+++ b/tests/interop/scripts/test-rtr-tcp-md5.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# RTR transport authentication receipt — local loopback, no containers.
+#
+# Runs the in-repo RTR v2 server with TCP MD5 (RFC 2385) required on its
+# listener and proves the `[[rpki.cache_servers]] md5_password` path end to
+# end through the rustbgpd binary:
+#   1. matching key   -> the cache syncs (end_of_data_ready = 1, vrp_count > 0)
+#   2. wrong key      -> no session; "RTR connection failed" with the key hint
+#   3. unsigned cache -> a keyed client stays down (no plaintext fallback)
+#
+# Usage: bash tests/interop/scripts/test-rtr-tcp-md5.sh
+#   RUSTBGPD_BIN   daemon binary (default target/debug/rustbgpd)
+#   RTR_PORT, METRICS_PORT, BGP_PORT   loopback ports (defaults 13323/19179/11179)
+set -euo pipefail
+
+RUSTBGPD_BIN="${RUSTBGPD_BIN:-target/debug/rustbgpd}"
+RTR_PORT="${RTR_PORT:-13323}"
+METRICS_PORT="${METRICS_PORT:-19179}"
+BGP_PORT="${BGP_PORT:-11179}"
+KEY="rtr-md5-receipt-key"
+SERVER_PY="$(dirname "$0")/rtr-v2-server.py"
+WORK="$(mktemp -d)"
+SERVER_PID=""
+DAEMON_PID=""
+
+cleanup() {
+    [[ -n "$DAEMON_PID" ]] && kill "$DAEMON_PID" 2>/dev/null || true
+    [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; echo "--- daemon log"; cat "$WORK/daemon.log"; exit 1; }
+
+start_server() { # $1 = listener MD5 key ("" = plain TCP)
+    RTR_LISTEN_PORT="$RTR_PORT" RTR_TCP_MD5_KEY="$1" \
+        python3 "$SERVER_PY" > "$WORK/server.log" 2>&1 &
+    SERVER_PID=$!
+    sleep 0.5
+    kill -0 "$SERVER_PID" 2>/dev/null || { cat "$WORK/server.log"; fail "RTR server did not start"; }
+}
+
+stop_server() { kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true; SERVER_PID=""; }
+
+write_config() { # $1 = daemon md5_password
+    cat > "$WORK/rustbgpd.toml" <<EOF
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = $BGP_PORT
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:$METRICS_PORT"
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "$WORK/grpc.sock"
+principal = "rustbgpd://operator/test-only"
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:$RTR_PORT"
+md5_password = "$1"
+refresh_interval = 5
+retry_interval = 2
+expire_interval = 60
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+EOF
+}
+
+start_daemon() {
+    "$RUSTBGPD_BIN" --check "$WORK/rustbgpd.toml" > "$WORK/check.log" 2>&1 || { cat "$WORK/check.log"; fail "config check"; }
+    "$RUSTBGPD_BIN" "$WORK/rustbgpd.toml" > "$WORK/daemon.log" 2>&1 &
+    DAEMON_PID=$!
+}
+
+stop_daemon() { kill "$DAEMON_PID" 2>/dev/null || true; wait "$DAEMON_PID" 2>/dev/null || true; DAEMON_PID=""; }
+
+# Prints the sample value, or 0 when the family has not been emitted yet
+# (gauges appear on first set).
+metric() {
+    curl -sf "http://127.0.0.1:$METRICS_PORT/metrics" 2>/dev/null \
+        | awk -v m="$1" '$1 ~ "^"m"([{ ]|$)" {print $2; found=1; exit} END {if (!found) print 0}'
+}
+
+wait_for_sync() {
+    for _ in $(seq 1 40); do
+        if [[ "$(metric 'bgp_rpki_cache_end_of_data_ready')" == "1" ]] \
+            && [[ "$(metric 'bgp_rpki_vrp_count')" =~ ^[1-9] ]]; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    return 1
+}
+
+assert_down() { # waits past the 10 s handshake bound for the logged diagnostic
+    for _ in $(seq 1 60); do
+        grep -q 'RTR connection failed' "$WORK/daemon.log" && break
+        sleep 0.5
+    done
+    grep -q 'RTR connection failed' "$WORK/daemon.log" || fail "no 'RTR connection failed' diagnostic"
+    grep -q 'TCP MD5 / TCP-AO key' "$WORK/daemon.log" || fail "diagnostic lacks the key-mismatch hint"
+    [[ "$(metric 'bgp_rpki_cache_end_of_data_ready')" == "0" ]] || fail "cache reported ready"
+    [[ "$(metric 'bgp_rpki_vrp_count')" == "0" ]] || fail "VRPs loaded without the key"
+}
+
+echo "case 1: matching key syncs"
+start_server "$KEY"; write_config "$KEY"; start_daemon
+wait_for_sync || fail "cache did not sync with the matching key"
+grep -q 'RTR transport authentication configured' "$WORK/daemon.log" || fail "auth not logged"
+grep -q "$KEY" "$WORK/daemon.log" && fail "key leaked into the daemon log"
+stop_daemon; stop_server
+echo "  PASS"
+
+echo "case 2: wrong key never completes the handshake"
+start_server "$KEY"; write_config "not-$KEY"; start_daemon
+assert_down
+stop_daemon; stop_server
+echo "  PASS"
+
+echo "case 3: keyed client against an unsigned cache stays down"
+start_server ""; write_config "$KEY"; start_daemon
+assert_down
+stop_daemon; stop_server
+echo "  PASS"
+
+echo "RTR TCP MD5 receipt: all cases passed"


### PR DESCRIPTION
## Summary

RTR cache sessions can now be authenticated at the TCP layer. `[[rpki.cache_servers]]` gains `md5_password` (RFC 2385) and a neighbor-shaped `tcp_ao` keyring (RFC 5925); the key is installed on the socket before the SYN leaves, using the same transport helpers the BGP active-open path uses. This follows the 8210bis transport section (TCP-AO SHOULD, MD5 MAY) and matches what OpenBGPD (`rtr ... tcp md5sig`) offers; the BIRD/FRR SSH transports and RFC 8210 TLS remain deferred.

- `crates/transport`: `connect_authenticated` / `preflight_authenticated_dial` build a socket, install MD5 and/or TCP-AO via the existing `set_tcp_md5sig` / `set_tcp_ao_config` helpers, and connect with a caller-supplied handshake bound. `install_active_tcp_ao_with` now takes `(remote_addr, keyring)` instead of the whole `TransportConfig`; the BGP path is otherwise unchanged.
- `crates/rpki` (published): additive `RtrClient::with_dialer` builder; both `TcpStream::connect` sites route through it. `RtrClientConfig` is unchanged, so no struct-literal break. Crate version is not bumped here (release-time sweep).
- Daemon: config schema, validation (mutual exclusion, keyring validation reused from neighbors, `<redacted>` placeholder rejection), `rbgp config effective` redaction, manual `Debug` that never renders the password, startup preflight, and the dialer wiring in `main.rs`.
- Lab: `tests/interop/scripts/rtr-v2-server.py` gains an optional listener-side TCP MD5 key (`RTR_TCP_MD5_KEY`, prefix-scoped `0.0.0.0/0`, unset = plain TCP as before); `tests/interop/scripts/test-rtr-tcp-md5.sh` is a loopback receipt driving the real binary through matching-key, wrong-key, and unsigned-cache cases.

## Behavior change

**Operator-visible:**

- With `md5_password` or `tcp_ao` set on a cache server, the key is installed before connect. Config validation rejects empty or over-80-byte MD5 values before socket setup. Kernel refusal of otherwise valid material, including TCP-AO on a kernel without `CONFIG_TCP_AO`, is a **startup error** (`RPKI cache server transport authentication rejected by the kernel`); there is no plaintext fallback at any point.
- A cache holding a different key drops the signed SYN silently. The authenticated dial bounds the handshake at 10 s and logs `RTR connection failed` with `... did not complete within 10s; the peer is unreachable or does not hold the same TCP MD5 / TCP-AO key`, then retries after `retry_interval` as before.
- `RTR transport authentication configured` is logged once per authenticated cache at startup (`md5`/`tcp_ao` booleans only; never the key).
- Caches without either field behave exactly as before (plain `TcpStream::connect`, no handshake bound).
- `[rpki]` was already restart-required; the new fields inherit that classification.

## Compatibility impact

- Config: additive fields on `[[rpki.cache_servers]]`; `deny_unknown_fields` still applies. Secrets are redacted by `rbgp config effective` and the `<redacted>` placeholder is rejected on reload, exactly as for neighbor `md5_password` / `tcp_ao`.
- Config validation: `md5_password` must contain 1..=80 UTF-8 bytes; empty and oversized values are rejected before socket setup.
- Public Rust API: `rustbgpd-rpki` gains `RtrClient::with_dialer` (additive). `rustbgpd-transport` gains two public functions; a private helper signature changed.
- Wire/metrics/RPC/protobuf: none.
- Docs: CONFIGURATION (new fields, "Transport authentication" example), KNOWN_ISSUES narrowed from "TCP-AO not supported for RTR" to "RTR over TLS or SSH is not supported" (and notes that RTR TCP-AO is startup-only, no SIGHUP rotation), deployment security checklist, INTEROP (lab section), rpki crate docs, CHANGELOG.

## Tests

New:

- `crates/transport/src/session/tests/authenticated_dial.rs`
  - `md5_dial_completes_with_matching_key_and_never_without_it` — loopback listener with `TCP_MD5SIG`; matching key accepted, wrong key and no key both time out with the key-mismatch hint and nothing is ever accepted.
  - `tcp_ao_dial_completes_with_matching_mkt_and_never_without_it` — same three outcomes with a mirrored TCP-AO MKT on the listener; skips on kernels without TCP-AO.
  - `preflight_reports_refused_md5_material_without_connecting` — 81-byte password is `InvalidInput`; a valid one passes.
- `crates/transport/src/socket_opts.rs`: `public_tcp_md5_setters_reject_empty_keys` keeps kernel deletion behind the explicit removal helper.
- `crates/rpki`: `rtr_client::tests::with_dialer_opens_every_connection_through_the_dialer` — the configured address is deliberately unreachable; only the dialer knows the listener.
- Daemon config (`src/config/tests/rpki.rs`): `rpki_cache_server_md5_password_parses_and_never_debug_prints`, `rpki_cache_server_rejects_empty_and_oversized_md5_passwords`, `rpki_cache_server_tcp_ao_parses_in_neighbor_shape`, `rpki_cache_server_rejects_md5_with_tcp_ao_and_invalid_tcp_ao`, `rpki_cache_server_secrets_are_redacted_in_effective_dump`.
- `src/config/tests/persistence.rs::redacted_placeholder_fails_validation_loudly` gains the two cache-server placeholder cases.

Lab receipt (`tests/interop/scripts/test-rtr-tcp-md5.sh`, run locally on this branch): case 1 matching key syncs — PASS; case 2 wrong key never completes the handshake (`RTR connection failed` with the key-mismatch hint, `bgp_rpki_vrp_count` stays 0) — PASS; case 3 keyed client against an unsigned cache stays down — PASS.

## Checks run

- `just gate` — exit 0 on the rebased branch (fmt check, repository contracts, strict workspace clippy, full workspace tests, library docs). A first gate run failed on two things this change owed and now includes: the committed `docs/rustbgpd.schema.json` was regenerated for the two new fields, and the RPKI kernel preflight was moved before the startup teardown-ownership boundary so `fatal_startup_error` stays out of the post-boundary region (`startup_preflight_precedes_first_owned_actor_and_late_activation`).
- Focused after rebase: `cargo test -p rustbgpd-transport authenticated_dial` (3 passed), `cargo test -p rustbgpd-rpki with_dialer` (1 passed), `cargo test -p rustbgpd --bin rustbgpd rpki_cache_server_rejects_empty_and_oversized_md5_passwords` (1 passed) and `redacted_placeholder_fails_validation_loudly` (1 passed) — all exit 0.
- `bash tests/interop/scripts/test-rtr-tcp-md5.sh` against the freshly built binary — exit 0 (three cases above).
- Pre-commit hook (`cargo fmt`, `cargo clippy`) passed on commit.

Not run: hosted interop lanes (the loopback lab is documented as a local receipt, not wired into `interop.yml`); `just gate-rib` / `gate-deps` / `gate-contract` (no feature-gated RIB, scale-harness, or Criterion surfaces touched).

## Proven / not proven

- Proven on this host (Linux 6.17, `CONFIG_TCP_AO`): TCP MD5 correct key syncs and wrong key never completes, at the socket seam (transport test) and end to end through the daemon binary against an MD5-required RTR listener (lab script). TCP-AO correct MKT connects and wrong MKT / no MKT never complete, at the socket seam (transport test).
- Not proven: TCP-AO end to end through the daemon against an RTR cache. No public RTR cache (Routinator, StayRTR, rpki-client, FORT) offers a TCP MD5 or TCP-AO listener, which is why the lab uses the in-repo RTR server; it gained MD5 only. The daemon's TCP-AO path is the same `install_active_tcp_ao_with` the BGP active open uses (M43 covers that end to end).
- Deferred: RTR over SSH (BIRD `transport ssh`, FRR `rpki cache ssh`) and TLS; live TCP-AO key rotation on RTR sockets (`[rpki]` stays restart-required).


