### PR TITLE
birdwatcher-adapter: emit extended communities in route JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `birdwatcher-adapter` route views now emit `bgp.ext_communities` (an empty
+  array when the route carries none), so Alice-LG shows route targets and
+  other extended communities instead of nothing. Each entry is birdwatcher's
+  `[kind, key, value]` string triple as parsed from BIRD 2.0.12 text: `rt` /
+  `ro` for the transitive two-octet-AS, IPv4-address, and four-octet-AS
+  families, `unknown 0x<type>` for other subtypes of those families, and
+  `generic` with the two 32-bit halves in hex for every other type. The
+  pinned IXP compatibility live fixture carries the empty array; filtered
+  routes are unchanged.
+
 - An UPDATE that changes only the link-local companion of an IPv6 next hop
   (RFC 2545 two-address form) is now re-advertised to downstream peers instead
   of being suppressed as an unchanged Adj-RIB-Out entry.

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -491,6 +491,7 @@ load_on_demand = true
 | route `metric` | `0` | Sentinel only; this is not an IGP metric. |
 | filtered route `bgp.origin` | `""` | ORIGIN is not retained for rejected routes. |
 | filtered route `bgp.local_pref`, `bgp.med` | `"100"`, omitted | Not retained for rejected routes: `local_pref` renders the effective default (the same rule the accepted views apply to a route without the attribute) and `med` is omitted. An explicit wire value on the rejected announcement is lost. |
+| route `bgp.ext_communities` | rendered | Accepted, exact, and noexport routes carry every extended community as birdwatcher's `[kind, key, value]` string triple parsed from BIRD 2.0.12 text: `rt` / `ro` for the transitive two-octet-AS, IPv4-address, and four-octet-AS families (key and value split per family), `unknown 0x<type>` for other subtypes of those families, and `generic` with the two 32-bit halves in hex for every other type (opaque, EVPN, RFC 8097 origin validation state). Alice-LG converts the two values with `Atoi`, so an IPv4 key or a hex half reads as `0` there, exactly as behind a real birdwatcher. Filtered routes carry none (rejects retain no extended communities). |
 
 Error behavior differs only on failure: when the daemon is unreachable
 the adapter returns `502 Bad Gateway` (the in-daemon server returned

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -45,7 +45,7 @@
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{self, Read};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::{Arc, RwLock};
 
@@ -2685,7 +2685,7 @@ fn format_connection(state: i32) -> &'static str {
 /// Alice-LG reads: `network`, `gateway`, `from_protocol`, `interface`,
 /// `metric`, `age`, `type`, `primary`, `learnt_from`, and `bgp` sub-object
 /// with `origin`, `as_path`, `next_hop`, `local_pref`, `med`, `communities`,
-/// `large_communities`.
+/// `large_communities`, `ext_communities`.
 ///
 /// `primary` reports what the response itself carries (`Route.best`);
 /// views whose upstream scope never marks best-ness pass an explicit
@@ -2723,6 +2723,13 @@ fn route_to_birdwatcher_with_primary(
         })
         .collect();
 
+    let ext_communities: Vec<Value> = route
+        .extended_communities
+        .iter()
+        .copied()
+        .map(extended_community_to_birdwatcher)
+        .collect();
+
     let from_protocol = route
         .peer_address
         .parse()
@@ -2751,6 +2758,7 @@ fn route_to_birdwatcher_with_primary(
         "local_pref": route.local_pref.to_string(),
         "communities": communities,
         "large_communities": large_communities,
+        "ext_communities": ext_communities,
     });
     // BIRD omits `BGP.med` entirely when the route carries no MED
     // attribute; mirror that presence semantics from the wire-presence
@@ -2781,6 +2789,42 @@ fn route_to_birdwatcher_with_primary(
         "learnt_from": route.peer_address,
         "bgp": bgp
     })
