### PR TITLE
cli: close pager stdin explicitly instead of relying on Child::wait

### DIFF
--- a/crates/cli/src/pager.rs
+++ b/crates/cli/src/pager.rs
@@ -115,6 +115,8 @@ fn run_pager(
         Err(error) => return Err(CliError::Io(error)),
     };
 
+    // Close the write end explicitly once the payload is out. `Child::wait` also
+    // closes it, so this is about stating the lifetime rather than fixing a hang.
     let mut stdin = child.stdin.take().expect("piped pager stdin");
     let write_result = stdin.write_all(payload.as_bytes());
     drop(stdin);
@@ -189,54 +191,6 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.to_string(), "pager exited with status 1");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn cat_pager_receives_eof_and_does_not_hang() {
-        use std::sync::mpsc;
-        use std::time::Duration;
-
-        let (tx, rx) = mpsc::channel();
-        let payload = "payload line 1\npayload line 2\n".to_string();
-        std::thread::spawn(move || {
-            let result = run_pager(
-                &["cat".into()],
-                &payload,
-                PagerMode::Always,
-                &mut Vec::new(),
-            );
-            let _ = tx.send(result);
-        });
-
-        let result = rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("cat did not receive EOF within 5s - stdin pipe was not closed before wait");
-        assert!(result.is_ok());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn early_exiting_pager_proves_pipe_closed_on_small_input() {
-        use std::sync::mpsc;
-        use std::time::Duration;
-
-        let (tx, rx) = mpsc::channel();
-        let payload = "x".to_string();
-        std::thread::spawn(move || {
-            let result = run_pager(
-                &["head".into(), "-c".into(), "1".into()],
-                &payload,
-                PagerMode::Always,
-                &mut Vec::new(),
-            );
-            let _ = tx.send(result);
-        });
-
-        let result = rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("head -c 1 did not exit within 5s - stdin pipe was not closed before wait");
-        assert!(result.is_ok());
     }
 
     #[cfg(unix)]

--- a/crates/cli/src/pager.rs
+++ b/crates/cli/src/pager.rs
@@ -115,11 +115,9 @@ fn run_pager(
         Err(error) => return Err(CliError::Io(error)),
     };
 
-    let write_result = child
-        .stdin
-        .as_mut()
-        .expect("piped pager stdin")
-        .write_all(payload.as_bytes());
+    let mut stdin = child.stdin.take().expect("piped pager stdin");
+    let write_result = stdin.write_all(payload.as_bytes());
+    drop(stdin);
     let status = child.wait()?;
     classify_pager_result(write_result, status)
 }
@@ -191,6 +189,67 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.to_string(), "pager exited with status 1");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cat_pager_receives_eof_and_does_not_hang() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let (tx, rx) = mpsc::channel();
+        let payload = "payload line 1\npayload line 2\n".to_string();
+        std::thread::spawn(move || {
+            let result = run_pager(
+                &["cat".into()],
+                &payload,
+                PagerMode::Always,
+                &mut Vec::new(),
+            );
+            let _ = tx.send(result);
+        });
+
+        let result = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("cat did not receive EOF within 5s - stdin pipe was not closed before wait");
+        assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn early_exiting_pager_proves_pipe_closed_on_small_input() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let (tx, rx) = mpsc::channel();
+        let payload = "x".to_string();
+        std::thread::spawn(move || {
+            let result = run_pager(
+                &["head".into(), "-c".into(), "1".into()],
+                &payload,
+                PagerMode::Always,
+                &mut Vec::new(),
+            );
+            let _ = tx.send(result);
+        });
+
+        let result = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("head -c 1 did not exit within 5s - stdin pipe was not closed before wait");
+        assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn brokenpipe_on_success_is_ignored() {
+        let status = Command::new("/bin/true").status().unwrap();
+        assert!(
+            classify_pager_result(
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed")),
+                status,
+            )
+            .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

In `crates/cli/src/pager.rs`, `run_pager` borrowed `child.stdin` via `as_mut()` and left the write end of the pipe to be closed by `child.wait()`. This takes the handle instead and drops it immediately after the payload is written, so the pipe's lifetime ends where the payload does rather than as a side effect of reaping the child.

**This is a readability change, not a bug fix.** An earlier revision of this PR claimed the borrow deadlocked pagers that read to EOF. That claim was wrong and has been withdrawn. `std::process::Child::wait` is:

```rust
pub fn wait(&mut self) -> io::Result<ExitStatus> {
    drop(self.stdin.take());
    self.handle.wait().map(ExitStatus)
}
```

The close is documented as being there precisely to avoid this deadlock, and `pager.rs` uses `std::process`. EOF was already delivered before the wait. The explicit `drop` moves that close a few instructions earlier, with nothing in between.

## What was measured

Both forms were compiled and run side by side on the toolchain in use (1.98.0), with a two-line payload and a ~1 MiB payload:

| pager | pre-change | post-change |
| --- | --- | --- |
| `cat` (reads to EOF) | exits, 0.7 ms / 0.9 ms | exits, 0.4 ms / 0.9 ms |
| `head -c 1`, `head -n 1` | exits 0, `BrokenPipe` on the large write | identical |
| `less -FRSX` under a pty | exits, 1.0 ms | exits, 1.1 ms |
| `sleep` (never reads stdin) | exits, `BrokenPipe` on the large write | identical |

No shape hangs under either form. `less -FRSX` resolves `--quit-if-one-screen` correctly without the change, because it does receive EOF; the claim that it could not is withdrawn. The non-reading pager is identical by construction: with a payload past the 64 KiB pipe buffer, `write_all` blocks on the full pipe before `wait()` is ever reached, so closing the handle after the write cannot help.

## Changes

- Take `child.stdin`, write the payload, and drop the handle before `child.wait()?`. A comment records that `Child::wait` also closes it, so the next reader does not reconstruct the deadlock rationale.
- Add `brokenpipe_on_success_is_ignored`, covering the one branch of `classify_pager_result` the existing tests miss: a `BrokenPipe` write error paired with a successful child exit is ignored. The neighbouring `child_status_is_checked_after_payload_delivery` covers only the failing-exit half of that pair.

Two tests from the earlier revision were removed. `cat_pager_receives_eof_and_does_not_hang` and `early_exiting_pager_proves_pipe_closed_on_small_input` both pass unchanged against the previous code — their 5 s `recv_timeout` never fires either way — so they asserted nothing. No test can distinguish the two forms under `std::process`; the distinction would only become load-bearing under `tokio::process`, whose `Child::wait` does not close stdin. A clarity refactor with no behaviour change is left without a new test.

## Testing

- `cargo test -p rustbgpctl`: 761 passed, 0 failed.
- `cargo fmt --all -- --check`: clean. `cargo clippy`: clean.

A full `just gate` was not run: the change is confined to one CLI file, alters no behaviour, and touches no shared, feature-gated, or wire surface.