### PR TITLE
Add a guided quickstart operator lab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `just lab quickstart up|verify|break|explain|down`: a guided local BGP
+  exercise using the Docker Compose demo. Verify a route, remove its import
+  policy, explain the RFC 8212 rejection, and restore the policy.
+  See the [operator lab guide](docs/tutorials/operator-labs.md).
+
 - **Operator-visible:** EVPN interop receipts for an IPv6 VXLAN underlay,
   the first in the suite to run tunnel endpoints, BGP transport, and EVPN
   next hops entirely on IPv6. M109
@@ -24,7 +29,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`tests/interop/m110-evpn-ipv6-underlay-irb.clab.yml`) covers symmetric
   Interface-less IRB over the same underlay and is a manual leg. Both
   topologies assert that the underlay carries no IPv4 address, so no
-  fallback path can satisfy an assertion. `docs/LIMITATIONS.md` now records
+  fallback path can satisfy an assertion. `docs/reference/limitations.md` now records
   that Interface-less IRB has no `RTA_VIA`: under an IPv6 VTEP only IPv6
   tenant prefixes are carried.
 
@@ -116,7 +121,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Established, performs the required socket, timer, and session actions,
   sends KEEPALIVEs on the negotiated timer, and prints each successfully
   parsed UPDATE. Its loopback tests exercise the library-embedding shape in
-  `docs/EMBEDDING.md`.
+  `docs/reference/embedding.md`.
 - `[[rpki.cache_servers]]` accepts `md5_password` (RFC 2385) or a
   neighbor-shaped `tcp_ao` keyring (RFC 5925); the key is installed on the
   RTR socket before connect. **Operator-visible:** key material the kernel

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Learn by running a small example.
 | Page | Scope |
 |------|-------|
 | [Quickstart](tutorials/quickstart.md) | Start a daemon, establish a session, and use the CLI. |
+| [Operator labs](tutorials/operator-labs.md) | Introduce a local policy fault, explain the rejected routes, and recover. |
 | [Docker Compose demo](../examples/docker-compose/README.md) | Run rustbgpd and an FRR peer together. |
 | [EVPN leaf example](../examples/evpn-vtep-leaf/README.md) | Follow a leaf-mode configuration walkthrough. |
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -7,3 +7,4 @@ Learn by running a small example.
 [All documentation](../README.md)
 
 - [Quickstart](quickstart.md) — Start a daemon, establish a session, and use the CLI.
+- [Operator labs](operator-labs.md) — Introduce a local policy fault, explain the rejected routes, and recover.

--- a/docs/tutorials/operator-labs.md
+++ b/docs/tutorials/operator-labs.md
@@ -1,0 +1,57 @@
+# Operator labs
+
+> **Document class: CURRENT.**
+
+Run a local BGP exercise, introduce a fault, and use the CLI to explain it.
+
+## Quickstart: an established session with no accepted routes
+
+This lab reuses the [Docker Compose demo](../../examples/docker-compose/README.md):
+rustbgpd and an FRR peer announcing sample routes. You remove the import policy,
+observe RFC 8212 rejecting the routes, and restore the policy. The commands run
+from the repository root.
+
+You need Linux, Bash, Python 3, `just`, and Docker with the Compose plugin and
+BuildKit. Your user must be able to run Docker. The first `up` builds the daemon
+from this checkout and pulls the pinned FRR image; build time depends on the
+machine and cache. Later runs reuse cached build layers.
+
+Stop the ordinary Compose demo before starting this lab: both use the same
+address ranges and loopback ports 50051 and 9179. The lab uses its own fixed
+Compose project, `rustbgpd-lab-quickstart`, with separate containers and state.
+Run one instance of this lab at a time.
+
+```bash
+just lab quickstart up
+just lab quickstart verify
+just lab quickstart break
+just lab quickstart explain
+```
+
+`up` waits for daemon health, restores the demo import policy, and waits for FRR
+to reach `Established` with `192.168.1.0/24` selected. `verify` checks that session
+and route; it exits unsuccessfully if either is missing. After `break`, that
+verification should fail even though the session remains established.
+
+`explain` shows the retained rejected routes and the cached import decision.
+Look for `policy_reject`, `rfc8212_missing_import_policy`, and `default-action
+deny`. The missing-import-policy metric is `1`: the peer is connected, but no
+explicit import policy permits its routes.
+
+Restore the original policy and verify recovery:
+
+```bash
+just lab quickstart up
+just lab quickstart verify
+just lab quickstart down
+```
+
+`down` removes only this lab's Compose containers, network, and state volume.
+It discards this lab's persisted configuration edits. It leaves the ordinary
+Compose demo and cached images intact. Run it after a failed or interrupted
+exercise too; repeating `down` is safe.
+
+For the underlying commands, see the [manual exercise](../../examples/docker-compose/README.md#break-explain-restore).
+For complete deployment scenarios, use the [cookbook](../cookbook/README.md).
+The [interop receipts](../receipts.md) describe the separate protocol validation
+labs and their measured evidence.

--- a/justfile
+++ b/justfile
@@ -4,6 +4,17 @@
 default:
     just --list
 
+# Run the guided local quickstart lab (up, verify, break, explain, down).
+[positional-arguments]
+lab name phase:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "$1" != quickstart ]]; then
+        echo "unknown lab: $1 (available: quickstart)" >&2
+        exit 2
+    fi
+    exec bash labs/quickstart/lab.sh "$2"
+
 # Run the broad local correctness baseline in diagnostic order.
 gate:
     just links

