### PR TITLE
rib: compare the effective BGP identifier before cluster length and peer address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   kernel `TCP_MD5SIG` key bound, 1..=80 bytes, with the same wording the
   `[[rpki.cache_servers]]` check already uses.
 
+- **Operator-visible:** best-path selection now applies RFC 4271 §9.1.2.2
+  step (f), preferring the route received from the speaker with the lowest
+  BGP Identifier. A route's ORIGINATOR_ID substitutes for the identifier when
+  present (RFC 4456 §9); otherwise the advertising peer's BGP Identifier from
+  its OPEN is used. Previously the step ran only when both routes carried
+  ORIGINATOR_ID, and it ran after the CLUSTER_LIST comparison. The order below
+  eBGP-over-iBGP (and the RFC 9107 ORR interior cost where it applies) is now
+  lowest effective BGP Identifier, shorter CLUSTER_LIST, lowest peer address.
+  Pairs that include a locally originated route skip the identifier step. The
+  unicast, VPN, labeled-unicast, FlowSpec, BGP-LS, and RT-Constrain chains all
+  follow this order; the EVPN chain is unchanged. Explain output and BMP path
+  marking report the new `lower_bgp_identifier` reason when at least one side
+  was compared by its peer's identifier and keep `lower_originator_id` when
+  both carried ORIGINATOR_ID; both map to the path-marking "router ID" reason
+  code.
+
 - Reject AS 0 in received and locally encoded AS paths and aggregators per RFC
   7607. Malformed ordinary paths are treated as withdraw, while affected AS4
   compatibility and aggregator attributes are discarded without entering
@@ -427,6 +443,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`md5_password must be 1..=80 bytes`) instead of loading and then failing
   when the session or listener socket installs the key. Such a value never
   produced a working session; shorten or remove it.
+- **Best-path selection can change after upgrade** between otherwise-equal
+  paths from different peers: the lowest advertising BGP Identifier (or
+  ORIGINATOR_ID) now decides before CLUSTER_LIST length and peer address,
+  where previously peer address decided unless both routes carried
+  ORIGINATOR_ID. Expect a one-time best-path change, and the corresponding
+  withdraw/announce toward peers, for prefixes that tied down to the peer
+  address. `rbgp rib --prefix <cidr> --explain` and BMP path marking report
+  the new `lower_bgp_identifier` reason; `lower_originator_id` is retained
+  for the both-ORIGINATOR_ID case.
 - Received `AS_PATH` attributes with more than 750 AS numbers and reachable
   NLRI are now treated as withdraw by default; without reachable NLRI, the
   session resets. Deployments that must relay arbitrarily long paths set

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -3,10 +3,11 @@
 //! Uses deterministic MED (always-compare) for simplicity, matching `GoBGP`.
 
 use std::cmp::Ordering;
+use std::net::Ipv4Addr;
 
 use rustbgpd_wire::{AsPath, AspaValidation, RpkiValidation};
 
-use crate::route::Route;
+use crate::route::{Route, RouteOrigin};
 
 /// Numeric preference for RPKI validation state: higher = more preferred.
 fn rpki_preference(v: RpkiValidation) -> u8 {
@@ -39,6 +40,62 @@ fn stale_rank(route: &Route) -> u8 {
     }
 }
 
+/// The identifier a route is compared by at RFC 4271 §9.1.2.2 step (f),
+/// with the RFC 4456 §9 substitution: its `ORIGINATOR_ID` when present,
+/// otherwise the BGP Identifier of the peer that advertised it.
+///
+/// Locally originated routes have no advertising speaker — their
+/// `peer_router_id` is the `0.0.0.0` injection sentinel, not a BGP
+/// Identifier — so they yield `None` and the step is skipped for any
+/// pair that includes one.
+#[must_use]
+pub(crate) fn effective_bgp_identifier(
+    origin_type: RouteOrigin,
+    originator_id: Option<Ipv4Addr>,
+    peer_router_id: Ipv4Addr,
+) -> Option<Ipv4Addr> {
+    match origin_type {
+        RouteOrigin::Local => None,
+        RouteOrigin::Ebgp | RouteOrigin::Ibgp => Some(originator_id.unwrap_or(peer_router_id)),
+    }
+}
+
+/// Decide step (f) for a pair of routes, each given as
+/// `(origin_type, originator_id, peer_router_id)`.
+///
+/// `None` when the step does not decide: equal effective identifiers, or
+/// either route locally originated. The reason is
+/// [`BestPathReason::LowerOriginatorId`] when both routes carried
+/// `ORIGINATOR_ID` and [`BestPathReason::LowerBgpIdentifier`] when at
+/// least one side fell back to its peer's BGP Identifier.
+#[must_use]
+pub(crate) fn compare_bgp_identifier(
+    a: (RouteOrigin, Option<Ipv4Addr>, Ipv4Addr),
+    b: (RouteOrigin, Option<Ipv4Addr>, Ipv4Addr),
+) -> Option<(Ordering, BestPathReason)> {
+    let id_a = effective_bgp_identifier(a.0, a.1, a.2)?;
+    let id_b = effective_bgp_identifier(b.0, b.1, b.2)?;
+    let cmp = id_a.cmp(&id_b);
+    if cmp == Ordering::Equal {
+        return None;
+    }
+    let reason = if a.1.is_some() && b.1.is_some() {
+        BestPathReason::LowerOriginatorId
+    } else {
+        BestPathReason::LowerBgpIdentifier
+    };
+    Some((cmp, reason))
+}
+
+/// The step (f) inputs of a unicast [`Route`].
+fn bgp_identity(route: &Route) -> (RouteOrigin, Option<Ipv4Addr>, Ipv4Addr) {
+    (
+        route.origin_type,
+        route.originator_id(),
+        route.peer_router_id,
+    )
+}
+
 /// The decisive step in a best-path comparison.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BestPathReason {
