### PR TITLE
ci: drop the unresolvable crates/wire Dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 # Dependabot config — keeps Cargo dependencies and GitHub Actions
-# pinned versions current. The wire crate is a separate manifest
-# (decoupled versioning + crates.io publish) so it gets its own
-# directory entry; the workspace covers the daemon + 9 internal
-# crates lockstep via the root Cargo.toml.
+# pinned versions current. The single workspace-root Cargo entry
+# covers the daemon and every workspace crate, including the
+# published ones, through the shared Cargo.lock. Member manifests
+# inherit workspace fields, so a per-crate directory entry cannot
+# resolve them and must not be added.
 #
 # Cadence: weekly. The Cargo ecosystem tends to produce a steady
 # trickle of patch releases (tonic, prost, tokio); weekly avoids
@@ -16,7 +17,7 @@
 
 version: 2
 updates:
-  # Workspace root: daemon + 9 internal crates.
+  # Workspace root: the daemon and every workspace crate.
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
@@ -49,18 +50,6 @@ updates:
       # Workspace-internal crates are path deps; updates land via the
       # release process, not Dependabot.
       - dependency-name: "rustbgpd-*"
-  # Wire crate: published to crates.io; its dependencies must stay
-  # current independently because external consumers pin against it.
-  - package-ecosystem: "cargo"
-    directory: "/crates/wire"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      core-deps:
-        patterns:
-          - "bytes"
-          - "thiserror"
 
   # GitHub Actions versions in workflows/. Catches deprecation
   # warnings (e.g. Node 20 → Node 24 transition) before they bite.


### PR DESCRIPTION
`.github/dependabot.yml` carried a second cargo entry for `directory: "/crates/wire"`. The wire crate manifest inherits `edition` and other package fields from the workspace root, so Dependabot's per-directory checkout cannot resolve it ("error inheriting `edition` from workspace root manifest's `workspace.package.edition` … failed to find a workspace root"). The "Dependabot Updates" workflow has failed on every weekly run for that entry, and it never opened a pull request.

The workspace-root cargo entry already covers the crate through the shared `Cargo.lock`, so this removes the `/crates/wire` entry and rewrites the header comment to state that the root entry covers the daemon and every workspace crate, including the published ones.

Checks: YAML parses (`yaml.safe_load`; remaining entries are `cargo:/` and `github-actions:/`); no script, workflow, or doc references the removed entry. No CHANGELOG line: prior Dependabot-config-only commits carried none.