+}
+
+/// Render one extended community as birdwatcher does: three strings,
+/// `[kind, key, value]`, captured from BIRD's `BGP.ext_community` text
+/// (birdwatcher `bird/parser.go` `parseRoutesExtendedCommunities`, which
+/// Alice-LG's `parseExtBgpCommunities` reads back with `strconv.Atoi` on
+/// the two values). The text itself follows BIRD 2.0.12 `ec_format`
+/// (`nest/a-set.c`): the kind is `rt` (subtype 0x02) or `ro` (subtype
+/// 0x03) for transitive two-octet-AS, IPv4-address, and four-octet-AS
+/// communities, any other subtype prints as `unknown 0x<type><subtype>`,
+/// and the key/value split follows the type byte (RFC 4360 §3.1/§3.2,
+/// RFC 5668). Every other type byte, including the non-transitive
+/// opaque family, renders as `generic` with the two 32-bit halves in hex.
+fn extended_community_to_birdwatcher(raw: u64) -> Value {
+    let type_field = (raw >> 48) as u32;
+    let kind = match type_field & 0xf0ff {
+        0x0002 => "rt".to_string(),
+        0x0003 => "ro".to_string(),
+        _ => format!("unknown {type_field:#x}"),
+    };
+    let (key, value) = match raw >> 56 {
+        0x00 | 0x40 => (((raw >> 32) & 0xffff).to_string(), (raw as u32).to_string()),
+        0x01 | 0x41 => (
+            Ipv4Addr::from((raw >> 16) as u32).to_string(),
+            (raw & 0xffff).to_string(),
+        ),
+        0x02 | 0x42 => (((raw >> 16) as u32).to_string(), (raw & 0xffff).to_string()),
+        _ => {
+            return serde_json::json!([
+                "generic",
+                format!("{:#x}", (raw >> 32) as u32),
+                format!("{:#x}", raw as u32),
+            ]);
+        }
+    };
+    serde_json::json!([kind, key, value])
 }
 
 /// Format a "now" timestamp in the layout Alice-LG expects for
@@ -3162,9 +3206,56 @@ mod tests {
             json["bgp"]["large_communities"],
             serde_json::json!([[65001, 1, 2]])
         );
+        // No extended communities on the route: an empty array, like
+        // `communities` (Alice-LG reads the key on every route).
+        assert_eq!(json["bgp"]["ext_communities"], serde_json::json!([]));
         // Bird's Eye shapes from the populated-oracle fixture.
         assert_eq!(json["bgp"]["aggregator"], "203.0.113.1 AS64496");
         assert_eq!(json["bgp"]["atomic_aggr"], "");
