### PR TITLE
evpn-linux: emit IpRemoved for the displaced MAC when an IP rebinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Operator-visible:** an IP that rebinds to a new MAC in the kernel
+  neighbour table now withdraws the old MAC+IP Type 2 route before the new
+  one is advertised. The kernel replaces the neighbour row's link-layer
+  address in place with one `RTM_NEWNEIGH` and sends no delete for the old
+  binding; the Linux observation layer now delivers that change as
+  `IpRemoved` for the displaced MAC followed by `IpAdded` for the new one.
+  Previously the old MAC's cached binding was silently overwritten and its
+  MAC+IP route stayed advertised until that MAC aged out of the bridge FDB.
+
 - **Operator-visible:** the daemon's warm-checkpoint reader and `rbgp diff
   snapshot from-mrt` now share one decoder for the `MP_REACH_NLRI` inside a
   `TABLE_DUMP_V2` RIB entry. It accepts both the RFC 6396 §4.3.4 reduced form

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -322,16 +322,31 @@ async fn notify_loop(
                 if let Some(obs) =
                     notify::classify_neigh(notify::NeighEventKind::New, &neigh, &cache)
                 {
-                    if let LocalMacObservation::IpAdded { mac, ip, .. } = obs
+                    if let LocalMacObservation::IpAdded { vni, mac, ip } = obs
                         && let Some(key) = notify::ip_neighbour_cache_key(&neigh)
                     {
-                        remember_ip_neighbour_mac(
+                        debug_assert_eq!(key.1, ip);
+                        // An IP rebinding to a new MAC is one RTM_NEWNEIGH
+                        // that replaces the row in place; the kernel sends
+                        // no RTM_DELNEIGH for the old binding. Synthesise it
+                        // so the originator withdraws the old MAC+IP route
+                        // before the new one is injected.
+                        if let Some(displaced) = remember_ip_neighbour_mac(
                             &mut ip_neighbour_macs,
                             &mut ip_neighbour_mac_order,
                             key,
                             mac,
-                        );
-                        debug_assert_eq!(key.1, ip);
+                        ) {
+                            forward_observation_or_record_drop(
+                                &local_mac_tx,
+                                LocalMacObservation::IpRemoved {
+                                    vni,
+                                    mac: displaced,
+                                    ip,
+                                },
+                                &on_observation_drop,
+                            );
+                        }
                     }
                     forward_observation_or_record_drop(&local_mac_tx, obs, &on_observation_drop);
                 }
@@ -426,13 +441,15 @@ fn forward_observation_or_record_drop(
     }
 }
 
+/// Remember `mac` for `key`, returning the previously cached MAC when
+/// `key` was bound to a different one (an in-place rebind).
 fn remember_ip_neighbour_mac(
     cache: &mut HashMap<(u32, IpAddr), MacAddress>,
     order: &mut VecDeque<(u32, IpAddr)>,
     key: (u32, IpAddr),
     mac: MacAddress,
-) {
-    remember_ip_neighbour_mac_with_limit(cache, order, key, mac, IP_NEIGHBOUR_MAC_CACHE_LIMIT);
+) -> Option<MacAddress> {
+    remember_ip_neighbour_mac_with_limit(cache, order, key, mac, IP_NEIGHBOUR_MAC_CACHE_LIMIT)
 }
 
 fn remember_ip_neighbour_mac_with_limit(
@@ -441,7 +458,7 @@ fn remember_ip_neighbour_mac_with_limit(
     key: (u32, IpAddr),
     mac: MacAddress,
     limit: usize,
-) {
+) -> Option<MacAddress> {
     let is_new = !cache.contains_key(&key);
     if is_new && cache.len() >= limit {
         while let Some(old_key) = order.pop_front() {
@@ -457,7 +474,7 @@ fn remember_ip_neighbour_mac_with_limit(
     if is_new {
         order.push_back(key);
     }
-    cache.insert(key, mac);
+    cache.insert(key, mac).filter(|previous| *previous != mac)
 }
 
 fn forget_ip_neighbour_mac(
@@ -1019,6 +1036,31 @@ mod tests {
     }
 
     #[test]
+    fn ip_neighbour_mac_cache_reports_displaced_mac_only_on_rebind() {
+        let mut cache = HashMap::new();
+        let mut order = VecDeque::new();
+        let key = (7, "192.0.2.1".parse::<IpAddr>().unwrap());
+        let old = MacAddress::new([0x02, 0, 0, 0, 0, 1]);
+        let new = MacAddress::new([0x02, 0, 0, 0, 0, 2]);
+
+        assert_eq!(
+            remember_ip_neighbour_mac_with_limit(&mut cache, &mut order, key, old, 4),
+            None
+        );
+        assert_eq!(
+            remember_ip_neighbour_mac_with_limit(&mut cache, &mut order, key, old, 4),
+            None,
+            "same-MAC re-announcement displaces nothing"
+        );
+        assert_eq!(
+            remember_ip_neighbour_mac_with_limit(&mut cache, &mut order, key, new, 4),
+            Some(old)
+        );
+        assert_eq!(cache.get(&key), Some(&new));
+        assert_eq!(order.len(), 1, "a rebind keeps one LRU slot for the key");
+    }
+
+    #[test]
     fn ip_neighbour_mac_cache_is_bounded() {
         let mut cache = HashMap::new();
         let mut order = VecDeque::new();
@@ -1038,6 +1080,65 @@ mod tests {
         forget_ip_neighbour_mac(&mut cache, &mut order, second_key);
         assert!(cache.is_empty());
         assert!(order.is_empty());
+    }
+
+    /// An IP that rebinds to a new MAC arrives as one `RTM_NEWNEIGH`
+    /// replacing the row in place; the kernel sends no `RTM_DELNEIGH`
+    /// for the old binding. The notify loop must deliver the change as
+    /// `IpRemoved` for the displaced MAC before `IpAdded` for the new
+    /// one, and add nothing on a same-MAC re-announcement.
+    #[tokio::test]
+    async fn notify_loop_rebind_emits_ip_removed_before_ip_added() {
+        use netlink_packet_core::{NetlinkHeader, NetlinkMessage};
+        use netlink_packet_route::AddressFamily;
+        use netlink_packet_route::neighbour::{NeighbourFlags, NeighbourState};
+
+        let (msg_tx, msg_rx) = futures::channel::mpsc::unbounded();
+        let (obs_tx, mut obs_rx) = mpsc::channel(16);
+        let (event_tx, _event_rx) = mpsc::channel(16);
+        let link_cache = Arc::new(Mutex::new(notify::tests::cache_for(100, 11, 22)));
+        let hook: ObservationDropHook =
+            Arc::new(|reason: &'static str| panic!("unexpected observation drop: {reason}"));
+
+        let ip: IpAddr = "192.0.2.10".parse().unwrap();
+        let old = [0x02, 0, 0, 0, 0, 0xAA];
+        let new = [0x02, 0, 0, 0, 0, 0xBB];
+        for mac in [old, new, new] {
+            let neigh = notify::tests::ip_neigh_msg(
+                AddressFamily::Inet,
+                99,
+                NeighbourState::Reachable,
+                NeighbourFlags::empty(),
+                Some(mac),
+                Some(ip),
+            );
+            let msg = NetlinkMessage::new(
+                NetlinkHeader::default(),
+                NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewNeighbour(neigh)),
+            );
+            msg_tx
+                .unbounded_send((msg, netlink_sys::SocketAddr::new(0, 0)))
+                .unwrap();
+        }
+        drop(msg_tx);
+        notify_loop(msg_rx, link_cache, obs_tx, event_tx, hook).await;
+
+        let mut got = Vec::new();
+        while let Some(obs) = obs_rx.recv().await {
+            got.push(obs);
+        }
+        let vni = rustbgpd_evpn::EvpnInstanceId::new(100).unwrap();
+        let old = MacAddress::new(old);
+        let new = MacAddress::new(new);
+        assert_eq!(
+            got,
+            vec![
+                LocalMacObservation::IpAdded { vni, mac: old, ip },
+                LocalMacObservation::IpRemoved { vni, mac: old, ip },
+                LocalMacObservation::IpAdded { vni, mac: new, ip },
+                LocalMacObservation::IpAdded { vni, mac: new, ip },
+            ]
+        );
     }
 
     #[test]

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -65,7 +65,11 @@
 //!    apply.
 //! 4. Extract MAC (`NDA_LLADDR`) and IP (`NDA_DST`).
 //! 5. Emit `IpAdded { vni, mac, ip }` (or `IpRemoved` on
-//!    `RTM_DELNEIGH`).
+//!    `RTM_DELNEIGH`). The notify loop remembers the MAC per
+//!    `(ifindex, ip)`; when an `RTM_NEWNEIGH` replaces that MAC in
+//!    place (an IP rebinding to a new MAC — the kernel sends no
+//!    `RTM_DELNEIGH` for the old binding), it emits `IpRemoved` for
+//!    the displaced MAC before the new `IpAdded`.
 //!
 //! # Why classification is a pure function
 //!
@@ -684,7 +688,7 @@ fn extract_ip(msg: &NeighbourMessage) -> Option<IpAddr> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use std::collections::{HashMap, HashSet};
 
     use netlink_packet_route::{
@@ -698,7 +702,7 @@ mod tests {
     use super::*;
     use crate::snapshot::KernelVxlanInfo;
 
-    fn cache_for(vni: u32, vxlan_ifindex: u32, port_ifindex: u32) -> LinkCache {
+    pub(crate) fn cache_for(vni: u32, vxlan_ifindex: u32, port_ifindex: u32) -> LinkCache {
         let mut bridges = HashMap::new();
         bridges.insert(
             "br100".to_string(),
@@ -1076,7 +1080,7 @@ mod tests {
     /// ARP/ND snooping tests. `bridge_ifindex` must match the bridge
     /// stored in the cache (not a bridge port — `AF_INET` /
     /// `AF_INET6` neighbours sit on the bridge itself).
-    fn ip_neigh_msg(
+    pub(crate) fn ip_neigh_msg(
         family: AddressFamily,
         bridge_ifindex: u32,
         state: NeighbourState,

--- a/crates/evpn-linux/tests/netns_dataplane.rs
+++ b/crates/evpn-linux/tests/netns_dataplane.rs
@@ -283,6 +283,28 @@ async fn expect_ip_added(
     }
 }
 
+async fn expect_ip_rebound(
+    rx: &mut tokio::sync::mpsc::Receiver<LocalMacObservation>,
+    want_vni: u32,
+    old_mac: MacAddress,
+    new_mac: MacAddress,
+    want_ip: IpAddr,
+) {
+    let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for IpRemoved of the displaced MAC")
+        .expect("local MAC channel closed");
+    assert!(
+        matches!(
+            first,
+            LocalMacObservation::IpRemoved { vni, mac, ip }
+                if vni.as_u32() == want_vni && mac == old_mac && ip == want_ip
+        ),
+        "expected IpRemoved for the displaced MAC first, got: {first:?}"
+    );
+    expect_ip_added(rx, want_vni, new_mac, want_ip).await;
+}
+
 async fn expect_no_observation(rx: &mut tokio::sync::mpsc::Receiver<LocalMacObservation>) {
     match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
         Err(_) => {}
@@ -826,6 +848,26 @@ async fn linux_dataplane_attributes_vlan_mac_ip_observations_inner() {
         ],
     );
     expect_ip_added(&mut rx, 200, shared_mac, shared_ip).await;
+
+    // Rebind the IP to a new MAC on the VNI 100 upper. The kernel
+    // updates the row in place with one RTM_NEWNEIGH and no delete;
+    // the observation layer must surface the displaced MAC first.
+    let rebound_mac = mac(0x67);
+    run(
+        "ip",
+        &[
+            "neigh",
+            "replace",
+            &shared_ip_str,
+            "lladdr",
+            &mac_str(rebound_mac),
+            "dev",
+            "brvlan.10",
+            "nud",
+            "reachable",
+        ],
+    );
+    expect_ip_rebound(&mut rx, 100, shared_mac, rebound_mac, shared_ip).await;
 
     run(
         "ip",

--- a/crates/evpn/src/origination_macip.rs
+++ b/crates/evpn/src/origination_macip.rs
@@ -24,9 +24,13 @@
 //!   Bridge-resident IP bindings don't carry a port; an IP migrating
 //!   to a new MAC surfaces as `IpRemoved(old_mac, ip)` followed by
 //!   `IpAdded(new_mac, ip)` — natural withdraw-then-inject without
-//!   the originator special-casing it. The kernel's relative ordering
-//!   of those two events is not established; a separate network-
-//!   namespace test is tracked.
+//!   the originator special-casing it. The observation layer
+//!   establishes that ordering: the kernel replaces a neighbour
+//!   row's link-layer address in place with one `RTM_NEWNEIGH` and
+//!   no delete, and the Linux notify loop delivers that as
+//!   `IpRemoved` for the displaced MAC followed by `IpAdded` for the
+//!   new one (asserted by the network-namespace test in
+//!   `rustbgpd-evpn-linux`).
 //! - **MAC-aged cascade** — when the kernel ages a MAC, every
 //!   `(MAC, *)` IP route must be withdrawn alongside the MAC-only
 //!   route. [`LocalMacIpOriginator::on_local_mac_aged`] is that hook;

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -4861,3 +4861,91 @@ async fn pending_ip_bindings_mac_entry_cap_bounds_the_map() {
         "pending-binding MAC entries are capped"
     );
 }
+
+/// An IP rebinding to a new MAC reaches the originator as
+/// `IpRemoved(old_mac, ip)` then `IpAdded(new_mac, ip)` — the Linux
+/// observation layer synthesises the removal because the kernel
+/// replaces the neighbour row in place. The old MAC+IP route is
+/// withdrawn (and that MAC downgraded to MAC-only) before the new
+/// MAC's MAC+IP route replaces its MAC-only route.
+#[tokio::test]
+async fn ip_rebound_to_new_mac_withdraws_old_route_and_injects_new() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let ip = ipa("192.0.2.10");
+
+    for (mac_byte, ifindex) in [(0xAA, 10), (0xBB, 11)] {
+        handle_observation(
+            &LocalMacObservation::Learned {
+                vni: vni(100),
+                mac: mac(mac_byte),
+                ifindex,
+            },
+            &mut state,
+            &instances,
+            &rib_tx,
+            &metrics,
+            &counts,
+            &std::collections::BTreeMap::new(),
+            &std::collections::BTreeSet::new(),
+        )
+        .await;
+    }
+    handle_observation(
+        &LocalMacObservation::IpAdded {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ip,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
+    )
+    .await;
+    log.lock().await.clear();
+
+    for obs in [
+        LocalMacObservation::IpRemoved {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ip,
+        },
+        LocalMacObservation::IpAdded {
+            vni: vni(100),
+            mac: mac(0xBB),
+            ip,
+        },
+    ] {
+        handle_observation(
+            &obs,
+            &mut state,
+            &instances,
+            &rib_tx,
+            &metrics,
+            &counts,
+            &std::collections::BTreeMap::new(),
+            &std::collections::BTreeSet::new(),
+        )
+        .await;
+    }
+
+    let actions = log.lock().await.clone();
+    assert_eq!(
+        actions,
+        vec![
+            RibAction::Withdraw(macip_key_with(100, 0xAA, Some("192.0.2.10"))),
+            RibAction::Inject(macip_key_with(100, 0xAA, None)),
+            RibAction::Withdraw(macip_key_with(100, 0xBB, None)),
+            RibAction::Inject(macip_key_with(100, 0xBB, Some("192.0.2.10"))),
+        ],
+        "expected old MAC+IP Withdraw, old MAC-only re-Inject, new MAC-only Withdraw, new MAC+IP Inject"
+    );
+}


### PR DESCRIPTION
## Problem

An IP that rebinds to a new MAC in the kernel neighbour table (`ip neigh replace <ip> lladdr <new-mac> ...`, or the neighbour subsystem updating `lladdr` in place) is delivered as a single `RTM_NEWNEIGH`; the kernel sends no `RTM_DELNEIGH` for the old binding.

The notify loop in `crates/evpn-linux/src/linux/mod.rs` keeps `ip_neighbour_macs: HashMap<(u32, IpAddr), MacAddress>` so a later `RTM_DELNEIGH` without `NDA_LLADDR` can still be classified. Its writer silently overwrote a different MAC for the same key:

```rust
let is_new = !cache.contains_key(&key);
...
cache.insert(key, mac);
```

and the loop forwarded only `IpAdded { vni, mac: new, ip }`. `IpRemoved` was produced solely for `NeighEventKind::Del` (`notify.rs`). The MAC+IP originator (`crates/evpn/src/origination_macip.rs` module docs, `src/evpn_originator/observation.rs` `handle_ip_added` / `handle_ip_removed`) assumes a rebind arrives as `IpRemoved(old_mac, ip)` then `IpAdded(new_mac, ip)`, so the old MAC's MAC+IP Type 2 route was never withdrawn: it stayed advertised until that MAC aged out of the bridge FDB.

## Fix

At the source, narrowest form:

- `remember_ip_neighbour_mac` / `remember_ip_neighbour_mac_with_limit` return the displaced MAC (`Option<MacAddress>`, `Some` only when the cached MAC for `(ifindex, ip)` differs from the new one). LRU bound and eviction are unchanged.
- The `RTM_NEWNEIGH` arm emits a synthetic `IpRemoved { vni, mac: displaced, ip }` immediately before the `IpAdded` for the new MAC. Ordering matters: `handle_ip_removed` after the inject would withdraw the new route.
- A same-MAC re-announcement displaces nothing and behaves as before.
- `origination_macip.rs` module docs now state the established contract instead of "relative ordering is not established"; the `notify.rs` pipeline docs describe the synthesised removal.

## Proofs

**Unit, red on the previous tree.** `linux::tests::notify_loop_rebind_emits_ip_removed_before_ip_added` drives `notify_loop` with three synthetic `RTM_NEWNEIGH` messages for one IP (`old`, `new`, `new`) and compares the whole observation stream. Before the fix:

```
left:  [IpAdded{old}, IpAdded{new}, IpAdded{new}]
right: [IpAdded{old}, IpRemoved{old}, IpAdded{new}, IpAdded{new}]
```

`ip_neighbour_mac_cache_reports_displaced_mac_only_on_rebind` covers the helper directly (same MAC twice → `None`; new MAC → `Some(old)`; one LRU slot kept). `ip_neighbour_mac_cache_is_bounded` is unchanged and still passes.

**Network namespace, red on the previous tree.** `linux_dataplane_attributes_vlan_mac_ip_observations` gains an `ip neigh replace 192.0.2.65 lladdr <new-mac> dev brvlan.10 nud reachable` step and asserts `IpRemoved{old}` then `IpAdded{new}` on VNI 100 (`expect_ip_rebound`). Run through the documented Docker harness (`crates/evpn-linux/tests/docker/run-netns-tests.sh macip_vlan_attribution`, `--cap-add=NET_ADMIN --cap-add=SYS_ADMIN`, no containerlab). Before the fix, on a real kernel:

```
expected IpRemoved for the displaced MAC first, got: IpAdded { vni: EvpnInstanceId(100), mac: MacAddress([2, 0, 0, 0, 0, 103]), ip: 192.0.2.65 }
```

After the fix the selector passes (outer and re-exec'd inner: `1 passed; 0 failed`). The direct `sudo -E env EVPN_LINUX_NETNS=1 cargo test ...` form was not used (no passwordless sudo); the Docker harness is the form the Kernel Dataplane workflow runs.

**Originator.** `evpn_originator::tests::ip_rebound_to_new_mac_withdraws_old_route_and_injects_new` feeds `IpRemoved(old, ip)` then `IpAdded(new, ip)` with both MACs locally learned and asserts `[Withdraw macip(old,ip), Inject mac(old), Withdraw mac(new), Inject macip(new,ip)]`. No existing test covered the pair.

## Compatibility

Observation-layer behaviour change only: consumers of `LocalMacObservation` now see `IpRemoved` for the displaced MAC on a rebind. No config, CLI, metric, RPC, or wire-format change. CHANGELOG entry under Unreleased / Fixed. `docs/evpn-enablement.md` and `docs/evpn-vtep-troubleshooting.md` make no statement about rebinds; nothing to align there.

## Checks

All exit 0: `cargo fmt --all -- --check`; `cargo clippy -p rustbgpd-evpn-linux -p rustbgpd-evpn --all-targets -- -D warnings`; `cargo test -p rustbgpd-evpn-linux` (460 lib tests plus every unprivileged integration binary); `cargo test -p rustbgpd-evpn`; `cargo clippy --bin rustbgpd -- -D warnings`; `cargo test --bin rustbgpd evpn` (496 passed); `scripts/check-clippy-reasons.py`; `scripts/check_public_tracker_ids.py`; `cargo doc --locked -p rustbgpd-evpn-linux -p rustbgpd-evpn --no-deps`; `cargo test -p rustbgpd-evpn-linux --test netns_dataplane --no-run`; Docker netns selector `macip_vlan_attribution`.