@@ -63,10 +120,15 @@ pub enum BestPathReason {
     /// by the Loc-RIB ladder (`best_path_cmp_with_reason` carries no
     /// vantage costs) — only [`best_path_cmp_orr_with_reason`] yields it.
     OrrInteriorCost,
-    /// Step 5.5: shorter `CLUSTER_LIST` wins (RFC 4456).
-    ShorterClusterList,
-    /// Step 5.6: lower `ORIGINATOR_ID` wins (RFC 4456).
+    /// Step 5.5: lower `ORIGINATOR_ID` wins when both routes carry the
+    /// attribute (RFC 4456 §9 substitution for the BGP Identifier).
     LowerOriginatorId,
+    /// Step 5.5: lower effective BGP Identifier wins (RFC 4271 §9.1.2.2
+    /// step (f)) when at least one side fell back to the advertising
+    /// peer's BGP Identifier because it carries no `ORIGINATOR_ID`.
+    LowerBgpIdentifier,
+    /// Step 5.6: shorter `CLUSTER_LIST` wins (RFC 4456 §9).
+    ShorterClusterList,
     /// Step 6: lower peer address.
     LowerPeerAddress,
     /// Step 6.1: lower inbound Add-Path identifier as a deterministic
@@ -94,8 +156,9 @@ impl BestPathReason {
             Self::LowerMed => "lower_med",
             Self::EbgpOverIbgp => "ebgp_over_ibgp",
             Self::OrrInteriorCost => "orr_interior_cost",
-            Self::ShorterClusterList => "shorter_cluster_list",
             Self::LowerOriginatorId => "lower_originator_id",
+            Self::LowerBgpIdentifier => "lower_bgp_identifier",
+            Self::ShorterClusterList => "shorter_cluster_list",
             Self::LowerPeerAddress => "lower_peer_address",
             Self::LowerPathId => "lower_path_id",
             Self::EvpnMacMobility => "evpn_mac_mobility",
@@ -156,16 +219,13 @@ pub fn best_path_cmp_with_reason(a: &Route, b: &Route) -> (Ordering, BestPathRea
         return (cmp, BestPathReason::EbgpOverIbgp);
     }
 
+    if let Some(decided) = compare_bgp_identifier(bgp_identity(a), bgp_identity(b)) {
+        return decided;
+    }
+
     let cmp = a.cluster_list().len().cmp(&b.cluster_list().len());
     if cmp != Ordering::Equal {
         return (cmp, BestPathReason::ShorterClusterList);
-    }
-
-    if let (Some(a_oid), Some(b_oid)) = (a.originator_id(), b.originator_id()) {
-        let cmp = a_oid.cmp(&b_oid);
-        if cmp != Ordering::Equal {
-            return (cmp, BestPathReason::LowerOriginatorId);
-        }
     }
 
     let cmp = a.peer.cmp(&b.peer);
@@ -181,7 +241,7 @@ pub fn best_path_cmp_with_reason(a: &Route, b: &Route) -> (Ordering, BestPathRea
 /// Same ordering as [`best_path_cmp_orr`], derived by composition rather
 /// than a third hand-maintained ladder: the plain reason ladder decides
 /// unless its decisive step is one of the tiebreakers *below* the ORR
-/// interior-cost step (`CLUSTER_LIST`, `ORIGINATOR_ID`, peer address,
+/// interior-cost step (BGP Identifier, `CLUSTER_LIST`, peer address,
 /// inbound Add-Path identifier) — in that case the vantage cost gets first
 /// shot and, when decisive, yields [`BestPathReason::OrrInteriorCost`].
 #[must_use]
@@ -194,8 +254,9 @@ pub fn best_path_cmp_orr_with_reason(
     let (ord, reason) = best_path_cmp_with_reason(a, b);
     let below_orr_step = matches!(
         reason,
-        BestPathReason::ShorterClusterList
-            | BestPathReason::LowerOriginatorId
+        BestPathReason::LowerOriginatorId
+            | BestPathReason::LowerBgpIdentifier
+            | BestPathReason::ShorterClusterList
             | BestPathReason::LowerPeerAddress
             | BestPathReason::LowerPathId
     );
@@ -314,6 +375,22 @@ pub fn best_path_reason_detail(reason: BestPathReason, a: &Route, b: &Route) -> 
             // both routes carry ORIGINATOR_ID.
             _ => "originator_id absent".to_string(),
         },
+        BestPathReason::LowerBgpIdentifier => {
+            let (x, y) = (
+                effective_bgp_identifier(a.origin_type, a.originator_id(), a.peer_router_id),
+                effective_bgp_identifier(b.origin_type, b.originator_id(), b.peer_router_id),
+            );
+            // Defensive: `None` (locally originated) never reaches this
+            // reason because the comparator skips the step for that pair.
+            let show =
+                |id: Option<Ipv4Addr>| id.map_or_else(|| "local".to_string(), |id| id.to_string());
+            format!(
+                "bgp_identifier {} {} {}",
+                show(x),
+                cmp_symbol(&x, &y),
+                show(y)
+            )
+        }
         BestPathReason::LowerPeerAddress => {
             format!(
                 "peer {} {} {}",
@@ -395,8 +472,11 @@ pub fn multipath_eligibility(best: &Route, other: &Route) -> MultipathEligibilit
 /// 5. eBGP over iBGP
 ///    5.3. ORR interior cost (RFC 9107) — [`best_path_cmp_orr`] only;
 ///    this comparator never runs it
-///    5.5. Shortest `CLUSTER_LIST` length (RFC 4456 §9)
-///    5.6. Lowest `ORIGINATOR_ID` (RFC 4456 §9) — only when both present
+///    5.5. Lowest effective BGP Identifier (RFC 4271 §9.1.2.2 step (f)):
+///    `ORIGINATOR_ID` when present, else the advertising peer's BGP
+///    Identifier (RFC 4456 §9); skipped for a pair that includes a
+///    locally originated route
+///    5.6. Shortest `CLUSTER_LIST` length (RFC 4456 §9)
 /// 6. Lowest peer address (tiebreaker)
 ///    Final identity tie: lowest inbound Add-Path identifier
 ///    (deterministic same-peer route identity only; RFC 7911 assigns no
@@ -409,7 +489,7 @@ pub fn best_path_cmp(a: &Route, b: &Route) -> Ordering {
 /// Compare two routes under RFC 9107 Optimal Route Reflection.
 ///
 /// The standard [`best_path_cmp`] chain with one extra step between
-/// step 5 (eBGP over iBGP) and step 5.5 (`CLUSTER_LIST`): the
+/// step 5 (eBGP over iBGP) and step 5.5 (BGP Identifier): the
 /// configured vantage's interior (SPF) cost to each route's `NEXT_HOP`.
 /// Lower cost wins; a known cost beats an unknown one (RFC 9107 §3.1:
 /// an unknown metric-to-next-hop MUST be least preferred); equal or
@@ -495,18 +575,17 @@ fn cmp_chain(a: &Route, b: &Route, orr_costs: Option<(Option<u64>, Option<u64>)>
         }
     }
 
-    // 5.5. Shortest CLUSTER_LIST length (RFC 4456 §9)
-    let cmp = a.cluster_list().len().cmp(&b.cluster_list().len());
-    if cmp != Ordering::Equal {
+    // 5.5. Lowest effective BGP Identifier (RFC 4271 §9.1.2.2 step (f)):
+    //      ORIGINATOR_ID substitutes when present (RFC 4456 §9); a pair
+    //      with a locally originated route skips the step.
+    if let Some((cmp, _)) = compare_bgp_identifier(bgp_identity(a), bgp_identity(b)) {
         return cmp;
     }
 
-    // 5.6. Lowest ORIGINATOR_ID (RFC 4456 §9) — only when both present
-    if let (Some(a_oid), Some(b_oid)) = (a.originator_id(), b.originator_id()) {
-        let cmp = a_oid.cmp(&b_oid);
-        if cmp != Ordering::Equal {
-            return cmp;
-        }
+    // 5.6. Shortest CLUSTER_LIST length (RFC 4456 §9)
+    let cmp = a.cluster_list().len().cmp(&b.cluster_list().len());
+    if cmp != Ordering::Equal {
+        return cmp;
     }
 
     // 6. Lowest peer address, then inbound Add-Path identifier. The
@@ -523,7 +602,7 @@ fn cmp_chain(a: &Route, b: &Route, orr_costs: Option<(Option<u64>, Option<u64>)>
 /// `AS_PATH`, `ORIGIN`, `MED` — **and** are the same eBGP/iBGP class (a group is
 /// never mixed; forwarding across an eBGP and an iBGP path at once is not a
 /// thing operators expect). The tiebreakers `best_path_cmp` applies below this
-/// point (`CLUSTER_LIST` length, `ORIGINATOR_ID`, peer address, inbound Add-Path
+/// point (BGP Identifier, `CLUSTER_LIST` length, peer address, inbound Add-Path
 /// identifier) are deliberately *not* compared: those exist precisely to pick
 /// one winner among otherwise co-equal paths, which are exactly the paths we
 /// want to bundle.
@@ -923,9 +1002,15 @@ mod tests {
         assert_eq!(best_path_cmp(&b, &a), Ordering::Greater);
     }
 
+    fn with_router_id(mut r: Route, id: Ipv4Addr) -> Route {
+        r.peer_router_id = id;
+        r
+    }
+
+    /// RFC 4456 §9 orders the identifier comparison before `CLUSTER_LIST`
+    /// length: the lower `ORIGINATOR_ID` wins despite a longer list.
     #[test]
-    fn cluster_list_beats_originator_id() {
-        // Shorter CLUSTER_LIST should win even if ORIGINATOR_ID is higher
+    fn originator_id_beats_shorter_cluster_list() {
         let a = with_originator_id(
             with_cluster_list(
                 base_route(Ipv4Addr::new(1, 0, 0, 1)),
@@ -940,20 +1025,118 @@ mod tests {
             ),
             Ipv4Addr::new(10, 0, 0, 1),
         );
-        assert_eq!(best_path_cmp(&a, &b), Ordering::Less);
+        assert_eq!(
+            best_path_cmp_with_reason(&a, &b),
+            (Ordering::Greater, BestPathReason::LowerOriginatorId)
+        );
+        assert_eq!(best_path_cmp(&b, &a), Ordering::Less);
     }
 
+    /// RFC 4271 §9.1.2.2 step (f): the lower BGP Identifier of the
+    /// advertising peer decides before the peer address does.
     #[test]
-    fn originator_id_only_when_both_present() {
-        // When only one route has ORIGINATOR_ID, it should fall through
-        let a = with_originator_id(
-            base_route(Ipv4Addr::new(1, 0, 0, 2)),
-            Ipv4Addr::new(10, 0, 0, 99),
+    fn lower_bgp_identifier_beats_peer_address() {
+        let a = with_router_id(
+            base_route(Ipv4Addr::new(10, 0, 0, 2)),
+            Ipv4Addr::new(1, 1, 1, 1),
         );
-        let b = base_route(Ipv4Addr::new(1, 0, 0, 1));
-        // ORIGINATOR_ID tiebreaker skipped (b has none), falls to peer address
-        // b has lower peer → b wins
-        assert_eq!(best_path_cmp(&a, &b), Ordering::Greater);
+        let b = with_router_id(
+            base_route(Ipv4Addr::new(10, 0, 0, 1)),
+            Ipv4Addr::new(2, 2, 2, 2),
+        );
+        assert_eq!(
+            best_path_cmp_with_reason(&a, &b),
+            (Ordering::Less, BestPathReason::LowerBgpIdentifier)
+        );
+        assert_eq!(
+            best_path_cmp_with_reason(&b, &a),
+            (Ordering::Greater, BestPathReason::LowerBgpIdentifier)
+        );
+        assert_eq!(best_path_cmp(&a, &b), Ordering::Less);
+        assert_eq!(best_path_cmp(&b, &a), Ordering::Greater);
+    }
+
+    /// RFC 4456 §9: `ORIGINATOR_ID` substitutes for the BGP Identifier on
+    /// the route that carries it; the other side keeps its peer's.
+    #[test]
+    fn originator_id_compares_against_peer_router_id_when_one_side_absent() {
+        let x = with_originator_id(
+            with_router_id(
+                base_route(Ipv4Addr::new(10, 0, 0, 1)),
+                Ipv4Addr::new(5, 5, 5, 5),
+            ),
+            Ipv4Addr::new(3, 3, 3, 3),
+        );
+        let y = with_router_id(
+            base_route(Ipv4Addr::new(10, 0, 0, 2)),
+            Ipv4Addr::new(1, 1, 1, 1),
+        );
+        // y's peer identifier 1.1.1.1 < x's ORIGINATOR_ID 3.3.3.3, despite
+        // x's lower peer address.
+        assert_eq!(
+            best_path_cmp_with_reason(&x, &y),
+            (Ordering::Greater, BestPathReason::LowerBgpIdentifier)
+        );
+        assert_eq!(
+            best_path_cmp_with_reason(&y, &x),
+            (Ordering::Less, BestPathReason::LowerBgpIdentifier)
+        );
+        assert_eq!(best_path_cmp(&x, &y), Ordering::Greater);
+    }
+
+    /// Step (f) precedes `CLUSTER_LIST` length: the lower effective
+    /// identifier wins even with the longer list.
+    #[test]
+    fn lower_bgp_identifier_beats_shorter_cluster_list() {
+        let a = with_cluster_list(
+            with_router_id(
+                base_route(Ipv4Addr::new(10, 0, 0, 2)),
+                Ipv4Addr::new(1, 1, 1, 1),
+            ),
+            vec![Ipv4Addr::new(10, 0, 0, 100), Ipv4Addr::new(10, 0, 0, 200)],
+        );
+        let b = with_cluster_list(
+            with_router_id(
+                base_route(Ipv4Addr::new(10, 0, 0, 1)),
+                Ipv4Addr::new(2, 2, 2, 2),
+            ),
+            vec![Ipv4Addr::new(10, 0, 0, 100)],
+        );
+        assert_eq!(
+            best_path_cmp_with_reason(&a, &b),
+            (Ordering::Less, BestPathReason::LowerBgpIdentifier)
+        );
+        assert_eq!(best_path_cmp(&b, &a), Ordering::Greater);
+    }
+
+    /// Locally originated routes have no advertising speaker: step (f) is
+    /// skipped for the pair and the `0.0.0.0` peer sentinel decides,
+    /// exactly as it did before the identifier step existed.
+    #[test]
+    fn local_route_skips_bgp_identifier_step() {
+        let mut local = base_route(Ipv4Addr::UNSPECIFIED);
+        local.origin_type = RouteOrigin::Local;
+        let mut learned = with_router_id(
+            base_route(Ipv4Addr::new(10, 0, 0, 1)),
+            Ipv4Addr::new(1, 1, 1, 1),
+        );
+        learned.origin_type = RouteOrigin::Ibgp;
+        assert_eq!(
+            effective_bgp_identifier(
+                local.origin_type,
+                local.originator_id(),
+                local.peer_router_id
+            ),
+            None
+        );
+        assert_eq!(
+            best_path_cmp_with_reason(&local, &learned),
+            (Ordering::Less, BestPathReason::LowerPeerAddress)
+        );
+        assert_eq!(
+            best_path_cmp_with_reason(&learned, &local),
+            (Ordering::Greater, BestPathReason::LowerPeerAddress)
+        );
     }
 
     #[test]
@@ -1126,9 +1309,17 @@ mod tests {
                 BestPathReason::LowerOriginatorId,
             ),
             (
+                "bgp_identifier",
+                with_router_id(base_route(p1), Ipv4Addr::new(2, 2, 2, 2)),
+                with_router_id(base_route(p2), Ipv4Addr::new(1, 1, 1, 1)),
+                BestPathReason::LowerBgpIdentifier,
+            ),
+            (
+                // Equal peer BGP Identifiers so step (f) ties and the
+                // peer address is the deciding step.
                 "peer",
-                base_route(p1),
-                base_route(p2),
+                with_router_id(base_route(p1), Ipv4Addr::new(9, 9, 9, 9)),
+                with_router_id(base_route(p2), Ipv4Addr::new(9, 9, 9, 9)),
                 BestPathReason::LowerPeerAddress,
             ),
             (
@@ -1464,6 +1655,30 @@ mod tests {
         assert_eq!(
             best_path_reason_detail(BestPathReason::LowerPathId, &path_9, &path_7),
             "path_id 9 > 7"
+        );
+    }
+
+    /// Step (f) detail renders the effective identifiers: the peer's BGP
+    /// Identifier, or `ORIGINATOR_ID` where RFC 4456 §9 substitutes it.
+    #[test]
+    fn reason_detail_renders_effective_bgp_identifiers() {
+        let p1 = Ipv4Addr::new(1, 0, 0, 1);
+        let p2 = Ipv4Addr::new(1, 0, 0, 2);
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::LowerBgpIdentifier,
+                &with_router_id(base_route(p1), Ipv4Addr::new(2, 2, 2, 2)),
+                &with_router_id(base_route(p2), Ipv4Addr::new(1, 1, 1, 1)),
+            ),
+            "bgp_identifier 2.2.2.2 > 1.1.1.1"
+        );
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::LowerBgpIdentifier,
+                &with_originator_id(base_route(p1), Ipv4Addr::new(3, 3, 3, 3)),
+                &with_router_id(base_route(p2), Ipv4Addr::new(1, 1, 1, 1)),
+            ),
+            "bgp_identifier 3.3.3.3 > 1.1.1.1"
         );
     }
 

--- a/crates/rib/src/bmp_sync.rs
+++ b/crates/rib/src/bmp_sync.rs
@@ -56,10 +56,13 @@ pub fn path_marking_reason_code(reason: BestPathReason) -> Option<u16> {
         BestPathReason::LowerMed => Some(bmp_tlv::REASON_MED),
         BestPathReason::EbgpOverIbgp => Some(bmp_tlv::REASON_PEER_TYPE),
         BestPathReason::OrrInteriorCost => Some(bmp_tlv::REASON_IGP_COST),
-        // RFC 4456 substitutes ORIGINATOR_ID for the BGP identifier on
-        // reflected routes — the same RFC 4271 §9.1.2.2 step the
-        // draft's "router ID" code names.
-        BestPathReason::LowerOriginatorId => Some(bmp_tlv::REASON_ROUTER_ID),
+        // Both reasons are RFC 4271 §9.1.2.2 step (f), the step the
+        // draft's "router ID" code names: RFC 4456 substitutes
+        // ORIGINATOR_ID for the BGP Identifier on reflected routes, and
+        // a route without one is compared by its peer's BGP Identifier.
+        BestPathReason::LowerOriginatorId | BestPathReason::LowerBgpIdentifier => {
+            Some(bmp_tlv::REASON_ROUTER_ID)
+        }
         BestPathReason::LowerPeerAddress => Some(bmp_tlv::REASON_PEER_ADDRESS),
         BestPathReason::StalePreference
         | BestPathReason::RpkiPreference
@@ -811,6 +814,7 @@ mod tests {
             (R::EbgpOverIbgp, Some(tlv::REASON_PEER_TYPE)),
             (R::OrrInteriorCost, Some(tlv::REASON_IGP_COST)),
             (R::LowerOriginatorId, Some(tlv::REASON_ROUTER_ID)),
+            (R::LowerBgpIdentifier, Some(tlv::REASON_ROUTER_ID)),
             (R::LowerPeerAddress, Some(tlv::REASON_PEER_ADDRESS)),
             (R::StalePreference, None),
             (R::RpkiPreference, None),
@@ -829,6 +833,11 @@ mod tests {
         // Numeric pins straight from Table 2 so a constant edit in the
         // bmp crate cannot silently shift the wire values.
         assert_eq!(path_marking_reason_code(R::HigherLocalPref), Some(0x0003));
+        assert_eq!(path_marking_reason_code(R::LowerOriginatorId), Some(0x0009));
+        assert_eq!(
+            path_marking_reason_code(R::LowerBgpIdentifier),
+            Some(0x0009)
+        );
         assert_eq!(path_marking_reason_code(R::LowerPeerAddress), Some(0x000A));
         assert_eq!(path_marking_reason_code(R::LowerPathId), None);
     }

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -12,7 +12,7 @@ use rustbgpd_wire::{AsPath, EvpnRouteKey, Origin, PathAttribute, Prefix};
 // Aliased to the std name so the storage types read unchanged.
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 
-use crate::best_path::best_path_cmp;
+use crate::best_path::{best_path_cmp, compare_bgp_identifier};
 use crate::prefix_map::FamilyPrefixMap;
 use crate::route::{
     BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecKey, FlowSpecRoute, LabeledRibRoute, Route,
@@ -794,10 +794,16 @@ fn evpn_stale_rank(route: &EvpnRibRoute) -> u8 {
 /// a higher sequence number. Absence of the MAC Mobility community is
 /// treated as sequence=0, sticky=false per RFC 7432 §7.7.
 ///
-/// All route types then fall through to the standard BGP chain, matching
-/// unicast `best_path_cmp` and `flowspec_tiebreak`:
+/// All route types then fall through to the standard BGP chain:
 /// stale → `LocalPref` → `AS_PATH` length → ORIGIN → MED →
 /// eBGP > iBGP → `CLUSTER_LIST` length → `ORIGINATOR_ID` → peer address.
+///
+/// The EVPN chain deliberately differs from unicast `best_path_cmp` and
+/// the other family chains in two ways: `CLUSTER_LIST` length is compared
+/// before the identifier, and the identifier step (`ORIGINATOR_ID`, else
+/// the peer's BGP Identifier) runs for every route, including locally
+/// originated VTEP routes whose `peer_router_id` is the `0.0.0.0`
+/// sentinel.
 fn evpn_tiebreak_simple(a: &EvpnRibRoute, b: &EvpnRibRoute) -> Ordering {
     // 0. Three-tier freshness: fresh (0) > GR-stale (1) > LLGR-stale (2)
     //    per RFC 4724 §4.2 / RFC 9494 §4.7. LLGR promotion clears
@@ -902,7 +908,7 @@ fn flowspec_stale_rank(route: &FlowSpecRoute) -> u8 {
 ///
 /// Uses the same preference chain as unicast `best_path_cmp`:
 /// stale → `LOCAL_PREF` → `AS_PATH` length → ORIGIN → MED →
-/// eBGP>iBGP → `CLUSTER_LIST` → `ORIGINATOR_ID` → peer address.
+/// eBGP>iBGP → BGP Identifier → `CLUSTER_LIST` → peer address.
 ///
 /// RPKI validation is not applicable to `FlowSpec` routes.
 fn flowspec_tiebreak(a: &FlowSpecRoute, b: &FlowSpecRoute) -> Ordering {
@@ -945,18 +951,19 @@ fn flowspec_tiebreak(a: &FlowSpecRoute, b: &FlowSpecRoute) -> Ordering {
         return cmp;
     }
 
-    // 5.5. Shortest CLUSTER_LIST length (RFC 4456 §9)
-    let cmp = a.cluster_list().len().cmp(&b.cluster_list().len());
-    if cmp != Ordering::Equal {
+    // 5.5. Lowest effective BGP Identifier (RFC 4271 §9.1.2.2 step (f);
+    //      ORIGINATOR_ID substitutes per RFC 4456 §9)
+    if let Some((cmp, _)) = compare_bgp_identifier(
+        (a.origin_type, a.originator_id(), a.peer_router_id),
+        (b.origin_type, b.originator_id(), b.peer_router_id),
+    ) {
         return cmp;
     }
 
-    // 5.6. Lowest ORIGINATOR_ID (RFC 4456 §9) — only when both present
-    if let (Some(a_oid), Some(b_oid)) = (a.originator_id(), b.originator_id()) {
-        let cmp = a_oid.cmp(&b_oid);
-        if cmp != Ordering::Equal {
-            return cmp;
-        }
+    // 5.6. Shortest CLUSTER_LIST length (RFC 4456 §9)
+    let cmp = a.cluster_list().len().cmp(&b.cluster_list().len());
+    if cmp != Ordering::Equal {
+        return cmp;
     }
 
     // 6. Lowest peer address (final tiebreaker)
@@ -996,16 +1003,16 @@ fn bgpls_tiebreak(a: &BgpLsRibRoute, b: &BgpLsRibRoute) -> Ordering {
         return cmp;
     }
 
-    let cmp = bgpls_cluster_list_len(a).cmp(&bgpls_cluster_list_len(b));
-    if cmp != Ordering::Equal {
+    if let Some((cmp, _)) = compare_bgp_identifier(
+        (a.origin_type, bgpls_originator_id(a), a.peer_router_id),
+        (b.origin_type, bgpls_originator_id(b), b.peer_router_id),
+    ) {
         return cmp;
     }
 
-    if let (Some(a_oid), Some(b_oid)) = (bgpls_originator_id(a), bgpls_originator_id(b)) {
-        let cmp = a_oid.cmp(&b_oid);
-        if cmp != Ordering::Equal {
-            return cmp;
-        }
+    let cmp = bgpls_cluster_list_len(a).cmp(&bgpls_cluster_list_len(b));
+    if cmp != Ordering::Equal {
+        return cmp;
     }
 
     cmp_ipaddr(&a.peer, &b.peer)
@@ -1084,7 +1091,7 @@ pub(crate) fn vpn_tiebreak(a: &VpnRibRoute, b: &VpnRibRoute) -> Ordering {
 /// Compare two VPN routes under RFC 9107 Optimal Route Reflection.
 ///
 /// The standard [`vpn_tiebreak`] chain with one extra step between the
-/// eBGP/iBGP step and `CLUSTER_LIST` — the same slot as
+/// eBGP/iBGP step and the BGP Identifier step — the same slot as
 /// [`crate::best_path::best_path_cmp_orr`]: the configured vantage's
 /// interior (SPF) cost to each route's `NEXT_HOP`. Lower cost wins; a
 /// known cost beats an unknown one (RFC 9107 §3.1); equal or
@@ -1154,16 +1161,16 @@ fn vpn_cmp_chain(
         }
     }
 
-    let cmp = vpn_cluster_list_len(a).cmp(&vpn_cluster_list_len(b));
-    if cmp != Ordering::Equal {
+    if let Some((cmp, _)) = compare_bgp_identifier(
+        (a.origin_type, vpn_originator_id(a), a.peer_router_id),
+        (b.origin_type, vpn_originator_id(b), b.peer_router_id),
+    ) {
         return cmp;
     }
 
-    if let (Some(a_oid), Some(b_oid)) = (vpn_originator_id(a), vpn_originator_id(b)) {
-        let cmp = a_oid.cmp(&b_oid);
-        if cmp != Ordering::Equal {
-            return cmp;
-        }
+    let cmp = vpn_cluster_list_len(a).cmp(&vpn_cluster_list_len(b));
+    if cmp != Ordering::Equal {
+        return cmp;
     }
 
     cmp_ipaddr(&a.peer, &b.peer)
@@ -1243,7 +1250,7 @@ pub(crate) fn labeled_tiebreak(a: &LabeledRibRoute, b: &LabeledRibRoute) -> Orde
 /// Reflection.
 ///
 /// The standard [`labeled_tiebreak`] chain with one extra step between the
-/// eBGP/iBGP step and `CLUSTER_LIST` — the same slot as
+/// eBGP/iBGP step and the BGP Identifier step — the same slot as
 /// [`crate::best_path::best_path_cmp_orr`]: the configured vantage's
 /// interior (SPF) cost to each route's `NEXT_HOP`. Lower cost wins; a
 /// known cost beats an unknown one (RFC 9107 §3.1); equal or
@@ -1313,16 +1320,16 @@ fn labeled_cmp_chain(
         }
     }
 
-    let cmp = labeled_cluster_list_len(a).cmp(&labeled_cluster_list_len(b));
-    if cmp != Ordering::Equal {
+    if let Some((cmp, _)) = compare_bgp_identifier(
+        (a.origin_type, labeled_originator_id(a), a.peer_router_id),
+        (b.origin_type, labeled_originator_id(b), b.peer_router_id),
+    ) {
         return cmp;
     }
 
-    if let (Some(a_oid), Some(b_oid)) = (labeled_originator_id(a), labeled_originator_id(b)) {
-        let cmp = a_oid.cmp(&b_oid);
-        if cmp != Ordering::Equal {
-            return cmp;
-        }
+    let cmp = labeled_cluster_list_len(a).cmp(&labeled_cluster_list_len(b));
+    if cmp != Ordering::Equal {
+        return cmp;
     }
 
     cmp_ipaddr(&a.peer, &b.peer)
@@ -1427,16 +1434,16 @@ fn rtc_tiebreak(a: &RtcRibRoute, b: &RtcRibRoute) -> Ordering {
         return cmp;
     }
 
-    let cmp = rtc_cluster_list_len(a).cmp(&rtc_cluster_list_len(b));
-    if cmp != Ordering::Equal {
+    if let Some((cmp, _)) = compare_bgp_identifier(
+        (a.origin_type, rtc_originator_id(a), a.peer_router_id),
+        (b.origin_type, rtc_originator_id(b), b.peer_router_id),
+    ) {
         return cmp;
     }
 
-    if let (Some(a_oid), Some(b_oid)) = (rtc_originator_id(a), rtc_originator_id(b)) {
-        let cmp = a_oid.cmp(&b_oid);
-        if cmp != Ordering::Equal {
-            return cmp;
-        }
+    let cmp = rtc_cluster_list_len(a).cmp(&rtc_cluster_list_len(b));
+    if cmp != Ordering::Equal {
+        return cmp;
     }
 
     cmp_ipaddr(&a.peer, &b.peer)
@@ -2617,6 +2624,63 @@ mod tests {
         let best = loc.get_flowspec(&flowspec_key(&rule)).unwrap();
         // Lowest peer IP wins
         assert_eq!(best.peer, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    }
+
+    // ---- RFC 4271 §9.1.2.2 step (f) on every non-unicast chain ---------
+    //
+    // Peer 10.0.0.2 advertises with the lower BGP Identifier; peer
+    // 10.0.0.1 has the lower address. The identifier decides first.
+
+    #[test]
+    fn flowspec_lower_bgp_identifier_beats_peer_address() {
+        let r1 = make_flowspec_route(2, 1, vec![PathAttribute::LocalPref(100)], RouteOrigin::Ibgp);
+        let r2 = make_flowspec_route(1, 2, vec![PathAttribute::LocalPref(100)], RouteOrigin::Ibgp);
+        assert_eq!(flowspec_tiebreak(&r1, &r2), Ordering::Less);
+        assert_eq!(flowspec_tiebreak(&r2, &r1), Ordering::Greater);
+    }
+
+    #[test]
+    fn bgpls_lower_bgp_identifier_beats_peer_address() {
+        let nlri = bgpls_nlri(21);
+        let mut r1 = make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 2);
+        r1.peer_router_id = Ipv4Addr::new(1, 1, 1, 1);
+        let mut r2 = make_bgpls_route(BgpLsFamily::LinkState, nlri, 1);
+        r2.peer_router_id = Ipv4Addr::new(2, 2, 2, 2);
+        assert_eq!(bgpls_tiebreak(&r1, &r2), Ordering::Less);
+        assert_eq!(bgpls_tiebreak(&r2, &r1), Ordering::Greater);
+    }
+
+    #[test]
+    fn vpn_lower_bgp_identifier_beats_peer_address() {
+        let nlri = vpn_nlri([10, 0, 9, 0], 24, 100);
+        let mut r1 = make_vpn_route(nlri.clone(), 2, 100);
+        r1.peer_router_id = Ipv4Addr::new(1, 1, 1, 1);
+        let mut r2 = make_vpn_route(nlri, 1, 100);
+        r2.peer_router_id = Ipv4Addr::new(2, 2, 2, 2);
+        assert_eq!(vpn_tiebreak(&r1, &r2), Ordering::Less);
+        assert_eq!(vpn_tiebreak(&r2, &r1), Ordering::Greater);
+    }
+
+    #[test]
+    fn labeled_lower_bgp_identifier_beats_peer_address() {
+        let nlri = labeled_nlri([10, 0, 9, 0], 24, 100);
+        let mut r1 = make_labeled_route(nlri.clone(), 2, 100);
+        r1.peer_router_id = Ipv4Addr::new(1, 1, 1, 1);
+        let mut r2 = make_labeled_route(nlri, 1, 100);
+        r2.peer_router_id = Ipv4Addr::new(2, 2, 2, 2);
+        assert_eq!(labeled_tiebreak(&r1, &r2), Ordering::Less);
+        assert_eq!(labeled_tiebreak(&r2, &r1), Ordering::Greater);
+    }
+
+    #[test]
+    fn rtc_lower_bgp_identifier_beats_peer_address() {
+        let nlri = rtc_test_nlri(900);
+        let mut r1 = make_rtc_route(nlri, 2, 100);
+        r1.peer_router_id = Ipv4Addr::new(1, 1, 1, 1);
+        let mut r2 = make_rtc_route(nlri, 1, 100);
+        r2.peer_router_id = Ipv4Addr::new(2, 2, 2, 2);
+        assert_eq!(rtc_tiebreak(&r1, &r2), Ordering::Less);
+        assert_eq!(rtc_tiebreak(&r2, &r1), Ordering::Greater);
     }
 
     // ---- EVPN MAC mobility tie-break tests (RFC 7432 §15.1) ------------

--- a/crates/rib/src/manager/tests/explain_mrt.rs
+++ b/crates/rib/src/manager/tests/explain_mrt.rs
@@ -611,6 +611,12 @@ async fn explain_best_path_attributes_each_loss_and_the_winning_step() {
         .iter()
         .map(|(peer, asns, lp)| make_multipath_route(prefix, *peer, asns.clone(), *lp))
         .collect();
+    // Every candidate carries the same peer BGP Identifier, so RFC 4271
+    // §9.1.2.2 step (f) ties and the peer address separates the twins.
+    assert!(
+        all.iter()
+            .all(|r| r.peer_router_id == all[0].peer_router_id)
+    );
     for route in &all {
         tx.send(RibUpdate::RoutesReceived {
             session_id: 0,
@@ -671,6 +677,64 @@ async fn explain_best_path_attributes_each_loss_and_the_winning_step() {
     assert_eq!(lp.vs_best_reason, BestPathReason::HigherLocalPref);
     assert_eq!(lp.vs_best_detail, "local_pref 100 < 200");
     assert_eq!(lp.multipath, MultipathEligibility::None);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 4271 §9.1.2.2 step (f) through the manager: between two otherwise
+/// equal paths the lower advertising BGP Identifier wins even though the
+/// other peer has the lower address, and explain attributes the decision
+/// to `lower_bgp_identifier` on both the winner and the loser.
+#[tokio::test]
+async fn explain_best_path_lower_bgp_identifier_beats_peer_address() {
+    use crate::best_path::BestPathReason;
+
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let handle = tokio::spawn(RibManager::new(rx, dummy_query_rx(), None, None, metrics).run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
+    let low_id_peer = Ipv4Addr::new(1, 0, 0, 2);
+    let low_addr_peer = Ipv4Addr::new(1, 0, 0, 1);
+    let mut low_id = make_multipath_route(prefix, low_id_peer, vec![65001], 200);
+    low_id.peer_router_id = Ipv4Addr::new(1, 1, 1, 1);
+    let mut low_addr = make_multipath_route(prefix, low_addr_peer, vec![65001], 200);
+    low_addr.peer_router_id = Ipv4Addr::new(2, 2, 2, 2);
+    for route in [&low_id, &low_addr] {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: route.peer,
+            announced: vec![route.clone()],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let explain = query_explain_best_path(&tx, Prefix::V4(prefix)).await;
+    let best = explain.best.as_ref().expect("best route");
+    assert_eq!(best.peer, IpAddr::V4(low_id_peer));
+    assert_eq!(
+        explain.best_reason,
+        Some(BestPathReason::LowerBgpIdentifier)
+    );
+    assert_eq!(
+        explain.best_reason_detail,
+        "bgp_identifier 1.1.1.1 < 2.2.2.2"
+    );
+    let loser = explain
+        .candidates
+        .iter()
+        .find(|c| c.route.peer == IpAddr::V4(low_addr_peer))
+        .expect("losing candidate");
+    assert_eq!(loser.vs_best_reason, BestPathReason::LowerBgpIdentifier);
+    assert_eq!(loser.vs_best_detail, "bgp_identifier 2.2.2.2 > 1.1.1.1");
 
     drop(tx);
     handle.await.unwrap();

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -431,8 +431,8 @@ Best-path rules (implemented), applied in order:
 3. Lowest ORIGIN (IGP < EGP < INCOMPLETE)
 4. Lowest MED (deterministic — always-compare across all peers, not just same-AS)
 5. eBGP over iBGP (only `RouteOrigin::Ebgp`; Local uses LOCAL_PREF/AS_PATH)
-5.5. Shortest CLUSTER_LIST length (RFC 4456 §9)
-5.6. Lowest ORIGINATOR_ID (RFC 4456 §9) — only when both routes carry the attribute
+5.5. Lowest effective BGP Identifier (RFC 4271 §9.1.2.2 step (f)): ORIGINATOR_ID substitutes for the advertising peer's BGP Identifier when present (RFC 4456 §9); locally originated routes skip this step. Explain reports `lower_originator_id` when both routes carried ORIGINATOR_ID and `lower_bgp_identifier` otherwise
+5.6. Shortest CLUSTER_LIST length (RFC 4456 §9)
 6. Lowest peer address (tiebreaker)
 7. Lowest inbound Add-Path path identifier (same-peer route identity only; reported as `lower_path_id` in explain)
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -702,6 +702,27 @@ Interpretation decisions:
 - PeerDown clears all routes for that peer.
 - Single `RibManager` tokio task owns all Adj-RIB-In state (ADR-0013).
 
+### §9.1.2.2 — Decision Process tie-breaking
+
+- Step (f), "prefer the route received from the speaker with the lowest
+  BGP Identifier", is implemented for the unicast, VPN, labeled-unicast,
+  FlowSpec, BGP-LS, and RT-Constrain decision chains. The identifier a
+  route is compared by is its ORIGINATOR_ID when present, otherwise the
+  BGP Identifier from the advertising peer's OPEN (RFC 4456 §9). The step
+  runs after eBGP-over-iBGP (and the RFC 9107 ORR interior-cost step when
+  one applies) and before the shorter-CLUSTER_LIST comparison, which in
+  turn precedes step (g), lowest peer address.
+- Locally originated routes have no advertising speaker and skip the
+  step: any pair that includes one falls through to the CLUSTER_LIST and
+  peer-address comparisons unchanged. The daemon's own BGP Identifier is
+  not substituted.
+- Explain output and BMP path marking report the step as
+  `lower_originator_id` when both routes carried ORIGINATOR_ID and as
+  `lower_bgp_identifier` otherwise; both map to the same path-marking
+  "router ID" reason code.
+- RFC 5004 (retain the existing external best path across identifier
+  changes) is not implemented.
+
 ---
 
 ## Interpretation Decisions
@@ -1383,7 +1404,15 @@ carries inactive (absent), unlimited (zero), or finite.
   RFC 4456 ordering after the BGP body — stale flag → ORIGIN →
   shortest CLUSTER_LIST → lowest ORIGINATOR_ID — matching the unicast
   decision process so a reflector with multiple equal-AS paths
-  converges deterministically.
+  converges deterministically. The EVPN identifier step has always
+  fallen back to the advertising peer's BGP Identifier when
+  ORIGINATOR_ID is absent. The unicast, VPN, labeled-unicast, FlowSpec,
+  BGP-LS, and RT-Constrain chains now do the same (see the RFC 4271
+  §9.1.2.2 notes under Milestone 1) but, per RFC 4456 §9, compare the
+  identifier before CLUSTER_LIST length and
+  skip the step for locally originated routes. EVPN keeps its
+  CLUSTER_LIST-first order and applies the identifier step to every
+  route, including locally originated VTEP routes.
 - **Initial dump on session up:** when an iBGP EVPN session reaches
   Established, the existing Adj-RIB-In is replayed to the new peer
   through the same Adj-RIB-Out path that handles steady-state

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -45,7 +45,12 @@ decisive comparison step (`only_path`, `higher_local_pref`,
 `shorter_as_path`, `lower_origin`, `lower_med`, ... down to
 `lower_peer_address` and the same-peer Add-Path identity tie
 `lower_path_id`) and the compared values behind it, plus its
-equal-cost multipath classification:
+equal-cost multipath classification. The RFC 4271 §9.1.2.2 step (f)
+identifier comparison reports as `lower_originator_id` when both routes
+carried ORIGINATOR_ID and as `lower_bgp_identifier` when at least one
+side was compared by its advertising peer's BGP Identifier (RFC 4456 §9
+substitution); it precedes `shorter_cluster_list`, and a pair that
+includes a locally originated route skips it:
 
 ```console
 $ rbgp rib --prefix 203.0.113.0/24 --explain

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -187,6 +187,10 @@ Loc-RIB best-path selection per RFC 4271 §9.1.2.
   Simpler, avoids ordering sensitivity, matches GoBGP default.
 - **Peer address tiebreaker** — router-id tiebreak deferred to M3/M4 when
   we have outbound route advertisement and need full BGP decision process.
+  Since implemented: the RFC 4271 §9.1.2.2 step (f) lowest-BGP-Identifier
+  comparison (ORIGINATOR_ID substituting per RFC 4456 §9, locally
+  originated routes excluded) now runs before the CLUSTER_LIST and peer
+  address steps; see DESIGN.md.
 - **eBGP/iBGP step skipped** — deferred until transport distinguishes session
   types and router-id is available for a more complete implementation.
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2421,9 +2421,10 @@ message ExplainBestPathResponse {
   // eliminated. Same snake_case step vocabulary as vs_best_reason
   // (stale_preference, rpki_preference, aspa_preference,
   // higher_local_pref, shorter_as_path, lower_origin, lower_med,
-  // ebgp_over_ibgp, shorter_cluster_list, lower_originator_id,
-  // lower_peer_address, lower_path_id, plus orr_interior_cost for a
-  // peer-scoped explanation using a resolved RFC 9107 vantage).
+  // ebgp_over_ibgp, lower_originator_id, lower_bgp_identifier,
+  // shorter_cluster_list, lower_peer_address, lower_path_id, plus
+  // orr_interior_cost for a peer-scoped explanation using a resolved
+  // RFC 9107 vantage).
   // "only_path" when the prefix has
   // exactly one path (trivial winner, no competing candidates). A prefix
   // with no paths at all is NOT_FOUND at the RPC layer, so this field is


### PR DESCRIPTION
## Summary

Best-path selection omitted RFC 4271 §9.1.2.2 step (f), "prefer the route received from the speaker with the lowest BGP Identifier", except when both routes carried ORIGINATOR_ID, and it ran that comparison after the CLUSTER_LIST length step. The router-id tiebreak had been recorded as a deferral in the M2 milestone notes.

### Decision-process change

- **Step (f) with the RFC 4456 §9 substitution.** The identifier a route is compared by is its ORIGINATOR_ID when present, otherwise the BGP Identifier from the advertising peer's OPEN (`Route.peer_router_id`). The lower identifier wins.
- **Order (RFC 4456 §9).** Below eBGP-over-iBGP (and the RFC 9107 ORR interior-cost step where one applies): lowest effective BGP Identifier, then shorter CLUSTER_LIST, then lowest peer address (then the Add-Path path identifier where applicable). The previous order compared CLUSTER_LIST length first.
- **Locally originated routes are excluded.** Their `peer_router_id` is the `0.0.0.0` injection sentinel, not a BGP Identifier. A pair that includes a `RouteOrigin::Local` route skips step (f) and falls through to the CLUSTER_LIST and peer-address comparisons exactly as before. The daemon's own router ID is not substituted.
- **Scope.** One shared helper, `effective_bgp_identifier(origin_type, originator_id, peer_router_id) -> Option<Ipv4Addr>` and `compare_bgp_identifier(a, b) -> Option<(Ordering, BestPathReason)>` in `crates/rib/src/best_path.rs`, now serves all seven sites: `best_path_cmp_with_reason`, `cmp_chain`, and the FlowSpec, BGP-LS, VPN, labeled-unicast, and RT-Constrain chains in `crates/rib/src/loc_rib.rs`. `evpn_tiebreak_simple` is left unchanged: it already fell back to the peer router-id, but it compares CLUSTER_LIST first and applies the identifier step to locally originated VTEP routes, so routing it through the helper would not have been a pure refactor. Its doc comment now states the difference.
- **RFC 5004** (retain the existing external best across identifier changes) is not implemented; that is a separate decision.

### Observable reason

- New `BestPathReason::LowerBgpIdentifier`, wire/JSON name `lower_bgp_identifier`, reported when at least one side was compared by its peer's BGP Identifier. `lower_originator_id` is retained for the case where both routes carried ORIGINATOR_ID. Detail renders as `bgp_identifier <a> <sym> <b>` with the effective identifiers.
- **BMP path marking.** The reason codes in `crates/rib/src/bmp_sync.rs` are protocol-defined (draft-ietf-grow-bmp-path-marking-tlv-05 §3.2, Table 2). Both reasons are the same decision-process step, so `lower_bgp_identifier` maps to the same `REASON_ROUTER_ID` (0x0009) as `lower_originator_id`. No local code was allocated.
- The ORR composition set (`below_orr_step`) includes the new reason alongside `LowerOriginatorId`.
- The explain RPC passes reason names through as strings; the proto comment listing the vocabulary is extended. No proto enum, CLI match, or stable-surface inventory enumerates reasons, so those are unchanged.

### Tests

Pinned in `crates/rib/src/best_path.rs` (each proven to fail against the pre-fix comparator with only the enum variant and helper present; failing assertion lines recorded from that run):

| Case | Test | Pre-fix failure |
|---|---|---|
| a. Conflicting router ID and peer address | `lower_bgp_identifier_beats_peer_address` | `best_path.rs:1042`: got `(Greater, LowerPeerAddress)`, expected `(Less, LowerBgpIdentifier)` |
| b. ORIGINATOR_ID on one side only | `originator_id_compares_against_peer_router_id_when_one_side_absent` | `best_path.rs:1071`: got `(Less, LowerPeerAddress)`, expected `(Greater, LowerBgpIdentifier)` |
| c. Identifier versus cluster length | `lower_bgp_identifier_beats_shorter_cluster_list` | `best_path.rs:1100`: got `(Greater, ShorterClusterList)`, expected `(Less, LowerBgpIdentifier)` |
| c'. Both ORIGINATOR_ID versus cluster length | `originator_id_beats_shorter_cluster_list` (replaces `cluster_list_beats_originator_id`) | `best_path.rs:1023`: got `(Less, ShorterClusterList)`, expected `(Greater, LowerOriginatorId)` |
| d. Local versus learned | `local_route_skips_bgp_identifier_step` | Behaviour-preservation pin: passes pre-fix by construction, asserting the winner and reason the pre-fix comparator produced (`(Less, LowerPeerAddress)` for local-vs-iBGP) plus `effective_bgp_identifier(...) == None` for the local route |

Also added: `reason_detail_renders_effective_bgp_identifiers`; one step (f) twin per non-unicast chain in `loc_rib.rs` (`flowspec_`/`bgpls_`/`vpn_`/`labeled_`/`rtc_lower_bgp_identifier_beats_peer_address`, all failing pre-fix); and the manager-level twin `explain_best_path_lower_bgp_identifier_beats_peer_address` in `crates/rib/src/manager/tests/explain_mrt.rs` (pre-fix: `explain_mrt.rs:722` best peer `1.0.0.1`, expected `1.0.0.2`).

Pre-existing tests updated to stay specific about the deciding step: the `with_reason_ordering_matches_plain_cmp_at_every_step` table gains a `bgp_identifier` row and its `peer` row now gives both routes equal non-zero router IDs; `originator_id_only_when_both_present` is replaced by case b; `explain_best_path_attributes_each_loss_and_the_winning_step` asserts all candidates share a peer router ID before relying on the peer-address step; `bmp_sync::reason_code_mapping_covers_every_variant` covers the new variant with numeric pins for both step (f) reasons.

### Documentation

`docs/DESIGN.md` (tie-break order), `docs/explain.md` (reason list), `docs/RFC_NOTES.md` (new §9.1.2.2 notes under Milestone 1; EVPN tie-break bullet appended), `docs/milestones.md` (deferral note appended, not deleted), `proto/rustbgpd.proto` (vocabulary comment), `CHANGELOG.md` (`### Changed` operator-visible entry and an Upgrade notes entry). Dated ADRs 0014 and 0029 are left as historical records.

### M104

Run locally on the fixed tree exactly as `tests/interop/m104-arouteserver-current-rs-differential/README.md` documents (Docker and containerlab without sudo). Prerequisites staged first: `install-bird3.sh --prepare-archive` / `--stage-archive` for BIRD 2.19.2, `docker build --target dev -t rustbgpd:dev .` (image `sha256:f64c5a8857d0…`), `bird:v2.19.2-m104`, `gobgp:v4.8.0-m104`, and the pinned `pierky/arouteserver@sha256:ba0e9c0b…` pull.

```
M90_ARS_IMAGE='pierky/arouteserver@sha256:ba0e9c0b541c63acf0765a08fd2e09c2bba9dc64af1f5bbdce7819e8d1c34d66' \
  bash tests/interop/m90-differential/prove-context-ingestion.sh
# PROOF PASS: 23 checks (exit 0)

containerlab deploy -t tests/interop/m104-arouteserver-current-rs-differential.clab.yml   # exit 0
M104_EXPECTED_GIT_SHA=<pre-rebase commit 5df195063> \
  bash tests/interop/scripts/test-m104-arouteserver-current-rs-differential.sh
# Results: 74 passed, 0 failed (exit 0); identities recorded source=5df195063…, rustbgpd=sha256:f64c5a8857d0…
containerlab destroy -t tests/interop/m104-arouteserver-current-rs-differential.clab.yml --cleanup   # exit 0
```

No divergence. The run predates the rebase onto `origin/main`; the rebase changed only the CHANGELOG merge, so the differential tree matches this PR's code.

### Checks

All run on the rebased tree (`CARGO_BUILD_JOBS=16`); exit code in parentheses.

- `cargo fmt --all -- --check` (0)
- `cargo clippy -p rustbgpd-rib --all-targets -- -D warnings` (0)
- `cargo test -p rustbgpd-rib` (0; 1258 passed)
- `cargo test --bin rustbgpd` (0; 2221 passed)
- `cargo test -p rustbgpd-api` (0) and `cargo test -p rustbgpctl` (0) — proto comment touched
- `cargo doc --locked --workspace --lib --no-deps` (0)
- `python3 scripts/check-v1-stable-surface.py` (0)
- `python3 scripts/check_public_tracker_ids.py` (0) and `python3 -m unittest scripts/test_check_public_tracker_ids.py` (0)
- `python3 scripts/check_ci_image_primer_contract.py` (0) and its `test_` companion (0)
- `python3 scripts/check-clippy-reasons.py` (0) and its `test_` companion (0)
- `just links` (0)

Not run here: `just gate-rib`, `just gate-deps`, `just gate-contract` (no feature-gated, scale-harness, or Criterion surface changed).
