### PR TITLE
cli: route human output through the fallible writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   accepts the connection but never answers is reported as unavailable (or
   stale, for data already on screen) by the next tick instead of freezing
   the refresh loop.
+- Human-readable `rbgp` output for connected commands now goes through the
+  same fallible stdout writer as JSON output, so a reader that closes the
+  pipe early (for example `rbgp rib | head -1`) ends the command quietly
+  with exit code 1 instead of a `failed printing to stdout` panic. Output
+  bytes are unchanged.
 
 ### Documentation
 

--- a/crates/cli/src/commands/bfd.rs
+++ b/crates/cli/src/commands/bfd.rs
@@ -2,7 +2,7 @@
 
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::bfd_service_client::BfdServiceClient;
 use crate::proto::{BfdSession, BfdSessionState, GetBfdSessionsRequest};
 use serde::Serialize;
@@ -90,18 +90,18 @@ fn print_sessions(sessions: &[BfdSession], json: bool) -> Result<(), CliError> {
         let out: Vec<JsonBfdSession> = sessions.iter().map(to_json).collect();
         output::print_json_pretty(&out)?;
     } else if sessions.is_empty() {
-        println!("No BFD sessions");
+        outln!("No BFD sessions")?;
     } else {
-        println!("{:<40} {:<11} {:<7} Diagnostic", "Peer", "State", "Strict");
-        println!("{}", "-".repeat(80));
+        outln!("{:<40} {:<11} {:<7} Diagnostic", "Peer", "State", "Strict")?;
+        outln!("{}", "-".repeat(80))?;
         for s in sessions {
-            println!(
+            outln!(
                 "{:<40} {:<11} {:<7} {}",
                 s.peer_address,
                 state_label(s.state),
                 if s.strict { "yes" } else { "no" },
                 human_diagnostic(s)
-            );
+            )?;
         }
     }
     Ok(())

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -1,6 +1,6 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::config_service_client::ConfigServiceClient;
 use crate::proto::{
     AbortConfigTransactionRequest, ApplyConfigTransactionRequest, ConfigTransactionApplyResponse,
@@ -71,7 +71,7 @@ pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result
     if json {
         output::print_serialized_json_line(&resp.diff_json)?;
     } else {
-        print!("{}", resp.human_text);
+        output::print_text(&resp.human_text)?;
     }
     Ok(resp.has_any_changes)
 }
@@ -120,9 +120,9 @@ pub async fn plan(
     if json {
         print_json(plan_to_json(&resp, plan_token.as_deref()))?;
     } else {
-        print_plan_human(&resp);
+        print_plan_human(&resp)?;
         if let Some(line) = plan_token_human_line(plan_token.as_deref()) {
-            println!("{line}");
+            outln!("{line}")?;
         }
     }
     Ok(resp.status != ConfigTransactionPlanStatus::Noop as i32)
@@ -297,7 +297,7 @@ fn print_apply_response(resp: &ConfigTransactionApplyResponse, json: bool) -> Re
     if json {
         print_json(apply_to_json(resp))?;
     } else {
-        print_apply_human(resp);
+        print_apply_human(resp)?;
     }
     if let Some(footer) = confirm_window_footer(resp.confirmation.as_ref()) {
         crate::output::print_next_step(json, &footer);
@@ -524,8 +524,8 @@ pub async fn confirm(connection: Connection, confirm_id: &str, json: bool) -> Re
             "human_text": resp.human_text,
         }))?;
     } else {
-        print!("{}", resp.human_text);
-        print_confirmation(resp.confirmation.as_ref());
+        output::print_text(&resp.human_text)?;
+        print_confirmation(resp.confirmation.as_ref())?;
     }
     crate::output::print_next_step(
         json,
@@ -552,11 +552,11 @@ pub async fn abort(connection: Connection, confirm_id: &str, json: bool) -> Resu
             "human_text": resp.human_text,
         }))?;
     } else {
-        print!("{}", resp.human_text);
+        output::print_text(&resp.human_text)?;
         if !resp.runtime_snapshot_token.is_empty() {
-            println!("runtime_snapshot_token: {}", resp.runtime_snapshot_token);
+            outln!("runtime_snapshot_token: {}", resp.runtime_snapshot_token)?;
         }
-        print_confirmation(resp.confirmation.as_ref());
+        print_confirmation(resp.confirmation.as_ref())?;
     }
     crate::output::print_next_step(
         json,
@@ -576,8 +576,8 @@ pub async fn status(connection: Connection, json: bool) -> Result<(), CliError> 
     if json {
         print_json(status_to_json(&resp))?;
     } else {
-        print!("{}", resp.human_text);
-        print_confirmation(resp.confirmation.as_ref());
+        output::print_text(&resp.human_text)?;
+        print_confirmation(resp.confirmation.as_ref())?;
     }
     Ok(())
 }
@@ -596,7 +596,7 @@ pub async fn history(connection: Connection, json: bool) -> Result<(), CliError>
     if json {
         print_json(history_to_json(&resp))?;
     } else {
-        print_history_human(&resp);
+        print_history_human(&resp)?;
     }
     Ok(())
 }
@@ -651,7 +651,7 @@ pub async fn rollback(
     if json {
         print_json(apply_to_json(&resp))?;
     } else {
-        print_apply_human(&resp);
+        print_apply_human(&resp)?;
     }
     if let Some(footer) = confirm_window_footer(resp.confirmation.as_ref()) {
         crate::output::print_next_step(json, &footer);
@@ -674,11 +674,12 @@ fn history_to_json(resp: &ListConfigHistoryResponse) -> serde_json::Value {
     })
 }
 
-fn print_history_human(resp: &ListConfigHistoryResponse) {
+fn print_history_human(resp: &ListConfigHistoryResponse) -> Result<(), CliError> {
     for entry in &resp.entries {
-        println!("{}", history_human_line(entry));
+        outln!("{}", history_human_line(entry))?;
     }
-    print!("{}", resp.human_text);
+    output::print_text(&resp.human_text)?;
+    Ok(())
 }
 
 fn history_human_line(entry: &crate::proto::ConfigHistoryEntry) -> String {
@@ -753,7 +754,7 @@ pub async fn effective(connection: Connection, json: bool) -> Result<(), CliErro
     if json {
         print_json(effective_to_json(&resp.toml)?)?;
     } else {
-        print!("{}", resp.toml);
+        output::print_text(&resp.toml)?;
     }
     Ok(())
 }
@@ -913,12 +914,12 @@ fn update_group_impact_to_json(plan: Option<&UpdateGroupImpactPlan>) -> serde_js
     })
 }
 
