### PR TITLE
cli: add --direction to rbgp policy explain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   impossible window (`<prefix> min <n> max <n>`). The entry is not rejected:
   RFC 5291 §5.2 clears the whole list on a malformed entry, which would fail
   open to permit-all.
+- `rbgp policy explain --direction <import|export>`. The default `import`
+  is the existing per-session import-decision cache lookup and still
+  requires `[policy.explain] enabled = true`; `export` runs the read-only
+  export dry run behind `rbgp rib --prefix <cidr> advertised <peer>
+  --explain` (unicast, unlabeled, best source) and needs no configuration.
+  `--path-id` with `--direction export` is rejected before the daemon is
+  dialed, pointing at the `rib advertised --explain --source-peer` /
+  `--source-path-id` flags for Add-Path source selection. Shell completions
+  regenerated.
 
 - **Operator-visible:** RFC 5883 multihop BFD. Setting
   `bfd = { profile = "...", multihop = true }` on a static global neighbor

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -150,7 +150,7 @@ rbgp policy chain set-import [--neighbor <addr>] <names...>
 rbgp policy chain set-export [--neighbor <addr>] <names...>
 rbgp policy chain clear-import [--neighbor <addr>]
 rbgp policy chain clear-export [--neighbor <addr>]
-rbgp policy explain --neighbor <addr> --prefix <cidr> [--path-id <n>]
+rbgp policy explain --neighbor <addr> --prefix <cidr> [--path-id <n>] [--direction import|export]
 rbgp policy check <file.rpol>                          # parse, typecheck, and run in-language tests in-process (no daemon; --coverage-min for a CI coverage gate)
 rbgp policy fmt <file.rpol>... [--check]               # canonical .rpol formatter (in-place; --check for CI; - = stdin)
 rbgp policy test <file.rpol> --policy <name> --direction import|export [--neighbor <addr>]   # dry-run over the live RIB
@@ -193,7 +193,11 @@ normal output from a current server.
 
 `policy explain` requires the daemon's import-decision cache, which is
 opt-in: set `[policy.explain] enabled = true` in the daemon config. On a
-stock daemon the command exits nonzero with that hint.
+stock daemon the command exits nonzero with that hint. `--direction export`
+is the `rib --prefix <cidr> advertised <addr> --explain` dry run under the
+same verb; it needs no configuration and does not take `--path-id` (use the
+`rib advertised --explain --source-peer/--source-path-id` flags for Add-Path
+source selection).
 
 `--count` applies the same family, prefix, longer-prefix, origin-ASN, exact
 AS-path membership, standard-community, large-community, RPKI-verdict, and

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -1331,6 +1331,41 @@ fn parse_cidr(prefix: &str) -> Result<(String, u32, proto::AddressFamily), CliEr
     }
 }
 
