### PR TITLE
build: resync the lockfile syn reference after the dependency batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]


### PR DESCRIPTION
The merged lockfile carried a stale `syn 3.0.3` dependency reference after sequential dependency merges. `cargo update --workspace` resolves it to the already-locked 3.0.4.

Check: `cargo metadata --locked` exits 0 on this branch (101 on main).