### PR TITLE
bench: pair VmHWM and VmRSS checkpoints with a strict zip

### DIFF
--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -200,7 +200,9 @@ def verify(directory, tiny=False):
         fail(f"RSS ceiling exceeded: process_tree_sampler_max_rss_kib={sampler_max} KiB")
     hwms = [observer[name]["direct_pid_vmhwm_kib"] for name in ("established", "staged", "wire")]
     values = [observer[name]["direct_pid_vmrss_kib"] for name in ("established", "staged", "wire")]
-    if any(hwm < value for hwm, value in zip(hwms, values, strict=True)):
+    if len(hwms) != len(values):
+        fail(f"resource checkpoint sample count mismatch: {len(hwms)} VmHWM vs {len(values)} VmRSS")
+    if any(hwm < value for hwm, value in zip(hwms, values)):
         fail("VmHWM is below VmRSS")
     if any(
         current + VMHWM_REGRESSION_TOLERANCE_KIB < previous

--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -200,7 +200,7 @@ def verify(directory, tiny=False):
         fail(f"RSS ceiling exceeded: process_tree_sampler_max_rss_kib={sampler_max} KiB")
     hwms = [observer[name]["direct_pid_vmhwm_kib"] for name in ("established", "staged", "wire")]
     values = [observer[name]["direct_pid_vmrss_kib"] for name in ("established", "staged", "wire")]
-    if any(hwm < value for hwm, value in zip(hwms, values)):
+    if any(hwm < value for hwm, value in zip(hwms, values, strict=True)):
         fail("VmHWM is below VmRSS")
     if any(
         current + VMHWM_REGRESSION_TOLERANCE_KIB < previous


### PR DESCRIPTION
## Summary

Two receipt verifiers pair sequences with `zip`. Each site was read for whether a length mismatch would invalidate the verdict.

### `bench/scale/rrtransport/verify_receipt.py` — `zip(hwms, values)`: explicit length check

`hwms` and `values` are the VmHWM and VmRSS samples of the `established`, `staged`, and `wire` checkpoints. The comparison is only meaningful pairwise over the same checkpoints, so the verifier now reports a sample-count mismatch as a verifier defect (through its own `fail()` path, exit 1) before the pairwise comparison, and the comparison keeps a plain `zip`. A strict `zip` inside `any(...)` would short-circuit before the length check ran, so the explicit check is the honest form.

The adjacent `zip(hwms, hwms[1:])` is a pairwise-window comparison and is unchanged.

### `tests/compat/ixp-manager-birdseye/verify_capture.py` — `zip(want, have)`: left as is

`path_matches` is a segment-wise glob. The guard above it rejects `have` shorter than `want`, and rejects unequal lengths only for non-semantics entries; for a semantics entry `have` may be longer than `want` because the entry covers the whole subtree under its path. The truncation is the intended prefix comparison, and `strict=True` would break subtree matching.

The Ruff `B905` ignore is unchanged; the other `zip` sites in the repository are out of scope.

## Checks

| Command | Exit |
|---|---|
| `python3 -m py_compile bench/scale/rrtransport/verify_receipt.py` | 0 |
| `bash bench/tests/test-rrtransport-receipt.sh` | 0 |
| `python3 scripts/check_developer_tooling.py` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |

The birdseye verifier has no local self-test; its `run.sh` drives containers and was not run because that file is unchanged.

