### PR TITLE
wire: correct the tunnel type numbers in the encapsulation accessor docs

### DIFF
--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -392,8 +392,10 @@ impl ExtendedCommunity {
     /// per the widely-deployed RFC 5512 layout: 4-byte reserved + 2-byte
     /// Tunnel Type). Type 0x03, subtype 0x0C.
     ///
-    /// Returns the Tunnel Type code. For VXLAN-EVPN (RFC 8365), the value is
-    /// 8. Other common values: 7 = NVGRE, 11 = MPLS-over-GRE.
+    /// Returns the Tunnel Type code from the IANA "BGP Tunnel Encapsulation
+    /// Attribute Tunnel Types" registry. Registry values include 8 = VXLAN,
+    /// 9 = NVGRE, 10 = MPLS, 11 = MPLS in GRE, 12 = VXLAN GPE, and
+    /// 13 = MPLS in UDP (RFC 7510); RFC 8365 overlays use 8, 9, and 11.
     ///
     /// The reserved bytes are intentionally not validated here: RFC 5512
     /// specifies MUST-zero on send, ignored on receive. FRR, `GoBGP`, Cisco,


### PR DESCRIPTION
## Summary

The `ExtendedCommunity::as_bgp_encapsulation` doc comment listed `7 = NVGRE`. Per the IANA "BGP Tunnel Encapsulation Attribute Tunnel Types" registry, 7 is IP in IP and NVGRE is 9. The comment now lists the RFC 8365 overlay values and cites the registry.

Registry rows (https://www.iana.org/assignments/bgp-tunnel-encapsulation/bgp-tunnel-encapsulation.xhtml):

| Value | Description | Reference |
|---|---|---|
| 7 | IP in IP | RFC 9012 |
| 8 | VXLAN Encapsulation | RFC 8365 |
| 9 | NVGRE Encapsulation | RFC 8365 |
| 10 | MPLS Encapsulation | RFC 8365 |
| 11 | MPLS in GRE Encapsulation | RFC 8365 |
| 12 | VXLAN GPE Encapsulation | RFC 8365 |
| 13 | MPLS in UDP Encapsulation | RFC 7510 |

Doc comment only. The one code constant carrying a tunnel type (`VXLAN_ENCAP: u16 = 8` in `crates/evpn/src/ip_vrf/origination.rs`) already matches the registry; no behavior change.

## Checks

- `cargo fmt --all -- --check`
- `cargo doc --locked -p rustbgpd-wire --no-deps`
- `cargo test -p rustbgpd-wire --doc`