### PR TITLE
ci: document both binaries in the rustdoc gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,12 @@ jobs:
       - run: cargo doc --locked --workspace --lib --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
+      - run: cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - run: cargo doc --locked -p rustbgpctl --bin rbgp --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
       - run: cargo doc --locked -p rustbgpd-wire --lib --no-deps --features tokio-codec
         env:
           RUSTDOCFLAGS: "-D warnings"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # invocations adapted to this workspace's CI flags from
 # `.github/workflows/ci.yml` (cargo clippy --workspace --all-targets
 # -- -D warnings; cargo test --workspace; cargo doc --workspace --lib
-# --no-deps).
+# --no-deps plus the rustbgpd and rbgp binaries).
 #
 # `cargo test --lib` + rustdoc are at pre-push (not pre-commit) so commits
 # stay fast; cargo fmt + clippy run on every commit.
@@ -47,6 +47,22 @@ repos:
       - id: cargo-doc
         name: cargo doc
         entry: cargo doc --locked --workspace --lib --no-deps
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: cargo-doc-rustbgpd-bin
+        name: cargo doc (rustbgpd binary)
+        entry: cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: cargo-doc-rbgp-bin
+        name: cargo doc (rbgp binary)
+        entry: cargo doc --locked -p rustbgpctl --bin rbgp --no-deps
         language: system
         always_run: true
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   carrying reachable NLRI is handled as RFC 7606 treat-as-withdraw and counted
   under `bgp_update_malformed_total{disposition="treat_as_withdraw"}`; without
   reachable NLRI, RFC 7606 section 5.2 requires a session reset.
+- The rustdoc gate (`just gate`, the pre-push hook, and CI) now documents the
+  `rustbgpd` and `rbgp` binaries in addition to the workspace libraries. The
+  root lib target shares its name with the daemon binary, so the previous
+  `--lib`-only run documented an empty stub and cargo skipped every daemon
+  module; one intra-doc link that pointed at a test-only item is now plain
+  text.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,9 @@ just --list
 The recipes intentionally expose their direct commands:
 
 - `just gate` runs formatting, lightweight repository contracts, strict