--- a/labs/quickstart/lab.sh
+++ b/labs/quickstart/lab.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Guided RFC 8212 exercise using the existing two-node Compose demo.
+set -euo pipefail
+
+if [[ $# != 1 ]]; then
+    echo 'usage: lab.sh up|verify|break|explain|down' >&2
+    exit 2
+fi
+case "$1" in
+    up|verify|break|explain|down) ;;
+    *) echo "unknown quickstart phase: $1" >&2; exit 2 ;;
+esac
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+compose=(docker compose --project-name rustbgpd-lab-quickstart
+    --file "$repo_root/examples/docker-compose/docker-compose.yml")
+
+rb() {
+    "${compose[@]}" exec -T rustbgpd rbgp -s http://127.0.0.1:50051 "$@"
+}
+
+healthy() {
+    rb --json health | python3 -c '
+import json, sys
+sys.exit(json.load(sys.stdin).get("healthy") is not True)
+'
+}
+
+verify() {
+    rb --json neighbor | python3 -c '
+import json, sys
+peers = json.load(sys.stdin)
+sys.exit(not any(p.get("address") == "10.99.0.20"
+    and p.get("remote_asn") == 65002 and p.get("state") == "Established"
+    and not p.get("stale", False) for p in peers))
+' || return 1
+    rb --json rib --prefix 192.168.1.0/24 | python3 -c '
+import json, sys
+routes = json.load(sys.stdin)
+sys.exit(not any(r.get("prefix") == "192.168.1.0/24"
+    and r.get("peer_address") == "10.99.0.20" and r.get("best") is True
+    for r in routes))
+'
+}
+
+rejected() {
+    rb metrics | grep -x 'bgp_rfc8212_missing_import_policy{peer="10.99.0.20"} 1' >/dev/null
+}
+
+wait_for() {
+    local attempt
+    for ((attempt = 0; attempt < 60; attempt++)); do
+        if "$@" >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "Timed out waiting for $*. Run 'just lab quickstart explain' or 'just lab quickstart down'." >&2
+    return 1
+}
+
+case "$1" in
+    up)
+        echo 'Building and starting the quickstart lab.'
+        "${compose[@]}" up -d --build
+        wait_for healthy
+        rb policy chain set-import lab-permit-all-import
+        wait_for verify
+        echo 'Ready: FRR is Established and 192.168.1.0/24 is selected.'
+        ;;
+    verify)
+        if ! verify; then
+            echo 'Verification failed: expected FRR Established and 192.168.1.0/24 selected.' >&2
+            exit 1
+        fi
+        echo 'Verified: FRR is Established and 192.168.1.0/24 is selected.'
+        ;;
+    break)
+        rb policy chain clear-import
+        wait_for rejected
+        echo 'Import policy removed. Inspect the rejected routes with: just lab quickstart explain'
+        ;;
+    explain)
+        echo 'Session state:'
+        rb neighbor
+        echo 'Retained rejected routes:'
+        rb rib received 10.99.0.20 --rejected
+        echo 'Import decision for 192.168.1.0/24:'
+        rb policy explain --neighbor 10.99.0.20 --prefix 192.168.1.0/24
+        echo 'Missing import policy (1 means RFC 8212 is blocking imports):'
+        rb metrics | grep '^bgp_rfc8212_missing_import_policy{'
+        ;;
+    down)
+        "${compose[@]}" down --volumes
+        ;;
+esac

