### PR TITLE
api: share the config persistence admission step across the three persisting services

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -24,7 +24,7 @@ use crate::runtime_config_settlement::{
 };
 use crate::server::{
     AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, check_config_mutation_gate,
-    fully_compensated_status, peer_manager_request, read_only_rejection,
+    fully_compensated_status, peer_manager_request, read_only_rejection, reserve_config_event_slot,
     stage_runtime_config_event_typed,
 };
 use rustbgpd_rib::{
@@ -33,7 +33,6 @@ use rustbgpd_rib::{
     UpdateGroupPeerComparison,
 };
 
-const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 const OWNED_NEIGHBOR_ACTOR_TIMEOUT: Duration = Duration::from_mins(10);
 /// Bound both channel admission and the reply from the single-threaded RIB
 /// actor.  This matches the existing internal RIB-query timeout precedent and
@@ -370,23 +369,6 @@ where
             }
         }
     }
-}
-
-async fn reserve_config_event_slot(
-    config_tx: Option<mpsc::Sender<ConfigEvent>>,
-) -> Result<Option<mpsc::OwnedPermit<ConfigEvent>>, Status> {
-    let Some(tx) = config_tx else {
-        return Ok(None);
-    };
-
-    let permit = tokio::time::timeout(CONFIG_PERSIST_RESERVE_TIMEOUT, tx.reserve_owned())
-        .await
-        .map_err(|_| {
-            Status::unavailable("config persistence queue busy — refusing mutation to avoid drift")
-        })?
-        .map_err(|_| Status::unavailable("config persistence unavailable"))?;
-
-    Ok(Some(permit))
 }
 
 async fn query_neighbor_rib_snapshots(
@@ -1671,6 +1653,55 @@ mod tests {
             selection_deferral: Vec::new(),
             outbound_prefix_limits: Vec::new(),
         }
+    }
+
+    fn persisting_service(
+        config_tx: mpsc::Sender<ConfigEvent>,
+    ) -> (NeighborService, mpsc::Receiver<PeerManagerCommand>) {
+        let (peer_tx, peer_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        (
+            NeighborService::new(
+                65001,
+                AccessMode::ReadWrite,
+                peer_tx,
+                rib_tx,
+                Some(config_tx),
+            ),
+            peer_rx,
+        )
+    }
+
+    async fn delete_dynamic_neighbor_error(svc: &NeighborService) -> Status {
+        svc.delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
+            prefix: "192.0.2.0/24".into(),
+        }))
+        .await
+        .unwrap_err()
+    }
+
+    /// Load-bearing: a closed or back-pressured persistence queue must reject
+    /// the mutation as `UNAVAILABLE` before anything reaches the peer manager.
+    #[tokio::test(start_paused = true)]
+    async fn config_persistence_admission_failures_are_unavailable() {
+        let (config_tx, config_rx) = mpsc::channel(1);
+        drop(config_rx);
+        let (svc, mut peer_rx) = persisting_service(config_tx);
+        let error = delete_dynamic_neighbor_error(&svc).await;
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(error.message(), "config persistence unavailable");
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+
+        let (config_tx, _config_rx) = mpsc::channel(1);
+        let _permit = config_tx.clone().reserve_owned().await.unwrap();
+        let (svc, mut peer_rx) = persisting_service(config_tx);
+        let error = delete_dynamic_neighbor_error(&svc).await;
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(
+            error.message(),
+            "config persistence queue busy — refusing mutation to avoid drift"
+        );
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 
     /// Load-bearing: mapping read-command admission loss to `INTERNAL` makes

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -24,11 +24,10 @@ use crate::runtime_config_settlement::{
 use crate::server::{
     AccessMode, ConfigMutationGateFn, OwnedCatalogDispatch, RuntimeConfigCoordinator,
     catalog_mutation_error_to_status, check_config_mutation_gate, dispatch_owned_catalog_mutation,
-    fully_compensated_status, peer_manager_request, read_only_rejection,
+    fully_compensated_status, peer_manager_request, read_only_rejection, reserve_config_event_slot,
     stage_runtime_config_event_typed, with_catalog_persist_ack,
 };
 
-const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 const OWNED_PEER_GROUP_ACTOR_TIMEOUT: Duration = Duration::from_mins(10);
 
 fn input_statement_to_proto(statement: &PolicyStatementDefinition) -> proto::PolicyStatement {
@@ -289,23 +288,6 @@ fn input_definition_to_proto(definition: &PeerGroupDefinition) -> proto::PeerGro
         import_policy_chain: definition.import_policy_chain.clone(),
         export_policy_chain: definition.export_policy_chain.clone(),
     }
-}
-
-async fn reserve_config_event_slot(
-    config_tx: Option<mpsc::Sender<ConfigEvent>>,
-) -> Result<Option<mpsc::OwnedPermit<ConfigEvent>>, Status> {
-    let Some(tx) = config_tx else {
-        return Ok(None);
-    };
-
-    let permit = tokio::time::timeout(CONFIG_PERSIST_RESERVE_TIMEOUT, tx.reserve_owned())
-        .await
-        .map_err(|_| {
-            Status::unavailable("config persistence queue busy — refusing mutation to avoid drift")
-        })?
-        .map_err(|_| Status::unavailable("config persistence unavailable"))?;
-
-    Ok(Some(permit))
 }
 
 /// gRPC service for peer-group CRUD and neighbor membership assignment.

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -27,11 +27,10 @@ use crate::runtime_config_settlement::{
 use crate::server::{
     AccessMode, ConfigMutationGateFn, OwnedCatalogDispatch, RuntimeConfigCoordinator,
     catalog_mutation_error_to_status, check_config_mutation_gate, dispatch_owned_catalog_mutation,
-    fully_compensated_status, read_only_rejection, stage_runtime_config_event_typed,
-    with_catalog_persist_ack,
+    fully_compensated_status, read_only_rejection, reserve_config_event_slot,
+    stage_runtime_config_event_typed, with_catalog_persist_ack,
 };
 
-const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 const OWNED_POLICY_ACTOR_TIMEOUT: Duration = Duration::from_mins(10);
 const POLICY_STATS_AGGREGATE_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -282,23 +281,6 @@ fn input_definition_to_proto(definition: &NamedPolicyDefinition) -> proto::Polic
             .map(input_statement_to_proto)
             .collect(),
     }
-}
-
-async fn reserve_config_event_slot(
-    config_tx: Option<mpsc::Sender<ConfigEvent>>,
-) -> Result<Option<mpsc::OwnedPermit<ConfigEvent>>, Status> {
-    let Some(tx) = config_tx else {
-        return Ok(None);
-    };
-
-    let permit = tokio::time::timeout(CONFIG_PERSIST_RESERVE_TIMEOUT, tx.reserve_owned())
-        .await
-        .map_err(|_| {
-            Status::unavailable("config persistence queue busy — refusing mutation to avoid drift")
-        })?
-        .map_err(|_| Status::unavailable("config persistence unavailable"))?;
-
-    Ok(Some(permit))
 }
 
 /// gRPC service for named policy CRUD and chain assignment.

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -1334,6 +1334,25 @@ pub(crate) fn read_only_rejection(access_mode: AccessMode) -> Option<Status> {
     }
 }
 
