### PR TITLE
wire: treat an offset-shifted IPv6 FlowSpec destination as no destination prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Operator-visible:** an IPv6 FlowSpec rule whose destination component
+  carries a non-zero offset no longer presents the unshifted address as its
+  destination prefix. RFC 8956 §3.1 matches the address shifted right by the
+  offset, so the rule names no routable prefix: import and export policy
+  prefix terms no longer match it, and RPKI origin validation of the
+  destination no longer runs against a prefix the rule does not name, the
+  same treatment as a rule with no destination component. The wire form is
+  still accepted unchanged.
+
 - **Operator-visible:** an IP that rebinds to a new MAC in the kernel
   neighbour table now withdraws the old MAC+IP Type 2 route before the new
   one is advertised. The kernel replaces the neighbour row's link-layer

--- a/crates/transport/src/session/tests/import_policy.rs
+++ b/crates/transport/src/session/tests/import_policy.rs
@@ -122,7 +122,8 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
 /// `prefix = None` in the import policy context — prefix-based deny terms
 /// (including exact-default ones) must not match it, while a rule with a
 /// real destination prefix still evaluates that prefix. Covers IPv4 and
-/// IPv6 `FlowSpec`.
+/// IPv6 `FlowSpec`, and an IPv6 destination whose non-zero offset means it
+/// names no prefix either.
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
@@ -172,6 +173,10 @@ async fn import_policy_prefix_term_does_not_match_destination_less_flowspec() {
                 Ipv4Addr::new(198, 51, 100, 0),
                 24,
             ))),
+            deny(Prefix::V6(Ipv6Prefix::new(
+                Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
+                32,
+            ))),
         ],
         default_action: PolicyAction::Permit,
     }])));
@@ -181,6 +186,17 @@ async fn import_policy_prefix_term_does_not_match_destination_less_flowspec() {
 
     let destless_v4 = destless_rule(6);
     let destless_v6 = destless_rule(17);
+    // RFC 8956 §3.1: a non-zero offset shifts the pattern, so this rule
+    // names no destination prefix and the exact 2001:db8::/32 deny above
+    // must not match it.
+    let offset_v6 = FlowSpecRule {
+        components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V6(
+            Ipv6PrefixOffset {
+                prefix: Ipv6Prefix::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 32),
+                offset: 16,
+            },
+        ))],
+    };
     let with_denied_prefix = FlowSpecRule {
         components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V4(
             Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
@@ -226,7 +242,7 @@ async fn import_policy_prefix_term_does_not_match_destination_less_flowspec() {
             next_hop: "2001:db8::2".parse().unwrap(),
             link_local_next_hop: None,
             announced: vec![],
-            flowspec_announced: vec![destless_v6.clone()],
+            flowspec_announced: vec![destless_v6.clone(), offset_v6.clone()],
             evpn_announced: vec![],
             bgpls_announced: vec![],
             labeled_announced: vec![],
@@ -240,8 +256,8 @@ async fn import_policy_prefix_term_does_not_match_destination_less_flowspec() {
     session.process_update(v6_update).await;
 
     assert_eq!(
-        session.import_policy_routes_permitted, 2,
-        "both destination-less rules must pass through to the default Permit"
+        session.import_policy_routes_permitted, 3,
+        "destination-less and offset-shifted rules must pass through to the default Permit"
     );
     assert_eq!(
         session.import_policy_routes_denied, 1,
@@ -258,10 +274,10 @@ async fn import_policy_prefix_term_does_not_match_destination_less_flowspec() {
         }
     }
     let rules: Vec<_> = announced.iter().map(|r| r.rule.clone()).collect();
-    assert_eq!(rules, vec![destless_v4, destless_v6]);
+    assert_eq!(rules, vec![destless_v4, destless_v6, offset_v6]);
     assert_eq!(
         announced.iter().map(|r| r.afi).collect::<Vec<_>>(),
-        vec![Afi::Ipv4, Afi::Ipv6]
+        vec![Afi::Ipv4, Afi::Ipv6, Afi::Ipv6]
     );
 }
 

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -7,6 +7,12 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## 0.19.1 - Unreleased
 
+- `FlowSpecRule::destination_prefix` returns `None` for an IPv6 destination
+  component with a non-zero offset. RFC 8956 §3.1 matches the address
+  shifted right by `offset` bits, so the component names no routable prefix,
+  and RFC 8956 §5 counts only an offset-0 destination toward validation
+  item (a). Previously the offset was dropped and the unshifted prefix was
+  returned. Encoding and decoding of such rules are unchanged.
 - Added the `mrt` module with `decode_table_dump_v2_mp_reach_next_hop`, which
   decodes the next hop of the `MP_REACH_NLRI` carried inside an RFC 6396
   `TABLE_DUMP_V2` RIB entry. Both the §4.3.4 reduced form (next-hop length,

--- a/crates/wire/src/flowspec.rs
+++ b/crates/wire/src/flowspec.rs
@@ -251,13 +251,18 @@ impl FlowSpecRule {
     }
 
     /// Extract the destination prefix from the rule, if present.
+    ///
+    /// An IPv6 destination with a non-zero offset yields `None`: RFC 8956
+    /// §3.1 matches the address shifted right by `offset` bits, so the
+    /// component names no routable prefix, and RFC 8956 §5 counts only an
+    /// offset-0 destination prefix toward validation item (a).
     #[must_use]
     pub fn destination_prefix(&self) -> Option<crate::nlri::Prefix> {
         self.components.iter().find_map(|c| match c {
             FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V4(p)) => {
                 Some(crate::nlri::Prefix::V4(*p))
             }
-            FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V6(p)) => {
+            FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V6(p)) if p.offset == 0 => {
                 Some(crate::nlri::Prefix::V6(p.prefix))
             }
             _ => None,
@@ -1778,6 +1783,49 @@ mod tests {
             }])],
         };
         assert!(rule.destination_prefix().is_none());
+    }
+
+    fn ipv6_destination_rule(offset: u8) -> FlowSpecRule {
+        FlowSpecRule {
+            components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V6(
+                Ipv6PrefixOffset {
+                    prefix: Ipv6Prefix::new(
+                        std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
+                        32,
+                    ),
+                    offset,
+                },
+            ))],
+        }
+    }
+
+    #[test]
+    fn ipv6_destination_prefix_offset_zero_extracts() {
+        let prefix = ipv6_destination_rule(0).destination_prefix().unwrap();
+        let crate::nlri::Prefix::V6(p) = prefix else {
+            panic!("expected V6 prefix");
+        };
+        assert_eq!(
+            p.addr,
+            std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)
+        );
+        assert_eq!(p.len, 32);
+    }
+
+    /// RFC 8956 §3.1: with a non-zero offset the pattern is the address
+    /// shifted right by `offset` bits, so the component names no routable
+    /// prefix. The wire form is still valid and round-trips unchanged; only
+    /// the extracted destination prefix is absent.
+    #[test]
+    fn ipv6_destination_prefix_with_offset_is_no_destination_prefix() {
+        let rule = ipv6_destination_rule(16);
+        assert_eq!(rule.destination_prefix(), None);
+
+        let mut buf = Vec::new();
+        try_encode_flowspec_nlri(std::slice::from_ref(&rule), &mut buf, Afi::Ipv6).unwrap();
+        let decoded = decode_flowspec_nlri(&buf, Afi::Ipv6).unwrap();
+        assert_eq!(decoded, vec![rule]);
+        assert_eq!(decoded[0].destination_prefix(), None);
     }
 
     #[test]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -1170,6 +1170,11 @@ carries inactive (absent), unlimited (zero), or finite.
 - Actions via extended communities: traffic-rate, traffic-action,
   traffic-marking, redirect.
 - NH length = 0 in MP_REACH_NLRI for FlowSpec.
