### PR TITLE
build: split the local gate into tiered just recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   dialed, pointing at the `rib advertised --explain --source-peer` /
   `--source-path-id` flags for Add-Path source selection. Shell completions
   regenerated.
+- Tiered `just` recipes for the local developer loop: `check-fast`,
+  `check-contracts`, `check-devtools`, `check-clippy`, `docs`, `test-crates`,
+  `test-bins`, and `test-integration` split `just gate` into runnable
+  pieces, and `test-feature-gated`, `test-ignored`, and `netns` expose the
+  feature-gated, ignored, and privileged network-namespace test surfaces that
+  hosted CI runs. `just gate` runs the same commands in the same order as
+  before.
 
 - **Operator-visible:** RFC 5883 multihop BFD. Setting
   `bfd = { profile = "...", multihop = true }` on a static global neighbor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,10 @@ just --list
 
 The recipes intentionally expose their direct commands:
 
-- `just gate` runs formatting, lightweight repository contracts, strict
-  workspace Clippy, the full workspace tests, and library docs (private items
-  included) and binary docs.
+- `just gate` runs the offline link check, the developer-tooling check,
+  formatting, lightweight repository contracts, strict workspace Clippy, the
+  full workspace tests, and library docs (private items included) and binary
+  docs, in that order.
   This is the broad local baseline and can take several minutes on a cold
   target directory. It is composed from the tiered recipes below and runs the
   same commands in the same order as before the split.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,23 @@ The recipes intentionally expose their direct commands:
   workspace Clippy, the full workspace tests, and library docs (private items
   included) and binary docs.
   This is the broad local baseline and can take several minutes on a cold
-  target directory.
+  target directory. It is composed from the tiered recipes below and runs the
+  same commands in the same order as before the split.
+- `just check-fast` runs formatting and the cheap repository contracts in
+  seconds without compiling anything. `just check-contracts` runs the slower
+  contract checkers (public tracker identifiers, documentation paths, metric
+  consumers) in a few minutes, also without compiling. `just check-devtools`
+  checks the pinned developer tooling and `just check-clippy` runs the strict
+  workspace lint.
+- `just test-crates` runs the library unit tests of every workspace crate
+  (the same command as the pre-push hook). `just test-bins` runs the unit
+  tests of every binary target; the daemon's own unit tests live in its
+  binary rather than a library. `just test-integration` runs every `tests/`
+  integration binary. Together with the doctests these three cover what
+  `cargo test --workspace` runs; each takes seconds to a few minutes on a
+  warm target directory.
+- `just docs` builds the library docs (private items included) and both
+  binary docs.
 - `just gate-rib` compiles the feature-gated RIB, transport, and API benchmark
   surfaces that the default workspace build cannot see, including the root
   FIB projection and both API feature combinations.

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ check-clippy:
 test-crates:
     cargo test --locked --workspace --lib
 
-# Run the unit tests of every binary target: the daemon, rbgp, the examples, and the tools.
+# Run the unit tests of every binary target: the daemon, rbgp, the example packages under examples/, and the tools.
 test-bins:
     cargo test --locked --workspace --bins
 

--- a/justfile
+++ b/justfile
@@ -7,13 +7,28 @@ default:
 # Run the broad local correctness baseline in diagnostic order.
 gate:
     just links
+    just check-devtools
+    just check-fast
+    just check-contracts
+    just check-clippy
+    cargo test --locked --workspace
+    just docs
+
+# Check the pinned developer tooling versions.
+check-devtools:
     python3 scripts/check_developer_tooling.py --self-test
     python3 scripts/check_developer_tooling.py
+
+# Check formatting and the cheap repository contracts (seconds, no compilation).
+check-fast:
     cargo fmt --all -- --check
     python3 -m unittest -v scripts/test_check_clippy_reasons.py
     python3 scripts/check-clippy-reasons.py
     python3 scripts/check-v1-stable-surface.py
     python3 scripts/reflow-release-notes.py --selftest
+
+# Check the slower repository contracts: public tracker ids, documentation paths, and metric consumers (minutes, no compilation).
+check-contracts:
     python3 -m unittest -v scripts/test_check_public_tracker_ids.py
     python3 scripts/check_public_tracker_ids.py
     python3 -m unittest -v scripts/test_check_ixp_manager_docs.py
@@ -22,8 +37,30 @@ gate:
     python3 scripts/check_release_checklist_paths.py
     python3 -m unittest -v scripts/test_check_metric_consumers.py
     python3 scripts/check-metric-consumers.py
+
+# Lint every workspace target with warnings denied.
+check-clippy:
     cargo clippy --locked --workspace --all-targets -- -D warnings
