### PR TITLE
Clarify EVPN reflector support boundaries

### DIFF
--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -152,8 +152,8 @@ impl RibManager {
     /// uses the same `should_suppress_ibgp_inner` helper with a synthetic
     /// placeholder `Route` carrying the EVPN route's peer metadata.
     ///
-    /// Phase 1: policy uses a placeholder `0.0.0.0/0` prefix; RT / community
-    /// matching works through the existing `RouteContext` fields.
+    /// Policy sees the actual IP prefix for Type 5 and `None` for Types 1–4;
+    /// RT / community matching uses the existing `RouteContext` fields.
     #[expect(
         clippy::fn_params_excessive_bools,
         clippy::too_many_arguments,

--- a/crates/transport/src/session/tests/outbound_attrs.rs
+++ b/crates/transport/src/session/tests/outbound_attrs.rs
@@ -806,3 +806,100 @@ fn ebgp_remove_private_as_all_prepends_after_removal() {
         vec![AsPathSegment::AsSequence(vec![100, 65535])]
     );
 }
+
+/// RFC 9252 service TLVs remain opaque on supported EVPN routes. Pin value
+/// preservation through the receive path and normal iBGP/eBGP export.
+#[tokio::test]
+async fn evpn_srv6_prefix_sid_value_survives_receive_and_export() {
+    use rustbgpd_wire::{
+        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MplsLabel,
+        RouteDistinguisher,
+    };
+    let (mut receiver, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
+    receiver.negotiated = Some(Arc::new(negotiated));
+
+    // RFC 9252 sections 3/3.1: L2 Service TLV (6), reserved byte, SID
+    // Information sub-TLV (1), End.DX2 SID, no optional sub-sub-TLVs.
+    let mut service = vec![6, 0, 25, 0, 1, 0, 21, 0];
+    service.extend("2001:db8:100::1".parse::<Ipv6Addr>().unwrap().octets());
+    service.extend([0, 0, 0x15, 0]);
+    let prefix_sid = PathAttribute::Unknown(RawAttribute {
+        flags: 0xe0,
+        type_code: rustbgpd_wire::constants::attr_type::PREFIX_SID,
+        data: Bytes::from(service),
+    });
+    let route = EvpnRoute::MacIp(EvpnMacIp {
+        rd: RouteDistinguisher([0, 0, 0xfd, 0xe8, 0, 0, 0, 100]),
+        esi: EthernetSegmentIdentifier::ZERO,
+        ethernet_tag: EthernetTagId(0),
+        mac: MacAddress([0x02, 0, 0, 0, 0, 1]),
+        ip: None,
+        label1: MplsLabel::new(0x30), // Implicit NULL without SID transposition.
+        label2: None,
+    });
+    let next_hop: IpAddr = "2001:db8::2".parse().unwrap();
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        prefix_sid.clone(),
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::L2Vpn,
+            safi: Safi::Evpn,
+            next_hop,
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![route.clone()],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+    ];
+    receiver
+        .process_update(UpdateMessage::build(
+            &[],
+            &[],
+            &attrs,
+            true,
+            false,
+            Ipv4UnicastMode::MpReach,
+        ))
+        .await;
+    let RibUpdate::RoutesReceived { evpn_announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected the EVPN announcement to be accepted");
+    };
+    assert_eq!(evpn_announced.len(), 1);
+    assert!(evpn_announced[0].attributes.contains(&prefix_sid));
+
+    for remote_asn in [65001, 65003] {
+        let mut exporter = make_test_session(65001, remote_asn);
+        exporter.negotiated = Some(Arc::new(negotiated_session(remote_asn, false)));
+        let profile = exporter.publish_export_profile();
+        let candidate = profile.prepare_evpn_candidate(&evpn_announced[0]);
+        let update = profile
+            .build_mp_reach(
+                candidate.afi,
+                candidate.safi,
+                candidate.next_hop,
+                None,
+                &candidate.attrs,
+                export::ReachNlri::Evpn(&[candidate.nlri]),
+                Ipv4UnicastMode::MpReach,
+            )
+            .unwrap();
+        let parsed = update.parse(true, false, &[]).unwrap();
+        assert!(
+            parsed.attributes.contains(&prefix_sid),
+            "peer ASN {remote_asn}"
+        );
+        assert!(parsed.attributes.iter().any(|attr| matches!(
+            attr, PathAttribute::MpReachNlri(mp)
+                if mp.evpn_announced == [route.clone()] && mp.next_hop == next_hop
+        )));
+    }
+}

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -579,9 +579,13 @@ controller-driven injection for Type 2 / Type 3. What remains:
   overlay-index testing, is exposed in the injection RPCs. Type 1 / Type 4
   multi-homing route injection is not exposed; native daemon Type 1/4
   origination exists via `[[ethernet_segments]]`.
