### PR TITLE
Add an IXP operator lab for RPKI and policy rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   AS-path-loop and an import-policy rejection through Alice's filtered view
   and global prefix lookup.
 
+- `just lab ixp up|verify|break|explain|down`: a local route-server exercise
+  with two FRR members and a pinned RPKI cache. Introduce an invalid origin
+  and a prefix-length rejection, explain the import and export decisions,
+  then restore and verify transparent route delivery to the other member.
+
 ### Changed
 
 - The three example programs (`event-bridge`, `peer-loop`, `birdwatcher-adapter`)

--- a/docs/tutorials/operator-labs.md
+++ b/docs/tutorials/operator-labs.md
@@ -52,6 +52,59 @@ Compose demo and cached images intact. Run it after a failed or interrupted
 exercise too; repeating `down` is safe.
 
 For the underlying commands, see the [manual exercise](../../examples/docker-compose/README.md#break-explain-restore).
+
+## IXP: connected members with rejected routes
+
+This lab runs one transparent route server, two FRR 10.7.1 members, and a
+local StayRTR 0.6.4 cache. Member A (AS65002) announces `198.51.100.0/24`.
+The cache authorizes that origin; member B (AS65003) receives the route with
+AS_PATH `65002` and next hop `10.98.0.20`, preserved by the route server.
+It uses the same host prerequisites as the quickstart lab.
+
+```bash
+just lab ixp up
+just lab ixp verify
+just lab ixp break
+just lab ixp explain
+```
+
+`up` builds the development image from this checkout, starts the four
+containers, restores member A's normal announcements, and waits for both
+sessions, the VRP cache, and member B's received route. `verify` checks all
+of these, including RPKI validity and transparent AS_PATH and next hop.
+
+`break` adds AS65099 to the end of member A's outgoing AS_PATH, changing the
+origin without changing the BGP session. The route is now RPKI-invalid and
+the `reject-rpki-invalid` policy rejects it. The same phase announces
+`203.0.113.0/25`, which has no covering VRP and is rejected independently by
+`reject-long-prefixes`. It waits for both retained rejections and checks that
+neither prefix is selected or present at member B. `verify` should now fail.
+
+`explain` shows the connected members, retained rejections, the covering VRP
+authorizing AS65002, and both import-policy decisions. The export explanation
+stops at `best_route`: an import-rejected route cannot be advertised to member B.
+Policy counters show which import terms matched.
+
+Restore the legitimate origin and remove the extra /25:
+
+```bash
+just lab ixp up
+just lab ixp verify
+just lab ixp down
+```
+
+The lab uses the dedicated Compose project `rustbgpd-lab-ixp` and subnet
+`10.98.0.0/24`, with no published host ports. Run one instance at a time and
+avoid an overlapping local Docker network. `down` removes its containers and
+network, including the temporary FRR changes; repeating it is safe. Run it
+after a failed or interrupted exercise too.
+
+The [configuration](../../labs/ixp/rustbgpd.toml) deliberately reduces IXP
+policy to two teaching examples. The VRP file is a static, synthetic fixture
+with expiry checking disabled in StayRTR; it is not a public RPKI validator.
+For the production configuration shape, see the
+[route-server example](../../examples/route-server/README.md).
+
 For complete deployment scenarios, use the [cookbook](../cookbook/README.md).
 The [interop receipts](../receipts.md) describe the separate protocol validation
 labs and their measured evidence.

--- a/justfile
+++ b/justfile
@@ -4,16 +4,15 @@
 default:
     just --list
 
-# Run the guided local quickstart lab (up, verify, break, explain, down).
+# Run a guided local lab (up, verify, break, explain, down).
 [positional-arguments]
 lab name phase:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [[ "$1" != quickstart ]]; then
-        echo "unknown lab: $1 (available: quickstart)" >&2
-        exit 2
-    fi
-    exec bash labs/quickstart/lab.sh "$2"
+    case "$1" in
+        quickstart|ixp) exec bash "labs/$1/lab.sh" "$2" ;;
+        *) echo "unknown lab: $1 (available: quickstart, ixp)" >&2; exit 2 ;;
+    esac
 
 # Run the broad local correctness baseline in diagnostic order.
 gate:

