### PR TITLE
ci: run the netns receipt and fuzz corpus cache self-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,12 @@ jobs:
       - name: Prove kernel-dataplane bird3 outage tolerance
         run: |
           python3 -m unittest -v scripts/test_kernel_dataplane_bird3_tolerance.py
+      # The Kernel Dataplane gate finalizes its netns selector receipt with
+      # this helper; its selector rosters and fail-closed summary have no
+      # other executor, so prove them here.
+      - name: Prove netns selector receipt finalizer
+        run: |
+          python3 -m unittest -v scripts/test_check_netns_selector_receipt.py
       - uses: dtolnay/rust-toolchain@v1 # stable
         with:
           toolchain: stable
@@ -141,6 +147,11 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_fuzz_toolchain_pin.py
           python3 scripts/check_fuzz_toolchain_pin.py
+      # The scheduled fuzz campaign restores and seals its corpus through this
+      # helper; nothing else executes its boundary tests.
+      - name: Prove fuzz corpus cache boundary
+        run: |
+          python3 -m unittest -v scripts/test_fuzz_corpus_cache.py
       - name: Install receipt-tool dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary

`scripts/test_check_netns_selector_receipt.py` and `scripts/test_fuzz_corpus_cache.py` were executed by no workflow and no `just` recipe. Every other `scripts/test_*.py` self-test runs in the `core` job, another workflow, or the justfile. Both are now run from the repository root in the `core` job, next to the existing checker self-tests.

- The netns test lands after the kernel-dataplane bird3 tolerance proof; it imports `scripts.check_netns_selector_receipt`, so the root working directory matters.
- The fuzz corpus cache test lands after the fuzz-toolchain pin proof, beside the other fuzz-helper self-tests that already run in `core`.

Neither helper runs standalone locally (both consume lane artifacts), so they follow the existing split and are not added to `just gate`, which only carries self-tests paired with a checker it also executes. The `classify_heavy_ci_paths.py` and image-primer fixture path lists are unchanged: they classify which heavy rosters a diff triggers, and adding an executor does not move either file.

## Checks

| Command | Exit |
| --- | --- |
| `python3 -m unittest -v scripts/test_check_netns_selector_receipt.py` (4 tests) | 0 |
| `python3 -m unittest -v scripts/test_fuzz_corpus_cache.py` (9 tests) | 0 |
| `python3 scripts/check_ci_image_primer_contract.py` | 0 |
| `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py` (53 tests) | 0 |
| `python3 scripts/check_ci_scale_split_contract.py` | 0 |
| `python3 scripts/check_developer_tooling.py` | 0 |
| `actionlint .github/workflows/ci.yml` | 0 |

Bare `actionlint` over the whole tree exits 1 on four pre-existing SC2086 info notes in `fuzz.yml`, which this change does not touch; the CI gate (`check_developer_tooling.py`) passes.