-fn print_update_group_impact(plan: Option<&UpdateGroupImpactPlan>) {
+fn print_update_group_impact(plan: Option<&UpdateGroupImpactPlan>) -> Result<(), CliError> {
     let Some(plan) = plan else {
-        return;
+        return Ok(());
     };
     if let Some(rollup) = &plan.rollup {
-        println!(
+        outln!(
             "update_group_impact_v{}: affected_peers={} affected_families={} shared_groups={} private_views={} capacity={} ({})",
             plan.schema_version,
             rollup.affected_peers,
@@ -927,11 +928,11 @@ fn print_update_group_impact(plan: Option<&UpdateGroupImpactPlan>) {
             rollup.projected_private_views,
             plan.capacity_class,
             plan.capacity_basis
-        );
+        )?;
     }
     for row in &plan.entries {
         if row.transition != "no_op" {
-            println!(
+            outln!(
                 "  {} afi/safi {}/{}: {} -> {} [{}; local_resync={}; route_refresh={}]",
                 row.peer,
                 row.afi,
@@ -941,9 +942,10 @@ fn print_update_group_impact(plan: Option<&UpdateGroupImpactPlan>) {
                 row.transition,
                 row.local_resync,
                 row.remote_route_refresh
-            );
+            )?;
         }
     }
+    Ok(())
 }
 
 fn confirmation_to_json(confirmation: Option<&ConfigTransactionConfirmation>) -> serde_json::Value {
@@ -968,8 +970,8 @@ fn status_to_json(resp: &ConfigTransactionStatusResponse) -> serde_json::Value {
     })
 }
 
-fn print_plan_human(resp: &ConfigTransactionPlanResponse) {
-    print!("{}", resp.human_text);
+fn print_plan_human(resp: &ConfigTransactionPlanResponse) -> Result<(), CliError> {
+    output::print_text(&resp.human_text)?;
     print_transaction_tail(
         resp.status,
         &resp.runtime_snapshot_token,
@@ -978,69 +980,75 @@ fn print_plan_human(resp: &ConfigTransactionPlanResponse) {
             ("unsupported_sections", &resp.unsupported_sections),
             ("restart_required_sections", &resp.restart_required_sections),
         ],
-    );
-    print_update_group_impact(resp.update_group_impact.as_ref());
+    )?;
+    print_update_group_impact(resp.update_group_impact.as_ref())?;
+    Ok(())
 }
 
-fn print_apply_human(resp: &ConfigTransactionApplyResponse) {
-    print!("{}", resp.human_text);
+fn print_apply_human(resp: &ConfigTransactionApplyResponse) -> Result<(), CliError> {
+    output::print_text(&resp.human_text)?;
     print_transaction_tail(
         resp.status,
         &resp.runtime_snapshot_token,
         &[("committed_sections", &resp.committed_sections)],
-    );
-    print_confirmation(resp.confirmation.as_ref());
-    print_update_group_impact(resp.update_group_impact.as_ref());
+    )?;
+    print_confirmation(resp.confirmation.as_ref())?;
+    print_update_group_impact(resp.update_group_impact.as_ref())?;
+    Ok(())
 }
 
-fn print_confirmation(confirmation: Option<&ConfigTransactionConfirmation>) {
+fn print_confirmation(
+    confirmation: Option<&ConfigTransactionConfirmation>,
+) -> Result<(), CliError> {
     let Some(confirmation) = confirmation else {
-        return;
+        return Ok(());
     };
-    println!(
+    outln!(
         "confirmation_status: {}",
         confirmation_status_label(confirmation.status)
-    );
+    )?;
     if !confirmation.confirm_id.is_empty() {
-        println!("confirm_id: {}", confirmation.confirm_id);
+        outln!("confirm_id: {}", confirmation.confirm_id)?;
     }
     if confirmation.timeout_seconds > 0 {
-        println!("confirm_timeout_seconds: {}", confirmation.timeout_seconds);
+        outln!("confirm_timeout_seconds: {}", confirmation.timeout_seconds)?;
     }
     if confirmation.deadline_unix_seconds > 0 {
-        println!(
+        outln!(
             "confirm_deadline_unix_seconds: {}",
             confirmation.deadline_unix_seconds
-        );
+        )?;
     }
     if !confirmation.runtime_snapshot_token.is_empty() {
-        println!(
+        outln!(
             "confirmation_runtime_snapshot_token: {}",
             confirmation.runtime_snapshot_token
-        );
+        )?;
     }
     if !confirmation.committed_sections.is_empty() {
-        println!(
+        outln!(
             "confirmation_committed_sections: {}",
             confirmation.committed_sections.join(", ")
-        );
+        )?;
     }
+    Ok(())
 }
 
 fn print_transaction_tail(
     status: i32,
     runtime_snapshot_token: &str,
     sections: &[(&str, &Vec<String>)],
-) {
-    println!("status: {}", status_label(status));
+) -> Result<(), CliError> {
+    outln!("status: {}", status_label(status))?;
     if !runtime_snapshot_token.is_empty() {
-        println!("runtime_snapshot_token: {runtime_snapshot_token}");
+        outln!("runtime_snapshot_token: {runtime_snapshot_token}")?;
     }
     for (label, values) in sections {
         if !values.is_empty() {
-            println!("{label}: {}", values.join(", "));
+            outln!("{label}: {}", values.join(", "))?;
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/control.rs
+++ b/crates/cli/src/commands/control.rs
@@ -1,6 +1,6 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output::{self, JsonHealth};
+use crate::output::{self, JsonHealth, outln};
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::{HealthRequest, MetricsRequest, ShutdownRequest, TriggerMrtDumpRequest};
 use std::collections::BTreeMap;
@@ -104,10 +104,10 @@ pub async fn health(connection: Connection, json: bool) -> Result<(), CliError> 
         };
         output::print_json_pretty(&out)?;
     } else {
-        println!("Status:  {}", output::colored_health(resp.healthy));
-        println!("Uptime:  {}", output::format_duration(resp.uptime_seconds));
-        println!("Peers:   {}", resp.active_peers);
-        println!("Routes:  {}", resp.total_routes);
+        outln!("Status:  {}", output::colored_health(resp.healthy))?;
+        outln!("Uptime:  {}", output::format_duration(resp.uptime_seconds))?;
+        outln!("Peers:   {}", resp.active_peers)?;
+        outln!("Routes:  {}", resp.total_routes)?;
     }
     Ok(())
 }
@@ -116,7 +116,7 @@ pub async fn metrics(connection: Connection) -> Result<(), CliError> {
     let mut client =
         ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let resp = client.get_metrics(MetricsRequest {}).await?.into_inner();
-    print!("{}", resp.prometheus_text);
+    output::print_text(&resp.prometheus_text)?;
     Ok(())
 }
 
@@ -146,7 +146,7 @@ pub async fn mrt_dump(connection: Connection, json: bool) -> Result<(), CliError
     if json {
         output::print_json_line(&serde_json::json!({ "file_path": resp.file_path }))?;
     } else {
-        println!("MRT dump written: {}", resp.file_path);
+        outln!("MRT dump written: {}", resp.file_path)?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 use crate::commands::watch::bgp_event_json_value;
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output::{self, JsonNeighbor};
+use crate::output::{self, JsonNeighbor, outln};
 use crate::proto::bfd_service_client::BfdServiceClient;
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::event_service_client::EventServiceClient;
@@ -141,7 +141,12 @@ struct Reporter {
 }
 
 impl Reporter {
-    fn record(&mut self, name: impl Into<String>, status: CheckStatus, detail: impl Into<String>) {
+    fn record(
+        &mut self,
+        name: impl Into<String>,
+        status: CheckStatus,
+        detail: impl Into<String>,
+    ) -> Result<(), CliError> {
         let check = Check {
             name: name.into(),
             status,
@@ -156,9 +161,10 @@ impl Reporter {
                 }
                 CheckStatus::Fail => format!("{}", "FAIL".if_supports_color(Stdout, |s| s.red())),
             };
-            println!("{marker}  {}", check.detail);
+            outln!("{marker}  {}", check.detail)?;
         }
         self.checks.push(check);
+        Ok(())
     }
 
     fn any_fail(&self) -> bool {
@@ -1933,7 +1939,7 @@ pub(crate) async fn run(
                 "daemon.reachable",
                 CheckStatus::Ok,
                 format!("daemon reachable at {}", opts.daemon_address),
-            );
+            )?;
             let mut control = ControlServiceClient::with_interceptor(
                 connection.channel(),
                 connection.interceptor(),
@@ -1962,7 +1968,7 @@ pub(crate) async fn run(
                 .await
                 .map(|response| response.into_inner());
             for check in validation_policy_posture_checks(posture) {
-                reporter.record(check.name, check.status, check.detail);
+                reporter.record(check.name, check.status, check.detail)?;
             }
 
             // system/health.json + the healthy check. The same probe outcome
@@ -1970,10 +1976,10 @@ pub(crate) async fn run(
             // authorization finding, not a health one.
             let health_result = control.get_health(HealthRequest {}).await;
             if let Some(check) = authz_reachable_check(health_result.as_ref().err()) {
-                reporter.record(check.name, check.status, check.detail);
+                reporter.record(check.name, check.status, check.detail)?;
             }
             let identity = authz_identity_check(opts.daemon_address, opts.token_file_configured);
-            reporter.record(identity.name, identity.status, identity.detail);
+            reporter.record(identity.name, identity.status, identity.detail)?;
             match health_result {
                 Ok(resp) => {
                     let health = resp.into_inner();
@@ -1998,7 +2004,7 @@ pub(crate) async fn run(
                             health.active_peers,
                             health.total_routes
                         ),
-                    );
+                    )?;
                     bundle.add_json(
                         "system/health.json",
                         &HealthSnapshot {
@@ -2015,7 +2021,7 @@ pub(crate) async fn run(
                         "daemon.healthy",
                         CheckStatus::Fail,
                         format!("health RPC failed: {e}"),
-                    );
+                    )?;
                 }
             }
 
@@ -2063,15 +2069,15 @@ pub(crate) async fn run(
                 Ok(resp) => {
                     let toml_text = resp.into_inner().toml;
                     for check in tcp_ao_capability_checks(&toml_text, tcp_ao_support) {
-                        reporter.record(check.name, check.status, check.detail);
+                        reporter.record(check.name, check.status, check.detail)?;
                     }
                     let rpki_caches = deploy_targets(&toml_text).rpki_caches;
                     if let Some(check) = rpki_vrp_table_check(&rpki_caches, metrics_text.as_deref())
                     {
-                        reporter.record(check.name, check.status, check.detail);
+                        reporter.record(check.name, check.status, check.detail)?;
                     }
                     if let Some(check) = authz_enforcement_check(&toml_text) {
-                        reporter.record(check.name, check.status, check.detail);
+                        reporter.record(check.name, check.status, check.detail)?;
                     }
                     state_dir = parse_state_dir(&toml_text);
                     effective_toml = Some(toml_text);
@@ -2107,7 +2113,7 @@ pub(crate) async fn run(
                         .collect();
                     for snapshot in &snapshots {
                         let check = bfd_check(snapshot);
-                        reporter.record(check.name, check.status, check.detail);
+                        reporter.record(check.name, check.status, check.detail)?;
                     }
                     bundle.add_json("peers/bfd.json", &snapshots)?;
                     true
@@ -2234,11 +2240,11 @@ pub(crate) async fn run(
                             policy_check.name,
                             policy_check.status,
                             policy_check.detail,
-                        );
+                        )?;
                         for check in
                             outbound_prefix_limit_checks(&identity, &n.outbound_prefix_limits)
                         {
-                            reporter.record(check.name, check.status, check.detail);
+                            reporter.record(check.name, check.status, check.detail)?;
                         }
                         records.push(NeighborDoctorRecord {
                             support: JsonNeighbor {
@@ -2277,7 +2283,7 @@ pub(crate) async fn run(
                                 "peers.configured",
                                 CheckStatus::Warn,
                                 "no active neighbor sessions and no dynamic-neighbor ranges configured",
-                            ),
+                            )?,
                             Some(ranges) => reporter.record(
                                 "peers.configured",
                                 CheckStatus::Ok,
@@ -2286,12 +2292,12 @@ pub(crate) async fn run(
                                     ranges.len(),
                                     if ranges.len() == 1 { "" } else { "s" }
                                 ),
-                            ),
+                            )?,
                             None => reporter.record(
                                 "peers.configured",
                                 CheckStatus::Warn,
                                 "no active neighbor sessions; dynamic-neighbor range inventory unavailable",
-                            ),
+                            )?,
                         }
                     }
                     for record in &records {
@@ -2317,7 +2323,7 @@ pub(crate) async fn run(
                             now,
                             &record.support.last_error,
                         ) {
-                            reporter.record(check.name, check.status, check.detail);
+                            reporter.record(check.name, check.status, check.detail)?;
                         }
                         if let Some(check) = gtsm_advisory_check(
                             record,
@@ -2325,7 +2331,7 @@ pub(crate) async fn run(
                             gtsm.as_ref(),
                             admin_enabled.as_ref(),
                         ) {
-                            reporter.record(check.name, check.status, check.detail);
+                            reporter.record(check.name, check.status, check.detail)?;
                         }
                     }
                     bundle.add_json(
@@ -2366,7 +2372,7 @@ pub(crate) async fn run(
                 "daemon.reachable",
                 CheckStatus::Fail,
                 format!("daemon unreachable: {e}"),
-            );
+            )?;
             sections.insert("config", "unavailable: daemon unreachable".to_string());
             sections.insert("peers", "unavailable: daemon unreachable".to_string());
             sections.insert(
@@ -2403,7 +2409,7 @@ pub(crate) async fn run(
         "host.run_context",
         CheckStatus::Ok,
         format!("run context: {run_context}"),
-    );
+    )?;
 
     // ---- daemon rlimits (local processes only) ------------------------
     let daemon_limits = local_daemon_limits();
@@ -2417,13 +2423,13 @@ pub(crate) async fn run(
             match parse_max_open_files(limits) {
                 Some((soft, hard)) => {
                     let check = nofile_check(*pid, soft, hard, run_context);
-                    reporter.record(check.name, check.status, check.detail);
+                    reporter.record(check.name, check.status, check.detail)?;
                 }
                 None => reporter.record(
                     format!("daemon.rlimit.nofile.{pid}"),
                     CheckStatus::Warn,
                     format!("daemon pid {pid}: could not parse Max open files from /proc limits"),
-                ),
+                )?,
             }
             bundle.add(
                 &format!("system/daemon-limits-{pid}.txt"),
@@ -2456,18 +2462,18 @@ pub(crate) async fn run(
             let targets = deploy_targets(toml_text);
             if !daemon_reachable && let Some(port) = targets.listen_port {
                 let check = listener_bind_check(port);
-                reporter.record(check.name, check.status, check.detail);
+                reporter.record(check.name, check.status, check.detail)?;
             }
             for check in reachability_checks(daemon_reachable, opts.daemon_address, &targets).await
             {
-                reporter.record(check.name, check.status, check.detail);
+                reporter.record(check.name, check.status, check.detail)?;
             }
             if state_dir.is_none() {
                 state_dir = parse_state_dir(toml_text);
             }
             let dir = PathBuf::from(state_dir.as_deref().unwrap_or(DEFAULT_STATE_DIR));
             for check in state_dir_checks(&dir) {
-                reporter.record(check.name, check.status, check.detail);
+                reporter.record(check.name, check.status, check.detail)?;
             }
             sections.insert("probes", format!("collected (targets from {source})"));
         }
@@ -2479,7 +2485,7 @@ pub(crate) async fn run(
                     "first-deploy probes skipped: daemon config unavailable and \
                      {DEFAULT_CONFIG_PATH} is not readable"
                 ),
-            );
+            )?;
             sections.insert("probes", "skipped: no config source".to_string());
         }
     }
@@ -2504,7 +2510,7 @@ pub(crate) async fn run(
         };
         let check =
             config_freshness_check(*pid, &config_path.display().to_string(), mtime, reference);
-        reporter.record(check.name, check.status, check.detail);
+        reporter.record(check.name, check.status, check.detail)?;
     }
 
     // ---- crashes/ ------------------------------------------------------
@@ -2515,7 +2521,7 @@ pub(crate) async fn run(
             "crashes.recent",
             CheckStatus::Ok,
             format!("no panic reports in {}", crash_dir.display()),
-        );
+        )?;
         sections.insert(
             "crashes",
             format!("collected (0 reports in {})", crash_dir.display()),
@@ -2529,7 +2535,7 @@ pub(crate) async fn run(
                 crash_reports.len(),
                 crash_dir.display()
             ),
-        );
+        )?;
         sections.insert(
             "crashes",
             format!(
@@ -2626,7 +2632,7 @@ pub(crate) async fn run(
             "sections": serde_json::to_value(&sections_summary)?,
         }))?;
     } else {
-        println!("Support bundle written: {}", bundle_path.display());
+        outln!("Support bundle written: {}", bundle_path.display())?;
     }
     Ok(if failed { 2 } else { 0 })
 }

--- a/crates/cli/src/commands/dynamic_neighbor.rs
+++ b/crates/cli/src/commands/dynamic_neighbor.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
     AddDynamicNeighborRequest, DeleteDynamicNeighborRequest, DynamicNeighborRange,
@@ -45,22 +45,27 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
             .collect();
         output::print_json_pretty(&out)?;
     } else if resp.ranges.is_empty() {
-        println!("No dynamic neighbor ranges configured");
+        outln!("No dynamic neighbor ranges configured")?;
     } else {
-        println!(
+        outln!(
             "{:<22} {:<24} {:<10} DESCRIPTION",
-            "PREFIX", "PEER_GROUP", "REMOTE_ASN"
-        );
+            "PREFIX",
+            "PEER_GROUP",
+            "REMOTE_ASN"
+        )?;
         for r in &resp.ranges {
             let asn = if r.remote_asn == 0 {
                 "any".to_string()
             } else {
                 r.remote_asn.to_string()
             };
-            println!(
+            outln!(
                 "{:<22} {:<24} {:<10} {}",
-                r.prefix, r.peer_group, asn, r.description
-            );
+                r.prefix,
+                r.peer_group,
+                asn,
+                r.description
+            )?;
         }
     }
     Ok(())

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -1,7 +1,7 @@
 use crate::commands::neighbor::{bare_ip_rpc_address, restore_matching_scoped_address};
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::evpn_service_client::EvpnServiceClient;
 use crate::proto::injection_service_client::InjectionServiceClient;
@@ -85,7 +85,7 @@ pub async fn list(
             .collect();
         output::print_json_pretty(&out)?;
     } else if resp.routes.is_empty() {
-        println!("No EVPN routes");
+        outln!("No EVPN routes")?;
     } else {
         // Two distinct concepts both spell "tag" in EVPN-land: the
         // route-type label (RFC 7432 §7) is `mac-ip` / `imet` / etc.,
@@ -128,12 +128,12 @@ pub async fn list(
             } else if r.tunnel_type != 0 {
                 detail.push(format!("encap-type={}", r.tunnel_type));
             }
-            println!(
+            outln!(
                 "[{route_label}] {} via {} from {}",
                 detail.join(" "),
                 r.next_hop,
                 r.peer_address,
-            );
+            )?;
         }
     }
     Ok(())
@@ -396,9 +396,9 @@ pub async fn clear_duplicate_mac(
                 "message": resp.message,
         }))?;
     } else if resp.cleared {
-        println!("EVPN duplicate-MAC quarantine cleared: {mac} on VNI {vni}");
+        outln!("EVPN duplicate-MAC quarantine cleared: {mac} on VNI {vni}")?;
     } else {
-        println!("No active EVPN duplicate-MAC quarantine: {mac} on VNI {vni}");
+        outln!("No active EVPN duplicate-MAC quarantine: {mac} on VNI {vni}")?;
     }
     Ok(())
 }
@@ -424,14 +424,14 @@ pub async fn list_duplicate_mac_quarantines(
             "complete": resp.complete,
         }))?;
     } else if resp.quarantines.is_empty() {
-        println!("No active EVPN duplicate-MAC quarantines");
+        outln!("No active EVPN duplicate-MAC quarantines")?;
     } else {
-        println!("VNI\tMAC");
+        outln!("VNI\tMAC")?;
         for row in resp.quarantines {
-            println!("{}\t{}", row.vni, row.mac);
+            outln!("{}\t{}", row.vni, row.mac)?;
         }
         if !resp.complete {
-            println!("... {} additional quarantines omitted", resp.omitted);
+            outln!("... {} additional quarantines omitted", resp.omitted)?;
         }
     }
     Ok(())
@@ -473,7 +473,7 @@ pub async fn set_es_drain(
                 "message": resp.message,
         }))?;
     } else {
-        println!("{}", resp.message);
+        outln!("{}", resp.message)?;
     }
     Ok(())
 }
@@ -498,13 +498,13 @@ pub async fn list_ethernet_segments(
         output::print_json_pretty(&ethernet_segments_to_json(&resp))?;
     } else if resp.segments.is_empty() {
         if filter.is_empty() {
-            println!("No Ethernet Segments configured");
+            outln!("No Ethernet Segments configured")?;
         } else {
-            println!("No Ethernet Segment matching {filter}");
+            outln!("No Ethernet Segment matching {filter}")?;
         }
     } else {
         for segment in &resp.segments {
-            println!("{}", format_ethernet_segment_human(segment));
+            outln!("{}", format_ethernet_segment_human(segment))?;
         }
     }
     Ok(())
