### PR TITLE
docs: correct two EVPN standards claims and record four RFCs against the VTEP lane

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -50,7 +50,7 @@ rustbgpd-vs-GoBGP comparison, which records the primary-source verification.
 | VPNv4 (RFC 4364) | Partial[^mpls-rr] | Yes | Yes | Yes | Yes |
 | VPNv6 | Partial[^mpls-rr] | Yes | Yes | Yes | Yes |
 | RT-Constrain (RFC 4684) | Partial[^mpls-rr] | Yes | Yes | Yes | No |
-| L2VPN EVPN (RFC 7432) | Partial[^evpn] | Yes | Yes | Yes | No |
+| L2VPN EVPN (RFC 7432) | Partial[^evpn] | Yes | Partial[^evpn-bird] | Yes | RIB only[^evpn-openbgpd] |
 | L2VPN VPLS | No | No | No | Yes | No |
 | IPv4 FlowSpec (RFC 8955) | Yes | Yes | Yes | Yes | Yes |
 | IPv6 FlowSpec | Yes | Yes | Yes | Yes | Yes |
@@ -94,6 +94,17 @@ IPv4/IPv6 `Prefix` routes.
     encapsulation, and VPWS/E-Tree remain demand-shaped service-provider
     breadth, not part of the current VXLAN/Linux alpha lane. See
     [evpn-enablement.md](evpn-enablement.md) for the full gate ladder.
