### PR TITLE
Add a route-reflector operator lab for duplicate origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and a prefix-length rejection, explain the import and export decisions,
   then restore and verify transparent route delivery to the other member.
 
+- `just lab rr up|verify|break|explain|down`: diagnose an unintended
+  duplicate origin, inspect the route reflector's identifier tie-break and
+  split-horizon export decision, and restore the intended source.
+
 ### Changed
 
 - The three example programs (`event-bridge`, `peer-loop`, `birdwatcher-adapter`)

--- a/docs/tutorials/operator-labs.md
+++ b/docs/tutorials/operator-labs.md
@@ -105,6 +105,42 @@ with expiry checking disabled in StayRTR; it is not a public RPKI validator.
 For the production configuration shape, see the
 [route-server example](../../examples/route-server/README.md).
 
+## Route reflector: an unintended origin wins
+
+This lab runs a route reflector and two FRR 10.7.1 clients in AS65001.
+Client A is the intended sole origin of `198.51.100.0/24`; client B receives
+its reflected route. It uses the same host prerequisites as the quickstart.
+
+```bash
+just lab rr up
+just lab rr verify
+just lab rr break
+just lab rr explain
+```
+
+`verify` checks both client sessions, the selected source, and receipt at
+client B with the original next hop and ORIGINATOR_ID. It also checks that
+the reflector does not advertise the route back to its source.
+
+`break` makes client B originate the same prefix. Its otherwise equal path
+wins because B has the lower BGP Identifier. Both sessions remain
+Established, but `verify` now fails because A is no longer the sole origin.
+`explain` shows the winning source, the identifier tie-break, and the
+`split_horizon` export stop toward that source.
+
+Remove B's unintended announcement and verify recovery:
+
+```bash
+just lab rr up
+just lab rr verify
+just lab rr down
+```
+
+The lab uses the dedicated Compose project `rustbgpd-lab-rr` and subnet
+`10.97.0.0/24`, with no published host ports. Run one instance at a time
+and avoid overlapping local networks. Repeating `up` restores the intended
+origin; repeating `down` safely removes the lab's containers and network.
+
 For complete deployment scenarios, use the [cookbook](../cookbook/README.md).
 The [interop receipts](../receipts.md) describe the separate protocol validation
 labs and their measured evidence.

--- a/justfile
+++ b/justfile
@@ -10,8 +10,8 @@ lab name phase:
     #!/usr/bin/env bash
     set -euo pipefail
     case "$1" in
-        quickstart|ixp) exec bash "labs/$1/lab.sh" "$2" ;;
-        *) echo "unknown lab: $1 (available: quickstart, ixp)" >&2; exit 2 ;;
+        quickstart|ixp|rr) exec bash "labs/$1/lab.sh" "$2" ;;
+        *) echo "unknown lab: $1 (available: quickstart, ixp, rr)" >&2; exit 2 ;;
     esac
 
 # Run the broad local correctness baseline in diagnostic order.

--- a/labs/rr/client-a.conf
+++ b/labs/rr/client-a.conf
@@ -1,0 +1,13 @@
+frr defaults traditional
+hostname client-a
+log stdout informational
+!
+router bgp 65001
+ bgp router-id 10.97.0.20
+ no bgp network import-check
+ neighbor 10.97.0.1 remote-as 65001
+ neighbor 10.97.0.1 timers 10 30
+ address-family ipv4 unicast
+  network 198.51.100.0/24
+ exit-address-family
+!

--- a/labs/rr/client-b.conf
+++ b/labs/rr/client-b.conf
@@ -1,0 +1,10 @@
+frr defaults traditional
+hostname client-b
+log stdout informational
+!
+router bgp 65001
+ bgp router-id 10.97.0.10
+ no bgp network import-check
+ neighbor 10.97.0.1 remote-as 65001
+ neighbor 10.97.0.1 timers 10 30
+!

--- a/labs/rr/docker-compose.yml
+++ b/labs/rr/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  rustbgpd:
+    build:
+      context: ../..
+      target: dev
+    volumes:
+      - ./rustbgpd.toml:/etc/rustbgpd/config.toml:ro
+      - ../../tests/fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
+    environment:
+      RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
+    networks:
+      rr:
+        ipv4_address: 10.97.0.1
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 524288
+
+  client-a:
+    image: quay.io/frrouting/frr:10.7.1
+    volumes:
+      - ../../examples/docker-compose/frr-daemons:/etc/frr/daemons:ro
+      - ./client-a.conf:/etc/frr/frr.conf:ro
+      - ./vtysh.conf:/etc/frr/vtysh.conf:ro
+    networks:
+      rr:
+        ipv4_address: 10.97.0.20
+    cap_add: [NET_ADMIN, NET_RAW, SYS_ADMIN]
+
+  client-b:
+    image: quay.io/frrouting/frr:10.7.1
+    volumes:
+      - ../../examples/docker-compose/frr-daemons:/etc/frr/daemons:ro
+      - ./client-b.conf:/etc/frr/frr.conf:ro
+      - ./vtysh.conf:/etc/frr/vtysh.conf:ro
+    networks:
+      rr:
+        ipv4_address: 10.97.0.30
+    cap_add: [NET_ADMIN, NET_RAW, SYS_ADMIN]
+
+networks:
+  rr:
+    ipam:
+      config:
+        - subnet: 10.97.0.0/24
+          gateway: 10.97.0.254