@@ -522,7 +522,7 @@ pub async fn runtime(connection: Connection, json: bool) -> Result<(), CliError>
     if json {
         output::print_json_pretty(&runtime_to_json(&state))?;
     } else {
-        println!(
+        outln!(
             "EVPN runtime generation={} lifecycle={} mutation={} l2-instances={} ip-vrfs={} ethernet-segments={} es-member-vnis={}",
             state.generation,
             runtime_lifecycle_label(state.lifecycle),
@@ -531,9 +531,9 @@ pub async fn runtime(connection: Connection, json: bool) -> Result<(), CliError>
             state.evpn_ip_vrfs_count,
             state.ethernet_segments_count,
             state.ethernet_segment_member_vnis_count,
-        );
+        )?;
         if !state.message.is_empty() {
-            println!("{}", state.message);
+            outln!("{}", state.message)?;
         }
     }
     Ok(())
@@ -558,7 +558,7 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
             resp.instances.iter().map(evpn_instance_to_json).collect();
         output::print_json_pretty(&out)?;
     } else if resp.instances.is_empty() {
-        println!("No local EVPN instances configured");
+        outln!("No local EVPN instances configured")?;
     } else {
         for inst in &resp.instances {
             let mut detail = vec![
@@ -587,7 +587,7 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
             if !inst.not_ready_reason.is_empty() {
                 detail.push(format!("reason=[{}]", inst.not_ready_reason));
             }
-            println!("{}", detail.join(" "));
+            outln!("{}", detail.join(" "))?;
         }
     }
     Ok(())
@@ -636,7 +636,7 @@ pub async fn list_managed_netdevs(connection: Connection, json: bool) -> Result<
         let out: Vec<serde_json::Value> = resp.netdevs.iter().map(managed_netdev_to_json).collect();
         output::print_json_pretty(&out)?;
     } else if resp.netdevs.is_empty() {
-        println!("No managed EVPN netdevs configured or observed");
+        outln!("No managed EVPN netdevs configured or observed")?;
     } else {
         for row in &resp.netdevs {
             let mut detail = vec![
@@ -699,7 +699,7 @@ pub async fn list_managed_netdevs(connection: Connection, json: bool) -> Result<
             if !row.reason.is_empty() {
                 detail.push(format!("reason=[{}]", row.reason));
             }
-            println!("{}", detail.join(" "));
+            outln!("{}", detail.join(" "))?;
         }
     }
     Ok(())
@@ -813,15 +813,15 @@ pub async fn list_nexthops(connection: Connection, json: bool) -> Result<(), Cli
         // non-Linux build, pre-first-report) where no drift loop is
         // running at all, so a derived "enabled" label would
         // misrepresent those cases.
-        println!(
+        outln!(
             "FDB nexthop groups: {} orphan-nexthops={} pending-deletes={} drift-recovery-disabled={}",
             resp.groups.len(),
             resp.orphan_nexthops_count,
             resp.pending_delete_count,
             resp.drift_recovery_disabled,
-        );
+        )?;
         if resp.groups.is_empty() {
-            println!("No owned FDB nexthop groups");
+            outln!("No owned FDB nexthop groups")?;
         } else {
             for group in &resp.groups {
                 // Use `nh_id=N via <gw>` per-member so IPv6 gateways
@@ -833,7 +833,7 @@ pub async fn list_nexthops(connection: Connection, json: bool) -> Result<(), Cli
                     .map(|m| format!("nh_id={} via {}", m.nexthop_id, m.gateway))
                     .collect::<Vec<_>>()
                     .join(", ");
-                println!(
+                outln!(
                     "vni={} esi={} tag={} group-id={} members=[{}] mac-refs=[{}]",
                     group.vni,
                     group.esi,
@@ -841,7 +841,7 @@ pub async fn list_nexthops(connection: Connection, json: bool) -> Result<(), Cli
                     group.group_id,
                     members,
                     group.ref_macs.join(","),
-                );
+                )?;
             }
         }
     }
@@ -1018,10 +1018,10 @@ pub async fn list_ip_vrfs(connection: Connection, json: bool) -> Result<(), CliE
         let out: Vec<serde_json::Value> = resp.ip_vrfs.iter().map(ip_vrf_to_json).collect();
         output::print_json_pretty(&out)?;
     } else if resp.ip_vrfs.is_empty() {
-        println!("No IP-VRFs configured");
+        outln!("No IP-VRFs configured")?;
     } else {
         for vrf in &resp.ip_vrfs {
-            println!("{}", format_ip_vrf_human(vrf));
+            outln!("{}", format_ip_vrf_human(vrf))?;
         }
     }
     Ok(())
@@ -1040,13 +1040,13 @@ pub async fn get_ip_vrf(connection: Connection, name: String, json: bool) -> Res
     if json {
         output::print_json_pretty(&ip_vrf_to_json(&vrf))?;
     } else {
-        println!("{}", format_ip_vrf_human(&vrf));
+        outln!("{}", format_ip_vrf_human(&vrf))?;
         // In the detail view we also print each not-ready reason on
         // its own indented line so operators can scan the failures
         // without parsing the parenthesized list.
         if !vrf.not_ready_reasons.is_empty() {
             for reason in &vrf.not_ready_reasons {
-                println!("  - {reason}");
+                outln!("  - {reason}")?;
             }
         }
     }
@@ -1180,10 +1180,10 @@ pub async fn diagnose(connection: Connection, json: bool) -> Result<(), CliError
                 "key_metrics": key_metrics,
         }))?;
     } else {
-        println!("EVPN diagnose");
-        println!("Instances: {}", instances.len());
-        println!("Originated local MACs: {originated_local_macs}");
-        println!(
+        outln!("EVPN diagnose")?;
+        outln!("Instances: {}", instances.len())?;
+        outln!("Originated local MACs: {originated_local_macs}")?;
+        outln!(
             "Type 2 routes: {} ({})",
             type2_routes.len(),
             if type2_routes.is_empty() {
@@ -1191,8 +1191,8 @@ pub async fn diagnose(connection: Connection, json: bool) -> Result<(), CliError
             } else {
                 "present"
             }
-        );
-        println!(
+        )?;
+        outln!(
             "Type 3 IMET routes: {} ({})",
             type3_routes.len(),
             if type3_routes.is_empty() {
@@ -1200,13 +1200,13 @@ pub async fn diagnose(connection: Connection, json: bool) -> Result<(), CliError
             } else {
                 "present"
             }
-        );
-        println!("Key EVPN metrics:");
+        )?;
+        outln!("Key EVPN metrics:")?;
         if key_metrics.is_empty() {
-            println!("  none observed");
+            outln!("  none observed")?;
         } else {
             for line in key_metrics {
-                println!("  {line}");
+                outln!("  {line}")?;
             }
         }
     }

--- a/crates/cli/src/commands/fib_table.rs
+++ b/crates/cli/src/commands/fib_table.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     DeleteFibTableRequest, FibTableConfig, ListFibTablesRequest, ListFibTablesResponse,
@@ -64,19 +64,22 @@ fn render(resp: &ListFibTablesResponse, json: bool) -> Result<(), CliError> {
         return Ok(());
     }
     if !resp.runtime_available {
-        println!(
+        outln!(
             "FIB reconciler not running (no [[fib_tables]] at startup, or non-Linux / netlink \
              unavailable); a restart is required to start it."
-        );
+        )?;
     }
     if resp.tables.is_empty() {
-        println!("No FIB tables configured");
+        outln!("No FIB tables configured")?;
         return Ok(());
     }
-    println!(
+    outln!(
         "{:<16} {:<9} {:<7} {:<24} MAX_ROUTES",
-        "NAME", "TABLE_ID", "METRIC", "FAMILIES"
-    );
+        "NAME",
+        "TABLE_ID",
+        "METRIC",
+        "FAMILIES"
+    )?;
     for t in &resp.tables {
         let families = if t.families.is_empty() {
             "(default)".to_string()
@@ -86,10 +89,14 @@ fn render(resp: &ListFibTablesResponse, json: bool) -> Result<(), CliError> {
         let max_routes = t
             .max_routes
             .map_or_else(|| "-".to_string(), |m| m.to_string());
-        println!(
+        outln!(
             "{:<16} {:<9} {:<7} {:<24} {}",
-            t.name, t.table_id, t.metric, families, max_routes
-        );
+            t.name,
+            t.table_id,
+            t.metric,
+            families,
+            max_routes
+        )?;
     }
     Ok(())
 }
@@ -144,10 +151,10 @@ pub async fn set(
     if json {
         render(&resp, true)?;
     } else {
-        println!(
+        outln!(
             "FIB table {name} applied ({} table(s) now active)",
             resp.tables.len()
-        );
+        )?;
     }
     Ok(())
 }
@@ -164,10 +171,10 @@ pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<()
     if json {
         render(&resp, true)?;
     } else {
-        println!(
+        outln!(
             "FIB table {name} deleted ({} table(s) now active)",
             resp.tables.len()
-        );
+        )?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/flowspec.rs
+++ b/crates/cli/src/commands/flowspec.rs
@@ -1,6 +1,6 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::injection_service_client::InjectionServiceClient;
 use crate::proto::{
     AddFlowSpecRequest, DeleteFlowSpecRequest, FlowSpecAction, FlowSpecComponent, FlowSpecRedirect,
@@ -86,18 +86,18 @@ pub async fn list(connection: Connection, family: Option<i32>, json: bool) -> Re
             .collect();
         output::print_json_pretty(&out)?;
     } else if resp.routes.is_empty() {
-        println!("No FlowSpec routes");
+        outln!("No FlowSpec routes")?;
     } else {
         for route in &resp.routes {
             let components: Vec<String> = route.components.iter().map(format_component).collect();
             let actions: Vec<String> = route.actions.iter().map(format_action).collect();
-            println!(
+            outln!(
                 "  match [{}] action [{}] from {} ({})",
                 components.join(", "),
                 actions.join(", "),
                 route.peer_address,
                 output::format_family(route.afi_safi),
-            );
+            )?;
         }
     }
     Ok(())

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -1,6 +1,6 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output::{self, JsonGlobal};
+use crate::output::{self, JsonGlobal, outln};
 use crate::proto::GetGlobalRequest;
 use crate::proto::global_service_client::GlobalServiceClient;
 
@@ -28,10 +28,10 @@ pub async fn run(connection: Connection, json: bool) -> Result<(), CliError> {
         };
         output::print_json_pretty(&out)?;
     } else {
-        println!("ASN:         {}", resp.asn);
-        println!("Router ID:   {}", resp.router_id);
-        println!("Listen Port: {}", resp.listen_port);
-        println!(
+        outln!("ASN:         {}", resp.asn)?;
+        outln!("Router ID:   {}", resp.router_id)?;
+        outln!("Listen Port: {}", resp.listen_port)?;
+        outln!(
             "TCP-AO:      {}{}",
             tcp_ao_support_label(resp.tcp_ao_support),
             if resp.tcp_ao_detail.is_empty() {
@@ -39,7 +39,7 @@ pub async fn run(connection: Connection, json: bool) -> Result<(), CliError> {
             } else {
                 format!(" ({})", resp.tcp_ao_detail)
             }
-        );
+        )?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -6,7 +6,7 @@ use crate::output::{
     self, JsonEffectiveNeighborPosture, JsonInboundPrefixLimit, JsonNegotiatedGracefulRestart,
     JsonNegotiatedSession, JsonNeighbor, JsonNeighborDetail, JsonOutboundPrefixLimit,
     JsonPathsLimit, JsonSelectionDeferralFamily, JsonTcpAoKeyState, JsonTcpAoState,
-    JsonUpdateGroupComparison,
+    JsonUpdateGroupComparison, outln,
 };
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
@@ -294,8 +294,7 @@ fn emit_effective_posture_human(value: &str) -> Result<(), CliError> {
     }) {
         return Ok(());
     }
-    print!("{value}");
-    Ok(())
+    output::print_text(value)
 }
 
 fn emit_neighbor_source_human(neighbor: &crate::proto::NeighborState) -> Result<(), CliError> {
@@ -314,7 +313,7 @@ fn emit_neighbor_source_human(neighbor: &crate::proto::NeighborState) -> Result<
     }) {
         return Ok(());
     }
-    print!("{value}");
+    output::print_text(&value)?;
     Ok(())
 }
 
@@ -329,7 +328,7 @@ pub async fn show(
             if json {
                 output::print_json_pretty(&comparison)?;
             } else {
-                print!("{}", render_update_group_comparison(&comparison));
+                output::print_text(&render_update_group_comparison(&comparison))?;
             }
             return Ok(());
         }
