### PR TITLE
build: add just recipes for the feature-gated, ignored, and netns test surfaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,23 @@ The recipes intentionally expose their direct commands:
   toolchain and system libraries as those benches.
 - `just fix` applies safe Clippy suggestions before formatting. Cargo's normal
   refusal to modify dirty or staged worktrees remains in force.
+- `just test-feature-gated` compiles and runs the feature-gated surfaces that
+  hosted CI exercises beyond the default workspace build: the wire
+  `tokio-codec` adapter, the `bench-internals` bench and receipt targets
+  (through `just gate-rib` and `just gate-contract`), both MRT snapshot
+  allocation modes, and the root crate's `--all-features` and
+  `--no-default-features` builds. The commands match `.github/workflows/ci.yml`.
+- `just test-ignored` runs the `#[ignore]`d receipts that need no privileges,
+  extra environment, or release build: the RIB sizing harnesses, the extended
+  update-group fault corpus, the policy-set allocation receipts, the
+  quickstart shutdown recurrence proof, and the `rbgp` route-diff scale
+  receipt. It finishes in under a minute on a warm target directory, adds
+  minutes of feature-gated builds on a cold one, and allocates a few hundred
+  MB. The `justfile` comment above the recipe names the ignored tests it
+  leaves out and why.
+- `just netns [selector]` runs the privileged network-namespace tests in
+  Docker through `crates/evpn-linux/tests/docker/run-netns-tests.sh`; the
+  selector defaults to `all` and the harness header lists the others.
 
 Hosted checks remain authoritative and cover more than these recipes: the
 declared MSRV, platform and workflow contracts, receipt classifiers, and
@@ -79,8 +96,9 @@ privileged interoperability lanes. In particular, the exact v0.64 migration
 test only runs when `RUSTBGPD_V064_VALIDATOR` points to the verified v0.64
 binary that CI prepares. Privileged network-namespace tests require Linux,
 `EVPN_LINUX_NETNS=1`, and `CAP_NET_ADMIN` plus `CAP_SYS_ADMIN`; use
-`crates/evpn-linux/tests/docker/run-netns-tests.sh` as documented in that
-harness's README. Neither prerequisite is installed or enabled by `just gate`.
+`crates/evpn-linux/tests/docker/run-netns-tests.sh` (or `just netns`) as
+documented in that harness's README. Neither prerequisite is installed or
+enabled by `just gate`.
 
 Treat the `justfile` as a convenient reviewed snapshot, not a single source of
 truth. Check the applicable workflows when changing CI or preparing a merge.

--- a/justfile
+++ b/justfile
@@ -67,3 +67,38 @@ gate-contract:
 fix:
     cargo clippy --fix --locked --workspace --all-targets -- -D warnings
     cargo fmt --all
+
+# Compile and run the feature-gated surfaces hosted CI checks beyond the default workspace build.
+test-feature-gated:
+    cargo clippy --locked -p rustbgpd-wire --all-targets --features tokio-codec -- -D warnings
+    just gate-rib
+    just gate-contract
+    cargo test --locked -p rustbgpd-rib --features bench-internals --bench selection_deferral_release -- --self-test
+    cargo test --locked -p rustbgpd-mrt --bench snapshot_allocation -- timing --candidate --smoke
+    cargo test --locked -p rustbgpd-mrt --features snapshot-allocation-diagnostics --bench snapshot_allocation -- diagnostic --candidate --smoke
+    cargo check --locked -p rustbgpd --all-features --lib
+    cargo test --locked -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation shared_set_batch_allocations_do_not_scale_per_peer -- --exact
+    cargo check --locked -p rustbgpd --no-default-features --all-targets
+    cargo test --locked -p rustbgpd-wire --features tokio-codec
+    cargo doc --locked -p rustbgpd-wire --lib --no-deps --features tokio-codec
+
+# Excluded ignored tests: the TCP-AO kernel receipts (transport listener and
+# socket_opts) need CONFIG_TCP_AO and privileges; the four config persistence
+# probes assert a release build; `unicast_prefix_peers_memory` needs its
+# announcer-count environment variable; `policy_set_store_dhat` needs the
+# `dhat-heap` feature and an output-file environment variable;
+# `minimizer_timeout_fixture` is a child-process fixture, not a test.
+
+# Run the ignored receipts that need no privileges, extra environment, or release build (under a minute warm; allocates a few hundred MB).
+test-ignored:
+    cargo test --locked -p rustbgpd-rib --test export_fanout_attr_memo -- --ignored
+    cargo test --locked -p rustbgpd-rib --test route_data_sharing_profile -- --ignored
+    RUSTBGPD_RIB_MEMORY_PROFILE=quick cargo test --locked -p rustbgpd-rib --features bench-internals --test memory_profile memory_profile_high_n -- --ignored
+    cargo test --locked -p rustbgpd-rib --lib manager::tests::update_groups_fault_corpus::deterministic_fault_corpus_extended -- --ignored --exact
+    cargo test --locked -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation -- --ignored
+    cargo test --locked -p rustbgpd --test quickstart_dynamic_neighbor -- --ignored
+    cargo test --locked -p rustbgpctl --lib scale_receipt_1m_routes -- --ignored
+
+# Run the privileged network-namespace tests in Docker; selectors are listed in crates/evpn-linux/tests/docker/run-netns-tests.sh.
+netns selector='all':
+    bash crates/evpn-linux/tests/docker/run-netns-tests.sh {{selector}}

--- a/justfile
+++ b/justfile
@@ -93,12 +93,12 @@ test-feature-gated:
 test-ignored:
     cargo test --locked -p rustbgpd-rib --test export_fanout_attr_memo -- --ignored
     cargo test --locked -p rustbgpd-rib --test route_data_sharing_profile -- --ignored
