### PR TITLE
api: report a closed command channel as unavailable on mutation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `transit_free.action` is `reject`; a null or absent action with
   `transit_free.asns` populated no longer emits reject terms arouteserver
   would not generate.
+- Mutation RPCs (`AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`,
+  `AddEvpnRoute`, `DeleteEvpnRoute`, `TriggerMrtDump`, and the peer-manager
+  mutations routed through the shared request path) now return `UNAVAILABLE`
+  instead of `INTERNAL` when the actor command channel is closed, matching
+  the documented status-code contract. A reply dropped after the actor
+  accepted the command still returns `INTERNAL`.
 
 - **Operator-visible:** `rs-config-render` now states `rs_control_communities`
   on every rendered member session instead of inheriting the daemon default:

--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -170,7 +170,7 @@ impl proto::control_service_server::ControlService for ControlService {
         trigger_tx
             .send(reply_tx)
             .await
-            .map_err(|_| Status::internal("MRT manager unavailable"))?;
+            .map_err(|_| Status::unavailable("MRT manager unavailable"))?;
 
         let result = reply_rx
             .await
@@ -325,6 +325,34 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    /// Load-bearing: a closed MRT trigger channel means the dump was never
+    /// requested, which the documented status contract reports as
+    /// `UNAVAILABLE`; only a reply lost after acceptance stays `INTERNAL`.
+    #[tokio::test]
+    async fn trigger_mrt_dump_send_failure_is_unavailable() {
+        let (peer_tx, _peer_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let (mrt_tx, mrt_rx) = mpsc::channel(1);
+        drop(mrt_rx);
+        let svc = ControlService::new(
+            AccessMode::ReadWrite,
+            tokio::time::Instant::now(),
+            BgpMetrics::new(),
+            peer_tx,
+            rib_tx,
+            shutdown_tx,
+            Some(mrt_tx),
+        );
+
+        let err = svc
+            .trigger_mrt_dump(Request::new(proto::TriggerMrtDumpRequest {}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unavailable);
+        assert_eq!(err.message(), "MRT manager unavailable");
     }
 
     #[tokio::test]

--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -294,7 +294,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+            .map_err(|_| Status::unavailable("RIB manager unavailable"))?;
 
         reply_rx
             .await
@@ -343,7 +343,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+            .map_err(|_| Status::unavailable("RIB manager unavailable"))?;
 
         reply_rx
             .await
@@ -412,7 +412,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+            .map_err(|_| Status::unavailable("RIB manager unavailable"))?;
 
         reply_rx
             .await
@@ -445,7 +445,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+            .map_err(|_| Status::unavailable("RIB manager unavailable"))?;
 
         reply_rx
             .await
@@ -502,7 +502,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+            .map_err(|_| Status::unavailable("RIB manager unavailable"))?;
 
         reply_rx
             .await
@@ -584,7 +584,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+            .map_err(|_| Status::unavailable("RIB manager unavailable"))?;
 
         reply_rx
             .await
@@ -1329,6 +1329,22 @@ mod tests {
             err.message(),
             "inject failed: storage not found during lookup"
         );
+    }
+
+    /// Load-bearing: a closed RIB command channel means the mutation was
+    /// never accepted, which the documented status contract reports as
+    /// `UNAVAILABLE`; only a reply lost after acceptance stays `INTERNAL`.
+    #[tokio::test]
+    async fn add_path_send_failure_is_unavailable() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        let svc = InjectionService::new(tx, AccessMode::ReadWrite);
+        let err = svc
+            .add_path(add_path_request(0, "192.0.2.1"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unavailable);
+        assert_eq!(err.message(), "RIB manager unavailable");
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -827,7 +827,7 @@ pub(crate) async fn peer_manager_request<R>(
         peer_mgr_tx
             .send(build_command(reply_tx))
             .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
+            .map_err(|_| Status::unavailable("peer manager unavailable"))?;
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))
@@ -3068,5 +3068,20 @@ mod tests {
         assert_eq!(result.unwrap_err().code(), tonic::Code::DeadlineExceeded);
         // Held so the command is accepted but never answered.
         drop(rx);
+    }
+
+    /// Load-bearing: a closed peer-manager command channel means the
+    /// mutation was never accepted, which the documented status contract
+    /// reports as `UNAVAILABLE`; a reply lost after acceptance stays
+    /// `INTERNAL` because the command may already have been applied.
+    #[tokio::test]
+    async fn closed_peer_manager_request_returns_unavailable() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        let error = peer_manager_request(&tx, |reply| PeerManagerCommand::ListPeers { reply })
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(error.message(), "peer manager unavailable");
     }
 }

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -818,6 +818,12 @@ const PEER_MANAGER_MUTATION_TIMEOUT: Duration = Duration::from_mins(10);
 /// still be applied by the actor afterwards — like any RPC deadline, the
 /// outcome is unknown — but the error propagates out of the shielded body,
 /// so the runtime-config lock guard drops instead of being held forever.