+pub(crate) const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(crate) async fn reserve_config_event_slot(
+    config_tx: Option<mpsc::Sender<ConfigEvent>>,
+) -> Result<Option<mpsc::OwnedPermit<ConfigEvent>>, Status> {
+    let Some(tx) = config_tx else {
+        return Ok(None);
+    };
+
+    let permit = tokio::time::timeout(CONFIG_PERSIST_RESERVE_TIMEOUT, tx.reserve_owned())
+        .await
+        .map_err(|_| {
+            Status::unavailable("config persistence queue busy — refusing mutation to avoid drift")
+        })?
+        .map_err(|_| Status::unavailable("config persistence unavailable"))?;
+
+    Ok(Some(permit))
+}
+
 impl Interceptor for AuthInterceptor {
     fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
         if let Some(store) = &self.credential_store {


### PR DESCRIPTION
## What moved

`reserve_config_event_slot` and `CONFIG_PERSIST_RESERVE_TIMEOUT` were copied byte-for-byte into `policy_service.rs`, `peer_group_service.rs`, and `neighbor_service.rs`. This moves the single definition into `crates/api/src/server.rs` (next to `read_only_rejection`, alongside the other cross-service helpers) as `pub(crate)`, deletes the three copies, and points the call sites at the shared function.

Pure relocation: no message text, code, or timeout changes. The post-admission paths in `server.rs` (write failure -> `FAILED_PRECONDITION`, dropped ack -> `INTERNAL`) are untouched.

## Byte-identity proof

The relocation was done by a script that extracted the function body from each of the three files and asserted `bodies[0] == bodies[1] == bodies[2]` before writing anything; the deleted hunks in the diff are identical to the added hunk in `server.rs` except for the `pub(crate)` visibility.

## New test

`neighbor_service::tests::config_persistence_admission_failures_are_unavailable` pins the neighbor path the same way the policy and peer-group services already were. It drives a real `DeleteDynamicNeighbor` mutation on a `NeighborService` through both failure paths:

- closed config channel -> `UNAVAILABLE` "config persistence unavailable"
- back-pressured config channel (capacity 1, permit held, `start_paused` clock) -> `UNAVAILABLE` "config persistence queue busy — refusing mutation to avoid drift"

and asserts nothing reached the peer manager in either case.

## Red proof

With the shared closed-channel branch temporarily changed to `Status::internal`, all three services' `config_persistence_admission_failures_are_unavailable` tests fail, for example:

```
thread 'neighbor_service::tests::config_persistence_admission_failures_are_unavailable' panicked at crates/api/src/neighbor_service.rs:1691:9:
  left: Internal
 right: Unavailable
```

Reverted before commit; all three pass on the committed tree.

## Checks

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings` — exit 0
- `cargo test -p rustbgpd-api` — exit 0 (729 passed)
- `python3 scripts/check-v1-stable-surface.py` — exit 0

No CHANGELOG entry: no behavior change, and the changelog has no precedent for pure-relocation entries. `docs/API.md` already documents the codes and stays accurate.
