### PR TITLE
transport: remove the unused singleton TCP-AO receipt seam

### DIFF
--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -1977,42 +1977,6 @@ fn tcp_ao_secret_eq(lhs: &[u8], rhs: &[u8]) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(
-    dead_code,
-    reason = "singleton receipt helper retained for focused ABI tests"
-)]
-fn receipt_from_raw_inventory(
-    keys: &[TcpAoGetSockOpt],
-    peer: IpAddr,
-    prefix_len: u8,
-    config: &TcpAoConfig,
-    exact_inventory: bool,
-) -> io::Result<TcpAoMktReceipt> {
-    let mut matching = Vec::new();
-    for raw in keys {
-        if raw_matches_owner(raw, peer, prefix_len, config)? {
-            matching.push(raw);
-        }
-    }
-    if matching.len() != 1 || (exact_inventory && keys.len() != 1) {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "TCP-AO kernel MKT inventory does not exactly contain the configured owner",
-        ));
-    }
-    Ok(TcpAoMktReceipt {
-        cores: vec![mkt_core(matching[0])?],
-        metadata: vec![TcpAoMktMetadata {
-            owner: crate::listener::TcpAoListenerOwnerKind::Static,
-            peer,
-            prefix_len,
-            preferred: config.preferred,
-            deprecated: config.deprecated,
-        }],
-    })
-}
-
-#[cfg(target_os = "linux")]
 fn keyring_receipt_from_raw_inventory(
     keys: &[TcpAoGetSockOpt],
     peer: IpAddr,
@@ -2105,23 +2069,8 @@ fn owned_receipt_from_raw_inventory(
 }
 
 /// Capture the kernel-normalized cryptographic identity of one configured
-/// owner. The returned secret-bearing receipt must remain short-lived.
-#[cfg(target_os = "linux")]
-#[allow(
-    dead_code,
-    reason = "singleton compatibility seam retained for Phase 1 callers"
-)]
-pub(crate) fn capture_tcp_ao_mkt_receipt(
-    socket: &impl AsRawFd,
-    peer: IpAddr,
-    prefix_len: u8,
-    config: &TcpAoConfig,
-    exact_inventory: bool,
-) -> io::Result<TcpAoMktReceipt> {
-    let keys = get_tcp_ao_keys_with(|entries| query_tcp_ao_keys(socket, entries))?;
-    receipt_from_raw_inventory(&keys, peer, prefix_len, config, exact_inventory)
-}
-
+/// owner's keyring. The returned secret-bearing receipt must remain
+/// short-lived.
 #[cfg(target_os = "linux")]
 pub(crate) fn capture_tcp_ao_keyring_receipt(
     socket: &impl AsRawFd,
@@ -2771,24 +2720,6 @@ fn tcp_ao_rnext_update(recv_id: u8, current: &TcpAoInfoSnapshot) -> TcpAoInfoOpt
 /// Inspect runtime TCP-AO socket state.
 #[cfg(not(target_os = "linux"))]
 pub(crate) fn get_tcp_ao_info<T>(_socket: &T) -> io::Result<TcpAoInfoSnapshot> {
-    Err(io::Error::new(
-        io::ErrorKind::Unsupported,
-        "TCP-AO inspection is only supported on Linux",
-    ))
-}
-
-#[cfg(not(target_os = "linux"))]
-#[allow(
-    dead_code,
-    reason = "singleton compatibility seam retained for Phase 1 callers"
-)]
-pub(crate) fn capture_tcp_ao_mkt_receipt<T>(
-    _socket: &T,
-    _peer: std::net::IpAddr,
-    _prefix_len: u8,
-    _config: &crate::config::TcpAoConfig,
-    _exact_inventory: bool,
-) -> io::Result<TcpAoMktReceipt> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "TCP-AO inspection is only supported on Linux",
@@ -3696,8 +3627,14 @@ mod tests {
         listener_raw.prefix = 24;
         listener_raw.flags = 0;
         listener_raw.pkt_good = 0;
-        let receipt =
-            receipt_from_raw_inventory(&[listener_raw], owner, 24, &config, false).unwrap();
+        let receipt = keyring_receipt_from_raw_inventory(
+            &[listener_raw],
+            owner,
+            24,
+            &TcpAoKeyring(vec![config]),
+            false,
+        )
+        .unwrap();
 
         let mut child_raw = raw_dump_key(connected, "hmac(sha256)", b"secret");
         child_raw.pkt_good = 101;
@@ -3768,11 +3705,12 @@ mod tests {
         assert_eq!(config.key.as_ref().len(), 13);
         let normalized = [0xa5; 16];
         let raw = raw_dump_key(peer, "cmac(aes)", &normalized);
-        let receipt = receipt_from_raw_inventory(&[raw], peer, 32, &config, true).unwrap();
+        let ring = TcpAoKeyring(vec![config]);
+        let receipt = keyring_receipt_from_raw_inventory(&[raw], peer, 32, &ring, true).unwrap();
         assert_eq!(receipt.cores[0].key.as_slice(), normalized);
         assert_ne!(
             receipt.cores[0].key.as_slice(),
-            config.key.as_ref().as_bytes()
+            ring.0[0].key.as_ref().as_bytes()
         );
     }
 


### PR DESCRIPTION
## What changed

`crates/transport/src/socket_opts.rs`: the single-key TCP-AO receipt seam is removed.

- Deleted `capture_tcp_ao_mkt_receipt` (Linux body and non-Linux stub) and its helper `receipt_from_raw_inventory`. `git grep` across `src/`, `crates/`, `tests/`, `bench/`, and `fuzz/` finds no caller of the wrapper on either platform; the helper was reached only by the wrapper and two unit tests.
- Removed the three `#[allow(dead_code, ...)]` attributes that existed only to keep those functions compiling.
- Moved the wrapper's doc comment onto `capture_tcp_ao_keyring_receipt`, which had none.
- `owned_receipt_from_raw_inventory` is a different, live function and is untouched.

## Why

The live rule is `capture_tcp_ao_keyring_receipt` / `keyring_receipt_from_raw_inventory` (one production caller in `crates/transport/src/session/io.rs`). The single-key rule sat beside it with nothing keeping the two in agreement; a one-entry keyring with exact-inventory fencing is the same check, so the singleton was a second copy of a rule that already existed.

## Test coverage

Both tests that used the deleted helper were read before deletion. Neither duplicated the keyring tests, so both were ported rather than dropped, each by switching one call to `keyring_receipt_from_raw_inventory` with a one-entry `TcpAoKeyring`:

- `tcp_ao_kernel_receipt_reconciles_normalized_core_and_rejects_inventory_drift`: every assertion kept. It is the only test of `annotate_tcp_ao_receipt` covering peer and prefix-length annotation from receipt metadata, preferred-flag propagation, and the six rejection cases (empty inventory, wrong secret, foreign extra key, wrong peer, wrong algorithm, wrong send-id). The keyring test at `tcp_ao_keyring_receipt_requires_and_annotates_complete_owned_inventory` covers only the two-key happy path and missing-key rejection.
- `tcp_ao_raw_config_receipt_accepts_kernel_normalized_aes_cmac_material`: both assertions kept. It is the only receipt-path test using `cmac(aes)` material with exact-inventory fencing; every keyring test uses `hmac(sha256)`. `config` is read after the call, so the test now references the ring's entry.

Assertions dropped as duplicates: none.

## What did not change

- No production behavior change; the one production caller already used the keyring path.
- No CHANGELOG entry: dead-code removal with no observable change.

## Gates

| Command | Exit | Result |
| --- | --- | --- |
| `cargo fmt --all -- --check` | 0 | clean |
| `cargo clippy -p rustbgpd-transport --all-targets -- -D warnings` | 0 | clean |
| `cargo test -p rustbgpd-transport` | 0 | 612 passed, 3 ignored; 22 passed; 16 passed (both ported tests ran and passed) |
| `cargo clippy --bin rustbgpd -- -D warnings` | 0 | clean |
| `cargo build --bin rustbgpd` | 0 | clean |
| `python3 scripts/check-clippy-reasons.py` | 0 | clean |
| `python3 scripts/check_public_tracker_ids.py` | 0 | clean |
