### PR TITLE
event-history: deny clippy::all and warn clippy::pedantic

### DIFF
--- a/crates/event-history/src/cursor.rs
+++ b/crates/event-history/src/cursor.rs
@@ -34,7 +34,7 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::{debug, warn};
 
-use crate::storage::{QueryFilter, StoreHandle};
+use crate::storage::{PersistedEvent, QueryFilter, StoreHandle};
 use crate::{
     Category, CommittedEvent, EhmState, EventHistoryError, EventHistoryManager, PayloadCodec,
 };
@@ -203,6 +203,11 @@ impl EventHistoryManager {
     /// Returns [`EventHistoryError::PassThrough`] when EHM is in
     /// pass-through mode (no durable backing). Live-only is still
     /// possible by calling [`Self::subscribe`] directly.
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "the handshake runs synchronously by design; the async signature is the public API the daemon awaits"
+    )]
     pub async fn subscribe_from_event(
         &self,
         req: SubscribeRequest,
@@ -243,25 +248,16 @@ pub(crate) fn subscribe_from_event_inner(
 
     let output_capacity = req.output_capacity.max(1);
     let (out_tx, out_rx) = mpsc::channel(output_capacity);
-    let stats = Arc::new(SubscribeStats::default());
+    let subscription_stats = Arc::new(SubscribeStats::default());
 
-    let req_clone = req.clone();
-    let stats_for_task = stats.clone();
+    let task_stats = Arc::clone(&subscription_stats);
     tokio::spawn(async move {
-        run_subscription(
-            req_clone,
-            high_watermark,
-            storage,
-            live_rx,
-            out_tx,
-            stats_for_task,
-        )
-        .await;
+        run_subscription(req, high_watermark, storage, live_rx, out_tx, task_stats).await;
     });
 
     Ok(EventSubscription {
         receiver: out_rx,
-        stats,
+        stats: subscription_stats,
     })
 }
 
@@ -336,32 +332,9 @@ async fn run_subscription(
             if rows.is_empty() {
                 break;
             }
-            let last_id = rows.last().map(|r| r.event_id).unwrap_or(high_watermark);
+            let last_id = rows.last().map_or(high_watermark, |r| r.event_id);
             for row in rows {
-                // Reconstruct a CommittedEvent from PersistedEvent.
-                let envelope = crate::EventEnvelope {
-                    timestamp_ns: row.timestamp_ns,
-                    category: row.category,
-                    event_type: row.event_type,
-                    peers: crate::EnvelopePeers {
-                        peer: row.peer.as_ref().and_then(|s| s.parse().ok()),
-                        previous_peer: row.previous_peer.as_ref().and_then(|s| s.parse().ok()),
-                        target_peer: row.target_peer.as_ref().and_then(|s| s.parse().ok()),
-                    },
-                    afi_safi: row.afi_safi,
-                    prefix: row.prefix,
-                    rd: row.rd,
-                    evpn_route_type: row.evpn_route_type,
-                    severity: row.severity,
-                    payload_codec: PayloadCodec::parse(&row.payload_codec)
-                        .unwrap_or(PayloadCodec::Opaque),
-                    payload: row.payload,
-                };
-                let committed = CommittedEvent {
-                    event_id: row.event_id,
-                    daemon_boot_id: row.daemon_boot_id.into(),
-                    envelope: envelope.into(),
-                };
+                let committed = committed_from_persisted(row);
                 if !req.filter.matches(&committed) {
                     continue;
                 }
@@ -420,6 +393,32 @@ async fn run_subscription(
     );
 }
 
+/// Reconstruct the [`CommittedEvent`] a replayed row was broadcast as.
+fn committed_from_persisted(row: PersistedEvent) -> CommittedEvent {
+    let envelope = crate::EventEnvelope {
+        timestamp_ns: row.timestamp_ns,
+        category: row.category,
+        event_type: row.event_type,
+        peers: crate::EnvelopePeers {
+            peer: row.peer.as_ref().and_then(|s| s.parse().ok()),
+            previous_peer: row.previous_peer.as_ref().and_then(|s| s.parse().ok()),
+            target_peer: row.target_peer.as_ref().and_then(|s| s.parse().ok()),
+        },
+        afi_safi: row.afi_safi,
+        prefix: row.prefix,
+        rd: row.rd,
+        evpn_route_type: row.evpn_route_type,
+        severity: row.severity,
+        payload_codec: PayloadCodec::parse(&row.payload_codec).unwrap_or(PayloadCodec::Opaque),
+        payload: row.payload,
+    };
+    CommittedEvent {
+        event_id: row.event_id,
+        daemon_boot_id: row.daemon_boot_id.into(),
+        envelope: envelope.into(),
+    }
+}
+
 fn retention_gap_missed_count(from_id: u64, floor: Option<u64>) -> Option<u64> {
     let next_id = from_id.saturating_add(1);
     floor.and_then(|floor| (next_id < floor).then(|| floor.saturating_sub(next_id)))
@@ -436,25 +435,28 @@ async fn emit_event(
 }
 
 async fn emit_lag(out_tx: &mpsc::Sender<EventSubscriptionItem>, missed: u64) -> bool {
-    match out_tx.send(EventSubscriptionItem::Lagged(missed)).await {
-        Ok(()) => true,
-        Err(_) => {
-            debug!("subscription output closed");
-            false
-        }
+    if out_tx
+        .send(EventSubscriptionItem::Lagged(missed))
+        .await
+        .is_ok()
+    {
+        true
+    } else {
+        debug!("subscription output closed");
+        false
     }
 }
 
 async fn emit_retention_gap(out_tx: &mpsc::Sender<EventSubscriptionItem>, missed: u64) -> bool {
-    match out_tx
+    if out_tx
         .send(EventSubscriptionItem::RetentionGap(missed))
         .await
+        .is_ok()
     {
-        Ok(()) => true,
-        Err(_) => {
-            debug!("subscription output closed before retention-gap signal");
-            false
-        }
+        true
+    } else {
+        debug!("subscription output closed before retention-gap signal");
+        false
     }
 }
 

--- a/crates/event-history/src/error.rs
+++ b/crates/event-history/src/error.rs
@@ -12,14 +12,14 @@ pub enum EventHistoryError {
     #[error("sqlite error: {0}")]
     Sqlite(#[from] rusqlite::Error),
 
-    /// On-disk schema_version is higher than this daemon supports.
+    /// On-disk `schema_version` is higher than this daemon supports.
     /// Operator must upgrade the binary or quarantine the DB.
     #[error(
         "events.db schema version {on_disk} is higher than supported {supported}; refusing to start"
     )]
     SchemaDowngrade { on_disk: u32, supported: u32 },
 
-    /// On-disk schema_version is lower than this daemon supports, and
+    /// On-disk `schema_version` is lower than this daemon supports, and
     /// no migration path is wired between those versions. v1 is the
     /// only schema today, so this fires only on tampering.
     #[error("events.db schema_version {from} cannot migrate to {to}; no migration path defined")]
@@ -48,7 +48,7 @@ pub enum EventHistoryError {
     StorageUnavailable,
 
     /// EHM has been driven into pass-through mode (allocator anchor
-    /// unrecoverable) and refuses to issue new event_ids. Operator
+    /// unrecoverable) and refuses to issue new `event_id`s. Operator
     /// resolves explicitly via `rbgp event-history reset-allocator`
     /// (P1 follow-up). See ADR-0072 "Allocator recovery ladder."
     #[error("event outbox in pass-through mode; allocator anchor unrecoverable")]

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -44,11 +44,8 @@
 //! ```
 
 #![deny(unsafe_code)]
-#![warn(clippy::all)]
-#![allow(
-    clippy::module_name_repetitions,
-    reason = "public cross-crate types keep the event-history domain explicit"
-)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
 
 mod cursor;
 mod error;
@@ -79,11 +76,11 @@ pub use storage::{PersistedEvent, QueryFilter, RetentionOutcome};
 /// Default capacity for each producer's mpsc channel into EHM.
 pub const DEFAULT_QUEUE_CAPACITY: usize = 4096;
 
-/// Default batch size — the larger of (this, batch_interval) wins per
+/// Default batch size — the larger of (this, `batch_interval`) wins per
 /// commit. See ADR-0072 hot-path section.
 pub const DEFAULT_BATCH_SIZE: usize = 1024;
 
-/// Default batch interval — the larger of (batch_size, this) wins per
+/// Default batch interval — the larger of (`batch_size`, this) wins per
 /// commit.
 pub const DEFAULT_BATCH_INTERVAL: Duration = Duration::from_millis(50);
 
@@ -340,7 +337,7 @@ pub struct EnvelopePeers {
 #[derive(Debug, Clone)]
 pub struct EventEnvelope {
     /// Producer wall-clock at enqueue. Used for causal-ordering signals
-    /// to external consumers; not the cursor (event_id is).
+    /// to external consumers; not the cursor (`event_id` is).
     pub timestamp_ns: i64,
     pub category: Category,
     pub event_type: String,
@@ -384,6 +381,12 @@ impl EventHistorySender {
     /// [`mpsc::error::TrySendError::Full`] — the producer drops the
     /// event, increments its drop counter, and flips the degraded
     /// flag. Never blocks the producer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`mpsc::error::TrySendError::Full`] when the producer queue
+    /// has no free slot and [`mpsc::error::TrySendError::Closed`] once the
+    /// manager has stopped admitting events; both hand the envelope back.
     // mpsc::error::TrySendError carries the envelope on the Full /
     // Closed variants — useful for delivery accounting despite the ~200B Err.
     #[allow(
@@ -423,7 +426,7 @@ impl EventHistorySender {
     }
 
     /// Currently available slots in the underlying mpsc channel. Benchmark
-    /// fences compare this with max_capacity to detect outstanding reservations
+    /// fences compare this with `max_capacity` to detect outstanding reservations
     /// or queued items. The exported queue-depth gauge reads the acceptance
     /// ledger instead.
     #[must_use]
@@ -658,7 +661,7 @@ impl std::fmt::Debug for EventHistoryManager {
             .field("latest_event_id", &self.state.latest_event_id())
             .field("degraded", &self.state.degraded())
             .field("pass_through", &self.state.pass_through())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -693,7 +696,7 @@ impl std::fmt::Debug for EventHistoryHandle {
             .field("latest_event_id", &self.state.latest_event_id())
             .field("degraded", &self.state.degraded())
             .field("pass_through", &self.state.pass_through())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -828,6 +831,17 @@ impl EhmState {
 impl EventHistoryManager {
     /// Start the actor + storage thread. Returns once the storage
     /// thread is initialized (the DB is open + bootstrapped).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventHistoryError::PassThrough`] when the allocator anchor
+    /// cannot be recovered, and any open, quarantine, or bootstrap error
+    /// the storage thread reports while initializing the database.
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "storage initialization is synchronous; the async signature is the public API the daemon awaits"
+    )]
     pub async fn start(config: EventHistoryConfig) -> Result<Self, EventHistoryError> {
         let daemon_boot_id: Arc<str> = uuid::Uuid::new_v4().to_string().into();
         let state = Arc::new(EhmState::default());
@@ -891,31 +905,20 @@ impl EventHistoryManager {
             metrics.bind_event_outbox_queue_depth_source(queue_depths.clone());
         }
 
-        let actor_state = state.clone();
-        let actor_store = store_handle.clone();
-        let actor_broadcast = broadcast_tx.clone();
-        let actor_boot_id = daemon_boot_id.clone();
-        let actor_config = config.clone();
-        let actor_queue_depths = queue_depths.clone();
         let shutdown_progress = Arc::new(ShutdownProgress::default());
-        let actor_shutdown_progress = Arc::clone(&shutdown_progress);
-
-        let actor = tokio::spawn(async move {
-            run_actor(
-                ActorContext {
-                    config: actor_config,
-                    state: actor_state,
-                    store: actor_store,
-                    broadcast_tx: actor_broadcast,
-                    daemon_boot_id: actor_boot_id,
-                    queue_depths: actor_queue_depths,
-                    shutdown_progress: actor_shutdown_progress,
-                },
-                producer_rx,
-                shutdown_rx,
-            )
-            .await;
-        });
+        let actor = tokio::spawn(run_actor(
+            ActorContext {
+                config: config.clone(),
+                state: state.clone(),
+                store: store_handle.clone(),
+                broadcast_tx: broadcast_tx.clone(),
+                daemon_boot_id: daemon_boot_id.clone(),
+                queue_depths: queue_depths.clone(),
+                shutdown_progress: Arc::clone(&shutdown_progress),
+            },
+            producer_rx,
+            shutdown_rx,
+        ));
 
         info!(
             path = %config.path.display(),
@@ -975,6 +978,11 @@ impl EventHistoryManager {
 
     /// Force a query against the durable store. Tests use this directly;
     /// the daemon wraps it in the `SubscribeFromEvent` cursor RPC.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventHistoryError::StorageUnavailable`] when the storage
+    /// thread has stopped, or the SQLite error the query raised.
     pub async fn query_persisted(
         &self,
         from_event_id: u64,
@@ -1054,16 +1062,15 @@ impl EventHistoryManager {
         self.sender.queue_depths.close();
         let _ = self.shutdown_tx.send(Some(deadline));
         if let Some(mut actor) = self.actor.take() {
-            let result = match tokio::time::timeout_at(deadline, &mut actor).await {
-                Ok(result) => result,
-                Err(_) => {
-                    #[cfg(test)]
-                    self.shutdown_progress
-                        .deadline_expiries
-                        .fetch_add(1, Ordering::AcqRel);
-                    actor.abort();
-                    actor.await
-                }
+            let result = if let Ok(result) = tokio::time::timeout_at(deadline, &mut actor).await {
+                result
+            } else {
+                #[cfg(test)]
+                self.shutdown_progress
+                    .deadline_expiries
+                    .fetch_add(1, Ordering::AcqRel);
+                actor.abort();
+                actor.await
             };
             if let Err(error) = result {
                 warn!(%error, "event-history actor did not complete cleanly during shutdown");
@@ -1212,6 +1219,10 @@ fn finalize_producer_ledger(
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "one select loop owns batching, shutdown draining, and retention scheduling; splitting it would scatter the shared deadline state"
+)]
 async fn run_actor(
     ctx: ActorContext,
     mut rx: mpsc::Receiver<EventEnvelope>,
@@ -1257,23 +1268,18 @@ async fn run_actor(
             tokio::pin!(batch_deadline);
             while buffer.len() < config.batch_size {
                 tokio::select! {
-                    maybe = rx.recv() => match maybe {
-                        Some(env) => receive_event(
-                            env,
-                            &mut buffer,
-                            &queue_depths,
-                        ),
-                        None => {
-                            let deadline = tokio::time::Instant::now() + SHUTDOWN_TIMEOUT;
-                            begin_actor_shutdown(
-                                deadline,
-                                &mut shutdown_deadline,
-                                &mut rx,
-                                &mut retention_task,
-                            );
-                            accepted_drained = true;
-                            break;
-                        }
+                    maybe = rx.recv() => if let Some(env) = maybe {
+                        receive_event(env, &mut buffer, &queue_depths);
+                    } else {
+                        let deadline = tokio::time::Instant::now() + SHUTDOWN_TIMEOUT;
+                        begin_actor_shutdown(
+                            deadline,
+                            &mut shutdown_deadline,
+                            &mut rx,
+                            &mut retention_task,
+                        );
+                        accepted_drained = true;
+                        break;
                     },
                     () = &mut batch_deadline => break,
                     changed = shutdown_rx.changed() => {
@@ -1472,6 +1478,11 @@ async fn run_actor(
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::float_cmp,
+        reason = "the metric samples asserted here are integer-valued counters and gauges; exact equality is the assertion"
+    )]
+
     use super::*;
     use storage::TestStoreOp::{Append, Flush, Shutdown};
 

--- a/crates/event-history/src/migrations.rs
+++ b/crates/event-history/src/migrations.rs
@@ -25,7 +25,7 @@ pub(crate) const META_SCHEMA_VERSION: &str = "schema_version";
 /// assigned `event_id`). See [`crate::sequence`].
 pub(crate) const META_LAST_EVENT_ID: &str = "last_event_id";
 
-/// Metadata-table key carrying the daemon boot ID (UUIDv4 stamped at
+/// Metadata-table key carrying the daemon boot ID (`UUIDv4` stamped at
 /// startup). Used by clients to detect restarts independently of the
 /// monotonic cursor.
 pub(crate) const META_LAST_BOOT_ID: &str = "last_boot_id";
@@ -118,8 +118,7 @@ fn first_init(conn: &mut Connection) -> Result<(), EventHistoryError> {
             META_CREATED_AT_UNIX,
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs().to_string())
-                .unwrap_or_else(|_| "0".to_string())
+                .map_or_else(|_| "0".to_string(), |d| d.as_secs().to_string())
         ],
     )?;
     txn.commit()?;
@@ -147,7 +146,7 @@ fn read_schema_version(conn: &Connection) -> Result<u32, EventHistoryError> {
 /// (the join-table peer index for "any-role" queries — see ADR-0072
 /// for the rationale). Plus `metadata` (allocator, schema version,
 /// boot id).
-const SCHEMA_V1: &str = r#"
+const SCHEMA_V1: &str = r"
 CREATE TABLE events (
     event_id           INTEGER NOT NULL PRIMARY KEY,
     timestamp_ns       INTEGER NOT NULL,
@@ -186,7 +185,7 @@ CREATE TABLE metadata (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-"#;
+";
 
 #[cfg(test)]
 mod tests {

--- a/crates/event-history/src/sequence.rs
+++ b/crates/event-history/src/sequence.rs
@@ -77,7 +77,7 @@ pub(crate) fn write_allocator(conn: &Connection, new_value: u64) -> Result<(), E
 /// is never called (which is itself a bug the test suite catches).
 #[derive(Debug)]
 pub(crate) struct Allocator {
-    /// The last-assigned event_id at the time we read the metadata.
+    /// The last-assigned `event_id` at the time we read the metadata.
     /// Increments locally per [`Self::next`]; persisted on
     /// [`Self::finalize`].
     next_to_assign: u64,
@@ -103,7 +103,7 @@ impl Allocator {
 
     /// Returns the next `event_id` and increments the local counter.
     /// `event_id` is a `u64` and we will never wrap in practice (at
-    /// 10k events/s, u64::MAX is ~58 million years away), but check
+    /// 10k events/s, `u64::MAX` is ~58 million years away), but check
     /// defensively.
     pub(crate) fn next(&mut self) -> Result<u64, EventHistoryError> {
         let assigned = self.next_to_assign.checked_add(1).ok_or_else(|| {

--- a/crates/event-history/src/storage.rs
+++ b/crates/event-history/src/storage.rs
@@ -447,17 +447,9 @@ pub(crate) fn spawn_store(
 ) -> Result<(StoreHandle, JoinHandle<()>, StorageInit), EventHistoryError> {
     let init = open_with_recovery(&path, synchronous)?;
     let (tx, rx) = mpsc::channel(capacity);
-    let path_clone = path.clone();
-    let boot_id_clone = daemon_boot_id.clone();
     let initial_allocator = init.initial_allocator;
     let join = tokio::task::spawn_blocking(move || {
-        run_storage_thread(
-            path_clone,
-            boot_id_clone,
-            initial_allocator,
-            synchronous,
-            rx,
-        );
+        run_storage_thread(&path, &daemon_boot_id, initial_allocator, synchronous, rx);
     });
     Ok((
         StoreHandle {
@@ -578,28 +570,27 @@ fn recover_after_quarantine(
     let quarantine_anchor = read_quarantine_allocator(stale);
     let sidecar_hint = read_sidecar(sidecar);
 
-    let fresh_anchor = match quarantine_anchor {
-        Some(v) => v,
-        None => {
-            // No authoritative anchor recoverable. If a stale file or
-            // sidecar exists, we KNOW prior IDs may have been issued —
-            // refusing here protects the never-reused promise. Caller
-            // decides what to do (required=true ⇒ fail-start,
-            // required=false ⇒ pass-through with degraded flag — see
-            // EventHistoryManager).
-            if stale.exists() || sidecar.exists() {
-                if let Some(sidecar_value) = sidecar_hint {
-                    warn!(
-                        sidecar_value,
-                        "ignoring sidecar allocator hint because it may lag committed events"
-                    );
-                }
-                return Err(EventHistoryError::PassThrough);
+    let fresh_anchor = if let Some(v) = quarantine_anchor {
+        v
+    } else {
+        // No authoritative anchor recoverable. If a stale file or
+        // sidecar exists, we KNOW prior IDs may have been issued —
+        // refusing here protects the never-reused promise. Caller
+        // decides what to do (required=true ⇒ fail-start,
+        // required=false ⇒ pass-through with degraded flag — see
+        // EventHistoryManager).
+        if stale.exists() || sidecar.exists() {
+            if let Some(sidecar_value) = sidecar_hint {
+                warn!(
+                    sidecar_value,
+                    "ignoring sidecar allocator hint because it may lag committed events"
+                );
             }
-            // Truly fresh install — no stale, no sidecar, no DB.
-            // Allocator starts at 0.
-            0
+            return Err(EventHistoryError::PassThrough);
         }
+        // Truly fresh install — no stale, no sidecar, no DB.
+        // Allocator starts at 0.
+        0
     };
 
     // Open (or create) the primary DB and seed its allocator to the
@@ -635,13 +626,13 @@ fn probe_open(path: &Path, synchronous: SynchronousMode) -> Result<u64, EventHis
 
 /// The dedicated storage thread loop. Runs on a `spawn_blocking` task.
 fn run_storage_thread(
-    path: PathBuf,
-    daemon_boot_id: Arc<str>,
+    path: &Path,
+    daemon_boot_id: &Arc<str>,
     initial_allocator: u64,
     synchronous: SynchronousMode,
     mut rx: mpsc::Receiver<StoreOp>,
 ) {
-    let mut conn = match Connection::open(&path) {
+    let mut conn = match Connection::open(path) {
         Ok(c) => c,
         Err(e) => {
             error!(error = %e, "storage thread failed to open DB; exiting");
@@ -671,12 +662,12 @@ fn run_storage_thread(
         "event history storage thread started"
     );
 
-    let sidecar = sidecar_path(&path);
+    let sidecar = sidecar_path(path);
 
     while let Some(op) = rx.blocking_recv() {
         match op {
             StoreOp::Append { envelopes, reply } => {
-                let outcome = append_batch_blocking(&mut conn, &path, envelopes, &daemon_boot_id);
+                let outcome = append_batch_blocking(&mut conn, path, &envelopes, daemon_boot_id);
                 let _ = reply.send(outcome);
             }
             StoreOp::Query {
@@ -714,7 +705,7 @@ fn run_storage_thread(
                 max_bytes,
                 reply,
             } => {
-                let outcome = retain_blocking(&mut conn, &path, max_events, max_bytes);
+                let outcome = retain_blocking(&mut conn, path, max_events, max_bytes);
                 let _ = reply.send(outcome);
             }
             StoreOp::FlushSidecar { reply } => {
@@ -745,7 +736,7 @@ fn run_storage_thread(
 fn append_batch_blocking(
     conn: &mut Connection,
     db_path: &Path,
-    envelopes: Vec<Arc<EventEnvelope>>,
+    envelopes: &[Arc<EventEnvelope>],
     daemon_boot_id: &Arc<str>,
 ) -> Result<AppendOutcome, EventHistoryError> {
     if envelopes.is_empty() {
@@ -780,7 +771,7 @@ fn append_batch_blocking(
         let mut insert_peer =
             txn.prepare("INSERT INTO event_peers (event_id, role, peer) VALUES (?1, ?2, ?3)")?;
 
-        for env in &envelopes {
+        for env in envelopes {
             let id = allocator.next()?;
             assigned_ids.push(id);
             // SQLite INTEGER is signed 64-bit; bind the event_id as i64 because
@@ -873,12 +864,13 @@ fn query_by_peer(
     }
     if filter.prefix.is_some() {
         let p = if category_str.is_some() { "?5" } else { "?4" };
-        sql.push_str(&format!(" AND e.prefix = {p}"));
+        sql.push_str(" AND e.prefix = ");
+        sql.push_str(p);
     }
     if filter.rd.is_some() {
         let extras = usize::from(category_str.is_some()) + usize::from(filter.prefix.is_some());
-        let p = format!("?{}", 4 + extras);
-        sql.push_str(&format!(" AND e.rd = {p}"));
+        sql.push_str(" AND e.rd = ?");
+        sql.push_str(&(4 + extras).to_string());
     }
     sql.push_str(" ORDER BY e.event_id ASC LIMIT ");
     sql.push_str(&limit.to_string());
@@ -904,7 +896,7 @@ fn query_by_peer(
     if let Some(r) = &filter.rd {
         bind.push(Box::new(r.clone()));
     }
-    let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
+    let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(AsRef::as_ref).collect();
     let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs), persisted_row_mapper)?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
@@ -933,12 +925,13 @@ fn query_no_peer(
         } else {
             "?3"
         };
-        sql.push_str(&format!(" AND prefix = {p}"));
+        sql.push_str(" AND prefix = ");
+        sql.push_str(p);
     }
     if filter.rd.is_some() {
         let extras = usize::from(filter.category.is_some()) + usize::from(filter.prefix.is_some());
-        let p = format!("?{}", 3 + extras);
-        sql.push_str(&format!(" AND rd = {p}"));
+        sql.push_str(" AND rd = ?");
+        sql.push_str(&(3 + extras).to_string());
     }
     sql.push_str(" ORDER BY event_id ASC LIMIT ");
     sql.push_str(&limit.to_string());
@@ -957,21 +950,17 @@ fn query_no_peer(
     if let Some(r) = &filter.rd {
         bind.push(Box::new(r.clone()));
     }
-    let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
+    let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(AsRef::as_ref).collect();
     let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs), persisted_row_mapper)?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
 
-/// SQLite's INTEGER column is signed 64-bit; we clamp at i64::MAX so
-/// a `u64::MAX` sentinel from query callers (e.g. "from_event_id=0,
-/// to_event_id=u64::MAX" for "all events") doesn't trip a ToSql
+/// SQLite's INTEGER column is signed 64-bit; we clamp at `i64::MAX` so
+/// a `u64::MAX` sentinel from query callers (e.g. `from_event_id=0,
+/// to_event_id=u64::MAX` for "all events") doesn't trip a `ToSql`
 /// conversion failure.
 fn clamp_event_id(value: u64) -> i64 {
-    if value > i64::MAX as u64 {
-        i64::MAX
-    } else {
-        value as i64
-    }
+    i64::try_from(value).unwrap_or(i64::MAX)
 }
 
 fn persisted_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedEvent> {
@@ -981,8 +970,14 @@ fn persisted_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedEv
         .ok_or_else(|| invalid_enum_error(2, "category", &category_raw))?;
     let severity = Severity::parse(&severity_raw)
         .ok_or_else(|| invalid_enum_error(11, "severity", &severity_raw))?;
+    // `event_id` is INTEGER NOT NULL and the allocator only issues positive
+    // ids, so a negative value is corruption; surface it the way rusqlite
+    // reports an out-of-range integral read instead of wrapping.
+    let event_id_raw: i64 = row.get(0)?;
+    let event_id = u64::try_from(event_id_raw)
+        .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, event_id_raw))?;
     Ok(PersistedEvent {
-        event_id: row.get::<_, i64>(0)? as u64,
+        event_id,
         timestamp_ns: row.get(1)?,
         category,
         event_type: row.get(3)?,
@@ -1020,11 +1015,8 @@ fn retain_blocking(
     let mut outcome = RetentionOutcome::default();
 
     // 1. Count cap.
-    let total: u64 = conn
-        .query_row("SELECT COUNT(*) FROM events", [], |row| {
-            row.get::<_, i64>(0)
-        })?
-        .max(0) as u64;
+    let total: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+    let total = u64::try_from(total).unwrap_or(0);
     if total > max_events {
         let to_evict = (total - max_events).min(5000);
         outcome.evicted_count_cap = evict_oldest(conn, to_evict as usize)?;
@@ -1063,6 +1055,9 @@ fn evict_oldest(conn: &mut Connection, limit: usize) -> Result<usize, EventHisto
     if limit == 0 {
         return Ok(0);
     }
+    // Bind LIMIT as SQLite's signed 64-bit integer; callers cap the batch
+    // well below `i64::MAX`, so the fallback is never taken in practice.
+    let limit = i64::try_from(limit).unwrap_or(i64::MAX);
     let txn = conn.transaction()?;
     // Delete from event_peers first (foreign keys are off; we own the
     // referential integrity).
@@ -1071,14 +1066,14 @@ fn evict_oldest(conn: &mut Connection, limit: usize) -> Result<usize, EventHisto
          WHERE event_id IN (
              SELECT event_id FROM events ORDER BY event_id ASC LIMIT ?1
          )",
-        params![limit as i64],
+        params![limit],
     )?;
     let deleted = txn.execute(
         "DELETE FROM events
          WHERE event_id IN (
              SELECT event_id FROM events ORDER BY event_id ASC LIMIT ?1
          )",
-        params![limit as i64],
+        params![limit],
     )?;
     txn.commit()?;
     Ok(deleted)
@@ -1089,14 +1084,14 @@ fn evict_oldest(conn: &mut Connection, limit: usize) -> Result<usize, EventHisto
 /// `events.db` → `events.db-wal` (not `events.db.db-wal` or
 /// `events.db-wal-wal`) and `events` (no extension) → `events-wal`.
 /// `path.with_extension(...)` REPLACES the extension, which gets it
-/// wrong in the no-extension case. Concatenate to the OsString
+/// wrong in the no-extension case. Concatenate to the `OsString`
 /// directly instead.
 fn file_size(path: &Path) -> u64 {
-    let main = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    let main = std::fs::metadata(path).map_or(0, |m| m.len());
     let mut wal_os = path.as_os_str().to_os_string();
     wal_os.push("-wal");
     let wal = std::path::PathBuf::from(wal_os);
-    let wal_size = std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
+    let wal_size = std::fs::metadata(&wal).map_or(0, |m| m.len());
     main + wal_size
 }
 
@@ -1119,10 +1114,14 @@ fn oldest_event_id_blocking(conn: &Connection) -> Result<Option<u64>, EventHisto
         .query_row("SELECT MIN(event_id) FROM events", [], |r| r.get(0))
         .map_err(EventHistoryError::Sqlite)?;
     // `event_id` is stored as INTEGER NOT NULL on insert; values must
-    // be positive (the allocator skips 0). Cast through i64 only because
-    // SQLite's INTEGER column type is i64; the runtime invariant gives
-    // us a safe `as u64` cast.
-    Ok(row.map(|v| v as u64))
+    // be positive (the allocator skips 0). Read through i64 only because
+    // SQLite's INTEGER column type is i64; a negative value is corruption
+    // and surfaces as an out-of-range read instead of wrapping.
+    row.map(|v| {
+        u64::try_from(v)
+            .map_err(|_| EventHistoryError::Sqlite(rusqlite::Error::IntegralValueOutOfRange(0, v)))
+    })
+    .transpose()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`crates/event-history` was the one workspace crate still on `#![warn(clippy::all)]` without `clippy::pedantic`. This brings its lint header in line with the rest of the workspace (`deny(clippy::all)`, `warn(clippy::pedantic)`) and clears everything pedantic surfaces. Public API is unchanged; the daemon compiles and lints clean against it.

## Findings

69 pedantic findings across 16 lints; 56 fixed in code, 13 covered by four `#[expect]` attributes.

| Lint | Count | Resolution |
|---|---|---|
| `doc_markdown` | 15 | backticked identifiers |
| `float_cmp` | 13 | module-level `#![expect]` in the unit-test module (integer-valued metric samples) |
| `needless_pass_by_value` | 6 | move instead of clone; slice and reference parameters on crate-private functions |
| `single_match_else` | 5 | `if let` |
| `map_unwrap_or` | 4 | `map_or` / `map_or_else` |
| `format_push_string` | 4 | `push_str` |
| `too_many_lines` | 3 | 2 fixed by extraction and a direct spawn; 1 `#[expect]` on the actor select loop |
| `missing_errors_doc` | 3 | `# Errors` sections |
| `cast_sign_loss` | 3 | `u64::try_from` |
| `cast_possible_wrap` | 3 | `i64::try_from` with the existing `i64::MAX` clamp |
| `unused_async` / `unused_async_trait_impl` | 2 + 2 | `#[expect]` on the two public async entry points whose bodies are synchronous by design |
| `redundant_closure_for_method_calls` | 2 | `AsRef::as_ref` |
| `missing_fields_in_debug` | 2 | `finish_non_exhaustive` |
| `similar_names` | 1 | rename |
| `needless_raw_string_hashes` | 1 | plain raw string |

The previous `#![allow(clippy::module_name_repetitions)]` is removed: the lint is not in the pedantic group and an explicit `warn` probe produced no findings in this crate.

## Behavior notes

- `Debug` output for `EventHistoryManager` and `EventHistoryHandle` now ends with `..`, reflecting the omitted join handles and channel ends.
- A negative `event_id` read from the database (only possible on a tampered file) now surfaces as `rusqlite::Error::IntegralValueOutOfRange` instead of wrapping to a large `u64`.
- `SubscribeRequest` is moved into the drain task instead of cloned; no observable change.

## Checks

| Command | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p rustbgpd-event-history --all-targets -- -D warnings` | 0 |
| `cargo test -p rustbgpd-event-history` | 0 (59 passed, 1 ignored) |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --locked -p rustbgpd-event-history --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