--- a/labs/ixp/docker-compose.yml
+++ b/labs/ixp/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  rustbgpd:
+    build:
+      context: ../..
+      target: dev
+    volumes:
+      - ./rustbgpd.toml:/etc/rustbgpd/config.toml:ro
+      - ../../tests/fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
+    environment:
+      RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
+    networks:
+      ixp:
+        ipv4_address: 10.98.0.10
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 524288
+
+  member-a:
+    image: quay.io/frrouting/frr:10.7.1
+    volumes:
+      - ../../examples/docker-compose/frr-daemons:/etc/frr/daemons:ro
+      - ./member-a.conf:/etc/frr/frr.conf:ro
+      - ./vtysh.conf:/etc/frr/vtysh.conf:ro
+    networks:
+      ixp:
+        ipv4_address: 10.98.0.20
+    cap_add: [NET_ADMIN, NET_RAW, SYS_ADMIN]
+
+  member-b:
+    image: quay.io/frrouting/frr:10.7.1
+    volumes:
+      - ../../examples/docker-compose/frr-daemons:/etc/frr/daemons:ro
+      - ./member-b.conf:/etc/frr/frr.conf:ro
+      - ./vtysh.conf:/etc/frr/vtysh.conf:ro
+    networks:
+      ixp:
+        ipv4_address: 10.98.0.30
+    cap_add: [NET_ADMIN, NET_RAW, SYS_ADMIN]
+
+  stayrtr:
+    # StayRTR 0.6.4, the same immutable image used by the RTR interop labs.
+    image: rpki/stayrtr@sha256:cdb93c0b661d97179a5525e00caf7d9e693a04da3b9002f7e24bebb194d9a77b
+    command: [-cache, /data/vrps.json, -bind, ':3323', -checktime=false, -protocol, '1', -refresh, '30']
+    volumes:
+      - ./vrps.json:/data/vrps.json:ro
+    networks:
+      ixp:
+        ipv4_address: 10.98.0.40
+
+networks:
+  ixp:
+    ipam:
+      config:
+        - subnet: 10.98.0.0/24

