### PR TITLE
cli: restore the terminal when the TUI is terminated by a signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `rbgp top` now restores the terminal (leaves the alternate screen, shows
+  the cursor, disables raw mode) when the process is terminated by SIGTERM,
+  SIGINT, or SIGHUP; the signal quits the dashboard the same way Ctrl-C does
+  and the process exits with status 0.
+
 - `birdwatcher-adapter` route views now emit `bgp.ext_communities` (an empty
   array when the route carries none), so Alice-LG shows route targets and
   other extended communities instead of nothing. Each entry is birdwatcher's

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -57,6 +57,8 @@ protoc-bin-vendored = "3"
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tokio-stream = { workspace = true, features = ["net"] }
+# Raises and delivers real signals in the TUI signal-restore tests.
+nix = { workspace = true, features = ["signal"] }
 rustbgpd-api.workspace = true
 rustbgpd-evpn.workspace = true
 # Fixture builder for the from-bmp adapter tests: captures are framed by

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -7,12 +7,13 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::ExecutableCommand;
-use crossterm::event::{self, Event};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
+use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::{mpsc, watch};
 
 use crate::connection::Connection;
@@ -21,6 +22,29 @@ use app::{App, RibIntent};
 use theme::Theme;
 
 struct TerminalGuard;
+
+/// Ctrl-C as the event loop sees it. Termination signals are forwarded as
+/// this key so they quit through the same guarded path.
+const QUIT_KEY: KeyEvent = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+/// Forward the first SIGTERM, SIGINT, or SIGHUP as [`QUIT_KEY`]. Raw mode
+/// turns Ctrl-C into a key event, but a signal from another process never
+/// reaches the event loop, and its default disposition would end the process
+/// inside the alternate screen with the cursor hidden.
+fn spawn_signal_forwarder(tx: mpsc::Sender<KeyEvent>) -> io::Result<()> {
+    let mut terminate = signal(SignalKind::terminate())?;
+    let mut interrupt = signal(SignalKind::interrupt())?;
+    let mut hangup = signal(SignalKind::hangup())?;
+    tokio::spawn(async move {
+        tokio::select! {
+            _ = terminate.recv() => {}
+            _ = interrupt.recv() => {}
+            _ = hangup.recv() => {}
+        }
+        let _ = tx.send(QUIT_KEY).await;
+    });
+    Ok(())
+}
 
 /// Leave the alternate screen and show the cursor. Ratatui hides the cursor
 /// during `draw()`, and `LeaveAlternateScreen` does not restore it.
