### PR TITLE
session: reset backoff and trigger reconnect on administrative reset in Idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,9 +241,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   one) now doubles its reconnect wait per consecutive failure, from
   `connect_retry_secs` up to 300 s, instead of retrying at a fixed
   interval. The streak clears after five minutes Established, on
-  `rbgp neighbor <addr> enable`, or on an administrative reset; TCP
-  connection failures, the max-prefix latch, disable, and graceful
-  shutdown are unchanged. `NeighborState.reconnect_in_seconds`, the
+  `rbgp neighbor <addr> enable`, or on an administrative reset. Resetting an
+  enabled static peer that is already Idle also starts its connection
+  immediately. TCP connection failures, the max-prefix latch, disable, and
+  graceful shutdown are unchanged. `NeighborState.reconnect_in_seconds`, the
   `rbgp neighbor <addr>` detail row `Reconnect In`, and its JSON key
   `reconnect_in_seconds` report the remaining wait. Older daemons leave the
   API field absent; JSON omits the value when absent or zero.

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1198,7 +1198,12 @@ impl PeerSession {
                 // ordinary reconnect timer on the Idle transition because
                 // `stop_requested` is deliberately left alone.
                 if self.fsm.state() == SessionState::Idle {
-                    debug!(peer = %self.peer_label, "administrative reset requested while idle");
+                    info!(peer = %self.peer_label, "administrative reset requested while idle");
+                    self.notification_idle_failures = 0;
+                    if !self.stop_requested {
+                        self.reconnect_timer = None;
+                        self.drive_fsm(Event::ManualStart).await;
+                    }
                 } else {
                     info!(peer = %self.peer_label, "administrative reset requested");
                     self.drive_fsm(Event::AdministrativeReset { reason }).await;

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -774,7 +774,7 @@ async fn administrative_reset_sends_cease_with_reason_and_arms_reconnect() {
 }
 
 #[tokio::test]
-async fn administrative_reset_in_idle_is_a_no_op() {
+async fn administrative_reset_in_idle_reconnects_without_teardown() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     assert_eq!(session.fsm.state(), SessionState::Idle);
 
@@ -789,7 +789,7 @@ async fn administrative_reset_in_idle_is_a_no_op() {
         rib_rx.try_recv().is_err(),
         "an idle session has nothing to tear down"
     );
-    assert_eq!(session.fsm.state(), SessionState::Idle);
+    assert_eq!(session.fsm.state(), SessionState::Connect);
     assert!(session.reconnect_timer.is_none());
 }
 
@@ -1290,6 +1290,69 @@ async fn administrative_reset_clears_notification_idle_backoff() {
     assert_eq!(pending_reconnect_secs(&session), 30);
     assert_eq!(session.notification_idle_failures, 0);
     assert_eq!(notification_cycle(&mut session).await, 30);
+}
+
+#[tokio::test(start_paused = true)]
+async fn administrative_reset_in_idle_clears_notification_backoff_and_reconnects() {
+    let mut session = make_test_session(65001, 65002);
+    notification_cycle(&mut session).await;
+    assert_eq!(notification_cycle(&mut session).await, 60);
+    assert_eq!(session.fsm.state(), SessionState::Idle);
+    assert!(session.reconnect_timer.is_some());
+    assert_eq!(session.notification_idle_failures, 2);
+
+    assert!(matches!(
+        session
+            .handle_command(PeerCommand::AdministrativeReset { reason: None })
+            .await,
+        ControlFlow::Continue(())
+    ));
+    assert_eq!(session.fsm.state(), SessionState::Connect);
+    assert!(session.reconnect_timer.is_none());
+    assert_eq!(session.notification_idle_failures, 0);
+
+    // Complete the reconnect handshake and tear it down with a NOTIFICATION.
+    // Backoff restarts from the base 30s instead of continuing from 120s.
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    session.drive_fsm(Event::TcpConnectionConfirmed).await;
+    session.drive_fsm(peer_open(65002)).await;
+    session.drive_fsm(Event::KeepaliveReceived).await;
+    assert_eq!(session.fsm.state(), SessionState::Established);
+
+    session.drive_fsm(peer_cease()).await;
+    assert_eq!(session.fsm.state(), SessionState::Idle);
+    assert_eq!(pending_reconnect_secs(&session), 30);
+    assert_eq!(session.notification_idle_failures, 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn administrative_reset_in_idle_when_stopped_clears_backoff_without_reconnecting() {
+    let mut session = make_test_session(65001, 65002);
+    notification_cycle(&mut session).await;
+    assert_eq!(notification_cycle(&mut session).await, 60);
+
+    assert!(matches!(
+        session
+            .handle_command(PeerCommand::Stop { reason: None })
+            .await,
+        ControlFlow::Continue(())
+    ));
+    assert_eq!(session.fsm.state(), SessionState::Idle);
+    assert!(session.reconnect_timer.is_none());
+    assert_eq!(session.notification_idle_failures, 2);
+    assert!(session.stop_requested);
+
+    assert!(matches!(
+        session
+            .handle_command(PeerCommand::AdministrativeReset { reason: None })
+            .await,
+        ControlFlow::Continue(())
+    ));
+    assert_eq!(session.fsm.state(), SessionState::Idle);
+    assert!(session.reconnect_timer.is_none());
+    assert_eq!(session.notification_idle_failures, 0);
+    assert!(session.stop_requested);
 }
 
 #[tokio::test(start_paused = true)]

--- a/docs/API.md
+++ b/docs/API.md
@@ -961,16 +961,19 @@ clear`, `clear bgp <peer>`): the session sends Cease / Administrative Reset
 (truncated to 128 bytes at a UTF-8 boundary, like `DisableNeighbor`) and closes
 the TCP connection. The peer's enable/disable state is untouched, so no
 `EnableNeighbor` follow-up is needed. A static active-open peer reconnects on
-its normal schedule. An accepted dynamic peer follows the normal Idle reap
-path and must dial in again; its next inbound connection is resolved from the
-current dynamic-range configuration. Scoped link-local peers pass `interface`
-as for the sibling RPCs.
+its normal schedule; if it is already Idle, reset clears any NOTIFICATION
+backoff and starts the connection immediately. An accepted dynamic peer follows
+the normal Idle reap path and must dial in again; its next inbound connection
+is resolved from the current dynamic-range configuration. Scoped link-local
+peers pass `interface` as for the sibling RPCs.
 
 - Unknown peers return `NOT_FOUND`; administratively disabled peers return
   `FAILED_PRECONDITION` (enable the peer instead of resetting it).
 - A session that is not `Established` is still accepted: `Connect`/`Active`
   drop back to `Idle` without a NOTIFICATION and follow the static or dynamic
-  lifecycle above; an `Idle` session is a no-op.
+  lifecycle above. For an enabled static peer already in `Idle`, reset clears
+  the NOTIFICATION reconnect backoff and starts a connection immediately; no
+  teardown event or session-down sample is emitted because no session exists.
 - When the peer negotiated RFC 8538 Notification Graceful Restart, the reset
   is sent as Cease / Hard Reset wrapping the Administrative Reset and its
   communication, so neither side retains stale routes across the bounce.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2406,15 +2406,18 @@ One-shot session bounce (`NeighborService.ResetNeighbor`): sends Cease /
 Administrative Reset with the optional RFC 9003 shutdown communication,
 and closes the TCP connection. Unlike `disable`, the peer stays enabled, so
 there is no `enable` to remember afterwards. A static active-open peer retries
-on its normal schedule. An accepted dynamic peer is removed on Idle and must
-dial in again; its next connection uses the current dynamic-range
-configuration. Unknown peers fail with `NOT_FOUND` and disabled peers with
-`FAILED_PRECONDITION`; an Idle peer is a no-op. Routes are not retained across
-an Established bounce: peers that negotiated RFC 8538 Notification Graceful
-Restart receive a Cease / Hard Reset wrapping the Administrative Reset. The
-sent event therefore reports the on-wire subcode 9 in that case rather than
-the inner Administrative Reset subcode 4. Only an Established active-primary
-teardown increments `bgp_session_down_total{reason="local_notification"}`.
+on its normal schedule. If an enabled static peer is already Idle, reset clears
+any NOTIFICATION backoff and starts the connection immediately; it emits no
+teardown event or session-down sample because no session exists. An accepted
+dynamic peer is removed on Idle and must dial in again; its next connection
+uses the current dynamic-range configuration. Unknown peers fail with
+`NOT_FOUND` and disabled peers with `FAILED_PRECONDITION`. Routes are not
+retained across an Established bounce: peers that negotiated RFC 8538
+Notification Graceful Restart receive a Cease / Hard Reset wrapping the
+Administrative Reset. The sent event therefore reports the on-wire subcode 9
+in that case rather than the inner Administrative Reset subcode 4. Only an
+Established active-primary teardown increments
+`bgp_session_down_total{reason="local_notification"}`.
 
 ### Trigger an MRT dump
 


### PR DESCRIPTION
## Summary

An administrative reset of an enabled static peer already waiting in `Idle`
now clears its NOTIFICATION backoff and starts a connection immediately. The
previous behavior reported success but left the peer waiting for the remaining
backoff interval, which could be as long as 300 seconds.

Administratively stopped peers remain stopped; reset clears their failure
streak without reconnecting.

## Changes

- Clear the NOTIFICATION failure streak on an administrative reset in `Idle`.
- Cancel the pending reconnect timer and drive `ManualStart` for enabled peers.
- Preserve the stopped state for disabled or otherwise stopped peers.
- Cover fresh Idle, backed-off Idle, a subsequent failure after reset, and the
  stopped-peer negative case.
- Update the API, operations guide, and unreleased changelog behavior.

## Verification

- `cargo test -p rustbgpd-transport --lib administrative_reset` — 6 passed
- `just links` — 0 errors
- Pre-commit `cargo fmt` and `cargo clippy` — passed
- Pre-push `cargo test` and `cargo doc` — passed