--- a/labs/ixp/lab.sh
+++ b/labs/ixp/lab.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Guided route-server RPKI and import-policy exercise.
+set -euo pipefail
+
+if [[ $# != 1 ]]; then
+    echo 'usage: lab.sh up|verify|break|explain|down' >&2
+    exit 2
+fi
+case "$1" in
+    up|verify|break|explain|down) ;;
+    *) echo "unknown ixp phase: $1" >&2; exit 2 ;;
+esac
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+compose=(docker compose --project-name rustbgpd-lab-ixp
+    --file "$repo_root/labs/ixp/docker-compose.yml")
+
+rb() {
+    "${compose[@]}" exec -T rustbgpd rbgp -s http://127.0.0.1:50051 "$@"
+}
+
+member_a() {
+    "${compose[@]}" exec -T member-a vtysh "$@"
+}
+
+sessions() {
+    rb --json neighbor | python3 -c '
+import json, sys
+peers = json.load(sys.stdin)
+sys.exit(not all(any(p.get("address") == address and p.get("remote_asn") == asn
+    and p.get("state") == "Established" and not p.get("stale", False) for p in peers)
+    for address, asn in (("10.98.0.20", 65002), ("10.98.0.30", 65003))))
+'
+}
+
+cache_ready() {
+    rb --json rpki caches | python3 -c '
+import json, sys
+sys.exit(not any(c.get("address") == "10.98.0.40:3323" and c.get("connected") is True
+    and (c.get("accepted") or {}).get("vrp_v4_count") == 1
+    for c in json.load(sys.stdin).get("caches", [])))
+'
+}
+
+member_b_route() {
+    "${compose[@]}" exec -T member-b vtysh -c "show bgp ipv4 unicast ${1:-198.51.100.0/24} json"
+}
+
+verify() {
+    sessions || return 1
+    cache_ready || return 1
+    rb --json rib --prefix 198.51.100.0/24 | python3 -c '
+import json, sys
+sys.exit(not any(r.get("prefix") == "198.51.100.0/24" and r.get("best") is True
+    and r.get("peer_address") == "10.98.0.20" and r.get("validation_state") == "valid"
+    for r in json.load(sys.stdin)))
+' || return 1
+    member_b_route | python3 -c '
+import json, sys
+sys.exit(not any(p.get("valid") is True and p.get("aspath", {}).get("string") == "65002"
+    and any(n.get("ip") == "10.98.0.20" for n in p.get("nexthops", []))
+    for p in json.load(sys.stdin).get("paths", [])))
+'
+}
+
+rejected() {
+    local prefix
+    sessions || return 1
+    cache_ready || return 1
+    rb --json rib received 10.98.0.20 --rejected | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+routes = data.get("rejected_routes", [])
+sys.exit(not (data.get("retention_enabled") is True and data.get("evictions_since_reset") == 0
+    and any(r.get("prefix") == "198.51.100.0/24" and r.get("reason") == "policy_reject"
+        and r.get("reason_detail") == "reject-rpki-invalid"
+        and r.get("rpki_validation") == "invalid" for r in routes)
+    and any(r.get("prefix") == "203.0.113.0/25" and r.get("reason") == "policy_reject"
+        and r.get("reason_detail") == "reject-long-prefixes"
+        and r.get("rpki_validation") == "not_found" for r in routes)))
+' || return 1
+    for prefix in 198.51.100.0/24 203.0.113.0/25; do
+        rb --json rib --prefix "$prefix" | python3 -c '
+import json, sys
+sys.exit(json.load(sys.stdin) != [])
+' || return 1
+        member_b_route "$prefix" | python3 -c '
+import json, sys
+sys.exit(bool(json.load(sys.stdin).get("paths", [])))
+' || return 1
+    done
+}
+
+wait_for() {
+    local attempt
+    for ((attempt = 0; attempt < 60; attempt++)); do
+        if "$@" >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "Timed out waiting for $*. Run 'just lab ixp explain' or 'just lab ixp down'." >&2
+    return 1
+}
+
+case "$1" in
+    up)
+        echo 'Building and starting the IXP lab.'
+        "${compose[@]}" up -d --build
+        wait_for sessions
+        wait_for cache_ready
+        running_config=$(member_a -c 'show running-config')
+        if [[ "$running_config" == *'network 203.0.113.0/25'* ]]; then
+            member_a -c 'configure terminal' -c 'router bgp 65002' \
+                -c 'address-family ipv4 unicast' -c 'no network 203.0.113.0/25'
+        fi
+        member_a -c 'configure terminal' -c 'router bgp 65002' \
+            -c 'address-family ipv4 unicast' \
+            -c 'no neighbor 10.98.0.10 route-map lab-invalid-origin out' \
+            -c end \
+            -c 'clear bgp 10.98.0.10 soft out'
+        wait_for verify
+        echo 'Ready: both members Established; the valid route reaches member-b unchanged.'
+        ;;
+    verify)
+        if ! verify; then
+            echo 'Verification failed: expected two members, live VRPs, and a valid route exported to member-b.' >&2
+            exit 1
+        fi
+        echo 'Verified: 198.51.100.0/24 is RPKI valid and reaches member-b with AS_PATH 65002 and next hop 10.98.0.20.'
+        ;;
+    break)
+        member_a -c 'configure terminal' -c 'router bgp 65002' \
+            -c 'address-family ipv4 unicast' \
+            -c 'neighbor 10.98.0.10 route-map lab-invalid-origin out' \
+            -c 'network 203.0.113.0/25' -c end \
+            -c 'clear bgp 10.98.0.10 soft out'
+        wait_for rejected
+        echo '198.51.100.0/24: origin AS65099 is RPKI-invalid; reject-rpki-invalid matched.'
+        echo '203.0.113.0/25: RPKI NotFound; reject-long-prefixes matched.'
+        echo 'Both sessions remain Established; neither rejected prefix is present at member-b.'
+        echo 'Inspect the reasons with: just lab ixp explain'
+        ;;
+    explain)
+        echo 'Member sessions:'
+        rb neighbor
+        echo 'Retained rejected routes:'
+        rb rib received 10.98.0.20 --rejected
+        echo 'Why the changed origin is invalid (the VRP authorizes AS65002):'
+        rb rpki validate 198.51.100.0/24 65099
+        echo 'Import policy decisions:'
+        rb policy explain --neighbor 10.98.0.20 --prefix 198.51.100.0/24
+        rb policy explain --neighbor 10.98.0.20 --prefix 203.0.113.0/25
+        echo 'Why member-b cannot receive the rejected route:'
+        rb rib --prefix 198.51.100.0/24 advertised 10.98.0.30 --explain
+        echo 'Import policy counters:'
+        rb policy stats --neighbor 10.98.0.20 --direction import
+        ;;
+    down)
+        "${compose[@]}" down --volumes
+        ;;
+esac