+///
+/// Returns `UNAVAILABLE` when the peer-manager command channel is closed,
+/// so the command was never accepted and nothing was applied.
+///
+/// Returns `INTERNAL` when the peer manager accepted the command but
+/// dropped its reply. The command may already have been applied.
 pub(crate) async fn peer_manager_request<R>(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     build_command: impl FnOnce(oneshot::Sender<R>) -> PeerManagerCommand,


### PR DESCRIPTION
## What changed

`docs/API.md` documents `UNAVAILABLE` for "a required actor, command channel, or persistence queue is unavailable, closed, or back-pressured", but eight mutation paths mapped a failed send into the actor command channel to `INTERNAL`:

- `crates/api/src/server.rs` `peer_manager_request` (the shared peer-manager mutation path used by the neighbor and peer-group services)
- `crates/api/src/injection_service.rs` `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute`
- `crates/api/src/control_service.rs` `TriggerMrtDump`

Each of those send-failure sites now returns `Status::unavailable` with its existing message text.

The dropped-reply sites immediately after each send (`"... dropped reply"`) are deliberately unchanged and still return `INTERNAL`: a command the actor accepted and then lost the reply for may already have been applied, so it is not a retry-safe outage. This matches the existing split in `server.rs` (`OwnedCatalogDispatch::NotAccepted` is `UNAVAILABLE`, `AcceptedReplyLost` is `INTERNAL`) and `neighbor_service.rs` (`OwnedNeighborDispatch`). No helper was introduced; `actor_read::rib_manager_read` maps dropped replies to `UNAVAILABLE` too, but that is only correct for idempotent reads.

Regression tests, each asserting `Code::Unavailable` with the channel receiver dropped before the call (all three fail with `left: Internal` before the fix):

- `injection_service::tests::add_path_send_failure_is_unavailable` (`injection_service.rs:1346` pre-fix)
- `server::tests::closed_peer_manager_request_returns_unavailable` (`server.rs:3084` pre-fix)
- `control_service::tests::trigger_mrt_dump_send_failure_is_unavailable` (`control_service.rs:354` pre-fix)

`docs/API.md` needed no wording change: the `UNAVAILABLE` row already describes a closed command channel, and the `INTERNAL` row still describes the dropped-reply case. CHANGELOG `### Fixed` entry added.

## Compatibility impact

gRPC status code on an error path only. Clients that previously saw `INTERNAL` with `"peer manager unavailable"`, `"RIB manager unavailable"`, or `"MRT manager unavailable"` from these mutation RPCs now see `UNAVAILABLE` with the same message. Success paths, request and response messages, the protobuf surface, and the dropped-reply `INTERNAL` mapping are unchanged. The `rbgp` CLI prefixes RPC errors by status code (`crates/cli/src/error.rs`), so these failures no longer print under the generic `daemon error` prefix reserved for `INTERNAL`.

## Checks

- `cargo fmt --all -- --check`: exit 0
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings`: exit 0
- `cargo test -p rustbgpd-api`: exit 0 (728 unit tests; the three new tests fail with `Code::Internal` before the fix)
- `python3 scripts/check-v1-stable-surface.py`: exit 0
