### PR TITLE
cli: validate the address family before connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -418,6 +418,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   their dependencies, and a panic in that task during shutdown is reported
   as a component failure and exits 1.
 
+- `rbgp` now rejects an unknown `--family` value before dialing the daemon,
+  so a typo reports `unknown address family: ...` instead of a connection
+  error when the daemon is unreachable. The message and exit code are
+  unchanged.
+
 ### Documentation
 
 - Publish a descriptive raw bridge event-skew receipt across six pinned Jammy

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2435,6 +2435,63 @@ fn validate_local_command(command: &Command) -> Result<(), CliError> {
             "set-export requires at least one policy name; use clear-export to drop the chain"
                 .into(),
         )),
+        // Every `--family` the connected handlers resolve through
+        // `parse_family`, in resolution order, so a typo fails before the
+        // transport is dialed. Views that forward the family string to the
+        // daemon (bgpls, vpn, labeled) are deliberately not listed.
+        Command::Watch {
+            family: Some(family),
+            ..
+        }
+        | Command::Events {
+            action: None,
+            family: Some(family),
+            ..
+        }
+        | Command::Events {
+            action:
+                Some(EventsAction::Watch {
+                    family: Some(family),
+                    ..
+                }),
+            ..
+        }
+        | Command::Flowspec {
+            family: Some(family),
+            ..
+        }
+        | Command::Rib {
+            action:
+                None
+                | Some(
+                    RibAction::Received { family: None, .. }
+                    | RibAction::Advertised { family: None, .. },
+                ),
+            family: Some(family),
+            ..
+        }
+        | Command::Rib {
+            action:
+                Some(
+                    RibAction::Received {
+                        family: Some(family),
+                        ..
+                    }
+                    | RibAction::Advertised {
+                        family: Some(family),
+                        ..
+                    },
+                ),
+            ..
+        } if parse_family(family).is_none() => Err(CliError::Argument(format!(
+            "unknown address family: {family}"
+        ))),
+        Command::Flowspec {
+            action: Some(FlowspecAction::Add { family, .. } | FlowspecAction::Delete { family, .. }),
+            ..
+        } if parse_family(family).is_none() => Err(CliError::Argument(format!(
+            "unknown address family: {family}"
+        ))),
         _ => Ok(()),
     }
 }
@@ -6990,6 +7047,16 @@ printf '%s\n' "${COMPREPLY[@]}"
             "rbgp top --interval 60",
             "rbgp policy chain set-import import-policy",
             "rbgp policy chain set-export export-policy fallback-policy",
+            "rbgp watch --family ipv6",
+            "rbgp flowspec --family ipv4_flowspec",
+            "rbgp flowspec add --family ipv6-flowspec",
+            "rbgp rib --family ipv4_unicast",
+            "rbgp rib --family ipv4-unicast advertised 192.0.2.1",
+            "rbgp rib received 192.0.2.1 --family ipv6_unicast",
+            "rbgp rib --family bgpls bgpls",
+            "rbgp rib --family vpnv4 vpn",
+            "rbgp events --family ipv4",
+            "rbgp events watch --family ipv6",
         ] {
             let cli = Cli::try_parse_from(args.split_whitespace()).unwrap();
             validate_local_command(&cli.command)
@@ -7015,6 +7082,28 @@ printf '%s\n' "${COMPREPLY[@]}"
             (
                 "policy chain set-export",
                 "set-export requires at least one policy name; use clear-export to drop the chain",
+            ),
+            ("watch --family bogus", "unknown address family: bogus"),
+            (
+                "flowspec add --family bogus",
+                "unknown address family: bogus",
+            ),
+            (
+                "flowspec --family ipv4_flowspec delete --family bogus",
+                "unknown address family: bogus",
+            ),
+            (
+                "rib --family bogus advertised 192.0.2.1",
+                "unknown address family: bogus",
+            ),
+            (
+                "rib received 192.0.2.1 --family bogus",
+                "unknown address family: bogus",
+            ),
+            ("events --family bogus", "unknown address family: bogus"),
+            (
+                "events watch --family bogus",
+                "unknown address family: bogus",
             ),
         ] {
             let command = format!("rbgp --addr http://127.0.0.1:1 {args}");


### PR DESCRIPTION
## Summary

`resolve_family` and the two inline `parse_family` calls in `flowspec add` / `flowspec delete` only ran after the gRPC connection succeeded, so `rbgp watch --family bogus` against an unreachable daemon reported the connection error instead of `unknown address family: bogus`.

The fix adds every locally parsed `--family` to `validate_local_command`, the existing pre-connect gate, in the same order the connected handlers resolve them (parent first, then the `flowspec add`/`delete` family). The message text and exit code 1 are unchanged. Views that forward the family string to the daemon (`rib bgpls`, `rib vpn`, `rib labeled`) are deliberately not listed, and the post-connect `resolve_family` calls stay as the conversion to the proto value.

## Tests

- `local_argument_errors_fail_before_transport` gains seven `--family bogus` cases (`watch`, `flowspec add`, `flowspec delete` with a valid parent family, `rib advertised`, `rib received`, `events`, `events watch`). Before the fix the first new case failed with `cannot reach rustbgpd at http://127.0.0.1:1 (connection refused)` instead of the local message.
- `local_command_validation_accepts_boundaries` gains valid-family cases, including `rib --family vpnv4 vpn`, which is not a `parse_family` value and must keep passing through to the daemon.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo test -p rustbgpctl`