+- An IPv6 destination component with a non-zero offset (RFC 8956 §3.1)
+  carries no destination prefix for policy, RPKI, or validation purposes:
+  the pattern is the address shifted right by the offset, so it names no
+  routable prefix, and RFC 8956 §5 counts only an offset-0 destination
+  toward validation item (a). The rule is still decoded and installed.
 - See ADR-0035.
 
 ---


### PR DESCRIPTION
## What changed

`FlowSpecRule::destination_prefix()` returned `Some(Prefix::V6(p.prefix))` for an IPv6 destination component and silently dropped `p.offset`. RFC 8956 §3.1 defines the pattern as the address shifted right by `offset` bits, so a component with a non-zero offset names no routable prefix; RFC 8956 §5 counts only an offset-0 destination prefix toward validation item (a). The two live callers (`crates/transport/src/session/inbound.rs`: import policy context and RPKI validation of the destination; `crates/rib/src/manager/distribution/flowspec.rs`: export policy context) treated the fabricated prefix as real.

The function now returns `None` when the IPv6 destination's offset is non-zero, the same representation already used for a rule with no destination component (the earlier "no fabricated `0.0.0.0/0`" fix). Signature unchanged; doc comment cites RFC 8956 §3.1/§5. Encoding and decoding are untouched: the wire form is still accepted and round-trips unchanged. IPv4 destinations (`FlowSpecPrefix::V4(Ipv4Prefix)`) have no offset field and are unaffected. No version bump.

## Tests

- `crates/wire/src/flowspec.rs`, next to `destination_prefix_extraction` / `rule_without_destination_prefix`: `ipv6_destination_prefix_offset_zero_extracts` (offset 0 still yields `2001:db8::/32`) and `ipv6_destination_prefix_with_offset_is_no_destination_prefix` (offset 16 yields `None`; encode/decode round-trip equals the original rule; the decoded rule also yields `None`).
- `crates/transport/src/session/tests/import_policy.rs`, `import_policy_prefix_term_does_not_match_destination_less_flowspec`: an exact `2001:db8::/32` deny term is added and an IPv6 destination rule with offset 16 rides the v6 UPDATE; it must pass through to the default Permit (permitted 3, denied 1) and reach the RIB.

Red proof on the pre-change tree:
- wire: `ipv6_destination_prefix_with_offset_is_no_destination_prefix` fails with `left: Some(V6(Ipv6Prefix { addr: 2001:db8::, len: 32 }))`, `right: None` (exit 101).
- transport: the extended test fails with `import_policy_routes_permitted` `left: 2`, `right: 3` (exit 101), because the fabricated `2001:db8::/32` matched the exact deny term.

## Docs and changelogs

`docs/RFC_NOTES.md` RFC 8955/8956 section gains one bullet. `crates/wire/CHANGELOG.md` entry under the prepared, unpublished 0.19.1 section; root `CHANGELOG.md` `[Unreleased]` `### Fixed` entry.

## Checks

| Gate | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --locked -p rustbgpd-wire --all-targets -- -D warnings` | 0 |
| `cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings` | 0 |
| `cargo test --locked -p rustbgpd-wire` | 0 |
| `cargo test --locked -p rustbgpd-wire --features tokio-codec` | 0 |
| `cargo test --locked -p rustbgpd-transport` | 0 |
| `cargo test --locked -p rustbgpd-rib flowspec` | 0 |
| `cargo doc --locked -p rustbgpd-wire --no-deps` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `python3 -m unittest scripts/test_check_embedding_versions.py` | 0 |
