### PR TITLE
docs: state the live-side blind spots of rbgp diff and add a rustbgpd snapshot sketch

### DIFF
--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -67,6 +67,18 @@ const LIVE_SOURCE_NOTES: &[&str] = &[
     "unknown attributes: path attributes outside the typed set (origin, as_path, next_hop, \
      med, local_pref, communities, extended/large communities) are not visible over gRPC \
      and are not compared",
+    "encode-time attributes: the transport finalizes each UPDATE after the advertised view \
+     is computed — the eBGP local-ASN prepend and remove-private-as, the eBGP next-hop \
+     rewrite to the local address (default for peers that are not route-server clients, or \
+     `set next-hop self`), and the GRACEFUL_SHUTDOWN community added by `rbgp gshut` — so a \
+     BMP rib_out_post capture carries them and the live side does not; a `set next-hop <ip>` \
+     is stored and visible",
+    "update groups: a peer sharing an update group has no stored per-peer Adj-RIB-Out; its \
+     live view is synthesized from the group table minus its own-sourced routes, \
+     exact-export rejections, and outbound prefix-limit exclusions",
+    "aggregation: AGGREGATOR and ATOMIC_AGGREGATE are exposed over gRPC but rbgp-ribsnap/1 \
+     has no field for them, so the live side drops them; a from-bmp snapshot keeps them in \
+     unknown_attrs, which diverges unless --ignore-attribute unknown is passed",
     "generation: the route-page epoch/generation pair is a process-local consistency fence, \
      compared only across live pages and peers; it is not a RIB snapshot generation and is \
      never compared with the producer-local snapshot header generation",

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -436,6 +436,9 @@ schema rbgp-ribdiff/1; normalization v1; ignored attributes: as_path, next_hop
 live-source notes:
   - as_path: the daemon proto exposes a flattened ASN list, so AS_PATH is compared as a single AS_SEQUENCE on both sides; AS_SET structure is not compared
   - unknown attributes: path attributes outside the typed set (origin, as_path, next_hop, med, local_pref, communities, extended/large communities) are not visible over gRPC and are not compared
+  - encode-time attributes: the transport finalizes each UPDATE after the advertised view is computed — the eBGP local-ASN prepend and remove-private-as, the eBGP next-hop rewrite to the local address (default for peers that are not route-server clients, or `set next-hop self`), and the GRACEFUL_SHUTDOWN community added by `rbgp gshut` — so a BMP rib_out_post capture carries them and the live side does not; a `set next-hop <ip>` is stored and visible
+  - update groups: a peer sharing an update group has no stored per-peer Adj-RIB-Out; its live view is synthesized from the group table minus its own-sourced routes, exact-export rejections, and outbound prefix-limit exclusions
+  - aggregation: AGGREGATOR and ATOMIC_AGGREGATE are exposed over gRPC but rbgp-ribsnap/1 has no field for them, so the live side drops them; a from-bmp snapshot keeps them in unknown_attrs, which diverges unless --ignore-attribute unknown is passed
   - generation: the route-page epoch/generation pair is a process-local consistency fence, compared only across live pages and peers; it is not a RIB snapshot generation and is never compared with the producer-local snapshot header generation
 verdict: in_sync
 per-peer summary:

--- a/docs/ribdiff.md
+++ b/docs/ribdiff.md
@@ -67,6 +67,22 @@ Live-source limitations (also printed in every report):
   (the proto exposes a flat ASN list); `AS_SET` structure is not compared.
 - **Unknown attributes**: path attributes outside the typed set are not
   visible over gRPC and are not compared.
+- **Encode-time attributes**: the transport finalizes each UPDATE after the
+  advertised view is computed. The eBGP local-ASN prepend and
+  remove-private-as, the eBGP next-hop rewrite to the local address (the
+  default for peers that are not route-server clients, or an export
+  `set next-hop self`), and the `GRACEFUL_SHUTDOWN` community added by
+  `rbgp gshut` are attached on the wire only. A BMP `rib_out_post` capture
+  carries them; the live side does not. An export `set next-hop <ip>` is
+  applied to the stored route and is visible.
+- **Update groups**: a peer sharing an update group has no stored per-peer
+  Adj-RIB-Out. Its live view is synthesized from the group table minus its
+  own-sourced routes, exact-export rejections, and outbound prefix-limit
+  exclusions.
+- **Aggregation**: `AGGREGATOR` and `ATOMIC_AGGREGATE` are exposed over gRPC
+  but `rbgp-ribsnap/1` has no field for them, so the live side drops them.
+  A from-bmp snapshot keeps them in `unknown_attrs`, which diverges unless
+  `--ignore-attribute unknown` is passed.
 - **Generation**: `ListRoutesResponse.page_version` exposes an opaque
   process-local `{epoch, generation}` consistency fence, not a numeric RIB
   snapshot generation. The adapter pins the complete pair across every live
@@ -153,7 +169,10 @@ duplicates; multiplicity is compared):
   byte-exact by the engine — but the live gRPC side cannot see unknown
   attributes, so a snapshot carrying them diverges against a live
   comparison unless `--ignore-attribute unknown` is passed (an explicit
-  operator decision, never a silent drop).
+  operator decision, never a silent drop). `AGGREGATOR` and
+  `ATOMIC_AGGREGATE` land here too: the from-bmp adapter preserves them as
+  wire triples, while the live conversion drops them because the schema
+  has no typed field for them.
 - `path_id`: optional; diagnostics only, never compared.
 
 Unknown fields are rejected (typo protection). All fields except
