### PR TITLE
ci: test the scale-harness workspace in one invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,14 +364,8 @@ jobs:
       - name: Check standalone scale harnesses and receipt classifiers
         run: |
           set -euo pipefail
-          cargo fmt --manifest-path bench/scale/rrharness/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/rrtransport/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/reloadstall/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml -- --check
-          cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked
+          cargo fmt --manifest-path bench/scale/Cargo.toml --all -- --check
+          cargo test --manifest-path bench/scale/Cargo.toml --workspace --locked
           cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml \
             --locked --all-targets -- -D warnings
           cargo run --manifest-path bench/scale/rrtransport/Cargo.toml --locked -- smoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,10 @@ The recipes intentionally expose their direct commands:
 - `just gate-rib` compiles the feature-gated RIB, transport, and API benchmark
   surfaces that the default workspace build cannot see, including the root
   FIB projection and both API feature combinations.
-- `just gate-deps` tests the four standalone scale-harness manifests. These
-  manifests share `bench/scale/Cargo.lock`, which is separate from the
-  workspace lockfile, and can add substantial cold-build time.
+- `just gate-deps` tests the standalone scale-harness workspace under
+  `bench/scale` in one invocation. That workspace has its own
+  `bench/scale/Cargo.lock`, separate from the root lockfile, and can add
+  substantial cold-build time.
 - `just gate-contract` executes every Criterion benchmark body once without
   collecting timings, with locked dependency resolution and fail-fast local
   behavior. The harness is Linux/GNU-Bash oriented and requires the same local

--- a/justfile
+++ b/justfile
@@ -55,12 +55,9 @@ gate-rib:
     cargo check --locked -p rustbgpd-api --features bench-internals --benches
     cargo check --locked -p rustbgpd-api --features bench-internals,vpn-query-allocation --bench vpn_query_allocation
 
-# Test the four standalone scale-harness manifests used by CI.
+# Test the standalone scale-harness workspace used by CI.
 gate-deps:
-    cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked
-    cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked
-    cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked
-    cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked
+    cargo test --manifest-path bench/scale/Cargo.toml --workspace --locked
 
 # Execute every Criterion benchmark body once without collecting timings.
 gate-contract:

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -33,10 +33,7 @@ EXPECTED_ROOT_COMMANDS = {
     WORKFLOWS[5]: Counter(test=3),
 }
 EXPECTED_STANDALONE_COMMANDS = (
-    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked"),
-    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked"),
-    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked"),
-    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked"),
+    (WORKFLOWS[0], "cargo test --manifest-path bench/scale/Cargo.toml --workspace --locked"),
     (WORKFLOWS[0],
      "cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml --locked --all-targets -- -D warnings"),
     (WORKFLOWS[0], "cargo run --manifest-path bench/scale/rrtransport/Cargo.toml --locked -- smoke"),

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -111,8 +111,8 @@ class ScaleSplitContractTests(unittest.TestCase):
             ),
             (
                 WORKFLOW,
-                "bench/scale/rrharness/Cargo.toml --locked",
-                "bench/scale/rrharness/Cargo.toml",
+                "bench/scale/Cargo.toml --workspace --locked",
+                "bench/scale/Cargo.toml --workspace",
             ),
             (
                 WORKFLOW,


### PR DESCRIPTION
## Summary

`bench/scale/Cargo.toml` is a Cargo workspace with four members (`enhanced-route-refresh`, `reloadstall`, `rrharness`, `rrtransport`), but `just gate-deps` and the `scale_receipts` job in `ci.yml` still ran `cargo fmt` and `cargo test` once per member through `--manifest-path bench/scale/<member>/Cargo.toml`. Each quartet is now a single invocation:

- `cargo fmt --manifest-path bench/scale/Cargo.toml --all -- --check`
- `cargo test --manifest-path bench/scale/Cargo.toml --workspace --locked`

`scripts/check_ci_scale_split_contract.py` freezes the standalone command inventory, so `EXPECTED_STANDALONE_COMMANDS` now carries the one workspace test literal in place of the four per-member literals, and the self-test's `--locked` mutation targets that line. The `CONTRIBUTING.md` description of `gate-deps` no longer says "four standalone manifests". The two per-member `cargo clippy` lines are left as they are.

## Member coverage

Both shapes run the same four test binaries with the same counts (the workspace runs members alphabetically):

| Binary | Per-member quartet | Workspace invocation |
| --- | --- | --- |
| `rrharness` | 11 passed | 11 passed |
| `rrtransport` | 7 passed | 7 passed |
| `reloadstall` | 32 passed | 32 passed |
| `enhanced_route_refresh_receipt` | 2 passed | 2 passed |

`cargo fmt --manifest-path bench/scale/Cargo.toml --all -v -- --check` lists source files from all four member directories.

## Checks

| Command | Exit |
| --- | --- |
| `python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py` (6 tests) | 0 |
| `python3 scripts/check_ci_scale_split_contract.py` | 0 |
| `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py` (53 tests) | 0 |
| `python3 scripts/check_ci_image_primer_contract.py` | 0 |
| `python3 scripts/check_developer_tooling.py` | 0 |
| `actionlint .github/workflows/ci.yml` | 0 |
| `cargo fmt --manifest-path bench/scale/Cargo.toml --all -- --check` | 0 |
| `just gate-deps` (cold target, 52 tests across four binaries) | 0 |
| old per-member `cargo test` quartet, for comparison | 0 |
