### PR TITLE
Retire stale fuzz and RPC census counts from prose

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -324,7 +324,7 @@ proof on the activated cell in hosted CI.
   300-second total engine budget). ClusterFuzzLite is therefore manual-dispatch
   only with a 180-minute cold-start bound and no crash-injection requirement on
   a PR. The existing cargo-fuzz workflow is the sole nightly campaign, while
-  the ordinary PR/push CI check enforces the exact fail-closed 19-target
+  the ordinary PR/push CI check enforces the exact fail-closed
   manifest/source inventory. Batch fuzzing, corpus pruning, storage, and
   coverage are not part of this slice; the official Rust integration currently
   supports AddressSanitizer only.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -130,7 +130,7 @@ see the full ~16,000-ASN path.
 ### Fuzzing
 
 Six fuzz crates (`crates/wire`, `crates/policy`, `crates/mrt`,
-`crates/evpn`, `crates/bfd`, `crates/rpki`) carry 21 fuzz targets covering
+`crates/evpn`, `crates/bfd`, `crates/rpki`) carry fuzz targets covering
 the message decoders, the policy frontend, structure-aware policy-chain
 compilation and explain-walk agreement, MRT snapshot and warm-bundle
 readers, EVPN parsing, the BFD control-packet decoder, and the RTR PDU
@@ -146,10 +146,11 @@ inventory is fail-closed: `scripts/check_fuzz_target_inventory.py` runs
 in CI and fails when the inventory drifts from the reviewed list.
 Every wire target has a tracked seed. The nightly workflow may reuse a bounded
 `main`-lineage corpus, but it restores into runner-temporary staging and
-validates the exact 12-directory layout, regular-file shape, per-target length
-bounds, SHA-256 manifest, 20,000-file ceiling, and 16 MiB ceiling before copying
-anything into the live corpus. Cache misses and cache-service outages use only
-the tracked seeds; matched content that fails validation stops the campaign.
+validates the exact reviewed target-directory set, regular-file shape,
+per-target length bounds, SHA-256 manifest, 20,000-file ceiling, and 16 MiB
+ceiling before copying anything into the live corpus. Cache misses and
+cache-service outages use only the tracked seeds; matched content that fails
+validation stops the campaign.
 The cache contains public test inputs only and is not a place for credentials
 or other private data.
 

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -474,10 +474,11 @@ family enums — remain exhaustively matchable on purpose.
 
 ## Fuzz tested
 
-Twelve fuzz targets exercise the codec continuously in CI:
+Fuzz targets exercise the codec in the nightly CI fuzz campaign:
 
 - `decode_message` — full BGP message framing
 - `decode_update` — UPDATE parsing with Add-Path and MP-BGP variants
+- `encode_update` — canonical IPv4 UPDATE encode round-trip
 - `decode_open` — OPEN + capability decode
 - `decode_route_refresh` — ROUTE-REFRESH / ORF decode
 - `decode_flowspec` — FlowSpec NLRI component decoding

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -348,8 +348,8 @@ specific method if the model warrants it.
 
 ## Code matrix
 
-`crates/api/src/authz.rs` contains the same 107-method classification
-as a static Rust table. `docs/grpc-method-inventory.json` is the
+`crates/api/src/authz.rs` contains the same method classification as a
+static Rust table. `docs/grpc-method-inventory.json` is the
 machine-readable export for auditors, tooling, and generated clients. The
 `authz` tests parse `proto/rustbgpd.proto` and fail if a new RPC is added
 without a tier assignment; they also parse the JSON export and fail if it drifts


### PR DESCRIPTION
## Summary

Five inventory counts stated in prose had drifted from the inventories CI
already pins. Documentation only; no behavior, configuration, or wire change.

The repository convention is to state capability, scope, and a pinned path
rather than a census total, because a total rots between audits and costs a
verification pass every time. Each count here is removed rather than
refreshed, unless something depends on the number being present. No checker
greps for any of these phrases (`scripts/` was searched for each surrounding
phrase before removal).