--- a/labs/quickstart/test_lab.py
+++ b/labs/quickstart/test_lab.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Check verification and argument boundaries without starting containers."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(*args, **env):
+    return subprocess.run(args, cwd=ROOT, env=os.environ | env, capture_output=True, text=True)
+
+
+with tempfile.TemporaryDirectory() as directory:
+    temporary = Path(directory)
+    docker = temporary / "docker"
+    docker.write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+Path(os.environ["CALLS"]).touch()
+scenario = os.environ.get("SCENARIO", "healthy")
+if "neighbor" in sys.argv:
+    print(json.dumps([{"address": "10.99.0.20", "remote_asn": 65002,
+        "state": "Idle" if scenario == "idle" else "Established",
+        "stale": scenario == "stale"}]))
+elif "rib" in sys.argv:
+    print(json.dumps([] if scenario == "missing" else [{
+        "prefix": "192.168.2.0/24" if scenario == "wrong-prefix" else "192.168.1.0/24",
+        "peer_address": "10.99.0.30" if scenario == "wrong-peer" else "10.99.0.20",
+        "best": scenario != "not-best"}]))
+else:
+    sys.exit(99)
+''')
+    docker.chmod(0o755)
+    calls = temporary / "calls"
+    environment = {"PATH": f"{temporary}:{os.environ['PATH']}", "CALLS": str(calls)}
+    script = str(ROOT / "labs/quickstart/lab.sh")
+    for scenario in ("healthy", "idle", "stale", "missing", "wrong-prefix", "wrong-peer", "not-best"):
+        result = run("bash", script, "verify", **environment, SCENARIO=scenario)
+        assert (result.returncode == 0) == (scenario == "healthy"), (scenario, result.stderr)
+    calls.unlink()
+    for arguments in ((), ("../up",), ("verify", "extra")):
+        result = run("bash", script, *arguments, **environment)
+        assert result.returncode == 2, result.stderr
+        assert not calls.exists(), "invalid phase reached Docker"
+    sentinel = temporary / "injected"
+    for name, phase in (("../quickstart", "up"), (f"$(touch {sentinel})", "up"),
+                        ("quickstart", f"$(touch {sentinel})")):
+        result = run("just", "lab", name, phase, **environment)
+        assert result.returncode != 0, result.stdout
+        assert not calls.exists(), "invalid lab or phase reached Docker"
+        assert not sentinel.exists(), "lab argument was executed by the shell"
+print("Quickstart verification and argument checks passed.")


### PR DESCRIPTION
Add `just lab quickstart up|verify|break|explain|down` around the existing Docker Compose demo. The lab waits for daemon health and a selected route, removes the import policy to demonstrate RFC 8212 rejection, shows the live decision, and restores the policy on the next `up`. A fixed Compose project owns its containers and state; `down` removes only that project and its volume.

The tutorial explains prerequisites, the shared address/port constraint with the ordinary demo, the expected failure after `break`, recovery, and cleanup. No topology copy or shared lab framework is introduced. Daemon behavior and configuration contracts are unchanged.

Validation: built the current checkout and ran every phase, including successful baseline verification, failed verification after the fault, retained rejection and import-explain output, recovery with the missing-policy metric returning to zero, repeated cleanup, and failed verification after shutdown. Confirmed no lab containers, network, or volume remained. Companion checks reject stale/missing/wrong route or peer data and unsafe lab/phase arguments. Shell syntax, Ruff, offline links, and diff checks pass. No Rust files changed, so the Rust build hooks were skipped for publication.