-- **RFC 9251 Route Types 6-8** (IGMP multicast), **RFC 9572 Route Types
-  9-11** (BUM segmentation), **RFC 7623 PBB-EVPN**, **MPLS encap**,
-  **BGP Add-Path (RFC 7911) for L2VPN EVPN** (Phase 5).
+- **RFC 9251 Route Types 6-8** (IGMP/MLD proxy) and **RFC 9572 Route
+  Types 9-11** (BUM segmentation) are not decoded or reflected: unknown
+  typed NLRIs are discarded per RFC 7606 §5.4. **RFC 7623 PBB-EVPN**,
+  **MPLS encap**, and **BGP Add-Path (RFC 7911) for L2VPN EVPN** remain
+  outside the implemented service boundary. See the
+  [adjacent standards matrix](../reference/rfc-notes.md#later-evpn-standards-against-the-vxlanlinux-lane)
+  for DCI and SRv6 attribute-preservation scope.
 
 ---
 

--- a/docs/explanation/use-cases.md
+++ b/docs/explanation/use-cases.md
@@ -601,18 +601,19 @@ cluster, multi-tenant DC, container overlay — and you need an iBGP route
 reflector that distributes EVPN routes (MAC advertisements, multicast
 memberships, IP prefixes) between VTEPs. The VTEPs themselves (SONiC or
 FRR leaves) handle local MAC learning, DF election, and VXLAN encap. You
-want a control plane that's API-first (no vtysh scraping), scales to
-thousands of VTEPs, and gives you structured observability.
+want a control plane with an API and structured observability. Published
+EVPN scale evidence is the three-peer M33 workload; it does not establish
+capacity for thousands of VTEPs. See the
+[EVPN benchmark receipt](../benchmarks.md#evpn-rr-scale-m33).
 
-**What rustbgpd does for you (Phase 1 RR bundle — full RFC 7432 Type 1-5
-reflection through controller injection; see
-[docs/project/evpn-enablement.md](../project/evpn-enablement.md), ADR-0050):**
+**EVPN route-reflector behavior** (see the
+[EVPN enablement plan](../project/evpn-enablement.md) and ADR-0050):
 
-- **RFC 7432 route reflection for all 5 route types** — EAD per-ES,
+- **EVPN Type 1–5 route reflection (RFC 7432 and RFC 9136)** — EAD per-ES,
   EAD per-EVI, MAC/IP, IMET, Ethernet Segment, IP Prefix (RFC 9136) —
-  reflected between VTEPs per RFC 4456 with full tie-break ordering
-  (stale → ORIGIN → CLUSTER_LIST length → ORIGINATOR_ID) and
-  source-peer split horizon.
+  reflected between VTEPs per RFC 4456 with the
+  [EVPN best-path ordering](../reference/rfc-notes.md)
+  and source-peer split horizon.
 - **MAC Mobility handling** — Type 2 best-path honors the MAC Mobility
   sequence number and the sticky flag per RFC 7432 §15.1, so a MAC
   move converges deterministically and sticky MACs aren't displaced.
@@ -644,13 +645,21 @@ reflection through controller injection; see
   delete-mac-ip / delete-imet / delete-ip-prefix`.
 - **gRPC observability** — `ListEvpnRoutes(route_type, peer, rd)` for
   filtered EVPN RIB queries; Prometheus metrics per peer include
-  `adj_rib_out_prefixes{family="evpn"}`. Max-prefix accounting counts
+  `bgp_rib_adj_out_prefixes{afi_safi="evpn"}`. Max-prefix accounting counts
   EVPN keys alongside unicast prefixes.
 - **RT-based policy** — existing `match_community` against Route Target
   extended communities filters EVPN routes the same way unicast RT
   matching works elsewhere. Type 5 IP-Prefix routes surface their
   prefix in the policy `RouteContext` so prefix-based clauses work
   on Type 5 too.
+
+The reflector retains eligible routes even when their RTs match no local
+VNI or VRF, and preserves the VTEP next hop on iBGP and eBGP export unless
+export policy names a replacement address. These defaults need no retention
+or next-hop-unchanged knobs. Policy and normal route selection still apply.
+Unsupported typed NLRIs, including RFC 9251 Types 6–8, are discarded rather
+than reflected; see the
+[adjacent standards matrix](../reference/rfc-notes.md#later-evpn-standards-against-the-vxlanlinux-lane).
 
 **What rustbgpd does for VTEP-mode operators:**
 
@@ -668,7 +677,7 @@ reflection through controller injection; see
   downgrades back). SDN controllers can still inject MAC-with-IP
   routes directly via `InjectionService::AddEvpnRoute` (controller injection).
 
-**What rustbgpd doesn't do yet (and which VTEPs handle for you):**
+**VTEP responsibilities and support boundaries:**
 
 - **EVPN multi-homing enforcement** — EVPN multi-homing (ESI, Type-1/Type-4)
   (v0.17.0, ADR-0057) shipped the observation half: Type 4 ES + Type 1 EAD-per-ES +
@@ -709,8 +718,9 @@ reflection through controller injection; see
   tool via `WatchEvents` / `SubscribeFromEvent` (typed `EvpnRouteEvent`
   payloads). BMP route monitoring and MRT `RIB_GENERIC` dumps carry EVPN
   routes as well.
-- Validate policy changes with `rbgp rib --prefix <PREFIX> --explain` before
-  pushing — routable-surface diffs, not CLI scraping.
+- Inspect EVPN routes with `rbgp evpn --route-type 2 --rd 65000:100`.
+  EVPN has no import/export or best-path explain entry point;
+  `rbgp rib --prefix <PREFIX> --explain` applies to unicast routes.
 
 **Example config:** `examples/rr-evpn-fabric/config.toml` — three VTEP
 peers in AS 65000 with `families = ["l2vpn_evpn"]` and

--- a/docs/reference/rfc-notes.md
+++ b/docs/reference/rfc-notes.md
@@ -1435,12 +1435,19 @@ carries inactive (absent), unlimited (zero), or finite.
   prefixes in the per-peer prefix counter, so `max_prefixes` triggers
   Cease/1 (Maximum Number of Prefixes Reached) when a misbehaving
   VTEP floods Type 2 routes.
-- **Policy context:** EVPN routes pass through the policy engine with
-  attribute / community / RT visibility (placeholder `0.0.0.0/0`
-  prefix matches FlowSpec's pattern); Type 5 IP-Prefix routes
-  additionally surface their actual prefix in `RouteContext`, so a
-  prefix-based clause filters Type 5 routes by the IP prefix carried
-  in the NLRI.
+- **Policy context:** EVPN routes expose attributes, communities, RTs,
+  and route type to import and export policy. Type 5 supplies its actual
+  IP prefix in `RouteContext`; Types 1–4 use `prefix: None`, so prefix
+  predicates do not match them, including a `0.0.0.0/0` prefix-list clause.
+  Use RT, community, or EVPN route-type predicates for those routes.
+- **Route-target retention:** the reflector does not require a received
+  route's RTs to match a local VNI or VRF. A reflector with no local EVPN
+  instances retains eligible routes and reflects selected paths, subject
+  to policy and normal export checks. RT matching for local dataplane
+  import is a separate operation; no `retain route-target all` knob is needed.
+- **Next-hop preservation:** EVPN export preserves the VTEP next hop by
+  default, including over eBGP. An export policy specifying a next-hop
+  address can change it; no next-hop-unchanged knob is required.
 - **GR / LLGR stale handling** (RFC 4724 + RFC 9494, Gate 2): EVPN
   routes participate in the stale-route pipeline alongside unicast
   and FlowSpec. On `PeerGracefulRestart`, `mark_stale_evpn((L2Vpn,
@@ -1682,12 +1689,21 @@ carries inactive (absent), unlimited (zero), or finite.
   carries 4 reserved bytes followed by a 2-byte Tunnel Type. RFC 9012
   §4.1 (Figure 14) keeps the RFC 5512 layout unchanged — Reserved
   (2 octets), Reserved (2 octets), Tunnel Type (2 octets) — so the
-  emitted form is the current standard, not a compatibility deviation.
+  emitted form is the current standard. See
+  [RFC 9012 §4.1](https://www.rfc-editor.org/rfc/rfc9012.html#section-4.1).
+  The contrary layout description in the dated
+  [ADR-0050](../adr/0050-evpn-route-reflector.md#6-typed-extended-community-accessors)
+  is a historical documentation error; the reserved-plus-tunnel-type wire
+  encoding did not change.
 - Tunnel Type values (IANA BGP Tunnel Encapsulation Attribute Tunnel
   Types): 8 = VXLAN, 9 = NVGRE, 11 = MPLS in GRE.
   `as_bgp_encapsulation()` returns the u16 tunnel type.
 - rustbgpd does not yet **negotiate** a preferred encap. VXLAN is
   assumed; non-VXLAN values are passed through untouched.
+- **Automatic RT derivation:** L2VNI auto-RT follows RFC 8365 §5.1.2.1;
+  L3VNI auto-RT uses AS:VNI. Both reject ASNs above 65535 with a typed
+  error. A four-octet-AS RT has only a two-octet local administrator and
+  cannot encode an arbitrary three-octet VNI; configure explicit RTs instead.
 
 ---
 
@@ -1736,12 +1752,15 @@ carries inactive (absent), unlimited (zero), or finite.
 
 ## Later EVPN standards against the VXLAN/Linux lane
 
-EVPN RFCs published after the lane's base set that bear on the VXLAN/Linux
-VTEP lane. Each row records the implementation status and why the standard
-matters to this lane.
+These adjacent EVPN standards affect the reflector, interconnect, or
+VXLAN/Linux VTEP roles. Each row separates attribute preservation from
+implemented service procedures.
 
 | RFC | Status | Relevance |
 |-----|--------|-----------|
+| [RFC 9014](https://www.rfc-editor.org/rfc/rfc9014.html) | Not implemented | EVPN overlay interconnect gateway procedures, including overlay-to-MPLS interworking and Interconnect Ethernet Segments, are not implemented. Reflecting supported EVPN routes does not provide a DCI gateway. |
+| [RFC 9252](https://www.rfc-editor.org/rfc/rfc9252.html) | Partial: opaque attribute preservation | On supported EVPN route types, the BGP Prefix-SID attribute (type 40), including SRv6 L2/L3 Service TLV payloads, survives receive and export with its value bytes intact. The [transport preservation test](../../crates/transport/src/session/tests/outbound_attrs.rs) covers a Type 2 route over iBGP and eBGP. Outer Prefix-SID TLV framing is validated; SRv6 nested TLV validation, SID interpretation, origination, and forwarding are not implemented. This is not full RFC 9252 service support. |
+| [RFC 9251](https://www.rfc-editor.org/rfc/rfc9251.html#section-9) | Not implemented, including reflection | Route Types 6–8 (SMET, Multicast Membership Report Synch, Multicast Leave Synch) are unrecognized and discarded on receive; they do not enter the RIB or propagate to other VTEPs. This follows [RFC 7606 §5.4](https://www.rfc-editor.org/rfc/rfc7606.html#section-5.4) typed-NLRI handling. There is no opaque route-type reflection or IGMP/MLD proxy implementation. |
 | RFC 9746 (Mar 2025; updates RFC 7432, RFC 8365) | Not implemented | Split Horizon Type (SHT) bits in the ESI Label extended community. §2.2: an egress NVE MUST NOT use an SHT other than 00 with VXLAN (tunnel type 8), so local bias is the only multi-homing split-horizon mechanism for VXLAN. This is the normative backing for the Linux softswitch local-bias limitation in [docs/reference/limitations.md](limitations.md); the ESI Label decoder reads only the single-active flag. |
 | RFC 9785 (Jun 2025; updates RFC 8584) | Partial | Highest-/Lowest-Preference DF election is implemented (`df_algorithm`), under the same unanimous-or-default negotiation restated in §4.1. The Don't-Preempt (DP) bit is originated (`df_dont_preempt`) and parsed but is not an election input, so stateful non-revertive election is not implemented. |
 | RFC 9722 (May 2025; updates RFC 8584) | Not implemented | Fast DF recovery: a Service Carving Time extended community on the Type 4 route synchronizes the DF election timer across the segment's PEs so they carve at the same instant. rustbgpd runs each election on its own timer. |


### PR DESCRIPTION
EVPN evaluators currently see a nonexistent explain command, a fabricated policy prefix, and an unsupported VTEP scale claim. Correct these statements and document the actual reflector defaults: local RT matches are not required, eBGP preserves the VTEP next hop unless policy changes it, and auto-RT rejects four-octet ASNs.

Add scoped RFC 9014, 9251, and 9252 support rows. Identify the old encapsulation-layout statement in ADR-0050 as a historical documentation error without rewriting the ADR. A focused transport test pins received EVPN Type 2 SRv6 Prefix-SID value preservation through iBGP and eBGP export. SRv6 interpretation, nested validation, and forwarding remain unsupported; runtime and wire behavior are unchanged.

Validation: focused transport preservation test, strict transport Clippy, formatting, offline Markdown links, and documentation contract checks passed. Full `just gate` passed, including workspace tests, strict workspace Clippy, and private library/binary rustdoc.
