### PR TITLE
telemetry: remove internal tracker identifiers from exported metric help and warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Prometheus metric help strings and runtime `warn` messages no longer carry
+  internal tracker identifiers; the behavioral explanation is kept and metric
+  names are unchanged. The public-text checker now also covers exported
+  runtime strings (metric help text and `tracing` message literals) in crate
+  sources, leaving comments, lint reasons, and test assertions untouched.
+
 - Policy prefix entries now reject `ge`/`le` bounds whose derived length range
   can never match: `le` below the prefix length, `ge` above `le`, or either
   bound below the prefix length or above the address-family maximum. TOML

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -1028,7 +1028,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 vni = ?key.0,
                 mac = %key.1,
                 "foreign kernel FDB row at this (vni, mac); operation withheld until the \
-                 foreign row goes away (LAN-283 fail-closed)"
+                 foreign row goes away (fail-closed)"
             );
         }
         self.state
@@ -1435,7 +1435,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             if l3_guard_failed {
                 tracing::warn!(
                     "L3 ownership guard dump failed; skipping all L3 kernel mutations this \
-                     pass (fail closed, LAN-283)"
+                     pass (fail closed)"
                 );
             }
             if let Some(live) = &l3_live {
@@ -1601,7 +1601,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                                     tracing::warn!(
                                         ?op,
                                         "foreign kernel row at this L3 key; install withheld \
-                                         until the foreign row goes away (LAN-283 fail-closed)"
+                                         until the foreign row goes away (fail-closed)"
                                     );
                                 }
                                 blocked_l3_now.insert(key);
@@ -1626,7 +1626,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             tracing::warn!(
                                 ?op,
                                 "live row under this L3 key is foreign; delete skipped and \
-                                 ownership relinquished (LAN-283)"
+                                 ownership relinquished"
                             );
                             crate::l3_diff::record_l3_success(
                                 &mut self.state.l3_owned,
@@ -1646,7 +1646,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             tracing::warn!(
                                 ?op,
                                 "L3VXLAN FDB row under this key is foreign; row delete \
-                                 skipped, group objects GC'd (LAN-283)"
+                                 skipped, group objects GC'd"
                             );
                             spare_foreign_nhg_row = true;
                         }
@@ -3236,7 +3236,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 vrf_id = key.0.as_u32(),
                 prefix = ?key.1,
                 "owned VRF route was replaced by a foreign entry; relinquishing ownership \
-                 (foreign row preserved, LAN-283)"
+                 (foreign row preserved)"
             );
         }
         let taken_neighbors: Vec<(u32, IpAddr)> = self
@@ -3254,7 +3254,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 l3vxlan_ifindex = key.0,
                 next_hop = %key.1,
                 "owned L3 neighbor was replaced by a foreign entry; relinquishing ownership \
-                 (foreign row preserved, LAN-283)"
+                 (foreign row preserved)"
             );
         }
         let taken_fdb: Vec<(u32, MacAddress)> = self
@@ -3272,7 +3272,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 l3vxlan_ifindex = key.0,
                 router_mac = %key.1,
                 "owned L3VXLAN FDB row was replaced by a foreign entry; relinquishing \
-                 ownership (foreign row preserved, LAN-283)"
+                 ownership (foreign row preserved)"
             );
         }
     }
@@ -3323,7 +3323,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 %mac,
                 ?vlan,
                 "owned FDB row was replaced by a foreign entry; relinquishing ownership \
-                 (foreign row preserved, LAN-283)"
+                 (foreign row preserved)"
             );
         }
     }
@@ -4274,7 +4274,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     tracing::warn!(
                         error = %e,
                         "shutdown snapshot dump failed; skipping owned-FDB drain (fail \
-                         closed, LAN-283) — next startup adopts the marker rows"
+                         closed) — next startup adopts the marker rows"
                     );
                     None
                 }
