### PR TITLE
fsm: keep Add-Path and extended-next-hop negotiation within the negotiated address families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   experimental-use range (type bit `0x80`) are no longer decoded as EVPN,
   opaque encapsulation, default-gateway, route-target, or route-origin
   communities.
+- Add-Path and extended-next-hop negotiation in `rustbgpd-fsm` are now
+  limited to the negotiated address families. A peer advertising Add-Path or
+  Extended Next Hop Encoding for a family outside the MultiProtocol
+  intersection no longer leaves that family in the session's Add-Path or
+  extended-next-hop set; the Add-Path case previously suppressed RFC 9972 BMP
+  Adj-RIB-In counts for sessions that never negotiated the family.
 
 - **Operator-visible:** `rs-config-render` now states `rs_control_communities`
   on every rendered member session instead of inheriting the daemon default:

--- a/crates/fsm/CHANGELOG.md
+++ b/crates/fsm/CHANGELOG.md
@@ -5,6 +5,14 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## Unreleased
 
+- `validate_open` now limits `NegotiatedSession::add_path_families` and
+  `NegotiatedSession::extended_nexthop_families` to the address families in
+  the negotiated MultiProtocol intersection, matching the existing Graceful
+  Restart and Long-Lived Graceful Restart handling. A peer that advertises
+  Add-Path or Extended Next Hop Encoding for a family it did not advertise
+  MultiProtocol for no longer leaves that family in either map.
+  `negotiate_add_path` and `negotiate_extended_nexthop` are unchanged.
+
 ## 0.6.0 - 2026-08-30
 
 - **Additive FSM API:** Added `Event::AdministrativeReset`, which sends