--- a/labs/rr/lab.sh
+++ b/labs/rr/lab.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Diagnose an unintended duplicate prefix announcement to a route reflector.
+set -euo pipefail
+
+if [[ $# != 1 ]]; then
+    echo 'usage: lab.sh up|verify|break|explain|down' >&2
+    exit 2
+fi
+case "$1" in
+    up|verify|break|explain|down) ;;
+    *) echo "unknown rr phase: $1" >&2; exit 2 ;;
+esac
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+compose=(docker compose --project-name rustbgpd-lab-rr
+    --file "$repo_root/labs/rr/docker-compose.yml")
+
+rb() {
+    "${compose[@]}" exec -T rustbgpd rbgp -s http://127.0.0.1:50051 "$@"
+}
+
+client_b() {
+    "${compose[@]}" exec -T client-b vtysh "$@"
+}
+
+sessions() {
+    rb --json neighbor | python3 -c '
+import json, sys
+peers = json.load(sys.stdin)
+sys.exit(not all(any(p.get("address") == address and p.get("remote_asn") == 65001
+    and p.get("state") == "Established" and p.get("route_reflector_client") is True
+    and not p.get("stale", False) for p in peers)
+    for address in ("10.97.0.20", "10.97.0.30")))
+'
+}
+
+reflected_to() {
+    "${compose[@]}" exec -T "$1" vtysh -c 'show bgp ipv4 unicast 198.51.100.0/24 json' |
+        python3 -c '
+import json, sys
+originator, next_hop = sys.argv[1:]
+sys.exit(not any(p.get("valid") is True and p.get("originatorId") == originator
+    and p.get("peer", {}).get("peerId") == "10.97.0.1"
+    and "10.97.0.1" in p.get("clusterList", {}).get("list", [])
+    and any(n.get("ip") == next_hop for n in p.get("nexthops", []))
+    for p in json.load(sys.stdin).get("paths", [])))
+' "$2" "$3"
+}
+
+not_reflected_to() {
+    rb --json rib --prefix 198.51.100.0/24 advertised "$2" --explain | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+sys.exit(not (data.get("decision") == "deny"
+    and data.get("route_peer_address") == sys.argv[1]
+    and any(g.get("gate") == "split_horizon" and g.get("verdict") == "stop"
+        for g in data.get("gates", []))))
+' "$2" || return 1
+    rb --json rib --prefix 198.51.100.0/24 advertised "$2" | python3 -c '
+import json, sys
+sys.exit(json.load(sys.stdin) != [])
+' || return 1
+    "${compose[@]}" exec -T "$1" vtysh -c 'show bgp ipv4 unicast 198.51.100.0/24 json' |
+        python3 -c '
+import json, sys
+sys.exit(any(p.get("peer", {}).get("peerId") == "10.97.0.1"
+    for p in json.load(sys.stdin).get("paths", [])))
+'
+}
+
+verify() {
+    sessions || return 1
+    rb --json rib --prefix 198.51.100.0/24 --explain | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+best = data.get("best_route") or {}
+sys.exit(not (best.get("peer_address") == "10.97.0.20"
+    and best.get("prefix") == "198.51.100.0/24" and best.get("best") is True
+    and data.get("candidates") == []))
+' || return 1
+    reflected_to client-b 10.97.0.20 10.97.0.20 || return 1
+    not_reflected_to client-a 10.97.0.20
+}
+
+duplicate_selected() {
+    sessions || return 1
+    rb --json rib --prefix 198.51.100.0/24 --explain | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+best = data.get("best_route") or {}
+candidates = data.get("candidates", [])
+sys.exit(not (best.get("peer_address") == "10.97.0.30"
+    and best.get("prefix") == "198.51.100.0/24" and best.get("best") is True
+    and data.get("best_reason") == "lower_bgp_identifier"
+    and len(candidates) == 1
+    and any((c.get("route") or {}).get("peer_address") == "10.97.0.20"
+        and c.get("vs_best_reason") == "lower_bgp_identifier"
+        and c.get("vs_best_ordering") == "worse" for c in candidates)))
+' || return 1
+    reflected_to client-a 10.97.0.10 10.97.0.30 || return 1
+    not_reflected_to client-b 10.97.0.30
+}
+
+wait_for() {
+    local attempt
+    for ((attempt = 0; attempt < 60; attempt++)); do
+        if "$@" >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "Timed out waiting for $*. Run 'just lab rr explain' or 'just lab rr down'." >&2
+    return 1
+}
+
+case "$1" in
+    up)
+        echo 'Building and starting the route-reflector lab.'
+        "${compose[@]}" up -d --build
+        wait_for sessions
+        running_config=$(client_b -c 'show running-config')
+        if [[ "$running_config" == *'network 198.51.100.0/24'* ]]; then
+            client_b -c 'configure terminal' -c 'router bgp 65001' \
+                -c 'address-family ipv4 unicast' -c 'no network 198.51.100.0/24'
+        fi
+        wait_for verify
+        echo 'Ready: client A is the only origin; client B receives its reflected route.'
+        ;;
+    verify)
+        if ! verify; then
+            echo 'Verification failed: expected client A as the sole origin, reflection to B, and no reflection back to A.' >&2
+            exit 1
+        fi
+        echo 'Verified: client A owns 198.51.100.0/24; reflection preserves its originator and next hop.'
+        ;;
+    break)
+        client_b -c 'configure terminal' -c 'router bgp 65001' \
+            -c 'address-family ipv4 unicast' -c 'network 198.51.100.0/24'
+        wait_for duplicate_selected
+        echo 'Client B now incorrectly originates the same prefix and wins on its lower BGP Identifier.'
+        echo 'Both sessions remain Established. Diagnose the changed source: just lab rr explain'
+        ;;
+    explain)
+        echo 'Client sessions:'
+        rb neighbor
+        echo 'Intended source: client A (10.97.0.20). Compare the actual winning source and candidates:'
+        rb rib --prefix 198.51.100.0/24 --explain
+        for peer in 10.97.0.20 10.97.0.30; do
+            echo "Export decision toward $peer (the selected source must stop at split_horizon):"
+            rb rib --prefix 198.51.100.0/24 advertised "$peer" --explain
+        done
+        ;;
+    down)
+        "${compose[@]}" down --volumes
+        ;;
+esac

