### PR TITLE
cli: fix unresolved intra-doc link in the route-listing RPC selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,11 @@ tests/interop/bird3-archive/*
 tests/interop/configs/m44-certs/
 tests/interop/configs/m54-certs/
 .last_review_sha
+.last_review_hardening_sha
 .lycheecache
 bench/scale/matrix/artifacts-*/
 
 # Local contributor-tool guidance (kept on disk, not tracked)
 /AGENTS.md
 /CLAUDE.md
+/WATCHDOG.yml

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -190,7 +190,7 @@ pub(crate) async fn fetch_tui_explain_advertised(
     Ok(response)
 }
 
-/// Which unicast route-listing RPC [`fetch_all_route_pages`] and the TUI
+/// Which unicast route-listing RPC [`fetch_route_listing`] and the TUI
 /// explorer drive.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RouteListRpc {


### PR DESCRIPTION
## Broken link

The `RouteListRpc` doc comment in `crates/cli/src/commands/rib.rs` linked to
`` [`fetch_all_route_pages`] ``. No item by that name exists anywhere in the
tree. The selector is consumed by `fetch_route_listing`, the paginating unicast
route fetcher defined immediately below it (and by the TUI explorer), so the
link now points at `` [`fetch_route_listing`] ``.

## Ignore entries

`.last_review_hardening_sha` and `/WATCHDOG.yml` are machine-local files that
were untracked and unignored, so `git add -A` would sweep them into a commit.
Each is placed beside its existing neighbour: the first next to
`.last_review_sha`, the second in the trailing local-guidance section alongside
`/AGENTS.md` and `/CLAUDE.md`.

## Verification

`cargo doc --locked --workspace --no-deps` exits **101** before the change
(`error: unresolved link to 'fetch_all_route_pages'` → `could not document
'rustbgpctl'`) and **0** after.

| Check | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo doc --locked --workspace --no-deps` | 0 |
| `cargo clippy --locked --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --locked --workspace` | 0 |

The existing doc gate runs `cargo doc --workspace --lib --no-deps`. That form
cannot see this file: `crates/cli/src/commands/rib.rs` belongs to the `rbgp`
binary target rather than the `rustbgpctl` lib target, so unresolved intra-doc
links in binary-target sources are outside the gate's coverage today.
