### PR TITLE
mrt: point the reader doc link at the wire-crate decoder

### DIFF
--- a/crates/cli/src/commands/ribsnap.rs
+++ b/crates/cli/src/commands/ribsnap.rs
@@ -17,8 +17,8 @@
 //! with nothing written to stdout.
 //!
 //! Wire notes (RFC 6396 §4.3.4): AS_PATH is always 4-octet. The
-//! `MP_REACH_NLRI` inside a RIB entry is decoded by `rustbgpd_wire`'s
-//! [`decode_table_dump_v2_mp_reach_next_hop`], shared with the daemon's
+//! `MP_REACH_NLRI` inside a RIB entry is decoded by
+//! [`rustbgpd_wire::mrt::decode_table_dump_v2_mp_reach_next_hop`], shared with the daemon's
 //! warm-checkpoint reader: both the reduced next-hop-only form and the
 //! full RFC 4760 form some collectors emit are accepted, and malformed
 //! shapes (bad next-hop length, truncation, AFI/length mismatch,

--- a/crates/mrt/src/reader.rs
+++ b/crates/mrt/src/reader.rs
@@ -9,8 +9,8 @@
 //! L2VPN/EVPN) are skipped and counted, not treated as errors. A RIB
 //! entry's `MP_REACH_NLRI` is accepted in both the RFC 6396 §4.3.4
 //! reduced form the writer emits and the full RFC 4760 form other
-//! collectors write; see [`decode_table_dump_v2_mp_reach_next_hop`] in
-//! `rustbgpd_wire`.
+//! collectors write; see
+//! [`rustbgpd_wire::mrt::decode_table_dump_v2_mp_reach_next_hop`].
 //!
 //! Input is treated as hostile — this will read an untrusted file at
 //! daemon boot. Every length field is bounds-checked, malformed input


### PR DESCRIPTION
`main` is red on the `core tests / rustdoc` job since #2291: `cargo doc --locked --workspace --lib --no-deps --document-private-items` fails with `error: unresolved link to decode_table_dump_v2_mp_reach_next_hop` and `could not document rustbgpd-mrt`. The reader's module doc in `crates/mrt/src/reader.rs` (and the `from-mrt` module doc in `crates/cli/src/commands/ribsnap.rs`, which the `rbgp` bin doc build covers) linked the decoder by bare name after it moved to `rustbgpd-wire`; both now link `rustbgpd_wire::mrt::decode_table_dump_v2_mp_reach_next_hop`. `cargo doc --locked --workspace --lib --no-deps --document-private-items`, `cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps`, and `cargo doc --locked -p rustbgpctl --bin rbgp --no-deps` all exit 0; `cargo fmt --all -- --check` exits 0.