@@ -486,235 +485,240 @@ pub async fn show(
         };
         emit_neighbor_detail_json(&out, n.negotiated_session.as_ref())?;
     } else {
-        println!(
+        outln!(
             "Neighbor:              {}",
             cfg.map(|c| c.address.as_str()).unwrap_or("")
-        );
+        )?;
         let interface = cfg.map(|c| c.interface.as_str()).unwrap_or("");
         if !interface.is_empty() {
-            println!("Interface:             {interface}");
+            outln!("Interface:             {interface}")?;
         }
-        println!(
+        outln!(
             "Remote ASN:            {}",
             cfg.map(|c| c.remote_asn).unwrap_or(0)
-        );
-        println!(
+        )?;
+        outln!(
             "Description:           {}",
             cfg.map(|c| c.description.as_str()).unwrap_or("")
-        );
+        )?;
         emit_neighbor_source_human(&n)?;
-        println!(
+        outln!(
             "Hold Time:             {}",
             cfg.map(|c| c.hold_time).unwrap_or(0)
-        );
+        )?;
         if let Some(minimum) = cfg.and_then(|c| c.min_hold_time) {
-            println!("Minimum Hold Time:     {minimum}");
+            outln!("Minimum Hold Time:     {minimum}")?;
         }
-        println!(
+        outln!(
             "Send Hold Time:        {}",
             cfg.and_then(|c| c.send_hold_time).unwrap_or(0)
-        );
-        println!("Max-Prefix Action:     {max_prefix_action}");
+        )?;
+        outln!("Max-Prefix Action:     {max_prefix_action}")?;
         if let Some(seconds) = cfg.and_then(|c| c.max_prefix_restart_seconds) {
-            println!("Max-Prefix Restart:    {seconds}s configured");
+            outln!("Max-Prefix Restart:    {seconds}s configured")?;
         }
         if let Some(remaining) = n.max_prefix_restart_remaining_millis {
-            println!("Max-Prefix Hold-Down:  {remaining}ms remaining");
+            outln!("Max-Prefix Hold-Down:  {remaining}ms remaining")?;
         }
-        println!(
+        outln!(
             "Families:              {}",
             cfg.map(|c| c.families.join(", ")).unwrap_or_default()
-        );
+        )?;
         if let Some(required) = cfg
             .map(|c| &c.required_families)
             .filter(|required| !required.is_empty())
         {
-            println!("Required Families:     {}", required.join(", "));
+            outln!("Required Families:     {}", required.join(", "))?;
         }
-        println!("Negotiation:           {}", negotiation_status_label(&n));
+        outln!("Negotiation:           {}", negotiation_status_label(&n))?;
         if let Some(negotiated) = n.negotiated_session.as_ref() {
-            print!("{}", render_negotiated_transport_details(negotiated));
-            println!(
+            output::print_text(&render_negotiated_transport_details(negotiated))?;
+            outln!(
                 "Remote Router ID:     {}",
                 negotiated.remote_router_id.as_deref().unwrap_or("unknown")
-            );
-            println!(
+            )?;
+            outln!(
                 "Four-Octet AS:        {}",
                 optional_bool_label(negotiated.four_octet_as)
-            );
-            print!("{}", render_negotiated_capability_details(negotiated));
-            println!(
+            )?;
+            output::print_text(&render_negotiated_capability_details(negotiated))?;
+            outln!(
                 "Negotiated Families:  {}",
                 negotiated_families_label(&negotiated.families)
-            );
-            println!(
+            )?;
+            outln!(
                 "Graceful Restart:     {}",
                 graceful_restart_status_label(negotiated.graceful_restart.as_ref())
-            );
+            )?;
             if let Some(gr) = negotiated.graceful_restart.as_ref() {
-                println!(
+                outln!(
                     "GR Peer Families:    {}",
                     negotiated_families_label(&gr.peer_families)
-                );
-                println!(
+                )?;
+                outln!(
                     "GR Peer Restart Time: {}",
                     optional_seconds_label(gr.peer_restart_time_seconds)
-                );
-                println!(
+                )?;
+                outln!(
                     "GR Effective Retention: {}",
                     gr.effective_retention_time_seconds.map_or_else(
                         || "disabled locally".to_string(),
                         |seconds| format!("{seconds}s")
                     )
-                );
+                )?;
             }
         }
         let peer_group = cfg.map(|c| c.peer_group.as_str()).unwrap_or("");
         if !peer_group.is_empty() {
-            println!("Peer Group:            {peer_group}");
+            outln!("Peer Group:            {peer_group}")?;
         }
-        println!("RR Client:             {}", n.route_reflector_client);
-        println!(
+        outln!("RR Client:             {}", n.route_reflector_client)?;
+        outln!(
             "Route Server Client:   {}",
             cfg.map(|c| c.route_server_client).unwrap_or(false)
-        );
+        )?;
         if let Some(codes) = cfg
             .map(|config| config.discard_path_attributes.as_slice())
             .filter(|codes| !codes.is_empty())
         {
-            println!("Discard Attributes:    {codes:?}");
+            outln!("Discard Attributes:    {codes:?}")?;
         }
         if cfg.map(|c| c.per_client_best).unwrap_or(false) {
-            println!("Per-Client Best:       true");
+            outln!("Per-Client Best:       true")?;
         }
         emit_effective_posture_human(&render_effective_posture(n.effective_posture.as_ref()))?;
-        println!("Distribution Mode:     {distribution_mode}");
+        outln!("Distribution Mode:     {distribution_mode}")?;
         let role = cfg.map(|c| c.role.as_str()).unwrap_or("");
         if !role.is_empty() {
-            println!("BGP Role:              {role}");
-            println!(
+            outln!("BGP Role:              {role}")?;
+            outln!(
                 "Strict Role:           {}",
                 cfg.map(|c| c.strict_role).unwrap_or(false)
-            );
+            )?;
             let remote_role = n.remote_role.as_str();
-            println!(
+            outln!(
                 "Remote Role:           {}",
                 if remote_role.is_empty() {
                     "not advertised"
                 } else {
                     remote_role
                 }
-            );
-            println!("Role Negotiated:       {}", n.role_negotiated);
+            )?;
+            outln!("Role Negotiated:       {}", n.role_negotiated)?;
         }
-        println!(
+        outln!(
             "Add-Path Receive:      {}",
             cfg.map(|c| c.add_path_receive).unwrap_or(false)
-        );
-        println!(
+        )?;
+        outln!(
             "Add-Path Send:         {}",
             cfg.map(|c| c.add_path_send).unwrap_or(false)
-        );
+        )?;
         let add_path_send_max = cfg.map(|c| c.add_path_send_max).unwrap_or(0);
         if add_path_send_max > 0 {
-            println!("Add-Path Send Max:     {add_path_send_max}");
+            outln!("Add-Path Send Max:     {add_path_send_max}")?;
         }
         for limit in &n.paths_limits {
             let effective_send = paths_limit_effective_send_label(limit.effective_send_limit);
-            println!(
+            outln!(
                 "Paths-Limit {}: configured={} advertised={} received={} effective-send={}",
                 limit.family,
                 limit.configured_receive_max,
                 limit.advertised_receive_max,
                 limit.received_receive_max,
                 effective_send
-            );
+            )?;
         }
-        println!(
+        outln!(
             "State:                 {}",
             output::colored_state_with_stale(n.state, n.stale)
-        );
+        )?;
         if n.slow_peer {
-            println!("Slow Peer:             true (outbound queue persistently backlogged)");
+            outln!("Slow Peer:             true (outbound queue persistently backlogged)")?;
         }
-        println!(
+        outln!(
             "GShut Advertise Intent: {}",
             graceful_shutdown_advertise_intent_label(n.graceful_shutdown_advertise_intent)
-        );
-        println!(
+        )?;
+        outln!(
             "Uptime:                {}",
             output::format_duration(n.uptime_seconds)
-        );
+        )?;
         if let Some(seconds) = n.reconnect_in_seconds.filter(|seconds| *seconds > 0) {
-            println!(
+            outln!(
                 "Reconnect In:          {}",
                 output::format_duration(seconds)
-            );
+            )?;
         }
-        println!("Prefixes Received:     {}", n.prefixes_received);
-        println!("  IPv4 Unicast:        {}", n.prefixes_received_ipv4);
-        println!("  IPv6 Unicast:        {}", n.prefixes_received_ipv6);
-        println!(
+        outln!("Prefixes Received:     {}", n.prefixes_received)?;
+        outln!("  IPv4 Unicast:        {}", n.prefixes_received_ipv4)?;
+        outln!("  IPv6 Unicast:        {}", n.prefixes_received_ipv6)?;
+        outln!(
             "Max Prefixes:          {}",
             max_prefix_capacity_label(effective_max_prefixes, n.max_prefix_headroom, n.stale)
-        );
-        println!(
+        )?;
+        outln!(
             "Max Prefixes IPv4:     {}",
             max_prefix_capacity_label(
                 n.effective_max_prefixes_ipv4,
                 n.max_prefix_headroom_ipv4,
                 n.stale
             )
-        );
-        println!(
+        )?;
+        outln!(
             "Max Prefixes IPv6:     {}",
             max_prefix_capacity_label(
                 n.effective_max_prefixes_ipv6,
                 n.max_prefix_headroom_ipv6,
                 n.stale
             )
-        );
-        println!("Prefixes Sent:         {}", n.prefixes_sent);
-        println!("Updates Received:      {}", n.updates_received);
-        println!("Updates Sent:          {}", n.updates_sent);
-        println!("Notifications Received:{}", n.notifications_received);
-        println!("Notifications Sent:    {}", n.notifications_sent);
-        println!("Messages Received:     {}", n.messages_received);
-        println!("Messages Sent:         {}", n.messages_sent);
-        println!(
+        )?;
+        outln!("Prefixes Sent:         {}", n.prefixes_sent)?;
+        outln!("Updates Received:      {}", n.updates_received)?;
+        outln!("Updates Sent:          {}", n.updates_sent)?;
+        outln!("Notifications Received:{}", n.notifications_received)?;
+        outln!("Notifications Sent:    {}", n.notifications_sent)?;
+        outln!("Messages Received:     {}", n.messages_received)?;
+        outln!("Messages Sent:         {}", n.messages_sent)?;
+        outln!(
             "Authentication:        {}",
             authentication_label(n.authentication)
-        );
+        )?;
         if matches!(
             crate::proto::AuthenticationMode::try_from(n.authentication),
             Ok(crate::proto::AuthenticationMode::TcpAo)
         ) {
-            println!(
+            outln!(
                 "TCP-AO Health:        {}",
                 tcp_ao_health_label(n.tcp_ao_health)
-            );
-            println!(
+            )?;
+            outln!(
                 "TCP-AO Rotation:      desired={} applied={} phase={}",
-                n.tcp_ao_desired_generation, n.tcp_ao_applied_generation, n.tcp_ao_rotation_phase
-            );
+                n.tcp_ao_desired_generation,
+                n.tcp_ao_applied_generation,
+                n.tcp_ao_rotation_phase
+            )?;
             if !n.tcp_ao_rotation_error.is_empty() {
-                println!("TCP-AO Rotation Error: {}", n.tcp_ao_rotation_error);
+                outln!("TCP-AO Rotation Error: {}", n.tcp_ao_rotation_error)?;
             }
         }
         if let Some(ao) = &n.tcp_ao {
-            println!(
+            outln!(
                 "TCP-AO Keys:           current={} rnext={}",
                 ao.current_key_id
                     .map_or_else(|| "none".to_string(), |v| v.to_string()),
                 ao.rnext_key_id
                     .map_or_else(|| "none".to_string(), |v| v.to_string())
-            );
-            println!(
+            )?;
+            outln!(
                 "TCP-AO Packets:        good={} bad={} key-not-found={} unsigned-required={}",
-                ao.packets_good, ao.packets_bad, ao.packets_key_not_found, ao.packets_ao_required
-            );
+                ao.packets_good,
+                ao.packets_bad,
+                ao.packets_key_not_found,
+                ao.packets_ao_required
+            )?;
             for key in &ao.keys {
-                println!(
+                outln!(
                     "  MKT {}/{}: send={} recv={} algorithm={} current={} rnext={} preferred={} deprecated={} vrf-ifindex={} good={} bad={}",
                     key.peer_address,
                     key.prefix_length,
@@ -729,36 +733,38 @@ pub async fn show(
                         .map_or_else(|| "unbound".to_string(), |value| value.to_string()),
                     key.packets_good,
                     key.packets_bad
-                );
+                )?;
             }
         }
-        println!("OTC Routes Blocked:    {}", n.otc_routes_blocked);
+        outln!("OTC Routes Blocked:    {}", n.otc_routes_blocked)?;
         // ADR-0112: two rows, never one. A peer with an import policy and no
         // export policy is a real and common half-configured state, and
         // collapsing it would hide the denied half.
-        println!("RFC 8212 Policy:");
-        println!(
+        outln!("RFC 8212 Policy:")?;
+        outln!(
             "  Import: {}",
             rfc8212_policy_status_label(n.rfc8212_import_policy)
-        );
-        println!(
+        )?;
+        outln!(
             "  Export: {}",
             rfc8212_policy_status_label(n.rfc8212_export_policy)
-        );
-        println!("Policy Stats:");
-        println!(
+        )?;
+        outln!("Policy Stats:")?;
+        outln!(
             "  Import — permitted: {} denied: {}",
-            n.import_policy_routes_permitted, n.import_policy_routes_denied
-        );
-        println!(
+            n.import_policy_routes_permitted,
+            n.import_policy_routes_denied
+        )?;
+        outln!(
             "  Export — permitted: {} denied: {}",
-            n.export_policy_routes_permitted, n.export_policy_routes_denied
-        );
+            n.export_policy_routes_permitted,
+            n.export_policy_routes_denied
+        )?;
         if !n.update_group.is_empty() {
-            println!("Update Group:          {}", n.update_group);
+            outln!("Update Group:          {}", n.update_group)?;
         }
         if !n.selection_deferral.is_empty() {
-            println!("Selection Deferral:");
+            outln!("Selection Deferral:")?;
             for row in &n.selection_deferral {
                 let state = if row.active {
                     format!(
@@ -778,11 +784,11 @@ pub async fn show(
                             .map_or_else(|| "none".to_string(), |id| id.to_string())
                     )
                 };
-                println!("  AFI {}/SAFI {} — {state}", row.afi, row.safi);
+                outln!("  AFI {}/SAFI {} — {state}", row.afi, row.safi)?;
             }
         }
         if !n.outbound_prefix_limits.is_empty() {
-            println!("Outbound Prefix Limits:");
+            outln!("Outbound Prefix Limits:")?;
             for row in &n.outbound_prefix_limits {
                 // Unlimited prints as `unlimited`, never a synthetic 0, and a
                 // blocking family names the stable reason it is withholding.
@@ -796,28 +802,32 @@ pub async fn show(
                     .reason
                     .as_deref()
                     .map_or_else(String::new, |reason| format!("; blocking={reason}"));
-                println!(
+                outln!(
                     "  {:<14} usage={}; {capacity}{blocking}",
-                    row.family, row.usage
-                );
+                    row.family,
+                    row.usage
+                )?;
             }
         }
         if !n.inbound_prefix_limits.is_empty() {
-            println!("Inbound Prefix Limits:");
+            outln!("Inbound Prefix Limits:")?;
             for row in &n.inbound_prefix_limits {
                 let blocking = row
                     .reason
                     .as_deref()
                     .map_or_else(String::new, |reason| format!("; blocking={reason}"));
-                println!(
+                outln!(
                     "  {:<22} usage={}; limit={}; headroom={}{blocking}",
-                    row.scope, row.usage, row.limit, row.headroom
-                );
+                    row.scope,
+                    row.usage,
+                    row.limit,
+                    row.headroom
+                )?;
             }
         }
-        println!("Flap Count:            {}", n.flap_count);
+        outln!("Flap Count:            {}", n.flap_count)?;
         if !n.last_error.is_empty() {
-            println!("Last Error:            {}", n.last_error);
+            outln!("Last Error:            {}", n.last_error)?;
         }
     }
     Ok(())
@@ -1355,7 +1365,7 @@ pub async fn refresh_outbound(
     if json {
         output::print_json_pretty(&refresh_outbound_json(address, response.scheduled))
     } else {
-        println!("{}", refresh_outbound_message(address));
+        outln!("{}", refresh_outbound_message(address))?;
         Ok(())
     }
 }

--- a/crates/cli/src/commands/neighbor_set.rs
+++ b/crates/cli/src/commands/neighbor_set.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::commands::policy_input::{JsonNeighborSetDefinition, load_json};
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::policy_service_client::PolicyServiceClient;
 use crate::proto::{
     DeleteNeighborSetRequest, GetNeighborSetRequest, ListNeighborSetsRequest, SetNeighborSetRequest,
@@ -55,21 +55,23 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
             .collect();
         output::print_json_pretty(&out)?;
     } else if resp.neighbor_sets.is_empty() {
-        println!("No neighbor sets configured");
+        outln!("No neighbor sets configured")?;
     } else {
-        println!(
+        outln!(
             "{:<32} {:<10} {:<6} PEER_GROUPS",
-            "NAME", "ADDRESSES", "ASNS"
-        );
+            "NAME",
+            "ADDRESSES",
+            "ASNS"
+        )?;
         for ns in &resp.neighbor_sets {
             let def = ns.definition.as_ref();
-            println!(
+            outln!(
                 "{:<32} {:<10} {:<6} {}",
                 ns.name,
                 def.map(|d| d.addresses.len()).unwrap_or(0),
                 def.map(|d| d.remote_asns.len()).unwrap_or(0),
                 def.map(|d| d.peer_groups.len()).unwrap_or(0),
-            );
+            )?;
         }
     }
     Ok(())
@@ -95,16 +97,16 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
         };
         output::print_json_pretty(&detail)?;
     } else {
-        println!("Name:        {}", resp.name);
-        println!(
+        outln!("Name:        {}", resp.name)?;
+        outln!(
             "Addresses:   {}",
             if def.addresses.is_empty() {
                 "(none)".to_string()
             } else {
                 def.addresses.join(", ")
             }
-        );
-        println!(
+        )?;
+        outln!(
             "Remote ASNs: {}",
             if def.remote_asns.is_empty() {
                 "(none)".to_string()
@@ -115,15 +117,15 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
                     .collect::<Vec<_>>()
                     .join(", ")
             }
-        );
-        println!(
+        )?;
+        outln!(
             "Peer Groups: {}",
             if def.peer_groups.is_empty() {
                 "(none)".to_string()
             } else {
                 def.peer_groups.join(", ")
             }
-        );
+        )?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/orr.rs
+++ b/crates/cli/src/commands/orr.rs
@@ -3,7 +3,7 @@
 
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::{
     ListOrrStatusRequest, ListOrrStatusResponse, OrrInputDiagnostics, OrrVantageStatusEntry,
 };
@@ -42,36 +42,40 @@ fn print_orr_status(resp: &ListOrrStatusResponse, json: bool) -> Result<(), CliE
     } else if resp.vantages.is_empty() {
         write_inactive_status(&mut std::io::stdout().lock(), resp)?;
     } else {
-        println!(
+        outln!(
             "{:<40} {:<10} {:<18} {:<8} Peers",
-            "Vantage", "Resolved", "Node", "Reach"
-        );
-        println!("{}", "-".repeat(90));
+            "Vantage",
+            "Resolved",
+            "Node",
+            "Reach"
+        )?;
+        outln!("{}", "-".repeat(90))?;
         for entry in &resp.vantages {
-            println!(
+            outln!(
                 "{:<40} {:<10} {:<18} {:<8} {}",
                 entry.vantage,
                 entry.resolved,
                 node_label(entry),
                 entry.reachable_nodes,
                 entry.peers.join(" ")
-            );
+            )?;
         }
-        println!(
+        outln!(
             "Topology: {} nodes, {} links",
-            resp.topology_nodes, resp.topology_links
-        );
+            resp.topology_nodes,
+            resp.topology_links
+        )?;
     }
     if !json {
         let diagnostics = input_diagnostics(resp);
-        println!(
+        outln!(
             "Topology inputs: included_default={} excluded_nondefault={} malformed_topology={} malformed_attribute_29={} default_with_ignored_flex_algo={}",
             diagnostics.included_default,
             diagnostics.excluded_nondefault,
             diagnostics.malformed_topology,
             diagnostics.malformed_attribute_29,
             diagnostics.default_with_ignored_flex_algo,
-        );
+        )?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/peer_group.rs
+++ b/crates/cli/src/commands/peer_group.rs
@@ -11,7 +11,7 @@ use crate::commands::neighbor::bare_ip_rpc_address;
 use crate::commands::policy_input::{JsonPeerGroupDefinition, load_json};
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::peer_group_service_client::PeerGroupServiceClient;
 use crate::proto::{
     ClearNeighborPeerGroupRequest, DeletePeerGroupRequest, GetPeerGroupRequest,
@@ -150,18 +150,21 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
             .collect();
         output::print_json_pretty(&out)?;
     } else if resp.peer_groups.is_empty() {
-        println!("No peer groups configured");
+        outln!("No peer groups configured")?;
     } else {
-        println!("{:<32} {:<24} IMPORT EXPORT", "NAME", "FAMILIES");
+        outln!("{:<32} {:<24} IMPORT EXPORT", "NAME", "FAMILIES")?;
         for pg in &resp.peer_groups {
             let def = pg.definition.as_ref();
             let families = def.map(|d| d.families.join(",")).unwrap_or_default();
             let import_len = def.map(|d| d.import_policy_chain.len()).unwrap_or(0);
             let export_len = def.map(|d| d.export_policy_chain.len()).unwrap_or(0);
-            println!(
+            outln!(
                 "{:<32} {:<24} {:>6} {:>6}",
-                pg.name, families, import_len, export_len
-            );
+                pg.name,
+                families,
+                import_len,
+                export_len
+            )?;
         }
     }
     Ok(())
@@ -182,111 +185,111 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
         let detail = json_peer_group_detail(resp.name.clone(), &def);
         output::print_json_pretty(&detail)?;
     } else {
-        println!("Name:                  {}", resp.name);
+        outln!("Name:                  {}", resp.name)?;
         if let Some(h) = def.hold_time {
-            println!("Hold Time:             {h}");
+            outln!("Hold Time:             {h}")?;
         }
         if let Some(h) = def.min_hold_time {
-            println!("Minimum Hold Time:     {h}");
+            outln!("Minimum Hold Time:     {h}")?;
         }
         if let Some(h) = def.send_hold_time {
-            println!("Send Hold Time:        {h}");
+            outln!("Send Hold Time:        {h}")?;
         }
         if let Some(m) = def.max_prefixes {
-            println!("Max Prefixes:          {m}");
+            outln!("Max Prefixes:          {m}")?;
         }
         if let Some(seconds) = def.max_prefix_restart_seconds {
-            println!("Max Prefix Restart:    {seconds}s");
+            outln!("Max Prefix Restart:    {seconds}s")?;
         }
         if def.has_md5_password.unwrap_or(false) {
-            println!("MD5 Password:          (set)");
+            outln!("MD5 Password:          (set)")?;
         }
         if let Some(t) = def.ttl_security {
-            println!("TTL Security:          {t}");
+            outln!("TTL Security:          {t}")?;
         }
         if let Some(hops) = def.ttl_security_hops {
-            println!("TTL Security Hops:     {hops}");
+            outln!("TTL Security Hops:     {hops}")?;
         }
         if !def.families.is_empty() {
-            println!("Families:              {}", def.families.join(", "));
+            outln!("Families:              {}", def.families.join(", "))?;
         }
         if !def.required_families.is_empty() {
-            println!(
+            outln!(
                 "Required Families:     {}",
                 def.required_families.join(", ")
-            );
+            )?;
         }
         if let Some(g) = def.graceful_restart {
-            println!("Graceful Restart:      {g}");
+            outln!("Graceful Restart:      {g}")?;
         }
         if let Some(t) = def.gr_restart_time {
-            println!("GR Restart Time:       {t}");
+            outln!("GR Restart Time:       {t}")?;
         }
         if let Some(t) = def.gr_peer_restart_time_max {
-            println!("GR Peer Restart Max:   {t}");
+            outln!("GR Peer Restart Max:   {t}")?;
         }
         if let Some(t) = def.gr_stale_routes_time {
-            println!("GR Stale Routes Time:  {t}");
+            outln!("GR Stale Routes Time:  {t}")?;
         }
         if let Some(t) = def.llgr_stale_time {
-            println!("LLGR Stale Time:       {t}");
+            outln!("LLGR Stale Time:       {t}")?;
         }
         if let Some(n) = &def.local_ipv6_nexthop {
-            println!("Local IPv6 Nexthop:    {n}");
+            outln!("Local IPv6 Nexthop:    {n}")?;
         }
         if let Some(rr) = def.route_reflector_client {
-            println!("RR Client:             {rr}");
+            outln!("RR Client:             {rr}")?;
         }
         if let Some(vantage) = &def.orr_vantage {
-            println!("ORR Vantage:           {vantage}");
+            outln!("ORR Vantage:           {vantage}")?;
         }
         if let Some(rs) = def.route_server_client {
-            println!("RS Client:             {rs}");
+            outln!("RS Client:             {rs}")?;
         }
         if let Some(pcb) = def.per_client_best {
-            println!("Per-Client Best:       {pcb}");
+            outln!("Per-Client Best:       {pcb}")?;
         }
         if let Some(r) = &def.remove_private_as {
-            println!("Remove Private AS:     {r}");
+            outln!("Remove Private AS:     {r}")?;
         }
         if !def.discard_path_attributes.is_empty() {
-            println!("Discard Attributes:    {:?}", def.discard_path_attributes);
+            outln!("Discard Attributes:    {:?}", def.discard_path_attributes)?;
         }
         if let Some(b) = def.add_path_receive {
-            println!("Add-Path Receive:      {b}");
+            outln!("Add-Path Receive:      {b}")?;
         }
         if let Some(b) = def.add_path_send {
-            println!("Add-Path Send:         {b}");
+            outln!("Add-Path Send:         {b}")?;
         }
         if let Some(m) = def.add_path_send_max
             && m > 0
         {
-            println!("Add-Path Send Max:     {m}");
+            outln!("Add-Path Send Max:     {m}")?;
         }
-        println!(
+        outln!(
             "Inline Import Policy:  {} statements",
             def.import_policy.len()
-        );
-        println!(
+        )?;
+        outln!(
             "Inline Export Policy:  {} statements",
             def.export_policy.len()
-        );
-        println!(
+        )?;
+        outln!(
             "Import Chain:          {}",
             if def.import_policy_chain.is_empty() {
                 "(none)".to_string()
             } else {
                 def.import_policy_chain.join(" -> ")
             }
-        );
-        println!(
+        )?;
+        outln!(
             "Export Chain:          {}",
             if def.export_policy_chain.is_empty() {
                 "(none)".to_string()
             } else {
                 def.export_policy_chain.join(" -> ")
             }
-        );
+        )?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -17,7 +17,7 @@ use crate::commands::neighbor::bare_ip_rpc_address;
 use crate::commands::policy_input::{JsonPolicyDefinition, load_json};
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::policy_service_client::PolicyServiceClient;
 use crate::proto::{
     self, ClearGlobalExportChainRequest, ClearGlobalImportChainRequest,
@@ -648,9 +648,11 @@ pub fn fmt_local(files: &[String], check: bool) -> i32 {
             continue;
         }
         if check {
-            println!("Diff in {file}:");
-            print!("{}", line_diff(&source, &formatted));
             failed = true;
+            let diff = format!("Diff in {file}:\n{}", line_diff(&source, &formatted));
+            if let Err(error) = output::print_text(&diff) {
+                output::report_write_error("policy diff output", &error);
+            }
         } else if let Err(error) = write_atomic(std::path::Path::new(file), &formatted) {
             eprintln!("Error: {error}");
             failed = true;
@@ -848,29 +850,31 @@ pub async fn test(
         eprintln!("{}: compile failed", opts.file);
         std::process::exit(1);
     }
-    println!(
+    outln!(
         "policy {:?} ({}) over {} route{}:",
         opts.policy,
         opts.direction,
         resp.routes_evaluated,
         if resp.routes_evaluated == 1 { "" } else { "s" }
-    );
-    println!(
+    )?;
+    outln!(
         "  accepted {}  rejected {}  modified {}",
-        resp.accepted, resp.rejected, resp.modified
-    );
+        resp.accepted,
+        resp.rejected,
+        resp.modified
+    )?;
     if !resp.term_hits.is_empty() {
-        println!("Term hits:");
+        outln!("Term hits:")?;
         for t in &resp.term_hits {
-            println!("  {:<32} {}", t.term, t.hits);
+            outln!("  {:<32} {}", t.term, t.hits)?;
         }
     }
     if !resp.diffs.is_empty() {
-        println!("Changes (up to {}):", opts.show_changes);
+        outln!("Changes (up to {}):", opts.show_changes)?;
         for d in &resp.diffs {
-            println!("  {}/{} (from {}):", d.prefix, d.prefix_length, d.peer);
+            outln!("  {}/{} (from {}):", d.prefix, d.prefix_length, d.peer)?;
             for change in &d.changes {
-                println!("    {change}");
+                outln!("    {change}")?;
             }
         }
     }
@@ -991,11 +995,11 @@ pub async fn stats(
     }
 
     if resp.chains.is_empty() && resp.datasets.is_empty() {
-        println!("No installed policy chains");
+        outln!("No installed policy chains")?;
         return Ok(());
     }
     if resp.chains.is_empty() {
-        println!("No installed policy chains");
+        outln!("No installed policy chains")?;
     }
     for chain in &resp.chains {
         // Import chains carry an install generation (bumps on every
@@ -1006,16 +1010,16 @@ pub async fn stats(
         } else {
             String::new()
         };
-        println!(
+        outln!(
             "{} {} chain — {} routes evaluated since install{generation}",
             operator_peer_address(peer, &chain.peer_address),
             chain.direction,
             chain.routes_evaluated
-        );
+        )?;
         // LAN-301: evaluation errors are fail-closed denies — surface
         // the count and the most recent blame line when nonzero.
         if chain.eval_errors > 0 {
-            println!(
+            outln!(
                 "  {} route{} denied by evaluation errors (fail closed); last: {}",
                 chain.eval_errors,
                 if chain.eval_errors == 1 { "" } else { "s" },
@@ -1024,9 +1028,9 @@ pub async fn stats(
                 } else {
                     &chain.last_error
                 },
-            );
+            )?;
         }
-        println!("  {:<32} {:<24} HITS", "POLICY", "TERM");
+        outln!("  {:<32} {:<24} HITS", "POLICY", "TERM")?;
         for t in &chain.terms {
             let policy = if t.policy.is_empty() {
                 "inline".to_string()
@@ -1038,27 +1042,34 @@ pub async fn stats(
             } else {
                 t.term.clone()
             };
-            println!("  {policy:<32} {term:<24} {}", t.hits);
+            outln!("  {policy:<32} {term:<24} {}", t.hits)?;
         }
     }
     // LAN-305: external dataset status — generation, size, and the
     // last refresh failure (prior snapshot still serving while set).
     if !resp.datasets.is_empty() {
-        println!("Datasets:");
-        println!(
+        outln!("Datasets:")?;
+        outln!(
             "  {:<24} {:<14} {:>4}  {:>8}  PATH",
-            "NAME", "KIND", "GEN", "RECORDS"
-        );
+            "NAME",
+            "KIND",
+            "GEN",
+            "RECORDS"
+        )?;
         for d in &resp.datasets {
-            println!(
+            outln!(
                 "  {:<24} {:<14} {:>4}  {:>8}  {}",
-                d.name, d.kind, d.generation, d.records, d.path
-            );
+                d.name,
+                d.kind,
+                d.generation,
+                d.records,
+                d.path
+            )?;
             if !d.last_error.is_empty() {
-                println!(
+                outln!(
                     "    last refresh FAILED ({}); prior snapshot still serving",
                     d.last_error
-                );
+                )?;
             }
         }
     }
@@ -1093,14 +1104,14 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
             .collect();
         output::print_json_pretty(&out)?;
     } else if resp.policies.is_empty() {
-        println!("No policies configured");
+        outln!("No policies configured")?;
     } else {
-        println!("{:<32} {:<10} STATEMENTS", "NAME", "DEFAULT");
+        outln!("{:<32} {:<10} STATEMENTS", "NAME", "DEFAULT")?;
         for p in &resp.policies {
             let def = p.definition.as_ref();
             let default_action = def.map(|d| d.default_action.as_str()).unwrap_or("-");
             let count = def.map(|d| d.statements.len()).unwrap_or(0);
-            println!("{:<32} {:<10} {}", p.name, default_action, count);
+            outln!("{:<32} {:<10} {}", p.name, default_action, count)?;
         }
     }
     Ok(())
@@ -1125,12 +1136,12 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
         };
         output::print_json_pretty(&detail)?;
     } else {
-        println!("Name:           {}", resp.name);
-        println!("Default Action: {}", def.default_action);
-        println!("Statements:     {}", def.statements.len());
+        outln!("Name:           {}", resp.name)?;
+        outln!("Default Action: {}", def.default_action)?;
+        outln!("Statements:     {}", def.statements.len())?;
         for (i, s) in def.statements.iter().enumerate() {
-            println!("  [{i}] action={}", s.action);
-            print_statement_details(s, "      ");
+            outln!("  [{i}] action={}", s.action)?;
+            print_statement_details(s, "      ")?;
         }
     }
     Ok(())
@@ -1369,15 +1380,15 @@ pub async fn explain_import(
         return Err(err);
     }
 
-    println!(
+    outln!(
         "import policy explain — peer {} prefix {}/{} (policy generation {})",
         operator_peer_address(Some(neighbor), &resp.peer_address),
         resp.prefix,
         resp.prefix_length,
         resp.current_policy_generation
-    );
+    )?;
     if resp.matches.len() > 1 {
-        println!("{} matching paths:", resp.matches.len());
+        outln!("{} matching paths:", resp.matches.len())?;
     }
     for m in &resp.matches {
         let path = if m.path_id == 0 {
@@ -1385,28 +1396,28 @@ pub async fn explain_import(
         } else {
             format!(" path-id {}", m.path_id)
         };
-        println!("  {}{}", outcome_label(m.outcome), path);
+        outln!("  {}{}", outcome_label(m.outcome), path)?;
         if outcome_has_decision(m.outcome) {
-            println!("    {}", decision_attribution_line(m));
-            println!(
+            outln!("    {}", decision_attribution_line(m))?;
+            outln!(
                 "    rpki:    {}    aspa: {}",
                 blank_dash(&m.rpki_validation),
                 blank_dash(&m.aspa_validation)
-            );
-            println!("    eval-ns: {}", m.evaluated_at_unix_ns);
+            )?;
+            outln!("    eval-ns: {}", m.evaluated_at_unix_ns)?;
             if let Some(mods) = &m.modifications {
                 let summary = modifications_summary(mods);
                 if !summary.is_empty() {
-                    println!("    mods:    {summary}");
+                    outln!("    mods:    {summary}")?;
                 }
             }
             for (i, s) in m.statements.iter().enumerate() {
                 if i == 0 {
-                    println!("    statements:");
+                    outln!("    statements:")?;
                 }
-                println!("      {}", statement_line(s));
+                outln!("      {}", statement_line(s))?;
                 for trace in &s.term_traces {
-                    println!("        {trace}");
+                    outln!("        {trace}")?;
                 }
             }
         }
@@ -1620,23 +1631,23 @@ pub async fn chain_show(
         output::print_json_pretty(&out)?;
     } else {
         let scope = neighbor.unwrap_or("global");
-        println!("Scope:        {scope}");
-        println!(
+        outln!("Scope:        {scope}")?;
+        outln!(
             "Import Chain: {}",
             if import.is_empty() {
                 "(none)".to_string()
             } else {
                 import.join(" -> ")
             }
-        );
-        println!(
+        )?;
+        outln!(
             "Export Chain: {}",
             if export.is_empty() {
                 "(none)".to_string()
             } else {
                 export.join(" -> ")
             }
-        );
+        )?;
     }
     Ok(())
 }
@@ -1778,67 +1789,69 @@ pub enum ChainDirection {
     Export,
 }
 
-fn print_statement_details(s: &proto::PolicyStatement, indent: &str) {
+fn print_statement_details(s: &proto::PolicyStatement, indent: &str) -> Result<(), CliError> {
     if let Some(p) = &s.prefix {
-        println!("{indent}prefix={p}");
+        outln!("{indent}prefix={p}")?;
     }
     if let Some(g) = s.ge {
-        println!("{indent}ge={g}");
+        outln!("{indent}ge={g}")?;
     }
     if let Some(l) = s.le {
-        println!("{indent}le={l}");
+        outln!("{indent}le={l}")?;
     }
     if !s.match_community.is_empty() {
-        println!("{indent}match_community={}", s.match_community.join(","));
+        outln!("{indent}match_community={}", s.match_community.join(","))?;
     }
     if let Some(p) = &s.match_as_path {
-        println!("{indent}match_as_path={p}");
+        outln!("{indent}match_as_path={p}")?;
     }
     if let Some(n) = &s.match_neighbor_set {
-        println!("{indent}match_neighbor_set={n}");
+        outln!("{indent}match_neighbor_set={n}")?;
     }
     if let Some(rt) = &s.match_route_type {
-        println!("{indent}match_route_type={rt}");
+        outln!("{indent}match_route_type={rt}")?;
     }
     if let Some(rt) = s.match_evpn_route_type {
-        println!("{indent}match_evpn_route_type={rt}");
+        outln!("{indent}match_evpn_route_type={rt}")?;
     }
     if let Some(v) = &s.match_rpki_validation {
-        println!("{indent}match_rpki_validation={v}");
+        outln!("{indent}match_rpki_validation={v}")?;
     }
     if let Some(v) = &s.match_aspa_validation {
-        println!("{indent}match_aspa_validation={v}");
+        outln!("{indent}match_aspa_validation={v}")?;
     }
     if let Some(n) = &s.match_next_hop {
-        println!("{indent}match_next_hop={n}");
+        outln!("{indent}match_next_hop={n}")?;
     }
     if let Some(lp) = s.set_local_pref {
-        println!("{indent}set_local_pref={lp}");
+        outln!("{indent}set_local_pref={lp}")?;
     }
     if let Some(med) = s.set_med {
-        println!("{indent}set_med={med}");
+        outln!("{indent}set_med={med}")?;
     }
     if let Some(n) = &s.set_next_hop {
-        println!("{indent}set_next_hop={n}");
+        outln!("{indent}set_next_hop={n}")?;
     }
     if !s.set_community_add.is_empty() {
-        println!(
+        outln!(
             "{indent}set_community_add={}",
             s.set_community_add.join(",")
-        );
+        )?;
     }
     if !s.set_community_remove.is_empty() {
-        println!(
+        outln!(
             "{indent}set_community_remove={}",
             s.set_community_remove.join(",")
-        );
+        )?;
     }
     if let Some(p) = &s.set_as_path_prepend {
-        println!(
+        outln!(
             "{indent}set_as_path_prepend=asn={} count={}",
-            p.asn, p.count
-        );
+            p.asn,
+            p.count
+        )?;
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -3,7 +3,7 @@ use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output::{
     self, JsonExplainAdvertisedRoute, JsonExplainModifications, JsonExplainReason,
-    JsonOrrExplainCandidate, JsonRouteSourceIdentity,
+    JsonOrrExplainCandidate, JsonRouteSourceIdentity, outln,
 };
 use crate::pager;
 use crate::proto::injection_service_client::InjectionServiceClient;
@@ -278,7 +278,7 @@ fn print_route_count(total_count: u64, json: bool) -> Result<(), CliError> {
     if json {
         output::print_json_pretty(&route_count_json(total_count))
     } else {
-        println!("{}", route_count_message(total_count));
+        outln!("{}", route_count_message(total_count))?;
         Ok(())
     }
 }
@@ -464,9 +464,9 @@ fn print_routes(
     if json {
         output::print_json_pretty(&JsonRoutes(routes))?;
     } else if routes.is_empty() {
-        println!("No routes");
+        outln!("No routes")?;
     } else {
-        output::print_route_table(routes, show_age);
+        output::print_route_table(routes, show_age)?;
     }
     Ok(())
 }
@@ -534,20 +534,24 @@ fn print_bgpls_routes(routes: &[BgpLsRouteEntry], json: bool) -> Result<(), CliE
     if json {
         output::print_json_pretty(&JsonBgpLsRoutes(routes))?;
     } else if routes.is_empty() {
-        println!("No BGP-LS routes");
+        outln!("No BGP-LS routes")?;
     } else {
-        println!(
+        outln!(
             "{:<12} {:<18} {:<12} {:<18} {:<18} Payload",
-            "Family", "NLRI Type", "RD", "Next Hop", "Peer"
-        );
-        println!("{}", "-".repeat(104));
+            "Family",
+            "NLRI Type",
+            "RD",
+            "Next Hop",
+            "Peer"
+        )?;
+        outln!("{}", "-".repeat(104))?;
         for route in routes {
             let rd = if route.route_distinguisher.is_empty() {
                 "-".to_string()
             } else {
                 hex_lower(&route.route_distinguisher)
             };
-            println!(
+            outln!(
                 "{:<12} {:<18} {:<12} {:<18} {:<18} {}",
                 bgpls_family_display(route),
                 bgpls_type_display(route),
@@ -555,7 +559,7 @@ fn print_bgpls_routes(routes: &[BgpLsRouteEntry], json: bool) -> Result<(), CliE
                 route.next_hop,
                 route.peer_address,
                 hex_lower(&route.payload)
-            );
+            )?;
         }
     }
     Ok(())
@@ -565,13 +569,17 @@ fn print_vpn_routes(routes: &[VpnRouteEntry], json: bool) -> Result<(), CliError
     if json {
         output::print_json_pretty(&JsonVpnRoutes(routes))?;
     } else if routes.is_empty() {
-        println!("No VPN routes");
+        outln!("No VPN routes")?;
     } else {
-        println!(
+        outln!(
             "{:<16} {:<24} {:<14} {:<18} {:<18} Route Targets",
-            "RD", "Prefix", "Labels", "Next Hop", "Peer"
-        );
-        println!("{}", "-".repeat(110));
+            "RD",
+            "Prefix",
+            "Labels",
+            "Next Hop",
+            "Peer"
+        )?;
+        outln!("{}", "-".repeat(110))?;
         for route in routes {
             let labels = route
                 .labels
@@ -579,7 +587,7 @@ fn print_vpn_routes(routes: &[VpnRouteEntry], json: bool) -> Result<(), CliError
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(",");
-            println!(
+            outln!(
                 "{:<16} {:<24} {:<14} {:<18} {:<18} {}",
                 route.route_distinguisher_str,
                 route.prefix,
@@ -587,7 +595,7 @@ fn print_vpn_routes(routes: &[VpnRouteEntry], json: bool) -> Result<(), CliError
                 route.next_hop,
                 route.peer_address,
                 vpn_route_targets(route).join(" ")
-            );
+            )?;
         }
     }
     Ok(())
@@ -597,13 +605,16 @@ fn print_labeled_routes(routes: &[LabeledRouteEntry], json: bool) -> Result<(), 
     if json {
         output::print_json_pretty(&JsonLabeledRoutes(routes))?;
     } else if routes.is_empty() {
-        println!("No labeled routes");
+        outln!("No labeled routes")?;
     } else {
-        println!(
+        outln!(
             "{:<24} {:<14} {:<18} {:<18} Path ID",
-            "Prefix", "Labels", "Next Hop", "Peer"
-        );
-        println!("{}", "-".repeat(88));
+            "Prefix",
+            "Labels",
+            "Next Hop",
+            "Peer"
+        )?;
+        outln!("{}", "-".repeat(88))?;
         for route in routes {
             let labels = route
                 .labels
@@ -611,10 +622,14 @@ fn print_labeled_routes(routes: &[LabeledRouteEntry], json: bool) -> Result<(), 
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(",");
-            println!(
+            outln!(
                 "{:<24} {:<14} {:<18} {:<18} {}",
-                route.prefix, labels, route.next_hop, route.peer_address, route.path_id
-            );
+                route.prefix,
+                labels,
+                route.next_hop,
+                route.peer_address,
+                route.path_id
+            )?;
         }
     }
     Ok(())
@@ -624,27 +639,30 @@ fn print_rtc_routes(routes: &[RtcRouteEntry], json: bool) -> Result<(), CliError
     if json {
         output::print_json_pretty(&JsonRtcRoutes(routes))?;
     } else if routes.is_empty() {
-        println!("No RTC routes");
+        outln!("No RTC routes")?;
     } else {
-        println!(
+        outln!(
             "{:<10} {:<20} {:<5} {:<18} From-Peer",
-            "Origin-AS", "Route-Target", "Len", "Next-Hop"
-        );
-        println!("{}", "-".repeat(76));
+            "Origin-AS",
+            "Route-Target",
+            "Len",
+            "Next-Hop"
+        )?;
+        outln!("{}", "-".repeat(76))?;
         for route in routes {
             let (origin_as, route_target) = if route.is_default {
                 ("-".to_string(), "default".to_string())
             } else {
                 (route.origin_as.to_string(), route.route_target.clone())
             };
-            println!(
+            outln!(
                 "{:<10} {:<20} {:<5} {:<18} {}",
                 origin_as,
                 route_target,
                 route.prefix_len,
                 route.next_hop,
                 rtc_from_peer(route)
-            );
+            )?;
         }
     }
     Ok(())
@@ -1097,18 +1115,18 @@ fn print_blackhole_discards(
             discards.iter().map(blackhole_discard_to_json).collect();
         output::print_json_pretty(&out)?;
     } else if discards.is_empty() {
-        println!("No BLACKHOLE discard routes");
+        outln!("No BLACKHOLE discard routes")?;
     } else {
-        println!("{:<43} {:<18} {:<10} Reason", "Prefix", "Peer", "State");
-        println!("{}", "-".repeat(88));
+        outln!("{:<43} {:<18} {:<10} Reason", "Prefix", "Peer", "State")?;
+        outln!("{}", "-".repeat(88))?;
         for d in discards {
-            println!(
+            outln!(
                 "{:<43} {:<18} {:<10} {}",
                 format!("{}/{}", d.prefix, d.prefix_length),
                 d.peer_address,
                 blackhole_state_label(d.state),
                 d.reason
-            );
+            )?;
         }
     }
     Ok(())
@@ -1134,15 +1152,19 @@ fn print_fib_routes(
             output::print_json_pretty(&routes)?;
         }
     } else if resp.routes.is_empty() {
-        println!("{}", empty_fib_routes_message(resp, include_page_meta));
+        outln!("{}", empty_fib_routes_message(resp, include_page_meta))?;
     } else {
-        println!(
+        outln!(
             "{:<16} {:<10} {:<43} {:<39} {:<10} Reason",
-            "Table", "Metric", "Prefix", "Next hop", "State"
-        );
-        println!("{}", "-".repeat(132));
+            "Table",
+            "Metric",
+            "Prefix",
+            "Next hop",
+            "State"
+        )?;
+        outln!("{}", "-".repeat(132))?;
         for r in &resp.routes {
-            println!(
+            outln!(
                 "{:<16} {:<10} {:<43} {:<39} {:<10} {}",
                 r.table_name,
                 r.metric,
@@ -1150,16 +1172,16 @@ fn print_fib_routes(
                 fib_next_hop_display(r),
                 fib_state_label(r.state),
                 r.reason
-            );
+            )?;
         }
     }
     if include_page_meta && !json {
-        println!("Total matching rows: {}", resp.total_count);
+        outln!("Total matching rows: {}", resp.total_count)?;
         if !resp.next_page_token.is_empty() {
-            println!("Next page token: {}", resp.next_page_token);
+            outln!("Next page token: {}", resp.next_page_token)?;
         }
         for sampling in fib_sampling_metadata(&resp.routes) {
-            println!(
+            outln!(
                 "Sampling: table={} metric={} reason={} sampled={} suppressed={} total={} max_routes={} sample_limit={} complete={}",
                 sampling.table_name,
                 sampling.metric,
@@ -1170,7 +1192,7 @@ fn print_fib_routes(
                 sampling.max_routes,
                 sampling.sample_limit,
                 sampling.complete
-            );
+            )?;
         }
     }
     Ok(())
@@ -1413,41 +1435,44 @@ fn print_explain_advertised(
             ExplainDecision::UnsupportedFamily => "Unsupported Family",
             ExplainDecision::Unspecified => "Unspecified",
         };
-    println!(
+    outln!(
         "{decision}: {}/{} to {}",
-        explain.prefix, explain.prefix_length, explain.peer_address
-    );
+        explain.prefix,
+        explain.prefix_length,
+        explain.peer_address
+    )?;
     if !explain.rd.is_empty() {
-        println!("RD:         {}", explain.rd);
+        outln!("RD:         {}", explain.rd)?;
     }
     if let Some(source) = &explain.source {
-        println!(
+        outln!(
             "Source path: {} inbound path ID {}",
-            source.peer_address, source.path_id
-        );
+            source.peer_address,
+            source.path_id
+        )?;
     }
     if let Some(group_id) = explain.update_group_id {
-        println!("Update group: {group_id} (shared staging; split horizon applied per member)");
+        outln!("Update group: {group_id} (shared staging; split horizon applied per member)")?;
     }
     if !explain.route_peer_address.is_empty() {
-        println!("Route peer: {}", explain.route_peer_address);
+        outln!("Route peer: {}", explain.route_peer_address)?;
     }
     if !explain.route_type.is_empty() {
-        println!("Route type: {}", explain.route_type);
+        outln!("Route type: {}", explain.route_type)?;
     }
     if !explain.next_hop.is_empty() {
-        println!("Next hop:   {}", explain.next_hop);
+        outln!("Next hop:   {}", explain.next_hop)?;
     }
     if let Some(line) = advertised_path_id_line(explain) {
-        println!("{line}");
+        outln!("{line}")?;
     }
     if !explain.orr_vantage.is_empty() {
-        println!("ORR vantage: {}", explain.orr_vantage);
+        outln!("ORR vantage: {}", explain.orr_vantage)?;
     }
     if !explain.orr_candidates.is_empty() {
-        println!("ORR candidates (per-vantage best first):");
+        outln!("ORR candidates (per-vantage best first):")?;
         for candidate in &explain.orr_candidates {
-            println!(
+            outln!(
                 "- {} next-hop {} cost={}{}",
                 candidate.peer_address,
                 candidate.next_hop,
@@ -1457,11 +1482,11 @@ fn print_explain_advertised(
                 } else {
                     ""
                 }
-            );
+            )?;
         }
     }
     if !explain.gates.is_empty() {
-        println!("Gate ladder (live evaluation order):");
+        outln!("Gate ladder (live evaluation order):")?;
         for step in &explain.gates {
             let mark = match ExportGateVerdict::try_from(step.verdict)
                 .unwrap_or(ExportGateVerdict::Unspecified)
@@ -1470,19 +1495,19 @@ fn print_explain_advertised(
                 ExportGateVerdict::Stop => "STOP",
                 ExportGateVerdict::NotApplicable | ExportGateVerdict::Unspecified => "n/a ",
             };
-            println!("  [{mark}] {:<14} {}", step.gate, step.detail);
+            outln!("  [{mark}] {:<14} {}", step.gate, step.detail)?;
         }
     }
     if explain.already_advertised {
-        println!(
+        outln!(
             "Adj-RIB-Out in sync: identical route already advertised - nothing would be \
              re-sent; remote acceptance is not observable"
-        );
+        )?;
     }
     if !explain.reasons.is_empty() {
-        println!("Reasons:");
+        outln!("Reasons:")?;
         for reason in &explain.reasons {
-            println!("- {}: {}", reason.code, reason.message);
+            outln!("- {}: {}", reason.code, reason.message)?;
         }
     }
     if let Some(mods) = explain.modifications.as_ref()
@@ -1498,70 +1523,70 @@ fn print_explain_advertised(
             || mods.as_path_prepend_asn.is_some()
             || mods.as_path_prepend_count.is_some())
     {
-        println!("Modifications:");
+        outln!("Modifications:")?;
         if let Some(value) = mods.set_local_pref {
-            println!("- set_local_pref: {value}");
+            outln!("- set_local_pref: {value}")?;
         }
         if let Some(value) = mods.set_med {
-            println!("- set_med: {value}");
+            outln!("- set_med: {value}")?;
         }
         if !mods.set_next_hop.is_empty() {
-            println!("- set_next_hop: {}", mods.set_next_hop);
+            outln!("- set_next_hop: {}", mods.set_next_hop)?;
         }
         if !mods.communities_add.is_empty() {
-            println!(
+            outln!(
                 "- communities_add: {}",
                 mods.communities_add
                     .iter()
                     .map(|c| output::format_community(*c))
                     .collect::<Vec<_>>()
                     .join(", ")
-            );
+            )?;
         }
         if !mods.communities_remove.is_empty() {
-            println!(
+            outln!(
                 "- communities_remove: {}",
                 mods.communities_remove
                     .iter()
                     .map(|c| output::format_community(*c))
                     .collect::<Vec<_>>()
                     .join(", ")
-            );
+            )?;
         }
         if !mods.extended_communities_add.is_empty() {
-            println!(
+            outln!(
                 "- extended_communities_add: {}",
                 mods.extended_communities_add
                     .iter()
                     .map(|ec| format!("0x{ec:016x}"))
                     .collect::<Vec<_>>()
                     .join(", ")
-            );
+            )?;
         }
         if !mods.extended_communities_remove.is_empty() {
-            println!(
+            outln!(
                 "- extended_communities_remove: {}",
                 mods.extended_communities_remove
                     .iter()
                     .map(|ec| format!("0x{ec:016x}"))
                     .collect::<Vec<_>>()
                     .join(", ")
-            );
+            )?;
         }
         if !mods.large_communities_add.is_empty() {
-            println!(
+            outln!(
                 "- large_communities_add: {}",
                 mods.large_communities_add.join(", ")
-            );
+            )?;
         }
         if !mods.large_communities_remove.is_empty() {
-            println!(
+            outln!(
                 "- large_communities_remove: {}",
                 mods.large_communities_remove.join(", ")
-            );
+            )?;
         }
         if let (Some(asn), Some(count)) = (mods.as_path_prepend_asn, mods.as_path_prepend_count) {
-            println!("- as_path_prepend: {asn} x {count}");
+            outln!("- as_path_prepend: {asn} x {count}")?;
         }
     }
     Ok(())
@@ -1711,54 +1736,64 @@ fn print_explain_best_path(
         return Ok(());
     }
 
-    println!(
+    outln!(
         "Best-path explanation for {}/{}",
-        resp.prefix, resp.prefix_length
-    );
+        resp.prefix,
+        resp.prefix_length
+    )?;
     if !resp.peer_address.is_empty() {
-        println!(
+        outln!(
             "Scope:      peer {} (Add-Path send_max={})",
-            resp.peer_address, resp.add_path_send_max
-        );
+            resp.peer_address,
+            resp.add_path_send_max
+        )?;
     }
     if !resp.orr_vantage.is_empty() {
-        println!("ORR vantage: {}", resp.orr_vantage);
+        outln!("ORR vantage: {}", resp.orr_vantage)?;
     }
 
     if let Some(ref best) = resp.best_route {
-        println!(
+        outln!(
             "Best route: peer={}, next_hop={}, as_path={:?}",
-            best.peer_address, best.next_hop, best.as_path
-        );
+            best.peer_address,
+            best.next_hop,
+            best.as_path
+        )?;
     } else {
-        println!("No best route");
+        outln!("No best route")?;
         return Ok(());
     }
 
     if resp.best_reason == "only_path" {
-        println!("Selected:   only path for this prefix");
+        outln!("Selected:   only path for this prefix")?;
     } else if resp.best_reason_detail.is_empty() {
-        println!("Selected:   {}", resp.best_reason);
+        outln!("Selected:   {}", resp.best_reason)?;
     } else {
-        println!(
+        outln!(
             "Selected:   {} ({}) vs runner-up",
-            resp.best_reason, resp.best_reason_detail
-        );
+            resp.best_reason,
+            resp.best_reason_detail
+        )?;
     }
 
     if resp.candidates.is_empty() {
-        println!("No candidates");
+        outln!("No candidates")?;
         return Ok(());
     }
 
-    println!();
+    outln!()?;
     let peer_scoped = !resp.peer_address.is_empty();
     if peer_scoped {
-        println!(
+        outln!(
             "{:<18} {:<18} {:<22} {:<26} {:<8} {:<10} Adv-PathID",
-            "Peer", "Next Hop", "Reason", "Detail", "Result", "Multipath"
-        );
-        println!("{}", "-".repeat(118));
+            "Peer",
+            "Next Hop",
+            "Reason",
+            "Detail",
+            "Result",
+            "Multipath"
+        )?;
+        outln!("{}", "-".repeat(118))?;
         for c in &resp.candidates {
             if let Some(ref r) = c.route {
                 let advert = if c.advertised_path_id == 0 {
@@ -1766,7 +1801,7 @@ fn print_explain_best_path(
                 } else {
                     c.advertised_path_id.to_string()
                 };
-                println!(
+                outln!(
                     "{:<18} {:<18} {:<22} {:<26} {:<8} {:<10} {}",
                     r.peer_address,
                     r.next_hop,
@@ -1775,18 +1810,22 @@ fn print_explain_best_path(
                     c.vs_best_ordering,
                     c.multipath,
                     advert
-                );
+                )?;
             }
         }
     } else {
-        println!(
+        outln!(
             "{:<18} {:<18} {:<22} {:<26} {:<8} Multipath",
-            "Peer", "Next Hop", "Reason", "Detail", "Result"
-        );
-        println!("{}", "-".repeat(106));
+            "Peer",
+            "Next Hop",
+            "Reason",
+            "Detail",
+            "Result"
+        )?;
+        outln!("{}", "-".repeat(106))?;
         for c in &resp.candidates {
             if let Some(ref r) = c.route {
-                println!(
+                outln!(
                     "{:<18} {:<18} {:<22} {:<26} {:<8} {}",
                     r.peer_address,
                     r.next_hop,
@@ -1794,7 +1833,7 @@ fn print_explain_best_path(
                     c.vs_best_detail,
                     c.vs_best_ordering,
                     c.multipath
-                );
+                )?;
             }
         }
     }
@@ -2150,19 +2189,19 @@ fn print_rejected_routes(resp: &ListRejectedRoutesResponse, json: bool) -> Resul
         });
     }
     if !resp.retention_enabled {
-        println!(
+        outln!(
             "Rejected-route retention is disabled for {} ([policy.reject_retention] enabled = false)",
             resp.peer_address
-        );
+        )?;
         return Ok(());
     }
     if resp.routes.is_empty() {
-        println!("No rejected routes retained for {}", resp.peer_address);
+        outln!("No rejected routes retained for {}", resp.peer_address)?;
     } else {
         write_rejected_routes_table(&mut std::io::stdout().lock(), resp)?;
     }
     if let Some(notice) = rejected_routes_completeness_notice(resp) {
-        println!("{notice}");
+        outln!("{notice}")?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/rpki.rs
+++ b/crates/cli/src/commands/rpki.rs
@@ -185,7 +185,7 @@ pub async fn validate(
     if json {
         output::print_json_pretty(&to_json(&response))?;
     } else {
-        print!("{}", render_human(&response));
+        output::print_text(&render_human(&response))?;
     }
     Ok(())
 }
@@ -281,7 +281,7 @@ pub async fn caches(connection: Connection, json: bool) -> Result<(), CliError> 
     if json {
         output::print_json_pretty(&caches_json(&response))?;
     } else {
-        print!("{}", render_caches_human(&response));
+        output::print_text(&render_caches_human(&response))?;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/topology.rs
+++ b/crates/cli/src/commands/topology.rs
@@ -3,7 +3,7 @@
 
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, outln};
 use crate::proto::{
     ListTopologyLinksRequest, ListTopologyNodesRequest, TopologyLinkEntry, TopologyNodeEntry,
 };
@@ -51,10 +51,10 @@ fn print_topology_nodes(nodes: &[TopologyNodeEntry], json: bool) -> Result<(), C
     if json {
         output::print_json_pretty(&JsonTopologyNodes(nodes))?;
     } else if nodes.is_empty() {
-        println!("No topology nodes");
+        outln!("No topology nodes")?;
     } else {
-        println!("{:<18} {:<10} {:<18} Links", "Key", "AS", "Router-ID");
-        println!("{}", "-".repeat(56));
+        outln!("{:<18} {:<10} {:<18} Links", "Key", "AS", "Router-ID")?;
+        outln!("{}", "-".repeat(56))?;
         for node in nodes {
             let asn = if node.asn == 0 {
                 "-".to_string()
@@ -66,13 +66,13 @@ fn print_topology_nodes(nodes: &[TopologyNodeEntry], json: bool) -> Result<(), C
             } else {
                 &node.router_id
             };
-            println!(
+            outln!(
                 "{:<18} {:<10} {:<18} {}",
                 short_key(&node.key),
                 asn,
                 router_id,
                 node.link_count
-            );
+            )?;
         }
     }
     Ok(())
@@ -82,18 +82,18 @@ fn print_topology_links(links: &[TopologyLinkEntry], json: bool) -> Result<(), C
     if json {
         output::print_json_pretty(&JsonTopologyLinks(links))?;
     } else if links.is_empty() {
-        println!("No topology links");
+        outln!("No topology links")?;
     } else {
-        println!("{:<18} {:<18} {:<8} Addresses", "Local", "Remote", "Cost");
-        println!("{}", "-".repeat(76));
+        outln!("{:<18} {:<18} {:<8} Addresses", "Local", "Remote", "Cost")?;
+        outln!("{}", "-".repeat(76))?;
         for link in links {
-            println!(
+            outln!(
                 "{:<18} {:<18} {:<8} {}",
                 endpoint_label(&link.local_router_id, &link.local_key),
                 endpoint_label(&link.remote_router_id, &link.remote_key),
                 link.cost,
                 link.addresses.join(" ")
-            );
+            )?;
         }
     }
     Ok(())

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -1,6 +1,6 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output::{self, JsonRouteEvent};
+use crate::output::{self, JsonRouteEvent, outln};
 use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
@@ -92,7 +92,7 @@ fn print_event(event: &RouteEvent, json: bool) -> Result<(), CliError> {
     } else {
         format!(" reason={}", event.reason)
     };
-    println!(
+    outln!(
         "[{}] {} {} from {}{}{}{}{}{}",
         event.timestamp,
         output::colored_event_type(format_event_type(event.event_type)),
@@ -103,7 +103,7 @@ fn print_event(event: &RouteEvent, json: bool) -> Result<(), CliError> {
         reason,
         path_id_str,
         event_id_str,
-    );
+    )?;
     Ok(())
 }
 
@@ -637,7 +637,7 @@ fn print_bgp_event(event: &BgpEvent, json: bool) -> Result<(), CliError> {
         return Ok(());
     }
 
-    println!("{}", format_bgp_event_line(event));
+    outln!("{}", format_bgp_event_line(event))?;
     Ok(())
 }
 
@@ -1244,7 +1244,7 @@ fn print_empty_history(json: bool, what: &str) -> Result<(), CliError> {
         let stdout = std::io::stdout();
         write_empty_json_history(&mut stdout.lock())?;
     } else {
-        println!("No {what} events recorded");
+        outln!("No {what} events recorded")?;
     }
     Ok(())
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -900,8 +900,8 @@ fn format_med(med_attr: Option<u32>) -> String {
 }
 
 /// Print route table with dynamic column widths and colored best marker.
-pub fn print_route_table(routes: &[proto::Route], show_age: bool) {
-    print!("{}", render_route_table_text(routes, show_age));
+pub fn print_route_table(routes: &[proto::Route], show_age: bool) -> Result<(), CliError> {
+    print_text(&render_route_table_text(routes, show_age))
 }
 
 pub(crate) fn render_route_table_text(routes: &[proto::Route], show_age: bool) -> String {
@@ -1088,7 +1088,7 @@ pub fn print_result(json: bool, action: &str, target: &str, message: &str) -> Re
         });
         print_json_pretty(&out)?;
     } else {
-        println!("{message}");
+        print_line(message)?;
     }
     Ok(())
 }
@@ -1175,6 +1175,31 @@ pub(crate) fn write_serialized_json_line<W: Write + ?Sized>(
 ) -> Result<(), CliError> {
     write_line(writer, json.as_bytes())
 }
+
+/// Print one text line through locked stdout. Unlike `println!`, a closed
+/// pipe is reported as an ordinary write error instead of a panic.
+pub fn print_line(text: &str) -> Result<(), CliError> {
+    let stdout = io::stdout();
+    write_text_line(&mut stdout.lock(), text)
+}
+
+/// Print already-rendered text byte-for-byte through locked stdout.
+pub fn print_text(text: &str) -> Result<(), CliError> {
+    let stdout = io::stdout();
+    write_bytes(&mut stdout.lock(), text.as_bytes())
+}
+
+/// `println!` through [`print_line`]: formats the arguments and returns the
+/// write result, which the caller must propagate.
+macro_rules! outln {
+    () => {
+        $crate::output::print_line("")
+    };
+    ($($arg:tt)*) => {
+        $crate::output::print_line(&format!($($arg)*))
+    };
+}
+pub(crate) use outln;
 
 /// Print a pretty JSON value through locked stdout.
 pub fn print_json_pretty<T: Serialize>(value: &T) -> Result<(), CliError> {

--- a/crates/cli/tests/stdout_closed.rs
+++ b/crates/cli/tests/stdout_closed.rs
@@ -4,6 +4,51 @@ use std::os::fd::OwnedFd;
 use std::os::unix::net::UnixStream;
 use std::process::{Command, Stdio};
 
+use rustbgpd_api::proto::global_service_server::{GlobalService, GlobalServiceServer};
+use rustbgpd_api::proto::{GetGlobalRequest, GlobalState};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+
+struct MockGlobalService;
+
+#[tonic::async_trait]
+impl GlobalService for MockGlobalService {
+    async fn get_global(
+        &self,
+        _request: Request<GetGlobalRequest>,
+    ) -> Result<Response<GlobalState>, Status> {
+        Ok(Response::new(GlobalState {
+            asn: 65001,
+            router_id: "10.0.0.1".to_string(),
+            listen_port: 179,
+            ..Default::default()
+        }))
+    }
+}
+
+/// Serve `GlobalService` from a background thread for the lifetime of the
+/// test process; returns the address to pass as `--addr`.
+fn spawn_global_service() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = format!("http://{}", listener.local_addr().unwrap());
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            listener.set_nonblocking(true).unwrap();
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            tonic::transport::Server::builder()
+                .add_service(GlobalServiceServer::new(MockGlobalService))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+    });
+    addr
+}
+
 fn run_with_closed_stdout(args: &[&str]) {
     let (reader, writer) = UnixStream::pair().unwrap();
     drop(reader);
@@ -40,4 +85,10 @@ fn offline_commands_quietly_handle_closed_stdout() {
             "/tests/fixtures/import/frr.conf"
         ),
     ]);
+}
+
+#[test]
+fn connected_human_output_quietly_handles_closed_stdout() {
+    let addr = spawn_global_service();
+    run_with_closed_stdout(&["--addr", &addr, "global"]);
 }


### PR DESCRIPTION
## Summary

Rust ignores SIGPIPE, so every `println!`/`print!` in the connected command modules panicked with `failed printing to stdout` once the reader closed the pipe (`rbgp rib | head -1`), while JSON output already went through the fallible writer in `output.rs` and ended quietly with exit code 1.

- `output::print_result`'s human branch and `print_route_table` now use two new thin helpers, `print_line` and `print_text`, over the existing `write_text_line`/`write_bytes` against a locked stdout.
- Every `println!` in `crates/cli/src/commands/*.rs` (354 sites across 18 modules) becomes `outln!(...)?`, a small macro that formats and returns `print_line`'s result; the 17 `print!` sites become `output::print_text(&...)?`. Printer helpers that were infallible (`config.rs` plan/apply/history/confirmation/transaction-tail printers, `policy.rs` `print_statement_details`, `doctor.rs` `Reporter::record`) now return `Result<(), CliError>` and their callers propagate. `policy fmt --check` keeps its direct-exit shape and reports a write error through `report_write_error`, as `write_formatted_stdout` already does.
- A closed stdout therefore surfaces as an ordinary `BrokenPipe` write error, which `main_error_diagnostic` already keeps quiet with exit code 1.

No stdout `println!`/`print!` remains outside test modules in `crates/cli/src/commands` or `output.rs`.

## Byte identity

Captured before and after the change, at one test thread with `--nocapture`, so every human table and JSON document the unit tests render lands on the real stdout in a fixed order:

- `cargo test -p rustbgpctl --bin rbgp -- --nocapture --test-threads=1`: 2527 lines before and after; identical once temp-directory names, ephemeral ports, and the free-disk-space figure in the doctor bundle JSON are normalized (the only remaining differences were `1546.4 GiB` vs `1512.6 GiB`).
- `cargo test -p rustbgpctl --lib -- --nocapture --test-threads=1`: identical except one timing figure.
- `rbgp --help`: identical.

One visible side effect in the test harness only: human output from unit tests now bypasses the harness's per-test capture (stdout writes are not captured, unlike `println!`), exactly as the JSON helpers already did.

## Tests

- `crates/cli/tests/stdout_closed.rs` gains `connected_human_output_quietly_handles_closed_stdout`: an in-test tonic `GlobalService` on a background thread, then `rbgp --addr http://127.0.0.1:<port> global` with stdout closed. Before the fix it failed at `assert_eq!(output.status.code(), Some(1))` with `left: Some(101)` (the `println!` panic); after the fix it exits 1 with no `panicked`/`stack backtrace` on stderr.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo test -p rustbgpctl`
