### PR TITLE
test: keep UPDATE fuzz recipes encodable

### DIFF
--- a/crates/wire/fuzz/fuzz_targets/encode_update.rs
+++ b/crates/wire/fuzz/fuzz_targets/encode_update.rs
@@ -101,7 +101,13 @@ fn attributes(recipe: &UpdateRecipe) -> Vec<PathAttribute> {
         _ => Origin::Incomplete,
     };
     let asn_count = usize::from(recipe.as_path_len) % (recipe.asns.len() + 1);
-    let asns: Vec<_> = recipe.asns.iter().copied().take(asn_count).collect();
+    let asns: Vec<_> = recipe
+        .asns
+        .iter()
+        .copied()
+        .take(asn_count)
+        .map(|asn| asn.max(1))
+        .collect();
     let as_path = if asns.is_empty() {
         AsPath { segments: vec![] }
     } else {
@@ -176,7 +182,7 @@ fn attributes(recipe: &UpdateRecipe) -> Vec<PathAttribute> {
     }
     if recipe.present & (1 << 8) != 0 {
         attrs.push(PathAttribute::Aggregator(Aggregator {
-            asn: recipe.aggregator_asn,
+            asn: recipe.aggregator_asn.max(1),
             router_id: Ipv4Addr::from(recipe.aggregator_id),
             partial: recipe.partial & (1 << 8) != 0,
         }));


### PR DESCRIPTION
## Summary

- keep canonical UPDATE fuzz recipes inside the encoder's valid ASN domain
- normalize generated AS zero values for AS_PATH and AGGREGATOR attributes
- leave production wire behavior unchanged

## Verification

- replayed the captured scheduled-fuzz artifact successfully
- ran `encode_update` for 121 seconds: 3,082,812 executions, no crash
- `python3 scripts/check_fuzz_target_inventory.py`
- commit and push hooks: format, Clippy, tests, and documentation
