### PR TITLE
ci: shellcheck the rrharness comparison driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,8 @@ jobs:
             bench/tests/test-rrtransport-receipt.sh \
             bench/tests/test-scale-provenance.sh \
             bench/tests/test-route-server-1000-receipt.sh \
-            bench/tests/test-scale-host-quiet.sh
+            bench/tests/test-scale-host-quiet.sh \
+            bench/scale/compare-rrharness.sh
           shellcheck bench/tests/test-vpn-query-receipt.sh
           shellcheck bench/tests/test-vpn-query-campaign.sh \
             bench/run-vpn-query-campaign.sh


### PR DESCRIPTION
## Summary

`bench/scale/compare-rrharness.sh` was syntax-checked with `bash -n` in the `scale_receipts` job but was absent from the shellcheck roster that covers every other `bench/scale` driver and its receipt tests. It is now appended to that roster. The existing roster lines keep their order and wrapping; the previous last entry only gains a `\` continuation.

shellcheck 0.9.0 reports no findings for the script before or after, so the script itself is unchanged.

## shellcheck output

```
$ shellcheck bench/scale/compare-rrharness.sh
(no output, exit 0)
$ shellcheck <full roster from ci.yml, including bench/scale/compare-rrharness.sh>
(no output, exit 0)
```

## Checks

| Command | Exit |
| --- | --- |
| `shellcheck bench/scale/compare-rrharness.sh` | 0 |
| `shellcheck` over the full updated roster | 0 |
| `python3 scripts/check_ci_image_primer_contract.py` | 0 |
| `python3 scripts/check_ci_scale_split_contract.py` | 0 |
| `python3 scripts/check_developer_tooling.py` | 0 |
| `actionlint .github/workflows/ci.yml` | 0 |
| `bash bench/tests/test-compare-criterion-harness.sh` | 0 |
| `bash bench/tests/test-rrharness-driver.sh` | 0 |
