### PR TITLE
bench: refresh the scale-harness lockfile for rustbgpd-wire 0.19.1

### DIFF
--- a/bench/scale/Cargo.lock
+++ b/bench/scale/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bytes",
  "thiserror 2.0.20",


### PR DESCRIPTION
## Summary

The `rustbgpd-wire` 0.19.1 bump moved the workspace pin, but the standalone scale-harness workspace under `bench/scale/` has its own `Cargo.lock`, which still pinned 0.19.0. Every `cargo --locked` invocation in that workspace (including all four in `bench/scale/rrtransport/run-receipt.sh`) refused to run, so the scale receipt job is red on `main`.

`cargo update -p rustbgpd-wire --offline` in `bench/scale/`; the diff is the single version line in `bench/scale/Cargo.lock`. `git grep -n -A1 'name = "rustbgpd-wire"' -- '*.lock'` shows no other lockfile pinning the crate (the root lockfile is already at 0.19.1).

## Checks

| Command | Exit |
|---|---|
| `just gate-deps` | 0 |
| `bash bench/tests/test-rrtransport-receipt.sh` | 0 (all destructive proofs pass, no temporary lock refresh) |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
