### PR TITLE
cli: bound each TUI refresh with a deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,6 +422,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   so a typo reports `unknown address family: ...` instead of a connection
   error when the daemon is unreachable. The message and exit code are
   unchanged.
+- `rbgp top` now bounds each refresh by the refresh interval. A daemon that
+  accepts the connection but never answers is reported as unavailable (or
+  stale, for data already on screen) by the next tick instead of freezing
+  the refresh loop.
 
 ### Documentation
 

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -465,7 +465,13 @@ pub(super) fn spawn_fetcher(
         // Poll loop
         let mut state = FetcherState::new();
         loop {
-            let snapshot = poll_once(&connection, &mut state).await;
+            // A daemon that accepts the connection but never answers must
+            // surface by the next tick instead of freezing the loop.
+            let snapshot =
+                match tokio::time::timeout(interval, poll_once(&connection, &mut state)).await {
+                    Ok(snapshot) => snapshot,
+                    Err(_) => timed_out_snapshot(&state, interval),
+                };
             if data_tx.send(snapshot).await.is_err() {
                 break;
             }
@@ -473,6 +479,32 @@ pub(super) fn spawn_fetcher(
         }
     });
     FetcherHandle(poller, route_fetcher)
+}
+
+/// The snapshot for a poll that outlived its deadline: cached data is
+/// stale and missing data is unavailable, exactly as an RPC error reports it.
+fn timed_out_snapshot(state: &FetcherState, deadline: Duration) -> DataSnapshot {
+    DataSnapshot {
+        global: state.global.clone(),
+        global_freshness: if state.global.is_some() {
+            Freshness::Fresh
+        } else {
+            Freshness::Unavailable
+        },
+        health: state.health.clone(),
+        health_fresh: false,
+        neighbors: state.neighbors.clone().unwrap_or_default(),
+        neighbors_freshness: if state.neighbors.is_some() {
+            Freshness::Stale
+        } else {
+            Freshness::Unavailable
+        },
+        dynamic_range_count: state.dynamic_range_count,
+        dynamic_ranges_freshness: state.dynamic_ranges_freshness,
+        rpki_vrp_count: state.rpki_vrp_count,
+        metrics_freshness: state.metrics_freshness,
+        error: Some(format!("refresh timed out after {deadline:?}")),
+    }
 }
 
 async fn poll_once(connection: &Connection, state: &mut FetcherState) -> DataSnapshot {
@@ -1471,6 +1503,57 @@ mod tests {
         assert_eq!(second.metrics_freshness, Freshness::Fresh);
         assert!(second.error.is_none());
         assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// A daemon that accepts the connection but never answers must surface
+    /// as unavailable by the refresh deadline instead of freezing the loop.
+    #[tokio::test]
+    async fn unresponsive_daemon_reports_unavailable_by_the_refresh_deadline() {
+        use rustbgpd_api::proto::global_service_server::{GlobalService, GlobalServiceServer};
+
+        struct HangingGlobalService;
+
+        #[tonic::async_trait]
+        impl GlobalService for HangingGlobalService {
+            async fn get_global(
+                &self,
+                _request: tonic::Request<rustbgpd_api::proto::GetGlobalRequest>,
+            ) -> Result<tonic::Response<rustbgpd_api::proto::GlobalState>, tonic::Status>
+            {
+                std::future::pending().await
+            }
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(GlobalServiceServer::new(HangingGlobalService))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+        let connection = connect(&addr, None).await.unwrap();
+        let (_enabled_tx, enabled_rx) = watch::channel(false);
+        let (event_tx, _event_rx) = mpsc::channel(1);
+        let (data_tx, mut data_rx) = mpsc::channel(1);
+        let _task = spawn_fetcher(
+            connection,
+            Duration::from_millis(200),
+            data_tx,
+            event_tx,
+            enabled_rx,
+        );
+
+        let snapshot = tokio::time::timeout(Duration::from_secs(2), data_rx.recv())
+            .await
+            .expect("no snapshot arrived within the refresh deadline")
+            .expect("fetcher lane closed");
+        assert_eq!(snapshot.global_freshness, Freshness::Unavailable);
+        assert!(!snapshot.health_fresh);
+        assert_eq!(snapshot.neighbors_freshness, Freshness::Unavailable);
+        assert_eq!(
+            snapshot.error.as_deref(),
+            Some("refresh timed out after 200ms")
+        );
     }
 
     /// Red proof: starting the primary stream while disabled or failing to


### PR DESCRIPTION
## Summary

`spawn_fetcher` in `crates/cli/src/tui/data.rs` awaited `poll_once` (`get_global`, `get_health`, `list_neighbors`, `get_metrics`) with no timeout; the only timeouts in the crate were connect-time. A daemon that accepts the connection but never answers froze the refresh loop forever with no `Freshness::Unavailable` transition.

Each poll is now wrapped in `tokio::time::timeout` with the refresh interval as the deadline. A poll that outlives it reports the snapshot an RPC error would: `global`/`neighbors` are `Unavailable` when nothing is cached and `Stale` when something is, `health_fresh` is false, and `error` carries `refresh timed out after <interval>`. The loop then sleeps and retries as before. Only `tui/data.rs` changes.

## Tests

- `tui::data::tests::unresponsive_daemon_reports_unavailable_by_the_refresh_deadline`: an in-test tonic `GlobalService` whose `get_global` never resolves, a 200 ms refresh interval, and a 2 s test-level bound on the first snapshot. Before the fix it failed at the 2 s bound (`no snapshot arrived within the refresh deadline`); after the fix the `Unavailable` snapshot arrives at 200 ms.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo test -p rustbgpctl`