-  workspace Clippy, the full workspace tests, and library docs. This is the
-  broad local baseline and can take several minutes on a cold target directory.
+  workspace Clippy, the full workspace tests, and library and binary docs.
+  This is the broad local baseline and can take several minutes on a cold
+  target directory.
 - `just gate-rib` compiles the feature-gated RIB, transport, and API benchmark
   surfaces that the default workspace build cannot see, including the root
   FIB projection and both API feature combinations.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -24,7 +24,9 @@ diff actually ran before tagging.
       upgrade receipt still match their machine sources.
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`
 - [ ] `cargo test --workspace`
-- [ ] `cargo doc --workspace --lib --no-deps` (warning denial comes from
+- [ ] `cargo doc --workspace --lib --no-deps`,
+      `cargo doc -p rustbgpd --bin rustbgpd --no-deps`, and
+      `cargo doc -p rustbgpctl --bin rbgp --no-deps` (warning denial comes from
       `.cargo/config.toml` `build.rustdocflags` — don't set a different
       `RUSTDOCFLAGS` env, it forks the doc-cache fingerprint and forces a
       full workspace re-doc on the next differently-flagged run)

--- a/justfile
+++ b/justfile
@@ -25,6 +25,8 @@ gate:
     cargo clippy --locked --workspace --all-targets -- -D warnings
     cargo test --locked --workspace
     cargo doc --locked --workspace --lib --no-deps
+    cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps
+    cargo doc --locked -p rustbgpctl --bin rbgp --no-deps
 
 # Check links between tracked Markdown files without making network requests.
 links:

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -25,7 +25,7 @@ WORKFLOWS = tuple(
                  "release-install-contract", "release", "update-group-fault")
 )
 EXPECTED_ROOT_COMMANDS = {
-    WORKFLOWS[0]: Counter(build=1, check=6, clippy=2, doc=2, test=7),
+    WORKFLOWS[0]: Counter(build=1, check=6, clippy=2, doc=4, test=7),
     WORKFLOWS[1]: Counter(test=1),
     WORKFLOWS[2]: Counter(test=6),
     WORKFLOWS[3]: Counter(build=1, test=2),
@@ -160,10 +160,12 @@ def check(root: Path) -> list[str]:
     for command in (
         "cargo test --locked --workspace",
         "cargo doc --locked --workspace --lib --no-deps",
+        "cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps",
+        "cargo doc --locked -p rustbgpctl --bin rbgp --no-deps",
     ):
         if text.count(command) != 1 or command not in core_tests:
             errors.append(f"{command} must exist exactly once in core_tests")
-    if core_tests.count('RUSTDOCFLAGS: "-D warnings"') != 2:
+    if core_tests.count('RUSTDOCFLAGS: "-D warnings"') != 4:
         errors.append("core_tests rustdoc warnings contract drifted")
 
     feature_commands = (

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -145,6 +145,8 @@ class ScaleSplitContractTests(unittest.TestCase):
             ("  evpn_bum_filter_kernel:\n", "  renamed_evpn:\n"),
             ("- run: cargo test --locked --workspace", "- run: true"),
             ("- run: cargo doc --locked --workspace --lib --no-deps", "- run: true"),
+            ("- run: cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps", "- run: true"),
+            ("- run: cargo doc --locked -p rustbgpctl --bin rbgp --no-deps", "- run: true"),
             (
                 "- run: cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings",
                 "- run: true",

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -1054,7 +1054,7 @@ impl PeerManager {
         }
     }
 
-    /// The applier half of [`Self::hot_update_peer`], without the
+    /// The applier half of `Self::hot_update_peer`, without the
     /// static-only guard.
     ///
     /// Everything it touches is per-session runtime state that an accepted


### PR DESCRIPTION
## Summary

- The rustdoc gate ran `cargo doc --locked --workspace --lib --no-deps`. The root package's lib target (`src/lib.rs`) is a `bench-internals` stub whose target name matches the `rustbgpd` binary, so cargo documented the empty stub and skipped the binary (cargo skips a bin whose name equals the lib target's), and `--lib` never reached the `rbgp` binary of `rustbgpctl`. Nothing under `src/` and nothing in `crates/cli/src/main.rs` had been link-checked.
- The gate now also runs `cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps` and `cargo doc --locked -p rustbgpctl --bin rbgp --no-deps`, identically in `justfile`, the pre-push hook (`.pre-commit-config.yaml`), and `.github/workflows/ci.yml`. Each per-package `--bin` run documents the binary plus its package lib (cargo fingerprints `doc-bin-rustbgpd`, `doc-lib-rustbgpd`, `doc-bin-rbgp`, `doc-lib-rustbgpctl`) and touches no `doc = false` target, unlike a workspace-level `--bins`, which overrides that opt-out.
- Warning denial is unchanged: `.cargo/config.toml` pins `build.rustdocflags = ["-D", "warnings"]` for local and hook runs, and each CI doc step sets the identical `RUSTDOCFLAGS: "-D warnings"`, so broken intra-doc links fail the widened gate without a second mechanism or a doc-cache fingerprint fork.
- `scripts/check_ci_scale_split_contract.py` and its self-test now require the two new `core_tests` steps and four `RUSTDOCFLAGS` pins; the root `doc` command inventory for `ci.yml` moves from 2 to 4.
- The wider gate found exactly one broken link: `src/peer_manager/lifecycle.rs:1057` linked `Self::hot_update_peer`, a `cfg(test)`-only method that does not exist under `cfg(doc)`. The reference is now plain backticked text; the wording is otherwise unchanged. The daemon binary documented cleanly after that fix and the `rbgp` binary was already clean.
- `CONTRIBUTING.md` and `docs/RELEASE_CHECKLIST.md` describe the wider gate; `CHANGELOG.md` gets a `### Changed` line.

Cargo also prints `warning: output filename collision at target/doc/rustbgpd/index.html` for the daemon run because the lib and bin share a name (cargo issue 6313). That is a cargo diagnostic, not a rustdoc one, so `-D warnings` does not apply to it and it does not fail the gate.

## Proof the gate can fail

With the `lifecycle.rs` link temporarily reintroduced, `cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps` exited 101:

```
error: unresolved link to `Self::hot_update_peer`
    --> src/peer_manager/lifecycle.rs:1057:31
```

The change was reverted before committing.

## Checks

| Command | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps` | 0 |
| `cargo doc --locked -p rustbgpctl --bin rbgp --no-deps` | 0 |
| `python3 -m unittest scripts/test_check_ci_scale_split_contract.py` | 0 (6 tests) |
| `python3 scripts/check_ci_scale_split_contract.py` | 0 |
| `python3 -m unittest scripts/test_check_release_checklist_paths.py` | 0 (12 tests) |
| `python3 scripts/check_release_checklist_paths.py` | 0 |
| `prek validate-config .pre-commit-config.yaml` | 0 |
| `just gate` | 0 |

Verified on the local stable toolchain (cargo 1.98.0); the `msrv` CI job is the proof at the declared Rust 1.95.
