### PR TITLE
peer-manager: reliably update dynamic peer remote_asn in bgp_peer_info metric

### DIFF
--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -1,5 +1,6 @@
 use std::net::IpAddr;
 
+use rustbgpd_api::peer_types::PeerKey;
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::{
     PeerHandle, SessionIdentity, SessionLifecycleNotification, SessionNotification,
@@ -117,6 +118,7 @@ impl PeerManager {
                     debug!(%peer_addr, session_id, ?role, "ignoring stale OpenReceived notification");
                     return;
                 }
+                self.learn_dynamic_remote_asn(&peer_key, peer_asn);
                 if self
                     .peers
                     .get(&peer_key)
@@ -479,17 +481,21 @@ impl PeerManager {
             debug!(%peer_addr, session_id, ?role, "ignoring stale StateChanged lifecycle notification");
             return;
         }
-        if let Some(peer_asn) = peer_asn.filter(|asn| *asn != 0)
-            && let Some(managed) = self.peers.get_mut(&peer_key)
+        if let Some(peer_asn) = peer_asn {
+            self.learn_dynamic_remote_asn(&peer_key, peer_asn);
+        }
+        self.publish_state_lifecycle_event(&peer_key, role, old, new);
+    }
+
+    fn learn_dynamic_remote_asn(&mut self, peer_key: &PeerKey, peer_asn: u32) {
+        if peer_asn != 0
+            && let Some(managed) = self.peers.get_mut(peer_key)
             && managed.is_dynamic
             && managed.remote_asn == 0
         {
             managed.remote_asn = peer_asn;
             managed.transport_config.peer.remote_asn = peer_asn;
-            // The learned ASN replaces the accept-any `remote_asn="0"`
-            // identity row.
-            self.publish_peer_info_metric(&peer_key);
+            self.publish_peer_info_metric(peer_key);
         }
-        self.publish_state_lifecycle_event(&peer_key, role, old, new);
     }
 }

--- a/src/peer_manager/tests/dynamic_ranges.rs
+++ b/src/peer_manager/tests/dynamic_ranges.rs
@@ -704,3 +704,115 @@ remote_asn = 65001
         );
     }
 }