+    }
+
+    /// Extended communities render as birdwatcher parses BIRD 2.0.12's
+    /// `BGP.ext_community` text: `[kind, key, value]` as three strings,
+    /// with the key/value split by type byte, `rt`/`ro` kinds for the
+    /// transitive AS/IPv4 families, `unknown 0x<type>` for other
+    /// subtypes of those families, and `generic` hex halves for every
+    /// other type byte (here RFC 8097 origin validation state, 0x43/0x00).
+    #[test]
+    fn route_conversion_renders_extended_communities_as_birdwatcher_triples() {
+        let route = proto::Route {
+            prefix: "10.1.0.0".to_string(),
+            prefix_length: 24,
+            extended_communities: vec![
+                // Two-octet AS route target 65000:100 (RFC 4360 §3.1).
+                0x0002_fde8_0000_0064,
+                // Four-octet AS route target 4200000000:5 (RFC 5668).
+                (0x0202 << 48) | (4_200_000_000u64 << 16) | 5,
+                // IPv4-address route origin 192.0.2.1:200 (RFC 4360 §3.2).
+                (0x0103 << 48) | (0xc000_0201u64 << 16) | 200,
+                // Non-transitive two-octet AS route target: BIRD 2.0.12
+                // names only the transitive rt/ro subtypes.
+                0x4002_fde8_0000_0064,
+                // Two-octet AS, unassigned subtype 0x05.
+                0x0005_fde8_0000_0001,
+                // Non-transitive opaque origin validation state (RFC
+                // 8097) carrying 65000 in the low half: generic form.
+                0x4300_0000_0000_fde8,
+            ],
+            ..Default::default()
+        };
+        let json = route_to_birdwatcher(&route, &IdentityResolver::default());
+
+        assert_eq!(
+            json["bgp"]["ext_communities"],
+            serde_json::json!([
+                ["rt", "65000", "100"],
+                ["rt", "4200000000", "5"],
+                ["ro", "192.0.2.1", "200"],
+                ["unknown 0x4002", "65000", "100"],
+                ["unknown 0x5", "65000", "1"],
+                ["generic", "0x43000000", "0xfde8"],
+            ])
+        );
     }
 
     #[test]

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -1183,6 +1183,11 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     for route in live["routes"].as_array().unwrap() {
         assert_eq!(route["network"], "10.99.0.0/24", "{live}");
         assert_eq!(route["from_protocol"], "pb_0001_as65020", "{live}");
+        assert_eq!(
+            route["bgp"]["ext_communities"],
+            serde_json::json!([]),
+            "{live}"
+        );
     }
     assert_eq!(
         live["routes"]

--- a/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
+++ b/tests/compat/ixp-manager-birdseye/fixtures/populated-live.json
@@ -32,6 +32,7 @@
                   100
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -81,6 +82,7 @@
                   100
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -131,6 +133,7 @@
                   600
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -187,6 +190,7 @@
                   200
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -248,6 +252,7 @@
                   200
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -309,6 +314,7 @@
                   200
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -365,6 +371,7 @@
                   600
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -415,6 +422,7 @@
                   300
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -464,6 +472,7 @@
                   300
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -527,6 +536,7 @@
                   600
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -795,6 +805,7 @@
                   100
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -845,6 +856,7 @@
                   600
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -901,6 +913,7 @@
                   200
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -942,6 +955,7 @@
                   300
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -974,6 +988,7 @@
               ],
               "atomic_aggr": "",
               "communities": [],
+              "ext_communities": [],
               "large_communities": [],
               "local_pref": "100",
               "med": 30,
@@ -1019,6 +1034,7 @@
                   600
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -1055,6 +1071,7 @@
                   700
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -1104,6 +1121,7 @@
                   100
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -1145,6 +1163,7 @@
                   200
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -1186,6 +1205,7 @@
                   300
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -1218,6 +1238,7 @@
               ],
               "atomic_aggr": "",
               "communities": [],
+              "ext_communities": [],
               "large_communities": [],
               "local_pref": "100",
               "med": 30,
@@ -1263,6 +1284,7 @@
                   600
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -1299,6 +1321,7 @@
                   700
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,
@@ -1335,6 +1358,7 @@
                   600
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64497,
@@ -1455,6 +1479,7 @@
                   200
                 ]
               ],
