### PR TITLE
test: await the residue cleanup thread instead of polling under a short budget

### DIFF
--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1978,7 +1978,10 @@ impl ConfigTransactionController {
             Ok(handle) => {
                 #[cfg(test)]
                 {
-                    *self.v3_residue_cleanup_thread.lock().unwrap() = Some(handle);
+                    *self
+                        .v3_residue_cleanup_thread
+                        .lock()
+                        .expect("cleanup thread handle slot must not be poisoned") = Some(handle);
                 }
                 #[cfg(not(test))]
                 drop(handle);

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -85,6 +85,10 @@ pub struct ConfigTransactionController {
     settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
     #[cfg(test)]
     v3_residue_cleanup_spawn_fail: Arc<AtomicBool>,
+    /// The most recently spawned residue cleanup thread, so tests can join it
+    /// instead of polling for the singleton release.
+    #[cfg(test)]
+    v3_residue_cleanup_thread: Arc<std::sync::Mutex<Option<std::thread::JoinHandle<()>>>>,
 }
 
 #[derive(Default)]
@@ -299,6 +303,8 @@ impl ConfigTransactionController {
             v3_residue_cleanup_active: Arc::new(AtomicBool::new(false)),
             settlement: None,
             v3_residue_cleanup_spawn_fail: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            v3_residue_cleanup_thread: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -319,6 +325,8 @@ impl ConfigTransactionController {
             settlement: None,
             #[cfg(test)]
             v3_residue_cleanup_spawn_fail: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            v3_residue_cleanup_thread: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -1959,20 +1967,27 @@ impl ConfigTransactionController {
             warn!(context, "v3 residue cleanup could not start");
             return;
         }
-        if let Err(error) = std::thread::Builder::new()
+        match std::thread::Builder::new()
             .name("rustbgpd-v3-cleanup".to_string())
             .spawn(move || {
                 let _reservation = reservation;
                 if cleanup.cleanup() {
                     warn!(context, "v3 residue cleanup failed");
                 }
-            })
-        {
-            warn!(
+            }) {
+            Ok(handle) => {
+                #[cfg(test)]
+                {
+                    *self.v3_residue_cleanup_thread.lock().unwrap() = Some(handle);
+                }
+                #[cfg(not(test))]
+                drop(handle);
+            }
+            Err(error) => warn!(
                 context,
                 error_kind = ?error.kind(),
                 "v3 locator is durably absent, but residue cleanup could not start"
-            );
+            ),
         }
     }
 

--- a/src/config_transaction_control/tests.rs
+++ b/src/config_transaction_control/tests.rs
@@ -3791,13 +3791,11 @@ async fn stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton() {
     .await
     .expect("residue cleanup must not delay confirm")
     .unwrap();
-    tokio::time::timeout(Duration::from_secs(1), async {
-        while !stall.started() {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("detached residue cleanup must start");
+    // The cleanup runs on a dedicated OS thread; await its own signal rather
+    // than polling, and keep the timeout only as a hang guard.
+    tokio::time::timeout(Duration::from_secs(30), stall.started())
+        .await
+        .expect("detached residue cleanup must start");
     assert!(!harness.locator.exists());
     assert!(!harness.raw.exists() && !harness.metadata.exists());
     assert!(harness.controller.state.lock().await.pending.is_none());
@@ -3845,18 +3843,30 @@ async fn stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton() {
     assert!(residue.iter().all(|name| second_state.join(name).exists()));
 
     let cleanup_active = Arc::clone(&harness.controller.v3_residue_cleanup_active);
+    let cleanup_thread = harness
+        .controller
+        .v3_residue_cleanup_thread
+        .lock()
+        .unwrap()
+        .take()
+        .expect("confirm must have spawned the residue cleanup thread");
     harness.ack_task.abort();
     let drop_started = std::time::Instant::now();
     drop(harness.controller);
     assert!(drop_started.elapsed() < Duration::from_secs(1));
     stall.release();
-    tokio::time::timeout(Duration::from_secs(2), async {
-        while cleanup_active.load(Ordering::Acquire) {
-            tokio::task::yield_now().await;
-        }
-    })
+    // Joining the thread is the completion signal: the singleton reservation
+    // is released before the thread exits, so no polling is needed and the
+    // timeout is only a hang guard.
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        tokio::task::spawn_blocking(move || cleanup_thread.join()),
+    )
     .await
-    .expect("detached cleanup must finish after release");
+    .expect("detached cleanup must finish after release")
+    .unwrap()
+    .expect("residue cleanup thread must not panic");
+    assert!(!cleanup_active.load(Ordering::Acquire));
 }
 
 #[tokio::test]

--- a/src/config_transaction_control/tests.rs
+++ b/src/config_transaction_control/tests.rs
@@ -3847,7 +3847,7 @@ async fn stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton() {
         .controller
         .v3_residue_cleanup_thread
         .lock()
-        .unwrap()
+        .expect("cleanup thread handle slot must not be poisoned")
         .take()
         .expect("confirm must have spawned the residue cleanup thread");
     harness.ack_task.abort();
@@ -3864,7 +3864,7 @@ async fn stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton() {
     )
     .await
     .expect("detached cleanup must finish after release")
-    .unwrap()
+    .expect("the blocking task joining the residue cleanup thread was cancelled or panicked")
     .expect("residue cleanup thread must not panic");
     assert!(!cleanup_active.load(Ordering::Acquire));
 }

--- a/src/confirm_journal/v3.rs
+++ b/src/confirm_journal/v3.rs
@@ -16,7 +16,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
-use std::sync::{Condvar, atomic::AtomicBool, atomic::Ordering};
+use std::sync::Condvar;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -628,14 +628,14 @@ impl ClaimedResidue {
 #[cfg(test)]
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ResidueCleanupStall {
-    started: Arc<AtomicBool>,
+    started: Arc<tokio::sync::Notify>,
     release: Arc<(Mutex<bool>, Condvar)>,
 }
 
 #[cfg(test)]
 impl ResidueCleanupStall {
     fn block(&self) {
-        self.started.store(true, Ordering::Release);
+        self.started.notify_one();
         let (lock, ready) = &*self.release;
         let mut released = lock.lock().unwrap();
         while !*released {
@@ -643,8 +643,9 @@ impl ResidueCleanupStall {
         }
     }
 
-    pub(crate) fn started(&self) -> bool {
-        self.started.load(Ordering::Acquire)
+    /// Resolves once the detached cleanup thread has reached the stall.
+    pub(crate) async fn started(&self) {
+        self.started.notified().await;
     }
 
     pub(crate) fn release(&self) {


### PR DESCRIPTION
## Summary

`stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton` failed in three of three full `cargo test --bin rustbgpd` runs on a loaded 64-core host (load average 8-14) and passed every time in isolation.

### Mechanism

- The terminal residue cleanup runs on a dedicated OS thread (`std::thread::Builder::spawn`, named `rustbgpd-v3-cleanup`) in `hand_off_v3`; it is neither a `tokio::spawn` task nor `spawn_blocking`. The thread reads and digests both residue files, unlinks them, and `fsync`s their directory once per residue, then drops the `V3Reservation`, which releases the singleton flag.
- The test is a plain `#[tokio::test]`, so it runs on a current-thread runtime. Its two `while cond { yield_now().await }` loops (one waiting for the thread to reach the stall, one waiting for the singleton release) re-queue the only task on the scheduler and spin hot; `yield_now` cannot advance an OS thread doing synchronous file I/O.
- Progress therefore depends only on kernel scheduling of that thread and on directory `fsync` latency. With 64 test threads concurrently publishing and removing journals in the same ext4 `/tmp`, journal commits serialize and the cleanup's fsyncs can exceed the two-second budget. In isolation they take milliseconds.

### Change

- `ResidueCleanupStall::started` is now a `tokio::sync::Notify` and `started()` is an awaitable; the thread signals it on reaching the stall.
- Under `cfg(test)` the controller retains the cleanup thread's `JoinHandle` (`v3_residue_cleanup_thread`), mirroring the existing `v3_residue_cleanup_spawn_fail` hook. The test takes the handle before dropping the controller, releases the stall, and joins the thread via `spawn_blocking`. The reservation is dropped before the thread exits, so `v3_residue_cleanup_active` is deterministically false after the join and is asserted directly.
- Both timeouts are now 30 s hang guards rather than wall-clock budgets.

No production code path changes: the new field and handle retention are `cfg(test)` only; the `not(test)` build detaches the handle as before.

### Sibling assertions

Only the two loops in this test share the mechanism (an OS thread polled with `yield_now` under a short timeout). The other `yield_now` loops in the file (the coordinator-acquire deadline tests) drive in-runtime tasks under paused time, and the auto-revert status poll uses `sleep` against an in-runtime timer; neither waits on an OS thread, so they are unchanged.

## Checks

| Command | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p rustbgpd --all-targets -- -D warnings` | 0 |
| `cargo test --bin rustbgpd stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton -- --exact ...` x20 in isolation | 0 (20/20) |
| `cargo test --bin rustbgpd` (2227 passed, 4 ignored) | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
