### PR TITLE
evpn: parse MAC and ESI text through one shared grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Operator-visible:** the EVPN MAC and ESI text forms are parsed by one
+  grammar shared by the configuration loader and the gRPC services: exactly
+  six (MAC) or ten (ESI) colon-separated groups of exactly two hex digits,
+  either case. `AddEvpnRoute`, `DeleteEvpnRoute`, and
+  `ClearDuplicateMacQuarantine` previously accepted one-digit and
+  three-digit MAC groups (`2:0:0:0:0:1`, `00f:00:00:00:00:01`) that
+  configuration load refused, and both entry points accepted a signed
+  two-character group (`+2:+0:+0:+0:+0:+1`). All three forms are now
+  rejected everywhere. gRPC refusals read `invalid MAC "<input>": <reason>`;
+  the configuration reason for a wrong MAC group count now reads
+  `expected 6 colon-separated hex octets`. Canonical `aa:bb:cc:dd:ee:ff`
+  input and the ESI RPC surface are unaffected.
+
 - EVPN: a local bridge-port move of a MAC advertised as MAC+IP now
   re-advertises every (MAC, IP) Type 2 route for that MAC with the MAC
   Mobility sequence incremented (RFC 9721 §5.1/§6.2); such moves were
@@ -500,6 +513,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Upgrade notes
 
+- **EVPN RPCs apply the configuration MAC grammar:** `AddEvpnRoute`,
+  `DeleteEvpnRoute`, and `ClearDuplicateMacQuarantine` now parse `mac` and
+  `router_mac` with the parser the configuration loader uses: exactly six
+  colon-separated groups of exactly two hex digits. Requests carrying a
+  one-digit group (`2:0:0:0:0:1`), a three-digit group
+  (`00f:00:00:00:00:01`), or a signed group (`+2:+0:+0:+0:+0:+1`) are now
+  refused with `INVALID_ARGUMENT`; the signed form is also refused at
+  configuration load for MAC and ESI fields, where it previously parsed.
+  Clients that send the canonical zero-padded form are unaffected.
 - **EVPN local port moves now re-advertise MAC+IP routes:** when a MAC that
   is advertised as MAC+IP moves between local bridge ports, peers receive one
   additional Type 2 per IP bound to that MAC, each carrying the incremented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,8 +187,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   two-character group (`+2:+0:+0:+0:+0:+1`). All three forms are now
   rejected everywhere. gRPC refusals read `invalid MAC "<input>": <reason>`;
   the configuration reason for a wrong MAC group count now reads
-  `expected 6 colon-separated hex octets`. Canonical `aa:bb:cc:dd:ee:ff`
-  input and the ESI RPC surface are unaffected.
+  `expected 6 colon-separated hex octets`. `ListEthernetSegments` and
+  `SetEthernetSegmentDrain` already parsed `esi` with the configuration
+  grammar but likewise accepted a signed group
+  (`+0:11:22:33:44:55:66:77:88:99`); they now refuse it with
+  `INVALID_ARGUMENT`. Canonical zero-padded MAC and ESI input is
+  unaffected.
 
 - EVPN: a local bridge-port move of a MAC advertised as MAC+IP now
   re-advertises every (MAC, IP) Type 2 route for that MAC with the MAC
@@ -513,15 +517,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Upgrade notes
 
-- **EVPN RPCs apply the configuration MAC grammar:** `AddEvpnRoute`,
+- **EVPN RPCs apply the configuration MAC and ESI grammar:** `AddEvpnRoute`,
   `DeleteEvpnRoute`, and `ClearDuplicateMacQuarantine` now parse `mac` and
   `router_mac` with the parser the configuration loader uses: exactly six
   colon-separated groups of exactly two hex digits. Requests carrying a
   one-digit group (`2:0:0:0:0:1`), a three-digit group
   (`00f:00:00:00:00:01`), or a signed group (`+2:+0:+0:+0:+0:+1`) are now