--- a/labs/ixp/member-a.conf
+++ b/labs/ixp/member-a.conf
@@ -1,0 +1,19 @@
+frr defaults traditional
+hostname member-a
+log stdout informational
+!
+route-map lab-invalid-origin permit 10
+ set as-path prepend 65099
+!
+router bgp 65002
+ bgp router-id 10.98.0.20
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 10.98.0.10 remote-as 65500
+ neighbor 10.98.0.10 timers 10 30
+ no neighbor 10.98.0.10 enforce-first-as
+ neighbor 10.98.0.10 local-role rs-client
+ address-family ipv4 unicast
+  network 198.51.100.0/24
+ exit-address-family
+!

--- a/labs/ixp/member-b.conf
+++ b/labs/ixp/member-b.conf
@@ -1,0 +1,12 @@
+frr defaults traditional
+hostname member-b
+log stdout informational
+!
+router bgp 65003
+ bgp router-id 10.98.0.30
+ no bgp ebgp-requires-policy
+ neighbor 10.98.0.10 remote-as 65500
+ neighbor 10.98.0.10 timers 10 30
+ no neighbor 10.98.0.10 enforce-first-as
+ neighbor 10.98.0.10 local-role rs-client
+!

--- a/labs/ixp/rustbgpd.toml
+++ b/labs/ixp/rustbgpd.toml
@@ -1,0 +1,66 @@
+# Reduced IPv4 learning lab, not a production IXP hygiene policy.
+[global]
+asn = 65500
+router_id = "10.98.0.10"
+listen_port = 179
+ebgp_requires_policy = true
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "127.0.0.1:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+
+[[rpki.cache_servers]]
+address = "10.98.0.40:3323"
+refresh_interval = 30
+retry_interval = 5
+expire_interval = 120
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.reject-long-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "0.0.0.0/0"
+ge = 25
+le = 32
+action = "deny"
+
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
+[policy]
+import_chain = ["reject-rpki-invalid", "reject-long-prefixes"]
+export_chain = ["rs-transparent-export"]
+
+[policy.explain]
+enabled = true
+
+[[neighbors]]
+address = "10.98.0.20"
+remote_asn = 65002
+description = "member-a"
+hold_time = 90
+route_server_client = true
+role = "route_server"
+
+[[neighbors]]
+address = "10.98.0.30"
+remote_asn = 65003
+description = "member-b"
+hold_time = 90
+route_server_client = true
+role = "route_server"

