### PR TITLE
cli: restore cursor visibility on TUI exit

### DIFF
--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -22,10 +22,17 @@ use theme::Theme;
 
 struct TerminalGuard;
 
+/// Leave the alternate screen and show the cursor. Ratatui hides the cursor
+/// during `draw()`, and `LeaveAlternateScreen` does not restore it.
+fn restore_screen(out: &mut impl io::Write) {
+    let _ = out.execute(LeaveAlternateScreen);
+    let _ = out.execute(crossterm::cursor::Show);
+}
+
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         let _ = disable_raw_mode();
-        let _ = io::stdout().execute(LeaveAlternateScreen);
+        restore_screen(&mut io::stdout());
     }
 }
 
@@ -113,4 +120,28 @@ pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_screen_emits_leave_alternate_then_cursor_show() {
+        let mut output = Vec::new();
+        restore_screen(&mut output);
+
+        let leave = output
+            .windows(b"\x1b[?1049l".len())
+            .position(|w| w == b"\x1b[?1049l")
+            .expect("restore_screen must emit LeaveAlternateScreen");
+        let show = output
+            .windows(b"\x1b[?25h".len())
+            .position(|w| w == b"\x1b[?25h")
+            .expect("restore_screen must emit cursor::Show");
+        assert!(
+            leave < show,
+            "LeaveAlternateScreen must precede cursor::Show"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Restore cursor visibility on TUI exit. Ratatui hides the cursor during TUI rendering, but `LeaveAlternateScreen` does not restore cursor visibility. Adding `crossterm::cursor::Show` to the shared `restore_screen` helper used by `TerminalGuard::drop` ensures the operator's cursor is restored upon exit.

## Changes

- Extract `restore_screen` so `TerminalGuard::drop` and the unit test share one write path.
- Execute `LeaveAlternateScreen` then `crossterm::cursor::Show` on that path.
- Unit test writes to a `Vec<u8>` through `restore_screen` and asserts both escape sequences (`\x1b[?1049l` then `\x1b[?25h`) and their order. Reversing the writes fails the test.

## Testing

- [x] `cargo test -p rustbgpctl --bin rbgp tui::tests` passes
- [x] `cargo clippy -p rustbgpctl` clean
- [x] `cargo fmt --check` clean

## Docs / release notes

- [x] CHANGELOG.md updated, or intentionally not needed (internal CLI fix)
- [x] ROADMAP.md updated, or intentionally not needed
- [x] User/operator docs updated, or intentionally not needed

## Related issues

Fixes LAN-1475
