### PR TITLE
policy: reject prefix-length ranges that cannot match in both frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Policy prefix entries now reject `ge`/`le` bounds whose derived length range
+  can never match: `le` below the prefix length, `ge` above `le`, or either
+  bound below the prefix length or above the address-family maximum. TOML
+  `[policy.definitions]` statements, `.rpol` prefix sets, `test` dataset
+  overrides, and dataset snapshot files share one validator and one wording.
+
 - Reject AS 0 in received and locally encoded AS paths and aggregators per RFC
   7607. Malformed ordinary paths are treated as withdraw, while affected AS4
   compatibility and aggregator attributes are discarded without entering
@@ -383,6 +389,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Upgrade notes
 
+- **Dead prefix-length ranges are now load errors:** a TOML policy prefix
+  entry or an `.rpol` prefix-set member whose `le` is below the prefix length
+  (`10.0.0.0/24 le 16`) or whose `ge` exceeds `le` (`10.0.0.0/24 ge 28 le 26`)
+  is rejected at load. Such entries previously loaded and matched nothing.
+  `.rpol` dataset snapshot files use the same grammar, so a snapshot holding
+  such a line is a startup error at initial load and, on SIGHUP reload, keeps
+  the prior generation with the existing refresh-failure WARN and counter.
+  Remove or correct the entry; the effective policy does not change.
 - Received `AS_PATH` attributes with more than 750 AS numbers and reachable
   NLRI are now treated as withdraw by default; without reachable NLRI, the
   session resets. Deployments that must relay arbitrarily long paths set

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -15,7 +15,7 @@ use crate::engine::{CommunityMatch, parse_community_match};
 use crate::ir::ArithOp;
 
 use crate::datasets::{DatasetData, DatasetKind, MAX_DATASET_RECORDS};
-use crate::sets::{AsnSet, CommunitySet, PrefixSet, PrefixSetEntry};
+use crate::sets::{AsnSet, CommunitySet, PrefixSet, PrefixSetEntry, check_length_bounds};
 
 use super::ast::{
     ActionStmt, AsnSetDef, CmpOp, CommunityArg, CommunityKind, CommunityLit, CommunitySetDef,
@@ -464,16 +464,24 @@ impl Parser<'_> {
     /// definitions, `test` dataset overrides, and the dataset file
     /// format (LAN-305: one literal grammar everywhere).
     fn prefix_entry(&mut self) -> PResult<PrefixEntryAst> {
-        let (prefix, _) = self.expect_prefix()?;
+        let (prefix, mut span) = self.expect_prefix()?;
         let mut ge = None;
         let mut le = None;
         if self.eat(Tok::GeKw).is_some() {
             let (value, value_span) = self.expect_u32("a prefix length after `ge`")?;
             ge = Some(self.prefix_len_bound(prefix, value, value_span)?);
+            span = span.to(value_span);
         }
         if self.eat(Tok::LeKw).is_some() {
             let (value, value_span) = self.expect_u32("a prefix length after `le`")?;
             le = Some(self.prefix_len_bound(prefix, value, value_span)?);
+            span = span.to(value_span);
+        }
+        if let Err(reason) = check_length_bounds(prefix.prefix_len(), address_bits(prefix), ge, le)
+        {
+            self.diags
+                .push(Diagnostic::new(span, reason, "cannot match"));
+            return Err(Fail);
         }
         Ok(PrefixEntryAst { prefix, ge, le })
     }
@@ -549,10 +557,7 @@ impl Parser<'_> {
     }
 
     fn prefix_len_bound(&mut self, prefix: Prefix, value: u32, span: Span) -> PResult<u8> {
-        let max = match prefix {
-            Prefix::V4(_) => 32u32,
-            Prefix::V6(_) => 128,
-        };
+        let max = u32::from(address_bits(prefix));
         if value > max {
             self.diags.push(Diagnostic::new(
                 span,
@@ -1805,6 +1810,14 @@ impl Parser<'_> {
                 Err(Fail)
             }
         }
+    }
+}
+
+/// Address-family length ceiling for a prefix's `ge`/`le` bounds.
+fn address_bits(prefix: Prefix) -> u8 {
+    match prefix {
+        Prefix::V4(_) => 32,
+        Prefix::V6(_) => 128,
     }
 }
 

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -332,6 +332,43 @@ fn set_membership_lowers_to_indexed_sets() {
 }
 
 #[test]
