### PR TITLE
ci: replace image-primer pin counts and call digests with structural checks

### DIFF
--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -335,15 +335,18 @@ def _check_lab_calls(name: str, job_name: str, job: str, errors: list[str]) -> N
     calls = LAB_CALL.findall(job)
     if not calls:
         errors.append(f"{prefix}: has no run-interop-test call")
+        return
     labels: set[str] = set()
     for call in calls:
         inputs = dict(LAB_CALL_INPUT.findall(call))
         missing = [key for key in ("label", "topology", "script") if key not in inputs]
         if missing:
             errors.append(f"{prefix}: run-interop-test call missing {', '.join(missing)}")
-            continue
+            return
         label = inputs["label"]
-        labels.add(label.replace("+", "-").upper())
+        # A space starts a descriptive suffix (``M43 crash-restart``); ``+`` and ``-``
+        # join scenario variants (``M37+IP`` is the m37-ip job's own identifier).
+        labels.add(label.split(" ", 1)[0].replace("+", "-").upper())
         token = _lab_token(label)
         if not inputs["topology"].startswith(f"tests/interop/{token}-"):
             errors.append(f"{prefix}: {label} topology drifted: {inputs['topology']}")

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import collections
 import hashlib
 import re
 import stat
@@ -149,25 +148,28 @@ PERMISSION_HASHES = {
     "interop.yml": "6f1d70d72bad231d43c575acef6946580e439c879794ed2ea1f4a40340245172",
     "kernel-dataplane.yml": "6f1d70d72bad231d43c575acef6946580e439c879794ed2ea1f4a40340245172",
 }