--- a/labs/rr/rustbgpd.toml
+++ b/labs/rr/rustbgpd.toml
@@ -1,0 +1,34 @@
+[global]
+asn = 65001
+router_id = "10.97.0.1"
+cluster_id = "10.97.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "127.0.0.1:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+
+[[neighbors]]
+address = "10.97.0.20"
+remote_asn = 65001
+description = "client-a-intended-origin"
+hold_time = 90
+route_reflector_client = true
+
+[[neighbors]]
+address = "10.97.0.30"
+remote_asn = 65001
+description = "client-b"
+hold_time = 90
+route_reflector_client = true

--- a/labs/rr/test_lab.py
+++ b/labs/rr/test_lab.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Reject wrong winners, missing reflection, and unsafe lab arguments without Docker."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+
+with tempfile.TemporaryDirectory() as directory:
+    temporary = Path(directory)
+    docker = temporary / "docker"
+    docker.write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+Path(os.environ["CALLS"]).touch()
+scenario = os.environ.get("SCENARIO", "healthy")
+duplicate = scenario.startswith("duplicate")
+winner = "10.97.0.30" if duplicate else "10.97.0.20"
+originator = "10.97.0.10" if duplicate else "10.97.0.20"
+if "neighbor" in sys.argv:
+    result = [{"address": address, "remote_asn": 65001,
+        "route_reflector_client": scenario != "not-client",
+        "state": "Idle" if scenario == "idle" else "Established"}
+        for address in ("10.97.0.20", "10.97.0.30")]
+    if scenario == "missing-peer": result.pop()
+elif "advertised" in sys.argv:
+    if "--explain" in sys.argv:
+        result = {"decision": "deny", "route_peer_address": winner,
+            "gates": [{"gate": "split_horizon", "verdict": "stop"}]}
+        if scenario == "wrong-gate": result["gates"][0]["gate"] = "policy"
+    else:
+        result = [{}] if scenario in ("source-export", "duplicate-source-export") else []
+elif "rib" in sys.argv:
+    route = {"prefix": "198.51.100.0/24", "peer_address": winner, "best": True}
+    result = {"best_route": route, "candidates": [],
+        "best_reason": "lower_bgp_identifier" if duplicate else "only_path"}
+    if duplicate or scenario == "extra-candidate":
+        result["candidates"].append({"route": {"peer_address": "10.97.0.20"},
+            "vs_best_reason": "lower_bgp_identifier", "vs_best_ordering": "worse"})
+    if scenario == "wrong-winner": route["peer_address"] = "10.97.0.30"
+    if scenario == "duplicate-wrong-reason": result["candidates"][0]["vs_best_reason"] = "higher_local_pref"
+    if scenario == "duplicate-missing-candidate": result["candidates"].pop()
+elif "show bgp ipv4 unicast 198.51.100.0/24 json" in sys.argv:
+    result = {"paths": [{"valid": True, "originatorId": originator,
+        "peer": {"peerId": "10.97.0.1"}, "clusterList": {"list": ["10.97.0.1"]},
+        "nexthops": [{"ip": winner}]}]}
+    if scenario in ("missing-reflection", "duplicate-missing-reflection"): result["paths"] = []
+    if scenario == "wrong-originator": result["paths"][0]["originatorId"] = "10.97.0.99"
+    if scenario == "missing-cluster": result["paths"][0]["clusterList"]["list"] = []
+    if scenario == "wrong-next-hop": result["paths"][0]["nexthops"][0]["ip"] = "10.97.0.1"
+    if ("client-b" if duplicate else "client-a") in sys.argv:
+        result = {"paths": [] if scenario != "source-received" else [{"peer": {"peerId": "10.97.0.1"}}]}
+elif "client-b" in sys.argv:
+    sys.exit(0)
+else:
+    sys.exit(99)
+print(json.dumps(result))
+''')
+    docker.chmod(0o755)
+    # Fail the first retry so a negative snapshot is tested without waiting a minute.
+    sleep = temporary / "sleep"
+    sleep.write_text("#!/bin/sh\nexit 97\n")
+    sleep.chmod(0o755)
+    calls = temporary / "calls"
+    environment = os.environ | {"PATH": f"{temporary}:{os.environ['PATH']}", "CALLS": str(calls)}
+    script = str(ROOT / "labs/rr/lab.sh")
+    for scenario in ("healthy", "idle", "not-client", "missing-peer", "wrong-winner",
+                     "extra-candidate", "missing-reflection", "wrong-originator", "missing-cluster",
+                     "wrong-next-hop", "wrong-gate", "source-export", "source-received"):
+        result = subprocess.run(["bash", script, "verify"], cwd=ROOT,
+                                env=environment | {"SCENARIO": scenario}, capture_output=True)
+        assert result.returncode == (0 if scenario == "healthy" else 1), (scenario, result.stderr)
+    for scenario in ("duplicate", "duplicate-wrong-reason", "duplicate-missing-candidate",
+                     "duplicate-missing-reflection", "duplicate-source-export"):
+        result = subprocess.run(["bash", script, "break"], cwd=ROOT,
+                                env=environment | {"SCENARIO": scenario}, capture_output=True)
+        assert result.returncode == (0 if scenario == "duplicate" else 97), (scenario, result.stderr)
+    calls.unlink()
+    for arguments in ((), ("../up",), ("verify", "extra"), ("$(touch injected)",)):
+        result = subprocess.run(["bash", script, *arguments], cwd=ROOT, env=environment,
+                                capture_output=True)
+        assert result.returncode == 2, result.stderr
+        assert not calls.exists(), "invalid phase reached Docker"
+    sentinel = temporary / "injected"
+    for name, phase in (("../rr", "up"), (f"$(touch {sentinel})", "up"),
+                        ("rr", f"$(touch {sentinel})")):
+        result = subprocess.run(["just", "lab", name, phase], cwd=ROOT, env=environment,
+                                capture_output=True)
+        assert result.returncode != 0, result.stdout
+        assert not calls.exists(), "invalid lab or phase reached Docker"
+        assert not sentinel.exists(), "lab argument was executed by the shell"
+print("RR verification and argument checks passed.")

--- a/labs/rr/vtysh.conf
+++ b/labs/rr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config


### PR DESCRIPTION
Add `just lab rr up|verify|break|explain|down` for a route reflector and two FRR clients. Client A is the intended sole origin; the fault makes client B announce the same prefix and win on its lower BGP Identifier. Both sessions stay established while verification of the intended source fails.

The lab checks the exact best-path reason, reflected receipt at the other client with ORIGINATOR_ID, CLUSTER_LIST, and original next hop, and suppression toward the winning source in both the advertised RIB and FRR's received paths. Repeating `up` withdraws the unintended announcement and verifies recovery. The isolated Compose project publishes no host ports.

Validation: a fresh-source build and full live startup, fault, failed verification, explanation, recovery, and repeated teardown passed, with no lab resources left. `python3 labs/rr/test_lab.py` covers wrong winners/reasons, missing reflection, source leakage, and argument boundaries. Existing quickstart/IXP dispatch checks, Compose validation, Bash syntax, Ruff, `just check-fast`, and offline links passed. No daemon behavior changes.