@@ -37,6 +61,8 @@ impl Drop for TerminalGuard {
 }
 
 pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> {
+    let (signal_tx, mut signal_rx) = mpsc::channel(1);
+    spawn_signal_forwarder(signal_tx)?;
     enable_raw_mode()?;
     let _guard = TerminalGuard;
     io::stdout().execute(EnterAlternateScreen)?;
@@ -65,9 +91,16 @@ pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> 
     loop {
         terminal.draw(|f| ui::draw(f, &mut app, &theme))?;
 
-        if event::poll(Duration::from_millis(50))?
+        let key = if let Ok(key) = signal_rx.try_recv() {
+            Some(key)
+        } else if event::poll(Duration::from_millis(50))?
             && let Event::Key(key) = event::read()?
         {
+            Some(key)
+        } else {
+            None
+        };
+        if let Some(key) = key {
             app.on_key(key);
             if app.should_quit {
                 rib_lane.cancel();
@@ -142,6 +175,25 @@ mod tests {
         assert!(
             leave < show,
             "LeaveAlternateScreen must precede cursor::Show"
+        );
+    }
+
+    #[tokio::test]
+    async fn termination_signal_arrives_as_the_ctrl_c_quit_key() {
+        let (tx, mut rx) = mpsc::channel(1);
+        spawn_signal_forwarder(tx).expect("register signal handlers");
+        nix::sys::signal::raise(nix::sys::signal::Signal::SIGHUP).expect("raise SIGHUP");
+        let key = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("signal forwarded within 5s")
+            .expect("forwarder sends before closing");
+        assert_eq!(key, QUIT_KEY, "a signal must arrive as the Ctrl-C key");
+
+        let mut app = App::new();
+        app.on_key(key);
+        assert!(
+            app.should_quit,
+            "the forwarded key must take the quit branch"
         );
     }
 }

--- a/crates/cli/tests/tui_signal_restore.rs
+++ b/crates/cli/tests/tui_signal_restore.rs
@@ -1,0 +1,121 @@
+#![cfg(target_os = "linux")]
+
+//! `rbgp top` must leave the alternate screen and show the cursor when the
+//! process is terminated by a signal, not only when the operator presses
+//! `q` or Ctrl-C. The TUI runs under a pseudo-terminal lent by util-linux
+//! `script`, which mirrors everything the TUI writes to its own stdout.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+
+const ENTER_ALTERNATE_SCREEN: &[u8] = b"\x1b[?1049h";
+const LEAVE_ALTERNATE_SCREEN: &[u8] = b"\x1b[?1049l";
+const CURSOR_POSITION_QUERY: &[u8] = b"\x1b[6n";
+const CURSOR_POSITION_REPORT: &[u8] = b"\x1b[1;1R";
+const HIDE_CURSOR: &[u8] = b"\x1b[?25l";
+const SHOW_CURSOR: &[u8] = b"\x1b[?25h";
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn count(haystack: &[u8], needle: &[u8]) -> usize {
+    haystack
+        .windows(needle.len())
+        .filter(|w| *w == needle)
+        .count()
+}
+
+#[test]
+fn sigterm_restores_the_terminal() {
+    // A bare listener completes the TCP handshake, which is all the CLI's
+    // connect step needs. The TUI's RPCs then stay in flight, which keeps it
+    // on screen with a visible error and no daemon to run.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = format!("http://{}", listener.local_addr().expect("local addr"));
+
+    // `exec` makes rbgp the direct child of `script`, so /proc names its pid.
+    let command = format!("exec {} -s {addr} top", env!("CARGO_BIN_EXE_rbgp"));
+    let mut script = Command::new("script")
+        .args(["-qec", &command, "/dev/null"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn script(1)");
+    // Held open so `script` never sees EOF on its stdin; it is also the
+    // TUI's keyboard.
+    let mut stdin = script.stdin.take().expect("script stdin");
+    let mut stdout = script.stdout.take().expect("script stdout");
+    let output = Arc::new(Mutex::new(Vec::new()));
+    let reader = {
+        let output = Arc::clone(&output);
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            while let Ok(n) = stdout.read(&mut buf)
+                && n > 0
+            {
+                output.lock().unwrap().extend_from_slice(&buf[..n]);
+            }
+        })
+    };
+
+    let children = format!("/proc/{0}/task/{0}/children", script.id());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut answered = 0;
+    let tui = loop {
+        // Nothing emulates a terminal behind the pty, so answer the cursor
+        // position query ratatui sends while setting up; unanswered, setup
+        // fails after a timeout and the event loop is never reached.
+        let queries = count(&output.lock().unwrap(), CURSOR_POSITION_QUERY);
+        while answered < queries {
+            stdin
+                .write_all(CURSOR_POSITION_REPORT)
+                .expect("answer cursor query");
+            stdin.flush().expect("flush cursor report");
+            answered += 1;
+        }
+        let child = std::fs::read_to_string(&children).unwrap_or_default();
+        // A hidden cursor means a frame was drawn, so the event loop is
+        // running when the signal arrives.
+        if find(&output.lock().unwrap(), HIDE_CURSOR).is_some()
+            && let Some(pid) = child.split_whitespace().next()
+        {
+            break Pid::from_raw(pid.parse().expect("child pid"));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "TUI never drew a frame; output: {:?}",
+            String::from_utf8_lossy(&output.lock().unwrap())
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    kill(tui, Signal::SIGTERM).expect("deliver SIGTERM");
+    let status = script.wait().expect("wait for script");
+    reader.join().expect("reader thread");
+    let output = output.lock().unwrap();
+
+    let enter = find(&output, ENTER_ALTERNATE_SCREEN).expect("alternate screen entered");
+    let after_enter = &output[enter + ENTER_ALTERNATE_SCREEN.len()..];
+    let leave = find(after_enter, LEAVE_ALTERNATE_SCREEN)
+        .expect("a TUI terminated by SIGTERM must leave the alternate screen");
+    let after_leave = &after_enter[leave + LEAVE_ALTERNATE_SCREEN.len()..];
+    assert!(
+        find(after_leave, SHOW_CURSOR).is_some(),
+        "a TUI terminated by SIGTERM must show the cursor after leaving the alternate screen"
+    );
+    // `script -e` returns the child's status (128 + signal for a signal
+    // death). A forwarded signal exits through the normal quit path.
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a signal-driven quit exits like `q`; status: {status:?}"
+    );
+}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2434,7 +2434,9 @@ rbgp top -i 5     # 5s poll interval
 ```
 
 Shows sessions, prefix counts, message rates, RPKI VRP counts, and
-streaming route events in a terminal UI. The route-event subscription is
+streaming route events in a terminal UI. `q` or Ctrl-C quits; SIGTERM,
+SIGINT, and SIGHUP quit the same way and restore the terminal before the
+process exits with status 0. The route-event subscription is
 opened only while the events panel is visible (`e`).
 The panel uses the lag-aware `WatchEvents` route stream, including exact missed
 counts and policy-filter source/target/reason/Add-Path context. Admission and


### PR DESCRIPTION
## Problem

`rbgp top` restores the terminal on `q`, Ctrl-C, and unwinding through `TerminalGuard`, but raw mode disables ISIG, so an external signal (`kill -TERM`, SIGHUP from a closing terminal, `kill -INT` from another shell) never reaches the event loop. The default disposition ends the process without running destructors and leaves the operator's terminal in the alternate screen with the cursor hidden. This is the remaining operator-quality gap after #2236.

## Mechanism

`crates/cli/src/tui/mod.rs` registers `tokio::signal::unix` listeners for SIGTERM, SIGINT, and SIGHUP before touching the terminal and spawns a task that forwards the first one as the Ctrl-C `KeyEvent` over a one-slot channel. The event loop drains that channel ahead of `crossterm::event::poll`, so a signal takes the same `App::on_key` quit branch as Ctrl-C, breaks out of the loop, and drops `TerminalGuard`, which disables raw mode, leaves the alternate screen, and shows the cursor exactly as a normal quit does. No new dependency: the CLI already runs inside a tokio runtime with the `signal` feature, and `nix` (already a dependency) gains the `signal` feature only for tests. No panic hook is installed; the guard already covers unwinding.

## Exit status

The CLI does not distinguish signal-driven exits, and the crate denies unsafe code, so re-raising the signal with its default disposition is not available. A forwarded signal exits through the ordinary quit path with status 0, the same as `q` and Ctrl-C, matching `top(1)` and `htop(1)`, which also restore the terminal and exit 0 on SIGTERM. The integration test pins this.

## Tests

- `tui::tests::termination_signal_arrives_as_the_ctrl_c_quit_key` (bin unit test): raises a real SIGHUP at the test process, asserts the forwarded key equals the Ctrl-C key and that `App::on_key` sets `should_quit`. It uses the new forwarder, so before the fix it does not compile.
- `tests/tui_signal_restore.rs::sigterm_restores_the_terminal` (integration): runs the real `rbgp top` under a pty from util-linux `script` against a bare TCP listener (connect succeeds, RPCs stay in flight), answers ratatui's cursor-position query so the event loop starts, sends SIGTERM to the TUI pid, and asserts `LeaveAlternateScreen` then `cursor::Show` appear after `EnterAlternateScreen` and that the exit status is 0. Against the pre-fix `mod.rs` it fails at line 108: `a TUI terminated by SIGTERM must leave the alternate screen`.

The integration test proves signal delivery itself; the same probe was also run by hand via `script -qec "exec rbgp -s http://127.0.0.1:<port> top" /dev/null` with `kill -TERM` on the child pid and by pressing `q`: both exit 0 and both end with the `\x1b[?1049l\x1b[?25h` restore sequence.

## Docs

- `docs/OPERATIONS.md` live-dashboard section states the quit keys, the signals, and the exit status.
- CHANGELOG `[Unreleased]` `### Fixed` entry.

## Gates

- `cargo fmt --all -- --check`: 0
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`: 0
- `cargo test -p rustbgpctl`: 0
- `python3 scripts/check-clippy-reasons.py`: 0
- `python3 scripts/check_public_tracker_ids.py`: 0

Nothing outside `crates/cli` changed besides docs and the changelog, so the workspace integration tests were not rerun.
