### PR TITLE
fsm: fence Action variants so a new one is noticed by the transport executor

### DIFF
--- a/crates/fsm/src/action.rs
+++ b/crates/fsm/src/action.rs
@@ -195,3 +195,77 @@ pub enum Action {
         remote_role: Option<BgpRole>,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `Action` variants the daemon's transport executor handles.
+    ///
+    /// `Action` is `#[non_exhaustive]`, so the executor in
+    /// `crates/transport/src/session/fsm.rs` cannot match it exhaustively and
+    /// treats any variant it does not name as a no-op. This match is
+    /// exhaustive because it lives inside the crate: adding a variant fails
+    /// to compile here. Extend this list only together with the change that
+    /// teaches that executor the new variant.
+    fn executor_variant_name(action: &Action) -> &'static str {
+        match action {
+            Action::SendOpen(_) => "SendOpen",
+            Action::SendKeepalive => "SendKeepalive",
+            Action::SendNotification(_) => "SendNotification",
+            Action::StartTimer(..) => "StartTimer",
+            Action::StopTimer(_) => "StopTimer",
+            Action::InitiateTcpConnection => "InitiateTcpConnection",
+            Action::CloseTcpConnection => "CloseTcpConnection",
+            Action::StateChanged { .. } => "StateChanged",
+            Action::SessionEstablished(_) => "SessionEstablished",
+            Action::SessionDown => "SessionDown",
+            Action::StaleTimerIgnored { .. } => "StaleTimerIgnored",
+            Action::RoleMismatchObserved { .. } => "RoleMismatchObserved",
+        }
+    }
+
+    #[test]
+    fn every_action_variant_is_named_for_the_transport_executor() {
+        const EXECUTOR_VARIANTS: [&str; 12] = [
+            "SendOpen",
+            "SendKeepalive",
+            "SendNotification",
+            "StartTimer",
+            "StopTimer",
+            "InitiateTcpConnection",
+            "CloseTcpConnection",
+            "StateChanged",
+            "SessionEstablished",
+            "SessionDown",
+            "StaleTimerIgnored",
+            "RoleMismatchObserved",
+        ];
+        for action in [
+            Action::SendKeepalive,
+            Action::StartTimer(TimerType::Hold, 90),
+            Action::StopTimer(TimerType::ConnectRetry),
+            Action::InitiateTcpConnection,
+            Action::CloseTcpConnection,
+            Action::StateChanged {
+                old: SessionState::Idle,
+                new: SessionState::Connect,
+            },
+            Action::SessionDown,
+            Action::StaleTimerIgnored {
+                state: SessionState::Idle,
+                timer: TimerType::Keepalive,
+            },
+            Action::RoleMismatchObserved {
+                local_role: None,
+                remote_role: None,
+            },
+        ] {
+            let name = executor_variant_name(&action);
+            assert!(
+                EXECUTOR_VARIANTS.contains(&name),
+                "{name} is not in the transport executor's variant list"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`Action` in `crates/fsm/src/action.rs` is `#[non_exhaustive]`, so the transport executor in `crates/transport/src/session/fsm.rs` must keep its `_ => {}` wildcard and treats any variant it does not name as a no-op. A newly added variant therefore compiles cleanly across the workspace and silently does nothing at runtime.

- Add an in-crate `tests` module to `action.rs` whose `executor_variant_name` match over `Action` is exhaustive (the `non_exhaustive` attribute does not apply inside the defining crate). Adding a variant now fails to compile in the fsm crate's own tests; the doc comment names the executor file that must learn the variant before the list is extended.
- `every_action_variant_is_named_for_the_transport_executor` checks the cheaply constructible variants against the fixed name list.

Proof: a temporary `FenceProbe` variant fails `cargo test -p rustbgpd-fsm --no-run` with `error[E0004]: non-exhaustive patterns: `&action::Action::FenceProbe` not covered` at the test module's match; reverted before commit.

## Compatibility

Test-only. `rustbgpd-fsm` is a published crate; no public item is added, removed, or changed. No CHANGELOG entry: the crate changelog records only API and behavior changes.

## Checks

- `cargo fmt --all -- --check` (exit 0)
- `cargo clippy -p rustbgpd-fsm --all-targets -- -D warnings` (exit 0)
- `cargo test -p rustbgpd-fsm` (exit 0)