+[^evpn-bird]: BIRD [3.3.2](https://bird.nic.cz/doc/bird-3.3.2.html) describes
+    its EVPN protocol as "a preliminary release limited to basic handling of
+    MAC and IMET EVPN routes"; the same manual lists EAD and ES routes as
+    "Currently not used by BIRD" and documents no IP Prefix (Type 5) route.
+    This claim is limited to that release.
+[^evpn-openbgpd]: OpenBGPD
+    [8.8](https://marc.info/?l=openbsd-announce&m=173887198302373) announced
+    "Preliminary support for EVPN in the RIB", and the
+    [OpenBSD-current `bgpd.conf(5)`](https://man.openbsd.org/bgpd.conf)
+    documents `announce EVPN [enforce]` per neighbor. The pinned 9.2 release
+    postdates 8.8; the announcement scopes the support to the RIB.
 
 ## Core Protocol
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -86,7 +86,10 @@ Known EVPN gaps:
 - True RFC VLAN-aware bundle VTEP origination and dataplane for non-zero
   Ethernet Tag remains future work; RR receive/reflect is implemented.
 - VXLAN local-bias split-horizon for all-active shared segments remains an
-  ASIC/offload-dependent limitation of the Linux softswitch path.
+  ASIC/offload-dependent limitation of the Linux softswitch path. RFC 9746
+  §2.2 makes local bias the only split-horizon mechanism for VXLAN (the ESI
+  Label Split Horizon Type MUST be 00 for tunnel type 8), so there is no
+  ESI-label alternative to implement for this lane.
 - Route types 6-11, PBB-EVPN, multicast EVPN, MPLS/SRv6 encapsulation,
   VPWS, and E-Tree are demand-shaped rather than part of the current
   VXLAN/Linux lane.

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -1596,8 +1596,11 @@ carries inactive (absent), unlimited (zero), or finite.
   `crates/evpn/src/df_election.rs` ships the pure
   `(state, event) → roles` state machine — RFC 7432 §8.5 service
   carving (sort candidates by originator IP ascending; `vni mod n`
-  picks the slot) plus RFC 8584 §3 algorithm negotiation (lowest
-  algorithm-id wins; `DefaultModulo` is the universal floor). New
+  picks the slot) plus RFC 8584 §2.2 algorithm negotiation (a
+  non-default algorithm runs only when every Type 4 route in the
+  segment advertises it; if even a single Type 4 advertisement is
+  received without the locally configured DF Alg, the RFC 7432 default
+  `DefaultModulo` MUST be used — the algorithm id is not a tiebreak). New
   `crates/evpn/src/origination_es.rs` ships three deterministic
   Type 1/4 originators: `LocalEsOriginator` (Type 4 ES),
   `LocalEadPerEsOriginator` (Type 1 EAD-per-ES with MAX_ET
@@ -1667,11 +1670,12 @@ carries inactive (absent), unlimited (zero), or finite.
 ## RFC 9012 / RFC 8365 — BGP Encapsulation Ext Community + VXLAN-EVPN
 
 - The BGP Encapsulation extended community (Type 0x03, Subtype 0x0C)
-  uses the widely-deployed **RFC 5512 layout** (4 bytes reserved +
-  2-byte Tunnel Type). RFC 9012 §4.1 specifies a different layout
-  (1-byte Tunnel Type + 5-byte Flags) but FRR, BIRD, Juniper, and
-  Cisco all emit the RFC 5512 form, so interop compatibility wins.
-- Tunnel Type values: 7 = NVGRE, 8 = VXLAN, 11 = MPLS-over-GRE.
+  carries 4 reserved bytes followed by a 2-byte Tunnel Type. RFC 9012
+  §4.1 (Figure 14) keeps the RFC 5512 layout unchanged — Reserved
+  (2 octets), Reserved (2 octets), Tunnel Type (2 octets) — so the
+  emitted form is the current standard, not a compatibility deviation.
+- Tunnel Type values (IANA BGP Tunnel Encapsulation Attribute Tunnel
+  Types): 8 = VXLAN, 9 = NVGRE, 11 = MPLS in GRE.
   `as_bgp_encapsulation()` returns the u16 tunnel type.
 - rustbgpd does not yet **negotiate** a preferred encap. VXLAN is
   assumed; non-VXLAN values are passed through untouched.
@@ -1718,6 +1722,22 @@ carries inactive (absent), unlimited (zero), or finite.
   tails, Linux softswitch local-bias limits, true shared-VNI / non-zero
   Ethernet Tag service, managed netdev ergonomics, and service-provider
   route families.
+
+---
+
+## Later EVPN standards against the VXLAN/Linux lane
+
+EVPN RFCs published after the lane's base set that bear on the VXLAN/Linux
+VTEP lane. Each row records the implementation status and why the standard
+matters to this lane.
+
+| RFC | Status | Relevance |
+|-----|--------|-----------|
+| RFC 9746 (Mar 2025; updates RFC 7432, RFC 8365) | Not implemented | Split Horizon Type (SHT) bits in the ESI Label extended community. §2.2: an egress NVE MUST NOT use an SHT other than 00 with VXLAN (tunnel type 8), so local bias is the only multi-homing split-horizon mechanism for VXLAN. This is the normative backing for the Linux softswitch local-bias limitation in [docs/LIMITATIONS.md](LIMITATIONS.md); the ESI Label decoder reads only the single-active flag. |
+| RFC 9785 (Jun 2025; updates RFC 8584) | Partial | Highest-/Lowest-Preference DF election is implemented (`df_algorithm`), under the same unanimous-or-default negotiation restated in §4.1. The Don't-Preempt (DP) bit is originated (`df_dont_preempt`) and parsed but is not an election input, so stateful non-revertive election is not implemented. |
+| RFC 9722 (May 2025; updates RFC 8584) | Not implemented | Fast DF recovery: a Service Carving Time extended community on the Type 4 route synchronizes the DF election timer across the segment's PEs so they carve at the same instant. rustbgpd runs each election on its own timer. |
+| RFC 9721 (Apr 2025; extends the RFC 7432 and RFC 9135 IRB procedures) | Not implemented | Extended IRB mobility: MAC/IP routes inherit the MAC route's sequence number, with duplicate detection extended to IP-to-different-MAC moves. rustbgpd keeps the RFC 7432 §15.1 per-route sequence rules, and the MAC-only local-move cascade decision is deferred in `crates/evpn/src/origination_macip.rs`. |
+| RFC 9786 (Jun 2025) | Not implemented | Port-active multi-homing redundancy mode (per-port active/standby). Demand-shaped alongside the other redundancy modes outside all-active and single-active. |
 
 ---
 


### PR DESCRIPTION
Docs-only accuracy pass over the EVPN standards claims in `docs/RFC_NOTES.md`, `docs/COMPARISON.md`, and `docs/LIMITATIONS.md`. Each change below quotes the primary source it was verified against.

## Corrections

**RFC 8584 algorithm negotiation** (`docs/RFC_NOTES.md`, Gate 8 entry). The note said "lowest algorithm-id wins; `DefaultModulo` is the universal floor". RFC 8584 section 2.2 says:

> Otherwise, if even a single advertisement for Route Type 4 is received without the locally configured DF Alg and capability, the default DF election algorithm MUST be used as prescribed in [RFC7432].

RFC 9785 section 4.1 restates the same fallback for the preference algorithms:

> ... assuming all the Ethernet Segment routes (including the local route) are consistent in this DF algorithm ... the PE runs the procedure in this section. Otherwise, the procedure falls back to the default DF algorithm.

`crates/evpn/src/df_election.rs` (`negotiate_algorithm`) already implements unanimous-or-default, and `crates/evpn/src/segment.rs` documents that "the ID is not a mismatch tiebreak". The doc now matches both.

**RFC 9012 Encapsulation extended community layout** (`docs/RFC_NOTES.md`). The note claimed RFC 9012 section 4.1 "specifies a different layout (1-byte Tunnel Type + 5-byte Flags)". Figure 14 in RFC 9012 section 4.1 is:

```
| 0x03 (1 octet)| 0x0c (1 octet)|       Reserved (2 octets)     |
|     Reserved (2 octets)       |    Tunnel Type (2 octets)     |
```

> The last two octets of the Value field encode a tunnel type.

The emitted layout was already correct; only the rationale was false. The adjacent tunnel-type list said `7 = NVGRE`; the IANA BGP Tunnel Encapsulation Attribute Tunnel Types registry lists 7 = IP in IP, 8 = VXLAN Encapsulation, 9 = NVGRE Encapsulation, 11 = MPLS in GRE Encapsulation, and RFC 9746 section 2.2 likewise cites "VXLAN (type 8), NVGRE (type 9)". The line now reads `8 = VXLAN, 9 = NVGRE, 11 = MPLS in GRE`. The rustdoc comment on `as_bgp_encapsulation` in `crates/wire/src/attribute.rs` carries the same `7 = NVGRE` value; it is left for a code follow-up since this PR is docs-only.

## Qualified comparison cells (`docs/COMPARISON.md`, L2VPN EVPN row)

**BIRD: `Yes` -> `Partial[^evpn-bird]`.** The BIRD 3.3.2 manual (EVPN section):

> The current EVPN implementation in BIRD is a preliminary release limited to basic handling of MAC and IMET EVPN routes, it will be subject to changes in the future.

and for both EAD and ES routes: "Currently not used by BIRD." The route-type list is EAD, MAC, IMET, ES; no IP Prefix route is documented.

**OpenBGPD: `No` -> `RIB only[^evpn-openbgpd]`.** The OpenBGPD 8.8 announcement (2025-02-06, openbsd-announce) lists:

> Preliminary support for EVPN in the RIB.

and OpenBSD-current `bgpd.conf(5)` documents `announce EVPN [enforce]` ("`EVPN` does not require a subsequent address family"). The pinned 9.2 release postdates 8.8. FRR and GoBGP cells were not touched.

## New rows (`docs/RFC_NOTES.md`, "Later EVPN standards against the VXLAN/Linux lane")

- **RFC 9746** (March 2025; Updates 7432, 8365) - not implemented. Section 2.2: "An egress NVE MUST NOT use an SHT value other than 00 when advertising an A-D per ES route with the following tunnel encapsulation types from [RFC9012]: VXLAN (type 8), NVGRE (type 9), MPLS (type 10), or no BGP Tunnel Encapsulation Extended Community at all." The local-bias entry in `docs/LIMITATIONS.md` now cites this.
- **RFC 9785** (June 2025; Updates 8584) - partial: preference election implemented; DP bit originated and parsed, non-revertive election not implemented (wording kept consistent with `docs/evpn-enablement.md` and `docs/CONFIGURATION.md`).
- **RFC 9722** (May 2025; Updates 8584) - not implemented: Service Carving Time synchronizes DF election timers across PEs.
- **RFC 9721** (April 2025; header carries no Updates line) - not implemented: extended IRB mobility; the row notes the deferred MAC-only local-move cascade decision in `crates/evpn/src/origination_macip.rs`.
- **RFC 9786** (June 2025) - not implemented: port-active redundancy mode, demand-shaped.

## Checks

- `python3 scripts/check_public_tracker_ids.py` - exit 0; `python3 -m unittest scripts/test_check_public_tracker_ids.py` - exit 0
- `just links` - exit 0 (lychee 0.24.2, offline; 0 errors)
- `python3 scripts/check_ixp_manager_docs.py` - exit 0; its unittest - exit 0 (the only doc checker under `scripts/`; no RFC-notes or comparison checker exists)
- No Rust changes; the commit hook's `cargo fmt`/`clippy` steps reported no files to check.
