### PR TITLE
rib: warn on a received ORF entry that can never match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Operator-visible:** a received Address-Prefix ORF entry whose maximum
+  length is below its own prefix length (for example `10.0.0.0/8 le 4`) can
+  never match a route. The daemon installs it exactly as before and now logs
+  one `warn` line per ORF update naming the peer, the family, and each
+  impossible window (`<prefix> min <n> max <n>`). The entry is not rejected:
+  RFC 5291 §5.2 clears the whole list on a malformed entry, which would fail
+  open to permit-all.
+
 - **Operator-visible:** RFC 5883 multihop BFD. Setting
   `bfd = { profile = "...", multihop = true }` on a static global neighbor
   uses UDP/4784 with the same profiles, inspection, metrics, events, and RFC

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -4155,6 +4155,29 @@ impl RibManager {
         if reset && !unknown_when {
             warn!(%peer, ?family, "malformed ORF entry — installed ORF list for this type reset");
         }
+        if !reset {
+            // A well-formed entry whose max length is below its own prefix
+            // length is installed as sent (RFC 5292 §4 allows it) but can
+            // never match. Report it; rejecting it would flush the list and
+            // fail open to permit-all.
+            let unmatchable: Vec<String> = entries
+                .iter()
+                .filter(|entry| entry.action == OrfAction::Add)
+                .filter_map(|entry| {
+                    let prefix = entry.prefix?;
+                    crate::orf::unmatchable_window(&prefix, entry.min_len, entry.max_len)
+                        .then(|| format!("{prefix} min {} max {}", entry.min_len, entry.max_len))
+                })
+                .collect();
+            if !unmatchable.is_empty() {
+                warn!(
+                    %peer,
+                    ?family,
+                    entries = ?unmatchable,
+                    "ORF entry installed but can never match — max length below prefix length"
+                );
+            }
+        }
         // An emptied filter (REMOVE-ALL or a reset) means permit-all again —
         // drop the entry so the absent-filter fast path applies.
         if now_empty && let Some(by_family) = self.peer_orf_filters.get_mut(&peer) {

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -29,6 +29,53 @@ fn bgpls_sendable() -> Vec<(Afi, Safi)> {
     vec![(Afi::BgpLs, Safi::BgpLs)]
 }
 
+/// Field capture for one tracing event: `str` and `u64` values keep their
+/// own rendering, everything else falls back to `Debug`.
+#[derive(Debug, Default)]
+struct CapturedFields(BTreeMap<String, String>);
+
+impl tracing::field::Visit for CapturedFields {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}
+
+/// Scoped test subscriber (`tracing::subscriber::with_default`) that records
+/// every event at `level` or more severe into `events`. Sibling tests drive
+/// the same callsites through `manager.run()` on tokio workers with no
+/// subscriber, so warm the callsite under test and call
+/// `tracing::callsite::rebuild_interest_cache()` inside the scope before the
+/// measured call.
+struct CaptureSubscriber {
+    level: tracing::Level,
+    events: Arc<std::sync::Mutex<Vec<CapturedFields>>>,
+}
+
+impl tracing::Subscriber for CaptureSubscriber {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        *metadata.level() <= self.level
+    }
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut fields = CapturedFields::default();
+        event.record(&mut fields);
+        self.events.lock().unwrap().push(fields);
+    }
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
 /// A chain with one exact-match Deny statement per prefix, default Permit.
 fn deny_prefixes_chain(prefixes: &[Prefix]) -> rustbgpd_policy::PolicyChain {
     rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {

--- a/crates/rib/src/manager/tests/orf.rs
+++ b/crates/rib/src/manager/tests/orf.rs
@@ -432,6 +432,128 @@ async fn orf_unknown_when_resets_filter_and_sweeps() {
     handle.await.unwrap();
 }
 
+/// Field capture for one tracing event (see the ASPA/update-group tests for
+/// the same shape).
+#[derive(Debug, Default)]
+struct CapturedFields(std::collections::BTreeMap<String, String>);
+
+impl tracing::field::Visit for CapturedFields {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}
+
+struct CaptureSubscriber(std::sync::Arc<std::sync::Mutex<Vec<CapturedFields>>>);
+
+impl tracing::Subscriber for CaptureSubscriber {
+    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut fields = CapturedFields::default();
+        event.record(&mut fields);
+        self.0.lock().unwrap().push(fields);
+    }
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// A manager with `peer` registered for outbound updates and nothing else.
+fn manager_with_outbound_peer(peer: IpAddr) -> (RibManager, mpsc::Receiver<OutboundRouteUpdate>) {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let (out_tx, out_rx) = mpsc::channel(1);
+    manager.outbound_peers.insert(peer, out_tx);
+    (manager, out_rx)
+}
+
+/// A well-formed ORF entry whose max length is below its own prefix length
+/// (`10/8 le 4`) can never match. It must stay installed — rejecting it would
+/// flush the list and fail open to permit-all — and be reported once per
+/// apply with the peer, family, and the impossible window.
+#[tokio::test]
+async fn orf_unmatchable_entry_is_installed_and_warned() {
+    use std::sync::{Arc as StdArc, Mutex};
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let entry = orf_permit(2, 0, 4, Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8));
+    let (mut manager, _out_rx) = manager_with_outbound_peer(peer);
+    let captured = StdArc::new(Mutex::new(Vec::new()));
+    tracing::subscriber::with_default(CaptureSubscriber(StdArc::clone(&captured)), || {
+        // Sibling tests drive the same callsite through `manager.run()` on
+        // tokio workers with no subscriber; whichever thread registers the
+        // callsite first caches its interest process-wide. Warm it on a
+        // throwaway manager, then re-register against this subscriber.
+        let (mut warm, _warm_rx) = manager_with_outbound_peer(peer);
+        let (warm_reply, _) = oneshot::channel();
+        warm.handle_peer_orf_update(
+            peer,
+            Afi::Ipv4,
+            Safi::Unicast,
+            WhenToRefresh::Defer,
+            &[entry],
+            warm_reply,
+        );
+        tracing::callsite::rebuild_interest_cache();
+        captured.lock().unwrap().clear();
+
+        let (reply, _) = oneshot::channel();
+        manager.handle_peer_orf_update(
+            peer,
+            Afi::Ipv4,
+            Safi::Unicast,
+            WhenToRefresh::Defer,
+            &[entry],
+            reply,
+        );
+    });
+
+    let filter = manager
+        .peer_orf_filters
+        .get(&peer)
+        .and_then(|by_family| by_family.get(&(Afi::Ipv4, Safi::Unicast)))
+        .expect("unmatchable entry stays installed");
+    assert!(
+        !filter.permits(&Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))),
+        "installed entry never matches, so the non-empty list denies"
+    );
+
+    let events = captured.lock().unwrap();
+    let warned: Vec<&CapturedFields> = events
+        .iter()
+        .filter(|fields| {
+            fields
+                .0
+                .get("message")
+                .is_some_and(|message| message.contains("can never match"))
+        })
+        .collect();
+    assert_eq!(warned.len(), 1, "exactly one warning per apply: {events:?}");
+    let fields = &warned[0].0;
+    assert_eq!(fields.get("peer").map(String::as_str), Some("10.0.0.2"));
+    assert_eq!(
+        fields.get("family").map(String::as_str),
+        Some("(Ipv4, Unicast)")
+    );
+    assert_eq!(
+        fields.get("entries").map(String::as_str),
+        Some(r#"["10.0.0.0/8 min 0 max 4"]"#)
+    );
+    assert!(
+        !events.iter().any(|fields| fields
+            .0
+            .get("message")
+            .is_some_and(|message| message.contains("malformed ORF entry"))),
+        "unmatchable is not malformed: the list must not be reset"
+    );
+}
+
 /// Regression: a graceful-restart flap must clear the RFC 5291 §6
 /// initial-advertisement gate. The gate is per-session; previously
 /// `handle_peer_graceful_restart` left `peer_orf_pending` populated, so a

--- a/crates/rib/src/manager/tests/orf.rs
+++ b/crates/rib/src/manager/tests/orf.rs
@@ -432,38 +432,6 @@ async fn orf_unknown_when_resets_filter_and_sweeps() {
     handle.await.unwrap();
 }
 
-/// Field capture for one tracing event (see the ASPA/update-group tests for
-/// the same shape).
-#[derive(Debug, Default)]
-struct CapturedFields(std::collections::BTreeMap<String, String>);
-
-impl tracing::field::Visit for CapturedFields {
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        self.0
-            .insert(field.name().to_string(), format!("{value:?}"));
-    }
-}
-
-struct CaptureSubscriber(std::sync::Arc<std::sync::Mutex<Vec<CapturedFields>>>);
-
-impl tracing::Subscriber for CaptureSubscriber {
-    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
-        true
-    }
-    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
-        tracing::span::Id::from_u64(1)
-    }
-    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
-    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
-    fn event(&self, event: &tracing::Event<'_>) {
-        let mut fields = CapturedFields::default();
-        event.record(&mut fields);
-        self.0.lock().unwrap().push(fields);
-    }
-    fn enter(&self, _: &tracing::span::Id) {}
-    fn exit(&self, _: &tracing::span::Id) {}
-}
-
 /// A manager with `peer` registered for outbound updates and nothing else.
 fn manager_with_outbound_peer(peer: IpAddr) -> (RibManager, mpsc::Receiver<OutboundRouteUpdate>) {
     let (_tx, rx) = mpsc::channel(1);
@@ -485,7 +453,11 @@ async fn orf_unmatchable_entry_is_installed_and_warned() {
     let entry = orf_permit(2, 0, 4, Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8));
     let (mut manager, _out_rx) = manager_with_outbound_peer(peer);
     let captured = StdArc::new(Mutex::new(Vec::new()));
-    tracing::subscriber::with_default(CaptureSubscriber(StdArc::clone(&captured)), || {
+    let subscriber = CaptureSubscriber {
+        level: tracing::Level::WARN,
+        events: StdArc::clone(&captured),
+    };
+    tracing::subscriber::with_default(subscriber, || {
         // Sibling tests drive the same callsite through `manager.run()` on
         // tokio workers with no subscriber; whichever thread registers the
         // callsite first caches its interest process-wide. Warm it on a

--- a/crates/rib/src/orf.rs
+++ b/crates/rib/src/orf.rs
@@ -123,23 +123,41 @@ fn valid_lengths(prefix: &Prefix, min_len: u8, max_len: u8) -> bool {
     true
 }
 
+/// The inclusive route-length window `[lo, hi]` an entry with this prefix and
+/// min/max matches (RFC 5292 §6; 0 = unspecified, both unspecified ⇒ exact
+/// length). The lower bound is clamped to the entry's own prefix length, so a
+/// `min_len` below it is harmless.
+fn length_window(prefix: &Prefix, min_len: u8, max_len: u8) -> (u8, u8) {
+    let entry_len = prefix.prefix_len();
+    if min_len == 0 && max_len == 0 {
+        return (entry_len, entry_len);
+    }
+    let lo = entry_len.max(min_len);
+    let hi = if max_len == 0 {
+        family_max(prefix)
+    } else {
+        max_len
+    };
+    (lo, hi)
+}
+
+/// Whether a well-formed ADD entry can never match any route: a non-zero
+/// `max_len` below the entry's own prefix length leaves an empty window. Such
+/// an entry is valid per RFC 5292 §4 and stays installed — rejecting it would
+/// flush the list and fail open to permit-all — so callers only report it.
+pub(crate) fn unmatchable_window(prefix: &Prefix, min_len: u8, max_len: u8) -> bool {
+    let (lo, hi) = length_window(prefix, min_len, max_len);
+    lo > hi
+}
+
 /// Whether `entry` matches `route` per RFC 5292 §6: containment plus the
 /// min/max length window (0 = unspecified; both unspecified ⇒ exact length).
 fn entry_matches(entry: &OrfFilterEntry, route: &Prefix) -> bool {
     if !prefix_contains(&entry.prefix, route) {
         return false;
     }
-    let entry_len = entry.prefix.prefix_len();
+    let (lo, hi) = length_window(&entry.prefix, entry.min_len, entry.max_len);
     let route_len = route.prefix_len();
-    if entry.min_len == 0 && entry.max_len == 0 {
-        return route_len == entry_len;
-    }
-    let lo = entry_len.max(entry.min_len);
-    let hi = if entry.max_len == 0 {
-        family_max(route)
-    } else {
-        entry.max_len
-    };
     route_len >= lo && route_len <= hi
 }
 
@@ -328,6 +346,28 @@ mod tests {
         let err = f.apply(&[add(2, OrfMatch::Permit, 24, 16, v4([192, 168, 0, 0], 16))]);
         assert!(err.is_err());
         assert!(f.is_empty(), "malformed entry resets the installed list");
+    }
+
+    #[test]
+    fn unmatchable_max_below_prefix_len_is_installed_and_reported() {
+        let mut f = OrfFilterSet::default();
+        // 10/8 le 4: max 4 < prefix length 8, so no route can ever sit in the
+        // window. Rejecting it would flush the list (fail-open flood), so it
+        // stays installed and is only reported.
+        let prefix = v4([10, 0, 0, 0], 8);
+        f.apply(&[add(2, OrfMatch::Permit, 0, 4, prefix)]).unwrap();
+        assert!(!f.is_empty(), "unmatchable entry is still installed");
+        assert!(unmatchable_window(&prefix, 0, 4));
+        assert!(
+            !f.permits(&v4([10, 0, 0, 0], 8)),
+            "never matches: implicit deny"
+        );
+        // min below the prefix length is clamped by the match, not impossible.
+        assert!(!unmatchable_window(&prefix, 4, 0));
+        assert!(!unmatchable_window(&prefix, 4, 8));
+        assert!(!unmatchable_window(&prefix, 0, 0));
+        // max equal to the prefix length still matches the exact prefix.
+        assert!(!unmatchable_window(&prefix, 0, 8));
     }
 
     #[test]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -981,6 +981,10 @@ does not change that boundary.
 - Unknown `When-to-refresh` values are invalid control input: rustbgpd resets
   the negotiated Address-Prefix ORF list for that family/type and forces a safe
   resync instead of treating the value as defer-like state.
+- A well-formed entry whose maximum length is below its own prefix length
+  (for example `10.0.0.0/8 le 4`) can never match; it is installed as sent and
+  reported with a `warn` log line naming the peer, family, and window, because
+  rejecting it would flush the list and fail open to permit-all.
 - Address-Prefix ORF entries are decoded only for IPv4/IPv6 unicast. L2VPN and
   unknown future SAFIs are preserved as raw ORF groups until their family-specific
   prefix encodings and export semantics are implemented.


### PR DESCRIPTION
## What changed

A well-formed Address-Prefix ORF entry whose maximum length is below its own prefix length (for example `10.0.0.0/8 le 4`) passes RFC 5292 §4 field validation but can never match: `entry_matches` clamps the lower bound to the entry's prefix length, so the window is empty. Such an entry was installed silently and contributed only to the implicit deny.

The daemon now keeps installing it exactly as before and emits one `warn` line per ORF update naming the peer, the family, and each impossible window (`<prefix> min <n> max <n>`), in the same field style as the existing `malformed ORF entry` line. No metric, no NOTIFICATION, no change to filtering.

## Decision

The entry is not rejected. A `false` from `valid_lengths` clears the installed list and the manager resets the family to permit-all before resyncing, so treating an unmatchable entry as malformed would fail open to a full-table flood.

Placement: `crates/rib/src/orf.rs` gains `length_window` (the `[lo, hi]` computation factored out of `entry_matches`) and a pure `pub(crate) fn unmatchable_window(prefix, min_len, max_len) -> bool` built on it, so the predicate and the matcher cannot drift. `OrfFilterSet::apply` keeps its `Result<(), ()>` contract unchanged; `handle_peer_orf_update` scans the received batch after a successful apply and warns once. Scanning the batch rather than the installed set means an entry installed by an earlier DEFER update is not re-reported on every later apply, and a batch that failed validation (list already cleared) is not reported at all. A `min_len` below the prefix length is not reported because the clamp makes it harmless.

## Tests

- `orf::tests::unmatchable_max_below_prefix_len_is_installed_and_reported` pins that `10/8 le 4` is accepted (apply `Ok`, list non-empty) and reported unmatchable, with the harmless `min` cases and `max == prefix_len` as negatives.
- `manager::tests::orf::orf_unmatchable_entry_is_installed_and_warned` captures tracing through the crate's existing local-subscriber pattern (callsite warm-up + `rebuild_interest_cache`) and asserts exactly one warning with `peer`, `family`, and `entries` fields, that the filter stays installed, and that the `malformed ORF entry` reset line does not fire.
- Red proof: the unit test against the pre-change tree fails to compile (`cannot find function unmatchable_window`, exit 101).

## Docs

`docs/RFC_NOTES.md` RFC 5291/5292 section gains one bullet; CHANGELOG Added entry. ADR-0075 is a dated record and is untouched.

## Checks

| Gate | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p rustbgpd-rib --all-targets -- -D warnings` | 0 |
| `cargo test -p rustbgpd-rib orf` (35 passed) | 0 |
| `cargo test -p rustbgpd-rib` (1266 passed, 2 ignored) | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `cargo doc --locked -p rustbgpd-rib --no-deps` | 0 |