@@ -210,6 +229,45 @@ Or with `jq`, from a JSON export shaped like
      '{record:"trailer",routes:$n}'
 } > incumbent.ndjson
 ```
+
+### From another rustbgpd
+
+`rbgp --json rib advertised <peer>` (without `--limit`, which nests the
+bounded form under `routes`) prints a JSON array of route objects whose
+field names are close to the snapshot's. The operator supplies `peer` and
+`peer_asn`; `origin` is a string; `med` is already the presence-aware
+value (`null` when the attribute is absent). Two fields must not be passed
+through: `local_pref` is the effective, defaulted value (100 on an eBGP
+export that carries no attribute), and copying it fabricates attribute
+presence — only `local_pref_attr`, present just when the attribute exists,
+may become the snapshot's `local_pref`; `peer_address` is the route's
+source peer, not the member it is advertised to.
+
+```bash
+PEER=192.0.2.1; PEER_ASN=64501
+rbgp --json rib advertised "$PEER" > advertised.json
+{
+  jq -nc '{record:"header",schema:"rbgp-ribsnap/1",source:"rustbgpd-rs1",generation:1}'
+  jq -c --arg peer "$PEER" --argjson peer_asn "$PEER_ASN" '
+    .[] | {record:"route", peer:$peer, peer_asn:$peer_asn,
+           prefix, next_hop, as_path, med, communities, extended_communities,
+           large_communities, path_id,
+           origin: {igp:0, egp:1, incomplete:2}[.origin],
+           local_pref: .local_pref_attr}   # never .local_pref: that is the effective default
+    | with_entries(select(.value != null))' advertised.json
+  jq -nc --argjson n "$(jq length advertised.json)" '{record:"trailer",routes:$n}'
+} > rustbgpd.ndjson
+```
+
+Community strings come out as `ASN:value` or a well-known alias
+(`NO_EXPORT`, `GRACEFUL_SHUTDOWN`, ...), both accepted by the snapshot
+parser; extended communities are the raw integers the schema expects
+(jq 1.7 or later keeps 64-bit values exact). This source has the same
+blind spots as the live side above — no unknown attributes, no
+encode-time attributes, no aggregation attributes — so it is a snapshot of
+what the daemon's RIB would advertise, not of what reached the wire. For a
+wire-true record of a rustbgpd export, capture its own BMP `rib_out_post`
+feed and convert it with `rbgp diff snapshot from-bmp`.
 
 ## Snapshot adapters
 


### PR DESCRIPTION
## Summary

Documentation-only; no behavior change beyond the `live_source_notes` strings that `rbgp diff advertised` prints.

### Live-side asymmetries now stated

`LIVE_SOURCE_NOTES` in `crates/cli/src/commands/diff.rs` and the matching bullets in `docs/ribdiff.md` said only that unknown path attributes are invisible on the live gRPC side. Three notes are added, each quoted from what the code does:

- **Encode-time attributes.** `prepare_unicast_attributes` / `prepare_mp_attributes` in the transport export profile finalize each UPDATE after the RIB's advertised view is computed: the eBGP local-ASN prepend and remove-private-as, the eBGP NEXT_HOP rewrite to the local address (the default for peers that are not route-server clients, and `set next-hop self`), and the `GRACEFUL_SHUTDOWN` community added by `rbgp gshut`. The BMP `rib_out_post` stream mirrors the encoded PDU, so it carries them; the live view does not. A `set next-hop <ip>` is applied to the stored route and is visible.
- **Update groups.** A grouped member holds no per-peer Adj-RIB-Out; its live view is synthesized from the group table minus own-sourced routes, exact-export rejections, and outbound prefix-limit exclusions (`grouped_advertised_routes_iter`).
- **Aggregation.** The proto exposes `aggregator` / `atomic_aggregate`; `rbgp-ribsnap/1` has no field for them and `convert_live_route` drops them, while `from-bmp` keeps them in `unknown_attrs`.

The AS_PATH flattening was already covered by the existing note and is unchanged. The cookbook's example report in `docs/cookbook/route-server-migration.md` gains the same three lines so it matches what the command prints. The existing `live_source_notes` tests (non-empty, no retired MED caveat, rendered in both outputs) still pass.

### Snapshot sketch from another rustbgpd

`docs/ribdiff.md` gains a jq sketch that maps `rbgp --json rib advertised <peer>` (a top-level array; the `--limit` form nests under `routes`) to `rbgp-ribsnap/1`: `origin` string to integer, `med` passed through (already the presence-aware value), `local_pref` taken only from `local_pref_attr` with an explicit warning that the bare `local_pref` is the effective default and would fabricate attribute presence, `peer`/`peer_asn` supplied by the operator, and a note that this source shares the live-side blind spots so it is not a substitute for a BMP `rib_out_post` capture.

The sketch was run against a live daemon: two released-image daemons peering over a Docker network, two routes injected with `rbgp rib add` (one with MED, AS path, a community, and a large community). The generated snapshot compared `in_sync` (exit 0) with `rbgp diff advertised`; passing the bare `local_pref` through instead produced `attribute-changed ... local_pref: 100 -> null` on every route (exit 1), which is the fabrication the warning describes.

## Checks

| Command | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `just links` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `cargo test -p rustbgpctl diff` (77 passed) | 0 |