+fn prefix_set_bounds_that_cannot_match_are_rejected() {
+    // A range whose derived `min..=max` is empty, or whose `ge` sits
+    // below the member length, is a compile error rather than an
+    // entry that silently matches nothing.
+    for (entry, reason) in [
+        (
+            "10.0.0.0/24 ge 28 le 16",
+            "le value 16 is less than prefix length 24",
+        ),
+        ("10.0.0.0/24 ge 28 le 26", "ge value 28 exceeds le value 26"),
+        (
+            "10.0.0.0/24 le 16",
+            "le value 16 is less than prefix length 24",
+        ),
+        (
+            "10.0.0.0/24 ge 16 le 28",
+            "ge value 16 is less than prefix length 24",
+        ),
+    ] {
+        let source = format!(
+            "prefix-set s {{ {entry} }}
+             policy p {{ term t {{ if route.prefix in s {{ accept }} }} }}"
+        );
+        let (_, rendered) = diagnostics_of(&source);
+        assert!(
+            rendered.contains(reason),
+            "{entry} must be rejected, got: {rendered}"
+        );
+    }
+    // Positive control: an ordered range compiles.
+    compile_ok(
+        "prefix-set s { 10.0.0.0/8 ge 16 le 24 }
+         policy p { term t { if route.prefix in s { accept } } }",
+    );
+}
+
+#[test]
 fn u32_equality_lowers_to_ge_and_le() {
     let chain = compile_ok("policy p { term t { if route.med == 50 { reject } } }");
     assert_eq!(
@@ -5563,6 +5600,13 @@ test missing-override-fails {
         // Wrong-kind content fails parse (this is what keeps a
         // mis-pointed path from silently probing garbage).
         assert!(parse_dataset_text("10.0.0.0/8\n", DatasetKind::Asn).is_err());
+        // Same bound rules as source sets: a range that cannot match
+        // is a load error, not a silent no-match.
+        let err = parse_dataset_text("10.0.0.0/24 le 16\n", DatasetKind::Prefix).expect_err("dead");
+        assert!(
+            err.contains("le value 16 is less than prefix length 24"),
+            "{err}"
+        );
     }
 
     /// Explain names the dataset and the pinned generation without

--- a/crates/policy/src/sets.rs
+++ b/crates/policy/src/sets.rs
@@ -63,6 +63,50 @@ fn matches_v6(entry: Ipv6Prefix, ge: Option<u8>, le: Option<u8>, candidate: Ipv6
     candidate.len >= min_len && candidate.len <= max_len
 }
 
+/// Reject a `(prefix_len, ge, le)` triple whose derived range (see
+/// [`prefix_entry_matches`]) can never contain a candidate length:
+/// every present bound must satisfy `prefix_len <= ge <= le <= max_bits`.
+/// Both policy frontends call this at load so a dead entry is a load
+/// error instead of a silent no-match. The `Err` carries the reason
+/// without location; callers add the prefix or source span.
+///
+/// # Errors
+///
+/// Returns the human-readable rule that the bounds violate.
+pub fn check_length_bounds(
+    prefix_len: u8,
+    max_bits: u8,
+    ge: Option<u8>,
+    le: Option<u8>,
+) -> Result<(), String> {
+    if let Some(ge) = ge {
+        if ge > max_bits {
+            return Err(format!("ge value {ge} exceeds {max_bits}"));
+        }
+        if ge < prefix_len {
+            return Err(format!(
+                "ge value {ge} is less than prefix length {prefix_len}"
+            ));
+        }
+    }
+    if let Some(le) = le {
+        if le > max_bits {
+            return Err(format!("le value {le} exceeds {max_bits}"));
+        }
+        if le < prefix_len {
+            return Err(format!(
+                "le value {le} is less than prefix length {prefix_len}"
+            ));
+        }
+    }
+    if let (Some(ge), Some(le)) = (ge, le)
+        && ge > le
+    {
+        return Err(format!("ge value {ge} exceeds le value {le}"));
+    }
+    Ok(())
+}
+
 #[inline]
 fn length_bounds(entry_len: u8, ge: Option<u8>, le: Option<u8>, max_bits: u8) -> (u8, u8) {
     match (ge, le) {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3000,7 +3000,10 @@ set_community_add = ["65001:100"]
 
 Without `ge`/`le`, only exact prefix-length matches count. With them, a route
 matches if its prefix falls within the given network *and* its mask length is
-within `[ge, le]`.
+within `[ge, le]`. The bounds must satisfy prefix length `<= ge <= le <=`
+address-family maximum (32 for IPv4, 128 for IPv6); an entry whose range could
+never match, such as `prefix = "10.0.0.0/24"` with `le = 16`, is rejected at
+load. `.rpol` prefix sets and dataset snapshot files apply the same rule.
 
 Example -- deny all specifics of 10.0.0.0/8 longer than /24:
 
@@ -4548,7 +4551,7 @@ starting:
 | `local_ipv6_nexthop` must be a valid non-link-local, non-loopback, non-multicast IPv6 address | `invalid local_ipv6_nexthop` |
 | `ttl_security_hops` must be 1--255 and requires effective `ttl_security = true`; a peer-group value requires `ttl_security = true` on that same group | `ttl_security_hops` / `requires ... ttl_security = true` |
 | `ge` must be >= prefix length and <= AFI max (32 for IPv4, 128 for IPv6) | `invalid ge` |
-| `le` must be <= AFI max | `invalid le` |
+| `le` must be >= prefix length and <= AFI max | `invalid le` |
 | `ge` must be <= `le` when both are set | `ge must be <= le` |
 | Config file must be valid TOML | `failed to parse TOML` |
 

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -137,7 +137,12 @@ asn-set NAME { ASN, ... }
   TOML frontend (and Cisco/Juniper prefix lists): the candidate is
   masked at the member's length and its length must fall in the
   derived range (`ge` only → `ge..=address_bits`; `le` only →
-  `member_len..=le`; neither → exact length).
+  `member_len..=le`; neither → exact length). Bounds must satisfy
+  `member_len <= ge <= le <= address_bits` (32 for IPv4, 128 for
+  IPv6); a member whose range could never match, such as
+  `10.0.0.0/24 le 16` or `10.0.0.0/24 ge 28 le 26`, is a compile
+  error. Dataset snapshot files use the same grammar and the same
+  rule.
 - Community sets may mix standard, large, and extended members.
   Membership (`in`) matches when **any route community of any kind
   matches any member** — the set is kind-partitioned internally, and

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -4,6 +4,7 @@ use super::{
     PeerGroupConfig, Policy, PolicyAction, PolicyChain, PolicyStatement, PolicyStatementConfig,
     Prefix, RouteModifications, Safi, parse_community_match,
 };
+use rustbgpd_policy::sets::check_length_bounds;
 use rustbgpd_policy::{
     NeighborSetMatch, RouteExtendedCommunityAdmin, RouteExtendedCommunityKind, RouteType,
     encode_route_extended_community,
@@ -50,32 +51,11 @@ fn parse_prefix_entry(
         });
     };
 
-    if let Some(ge) = ge {
-        if ge > max_len {
-            return Err(ConfigError::InvalidPolicyEntry {
-                reason: format!("ge value {ge} exceeds {max_len} in {prefix_str:?}"),
-            });
+    check_length_bounds(len, max_len, ge, le).map_err(|reason| {
+        ConfigError::InvalidPolicyEntry {
+            reason: format!("{reason} in {prefix_str:?}"),
         }
-        if ge < len {
-            return Err(ConfigError::InvalidPolicyEntry {
-                reason: format!("ge value {ge} is less than prefix length {len} in {prefix_str:?}"),
-            });
-        }
-    }
-    if let Some(le) = le
-        && le > max_len
-    {
-        return Err(ConfigError::InvalidPolicyEntry {
-            reason: format!("le value {le} exceeds {max_len} in {prefix_str:?}"),
-        });
-    }
-    if let (Some(ge), Some(le)) = (ge, le)
-        && ge > le
-    {
-        return Err(ConfigError::InvalidPolicyEntry {
-            reason: format!("ge value {ge} exceeds le value {le} in {prefix_str:?}"),
-        });
-    }
+    })?;
     Ok(prefix)
 }
 

--- a/src/config/tests/policy_parsing.rs
+++ b/src/config/tests/policy_parsing.rs
@@ -303,6 +303,28 @@ ge = 8
 }
 
 #[test]
+fn policy_le_less_than_prefix_len_rejected() {
+    let toml_str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[policy.definitions.t]
+[[policy.definitions.t.statements]]
+action = "deny"
+prefix = "10.0.0.0/24"
+le = 16
+"#;
+    let err = parse(toml_str).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidPolicyEntry { .. }));
+}
+
+#[test]
 fn policy_ge_exceeds_le_rejected() {
     let toml_str = r#"
 [global]


### PR DESCRIPTION
## What changed

A policy prefix entry whose derived length range is empty loaded and matched nothing. Two frontends had the gap at different points:

- TOML `[policy.definitions]` statements: `parse_prefix_entry` checked `ge` against the prefix length and both bounds against the address-family maximum, but not `le` against the prefix length, so `prefix = "10.0.0.0/24"` with `le = 16` loaded.
- `.rpol` prefix-set members: `prefix_len_bound` only capped each value at 32/128 and never cross-checked, so `10.0.0.0/24 ge 28 le 16` and `10.0.0.0/24 ge 16 le 28` compiled. The same `prefix_entry` grammar serves set definitions, `test` dataset overrides, and dataset snapshot files.

One validator, `rustbgpd_policy::sets::check_length_bounds`, now sits beside the range derivation and requires prefix length `<= ge <= le <=` address bits. `parse_prefix_entry` replaces its inline checks with it (same error variant, same `... in "<prefix>"` message suffix); `Parser::prefix_entry` calls it after both bounds are read and emits a diagnostic spanning the entry. Dataset snapshot files get the rule through the shared parser.

## Compatibility impact

Config acceptance tightens. Newly rejected at load:

- a TOML policy statement whose `le` is below the prefix length (`prefix = "10.0.0.0/24"`, `le = 16`);
- an `.rpol` prefix-set member, `test` dataset override, or dataset snapshot line whose `le` is below the prefix length, whose `ge` is below the prefix length, or whose `ge` exceeds `le`.

Every such entry previously loaded and could never match, so the effective policy of an affected deployment does not change; the config now fails to load until the entry is corrected. A dataset snapshot holding such a line is a startup error at initial load and keeps the prior generation on SIGHUP reload, per the existing dataset refresh contract. Wording of the previously rejected TOML cases is unchanged. Documented in `CHANGELOG.md` (`### Changed` and `### Upgrade notes`), `docs/rpol-language.md` (sets section), and `docs/CONFIGURATION.md` (prefix-length matching and the validation table row for `le`).

## Tests

- `config::tests::policy_parsing::policy_le_less_than_prefix_len_rejected` (new)
- `rpol::tests::prefix_set_bounds_that_cannot_match_are_rejected` (new; three rejected shapes plus a positive control)
- `rpol::tests::datasets::dataset_file_format_parses_and_reports_lines` (extended with a dead-range snapshot line)

All three fail on `origin/main` without the fix (the config loads and `unwrap_err` / `expect_err` panic) and pass with it.

## Checks

| Command | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p rustbgpd-policy --all-targets -- -D warnings` | 0 |
| `cargo clippy --bin rustbgpd --all-targets -- -D warnings` | 0 |
| `cargo test -p rustbgpd-policy` | 0 (419 passed) |
| `cargo test --bin rustbgpd config` | 0 (997 passed, 4 ignored) |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `python3 scripts/test_check_public_tracker_ids.py` | 0 |

No config-documentation checker exists under `scripts/`; the public-tracker-id checker is the closest docs contract and was run with its self-test.