+/// Rejection for `--path-id` with `--direction export`: the identifier
+/// selects an Add-Path entry in the import-decision cache, while the
+/// export dry run takes its source identity from the `rib advertised
+/// --explain` flags.
+pub const EXPLAIN_EXPORT_PATH_ID_ERROR: &str = "--path-id applies to --direction import only; \
+     for Add-Path source selection on the export side use \
+     `rib --prefix <cidr> advertised <peer> --explain --source-peer <addr> --source-path-id <id>`";
+
+/// `rbgp policy explain --direction <import|export>`.
+///
+/// `import` reads the per-session import-decision cache
+/// ([`explain_import`]); `export` is the read-only export dry run
+/// behind `rib --prefix <cidr> advertised <peer> --explain`
+/// ([`super::rib::explain_advertised`]) for the unicast, unlabeled,
+/// best-source case. The CLI rejects `--path-id` with `export` before
+/// dialing the daemon; the check here keeps this entry point honest for
+/// any other caller.
+pub async fn explain(
+    connection: Connection,
+    neighbor: &str,
+    prefix: &str,
+    path_id: Option<u32>,
+    direction: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    if direction != "export" {
+        return explain_import(connection, neighbor, prefix, path_id, json).await;
+    }
+    if path_id.is_some() {
+        return Err(CliError::Argument(EXPLAIN_EXPORT_PATH_ID_ERROR.into()));
+    }
+    super::rib::explain_advertised(connection, neighbor, prefix, None, false, None, None, json)
+        .await
+}
+
 pub async fn explain_import(
     connection: Connection,
     neighbor: &str,
@@ -2374,6 +2409,90 @@ mod tests {
             captured.afi_safi,
             crate::proto::AddressFamily::Ipv4Unicast as i32
         );
+    }
+
+    /// `--direction export` is the `rib advertised --explain` dry run:
+    /// it must reach `ExplainAdvertisedRoute` (not the import cache)
+    /// with the neighbor and prefix, no RD, unlabeled, no source
+    /// identity, and render in both text and JSON.
+    #[tokio::test]
+    async fn explain_direction_export_calls_advertised_rpc() {
+        let server = spawn_mock_server(None).await;
+        for json in [true, false] {
+            let connection = connect(&server.addr, None).await.unwrap();
+            explain(
+                connection,
+                "fe80::1%eth0",
+                "203.0.113.0/24",
+                None,
+                "export",
+                json,
+            )
+            .await
+            .unwrap();
+            let req = server
+                .state
+                .last_explain_advertised
+                .lock()
+                .await
+                .take()
+                .expect("export explain reached ExplainAdvertisedRoute");
+            assert_eq!(req.peer_address, "fe80::1");
+            assert_eq!(req.prefix, "203.0.113.0");
+            assert_eq!(req.prefix_length, 24);
+            assert_eq!(req.rd, "");
+            assert!(!req.labeled);
+            assert_eq!(req.source, None);
+        }
+        assert!(
+            server.state.last_explain_import.lock().await.is_none(),
+            "export explain must not consult the import-decision cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn explain_direction_import_is_the_cache_lookup() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        explain(
+            connection,
+            "192.0.2.1",
+            "192.0.2.0/24",
+            Some(7),
+            "import",
+            true,
+        )
+        .await
+        .unwrap();
+        let req = server
+            .state
+            .last_explain_import
+            .lock()
+            .await
+            .clone()
+            .expect("import explain reached ExplainImportPolicy");
+        assert_eq!(req.path_id, Some(7));
+        assert!(server.state.last_explain_advertised.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn explain_direction_export_rejects_path_id_before_any_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let err = explain(
+            connection,
+            "192.0.2.1",
+            "192.0.2.0/24",
+            Some(3),
+            "export",
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, CliError::Argument(_)), "{err}");
+        assert_eq!(err.to_string(), EXPLAIN_EXPORT_PATH_ID_ERROR);
+        assert!(server.state.last_explain_advertised.lock().await.is_none());
+        assert!(server.state.last_explain_import.lock().await.is_none());
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -1345,8 +1345,9 @@ pub const EXPLAIN_EXPORT_PATH_ID_ERROR: &str = "--path-id applies to --direction
 /// ([`explain_import`]); `export` is the read-only export dry run
 /// behind `rib --prefix <cidr> advertised <peer> --explain`
 /// ([`super::rib::explain_advertised`]) for the unicast, unlabeled,
-/// best-source case. The CLI rejects `--path-id` with `export` before
-/// dialing the daemon; the check here keeps this entry point honest for
+/// best-source case. The CLI's `value_parser` and `validate_local_command`
+/// refuse an unknown direction and `--path-id` with `export` before
+/// dialing the daemon; the checks here keep this entry point honest for
 /// any other caller.
 pub async fn explain(
     connection: Connection,
@@ -1356,14 +1357,21 @@ pub async fn explain(
     direction: &str,
     json: bool,
 ) -> Result<(), CliError> {
-    if direction != "export" {
-        return explain_import(connection, neighbor, prefix, path_id, json).await;
+    match direction {
+        "import" => explain_import(connection, neighbor, prefix, path_id, json).await,
+        "export" if path_id.is_some() => {
+            Err(CliError::Argument(EXPLAIN_EXPORT_PATH_ID_ERROR.into()))
+        }
+        "export" => {
+            super::rib::explain_advertised(
+                connection, neighbor, prefix, None, false, None, None, json,
+            )
+            .await
+        }
+        other => Err(CliError::Argument(format!(
+            "unknown explain direction {other:?}; expected import or export"
+        ))),
     }
-    if path_id.is_some() {
-        return Err(CliError::Argument(EXPLAIN_EXPORT_PATH_ID_ERROR.into()));
-    }
-    super::rib::explain_advertised(connection, neighbor, prefix, None, false, None, None, json)
-        .await
 }
 
 pub async fn explain_import(
@@ -2491,6 +2499,22 @@ mod tests {
         .unwrap_err();
         assert!(matches!(err, CliError::Argument(_)), "{err}");
         assert_eq!(err.to_string(), EXPLAIN_EXPORT_PATH_ID_ERROR);
+        assert!(server.state.last_explain_advertised.lock().await.is_none());
+        assert!(server.state.last_explain_import.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn explain_rejects_unknown_direction_before_any_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let err = explain(connection, "192.0.2.1", "192.0.2.0/24", None, "both", false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Argument(_)), "{err}");
+        assert_eq!(
+            err.to_string(),
+            "unknown explain direction \"both\"; expected import or export"
+        );
         assert!(server.state.last_explain_advertised.lock().await.is_none());
         assert!(server.state.last_explain_import.lock().await.is_none());
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -790,23 +790,34 @@ enum PolicyAction {
         #[arg(long, default_value = "export", value_parser = ["import", "export", "both"])]
         direction: String,
     },
-    /// Explain the import-policy decision for a prefix on a neighbor
+    /// Explain the policy decision for a prefix on a neighbor
     ///
-    /// Explains why a prefix was permitted / denied / withdrawn, or
-    /// not-seen / evicted / stale (ADR-0073). Reads the per-session
-    /// decision cache; requires `[policy.explain].enabled` on the
-    /// daemon (errors distinctly when the cache is disabled or the
-    /// neighbor has no live session — those are not `not_seen`).
+    /// Import (the default) explains why a prefix was permitted /
+    /// denied / withdrawn, or not-seen / evicted / stale (ADR-0073).
+    /// Reads the per-session decision cache; requires
+    /// `[policy.explain].enabled` on the daemon (errors distinctly
+    /// when the cache is disabled or the neighbor has no live session
+    /// — those are not `not_seen`). `--direction export` is the same
+    /// answer as `rib --prefix <cidr> advertised <neighbor> --explain`.
     Explain {
-        /// Neighbor (peer) address whose import-decision cache to read
+        /// Neighbor (peer) address whose decision to explain
         #[arg(long, visible_alias = "peer")]
         neighbor: String,
         /// Prefix in CIDR form, e.g. `192.0.2.0/24` or `2001:db8::/32`
         #[arg(long)]
         prefix: String,
-        /// Add-Path identifier; omit to show every matching path
+        /// Add-Path identifier (import only); omit to show every matching path
         #[arg(long)]
         path_id: Option<u32>,
+        /// Direction: import (default) or export
+        ///
+        /// `import` reads the daemon's per-session import-decision
+        /// cache and requires `[policy.explain] enabled = true` in the
+        /// daemon config. `export` runs the read-only export dry run
+        /// (the same answer as `rib --prefix <cidr> advertised
+        /// <neighbor> --explain`) and needs no configuration.
+        #[arg(long, default_value = "import", value_parser = ["import", "export"])]
+        direction: String,
     },
 }
 
@@ -2435,6 +2446,16 @@ fn validate_local_command(command: &Command) -> Result<(), CliError> {
             "set-export requires at least one policy name; use clear-export to drop the chain"
                 .into(),
         )),
+        Command::Policy {
+            action:
+                PolicyAction::Explain {
+                    direction,
+                    path_id: Some(_),
+                    ..
+                },
+        } if direction == "export" => Err(CliError::Argument(
+            commands::policy::EXPLAIN_EXPORT_PATH_ID_ERROR.into(),
+        )),
         // Every `--family` the connected handlers resolve through
         // `parse_family`, in resolution order, so a typo fails before the
         // transport is dialed. Views that forward the family string to the
@@ -3792,8 +3813,9 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 neighbor,
                 prefix,
                 path_id,
+                direction,
             } => {
-                commands::policy::explain_import(connection, &neighbor, &prefix, path_id, json)
+                commands::policy::explain(connection, &neighbor, &prefix, path_id, &direction, json)
                     .await
             }
             PolicyAction::Chain { action } => match action {
@@ -4025,7 +4047,7 @@ mod tests {
             ("README.md", 4),
             ("docs/QUICKSTART.md", 5),
             ("docs/cookbook/route-server.md", 3),
-            ("docs/explain.md", 6),
+            ("docs/explain.md", 7),
             ("docs/OPERATIONS.md", 2),
         ];
 
@@ -7083,6 +7105,10 @@ printf '%s\n' "${COMPREPLY[@]}"
                 "policy chain set-export",
                 "set-export requires at least one policy name; use clear-export to drop the chain",
             ),
+            (
+                "policy explain --neighbor 10.0.0.2 --prefix 10.0.0.0/24 --path-id 3 --direction export",
+                commands::policy::EXPLAIN_EXPORT_PATH_ID_ERROR,
+            ),
             ("watch --family bogus", "unknown address family: bogus"),
             (
                 "flowspec add --family bogus",
@@ -7245,6 +7271,48 @@ printf '%s\n' "${COMPREPLY[@]}"
             };
             assert_eq!(peer.as_deref(), Some("10.0.0.1"), "evpn {flag}");
         }
+    }
+
+    /// `policy explain` has always been import-only, so omitting
+    /// `--direction` must keep that answer; `export` is the only other
+    /// value (`both` is a `policy stats` notion, not an explain one).
+    #[test]
+    fn policy_explain_direction_parses_and_defaults_to_import() {
+        let base = [
+            "rbgp",
+            "policy",
+            "explain",
+            "--neighbor",
+            "10.0.0.1",
+            "--prefix",
+            "10.0.0.0/24",
+        ];
+        let direction_of = |cli: Cli| {
+            let Command::Policy {
+                action: PolicyAction::Explain { direction, .. },
+            } = cli.command
+            else {
+                panic!("expected Policy Explain");
+            };
+            direction
+        };
+        assert_eq!(direction_of(Cli::try_parse_from(base).unwrap()), "import");
+        for direction in ["import", "export"] {
+            let cli = Cli::try_parse_from(base.into_iter().chain(["--direction", direction]))
+                .unwrap_or_else(|error| panic!("--direction {direction}: {error}"));
+            assert_eq!(direction_of(cli), direction);
+        }
+        assert!(
+            Cli::try_parse_from(base.into_iter().chain(["--direction", "both"])).is_err(),
+            "explain has no `both` direction"
+        );
+        // `--path-id` with export parses; the rejection is a local
+        // argument error (see `local_argument_errors_fail_before_transport`).
+        Cli::try_parse_from(
+            base.into_iter()
+                .chain(["--path-id", "3", "--direction", "export"]),
+        )
+        .unwrap();
     }
 
     /// LAN-329: `--remote-asn` is canonical, `--asn` stays as a

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2283,6 +2283,11 @@ rbgp policy explain --neighbor 10.0.0.2 --prefix 2001:db8::/32 --json
 rbgp policy explain --neighbor 10.0.0.2 --prefix 192.0.2.0/24 --path-id 3
 ```
 
+`--direction export` runs the
+[export dry run](#explain-an-export-decision-why-diddidnt-route-x-go-to-peer-y)
+under the same verb (identical to `rbgp rib --prefix <cidr> advertised <peer>
+--explain` without RD, labeled, or source flags); it needs no configuration.
+
 The address family is inferred from the prefix (IPv4 / IPv6 unicast).
 Each result reports an outcome:
 

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -26,7 +26,7 @@ catalog.
 | Question | Command |
 |----------|---------|
 | Why was this path selected as best? | `rbgp rib --prefix <cidr> --explain` |
-| Why did/didn't this prefix go to that peer? | `rbgp rib --prefix <cidr> advertised <peer> --explain` |
+| Why did/didn't this prefix go to that peer? | `rbgp rib --prefix <cidr> advertised <peer> --explain`, or the same answer as `rbgp policy explain --neighbor <peer> --prefix <cidr> --direction export` |
 | What did import policy decide for this prefix from that peer? (opt-in: `[policy.explain] enabled = true`) | `rbgp policy explain --neighbor <peer> --prefix <cidr>` |
 | Which of a member's routes were filtered, and why? | `rbgp rib received <peer> --rejected` |
 | What would this candidate policy do to the live RIB? | `rbgp policy test <file> --policy <name> --direction import` |
@@ -256,8 +256,9 @@ rbgp policy explain --neighbor 198.51.100.2 --prefix 203.0.113.0/24
 rbgp rpki validate 203.0.113.0/24 64501
 
 # 4. Accepted but another member doesn't see it? Walk the export ladder
-#    toward that member.
+#    toward that member (either spelling; the second needs no config).
 rbgp rib --prefix 203.0.113.0/24 advertised 198.51.100.7 --explain
+rbgp policy explain --neighbor 198.51.100.7 --prefix 203.0.113.0/24 --direction export
 
 # 5. Accepted but lost best-path selection? See what beat it.
 rbgp rib --prefix 203.0.113.0/24 --explain

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -2606,10 +2606,11 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (explain)
 _arguments "${_arguments_options[@]}" : \
-'--neighbor=[Neighbor (peer) address whose import-decision cache to read]:NEIGHBOR:_default' \
-'--peer=[Neighbor (peer) address whose import-decision cache to read]:NEIGHBOR:_default' \
+'--neighbor=[Neighbor (peer) address whose decision to explain]:NEIGHBOR:_default' \
+'--peer=[Neighbor (peer) address whose decision to explain]:NEIGHBOR:_default' \
 '--prefix=[Prefix in CIDR form, e.g. \`192.0.2.0/24\` or \`2001\:db8\:\:/32\`]:PREFIX:_default' \
-'--path-id=[Add-Path identifier; omit to show every matching path]:PATH_ID:_default' \
+'--path-id=[Add-Path identifier (import only); omit to show every matching path]:PATH_ID:_default' \
+'--direction=[Direction\: import (default) or export]:DIRECTION:(import export)' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -5289,7 +5290,7 @@ _rbgp__subcmd__help__subcmd__policy_commands() {
 'delete:Delete a policy by name' \
 'chain:Manage global / per-neighbor import/export chains' \
 'stats:Show live per-term policy hit counters' \
-'explain:Explain the import-policy decision for a prefix on a neighbor' \
+'explain:Explain the policy decision for a prefix on a neighbor' \
     )
     _describe -t commands 'rbgp help policy commands' commands "$@"
 }
@@ -5791,7 +5792,7 @@ _rbgp__subcmd__policy_commands() {
 'chain:Manage global / per-neighbor import/export chains' \
 'stats:Show live per-term policy hit counters' \
 'counters:Show live per-term policy hit counters' \
-'explain:Explain the import-policy decision for a prefix on a neighbor' \
+'explain:Explain the policy decision for a prefix on a neighbor' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp policy commands' commands "$@"
@@ -5912,7 +5913,7 @@ _rbgp__subcmd__policy__subcmd__help_commands() {
 'delete:Delete a policy by name' \
 'chain:Manage global / per-neighbor import/export chains' \
 'stats:Show live per-term policy hit counters' \
-'explain:Explain the import-policy decision for a prefix on a neighbor' \
+'explain:Explain the policy decision for a prefix on a neighbor' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp policy help commands' commands "$@"

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -7714,7 +7714,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__explain)
-            opts="-s -j -h --peer --neighbor --prefix --path-id --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --prefix --path-id --direction --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7734,6 +7734,10 @@ _rbgp() {
                     ;;
                 --path-id)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --direction)
+                    COMPREPLY=($(compgen -W "import export" -- "${cur}"))
                     return 0
                     ;;
                 --addr)

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -1207,7 +1207,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_su
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "stats" -d 'Show live per-term policy hit counters'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "counters" -d 'Show live per-term policy hit counters'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "explain" -d 'Explain the policy decision for a prefix on a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -1316,9 +1316,11 @@ never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l neighbor -l peer -d 'Neighbor (peer) address whose import-decision cache to read' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l neighbor -l peer -d 'Neighbor (peer) address whose decision to explain' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l prefix -d 'Prefix in CIDR form, e.g. `192.0.2.0/24` or `2001:db8::/32`' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l path-id -d 'Add-Path identifier; omit to show every matching path' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l path-id -d 'Add-Path identifier (import only); omit to show every matching path' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l direction -d 'Direction: import (default) or export' -r -f -a "import\t''
+export\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l pager -d 'Page complete human unicast RIB listings' -r -f -a "auto\t''
@@ -1336,7 +1338,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a policy by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "stats" -d 'Show live per-term policy hit counters'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "explain" -d 'Explain the policy decision for a prefix on a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -1662,7 +1664,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "delete" -d 'Delete a policy by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "stats" -d 'Show live per-term policy hit counters'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "explain" -d 'Explain the policy decision for a prefix on a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "list" -d 'List configured neighbor sets'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "get" -d 'Show one neighbor set by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "set" -d 'Set (create or replace) a neighbor set from a JSON file'


### PR DESCRIPTION
## What changed

`rbgp policy explain` gains `--direction <import|export>`, default `import`.

- `import` (default) is the existing per-session import-decision cache lookup and is unchanged; it still requires `[policy.explain] enabled = true` on the daemon.
- `export` dispatches to the existing export dry run behind `rbgp rib --prefix <cidr> advertised <peer> --explain` with `rd = None`, `labeled = false`, and no source identity; it needs no configuration. Same `--json` handling.
- `--path-id` together with `--direction export` is rejected before the daemon is dialed (`validate_local_command`), with a message that points at `rib --prefix <cidr> advertised <peer> --explain --source-peer <addr> --source-path-id <id>` for Add-Path source selection. Exit code 1, the same path as every other local argument error; clap's invalid-value rejection of `--direction both` exits 2 as before for any enum flag.
- The `--direction` help text states which answer needs `[policy.explain] enabled = true` and where each answer comes from.

No RPC, protobuf, inventory, or authz change; no `explain-export` subcommand.

## Design

The branch lives in a new `commands::policy::explain(connection, neighbor, prefix, path_id, direction, json)` so it is testable against the mock server; `main.rs` dispatches there. The rejection message is one `pub const` (`EXPLAIN_EXPORT_PATH_ID_ERROR`) used by both the pre-connect `validate_local_command` arm and the function itself, so the two cannot drift and the entry point stays correct standalone.

## Tests

- `tests::policy_explain_direction_parses_and_defaults_to_import`: omitting `--direction` yields `import`; `import` and `export` parse; `both` is refused; `--path-id` with `export` parses (the rejection is a local argument error).
- `tests::local_argument_errors_fail_before_transport` gains the `--path-id` + `--direction export` case against an unreachable address, proving it fails before transport.
- `commands::policy::tests::explain_direction_export_calls_advertised_rpc`: text and JSON both reach `ExplainAdvertisedRoute` with the bare peer, prefix, empty RD, unlabeled, no source, and never touch `ExplainImportPolicy`.
- `commands::policy::tests::explain_direction_import_is_the_cache_lookup` and `explain_direction_export_rejects_path_id_before_any_rpc`.
- Red proof: on the pre-change tree the parse test fails with clap `UnknownArgument "--direction"` (exit 101).

## Docs

`docs/explain.md` table row and a curated conformance example (count bumped 6 to 7 in the doc gate); `crates/cli/README.md` synopsis and cache note; `docs/OPERATIONS.md` import-explain section; CHANGELOG Added entry. `examples/completions/*` regenerated with `rbgp completions <shell>` from the built binary (the `checked_in_completions_match_current_cli` pin is green).

`tests/interop_policy_explain.rs` is a structural fence over interop scripts' explain config fragments, not a CLI exit-code contract, so no workspace-level test target was needed.

## Checks

| Gate | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p rustbgpctl --all-targets -- -D warnings` | 0 |
| `cargo test -p rustbgpctl` (lib 22, bin 707, integration 38+2+1) | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `just links` (0 errors) | 0 |
| `cargo doc --locked -p rustbgpctl --bin rbgp --no-deps` | 0 |
| `rbgp --addr http://127.0.0.1:1 policy explain ... --path-id 3 --direction export` | 1 (argument error, no connect attempt) |