+
+/// Proves that when `SessionNotification::OpenReceived` is processed on the lossless
+/// coordination channel, `PeerManager` updates `managed.remote_asn`, `transport_config`,
+/// and `bgp_peer_info` with the learned remote ASN, even if the lossy `StateChanged`
+/// lifecycle notification was dropped due to channel overflow during a connection storm.
+#[tokio::test]
+async fn dynamic_peer_open_received_updates_remote_asn_and_metric_without_state_changed() {
+    let mut mgr = test_peer_manager();
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let peer = key(addr);
+
+    let counters = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        addr,
+        0,
+        fake_peer_handle(addr, SessionState::OpenSent, None, counters),
+        false,
+    );
+    mgr.peers.get_mut(&peer).unwrap().is_dynamic = true;
+
+    // Simulate dynamic peer admission publishing the initial remote_asn="0" identity row.
+    mgr.publish_peer_info_metric(&peer);
+
+    let peer_info_remote_asn = |mgr: &PeerManager| -> Option<String> {
+        mgr.metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_peer_info")
+            .and_then(|family| {
+                family.get_metric().iter().find_map(|metric| {
+                    let has_peer = metric
+                        .get_label()
+                        .iter()
+                        .any(|l| l.name() == "peer" && l.value() == "10.0.0.2");
+                    if has_peer {
+                        metric
+                            .get_label()
+                            .iter()
+                            .find(|l| l.name() == "remote_asn")
+                            .map(|l| l.value().to_string())
+                    } else {
+                        None
+                    }
+                })
+            })
+    };
+
+    assert_eq!(peer_info_remote_asn(&mgr).as_deref(), Some("0"));
+
+    let session_id = mgr.peers[&peer].session_id;
+
+    // Session transitions to OpenConfirm, triggering OpenReceived on the lossless notify_tx.
+    // Notice we deliberately DO NOT invoke handle_session_lifecycle_notification with
+    // StateChanged, modeling a dropped StateChanged event on the bounded lossy channel.
+    mgr.handle_session_notification(SessionNotification::OpenReceived {
+        session_id,
+        role: rustbgpd_transport::SessionRole::Primary,
+        peer_addr: addr,
+        remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        peer_asn: 65099,
+    })
+    .await;
+
+    // Peer state must reflect learned ASN immediately.
+    let managed = mgr.peers.get(&peer).unwrap();
+    assert_eq!(managed.remote_asn, 65099);
+    assert_eq!(managed.transport_config.peer.remote_asn, 65099);
+
+    // bgp_peer_info metric must report the learned ASN instead of 0.
+    assert_eq!(peer_info_remote_asn(&mgr).as_deref(), Some("65099"));
+
+    // Verify there are no duplicate bgp_peer_info rows for this peer.
+    let peer_info_asns: Vec<String> = mgr
+        .metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == "bgp_peer_info")
+        .map(|family| {
+            family
+                .get_metric()
+                .iter()
+                .filter(|m| {
+                    m.get_label()
+                        .iter()
+                        .any(|l| l.name() == "peer" && l.value() == "10.0.0.2")
+                })
+                .filter_map(|m| {
+                    m.get_label()
+                        .iter()
+                        .find(|l| l.name() == "remote_asn")
+                        .map(|l| l.value().to_string())
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(peer_info_asns, vec!["65099".to_string()]);
+
+    // If StateChanged arrives subsequently, it behaves idempotently.
+    mgr.handle_session_lifecycle_notification(&SessionLifecycleNotification::StateChanged {
+        session_id,
+        role: rustbgpd_transport::SessionRole::Primary,
+        peer_addr: addr,
+        peer_asn: Some(65099),
+        old: SessionState::OpenConfirm,
+        new: SessionState::Established,
+    });
+    assert_eq!(mgr.peers[&peer].remote_asn, 65099);
+    assert_eq!(peer_info_remote_asn(&mgr).as_deref(), Some("65099"));
+}


### PR DESCRIPTION
## Summary

Reliably learn dynamic peer remote ASN and update the `bgp_peer_info` Prometheus metric upon receiving `SessionNotification::OpenReceived` over the unbounded lossless coordination channel, rather than relying exclusively on the lossy `SessionLifecycleNotification::StateChanged` channel.

For wildcard dynamic neighbor ranges (where `remote_asn = 0`), the peer's actual ASN is learned upon receipt of the peer's BGP OPEN message. Previously, `PeerManager` only updated `managed.remote_asn` and republished `bgp_peer_info` in `handle_state_changed_notification`.

Because `session_lifecycle_tx` is a bounded channel using `try_send` (to prevent session actor backpressure during telemetry churn), `StateChanged` can be dropped during connection storms. When this occurred, `PeerManager` never learned the remote ASN, and `bgp_peer_info` remained permanently stuck reporting `remote_asn="0"` despite the session reaching `Established`.

## Changes

- Extract `learn_dynamic_remote_asn` in `src/peer_manager/notifications.rs` and call it from:
  - `SessionNotification::OpenReceived` (lossless `notify_tx` path — the load-bearing trigger)
  - `handle_state_changed_notification` (idempotent fallback if `StateChanged` still arrives)
- The helper is a no-op unless `peer_asn != 0`, the peer is dynamic, and `managed.remote_asn == 0`.
- Regression test `dynamic_peer_open_received_updates_remote_asn_and_metric_without_state_changed` proves `bgp_peer_info` updates when `OpenReceived` is processed even if `StateChanged` was dropped, and that a later `StateChanged` is idempotent.

## Testing

- [x] Unit test `peer_manager::tests::dynamic_ranges::dynamic_peer_open_received_updates_remote_asn_and_metric_without_state_changed` passes
- [x] All 385 `peer_manager::tests` pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean

## Related issues

Fixes LAN-1473
