### PR TITLE
rib: apply the shared identifier-first tiebreak to EVPN and skip locally originated routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,11 +208,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   lowest effective BGP Identifier, shorter CLUSTER_LIST, lowest peer address.
   Pairs that include a locally originated route skip the identifier step. The
   unicast, VPN, labeled-unicast, FlowSpec, BGP-LS, and RT-Constrain chains all
-  follow this order; the EVPN chain is unchanged. Explain output and BMP path
-  marking report the new `lower_bgp_identifier` reason when at least one side
-  was compared by its peer's identifier and keep `lower_originator_id` when
-  both carried ORIGINATOR_ID; both map to the path-marking "router ID" reason
-  code.
+  follow this order, as does the EVPN chain (next entry). Explain output and
+  BMP path marking report the new `lower_bgp_identifier` reason when at least
+  one side was compared by its peer's identifier and keep `lower_originator_id`
+  when both carried ORIGINATOR_ID; both map to the path-marking "router ID"
+  reason code.
+
+- **Operator-visible:** EVPN best-path selection now runs the same order
+  below eBGP-over-iBGP as every other family: lowest effective BGP Identifier
+  (ORIGINATOR_ID when present, else the advertising peer's BGP Identifier),
+  shorter CLUSTER_LIST, lowest peer address. Previously the EVPN chain
+  compared CLUSTER_LIST length before the identifier, and it compared a
+  locally originated VTEP route by its `0.0.0.0` injection sentinel. A pair
+  that includes a locally originated route now skips the identifier step, as
+  the other chains already do; such a pair is decided by CLUSTER_LIST length,
+  then the peer-address step, which the sentinel still wins, so its outcome is
+  unchanged.
 
 - Reject AS 0 in received and locally encoded AS paths and aggregators per RFC
   7607. Malformed ordinary paths are treated as withdraw, while affected AS4
@@ -505,6 +516,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   address. `rbgp rib --prefix <cidr> --explain` and BMP path marking report
   the new `lower_bgp_identifier` reason; `lower_originator_id` is retained
   for the both-ORIGINATOR_ID case.
+- **EVPN best-path selection can change after upgrade** between
+  otherwise-equal routes for the same EVPN key received from different
+  peers: the lowest effective BGP Identifier (ORIGINATOR_ID, else the
+  advertising peer's BGP Identifier) now decides before CLUSTER_LIST length,
+  and a locally originated VTEP route no longer wins the identifier step by
+  its `0.0.0.0` sentinel. Expect a one-time best-path change, and the
+  corresponding withdraw/announce toward VTEP peers, for keys whose paths
+  tied down to CLUSTER_LIST length across different identifiers. Pairs that
+  include a locally originated route keep their prior outcome.
 - Received `AS_PATH` attributes with more than 750 AS numbers and reachable
   NLRI are now treated as withdraw by default; without reachable NLRI, the
   session resets. Deployments that must relay arbitrarily long paths set

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -447,9 +447,9 @@ impl LocRib {
     ///
     /// Tie-break: Type 2 routes first run the MAC Mobility head (sticky
     /// flag + sequence number per RFC 7432 §15.1); all types then fall
-    /// through to the standard BGP chain (`LocalPref` → `AS_PATH` → MED
-    /// → eBGP>iBGP → peer address). DF-election hints for Type 1/4 are
-    /// left to downstream VTEPs; the RR just reflects.
+    /// through to the standard BGP chain (see `evpn_tiebreak_simple`).
+    /// DF-election hints for Type 1/4 are left to downstream VTEPs; the
+    /// RR just reflects.
     ///
     /// Returns `true` if the selection changed.
     pub fn recompute_evpn<'a>(
@@ -794,16 +794,17 @@ fn evpn_stale_rank(route: &EvpnRibRoute) -> u8 {
 /// a higher sequence number. Absence of the MAC Mobility community is
 /// treated as sequence=0, sticky=false per RFC 7432 §7.7.
 ///
-/// All route types then fall through to the standard BGP chain:
+/// All route types then fall through to the same chain as unicast
+/// `best_path_cmp` and the other family chains:
 /// stale → `LocalPref` → `AS_PATH` length → ORIGIN → MED →
-/// eBGP > iBGP → `CLUSTER_LIST` length → `ORIGINATOR_ID` → peer address.
+/// eBGP > iBGP → effective BGP Identifier → `CLUSTER_LIST` length →
+/// peer address.
 ///
-/// The EVPN chain deliberately differs from unicast `best_path_cmp` and
-/// the other family chains in two ways: `CLUSTER_LIST` length is compared
-/// before the identifier, and the identifier step (`ORIGINATOR_ID`, else
-/// the peer's BGP Identifier) runs for every route, including locally
-/// originated VTEP routes whose `peer_router_id` is the `0.0.0.0`
-/// sentinel.
+/// The identifier step compares `ORIGINATOR_ID` when present, else the
+/// advertising peer's BGP Identifier (RFC 4456 §9), and is skipped for
+/// any pair that includes a locally originated VTEP route: its
+/// `peer_router_id` is the `0.0.0.0` injection sentinel, not a BGP
+/// Identifier.
 fn evpn_tiebreak_simple(a: &EvpnRibRoute, b: &EvpnRibRoute) -> Ordering {
     // 0. Three-tier freshness: fresh (0) > GR-stale (1) > LLGR-stale (2)
     //    per RFC 4724 §4.2 / RFC 9494 §4.7. LLGR promotion clears
@@ -865,15 +866,17 @@ fn evpn_tiebreak_simple(a: &EvpnRibRoute, b: &EvpnRibRoute) -> Ordering {
         (false, true) => return Ordering::Greater,
         _ => {}
     }
-    // 6. Shorter CLUSTER_LIST wins (RFC 4456 §9).
-    match a.cluster_list().len().cmp(&b.cluster_list().len()) {
-        Ordering::Equal => {}
-        other => return other,
+    // 6. Lowest effective BGP Identifier (RFC 4271 §9.1.2.2 step (f);
+    //    ORIGINATOR_ID substitutes per RFC 4456 §9). Skipped for a pair
+    //    that includes a locally originated route.
+    if let Some((cmp, _)) = compare_bgp_identifier(
+        (a.origin_type, a.originator_id(), a.peer_router_id),
+        (b.origin_type, b.originator_id(), b.peer_router_id),
+    ) {
+        return cmp;
     }
-    // 7. Lower ORIGINATOR_ID wins (falls back to peer router-id, RFC 4456 §9).
-    let a_oid = a.originator_id().unwrap_or(a.peer_router_id);
-    let b_oid = b.originator_id().unwrap_or(b.peer_router_id);
-    match a_oid.cmp(&b_oid) {
+    // 7. Shorter CLUSTER_LIST wins (RFC 4456 §9).
+    match a.cluster_list().len().cmp(&b.cluster_list().len()) {
         Ordering::Equal => {}
         other => return other,
     }
@@ -3002,19 +3005,108 @@ mod tests {
     #[test]
     fn evpn_shorter_cluster_list_wins() {
         let short = make_evpn_type2(
-            2,
+            3,
             vec![PathAttribute::ClusterList(vec![Ipv4Addr::new(
                 10, 0, 0, 100,
             )])],
         );
-        let long = make_evpn_type2(
-            3,
+        let mut long = make_evpn_type2(
+            2,
             vec![PathAttribute::ClusterList(vec![
                 Ipv4Addr::new(10, 0, 0, 100),
                 Ipv4Addr::new(10, 0, 0, 200),
             ])],
         );
+        // Both routes share one BGP Identifier so the identifier step
+        // cannot decide, and `long` has the lower peer address
+        // (10.0.0.2 < 10.0.0.3) so the final tiebreak would pick it.
+        // CLUSTER_LIST length is therefore genuinely what decides.
+        long.peer_router_id = short.peer_router_id;
         assert_eq!(evpn_tiebreak_simple(&short, &long), Ordering::Less);
+        assert_eq!(evpn_tiebreak_simple(&long, &short), Ordering::Greater);
+    }
+
+    /// The effective BGP Identifier decides before `CLUSTER_LIST` length
+    /// (RFC 4271 §9.1.2.2 step (f), then RFC 4456 §9), matching every
+    /// other family chain: the route from the lower identifier wins even
+    /// with the longer `CLUSTER_LIST`.
+    #[test]
+    fn evpn_lower_bgp_identifier_beats_shorter_cluster_list() {
+        let low_id_long_list = make_evpn_type2(
+            2,
+            vec![PathAttribute::ClusterList(vec![
+                Ipv4Addr::new(10, 0, 0, 100),
+                Ipv4Addr::new(10, 0, 0, 200),
+            ])],
+        );
+        let high_id_short_list = make_evpn_type2(
+            3,
+            vec![PathAttribute::ClusterList(vec![Ipv4Addr::new(
+                10, 0, 0, 100,
+            )])],
+        );
+        assert_eq!(
+            evpn_tiebreak_simple(&low_id_long_list, &high_id_short_list),
+            Ordering::Less
+        );
+        assert_eq!(
+            evpn_tiebreak_simple(&high_id_short_list, &low_id_long_list),
+            Ordering::Greater
+        );
+    }
+
+    /// A route without `ORIGINATOR_ID` is compared by its advertising
+    /// peer's BGP Identifier against the other route's `ORIGINATOR_ID`
+    /// (RFC 4456 §9 substitution on one side only).
+    #[test]
+    fn evpn_originator_id_falls_back_to_peer_identifier_when_one_side_absent() {
+        let with_originator = make_evpn_type2(
+            2,
+            vec![PathAttribute::OriginatorId(Ipv4Addr::new(3, 3, 3, 3))],
+        );
+        let mut without = make_evpn_type2(3, vec![]);
+        without.peer_router_id = Ipv4Addr::new(1, 1, 1, 1);
+        // Peer address alone would pick `with_originator` (10.0.0.2 <
+        // 10.0.0.3); the identifier step must decide for `without`.
+        assert_eq!(
+            evpn_tiebreak_simple(&without, &with_originator),
+            Ordering::Less
+        );
+        assert_eq!(
+            evpn_tiebreak_simple(&with_originator, &without),
+            Ordering::Greater
+        );
+    }
+
+    /// A locally originated route carries the `0.0.0.0` injection sentinel
+    /// as `peer_router_id`, which is not a BGP Identifier. The identifier
+    /// step is skipped for any pair that includes one, so the pair falls
+    /// through to `CLUSTER_LIST` length: the received route with the
+    /// shorter list wins even though `0.0.0.0` would have won a naive
+    /// identifier comparison.
+    #[test]
+    fn evpn_local_route_skips_identifier_step() {
+        let mut local = make_evpn_type2(
+            0,
+            vec![PathAttribute::ClusterList(vec![Ipv4Addr::new(
+                10, 0, 0, 100,
+            )])],
+        );
+        local.origin_type = RouteOrigin::Local;
+        local.peer_router_id = Ipv4Addr::UNSPECIFIED;
+        let received = make_evpn_type2(2, vec![]);
+        assert_eq!(evpn_tiebreak_simple(&received, &local), Ordering::Less);
+        assert_eq!(evpn_tiebreak_simple(&local, &received), Ordering::Greater);
+
+        // With equal CLUSTER_LIST lengths the pair falls through to the
+        // peer-address step, where the sentinel `0.0.0.0` is lowest.
+        let mut local_plain = make_evpn_type2(0, vec![]);
+        local_plain.origin_type = RouteOrigin::Local;
+        local_plain.peer_router_id = Ipv4Addr::UNSPECIFIED;
+        assert_eq!(
+            evpn_tiebreak_simple(&local_plain, &received),
+            Ordering::Less
+        );
     }
 
     /// Regression: lower `ORIGINATOR_ID` breaks ties before peer address.

--- a/crates/rib/src/manager/tests/evpn.rs
+++ b/crates/rib/src/manager/tests/evpn.rs
@@ -1120,6 +1120,170 @@ async fn inject_evpn_reflects_to_peer() {
     handle.await.unwrap();
 }
 
+fn with_evpn_cluster_list(mut route: EvpnRibRoute, ids: &[Ipv4Addr]) -> EvpnRibRoute {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::ClusterList(ids.to_vec()));
+    route
+}
+
+async fn evpn_rr_client_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: Ipv4Addr,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: IpAddr::V4(peer),
+        peer_asn: 65000,
+        peer_router_id: peer,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: evpn_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+    out_rx
+}
+
+async fn evpn_routes_received(tx: &mpsc::Sender<RibUpdate>, peer: Ipv4Addr, route: EvpnRibRoute) {
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(peer),
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![route],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+}
+
+async fn next_evpn_announce_next_hop(
+    out_rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+    what: &str,
+) -> IpAddr {
+    let msg = tokio::time::timeout(Duration::from_secs(2), out_rx.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{what}: expected an EVPN announce within 2s"))
+        .expect("outbound channel open");
+    assert_eq!(
+        msg.evpn_announce.len(),
+        1,
+        "{what}: {:?}",
+        msg.evpn_announce
+    );
+    msg.evpn_announce[0].next_hop
+}
+
+/// A locally injected EVPN route carries the `0.0.0.0` injection sentinel
+/// as `peer_router_id`, so the identifier step is skipped for any pair
+/// that includes it and the pair falls through to `CLUSTER_LIST` length.
+/// A received route for the same key with the shorter list wins and is
+/// what the reflector's other client receives.
+#[tokio::test]
+async fn inject_evpn_local_route_yields_to_shorter_cluster_list() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = Ipv4Addr::new(10, 0, 0, 1);
+    let client = Ipv4Addr::new(10, 0, 0, 2);
+    let _source_rx = evpn_rr_client_up(&tx, source).await;
+    let mut client_rx = evpn_rr_client_up(&tx, client).await;
+
+    let mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x07];
+    let mut local = make_evpn_macip(Ipv4Addr::UNSPECIFIED, mac, None, false);
+    local.origin_type = crate::route::RouteOrigin::Local;
+    let local = with_evpn_cluster_list(local, &[Ipv4Addr::new(10, 0, 0, 200)]);
+    let key = local.key();
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::InjectEvpn {
+        route: local,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx
+        .await
+        .expect("inject reply")
+        .expect("inject succeeds");
+    assert_eq!(
+        next_evpn_announce_next_hop(&mut client_rx, "injected route").await,
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    );
+
+    // Same key from a client, no CLUSTER_LIST: the shorter list wins over
+    // the local route because the identifier step is skipped for the pair.
+    let received = make_evpn_macip(source, mac, None, false);
+    assert_eq!(received.key(), key);
+    evpn_routes_received(&tx, source, received).await;
+    assert_eq!(
+        next_evpn_announce_next_hop(&mut client_rx, "received route replaces local").await,
+        IpAddr::V4(source)
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Between two received EVPN routes for one key, the lower advertising
+/// BGP Identifier decides before `CLUSTER_LIST` length, so the reflector
+/// switches its clients to the route from the lower identifier even
+/// though it carries the longer list.
+#[tokio::test]
+async fn evpn_lower_identifier_reflected_over_shorter_cluster_list() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let low_id = Ipv4Addr::new(10, 0, 0, 1);
+    let high_id = Ipv4Addr::new(10, 0, 0, 2);
+    let client = Ipv4Addr::new(10, 0, 0, 3);
+    let _low_rx = evpn_rr_client_up(&tx, low_id).await;
+    let _high_rx = evpn_rr_client_up(&tx, high_id).await;
+    let mut client_rx = evpn_rr_client_up(&tx, client).await;
+
+    let mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x08];
+    let short_list = with_evpn_cluster_list(
+        make_evpn_macip(high_id, mac, None, false),
+        &[Ipv4Addr::new(10, 0, 0, 200)],
+    );
+    let long_list = with_evpn_cluster_list(
+        make_evpn_macip(low_id, mac, None, false),
+        &[Ipv4Addr::new(10, 0, 0, 200), Ipv4Addr::new(10, 0, 0, 201)],
+    );
+    assert_eq!(short_list.key(), long_list.key());
+
+    evpn_routes_received(&tx, high_id, short_list).await;
+    assert_eq!(
+        next_evpn_announce_next_hop(&mut client_rx, "first route").await,
+        IpAddr::V4(high_id)
+    );
+
+    evpn_routes_received(&tx, low_id, long_list).await;
+    assert_eq!(
+        next_evpn_announce_next_hop(&mut client_rx, "lower identifier becomes best").await,
+        IpAddr::V4(low_id)
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Withdrawing an unknown EVPN key surfaces a user-visible error
 /// (controller got a bad route identifier).
 #[tokio::test]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -508,7 +508,7 @@ Added 2026-04 per ADR-0050. Extends the RIB / transport / gRPC stack with a para
 
 **Reflection reuses existing RFC 4456 helper.** `stage_evpn_routes` builds a synthetic `Route` probe carrying only peer / router-id / origin-type metadata and passes it to the existing `should_suppress_ibgp_inner`. Same pattern FlowSpec uses — no EVPN-specific reflection logic.
 
-**Best-path: type-specific head + shared BGP body.** `evpn_tiebreak_simple` runs a Type-2-specific MAC Mobility head (sticky flag + sequence per RFC 7432 §15.1), then falls through to the standard BGP chain (LocalPref → AS_PATH → MED → eBGP>iBGP → peer). Type 1/4 DF-election tiebreaks are not implemented — the RR reflects, downstream VTEPs elect. Types 3/5 have no type-specific head.
+**Best-path: type-specific head + shared BGP body.** `evpn_tiebreak_simple` runs the stale rank and a Type-2-specific MAC Mobility head (sticky flag + sequence per RFC 7432 §15.1), then falls through to the same chain as unicast (LocalPref → AS_PATH → ORIGIN → MED → eBGP>iBGP → effective BGP Identifier → CLUSTER_LIST length → peer address, with the identifier step skipped for a pair that includes a locally originated route). Type 1/4 DF-election tiebreaks are not implemented — the RR reflects, downstream VTEPs elect. Types 3/5 have no type-specific head.
 
 **Policy uses placeholder prefix.** EVPN `RouteContext` carries a synthesized `0.0.0.0/0` prefix — the existing context fields (extended communities, communities, AS_PATH, peer metadata) are what operators actually filter on. RT-based filtering works through the existing `match_community` clause. A dedicated `match_evpn_route_type` clause shipped in v0.11.0 and matches the RFC 7432 §7 / RFC 9136 route type directly.
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -1400,19 +1400,19 @@ carries inactive (absent), unlimited (zero), or finite.
   branches emit a proper EVPN withdrawal toward the looping peer
   (rather than silently dropping the route in the Adj-RIB-Out), so a
   client that previously received the route observes a clean retract.
-- **Best-path tie-break:** the EVPN best-path chain runs the full
-  RFC 4456 ordering after the BGP body — stale flag → ORIGIN →
-  shortest CLUSTER_LIST → lowest ORIGINATOR_ID — matching the unicast
-  decision process so a reflector with multiple equal-AS paths
-  converges deterministically. The EVPN identifier step has always
-  fallen back to the advertising peer's BGP Identifier when
-  ORIGINATOR_ID is absent. The unicast, VPN, labeled-unicast, FlowSpec,
-  BGP-LS, and RT-Constrain chains now do the same (see the RFC 4271
-  §9.1.2.2 notes under Milestone 1) but, per RFC 4456 §9, compare the
-  identifier before CLUSTER_LIST length and
-  skip the step for locally originated routes. EVPN keeps its
-  CLUSTER_LIST-first order and applies the identifier step to every
-  route, including locally originated VTEP routes.
+- **Best-path tie-break:** the EVPN best-path chain runs the same
+  ordering as the unicast decision process after the MAC Mobility head —
+  stale flag → LOCAL_PREF → AS_PATH length → ORIGIN → MED → eBGP over
+  iBGP → lowest effective BGP Identifier → shortest CLUSTER_LIST →
+  lowest peer address — so a reflector with multiple equal-AS paths
+  converges deterministically. The identifier step compares
+  ORIGINATOR_ID when present and otherwise the advertising peer's BGP
+  Identifier (RFC 4456 §9), the same substitution the unicast, VPN,
+  labeled-unicast, FlowSpec, BGP-LS, and RT-Constrain chains apply (see
+  the RFC 4271 §9.1.2.2 notes under Milestone 1). Every family uses this
+  order, and every family skips the identifier step for a pair that
+  includes a locally originated route: a locally originated VTEP route
+  carries the `0.0.0.0` injection sentinel, not a BGP Identifier.
 - **Initial dump on session up:** when an iBGP EVPN session reaches
   Established, the existing Adj-RIB-In is replayed to the new peer
   through the same Adj-RIB-Out path that handles steady-state

--- a/docs/adr/0050-evpn-route-reflector.md
+++ b/docs/adr/0050-evpn-route-reflector.md
@@ -126,6 +126,13 @@ Not forked into its own function: keeping a single `evpn_tiebreak_simple`
 with a dispatch head is cheaper to maintain than a per-route-type
 function tree.
 
+> **Superseded ordering, 2026-09-04:** the shared BGP body above predates
+> the RFC 4456 attributes. The chain now runs the same order as unicast —
+> effective BGP Identifier (ORIGINATOR_ID, else the advertising peer's
+> BGP Identifier) before CLUSTER_LIST length, then peer address — and
+> skips the identifier step for a pair that includes a locally originated
+> route. `docs/DESIGN.md` (EVPN best-path) records the current chain.
+
 ### 6 typed extended-community accessors
 
 Added to `ExtendedCommunity`:


### PR DESCRIPTION
## Summary

`evpn_tiebreak_simple` (`crates/rib/src/loc_rib.rs`) is aligned to the identifier-first tiebreak that every other family chain already runs.

**Old order** below eBGP-over-iBGP: shorter CLUSTER_LIST → lower ORIGINATOR_ID, falling back to the peer's BGP Identifier for every route, including locally originated VTEP routes whose `peer_router_id` is the `0.0.0.0` injection sentinel → lower peer address.

**New order:** lowest effective BGP Identifier via the shared `compare_bgp_identifier` (ORIGINATOR_ID when present, else the advertising peer's BGP Identifier; skipped for any pair that includes a `RouteOrigin::Local` route) → shorter CLUSTER_LIST → lower peer address. Steps 0–5 (stale rank, MAC Mobility head, LOCAL_PREF, AS_PATH, ORIGIN, MED, eBGP over iBGP) are untouched.

**Sentinel exclusion.** All four origination sites (`src/evpn_originator/mod.rs`, `src/evpn_imet.rs`, `src/evpn_segment.rs`, `src/evpn_l3_originator.rs`) build `RouteOrigin::Local` routes with `peer = peer_router_id = 0.0.0.0`. The identifier step no longer compares that sentinel. Note that this does not change the selection outcome for a local-vs-received pair: CLUSTER_LIST length keeps its position relative to the peer-address step, and the peer-address step is decided by the same `0.0.0.0` sentinel. The operator-visible change is confined to received-vs-received pairs whose identifiers and CLUSTER_LIST lengths disagree. The CHANGELOG and upgrade note say so.

## Tests

Pre-fix runs were captured before the comparator change:

- `loc_rib::tests::evpn_lower_bgp_identifier_beats_shorter_cluster_list` — fails pre-fix at `crates/rib/src/loc_rib.rs:3045` (`left: Greater, right: Less`).
- `manager::tests::evpn::evpn_lower_identifier_reflected_over_shorter_cluster_list` — two RR clients advertise one MAC/IP key; the lower identifier carries the longer CLUSTER_LIST; a third client must be switched to it. Fails pre-fix with `lower identifier becomes best: expected an EVPN announce within 2s` (the reflector kept the shorter-list route).
- `evpn_shorter_cluster_list_wins` — peer octets swapped and the identifiers made equal, so CLUSTER_LIST length is genuinely what decides (the swap alone would let the identifier step decide for `long`).
- `evpn_originator_id_falls_back_to_peer_identifier_when_one_side_absent`, `evpn_local_route_skips_identifier_step`, and the manager-level `inject_evpn_local_route_yields_to_shorter_cluster_list` pass before and after; they pin the one-sided substitution and the sentinel exclusion (the last two pass pre-fix because CLUSTER_LIST ran first there).

The MAC Mobility, stale/LLGR, and label-change tests are untouched.

## Docs

- `docs/RFC_NOTES.md` — EVPN best-path paragraph now states the shared order and the local-route skip.
- `docs/DESIGN.md` — EVPN chain summary corrected to the full order.
- `docs/adr/0050-evpn-route-reflector.md` — dated superseding note appended after the best-path block; the block itself is unchanged.
- `docs/evpn-enablement.md` — the sentence naming `evpn_tiebreak_simple` describes sticky preservation, not the order; left unchanged.
- `CHANGELOG.md` — `### Changed` entry and an upgrade note; the earlier best-path entry's "the EVPN chain is unchanged" clause is amended so the two entries agree.

## Why no lab run

The comparator has a single caller (`LocRib::recompute_evpn`) and no wire or netlink surface, and every EVPN lab topology is single-originator per key, so a lab cannot exercise the pair this change decides. The manager-level test covers the reflection path end to end.

## Gates

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p rustbgpd-rib --all-targets -- -D warnings` | 0 |
| `cargo test -p rustbgpd-rib` (1263 passed, 2 ignored) | 0 |
| `cargo test --bin rustbgpd evpn` (493 passed) | 0 |
| `python3 scripts/check-v1-stable-surface.py` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `just links` | 0 |