-    RUSTBGPD_RIB_MEMORY_PROFILE=quick cargo test --locked -p rustbgpd-rib --features bench-internals --test memory_profile memory_profile_high_n -- --ignored
+    RUSTBGPD_RIB_MEMORY_PROFILE=quick cargo test --locked -p rustbgpd-rib --features bench-internals --test memory_profile memory_profile_high_n -- --ignored --exact
     cargo test --locked -p rustbgpd-rib --lib manager::tests::update_groups_fault_corpus::deterministic_fault_corpus_extended -- --ignored --exact
     cargo test --locked -p rustbgpd --no-default-features --features bench-internals --test policy_set_store_allocation -- --ignored
     cargo test --locked -p rustbgpd --test quickstart_dynamic_neighbor -- --ignored
-    cargo test --locked -p rustbgpctl --lib scale_receipt_1m_routes -- --ignored
+    cargo test --locked -p rustbgpctl --lib ribdiff::tests::scale_receipt_1m_routes -- --ignored --exact
 
 # Run the privileged network-namespace tests in Docker; selectors are listed in crates/evpn-linux/tests/docker/run-netns-tests.sh.
 netns selector='all':
-    bash crates/evpn-linux/tests/docker/run-netns-tests.sh {{selector}}
+    bash crates/evpn-linux/tests/docker/run-netns-tests.sh "{{selector}}"


### PR DESCRIPTION
## What changed

Three additive `just` recipes; no existing recipe changes.

- `test-feature-gated` runs, in CI order, the feature-gated commands from `.github/workflows/ci.yml` that a bare `cargo test --workspace` never compiles: the wire `tokio-codec` clippy/test/doc, the `bench-internals` bench checks (through `just gate-rib`), the Criterion smoke (through `just gate-contract`), the selection-deferral self-test, both MRT `snapshot_allocation` modes, the root crate's `--all-features --lib` and `--no-default-features --all-targets` checks, and the policy-set-store allocation gate.
- `test-ignored` runs the eight `#[ignore]`d tests that need no privileges, extra environment, or release build, with explicit `-p`/`--test` targets and `-- --ignored`. A comment above the recipe names what it leaves out and why.
- `netns [selector='all']` wraps `crates/evpn-linux/tests/docker/run-netns-tests.sh`; selector names are unchanged.

`CONTRIBUTING.md` gains one bullet per recipe and mentions `just netns` next to the existing harness pointer.

## `#[ignore]` inventory (20 grep sites in 12 files; 18 attributes plus 2 doc-comment mentions)

| Test | Class | In `test-ignored` |
|---|---|---|
| `crates/rib/tests/export_fanout_attr_memo.rs` `policy_fanout_live_heap_near_no_policy_baseline` | sizing receipt, unprivileged | yes |
| `crates/rib/tests/route_data_sharing_profile.rs` `route_data_sharing_profile` | sizing receipt, unprivileged | yes |
| `crates/rib/tests/memory_profile.rs` `memory_profile_high_n` | sizing receipt; `full` profile is long-running, run with `RUSTBGPD_RIB_MEMORY_PROFILE=quick` | yes (quick) |
| `crates/rib/src/manager/tests/update_groups_fault_corpus.rs` `deterministic_fault_corpus_extended` | bounded corpus; defaults equal the weekly workflow's caps | yes |
| `tests/policy_set_store_allocation.rs` `shared_large_set_receipt`, `unique_large_set_peak_receipt` | receipts behind `bench-internals` (same flags CI uses for that target) | yes |
| `tests/quickstart_dynamic_neighbor.rs` `documented_starter_shutdown_recurrence_is_bounded_and_isolated` | bounded 24-lifecycle proof, unprivileged | yes |
| `crates/cli/src/ribdiff.rs` `scale_receipt_1m_routes` | 1M-route receipt; passes in debug in seconds | yes |
| `crates/rib/tests/unicast_prefix_peers_memory.rs` `unicast_prefix_peers_memory` | needs an announcer-count env var (panics without) | no, named in comment |
| `tests/policy_set_store_dhat.rs` `shared_set_resolution_dhat` | needs `dhat-heap` feature and an output-file env var | no, named in comment |
| `crates/rib/src/manager/tests/update_groups_fault_corpus.rs` `minimizer_timeout_fixture` | child-process fixture, not a test | no |
| `crates/transport/src/listener.rs` (2), `crates/transport/src/socket_opts.rs` (1) | need `CONFIG_TCP_AO` kernel and privileges; run by `kernel-dataplane.yml` | no |
| `src/config/tests/mod.rs` (4 release probes) | assert a release build, 3.2M statements | no |
| `route_data_sharing_profile.rs:12`, `export_fanout_attr_memo.rs:13` | `//!` doc text, not attributes | n/a |

## Checks

Warm target directory; the box was shared with other builds, so treat times as upper bounds.

| Check | Exit | Time |
|---|---|---|
| `just --list` (shows the three recipes) | 0 | |
| `just --dry-run test-feature-gated` | 0 | |
| `just test-feature-gated` | 0 | 332 s |
| `just test-ignored` (8 tests, all pass) | 0 | 35 s |
| `just --dry-run netns spike` | 0 | |
| `bash -n crates/evpn-linux/tests/docker/run-netns-tests.sh` | 0 | |
| `cargo fmt --all -- --check` | 0 | |
| `python3 scripts/check_public_tracker_ids.py` | 0 | |
| `python3 scripts/check_release_checklist_paths.py` | 0 | |
| `just links` | 0 | |

The Docker netns harness was not executed.
