### PR TITLE
systemd: set sd_notify Unix datagram socket to non-blocking

### DIFF
--- a/src/sd_notify.rs
+++ b/src/sd_notify.rs
@@ -48,7 +48,9 @@ impl SdNotify {
     /// notification; the interval is floored at 100 ms.
     pub fn new(socket: Option<&str>, watchdog_interval: Option<Duration>) -> Self {
         let target = socket.and_then(|raw| match socket_addr(raw).and_then(|addr| {
-            UnixDatagram::unbound().map(|datagram| Arc::new((datagram, addr)))
+            let datagram = UnixDatagram::unbound()?;
+            datagram.set_nonblocking(true)?;
+            Ok(Arc::new((datagram, addr)))
         }) {
             Ok(target) => Some(target),
             Err(error) => {
@@ -324,5 +326,56 @@ mod tests {
         let notify = SdNotify::new(Some(&too_long), Some(Duration::from_secs(1)));
         assert!(!notify.is_enabled());
         notify.ready();
+    }
+
+    #[test]
+    #[allow(
+        unsafe_code,
+        reason = "test inspects descriptor flags directly to prove O_NONBLOCK is set"
+    )]
+    fn notifier_socket_is_nonblocking_and_send_does_not_block() {
+        use std::os::unix::io::AsRawFd;
+
+        let (receiver, name) = abstract_socket();
+        let notify = SdNotify::new(Some(&name), None);
+        assert!(notify.is_enabled());
+
+        let target = notify
+            .target
+            .as_ref()
+            .expect("notification target initialized");
+        let (datagram, _) = target.as_ref();
+
+        assert!(matches!(datagram.take_error(), Ok(None)));
+
+        let fd = datagram.as_raw_fd();
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        assert_ne!(flags, -1, "fcntl F_GETFL failed");
+        assert_ne!(
+            flags & libc::O_NONBLOCK,
+            0,
+            "systemd notification socket must have O_NONBLOCK set"
+        );
+
+        // Minimise receiver buffer to reliably saturate the queue.
+        let rcvbuf: libc::c_int = 1024;
+        let ret = unsafe {
+            libc::setsockopt(
+                receiver.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                std::ptr::addr_of!(rcvbuf).cast(),
+                libc::socklen_t::try_from(std::mem::size_of_val(&rcvbuf)).unwrap(),
+            )
+        };
+        assert_eq!(ret, 0, "setsockopt SO_RCVBUF failed");
+
+        // Flooding unread notifications must not block or hang when the socket buffer fills.
+        for _ in 0..5000 {
+            notify.ready();
+        }
+
+        // Datagrams were delivered up to socket capacity.
+        assert_eq!(recv(&receiver).as_deref(), Some("READY=1"));
     }
 }


### PR DESCRIPTION
## Summary

Configure the unbound Unix datagram socket used for systemd lifecycle and watchdog notifications in non-blocking mode.

Systemd's reference `sd_notify()` implementation specifies non-blocking datagram semantics (`MSG_DONTWAIT` / non-blocking socket). Notifications are best-effort datagram status messages and must never block the application runtime. Under high host load or when `/run/systemd/notify` buffer saturates, synchronous blocking calls could stall Tokio worker threads driving watchdog pings or delay daemon shutdown during `sd_notify.stopping()`. Setting non-blocking mode ensures buffer exhaustion yields `WouldBlock` (logged as a warning) without blocking execution.

## Changes

- Set `datagram.set_nonblocking(true)?` immediately after `UnixDatagram::unbound()` in `SdNotify::new`.
- Add unit test `notifier_socket_is_nonblocking_and_send_does_not_block` in `src/sd_notify.rs` verifying `O_NONBLOCK` descriptor flag configuration, error state, and non-blocking transmission against a saturated receiver buffer.

## Testing

- [x] `cargo test --bin rustbgpd sd_notify` passes
- [x] `cargo clippy --bin rustbgpd --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Relevant interop test run (if protocol/transport change)
- [ ] Performance-affecting changes have a pinned A/B receipt plus a machine-readable summary indexed from `docs/RECEIPTS.md`, or this item is intentionally not applicable

## Docs / release notes

- [ ] CHANGELOG.md updated, or intentionally not needed
- [ ] ROADMAP.md updated, or intentionally not needed
- [ ] User/operator docs updated, or intentionally not needed
- [ ] If this PR touches a hot tracking doc, the edit follows the low-conflict convention in CONTRIBUTING.md

## Related issues

Fixes LAN-1474