--- a/labs/ixp/test_lab.py
+++ b/labs/ixp/test_lab.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check lab verification and argument boundaries without starting containers."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+
+with tempfile.TemporaryDirectory() as directory:
+    temporary = Path(directory)
+    docker = temporary / "docker"
+    docker.write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+Path(os.environ["CALLS"]).touch()
+scenario = os.environ.get("SCENARIO", "healthy")
+fault = scenario in ("rejected", "leaked-long-prefix")
+if "neighbor" in sys.argv:
+    result = [{"address": address, "remote_asn": asn,
+        "state": "Idle" if scenario == "idle" else "Established",
+        "stale": scenario == "stale"}
+        for address, asn in (("10.98.0.20", 65002), ("10.98.0.30", 65003))]
+    if scenario == "one-member": result.pop()
+elif "caches" in sys.argv:
+    result = {"caches": [{"address": "10.98.0.40:3323", "connected": scenario != "cache-down",
+        "accepted": {"vrp_v4_count": 0 if scenario == "empty-vrps" else 1}}]}
+elif "--rejected" in sys.argv:
+    result = {"retention_enabled": True, "evictions_since_reset": 0,
+        "rejected_routes": [
+            {"prefix": "198.51.100.0/24", "reason": "policy_reject",
+             "reason_detail": "reject-rpki-invalid", "rpki_validation": "invalid"},
+            {"prefix": "203.0.113.0/25", "reason": "policy_reject",
+             "reason_detail": "reject-long-prefixes", "rpki_validation": "not_found"}]}
+elif "rib" in sys.argv:
+    result = [] if scenario == "missing-route" or fault else [{
+        "prefix": "198.51.100.0/24", "best": scenario != "not-best",
+        "peer_address": "10.98.0.30" if scenario == "wrong-peer" else "10.98.0.20",
+        "validation_state": "invalid" if scenario == "invalid" else "valid"}]
+elif "member-b" in sys.argv:
+    result = {"paths": [] if scenario == "not-exported" else [{
+        "valid": scenario != "unusable",
+        "aspath": {"string": "65500 65002" if scenario == "as-prepend" else "65002"},
+        "nexthops": [{"ip": "10.98.0.10" if scenario == "next-hop-self" else "10.98.0.20"}]}]}
+    if fault and not (scenario == "leaked-long-prefix" and "203.0.113.0/25" in sys.argv[-1]):
+        result = {"paths": []}
+elif "member-a" in sys.argv:
+    sys.exit(0)
+else:
+    sys.exit(99)
+print(json.dumps(result))
+''')
+    docker.chmod(0o755)
+    sleep = temporary / "sleep"
+    sleep.write_text("#!/bin/sh\nexit 0\n")
+    sleep.chmod(0o755)
+    calls = temporary / "calls"
+    environment = os.environ | {"PATH": f"{temporary}:{os.environ['PATH']}", "CALLS": str(calls)}
+    script = str(ROOT / "labs/ixp/lab.sh")
+    for scenario in ("healthy", "idle", "stale", "one-member", "cache-down", "empty-vrps",
+                     "missing-route", "not-best", "wrong-peer", "invalid", "not-exported",
+                     "unusable", "as-prepend", "next-hop-self"):
+        result = subprocess.run(["bash", script, "verify"], cwd=ROOT,
+                                env=environment | {"SCENARIO": scenario}, capture_output=True)
+        assert (result.returncode == 0) == (scenario == "healthy"), (scenario, result.stderr)
+    for scenario in ("rejected", "leaked-long-prefix"):
+        result = subprocess.run(["bash", script, "break"], cwd=ROOT,
+                                env=environment | {"SCENARIO": scenario}, capture_output=True)
+        assert (result.returncode == 0) == (scenario == "rejected"), (scenario, result.stderr)
+    calls.unlink()
+    for arguments in ((), ("../up",), ("verify", "extra")):
+        result = subprocess.run(["bash", script, *arguments], cwd=ROOT, env=environment,
+                                capture_output=True)
+        assert result.returncode == 2, result.stderr
+        assert not calls.exists(), "invalid phase reached Docker"
+    sentinel = temporary / "injected"
+    for name, phase in (("../ixp", "up"), (f"$(touch {sentinel})", "up"),
+                        ("ixp", f"$(touch {sentinel})")):
+        result = subprocess.run(["just", "lab", name, phase], cwd=ROOT, env=environment,
+                                capture_output=True)
+        assert result.returncode != 0, result.stdout
+        assert not calls.exists(), "invalid lab or phase reached Docker"
+        assert not sentinel.exists(), "lab argument was executed by the shell"
+print("IXP verification and argument checks passed.")

--- a/labs/ixp/vrps.json
+++ b/labs/ixp/vrps.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {"generated": 1710000000, "valid": 1710086400},
+  "roas": [
+    {"asn": "AS65002", "prefix": "198.51.100.0/24", "maxLength": 24, "ta": "lab-only"}
+  ]
+}

--- a/labs/ixp/vtysh.conf
+++ b/labs/ixp/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config


### PR DESCRIPTION
Add `just lab ixp up|verify|break|explain|down` for a transparent route server, two FRR members, and a pinned local StayRTR cache. The fault changes a route's origin to make it RPKI-invalid and independently announces a /25 denied by the prefix-length policy. Both sessions stay established while neither rejected prefix reaches the other member.

The guide walks through the retained rejection reasons, covering VRP, import decisions, export stop, and import counters. Repeating `up` restores the legitimate origin and verifies transparent AS_PATH and next-hop delivery. The Compose project uses its own subnet and publishes no host ports. The configuration and synthetic VRPs are teaching fixtures, not production policy.

Validation: fresh-source Docker build and complete live up/verify/break/failed-verify/explain/recovery/verify/down/down cycle passed. Confirmed the lab left no containers, networks, or volumes. Targeted verification and argument tests include a leaked /25 negative case; existing quickstart dispatch tests, Compose configuration, Bash syntax, Ruff, `just check-fast`, and offline links passed. No daemon behavior changes.
