### PR TITLE
daemon: exit 2 from --diff when the current config cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   SIGINT, or SIGHUP; the signal quits the dashboard the same way Ctrl-C does
   and the process exits with status 0.
 
+- **Operator-visible:** `rustbgpd --diff` now exits 2 when the current
+  config (the second path) cannot be loaded, as documented and as the
+  candidate side already did; it previously exited 1, the code that means
+  the diff carries actionable changes. The diagnostic text is unchanged.
+  Daemon boot and `--check` still exit 1 on a config that cannot be loaded.
 - `birdwatcher-adapter` route views now emit `bgp.ext_communities` (an empty
   array when the route carries none), so Alice-LG shows route targets and
   other extended communities instead of nothing. Each entry is birdwatcher's

--- a/src/main.rs
+++ b/src/main.rs
@@ -2406,7 +2406,8 @@ The config was rejected, or
 .B \-\-check \-\-strict
 reported at least one warning. For
 .BR \-\-diff ,
-1 means the diff carries actionable changes. A running daemon also exits
+1 means the diff carries actionable changes; a config that cannot be
+loaded exits 2 there. A running daemon also exits
 1 when a component failure ends it (legacy BGP listen mode could bind
 neither family; explicit
 .B listen_addresses
@@ -2420,7 +2421,10 @@ restarts it. An operator\-initiated shutdown exits 0.
 .TP
 .B 2
 Invalid invocation: an unusable flag combination or a missing
-argument.
+argument. For
+.BR \-\-diff ,
+also a candidate or current config that could not be loaded, or a
+diff that could not be serialized.
 .TP
 .B 70
 Internal error.
@@ -2493,12 +2497,14 @@ fn main() -> ExitCode {
                0  Success. For --check: the config is valid; without --strict this\n     \
                   includes a valid config that was warned about\n  \
                1  The config was rejected, or --check --strict found warnings.\n     \
+                  For --diff: the diff carries actionable changes.\n     \
                   A running daemon exits 1 on a component failure that ends it\n     \
                   (legacy BGP mode bound neither family; an explicit listen_addresses\n     \
                   endpoint failed to bind; configured metrics/readiness bind failure;\n     \
                   or unexpected RIB manager, peer manager, RPKI subsystem,\n     \
                   gRPC server, BGP listener task, or BGP accept-forwarding task exit)\n  \
-               2  Invalid invocation (unknown flag combination, missing argument)\n  \
+               2  Invalid invocation (unknown flag combination, missing argument).\n     \
+                  For --diff: also a config that could not be loaded\n  \
                70 Internal error",
                     env!("CARGO_PKG_VERSION"),
                     crate::config::profiles::PROFILE_NAMES.join(", ")
@@ -2726,7 +2732,11 @@ fn main() -> ExitCode {
             Ok(snapshot) => Arc::new(snapshot),
             Err(diagnostic) => {
                 eprintln!("{diagnostic}");
-                process::exit(1);
+                // `--diff` documents 2 for a config that cannot be loaded on
+                // either side, the same code its candidate load uses below;
+                // 1 there means the diff carries actionable changes. Boot and
+                // `--check` keep 1.
+                process::exit(if diff_path.is_some() { 2 } else { 1 });
             }
         }
     };

--- a/tests/cli_invocation.rs
+++ b/tests/cli_invocation.rs
@@ -157,3 +157,41 @@ fn valid_one_shot_interleavings_and_literal_dash_paths_still_work() {
     assert!(output.stdout.starts_with(b"config OK:"), "{output:?}");
     assert!(output.stderr.is_empty(), "{output:?}");
 }
+
+/// `--diff` documents exit 2 for a config that cannot be loaded. The current
+/// config (second path) shares its loader with daemon boot and `--check`,
+/// which exit 1, so the diff mode must map that failure itself.
+#[test]
+fn diff_exits_2_when_the_current_config_cannot_be_loaded() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let candidate = temp.path().join("candidate.toml");
+    std::fs::write(&candidate, starter_config()).expect("write candidate config");
+    let candidate = candidate.to_str().expect("UTF-8 path");
+    let missing = temp.path().join("missing.toml");
+    let missing = missing.to_str().expect("UTF-8 path");
+
+    let output = run(&["--diff", candidate, missing], None);
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error: failed to read") && stderr.contains("missing.toml"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn check_still_exits_1_when_the_config_cannot_be_loaded() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let missing = temp.path().join("missing.toml");
+    let missing = missing.to_str().expect("UTF-8 path");
+
+    let output = run(&["--check", missing], None);
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error: failed to read") && stderr.contains("missing.toml"),
+        "{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

`rustbgpd --diff <candidate> [<current>]` documents its exit codes as 0 = no actionable changes, 1 = actionable changes found, 2 = error (bad config, missing file). The candidate load already exited 2, but the current config is loaded by the path shared with daemon boot and `--check`, which exit 1, so a missing or invalid current config exited 1 and was indistinguishable from "actionable changes found".

This maps that load failure to exit 2 at the shared loader's error site, only when `--diff` is active. Diagnostic text, daemon boot, and `--check` behavior are unchanged; the stdout-write failure path keeps its existing exit 1.

## Compatibility

- Exit code of `rustbgpd --diff` when the current config cannot be loaded: 1 -> 2 (operator-visible; CHANGELOG `### Fixed`).
- Man page and `--help` exit-status text now state the `--diff` codes explicitly. `docs/OPERATIONS.md` already stated the contract this change satisfies; no Markdown edits were needed.

## Tests

- `tests/cli_invocation.rs::diff_exits_2_when_the_current_config_cannot_be_loaded` — fails before the fix (`left: Some(1)`, `right: Some(2)`).
- `tests/cli_invocation.rs::check_still_exits_1_when_the_config_cannot_be_loaded` — pins the unchanged `--check` code.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --bin rustbgpd -- -D warnings`
- `cargo test --bin rustbgpd`
- `cargo test --test cli_invocation`
- `cargo test --test daemon_stdout_closed` (stdout-exit pin unaffected)
- `python3 scripts/check_public_tracker_ids.py`