-  refused with `INVALID_ARGUMENT`; the signed form is also refused at
-  configuration load for MAC and ESI fields, where it previously parsed.
-  Clients that send the canonical zero-padded form are unaffected.
+  refused with `INVALID_ARGUMENT`. `ListEthernetSegments` and
+  `SetEthernetSegmentDrain` now refuse a signed ESI group
+  (`+0:11:22:33:44:55:66:77:88:99`) the same way, and configuration load
+  refuses the signed form for MAC and ESI fields, where it previously
+  parsed. Clients that send canonical zero-padded MAC and ESI input are
+  unaffected.
 - **EVPN local port moves now re-advertise MAC+IP routes:** when a MAC that
   is advertised as MAC+IP moves between local bridge ports, peers receive one
   additional Type 2 per IP bound to that MAC, each carrying the incremented

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -2148,6 +2148,13 @@ mod tests {
         assert!(super::parse_esi("not-an-esi").is_err());
     }
 
+    #[test]
+    fn parse_esi_rejects_signed_group() {
+        // The shared grammar requires two hex digits per octet, so the
+        // leading sign `u8::from_str_radix` would accept is refused.
+        assert!(super::parse_esi("+0:11:22:33:44:55:66:77:88:99").is_err());
+    }
+
     #[tokio::test]
     async fn apply_evpn_runtime_rejects_read_only_listener() {
         let apply: EvpnRuntimeApplyFn = Arc::new(|_| {

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -21,7 +21,7 @@ use rustbgpd_evpn::{
     EvpnInstance, EvpnInstanceId, EvpnInstanceTable, EvpnRuntimeLifecycle, EvpnRuntimeModel,
     EvpnRuntimeMutationState, EvpnRuntimePlan, EvpnRuntimeSnapshot, FdbNexthopDataplaneStatus,
     InstanceDataplaneStatus, InstanceState, IpVrfDataplaneStatus, MacAddress, ManagedNetdevStatus,
-    SameEsiBiasTable,
+    SameEsiBiasTable, parse_esi,
 };
 use tonic::{Request, Response, Status};
 
@@ -677,7 +677,7 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
         let req = request.into_inner();
         let vni = EvpnInstanceId::new(req.vni)
             .map_err(|err| Status::invalid_argument(format!("invalid VNI: {err}")))?;
-        let mac = MacAddress::new(crate::injection_service::parse_mac(&req.mac)?);
+        let mac = crate::injection_service::parse_mac(&req.mac)?;
         let clear = self.duplicate_mac_clear.as_ref().ok_or_else(|| {
             Status::unavailable("EVPN duplicate-MAC clear control is unavailable")
         })?;
@@ -772,26 +772,6 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
             .map(Response::new)
             .map_err(EvpnRuntimeApplyError::into_status)
     }
-}
-
-/// Parse a 10-byte ESI from the operator text form used across this
-/// proto (`XX:XX:XX:XX:XX:XX:XX:XX:XX:XX`). Mirrors the daemon config
-/// parser — the wire crate intentionally doesn't implement `FromStr`
-/// for `EthernetSegmentIdentifier` (the on-the-wire form is raw
-/// bytes), so the API layer owns its own parse of the display form.
-fn parse_esi(raw: &str) -> Result<rustbgpd_evpn::EthernetSegmentIdentifier, &'static str> {
-    let parts: Vec<&str> = raw.split(':').collect();
-    if parts.len() != 10 {
-        return Err("expected 10 colon-separated hex octets");
-    }
-    let mut bytes = [0u8; 10];
-    for (i, octet) in parts.iter().enumerate() {
-        if octet.len() != 2 {
-            return Err("each octet must be exactly 2 hex digits");
-        }
-        bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
-    }
-    Ok(rustbgpd_evpn::EthernetSegmentIdentifier::new(bytes))
 }
 
 /// Operator-facing summary for a drain request. `requested` is the

--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -529,7 +529,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
                 EvpnRouteKey::MacIp {
                     rd,
                     ethernet_tag: EthernetTagId(req.ethernet_tag),
-                    mac: MacAddress(mac),
+                    mac,
                     ip: parse_optional_ip(&req.ip)?,
                 }
             }
@@ -915,23 +915,16 @@ fn parse_rd(s: &str) -> Result<RouteDistinguisher, Status> {
     }
 }
 