--- a/crates/fsm/src/negotiation.rs
+++ b/crates/fsm/src/negotiation.rs
@@ -253,8 +253,13 @@ pub fn validate_open(
         .flatten()
         .copied()
         .collect();
-    let extended_nexthop_families =
-        negotiate_extended_nexthop(&our_extended_nexthop_caps, &peer_extended_nexthop_caps);
+    // RFC 8950 applies per negotiated NLRI AFI/SAFI: keep only families both
+    // sides advertised in MultiProtocol, as the GR and LLGR filters above do.
+    let extended_nexthop_families: HashMap<(Afi, Safi), Afi> =
+        negotiate_extended_nexthop(&our_extended_nexthop_caps, &peer_extended_nexthop_caps)
+            .into_iter()
+            .filter(|(family, _)| negotiated_families.contains(family))
+            .collect();
 
     // Negotiate Add-Path (RFC 7911)
     let our_add_path_caps = config.add_path_capabilities();
@@ -268,7 +273,13 @@ pub fn validate_open(
         .flatten()
         .copied()
         .collect();
-    let add_path_families = negotiate_add_path(&our_add_path_caps, &peer_add_path_caps);
+    // RFC 7911 applies per negotiated AFI/SAFI: keep only families both sides
+    // advertised in MultiProtocol, as the GR and LLGR filters above do.
+    let add_path_families: HashMap<(Afi, Safi), AddPathMode> =
+        negotiate_add_path(&our_add_path_caps, &peer_add_path_caps)
+            .into_iter()
+            .filter(|(family, _)| negotiated_families.contains(family))
+            .collect();
     let peer_paths_limits: HashMap<(Afi, Safi), u16> = open
         .capabilities
         .iter()
@@ -1382,6 +1393,10 @@ mod tests {
         cfg.add_path_send = true;
         cfg.add_path_send_max = 8;
         let mut open = peer_open();
+        open.capabilities.push(Capability::MultiProtocol {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+        });
         open.capabilities.push(Capability::AddPath(vec![
             AddPathFamily {
                 afi: Afi::Ipv4,
@@ -1669,6 +1684,72 @@ mod tests {
         assert_eq!(
             neg.add_path_families.get(&(Afi::Ipv4, Safi::Unicast)),
             Some(&AddPathMode::Receive)
+        );
+    }
+
+    #[test]
+    fn validate_open_add_path_limited_to_negotiated_families() {
+        let mut cfg = test_config();
+        cfg.families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+        cfg.add_path_receive = true;
+        // Peer advertises MultiProtocol for ipv4/unicast only, but Add-Path
+        // for both ipv4/unicast and ipv6/unicast.
+        let mut open = peer_open();
+        open.capabilities.push(Capability::AddPath(vec![
+            AddPathFamily {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                send_receive: AddPathMode::Send,
+            },
+            AddPathFamily {
+                afi: Afi::Ipv6,
+                safi: Safi::Unicast,
+                send_receive: AddPathMode::Send,
+            },
+        ]));
+
+        let neg = validate_open(&open, &cfg).unwrap();
+        assert!(
+            !neg.negotiated_families
+                .contains(&(Afi::Ipv6, Safi::Unicast))
+        );
+        assert_eq!(
+            neg.add_path_families.get(&(Afi::Ipv4, Safi::Unicast)),
+            Some(&AddPathMode::Receive)
+        );
+        assert!(
+            !neg.add_path_families
+                .contains_key(&(Afi::Ipv6, Safi::Unicast)),
+            "Add-Path must not be negotiated for a family outside the MP intersection"
+        );
+    }
+
+    #[test]
+    fn validate_open_extended_nexthop_limited_to_negotiated_families() {
+        let mut cfg = test_config();
+        cfg.families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+        // Peer advertises MultiProtocol for ipv6/unicast only, but Extended
+        // Next Hop for ipv4/unicast NLRI over an ipv6 next hop.
+        let mut open = peer_open();
+        open.capabilities
+            .retain(|c| !matches!(c, Capability::MultiProtocol { .. }));
+        open.capabilities.push(Capability::MultiProtocol {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+        });
+        open.capabilities
+            .push(Capability::ExtendedNextHop(vec![ExtendedNextHopFamily {
+                nlri_afi: Afi::Ipv4,
+                nlri_safi: Safi::Unicast,
+                next_hop_afi: Afi::Ipv6,
+            }]));
+
+        let neg = validate_open(&open, &cfg).unwrap();
+        assert_eq!(neg.negotiated_families, vec![(Afi::Ipv6, Safi::Unicast)]);
+        assert!(
+            !neg.extended_nexthop_families
+                .contains_key(&(Afi::Ipv4, Safi::Unicast)),
+            "extended next hop must not be negotiated for a family outside the MP intersection"
         );
     }
 


### PR DESCRIPTION
## What changed

`validate_open` in `rustbgpd-fsm` computed `negotiate_add_path` (RFC 7911) and `negotiate_extended_nexthop` (RFC 8950) from the local configuration and the peer OPEN but never filtered either result against the negotiated MultiProtocol intersection. The Graceful Restart and Long-Lived Graceful Restart paths beside them already filter with `negotiated_families.contains(..)`.

- A peer that advertises MultiProtocol for ipv4/unicast only but Add-Path for ipv4/unicast and ipv6/unicast left ipv6/unicast in `NegotiatedSession::add_path_families`; downstream, `rfc9972_adj_rib_in_counts` in `src/peer_manager/snapshot.rs` then suppressed BMP Adj-RIB-In counts for a session that never negotiated ipv6.
- A peer that advertises MultiProtocol for ipv6/unicast only but Extended Next Hop Encoding for ipv4/unicast NLRI left ipv4/unicast in `NegotiatedSession::extended_nexthop_families`.

Both negotiated maps are now filtered to families in the MultiProtocol intersection, matching the GR filter shape. The `negotiate_add_path` and `negotiate_extended_nexthop` helpers are unchanged (family-agnostic by design).

## Tests

- New: `validate_open_add_path_limited_to_negotiated_families`. Local config enables ipv4/unicast and ipv6/unicast with Add-Path receive; the peer OPEN advertises MultiProtocol ipv4/unicast only plus Add-Path Send for both families. Asserts ipv4/unicast is negotiated as `Receive` and ipv6/unicast is absent. On the unfixed tree it fails at `crates/fsm/src/negotiation.rs:1702` with `Add-Path must not be negotiated for a family outside the MP intersection`.
- New: `validate_open_extended_nexthop_limited_to_negotiated_families`. Local config enables ipv4/unicast and ipv6/unicast (so the local side advertises ipv4/unicast-over-ipv6); the peer OPEN advertises MultiProtocol ipv6/unicast only plus the same Extended Next Hop tuple. Asserts ipv4/unicast is absent from `extended_nexthop_families`. On the unfixed tree it fails at `crates/fsm/src/negotiation.rs:1744` with `extended next hop must not be negotiated for a family outside the MP intersection`. The local side only ever advertises the ipv4/unicast-over-ipv6 tuple (`PeerConfig::extended_nexthop_capabilities`), so a peer-side second tuple such as ipv4/mplsvpn is never negotiated with or without the filter; the test therefore withholds MultiProtocol ipv4/unicast instead.
- Adjusted: `paths_limit_caps_only_matching_add_path_send_family` relied on ipv6/unicast Add-Path being negotiated on a peer OPEN that only advertised ipv4/unicast MultiProtocol (it asserted an ipv6/unicast send limit of 8). Its peer OPEN now also advertises MultiProtocol ipv6/unicast, keeping its subject, per-family PathsLimit capping, intact. No existing test codified the extended-next-hop gap: `validate_open_negotiates_extended_nexthop` already advertises MultiProtocol ipv6/unicast, and the transport session tests build `NegotiatedSession` directly with a consistent family set.

## Compatibility

Published crate (`rustbgpd-fsm`, 0.6.0 on crates.io). Negotiation behavior change: Add-Path and extended-next-hop entries for families outside the MultiProtocol intersection are dropped. No API signature change. Entries added to `crates/fsm/CHANGELOG.md` (Unreleased) and the workspace `CHANGELOG.md`.

## Checks

| Command | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p rustbgpd-fsm --all-targets -- -D warnings` | 0 |
| `cargo test -p rustbgpd-fsm` | 0 (159 passed) |
| `cargo test -p rustbgpd-transport` | 0 |
| `cargo test --bin rustbgpd snapshot` | 0 |