-    cargo test --locked --workspace
+
+# Run the library unit tests of every workspace crate (the daemon's unit tests live in its binary; see test-bins).
+test-crates:
+    cargo test --locked --workspace --lib
+
+# Run the unit tests of every binary target: the daemon, rbgp, the examples, and the tools.
+test-bins:
+    cargo test --locked --workspace --bins
+
+# Two root-crate test targets carry required-features, and a `--test` glob
+# refuses those instead of skipping them, so the root package is selected
+# with `--tests`; that runs the daemon's binary unit tests again.
+
+# Run every integration test binary in the workspace (no library unit tests or doctests).
+test-integration:
+    cargo test --locked --workspace --exclude rustbgpd --test '*'
+    cargo test --locked -p rustbgpd --tests
+
+# Build the library docs (private items included) and both binary docs.
+docs:
     cargo doc --locked --workspace --lib --no-deps --document-private-items
     cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps
     cargo doc --locked -p rustbgpctl --bin rbgp --no-deps


### PR DESCRIPTION
## What changed

`just gate` is now composed from tiered recipes and runs exactly the same commands in the same order as before:

```
gate:
    just links
    just check-devtools
    just check-fast
    just check-contracts
    just check-clippy
    cargo test --locked --workspace
    just docs
```

New recipes: `check-devtools`, `check-fast` (fmt plus the sub-second contract checkers), `check-contracts` (the public-tracker-id and metric-consumer pairs, with the two cheap docs checkers that sit between them in the existing order), `check-clippy`, `test-crates`, `test-bins`, `test-integration`, and `docs`. `CONTRIBUTING.md` describes the tiers with qualitative timings and notes that `test-crates` is the pre-push hook's command; `CHANGELOG.md` gets one `Added` entry covering this and the companion CI-surface recipes PR.

Two naming choices differ from the original sketch, for honesty about what runs:

- `test-bins` (`cargo test --locked --workspace --bins`) rather than a daemon-only recipe: 805 of the 3044 binary unit tests live outside the daemon (`rbgp` 703, `birdwatcher-adapter` 49, a transport tool 34, `evpn-load` tester 12, `peer-loop` 5, `rs-config-render` 2), so a daemon-only tier would leave them uncovered.
- `test-integration` is two lines. `cargo test --workspace --test '*'` exits 101 here: two root-crate test targets carry `required-features`, and a `--test` glob refuses them instead of skipping them. The recipe therefore runs `--workspace --exclude rustbgpd --test '*'` plus `-p rustbgpd --tests`; the second line also reruns the daemon's binary unit tests (stated in the recipe comment).

## Expansion proof

`just --dry-run gate` before and after, recursively expanding each plain `just <recipe>` line (the shebang `links` recipe kept as a leaf): `diff` is empty, 21 lines both sides.

## Coverage proof (`cargo test --locked ... -- --list` totals)

| Command | Tests | Binaries |
|---|---|---|
| `--workspace` (what `gate` runs) | 8875 | 121 = 18 lib + 8 bin + 77 integration + 18 doc |
| `--workspace --lib` (`test-crates`) | 5282 | 18 |
| `--workspace --bins` (`test-bins`) | 3044 | 9 (the 3010 above plus 34 in transport's `test = false` tool binary, which `--bins` forces) |
| `--workspace --exclude rustbgpd --test '*'` | 400 | 47 |
| `-p rustbgpd --tests` | 2416 | 32 (177 integration in 30 binaries, plus the 2239 daemon bin unit tests again) |
| `--workspace --doc` | 6 | 18 |
| `--workspace --tests` (for reference) | 8869 | 103 |
| `--workspace --test '*'` | error 101 (`policy_set_store_allocation` requires `bench-internals`) | |

5282 + 3010 + (400 + 177) + 6 = 8875: the three tiers plus doctests cover the workspace run.

## Timings (warm target directory; the box was shared with other builds, so treat as upper bounds)

| Recipe | Exit | Time |
|---|---|---|
| `just gate` (first attempt) | 101 | 473 s |
| `just gate` (second attempt) | 0 | 512 s |
| `just links` | 0 | 0.1 s |
| `just check-devtools` | 0 | 0.2 s |
| `just check-fast` | 0 | 4.9 s |
| `just check-contracts` | 0 | 182 s |
| `just check-clippy` | 0 | 14 s |
| `just test-crates` | 0 | 33 s |
| `just test-bins` | 0 | 29 s |
| `just test-integration` | 0 | 267 s |
| `just docs` | 0 | 37 s |

The first `gate` attempt failed only at `cargo test --locked --workspace`: two tests in `crates/event-history/tests/byte_equality.rs` hit their 2-second broadcast timeouts while another workspace build was saturating the machine. The same test binary passed in isolation immediately afterwards (exit 0, 3 s) and the full second attempt passed; the recipe change touches no Rust code.

## Other checks

| Check | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `python3 scripts/check_public_tracker_ids.py` | 0 |
| `python3 scripts/check_release_checklist_paths.py` | 0 |
| `just links` | 0 |
| `just --list` | 0 |