@@ -4313,8 +4313,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     tracing::warn!(
                         ?vni,
                         %mac,
-                        "foreign FDB row under owned key at shutdown; drain skips it \
-                         (LAN-283)"
+                        "foreign FDB row under owned key at shutdown; drain skips it"
                     );
                     continue;
                 }
@@ -4370,8 +4369,8 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 !l3_drain_plan.ops.is_empty() && !l3_ip_vrfs.is_empty() && l3_drain_live.is_none();
             if l3_drain_guard_failed {
                 tracing::warn!(
-                    "shutdown L3 ownership dump failed; skipping L3 drain (fail closed, \
-                     LAN-283) — next startup adopts the marker rows"
+                    "shutdown L3 ownership dump failed; skipping L3 drain (fail closed) — \
+                     next startup adopts the marker rows"
                 );
             }
             let l3_drain_ops: &[DataplaneOp] = if l3_drain_guard_failed {
@@ -4388,8 +4387,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             self.state.foreign_since_report.deletes_skipped += 1;
                             tracing::warn!(
                                 ?op,
-                                "foreign row under owned L3 key at shutdown; drain skips \
-                                 it (LAN-283)"
+                                "foreign row under owned L3 key at shutdown; drain skips it"
                             );
                             crate::l3_diff::record_l3_success(
                                 &mut self.state.l3_owned,
@@ -4408,8 +4406,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             self.state.foreign_since_report.deletes_skipped += 1;
                             tracing::warn!(
                                 ?op,
-                                "foreign row under owned L3 key at shutdown; drain skips \
-                                 it (LAN-283)"
+                                "foreign row under owned L3 key at shutdown; drain skips it"
                             );
                             continue;
                         }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1007,7 +1007,7 @@ impl BgpMetrics {
             Opts::new(
                 "bgp_rejected_routes_retained",
                 "Rejected inbound routes currently retained for the \
-                 looking-glass filtered-route surface (LAN-472), per peer. \
+                 looking-glass filtered-route surface, per peer. \
                  Bounded by [policy.reject_retention] capacity; refreshed on \
                  every retention mutation and reset on session reset.",
             ),
@@ -1056,7 +1056,7 @@ impl BgpMetrics {
 
         let rib_attr_intern_global_size = IntGauge::new(
             "bgp_rib_attr_intern_global_size",
-            "Unique attribute sets in the daemon-wide cross-peer intern table (LAN-336). Reclaim sweeps drop entries no route references; refreshed at every insert/remove batch seam.",
+            "Unique attribute sets in the daemon-wide cross-peer intern table. Reclaim sweeps drop entries no route references; refreshed at every insert/remove batch seam.",
         )
         .expect("valid metric definition");
 
@@ -1930,7 +1930,7 @@ impl BgpMetrics {
         let policy_dataset_refresh_errors = IntCounterVec::new(
             Opts::new(
                 "bgp_policy_dataset_refresh_errors_total",
-                "Policy dataset (LAN-305) refresh failures by dataset; the prior snapshot keeps serving probes.",
+                "Policy dataset refresh failures by dataset; the prior snapshot keeps serving probes.",
             ),
             &["dataset"],
         )
@@ -2268,25 +2268,25 @@ impl BgpMetrics {
 
         let evpn_foreign_replaces_blocked = IntCounter::new(
             "evpn_foreign_replaces_blocked_total",
-            "EVPN dataplane installs/replaces withheld because an exact-key foreign kernel row exists (LAN-283 fail-closed).",
+            "EVPN dataplane installs/replaces withheld because an exact-key foreign kernel row exists (fail-closed).",
         )
         .expect("valid metric definition");
 
         let evpn_foreign_deletes_skipped = IntCounter::new(
             "evpn_foreign_deletes_skipped_total",
-            "EVPN dataplane deletes skipped during withdrawal/NotReady/shutdown because the live kernel row is no longer rustbgpd's (LAN-283).",
+            "EVPN dataplane deletes skipped during withdrawal/NotReady/shutdown because the live kernel row is no longer rustbgpd's.",
         )
         .expect("valid metric definition");
 
         let evpn_foreign_owned_relinquished = IntCounter::new(
             "evpn_foreign_owned_relinquished_total",
-            "EVPN dataplane owned keys relinquished after a live snapshot showed a foreign writer replaced the row (LAN-283).",
+            "EVPN dataplane owned keys relinquished after a live snapshot showed a foreign writer replaced the row.",
         )
         .expect("valid metric definition");
 
         let evpn_foreign_nhid_range_conflicts = IntCounter::new(
             "evpn_foreign_nhid_range_conflicts_total",
-            "Foreign kernel nexthop objects found inside a rustbgpd-reserved NHID range (shape conflict; LAN-290 fail-closed quarantine). Counted once per conflicting ID.",
+            "Foreign kernel nexthop objects found inside a rustbgpd-reserved NHID range (shape conflict; fail-closed quarantine). Counted once per conflicting ID.",
         )
         .expect("valid metric definition");
 

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -368,7 +368,7 @@ impl PeerSession {
                     capacity,
                     backlog_for = ?since.elapsed(),
                     "peer flagged slow: session alive but outbound queue \
-                     persistently backlogged (LAN-470)"
+                     persistently backlogged"
                 );
             }
         } else {

--- a/scripts/check_public_tracker_ids.py
+++ b/scripts/check_public_tracker_ids.py
@@ -19,6 +19,16 @@ checksums; they are frozen captures, not living documentation. The
 exemption is derived from the seal files themselves rather than a hand-kept
 list, so it narrows automatically as receipts age out and cannot be widened
 by editing this guard.
+
+Exported runtime text is the one crate-source surface fenced here. Crate
+sources stay outside the document scan (see the scope note below), but two
+kinds of string literal inside them leave the repository at runtime:
+Prometheus metric help text and `tracing` event messages. An operator
+reading `/metrics` or a log line cannot resolve a tracker ID any more than
+a doc reader can, so those literals are matched by shape — a metric
+`Opts::new`/`IntGauge::new`-style registration or a `warn!`-family macro
+call — while comments, lint `reason` strings, test modules, and test
+directories keep the conventional in-repository cross-reference.
 """
 
 from __future__ import annotations
@@ -62,6 +72,22 @@ SCANNED_FILES = frozenset(
 
 # Binary blobs and compressed captures carry no reviewable prose.
 SKIPPED_SUFFIXES = frozenset({".gz", ".png", ".svg", ".zst", ".bin"})
+
+# Exported runtime text: `.rs` files under the daemon and crate source trees,
+# minus test directories and `tests.rs` modules. Within them only string
+# literals inside these call shapes are exported — metric registrations
+# (`Opts::new("name", "help")`, `IntGauge::new("name", "help")`, custom
+# collector `Desc::new`) and `tracing` event macros.
+RUNTIME_SOURCE = re.compile(r"^(?:src|crates/[^/]+/src)/.*\.rs$")
+RUNTIME_TEXT_HEAD = re.compile(
+    r"(?:\btracing::)?\b(?:error|warn|info|debug|trace)!\s*\("
+    r"|\b(?:Opts|HistogramOpts|Desc|IntCounter|IntGauge|Counter|Gauge|Histogram)"
+    r"::new\s*\("
+)
+STRING_LITERAL = re.compile(r'"(?:[^"\\]|\\[\s\S])*"')
+RAW_STRING_LITERAL = re.compile(r'r(#*)"[\s\S]*?"\1')
+CHAR_LITERAL = re.compile(r"'(?:[^'\\\n]|\\(?:x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]+\}|.))'")
+CFG_TEST = re.compile(r"#\[cfg\(test\)\]")
 
 TRACKER_ID = re.compile(r"\bLAN-\d+\b")
 HOME_PATH = re.compile(rb"/(?:home|Users)/(?![<$\{])[^/\s\"'<>]+")
@@ -264,6 +290,129 @@ def audit_document(relative: str, text: str) -> list[str]:
     return failures
 
 
+def _literal_end(code: str, index: int) -> int | None:
+    """Return the end of the string or char literal starting at `index`."""
+    char = code[index]
+    previous = code[index - 1] if index else " "
+    if char == '"':
+        match = STRING_LITERAL.match(code, index)
+    elif char == "'":
+        match = CHAR_LITERAL.match(code, index)
+    elif char == "r" and (previous == "b" or not (previous.isalnum() or previous == "_")):
+        match = RAW_STRING_LITERAL.match(code, index)
+    else:
+        match = None
+    return None if match is None else match.end()
+
+
+def _blank(text: str) -> str:
+    return re.sub(r"[^\n]", " ", text)
+
+
+def _blank_comments(text: str) -> str:
+    """Blank `//`, `///`, and `/* */` comments, keeping newlines and literals."""
+    out: list[str] = []
+    index = 0
+    while index < len(text):
+        end = _literal_end(text, index)
+        if end is not None:
+            out.append(text[index:end])
+            index = end
+        elif text.startswith("//", index):
+            end = text.find("\n", index)
+            end = len(text) if end < 0 else end
+            out.append(_blank(text[index:end]))
+            index = end
+        elif text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            end = len(text) if end < 0 else end + 2
+            out.append(_blank(text[index:end]))
+            index = end
+        else:
+            out.append(text[index])
+            index += 1
+    return "".join(out)
+
+
+def _balanced_end(code: str, index: int, open_char: str, close_char: str) -> int:
+    """Return the index just past the bracket closing the one at `index`."""
+    depth = 0
+    while index < len(code):
+        end = _literal_end(code, index)
+        if end is not None:
+            index = end
+            continue
+        if code[index] == open_char:
+            depth += 1
+        elif code[index] == close_char:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    return len(code)
+
+
+def _blank_test_modules(code: str) -> str:
+    """Blank every `#[cfg(test)]` block item in comment-free code."""
+    while match := CFG_TEST.search(code):
+        index = match.end()
+        while index < len(code) and code[index] not in "{;":
+            index = _literal_end(code, index) or index + 1
+        if index >= len(code) or code[index] == ";":
+            # A `#[cfg(test)] mod tests;` declaration or `use`: the body
+            # lives in a test directory that discovery already skips.
+            code = code[: match.start()] + _blank(match.group(0)) + code[match.end() :]
+            continue
+        end = _balanced_end(code, index, "{", "}")
+        code = code[: match.start()] + _blank(code[match.start() : end]) + code[end:]
+    return code
+
+
+def discover_runtime_sources() -> dict[str, str]:
+    """Map each runtime Rust source file to its text."""
+    sources: dict[str, str] = {}
+    for path in tracked_files():
+        relative = path.relative_to(ROOT).as_posix()
+        if not RUNTIME_SOURCE.match(relative):
+            continue
+        parts = Path(relative).parts
+        if "tests" in parts or path.stem == "tests":
+            continue
+        try:
+            sources[relative] = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+    if not sources:
+        raise TrackerIdGuardError(
+            "no runtime sources were discovered, so the walk is broken: "
+            "the repository ships src/ and crates/*/src/ Rust trees"
+        )
+    return dict(sorted(sources.items()))
+
+
+def audit_runtime_text(relative: str, text: str) -> list[str]:
+    """Report every private tracker ID exported by metric help or log text."""
+    code = _blank_test_modules(_blank_comments(text))
+    failures: list[str] = []
+    seen: set[tuple[int, str]] = set()
+    for head in RUNTIME_TEXT_HEAD.finditer(code):
+        open_paren = head.end() - 1
+        close = _balanced_end(code, open_paren, "(", ")")
+        for literal in STRING_LITERAL.finditer(code, open_paren, close):
+            for match in TRACKER_ID.finditer(literal.group(0)):
+                number = code.count("\n", 0, literal.start() + match.start()) + 1
+                if (number, match.group(0)) in seen:
+                    continue
+                seen.add((number, match.group(0)))
+                failures.append(
+                    f"{relative}:{number} exports the private tracker ID "
+                    f"{match.group(0)!r} in runtime text (metric help or log "
+                    "message), which an operator cannot resolve; keep the "
+                    "explanation and drop the ID"
+                )
+    return failures
+
+
 def audit_artifact_home_paths(
     paths: list[Path] | None = None, root: Path | None = None
 ) -> list[str]:
@@ -313,6 +462,7 @@ def audit_artifact_home_paths(
 def main() -> int:
     try:
         documents = discover_documents()
+        sources = discover_runtime_sources()
     except TrackerIdGuardError as error:
         print(f"public tracker ID check failed: {error}", file=sys.stderr)
         return 1
@@ -322,6 +472,11 @@ def main() -> int:
         for relative, text in documents.items()
         for failure in audit_document(relative, text)
     ]
+    failures.extend(
+        failure
+        for relative, text in sources.items()
+        for failure in audit_runtime_text(relative, text)
+    )
     try:
         failures.extend(audit_artifact_home_paths())
     except TrackerIdGuardError as error:
@@ -334,7 +489,7 @@ def main() -> int:
 
     print(
         f"public tracker ID check passed: {len(documents)} public documents "
-        "cite no private tracker IDs"
+        f"cite no private tracker IDs; {len(sources)} runtime sources export none"
     )
     return 0
 

--- a/scripts/test_check_public_tracker_ids.py
+++ b/scripts/test_check_public_tracker_ids.py
@@ -29,6 +29,54 @@ CLEAN_LINES = (
     "Milestone M84 covers multi-cache RTR conformance.",
 )
 
+RUNTIME_POSITIVES = {
+    "metric help": (
+        'let g = IntGauge::new(\n'
+        '    "bgp_example",\n'
+        '    "Example gauge (LAN-336). Refreshed per batch.",\n'
+        ')\n.expect("valid");\n'
+    ),
+    "metric opts help": (
+        'IntCounterVec::new(Opts::new("bgp_example_total", '
+        '"Counted (LAN-283 fail-closed)."), &["peer"])'
+    ),
+    "warn literal": (
+        "warn!(\n"
+        "    peer = %label,\n"
+        '    "peer flagged slow: outbound queue \\\n'
+        '     persistently backlogged (LAN-470)"\n'
+        ");\n"
+    ),
+    "error literal with tracing prefix": (
+        'tracing::error!(?op, "install withheld (LAN-283)");\n'
+    ),
+}
+
+RUNTIME_NEGATIVES = {
+    "comment": '// LAN-283 rule 1 observability\nwarn!("foreign row withheld");\n',
+    "doc comment": "/// LAN-283: keys withheld.\npub foreign: u32,\n",
+    "url in a string is not a comment": (
+        'warn!("see https://example.invalid/x"); // LAN-1 comment\n'
+    ),
+    "lint reason": (
+        '#[allow(dead_code, reason = "LAN-311 wiring lands later")]\nfn f() {}\n'
+    ),
+    "test module assertion": (
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        "    #[test]\n"
+        "    fn t() {\n"
+        '        assert_eq!(1, 1, "must hold (LAN-311)");\n'
+        '        warn!("even a log in tests (LAN-1)");\n'
+        "    }\n"
+        "}\n"
+    ),
+    "test module declaration does not swallow the file": (
+        "#[cfg(test)]\nmod tests;\n"
+        'let s = "not a metric or log literal (LAN-1)";\n'
+    ),
+}
+
 
 def write_fixture(root: Path, relative: str, contents: str | bytes) -> Path:
     path = root / relative
@@ -68,6 +116,34 @@ class PublicTrackerIdTests(unittest.TestCase):
             with self.subTest(line=line):
                 failures = guard.audit_document("docs/example.md", f"{line}\n")
                 self.assertEqual(failures, [], f"{line!r} must be accepted")
+
+    def test_repository_runtime_sources_are_discovered_and_clean(self) -> None:
+        sources = guard.discover_runtime_sources()
+        self.assertIn("crates/telemetry/src/metrics.rs", sources)
+        self.assertIn("src/main.rs", sources)
+        self.assertFalse(
+            [name for name in sources if "/tests/" in name or name.endswith("/tests.rs")],
+            "test directories and modules must stay out of the runtime scan",
+        )
+        for relative, text in sources.items():
+            with self.subTest(source=relative):
+                self.assertEqual(guard.audit_runtime_text(relative, text), [])
+
+    def test_exported_runtime_text_is_rejected(self) -> None:
+        for label, code in RUNTIME_POSITIVES.items():
+            with self.subTest(label=label):
+                failures = guard.audit_runtime_text("crates/x/src/lib.rs", code)
+                self.assertEqual(len(failures), 1, failures)
+                self.assertIn("crates/x/src/lib.rs:", failures[0])
+        # A continuation line reports the line the ID sits on.
+        failures = guard.audit_runtime_text("src/io.rs", RUNTIME_POSITIVES["warn literal"])
+        self.assertIn("src/io.rs:4 ", failures[0])
+        self.assertIn("'LAN-470'", failures[0])
+
+    def test_conventional_source_cross_references_are_accepted(self) -> None:
+        for label, code in RUNTIME_NEGATIVES.items():
+            with self.subTest(label=label):
+                self.assertEqual(guard.audit_runtime_text("src/lib.rs", code), [])
 
     def test_artifact_home_paths_cover_plain_gzip_and_placeholders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

Private tracker identifiers appeared in 22 exported runtime strings that operators see and cannot resolve. Each identifier is removed and the behavioral explanation kept. No metric name or log-message structure changes.

- `crates/telemetry` (7): help text of `bgp_rejected_routes_retained`, `bgp_rib_attr_intern_global_size`, `bgp_policy_dataset_refresh_errors_total`, `evpn_foreign_replaces_blocked_total`, `evpn_foreign_deletes_skipped_total`, `evpn_foreign_owned_relinquished_total`, `evpn_foreign_nhid_range_conflicts_total`.
- `crates/transport` (1): the slow-peer flagged warning.
- `crates/evpn-linux` (14): the foreign-row fail-closed, relinquish, and shutdown-drain warnings in the reconcile actor.

Published docs paraphrase rather than quote the help text and already carried no identifiers, so no `docs/` rows change.

## Checker

`scripts/check_public_tracker_ids.py` gains a second, narrow rule for exported runtime text. It scans `.rs` files under `src/` and `crates/*/src/` (excluding test directories, `tests.rs` modules, and `#[cfg(test)]` blocks) and reports tracker identifiers inside metric registration help strings (`Opts::new`, `IntGauge::new`, `IntCounter::new`, `HistogramOpts::new`, `Desc::new` and siblings) and `tracing` event macro literals, after blanking comments so in-repository cross-references and lint `reason` strings stay untouched. The recorded `docs/`-only decision for the document scan is unchanged and documented alongside the new rule in the header.

Run against the pre-fix tree, the rule reported exactly the 22 sites above; it passes on this branch. Self-tests add a metric help positive, a `warn!` positive, and comment, lint-reason, and test-module negatives.

## Compatibility

- Metric help text is a metrics surface; names, labels, and types are unchanged. Only the help wording loses the parenthesised identifier.
- Log message wording changes only by removing the identifier and its surrounding parenthesis.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-telemetry -p rustbgpd-transport -p rustbgpd-evpn-linux --all-targets -- -D warnings`
- `cargo test -p rustbgpd-telemetry`, `-p rustbgpd-transport`, `-p rustbgpd-evpn-linux`
- `python3 -m unittest scripts/test_check_public_tracker_ids.py` and `python3 scripts/check_public_tracker_ids.py`
- `scripts/check-metric-consumers.py` and `scripts/check_metric_release_notes.py` with their unit tests
- `python3 scripts/check-clippy-reasons.py`