-CALL_HASHES = {
-    "interop.yml": "4f21857a91c96ea0b6743dbfcb709a26ffdcbb071357c0e7e489fd8a0174916c",
-    "kernel-dataplane.yml": "ffe292e5ed004a8c1ca0f271ddd934311e2a0dc0b3401f95ec9bd7ac4c3a675b",
-}
-PINS = collections.Counter(
+# External actions are pinned by reviewed version tag: no branch refs and no
+# bare commit SHAs. Adding an action or moving to a new major edits this set.
+PINS = frozenset(
     {
-        "actions/checkout@v7": 97,
-        "dtolnay/rust-toolchain@v1 # stable": 3,
-        "Swatinem/rust-cache@v2": 5,
-        "dtolnay/rust-toolchain@v1 # 1.95": 2,
-        "docker/setup-buildx-action@v4": 51,
-        "docker/build-push-action@v7": 56,
-        "actions/cache@v6": 7,
-        "actions/upload-artifact@v7": 12,
-        "actions/download-artifact@v8": 5,
-        "rustsec/audit-check@v2.0.0": 1,
-        "EmbarkStudios/cargo-deny-action@v2": 1,
+        "actions/cache@v6",
+        "actions/checkout@v7",
+        "actions/download-artifact@v8",
+        "actions/upload-artifact@v7",
+        "docker/build-push-action@v7",
+        "docker/setup-buildx-action@v4",
+        "dtolnay/rust-toolchain@v1",
+        "EmbarkStudios/cargo-deny-action@v2",
+        "rustsec/audit-check@v2.0.0",
+        "Swatinem/rust-cache@v2",
     }
 )
+VERSION_TAG = re.compile(r"@v\d+(?:\.\d+){0,2}$")
+LAB_CALL = re.compile(
+    r"(?ms)^        uses: \./\.github/actions/run-interop-test\n(.*?)(?=^      - |\Z)"
+)
+LAB_CALL_INPUT = re.compile(r"(?m)^          (label|topology|script): (.+)$")
+SETUP_HOST_ACTION = "uses: ./.github/actions/setup-dataplane-host"
 
 GOBGP_PRODUCER_JOB_CONTRACT = (
     "    needs: classify_changes",
@@ -320,6 +322,36 @@ def _list_needs(block: str) -> list[str]:
     if not match:
         return []
     return re.findall(r"(?m)^      - ([\w-]+)$", match.group(1))
+
+
+def _lab_token(label: str) -> str:
+    """Scenario token of a lab label: ``M37+IP`` -> ``m37``, ``M43 crash-restart`` -> ``m43``."""
+    return re.split(r"[ +-]", label, maxsplit=1)[0].lower()
+
+
+def _check_lab_calls(name: str, job_name: str, job: str, errors: list[str]) -> None:
+    """Every lab job drives its own scenarios through complete run-interop-test calls."""
+    prefix = f"{name}:{job_name}"
+    calls = LAB_CALL.findall(job)
+    if not calls:
+        errors.append(f"{prefix}: has no run-interop-test call")
+    labels: set[str] = set()
+    for call in calls:
+        inputs = dict(LAB_CALL_INPUT.findall(call))
+        missing = [key for key in ("label", "topology", "script") if key not in inputs]
+        if missing:
+            errors.append(f"{prefix}: run-interop-test call missing {', '.join(missing)}")
+            continue
+        label = inputs["label"]
+        labels.add(label.replace("+", "-").upper())
+        token = _lab_token(label)
+        if not inputs["topology"].startswith(f"tests/interop/{token}-"):
+            errors.append(f"{prefix}: {label} topology drifted: {inputs['topology']}")
+        if not inputs["script"].startswith(f"tests/interop/scripts/test-{token}-"):
+            errors.append(f"{prefix}: {label} script drifted: {inputs['script']}")
+    for token in job_name.split("_"):
+        if token.upper() not in labels:
+            errors.append(f"{prefix}: no run-interop-test call labelled {token.upper()}")
 
 
 def _expected_jobs(block: str) -> list[str]:
@@ -995,12 +1027,15 @@ def check(root: Path) -> list[str]:
                         errors.append(f"interop.yml:m85: permits {forbidden}")
             if CHECKOUT not in job:
                 errors.append(f"{name}:{job_name}: pinned checkout drifted")
+            _check_lab_calls(name, job_name, job, errors)
             if setup:
-                if "uses: ./.github/actions/setup-dataplane-host" not in job:
+                if job.count(SETUP_HOST_ACTION) != 1:
                     errors.append(f"{name}:{job_name}: setup call drifted")
                 if GRPCURL_ACTION in job:
                     errors.append(f"{name}:{job_name}: bypasses shared host setup")
             else:
+                if SETUP_HOST_ACTION in job:
+                    errors.append(f"{name}:{job_name}: kernel host setup in interop lab")
                 if job.count(GRPCURL_ACTION) != 1:
                     errors.append(
                         f"{name}:{job_name}: must consume one grpcurl artifact"
@@ -1056,16 +1091,6 @@ def check(root: Path) -> list[str]:
         for forbidden in ("continue-on-error:", "if: success()"):
             if forbidden in aggregate:
                 errors.append(f"{name}:check permits {forbidden}")
-        calls = "\n".join(
-            line.strip()
-            for line in texts[name].splitlines()
-            if re.search(
-                r"(setup-dataplane-host|run-interop-test|label:|topology:|script:)",
-                line,
-            )
-        )
-        if _hash(calls) != CALL_HASHES[name]:
-            errors.append(f"{name}: existing test/setup calls drifted")
     m92 = _jobs(texts["interop.yml"]).get("m92", "")
     required = {
         GRPCURL_ACTION: 1,
@@ -1644,23 +1669,26 @@ def check(root: Path) -> list[str]:
     if "bird.nic.cz" in bird3_surfaces:
         errors.append("bird.nic.cz URL escaped the installer/Dockerfile")
 
-    pins = collections.Counter()
-    for text in [
-        *texts.values(),
-        action,
-        prepare_grpcurl_action,
-        prepare_gobgp_action,
-        prime_dev_image_action,
-        grpcurl_action,
-        gnmic_action,
-        gobgp_action,
-        bird3_action,
-    ]:
+    pin_surfaces = {
+        **{f".github/workflows/{name}": text for name, text in texts.items()},
+        ".github/actions/setup-dataplane-host/action.yml": action,
+        ".github/actions/prepare-grpcurl-artifact/action.yml": prepare_grpcurl_action,
+        ".github/actions/prepare-gobgp-artifact/action.yml": prepare_gobgp_action,
+        ".github/actions/prime-rustbgpd-dev-cache/action.yml": prime_dev_image_action,
+        ".github/actions/install-grpcurl-artifact/action.yml": grpcurl_action,
+        ".github/actions/install-gnmic-artifact/action.yml": gnmic_action,
+        ".github/actions/stage-gobgp-artifact/action.yml": gobgp_action,
+        ".github/actions/stage-bird3-artifact/action.yml": bird3_action,
+    }
+    for source, text in pin_surfaces.items():
         for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE):
-            if not value.strip().startswith("./"):
-                pins[value.strip()] += 1
-    if pins != PINS:
-        errors.append("external action pins/counts drifted")
+            ref = value.split("#", 1)[0].strip()
+            if ref.startswith("./"):
+                continue
+            if not VERSION_TAG.search(ref):
+                errors.append(f"{source}: action ref is not a reviewed version tag: {ref}")
+            elif ref not in PINS:
+                errors.append(f"{source}: action ref is not in the reviewed pin set: {ref}")
 
     dockerfile = (root / "Dockerfile").read_text()
     builder = dockerfile.split("FROM chef AS builder\n", 1)[-1].split("\nFROM ", 1)[0]

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -11,7 +11,14 @@ from unittest import mock
 from pathlib import Path
 
 from scripts import classify_heavy_ci_paths as heavy
-from scripts.check_ci_image_primer_contract import INTEROP, KERNEL, _list_needs, check
+from scripts.check_ci_image_primer_contract import (
+    INTEROP,
+    KERNEL,
+    PINS,
+    VERSION_TAG,
+    _list_needs,
+    check,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -96,7 +103,7 @@ class PrimerContractTests(unittest.TestCase):
         ):
             shutil.copy2(ROOT / "tests" / "interop" / name, interop / name)
 
-    def mutate(self, relative, old, new="", occurrence=0):
+    def mutate(self, relative, old, new="", occurrence=0, expect=None):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             for fixture in (
@@ -141,7 +148,10 @@ class PrimerContractTests(unittest.TestCase):
                 )
                 start = index + len(old)
             path.write_text(text[:index] + new + text[index + len(old) :])
-            self.assertTrue(check(root), f"mutation stayed green: {relative}: {old}")
+            errors = check(root)
+            self.assertTrue(errors, f"mutation stayed green: {relative}: {old}")
+            if expect is not None:
+                self.assertIn(expect, errors)
 
     def stage_indexed_fixture(self, root):
         for fixture in (
@@ -208,6 +218,116 @@ class PrimerContractTests(unittest.TestCase):
 
     def test_live_contract(self):
         self.assertEqual([], check(ROOT))
+
+    def test_external_action_refs_are_reviewed_version_tags(self):
+        for ref in PINS:
+            self.assertRegex(ref, VERSION_TAG)
+        audit = ".github/workflows/audit.yml"
+        ci = ".github/workflows/ci.yml"
+        bird3 = ".github/actions/stage-bird3-artifact/action.yml"
+        sha = "0123456789abcdef0123456789abcdef01234567"
+        cases = (
+            (
+                audit,
+                "actions/checkout@v7",
+                "actions/checkout@main",
+                f"{audit}: action ref is not a reviewed version tag: actions/checkout@main",
+            ),
+            (
+                audit,
+                "actions/checkout@v7",
+                f"actions/checkout@{sha}",
+                f"{audit}: action ref is not a reviewed version tag: actions/checkout@{sha}",
+            ),
+            (
+                audit,
+                "actions/checkout@v7",
+                "actions/checkout@v8",
+                f"{audit}: action ref is not in the reviewed pin set: actions/checkout@v8",
+            ),
+            (
+                audit,
+                "      - uses: actions/checkout@v7\n",
+                "      - uses: actions/checkout@v7\n      - uses: actions/setup-python@v5\n",
+                f"{audit}: action ref is not in the reviewed pin set: actions/setup-python@v5",
+            ),
+            (
+                ci,
+                "dtolnay/rust-toolchain@v1 # stable",
+                "dtolnay/rust-toolchain@master # stable",
+                f"{ci}: action ref is not a reviewed version tag: dtolnay/rust-toolchain@master",
+            ),
+            (
+                bird3,
+                "actions/download-artifact@v8",
+                "actions/download-artifact@main",
+                f"{bird3}: action ref is not a reviewed version tag: "
+                "actions/download-artifact@main",
+            ),
+        )
+        for relative, old, new, expect in cases:
+            with self.subTest(relative=relative, ref=new.strip()):
+                self.mutate(relative, old, new, expect=expect)
+
+    def test_lab_call_structure_is_load_bearing(self):
+        interop = ".github/workflows/interop.yml"
+        kernel = ".github/workflows/kernel-dataplane.yml"
+        m1_call = (
+            "        uses: ./.github/actions/run-interop-test\n"
+            "        with:\n"
+            "          label: M1\n"
+            "          topology: tests/interop/m1-frr.clab.yml\n"
+            "          script: tests/interop/scripts/test-m1-frr.sh\n"
+        )
+        self.assertEqual(1, (ROOT / interop).read_text().count(m1_call))
+        for old, new, expect in (
+            ("          label: M1\n", "", "interop.yml:m1: run-interop-test call missing label"),
+            (
+                "          topology: tests/interop/m1-frr.clab.yml\n",
+                "",
+                "interop.yml:m1: run-interop-test call missing topology",
+            ),
+            (
+                "          script: tests/interop/scripts/test-m1-frr.sh\n",
+                "",
+                "interop.yml:m1: run-interop-test call missing script",
+            ),
+            ("label: M1\n", "label: M2\n", "interop.yml:m1: no run-interop-test call labelled M1"),
+            (
+                "topology: tests/interop/m1-frr.clab.yml",
+                "topology: tests/interop/m13-policy-frr.clab.yml",
+                "interop.yml:m1: M1 topology drifted: tests/interop/m13-policy-frr.clab.yml",
+            ),
+            (
+                "script: tests/interop/scripts/test-m1-frr.sh",
+                "script: tests/interop/scripts/test-m13-policy-frr.sh",
+                "interop.yml:m1: M1 script drifted: tests/interop/scripts/test-m13-policy-frr.sh",
+            ),
+        ):
+            with self.subTest(seam=old.strip()):
+                self.mutate(interop, m1_call, m1_call.replace(old, new), expect=expect)
+        with self.subTest(seam="interop lab gains kernel host setup"):
+            self.mutate(
+                interop,
+                m1_call,
+                m1_call + "      - uses: ./.github/actions/setup-dataplane-host\n",
+                expect="interop.yml:m1: kernel host setup in interop lab",
+            )
+        host_setup = "      - uses: ./.github/actions/setup-dataplane-host\n"
+        with self.subTest(seam="kernel lab duplicates host setup"):
+            self.mutate(
+                kernel,
+                host_setup,
+                host_setup * 2,
+                expect="kernel-dataplane.yml:m36: setup call drifted",
+            )
+        with self.subTest(seam="kernel lab loses its scenario call"):
+            self.mutate(
+                kernel,
+                "        uses: ./.github/actions/run-interop-test\n",
+                "        uses: ./.github/actions/install-containerlab\n",
+                expect="kernel-dataplane.yml:m36: has no run-interop-test call",
+            )
 
     def test_v064_producer_is_load_bearing(self):
         cache_key = (

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -104,6 +104,13 @@ class PrimerContractTests(unittest.TestCase):
             shutil.copy2(ROOT / "tests" / "interop" / name, interop / name)
 
     def mutate(self, relative, old, new="", occurrence=0, expect=None):
+        errors = self.mutated_errors(relative, old, new, occurrence)
+        self.assertTrue(errors, f"mutation stayed green: {relative}: {old}")
+        if expect is not None:
+            self.assertIn(expect, errors)
+        return errors
+
+    def mutated_errors(self, relative, old, new="", occurrence=0):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             for fixture in (
@@ -148,10 +155,7 @@ class PrimerContractTests(unittest.TestCase):
                 )
                 start = index + len(old)
             path.write_text(text[:index] + new + text[index + len(old) :])
-            errors = check(root)
-            self.assertTrue(errors, f"mutation stayed green: {relative}: {old}")
-            if expect is not None:
-                self.assertIn(expect, errors)
+            return check(root)
 
     def stage_indexed_fixture(self, root):
         for fixture in (
@@ -322,11 +326,40 @@ class PrimerContractTests(unittest.TestCase):
                 expect="kernel-dataplane.yml:m36: setup call drifted",
             )
         with self.subTest(seam="kernel lab loses its scenario call"):
-            self.mutate(
+            errors = self.mutate(
                 kernel,
                 "        uses: ./.github/actions/run-interop-test\n",
                 "        uses: ./.github/actions/install-containerlab\n",
                 expect="kernel-dataplane.yml:m36: has no run-interop-test call",
+            )
+            self.assertEqual(
+                ["kernel-dataplane.yml:m36: has no run-interop-test call"],
+                [error for error in errors if error.startswith("kernel-dataplane.yml:m36:")],
+            )
+        with self.subTest(seam="incomplete call reports one cause"):
+            errors = self.mutate(
+                interop,
+                m1_call,
+                m1_call.replace("          label: M1\n", ""),
+                expect="interop.yml:m1: run-interop-test call missing label",
+            )
+            self.assertEqual(
+                ["interop.yml:m1: run-interop-test call missing label"],
+                [error for error in errors if error.startswith("interop.yml:m1:")],
+            )
+        with self.subTest(seam="descriptive label satisfies the roster"):
+            self.assertEqual(
+                [],
+                self.mutated_errors(
+                    kernel, "          label: M36\n", "          label: M36 crash-restart\n"
+                ),
+            )
+        with self.subTest(seam="variant label is the job identifier"):
+            self.mutate(
+                kernel,
+                "          label: M37+IP\n",
+                "          label: M37\n",
+                expect="kernel-dataplane.yml:m37-ip: no run-interop-test call labelled M37-IP",
             )
 
     def test_v064_producer_is_load_bearing(self):


### PR DESCRIPTION
## Summary

`scripts/check_ci_image_primer_contract.py` froze two things that unrelated feature work kept re-deriving:

- `PINS`: a `collections.Counter` of exact global use counts per external action (`"actions/checkout@v7": 97`, ...), compared with `!=`.
- `CALL_HASHES`: sha256 digests over every `interop.yml` / `kernel-dataplane.yml` line matching `(setup-dataplane-host|run-interop-test|label:|topology:|script:)`.

Both become explicit checks whose failures name the file and the offending ref, job, or value. `TRIGGER_HASHES` and `PERMISSION_HASHES` are untouched.

### Pin set

`PINS` is now the set of reviewed refs. Every `uses:` in the four covered workflows (`ci.yml`, `audit.yml`, `interop.yml`, `kernel-dataplane.yml`) and the eight composite actions the checker already reads must be a version-tag ref (`@vN`, `@vN.N`, or `@vN.N.N`) and be in the set. Trailing channel comments on the `dtolnay/rust-toolchain@v1 # stable` lines are ignored. Failure messages:

```
.github/workflows/audit.yml: action ref is not a reviewed version tag: rustsec/audit-check@main
.github/workflows/kernel-dataplane.yml: action ref is not in the reviewed pin set: actions/setup-node@v4
```

### Lab call structure

The digests become a per-job check inside the existing lab-job loop (the one that already checks needs, checkout, grpcurl consumption, and host setup per job):

```
interop.yml:m13: run-interop-test call missing label
interop.yml:m13: no run-interop-test call labelled M13
interop.yml:m1: M1 topology drifted: tests/interop/m13-policy-frr.clab.yml
kernel-dataplane.yml:m36: setup call drifted
```

## Invariants kept

1. Every external action ref is a version tag: no `@main`/`@master`/branch refs and no bare commit SHAs (the pin posture from the SHA-to-tag move, with the toolchain following the `v1` line).
2. Every external action ref is in the reviewed set: a new action, or a move to a new major, fails until the set is edited.
3. Every lab job in the `INTEROP` and `KERNEL` rosters has at least one `run-interop-test` call.
4. Every `run-interop-test` call carries `label`, `topology`, and `script`.
5. Each call's topology and script paths carry the label's scenario token (`M37+IP` and `M43 crash-restart` resolve to `m37-...` and `m43-...`), so a scenario cannot be silently swapped for another under the same label.
6. Every token of a lab job name appears among that job's labels (`m26_m27_m28_m59_m91` must still run M26, M27, M28, M59, and M91), so a combined job cannot drop a member. A space-separated descriptive suffix (`M43 crash-restart`) is ignored for this roster; `+`/`-` joined variants are kept because `M37+IP` is the `m37-ip` job's own identifier, so swapping it for plain `M37` is still caught.
7. Every kernel lab job calls `setup-dataplane-host` exactly once (the old check only required presence); interop lab jobs never do.
8. Every per-job contract that already existed (needs rosters, cache/upload/download steps in the artifact producers, primer and gobgp job bodies, the M76/M77/M83/M85/M92/M99–M104 seams, netns receipt seams) is unchanged. Neutering the two old checks left every one of those mutation cases still red, so none of them relied on the global count alone.

## Invariants dropped

1. Exact global use count per action. Of the 29 commits that touched the `PINS` block, 4 changed the key set (creation, the SHA-to-tag move, the v0.64 validator adding cache/upload/download, the toolchain moving to `v1`) and 25 changed only counts because a feature PR added or removed a job. The count could not say which step changed, and the self-test shows every add/remove case that matters is protected by a per-job contract.
2. The call-line digests. All 14 commits touching `CALL_HASHES` re-derived a hash; the regex also matched four prose comment lines in `kernel-dataplane.yml`, so editing a comment forced a re-derivation. An opaque digest cannot name what drifted.

## Edit-frequency evidence

```
$ git log -G'"actions/checkout@v7": [0-9]+' -- scripts/check_ci_image_primer_contract.py | wc -l   # 20 commits, 2026-08-07 .. 2026-09-02
$ git log -L '/^PINS = collections.Counter/,/^)/:scripts/check_ci_image_primer_contract.py' -s   # 29 commits: 4 key-set changes, 25 count-only
$ git log -L '/^CALL_HASHES = {/,/^}/:scripts/check_ci_image_primer_contract.py' -s                # 14 commits, every one a re-derivation
```

Neutering both old comparisons and running the self-test made exactly six subtests pass: `test_m76_gobgp48_job_is_load_bearing` (`label: M76`), `test_m77_gobgp48_job_is_load_bearing` (`label: M77`), `test_destructive_workflow_seams` (M1 `run-interop-test` replaced), and the three `test_combined_cheap_interop_job_and_m91_target_are_load_bearing` label/topology/script swaps. Each is now caught by the structural check with a named message.

## Self-test changes

`mutate()` gains an optional `expect=` argument that asserts a specific message and returns the error list through a new `mutated_errors` helper. A job with no `run-interop-test` call, or a call missing a required input, yields exactly one lab-call error (the check returns after the primary cause); the test asserts that count, that a descriptive label still satisfies the roster, and that a variant-label swap is caught. Two tests are added: `test_external_action_refs_are_reviewed_version_tags` (branch ref, bare SHA, unknown major, new action, toolchain comment stripping, composite-action surface) and `test_lab_call_structure_is_load_bearing` (each missing key, label/topology/script swap, interop job gaining host setup, kernel job duplicating host setup, kernel job losing its call).

## Checks

| Command | Exit |
| --- | --- |
| `python3 scripts/check_ci_image_primer_contract.py` | 0 |
| `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py` (55 tests) | 0 |
| `python3 scripts/check_ci_scale_split_contract.py` | 0 |
| `python3 scripts/check_developer_tooling.py` (ruff + actionlint) | 0 |
| `ruff check` on both files | 0 |
