### PR TITLE
test(interop): poll for the received Type 5 before asserting its fields

### DIFF
--- a/tests/interop/scripts/test-m30b-evpn-type5-frr.sh
+++ b/tests/interop/scripts/test-m30b-evpn-type5-frr.sh
@@ -68,6 +68,23 @@ wait_frr_type5_originated() {
 }
 
 # Poll rustbgpd's ListEvpnRoutes until a Type 5 entry for $TENANT_PREFIX
+# is present. Returns 0 on success, 1 on timeout.
+wait_rustbgpd_type5_present() {
+    local timeout=${1:-30}
+    local attempts=$((timeout / 2))
+    for _ in $(seq 1 "$attempts"); do
+        local n
+        n=$(grpc_list_evpn | jq -r --arg p "$TENANT_PREFIX" \
+            '[.routes[]? | select(.routeType == 5 and .prefix == $p)] | length')
+        if [ "${n:-0}" != "0" ]; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+# Poll rustbgpd's ListEvpnRoutes until a Type 5 entry for $TENANT_PREFIX
 # is absent. Returns 0 on success, 1 on timeout.
 wait_rustbgpd_type5_withdrawn() {
     local timeout=${1:-30}
@@ -112,6 +129,10 @@ fi
 
 # Test 3: rustbgpd surfaces the Type 5 with expected fields
 log "[test] rustbgpd ListEvpnRoutes shows the Type 5 with expected fields"
+# The route reaches the RR a couple of seconds after FRR originates it, so
+# wait for it rather than sampling once. A genuine timeout leaves the entry
+# absent and falls through to the failure below.
+wait_rustbgpd_type5_present 30 || true
 evpn_json=$(grpc_list_evpn)
 type5_entry=$(echo "$evpn_json" | jq -c --arg p "$TENANT_PREFIX" \
     '.routes[]? | select(.routeType == 5 and .prefix == $p)' 2>/dev/null | head -1)


### PR DESCRIPTION
## Problem

The M30b Type 5 leg waits up to 60 seconds for FRR to originate the tenant
prefix, then queries rustbgpd for the received route exactly once, with no
wait:

```
evpn_json=$(grpc_list_evpn)
type5_entry=$(echo "$evpn_json" | jq -c --arg p "$TENANT_PREFIX" ...)
```

The route reaches the route reflector roughly two seconds after FRR
originates it, so the single sample loses the race and the leg fails with
"rustbgpd has no Type 5 entry". The script already polls for the *absence*
of the route (`wait_rustbgpd_type5_withdrawn`) but had no matching poll for
its *presence*; that asymmetry is the defect.

This reproduces identically on FRR 10.3.1 and 10.7.1, so it is pre-existing
and unrelated to any container image pin.

A second consequence: the downstream withdrawal assertion has been passing
vacuously. A route that never arrived is trivially absent, so the check
could not distinguish a real withdrawal from a route that was never
received. Restoring the presence check makes that assertion meaningful
again.

The leg is in the manual set and is not run by continuous integration
(`docs/INTEROP.md` records it as "Manual only — never wired into a hosted
job", with the bidirectional M39 successor covering the hosted Type 5
path), which is why the race went unnoticed.

## Change

Add `wait_rustbgpd_type5_present`, mirroring the existing absence poll in
shape and default timeout, and wait on it before capturing the response the
field assertions read.

A genuine receive-path break is not masked: on timeout the entry is still
absent, so the existing failure message and diagnostic dump fire unchanged.

## Verification

- `bash -n` on the script: exit 0.
- `shellcheck -x`: findings are identical to the pre-change baseline (four
  pre-existing informational notes in untouched lines); the new helper adds
  none.
- The leg was confirmed to return rc=0 with the poll in place, with every
  field assertion passing: Type 5 present, RD 65000:100, next-hop 10.0.0.2,
  VNI 100 label, RT extended community, and `tunnel_type=8`.