## What changed

- `SECURITY.md` — "carry 21 fuzz targets" **removed the census**. The pin is
  `scripts/check_fuzz_target_inventory.py` (`EXPECTED_COUNT = 22`), which the
  same paragraph already cites; `docs/FUZZING.md` and `docs/RECEIPTS.md`
  already state 22. The sentence still names the six fuzz crates and what
  they cover.
- `SECURITY.md` — "the exact 12-directory layout" **removed the census**, now
  "the exact reviewed target-directory set". `scripts/fuzz_corpus_cache.py`
  derives the expected set from `TARGET_MAX_LENS`, which holds 13 wire
  targets, matching the 13 files in `crates/wire/fuzz/fuzz_targets/`. The
  layout is exact because it is derived, not because it is a fixed number.
- `ROADMAP.md` — "the exact fail-closed 19-target manifest/source inventory"
  **removed the census**; it tracked the same drifting pin as the first item.
  The neighbouring "17-target build/check" is left as written: it is a dated
  statement about the closed OSS-Fuzz submission, not a live count.
- `crates/wire/README.md` — "Twelve fuzz targets exercise the codec
  continuously in CI" **removed the census** and corrected the cadence to
  "Fuzz targets exercise the codec in the nightly CI fuzz campaign"
  (`.github/workflows/fuzz.yml` is a nightly cron plus manual dispatch; PR CI
  proves the inventory, it does not fuzz). Added the missing `encode_update`
  bullet, so the list now covers all 13 targets. This file ships to crates.io.
- `docs/grpc-method-inventory.md` — "the same 107-method classification"
  **removed the census**. The file contradicted itself: its own `## Totals`
  table and the note under it say 108, and `crates/api/src/authz.rs` asserts
  `METHODS.len() == 108`.

  On the generated-file question: this document is **not** generated. Its
  `## Maintenance` section instructs manual row and count bumps, and the
  `authz` tests enforce the per-service `### Service (N RPCs)` headings, the
  per-service rows against `docs/grpc-method-inventory.json`, and the
  `## Totals` table counts and percentages. That enforcement parses only
  headings and table rows — `markdown_totals` reads lines under `## Totals`
  and stops there — so the prose sentence under `## Code matrix` is
  unenforced free text. Removing its count leaves every enforced surface
  untouched and removes the contradiction; the enforced total sits twelve
  lines above it.

## Checks run

All exit 0.

- `just links` (lychee 0.24.2, offline)
- The `gate` recipe's Python checkers and self-tests: `check_developer_tooling`
  (self-test + run), `test_check_clippy_reasons` + `check-clippy-reasons`,
  `check-v1-stable-surface`, `reflow-release-notes --selftest`,
  `test_check_public_tracker_ids` + `check_public_tracker_ids`,
  `test_check_ixp_manager_docs` + `check_ixp_manager_docs`,
  `test_check_release_checklist_paths` + `check_release_checklist_paths`,
  `test_check_metric_consumers` + `check-metric-consumers`
- Fuzz inventory: `test_check_fuzz_target_inventory` +
  `check_fuzz_target_inventory`, plus `test_fuzz_corpus_cache`
- Public docs contract (both matrix legs of
  `.github/workflows/public-docs-contract.yml`): embedding versions and crate
  map, metric release notes, perf receipt freshness, and the public-lane
  checkers listed above
- `CARGO_BUILD_JOBS=16 cargo test -p rustbgpd-wire` — `readme_contract` passes
- `cargo test -p rustbgpd-api authz --no-fail-fast` — the markdown/JSON drift
  tests that pin `docs/grpc-method-inventory.md`

The full `just gate` was not run: this change touches only Markdown prose, and
the Rust surfaces that consume these files (`crates/wire/tests/readme_contract.rs`,
the `authz` markdown tests) were exercised directly.