+              "ext_communities": [],
               "large_communities": [
                 [
                   64496,


### PR DESCRIPTION
## What changed

`route_to_birdwatcher_with_primary` never read `Route.extended_communities`
(`proto/rustbgpd.proto`, `repeated uint64 extended_communities = 11`), so the
accepted, exact, and noexport route views (all of which delegate to it) showed
Alice-LG no route targets, route origins, or any other extended community.

- New `extended_community_to_birdwatcher(raw: u64) -> Value` renders one
  community as birdwatcher does from BIRD's text, and every route view now
  emits `bgp.ext_communities` next to `large_communities`, as an empty array
  when the route carries none (the same presence rule as `communities`).
- The adapter does not depend on `rustbgpd-wire`, so the type and subtype
  bytes are decoded inline instead of adding a dependency.
- The filtered/rejected view is unchanged: `RejectedRoute` carries no extended
  communities.

## Target shape, pinned from primary sources

The compatibility gate pins Alice-LG 6.2.0 (`tests/compat/ixp-manager-birdseye/README.md`,
commit `e9fa175d00eb192cb09fe1b460bb53a54398fc34`) and BIRD 2.0.12
(`Dockerfile.oracle`). No birdwatcher version is pinned in-tree; birdwatcher
2.2.5 (its latest tag, 2024-01-17) was read.

- birdwatcher 2.2.5 `bird/parser.go`: `regex.routes.extendedCommunity` is
  `^\(([^,]+),\s*([^,]+),\s*([^,]+)\)` and `parseRoutesExtendedCommunities`
  appends `[]interface{}{groups[1], groups[2], groups[3]}` under the key
  `ext_communities`. Every element is a **string**, including the two values.
- Alice-LG 6.2.0 `pkg/api/response.go`: `type ExtCommunity []interface{}`,
  `BGPInfo.ExtCommunities ... json:"ext_communities"`.
  `pkg/sources/birdwatcher/parsers.go` `parseExtBgpCommunities` requires
  exactly three elements and converts elements 1 and 2 with
  `strconv.Atoi(cdata[i].(string))`; a non-string element would panic there,
  so numbers must not be emitted.
- BIRD 2.0.12 `nest/a-set.c` `ec_format` and `nest/attrs.h` `ec_subtype`:
  kind = `rt` (subtype `0x02`) or `ro` (subtype `0x03`) after masking the type
  field with `0xf0ff`, otherwise `unknown 0x<type>`; the value split follows
  the type byte: `0x00`/`0x40` two-octet AS (`key = (ec >> 32) & 0xFFFF`,
  `val = low 32 bits`), `0x01`/`0x41` IPv4 address (`key = ec >> 16` printed
  dotted-quad, `val = ec & 0xFFFF`), `0x02`/`0x42` four-octet AS
  (`key = ec >> 16`, `val = ec & 0xFFFF`); every other type byte prints
  `(generic, 0x<hi>, 0x<lo>)` with the two 32-bit halves in lowercase hex.

Two expectations in the task differed from the sources and the sources were
followed:

- Non-transitive route targets (`0x40`/`0x41`/`0x42`, subtype `0x02`) render
  as `unknown 0x4002` (and so on), not `rt`: BIRD 2.0.12 only names the
  transitive subtypes because `0x4002 & 0xf0ff != 0x0002`.
- RFC 9234 OTC is path attribute 35, not an extended community. The
  `0x43`/`0x00` value in the test is RFC 8097 origin validation state and
  renders in the generic form, as it would behind BIRD.

## Compatibility impact

- Route JSON gains one key, `bgp.ext_communities`, on every accepted, exact,
  and noexport route. Alice-LG 6.2.0 already reads it; consumers that ignore
  unknown keys are unaffected.
- `tests/compat/ixp-manager-birdseye/fixtures/populated-live.json` gains
  `"ext_communities": []` on all 25 pinned accepted routes, written with the
  same `json.dumps(indent=2, sort_keys=True)` the gate uses.
- No `runtime_divergences` entry is added. `verify_capture.py` `flatten`
  turns an empty array into no leaf, no route in the populated leg carries an
  extended community, so the new key produces no oracle/live difference; an
  `extra` entry for `routes.*.bgp.ext_communities` would be reported stale
  and fail the gate. Replaying `check_divergences` offline over the pinned
  oracle fixture and the updated live fixture gives 0 unlisted, 0 stale, no
  redundant entries, and confirms such an entry would be stale.

## Tests

- `route_conversion_renders_extended_communities_as_birdwatcher_triples`
  (two-octet-AS RT, four-octet-AS RT, IPv4 RO, non-transitive RT, unassigned
  subtype, RFC 8097 state) and an empty-array assertion in
  `route_conversion_matches_birdwatcher_shape`. Both fail before the fix
  (`left: Null` at `main.rs:3167` and `main.rs:3204`).
- `tests/birdwatcher_adapter_smoke.rs` asserts the key on the live accepted
  view.

## Checks

- `cargo fmt --all -- --check`: exit 0
- `cargo clippy -p birdwatcher-adapter --all-targets -- -D warnings`: exit 0
- `cargo test -p birdwatcher-adapter`: exit 0 (47 passed)
- `cargo test --test birdwatcher_adapter_smoke`: exit 0 (2 passed)
- `python3 scripts/check_public_tracker_ids.py`: exit 0
- `tests/compat/ixp-manager-birdseye/` has no Python unit tests; the
  container-backed compatibility gate itself was not run locally.