-pub(crate) fn parse_mac(s: &str) -> Result<[u8; 6], Status> {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 6 {
-        return Err(Status::invalid_argument(format!(
-            "MAC must be six colon-separated hex octets; got {s:?}"
-        )));
-    }
-    let mut out = [0u8; 6];
-    for (i, p) in parts.iter().enumerate() {
-        out[i] = u8::from_str_radix(p, 16)
-            .map_err(|_| Status::invalid_argument(format!("MAC octet {i} not valid hex: {p:?}")))?;
-    }
-    Ok(out)
+/// Parse a request MAC through the grammar shared with the configuration
+/// loader, reporting a refusal as `INVALID_ARGUMENT` with the offending
+/// input.
+pub(crate) fn parse_mac(s: &str) -> Result<MacAddress, Status> {
+    rustbgpd_evpn::parse_mac_address(s)
+        .map_err(|e| Status::invalid_argument(format!("invalid MAC {s:?}: {e}")))
 }
 
 fn parse_router_mac(s: &str) -> Result<MacAddress, Status> {
-    let mac = MacAddress(parse_mac(s)?);
+    let mac = parse_mac(s)?;
     let octets = mac.octets();
     if octets.iter().all(|&b| b == 0) {
         return Err(Status::invalid_argument(
@@ -1043,7 +1036,7 @@ fn build_type2(
         rd,
         esi: EthernetSegmentIdentifier::ZERO,
         ethernet_tag: EthernetTagId(req.ethernet_tag),
-        mac: MacAddress(mac),
+        mac,
         ip,
         label1: MplsLabel::new(req.label),
         label2,
@@ -1681,14 +1674,20 @@ mod tests {
 
     #[test]
     fn parse_mac_roundtrip() {
-        let bytes = parse_mac("aa:bb:cc:dd:ee:ff").unwrap();
-        assert_eq!(bytes, [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        let mac = parse_mac("aa:bb:cc:dd:ee:ff").unwrap();
+        assert_eq!(mac.octets(), [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
     }
 
     #[test]
     fn parse_mac_rejects_malformed() {
         assert!(parse_mac("aa:bb:cc").is_err());
         assert!(parse_mac("aa:bb:cc:dd:ee:gg").is_err());
+        // Same grammar as the configuration parser: exactly two hex
+        // digits per octet, so short groups and signed groups (which
+        // `u8::from_str_radix` would otherwise accept) are rejected.
+        assert!(parse_mac("2:0:0:0:0:1").is_err());
+        assert!(parse_mac("+2:+0:+0:+0:+0:+1").is_err());
+        assert!(parse_mac("00f:00:00:00:00:01").is_err());
     }
 
     #[tokio::test]

--- a/crates/evpn/src/colon_hex.rs
+++ b/crates/evpn/src/colon_hex.rs
@@ -1,0 +1,174 @@
+//! Operator text form of the EVPN identifiers that RFC 7432 carries as
+//! raw octets.
+//!
+//! `rustbgpd_wire` implements `Display` for [`MacAddress`] and
+//! [`EthernetSegmentIdentifier`] but no `FromStr`: the on-the-wire form
+//! is raw bytes, not the colon-separated hex that operators type. The
+//! configuration loader and the gRPC services both accept that text
+//! form, and this module is the one parser they share, so an input
+//! cannot load through one entry point and be refused by the other.
+//!
+//! The grammar is strict: exactly six (MAC) or ten (ESI) groups
+//! separated by `:`, each group exactly two hex digits in either case,
+//! and nothing else. A leading sign, a one- or three-digit group,
+//! surrounding whitespace, and a trailing separator are all rejected.
+
+use rustbgpd_wire::{EthernetSegmentIdentifier, MacAddress};
+
+/// Why [`parse_mac_address`] or [`parse_esi`] refused an input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ColonHexParseError {
+    /// The input did not split into the expected number of `:`-separated
+    /// groups.
+    #[error("expected {expected} colon-separated hex octets")]
+    GroupCount {
+        /// Number of groups the identifier requires.
+        expected: usize,
+    },
+    /// A group was not exactly two characters wide.
+    #[error("each octet must be exactly 2 hex digits")]
+    OctetWidth,
+    /// A group held something other than two hex digits.
+    #[error("invalid hex octet")]
+    InvalidHex,
+}
+
+/// Parse a MAC address from its `aa:bb:cc:dd:ee:ff` text form.
+///
+/// # Errors
+///
+/// Returns [`ColonHexParseError`] unless the input is exactly six
+/// `:`-separated groups of exactly two hex digits.
+pub fn parse_mac_address(raw: &str) -> Result<MacAddress, ColonHexParseError> {
+    parse_octets(raw).map(MacAddress::new)
+}
+
+/// Parse an Ethernet Segment Identifier from its
+/// `00:11:22:33:44:55:66:77:88:99` text form.
+///
+/// # Errors
+///
+/// Returns [`ColonHexParseError`] unless the input is exactly ten
+/// `:`-separated groups of exactly two hex digits.
+pub fn parse_esi(raw: &str) -> Result<EthernetSegmentIdentifier, ColonHexParseError> {
+    parse_octets(raw).map(EthernetSegmentIdentifier::new)
+}
+
+fn parse_octets<const N: usize>(raw: &str) -> Result<[u8; N], ColonHexParseError> {
+    let groups: Vec<&str> = raw.split(':').collect();
+    if groups.len() != N {
+        return Err(ColonHexParseError::GroupCount { expected: N });
+    }
+    let mut out = [0u8; N];
+    for (slot, group) in out.iter_mut().zip(groups) {
+        if group.len() != 2 {
+            return Err(ColonHexParseError::OctetWidth);
+        }
+        // `u8::from_str_radix` accepts a leading `+`, so the digit check
+        // has to be explicit for the grammar to be exactly two hex digits.
+        if !group.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(ColonHexParseError::InvalidHex);
+        }
+        *slot = u8::from_str_radix(group, 16).map_err(|_| ColonHexParseError::InvalidHex)?;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ColonHexParseError::{GroupCount, InvalidHex, OctetWidth};
+    use super::*;
+
+    const MAC: &str = "aa:bb:cc:dd:ee:ff";
+    const ESI: &str = "00:11:22:33:44:55:66:77:88:99";
+
+    #[test]
+    fn mac_accepts_strict_forms() {
+        let expected = MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        assert_eq!(parse_mac_address(MAC), Ok(expected));
+        assert_eq!(parse_mac_address("AA:BB:CC:DD:EE:FF"), Ok(expected));
+        assert_eq!(parse_mac_address("aA:Bb:cC:Dd:eE:Ff"), Ok(expected));
+        assert_eq!(
+            parse_mac_address("00:00:00:00:00:00"),
+            Ok(MacAddress::new([0; 6]))
+        );
+        assert_eq!(
+            parse_mac_address("ff:ff:ff:ff:ff:ff"),
+            Ok(MacAddress::new([0xff; 6]))
+        );
+        assert_eq!(parse_mac_address(MAC).unwrap().to_string(), MAC);
+    }
+
+    #[test]
+    fn mac_rejects_loose_forms() {
+        let cases = [
+            ("aa:bb:cc:dd:ee", GroupCount { expected: 6 }),
+            ("aa:bb:cc:dd:ee:ff:00", GroupCount { expected: 6 }),
+            ("aa:bb:cc:dd:ee:ff:", GroupCount { expected: 6 }),
+            ("", GroupCount { expected: 6 }),
+            ("aabbccddeeff", GroupCount { expected: 6 }),
+            ("aa-bb-cc-dd-ee-ff", GroupCount { expected: 6 }),
+            ("2:0:0:0:0:1", OctetWidth),
+            ("00f:00:00:00:00:01", OctetWidth),
+            (" aa:bb:cc:dd:ee:ff", OctetWidth),
+            ("aa:bb:cc:dd:ee:ff ", OctetWidth),
+            ("+2:+0:+0:+0:+0:+1", InvalidHex),
+            ("-2:00:00:00:00:01", InvalidHex),
+            ("aa:bb:cc:dd:ee:gg", InvalidHex),
+            ("aa:bb:cc:dd:ee: f", InvalidHex),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(parse_mac_address(input), Err(expected), "{input:?}");
+        }
+    }
+
+    #[test]
+    fn esi_accepts_strict_forms() {
+        let expected = EthernetSegmentIdentifier::new([
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+        ]);
+        assert_eq!(parse_esi(ESI), Ok(expected));
+        assert_eq!(
+            parse_esi("0A:1B:2C:3D:4E:5F:6a:7b:8c:9d"),
+            Ok(EthernetSegmentIdentifier::new([
+                0x0a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f, 0x6a, 0x7b, 0x8c, 0x9d,
+            ]))
+        );
+        assert_eq!(
+            parse_esi("00:00:00:00:00:00:00:00:00:00"),
+            Ok(EthernetSegmentIdentifier::new([0; 10]))
+        );
+        assert_eq!(
+            parse_esi("ff:ff:ff:ff:ff:ff:ff:ff:ff:ff"),
+            Ok(EthernetSegmentIdentifier::new([0xff; 10]))
+        );
+        assert_eq!(parse_esi(ESI).unwrap().to_string(), ESI);
+    }
+
+    #[test]
+    fn esi_rejects_loose_forms() {
+        let cases = [
+            ("00:11:22:33:44:55:66:77:88", GroupCount { expected: 10 }),
+            (
+                "00:11:22:33:44:55:66:77:88:99:aa",
+                GroupCount { expected: 10 },
+            ),
+            (
+                "00:11:22:33:44:55:66:77:88:99:",
+                GroupCount { expected: 10 },
+            ),
+            ("", GroupCount { expected: 10 }),
+            ("not-an-esi", GroupCount { expected: 10 }),
+            ("0:11:22:33:44:55:66:77:88:99", OctetWidth),
+            ("000:11:22:33:44:55:66:77:88:99", OctetWidth),
+            (" 00:11:22:33:44:55:66:77:88:99", OctetWidth),
+            ("00:11:22:33:44:55:66:77:88:99 ", OctetWidth),
+            ("+0:11:22:33:44:55:66:77:88:99", InvalidHex),
+            ("-0:11:22:33:44:55:66:77:88:99", InvalidHex),
+            ("00:11:22:33:44:55:66:77:88:9g", InvalidHex),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(parse_esi(input), Err(expected), "{input:?}");
+        }
+    }
+}

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -75,7 +75,9 @@
 //!   construction (the daemon's `evpn_l3_originator` task drives
 //!   it under `IpVrfStatus::Ready`).
 //!
-//! Other modules: `aliasing` (canonical alias VTEP set per
+//! Other modules: `colon_hex` (the operator text form of MAC and
+//! ESI values, shared by the configuration loader and the gRPC
+//! services), `aliasing` (canonical alias VTEP set per
 //! `RemoteMacEntry`, plus the ADR-0083 single-active eligible-set /
 //! backup-PE derivation), `df_election` (Gate 8 RFC 7432 §8.5),
 //! `label_allocator` (Gate 8b per-ESI EVPN label),
@@ -92,6 +94,7 @@
 #![warn(clippy::pedantic)]
 
 pub mod aliasing;
+pub mod colon_hex;
 pub mod dataplane;
 pub mod df_election;
 pub mod duplicate_mac;
@@ -113,6 +116,7 @@ pub use aliasing::{
     AliasEadPerEvi, AliasIndex, EadPerEsMode, SingleActiveBackupView, SingleActiveEligibleIndex,
     alias_resolved_next_hops, group_members,
 };
+pub use colon_hex::{ColonHexParseError, parse_esi, parse_mac_address};
 pub use dataplane::{
     AcGateEntry, AcGateState, AppliedOp, BumEnforcementEntry, BumEnforcementKey,
     BumEnforcementReadiness, BumEnforcementStatus, BumEnforcementTable, BumForwardingAction,

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -803,7 +803,7 @@
           }
         },
         "sticky_macs": {
-          "description": "MACs to be originated with the RFC 7432 §15.4 sticky bit when\nthe local kernel learns them. Textual form: `aa:bb:cc:dd:ee:ff`\n(lowercase hex, six octets). Empty by default. See ADR-0056.",
+          "description": "MACs to be originated with the RFC 7432 §15.4 sticky bit when\nthe local kernel learns them. Textual form: `aa:bb:cc:dd:ee:ff`\n(six two-digit hex octets, either case). Empty by default. See ADR-0056.",
           "type": "array",
           "default": [],
           "items": {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,7 @@ use rustbgpd_evpn::runtime_plan_shape::validate_supported_plan_shape;
 use rustbgpd_evpn::{
     BridgeVlan, DfAlgorithm, DuplicateMacAction, DuplicateMacConfig, EthernetSegment, EvpnInstance,
     EvpnInstanceId, EvpnInstanceTable, EvpnRuntimeCandidate, EvpnRuntimeModel, IpVrf, IpVrfId,
-    IpVrfTable, OverlayIndexMode, RedundancyMode, RouteTarget,
+    IpVrfTable, OverlayIndexMode, RedundancyMode, RouteTarget, parse_esi, parse_mac_address,
 };
 use rustbgpd_policy::{
     CommunityMatch, NextHopAction, Policy, PolicyAction, PolicyChain, PolicyStatement,
@@ -5429,25 +5429,6 @@ fn parse_duplicate_mac_detection(
     })
 }
 
-/// Parse a `aa:bb:cc:dd:ee:ff` MAC string into a [`MacAddress`]. The
-/// wire crate intentionally does not implement `FromStr` on
-/// `MacAddress` (RFC 7432 NLRI uses raw bytes, not the operator
-/// notation), so the daemon owns this parse.
-fn parse_mac_address(raw: &str) -> Result<MacAddress, &'static str> {
-    let parts: Vec<&str> = raw.split(':').collect();
-    if parts.len() != 6 {
-        return Err("expected 6 colon-separated octets");
-    }
-    let mut bytes = [0u8; 6];
-    for (i, octet) in parts.iter().enumerate() {
-        if octet.len() != 2 {
-            return Err("each octet must be exactly 2 hex digits");
-        }
-        bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
-    }
-    Ok(MacAddress::new(bytes))
-}
-
 /// Default ADR-0085 decision 3 recovery hold-off: how long a bound
 /// ES's link drain is held after carrier returns. Mirrors the RFC
 /// 8584 §3 DF-wait rationale (don't attract traffic before the
@@ -5950,27 +5931,6 @@ fn validate_esi_overlay_index_vrf(
 fn is_unicast_nonzero_mac(mac: MacAddress) -> bool {
     let octets = mac.octets();
     octets != [0; 6] && (octets[0] & 1) == 0
-}
-
-/// Parse a 10-byte ESI from operator text form
-/// (`XX:XX:XX:XX:XX:XX:XX:XX:XX:XX`). Each octet must be exactly
-/// two hex digits. The wire crate intentionally doesn't implement
-/// `FromStr` on `EthernetSegmentIdentifier` (the on-the-wire form
-/// is raw bytes, not the operator notation), so the daemon owns
-/// this parse.
-fn parse_esi(raw: &str) -> Result<EthernetSegmentIdentifier, &'static str> {
-    let parts: Vec<&str> = raw.split(':').collect();
-    if parts.len() != 10 {
-        return Err("expected 10 colon-separated hex octets");
-    }
-    let mut bytes = [0u8; 10];
-    for (i, octet) in parts.iter().enumerate() {
-        if octet.len() != 2 {
-            return Err("each octet must be exactly 2 hex digits");
-        }
-        bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
-    }
-    Ok(EthernetSegmentIdentifier::new(bytes))
 }
 
 /// Resolve the `[gnmi_dialout]` section into runtime dial-out target

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2706,7 +2706,7 @@ pub struct EvpnInstanceConfig {
     pub advertise_svi_mac: bool,
     /// MACs to be originated with the RFC 7432 §15.4 sticky bit when
     /// the local kernel learns them. Textual form: `aa:bb:cc:dd:ee:ff`
-    /// (lowercase hex, six octets). Empty by default. See ADR-0056.
+    /// (six two-digit hex octets, either case). Empty by default. See ADR-0056.
     #[serde(default)]
     pub sticky_macs: Vec<String>,
     /// Optional name of an `[[evpn_ip_vrfs]]` entry that binds this


### PR DESCRIPTION
## What changed

The MAC-address and Ethernet Segment Identifier text forms (`aa:bb:cc:dd:ee:ff`, `00:11:22:33:44:55:66:77:88:99`) are now parsed by one grammar in `rustbgpd_evpn::colon_hex` (`parse_mac_address`, `parse_esi`, `ColonHexParseError`). The four hand-written copies in `src/config/mod.rs` and `crates/api/src/{injection_service,evpn_service}.rs` are deleted and their call sites route through the shared functions. Configuration keeps its `ConfigError` variants and message shape; the gRPC call sites map into `INVALID_ARGUMENT` with the offending input, as before.

The wire crate is published, so `MacAddress` and `EthernetSegmentIdentifier` gain no `FromStr` in this change.

## The drift

The two ESI parsers were byte-identical. The two MAC parsers were not. Configuration:

```rust
fn parse_mac_address(raw: &str) -> Result<MacAddress, &'static str> {
    let parts: Vec<&str> = raw.split(':').collect();
    if parts.len() != 6 {
        return Err("expected 6 colon-separated octets");
    }
    let mut bytes = [0u8; 6];
    for (i, octet) in parts.iter().enumerate() {
        if octet.len() != 2 {
            return Err("each octet must be exactly 2 hex digits");
        }
        bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
    }
    Ok(MacAddress::new(bytes))
}
```

Injection service:

```rust
pub(crate) fn parse_mac(s: &str) -> Result<[u8; 6], Status> {
    let parts: Vec<&str> = s.split(':').collect();
    if parts.len() != 6 {
        return Err(Status::invalid_argument(format!(
            "MAC must be six colon-separated hex octets; got {s:?}"
        )));
    }
    let mut out = [0u8; 6];
    for (i, p) in parts.iter().enumerate() {
        out[i] = u8::from_str_radix(p, 16)
            .map_err(|_| Status::invalid_argument(format!("MAC octet {i} not valid hex: {p:?}")))?;
    }
    Ok(out)
}
```

The injection copy has no per-group width guard, so `2:0:0:0:0:1` and `00f:00:00:00:00:01` were accepted by `AddEvpnRoute`, `DeleteEvpnRoute`, `router_mac`, and `ClearDuplicateMacQuarantine` but refused at configuration load. `u8::from_str_radix` accepts a leading `+` (`u8::from_str_radix("+2", 16) == Ok(2)`), and `+2` is two characters wide, so `+2:+0:+0:+0:+0:+1` passed both parsers, including the configuration one.

## Behavior change

- The RPCs above now apply the configuration grammar: exactly six colon-separated groups of exactly two hex digits, either case. `2:0:0:0:0:1`, `00f:00:00:00:00:01`, and `+2:+0:+0:+0:+0:+1` are refused with `INVALID_ARGUMENT` (`invalid MAC "<input>": <reason>`).
- Configuration load now also refuses a signed two-character group (`+f`) in MAC and ESI fields, which previously parsed. The configuration message for a wrong MAC group count reads `expected 6 colon-separated hex octets` (previously without `hex`); the other messages are unchanged.
- `ListEthernetSegments` and `SetEthernetSegmentDrain` already parsed `esi` with the configuration grammar, but the old copy had the same `from_str_radix` sign loophole, so they likewise accepted a signed group (`+0:11:22:33:44:55:66:77:88:99`). They now refuse it with `INVALID_ARGUMENT`; canonical zero-padded ESI input is unaffected. `parse_esi_rejects_signed_group` in `crates/api/src/evpn_service.rs` pins this.
- The `sticky_macs` schema description said `lowercase hex`; the parser has always accepted either case, so the description and the generated `docs/rustbgpd.schema.json` now say so. The CLI help and `docs/CONFIGURATION.md` already describe the grammar as implemented.

## Red proof

`parse_mac_rejects_malformed` in `crates/api/src/injection_service.rs` was extended with the three loose inputs and run against the unchanged base tree first:

```
test injection_service::tests::parse_mac_rejects_malformed ... FAILED
assertion failed: parse_mac("2:0:0:0:0:1").is_err()
test result: FAILED. 0 passed; 1 failed
```

It passes with this change. The shared module carries its own accepted/rejected tables for both MAC and ESI (case variants, all-zero, all-`ff`; 5/7 and 9/11 groups; one- and three-digit groups; leading `+`/`-`; non-hex; empty; trailing colon; surrounding and embedded whitespace).

## Checks

| Check | Exit | Result |
|---|---|---|
| `cargo fmt --all -- --check` | 0 | clean |
| `cargo clippy -p rustbgpd-evpn -p rustbgpd-api --all-targets -- -D warnings` | 0 | clean |
| `cargo test -p rustbgpd-evpn` | 0 | 348 passed |
| `cargo test -p rustbgpd-api` | 0 | 729 passed (first commit); `evpn_service` filter 38 passed after the follow-up |
| `cargo clippy --bin rustbgpd -- -D warnings` | 0 | clean |
| `cargo test --bin rustbgpd config` | 0 | 1000 passed, 4 ignored |
| `cargo test --bin rustbgpd evpn` | 0 | 495 passed |
| `BLESS=1 cargo test --bin rustbgpd config_json_schema_committed_copy_is_fresh` | 0 | schema regenerated (1 line) |
| `python3 scripts/check-clippy-reasons.py` | 0 | clean |
| `python3 scripts/check_public_tracker_ids.py` | 0 | clean |
| `cargo doc --locked -p rustbgpd-evpn --no-deps` | 0 | no warnings |

Not run locally: `just gate`, hosted interop and kernel-dataplane lanes.
