### PR TITLE
Add BMP monitoring operator lab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   duplicate origin, inspect the route reflector's identifier tie-break and
   split-horizon export decision, and restore the intended source.
 
+- `just lab monitoring up|verify|break|explain|down`: stop a BMP collector
+  while BGP remains live, inspect delivery diagnostics, and verify a decoded
+  Loc-RIB route snapshot after the collector reconnects.
+
 ### Changed
 
 - The three example programs (`event-bridge`, `peer-loop`, `birdwatcher-adapter`)

--- a/docs/tutorials/operator-labs.md
+++ b/docs/tutorials/operator-labs.md
@@ -141,6 +141,52 @@ The lab uses the dedicated Compose project `rustbgpd-lab-rr` and subnet
 and avoid overlapping local networks. Repeating `up` restores the intended
 origin; repeating `down` safely removes the lab's containers and network.
 
+## Monitoring: BGP stays up while the collector is down
+
+This lab runs rustbgpd, an FRR 10.7.1 peer, and a small Python BMP receiver.
+The peer announces `198.51.100.0/24`. Explicit Loc-RIB monitoring lets the
+collector receive a snapshot of selected routes when it connects, including
+after an outage. It uses the same host prerequisites as the quickstart.
+
+```bash
+just lab monitoring up
+just lab monitoring verify
+just lab monitoring break
+just lab monitoring explain
+```
+
+`up` preserves existing daemon and peer containers, waits for the session and
+selected route, then creates a fresh receiver. After changing lab source or
+configuration, run `down` before `up` to rebuild the whole topology.
+`verify` checks BGP state and decodes the receiver's captured BMP messages:
+the selected IPv4 prefix must appear before its End-of-RIB marker on the
+newest collector connection. An old capture cannot certify a fresh start.
+
+`break` stops the receiver. A temporary probe-route announcement and
+withdrawal prompt BMP writes, while the example prefix and its BGP session
+remain live. `verify` now fails because the receiver is unavailable.
+`explain` shows the working BGP session and route alongside collector retry
+logs and BMP metrics. Replay attempts count connections, not successful
+delivery; a stopped receiver need not increment the drop counter.
+
+`doctor` reports collector reachability from the CLI's vantage point. It
+does not prove BMP delivery; the decoded snapshot check supplies that proof
+for this exercise.
+
+Restore the receiver and verify that the selected route is replayed:
+
+```bash
+just lab monitoring up
+just lab monitoring verify
+just lab monitoring down
+```
+
+The lab uses the dedicated Compose project `rustbgpd-lab-monitoring` and
+subnet `10.96.0.0/24`, with no published host ports. Run one instance at a
+time and avoid overlapping local networks. `down` removes its containers,
+network, and temporary captures; repeating it is safe. This is a focused
+collector exercise, without a Prometheus or Grafana installation.
+
 For complete deployment scenarios, use the [cookbook](../cookbook/README.md).
 The [interop receipts](../receipts.md) describe the separate protocol validation
 labs and their measured evidence.

--- a/justfile
+++ b/justfile
@@ -10,8 +10,8 @@ lab name phase:
     #!/usr/bin/env bash
     set -euo pipefail
     case "$1" in
-        quickstart|ixp|rr) exec bash "labs/$1/lab.sh" "$2" ;;
-        *) echo "unknown lab: $1 (available: quickstart, ixp, rr)" >&2; exit 2 ;;
+        quickstart|ixp|rr|monitoring) exec bash "labs/$1/lab.sh" "$2" ;;
+        *) echo "unknown lab: $1 (available: quickstart, ixp, rr, monitoring)" >&2; exit 2 ;;
     esac
 
 # Run the broad local correctness baseline in diagnostic order.

--- a/labs/monitoring/check_bmp.py
+++ b/labs/monitoring/check_bmp.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Verify this lab's IPv4 Loc-RIB snapshot from raw BMPv3 messages."""
+import ipaddress
+import json
+import struct
+import sys
+
+PREFIX = "198.51.100.0/24"
+
+
+def snapshot(messages):
+    if not messages:
+        raise ValueError("no BMP messages")
+    connection = max(m["conn"] for m in messages)
+    stream = [m for m in messages if m["conn"] == connection]
+    peer_up = False
+    prefixes = set()
+    for sequence, message in enumerate(stream):
+        raw = bytes.fromhex(message["hex"])
+        if (message["seq"] != sequence or len(raw) < 6 or raw[0] != 3
+                or struct.unpack_from("!I", raw, 1)[0] != len(raw)):
+            raise ValueError("invalid BMP framing or sequence")
+        kind = raw[5]
+        if sequence == 0 and kind != 4:
+            raise ValueError("stream does not start with Initiation")
+        if kind == 5:
+            raise ValueError("BMP Termination before snapshot completion")
+        if kind not in (0, 2, 3):
+            continue
+        if len(raw) < 48:
+            raise ValueError("truncated per-peer header")
+        if raw[6] != 3:
+            continue
+        if kind == 2:
+            raise ValueError("Loc-RIB PeerDown before snapshot completion")
+        if kind == 3:
+            if peer_up:
+                raise ValueError("repeated Loc-RIB PeerUp before snapshot completion")
+            peer_up = True
+            continue
+        if not peer_up:
+            raise ValueError("Loc-RIB RouteMonitoring precedes PeerUp")
+        update = raw[48:]
+        if (len(update) < 23 or update[:16] != b"\xff" * 16 or update[18] != 2
+                or struct.unpack_from("!H", update, 16)[0] != len(update)):
+            raise ValueError("invalid BGP UPDATE framing")
+        withdrawn = struct.unpack_from("!H", update, 19)[0]
+        if 23 + withdrawn > len(update):
+            raise ValueError("truncated withdrawals")
+        attributes = struct.unpack_from("!H", update, 21 + withdrawn)[0]
+        offset = 23 + withdrawn + attributes
+        if offset > len(update):
+            raise ValueError("truncated attributes")
+        if len(update) == 23 and not withdrawn and not attributes:
+            if PREFIX not in prefixes:
+                raise ValueError(f"IPv4 End-of-RIB before {PREFIX} was replayed")
+            return connection, prefixes
+        if withdrawn:
+            raise ValueError("withdrawal inside initial Loc-RIB snapshot")
+        while offset < len(update):
+            bits = update[offset]
+            size = (bits + 7) // 8
+            offset += 1
+            if bits > 32 or offset + size > len(update):
+                raise ValueError("invalid IPv4 NLRI")
+            address = ipaddress.IPv4Address(update[offset:offset + size].ljust(4, b"\0"))
+            prefixes.add(str(ipaddress.IPv4Network((address, bits), strict=True)))
+            offset += size
+    raise ValueError("no complete IPv4 Loc-RIB snapshot")
+
+
+if __name__ == "__main__":
+    try:
+        connection, prefixes = snapshot([json.loads(line) for line in sys.stdin if line.strip()])
+    except (ValueError, KeyError, TypeError, struct.error) as error:
+        sys.exit(f"BMP verification failed: {error}")
+    print(f"BMP connection {connection}: decoded {', '.join(sorted(prefixes))}, then IPv4 End-of-RIB.")

--- a/labs/monitoring/docker-compose.yml
+++ b/labs/monitoring/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  rustbgpd:
+    build:
+      context: ../..
+      target: dev
+    volumes:
+      - ./rustbgpd.toml:/etc/rustbgpd/config.toml:ro
+      - ../../tests/fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
+    environment:
+      RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
+      RUST_LOG: info,rustbgpd_bmp=debug
+    networks:
+      monitoring:
+        ipv4_address: 10.96.0.10
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 524288
+
+  frr:
+    image: quay.io/frrouting/frr:10.7.1
+    volumes:
+      - ../../examples/docker-compose/frr-daemons:/etc/frr/daemons:ro
+      - ./frr.conf:/etc/frr/frr.conf:ro
+      - ./vtysh.conf:/etc/frr/vtysh.conf:ro
+    cap_add: [NET_ADMIN, NET_RAW, SYS_ADMIN]
+    networks:
+      monitoring:
+        ipv4_address: 10.96.0.20
+
+  receiver:
+    image: python:3.12-slim
+    # Reuse the raw-byte receiver from the BMP interoperability receipt.
+    command: [python3, /opt/bmp-raw-sink.py]
+    volumes:
+      - ../../tests/interop/scripts/bmp-raw-sink.py:/opt/bmp-raw-sink.py:ro
+    networks:
+      monitoring:
+        ipv4_address: 10.96.0.30
+
+networks:
+  monitoring:
+    ipam:
+      config:
+        - subnet: 10.96.0.0/24

--- a/labs/monitoring/frr.conf
+++ b/labs/monitoring/frr.conf
@@ -1,0 +1,16 @@
+frr version 10.7.1
+frr defaults traditional
+log stdout informational
+!
+ip route 198.51.100.0/24 Null0
+ip route 203.0.113.0/24 Null0
+!
+router bgp 65002
+ bgp router-id 10.96.0.20
+ no bgp ebgp-requires-policy
+ neighbor 10.96.0.10 remote-as 65001
+ !
+ address-family ipv4 unicast
+  network 198.51.100.0/24
+ exit-address-family
+!

--- a/labs/monitoring/lab.sh
+++ b/labs/monitoring/lab.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# A BMP collector outage leaves the BGP session and selected route intact.
+set -euo pipefail
+
+if [[ $# != 1 ]]; then
+    echo 'usage: lab.sh up|verify|break|explain|down' >&2
+    exit 2
+fi
+case "$1" in
+    up|verify|break|explain|down) ;;
+    *) echo "unknown monitoring phase: $1" >&2; exit 2 ;;
+esac
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+compose=(docker compose --project-name rustbgpd-lab-monitoring
+    --file "$repo_root/labs/monitoring/docker-compose.yml")
+
+rb() {
+    "${compose[@]}" exec -T rustbgpd rbgp -s http://127.0.0.1:50051 "$@"
+}
+
+routing() {
+    rb --json neighbor | python3 -c '
+import json, sys
+sys.exit(not any(p.get("address") == "10.96.0.20" and p.get("remote_asn") == 65002
+    and p.get("state") == "Established" and not p.get("stale", False)
+    for p in json.load(sys.stdin)))
+' || return 1
+    rb --json rib --prefix 198.51.100.0/24 | python3 -c '
+import json, sys
+sys.exit(not any(r.get("prefix") == "198.51.100.0/24" and r.get("best") is True
+    and r.get("peer_address") == "10.96.0.20" for r in json.load(sys.stdin)))
+'
+}
+
+verify() {
+    routing || return 1
+    "${compose[@]}" exec -T receiver cat /tmp/bmp-raw-11019.jsonl \
+        | python3 "$repo_root/labs/monitoring/check_bmp.py"
+}
+
+probe_route() {
+    rb --json rib --prefix 203.0.113.0/24 | python3 -c '
+import json, sys
+routes = json.load(sys.stdin)
+present = any(r.get("prefix") == "203.0.113.0/24" and r.get("best") is True
+    and r.get("peer_address") == "10.96.0.20" for r in routes)
+sys.exit(not present if sys.argv[1] == "present" else routes != [])
+' "$1"
+}
+
+wait_for() {
+    local attempt
+    for ((attempt = 0; attempt < 60; attempt++)); do
+        if "$@" >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "Timed out waiting for $*. Run 'just lab monitoring explain' or 'just lab monitoring down'." >&2
+    return 1
+}
+
+case "$1" in
+    up)
+        "${compose[@]}" up -d --build --no-recreate rustbgpd frr
+        wait_for routing
+        # A fresh receiver cannot accidentally certify a previous capture.
+        "${compose[@]}" up -d --force-recreate receiver
+        wait_for verify
+        verify
+        echo 'Ready: BGP is Established and the collector decoded the selected route snapshot.'
+        ;;
+    verify)
+        if ! verify; then
+            echo 'Verification failed: expected live BGP and a decoded BMP route snapshot.' >&2
+            exit 1
+        fi
+        ;;
+    break)
+        "${compose[@]}" stop receiver
+        # Produce BMP writes so the exporter discovers the closed TCP stream;
+        # the selected example route and its BGP session stay unchanged.
+        "${compose[@]}" exec -T frr vtysh -c 'configure terminal' \
+            -c 'router bgp 65002' -c 'address-family ipv4 unicast' \
+            -c 'network 203.0.113.0/24'
+        wait_for probe_route present
+        "${compose[@]}" exec -T frr vtysh -c 'configure terminal' \
+            -c 'router bgp 65002' -c 'address-family ipv4 unicast' \
+            -c 'no network 203.0.113.0/24'
+        wait_for probe_route absent
+        routing
+        echo 'Collector stopped; the BGP session and 198.51.100.0/24 remain live.'
+        echo 'Inspect BMP delivery with: just lab monitoring explain'
+        ;;
+    explain)
+        rb neighbor
+        rb rib --prefix 198.51.100.0/24 --explain
+        echo 'Collector lifecycle and retry logs:'
+        logs=$("${compose[@]}" logs --tail 30 rustbgpd)
+        printf '%s\n' "$logs" | grep -E 'BMP|collector' || true
+        echo 'Replay attempts count collector connections, not successful route delivery.'
+        echo 'Drop counters describe queue/dump failures; a stopped receiver need not increment them.'
+        metrics=$(rb metrics)
+        printf '%s\n' "$metrics" | grep -E '^bmp_(replay_attempts_total|collector_drops_total)' || true
+        echo 'Doctor reports TCP reachability from the CLI; it does not verify BMP delivery.'
+        rb doctor
+        ;;
+    down)
+        "${compose[@]}" down --volumes
+        ;;
+esac

--- a/labs/monitoring/rustbgpd.toml
+++ b/labs/monitoring/rustbgpd.toml
@@ -1,0 +1,43 @@
+# Local BMP learning lab; the collector receives the selected Loc-RIB routes.
+[global]
+asn = 65001
+router_id = "10.96.0.10"
+listen_port = 179
+ebgp_requires_policy = true
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "127.0.0.1:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+
+[policy.definitions.lab-permit]
+default_action = "permit"
+
+[policy]
+import_chain = ["lab-permit"]
+export_chain = ["lab-permit"]
+
+[bmp]
+sys_name = "monitoring-lab"
+
+[[bmp.collectors]]
+address = "10.96.0.30:11019"
+reconnect_interval = 2
+monitor = ["loc_rib"]
+
+[[neighbors]]
+address = "10.96.0.20"
+remote_asn = 65002
+description = "frr-peer"
+hold_time = 90
+families = ["ipv4_unicast"]

--- a/labs/monitoring/test_lab.py
+++ b/labs/monitoring/test_lab.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Negative BMP snapshot and lab-argument checks; no containers required."""
+import copy
+import importlib.util
+import json
+import os
+from pathlib import Path
+import struct
+import subprocess
+import tempfile
+
+DIRECTORY = Path(__file__).resolve().parent
+ROOT = DIRECTORY.parents[1]
+spec = importlib.util.spec_from_file_location("check_bmp", DIRECTORY / "check_bmp.py")
+check = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check)
+
+
+def message(kind, body, sequence, connection=0):
+    raw = struct.pack("!BIB", 3, 6 + len(body), kind) + body
+    return {"conn": connection, "seq": sequence, "hex": raw.hex()}
+
+
+def update(nlri=b""):
+    return b"\xff" * 16 + struct.pack("!HBHH", 23 + len(nlri), 2, 0, 0) + nlri
+
+
+peer = b"\x03" + bytes(41)
+valid = [message(4, b"", 0), message(3, peer, 1),
+         message(0, peer + update(b"\x18\xc6\x33\x64"), 2),
+         message(0, peer + update(), 3)]
+assert check.snapshot(valid) == (0, {"198.51.100.0/24"})
+invalid = [[], valid[:-1], [valid[0], *valid[2:]], valid[:2] + [valid[3]]]
+wrong_prefix = copy.deepcopy(valid)
+wrong_prefix[2]["hex"] = message(0, peer + update(b"\x18\xcb\x00\x71"), 2)["hex"]
+invalid.append(wrong_prefix)
+wrong_type = copy.deepcopy(valid)
+wrong_type[2]["hex"] = message(0, bytes(42) + update(b"\x18\xc6\x33\x64"), 2)["hex"]
+invalid.append(wrong_type)
+for nlri in (b"\x21", b"\x18\xc6"):
+    malformed_nlri = copy.deepcopy(valid)
+    malformed_nlri[2] = message(0, peer + update(nlri), 2)
+    invalid.append(malformed_nlri)
+for raw in [bytes.fromhex(valid[2]["hex"])[:-1],
+            b"\x04" + bytes.fromhex(valid[2]["hex"])[1:],
+            struct.pack("!BIB", 3, 71, 0) + peer + update(b"\x21")]:
+    corrupt = copy.deepcopy(valid)
+    corrupt[2]["hex"] = raw.hex()
+    invalid.append(corrupt)
+# Complete old data must not certify an incomplete replacement connection.
+invalid.append(valid + [message(4, b"", 0, 1), message(3, peer, 1, 1)])
+for interruption in ([message(2, peer, 3), message(3, peer, 4)],
+                     [message(3, peer, 3)], [message(5, b"", 3)]):
+    invalid.append(valid[:3] + interruption + [message(0, peer + update(), 3 + len(interruption))])
+for capture in invalid:
+    try:
+        check.snapshot(capture)
+    except (ValueError, KeyError, struct.error):
+        continue
+    raise AssertionError("invalid or incomplete BMP snapshot accepted")
+
+with tempfile.TemporaryDirectory() as directory:
+    temporary = Path(directory)
+    capture = temporary / "capture.jsonl"
+    capture.write_text("\n".join(json.dumps(m) for m in valid) + "\n")
+    docker = temporary / "docker"
+    docker.write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+Path(os.environ["CALLS"]).touch()
+scenario = os.environ.get("SCENARIO", "healthy")
+probe = Path(os.environ["CALLS"] + ".probe")
+if "stop" in sys.argv:
+    sys.exit(0)
+if "vtysh" in sys.argv:
+    if sys.argv[-1] == "network 203.0.113.0/24" and scenario != "ignored-probe":
+        probe.touch()
+    if sys.argv[-1] == "no network 203.0.113.0/24" and scenario != "stuck-probe":
+        probe.unlink(missing_ok=True)
+    sys.exit(0)
+if "neighbor" in sys.argv:
+    print(json.dumps([{"address": "10.96.0.20", "remote_asn": 65002,
+        "state": "Idle" if scenario == "idle" else "Established"}]))
+elif "rib" in sys.argv:
+    prefix = sys.argv[sys.argv.index("--prefix") + 1]
+    present = probe.exists() if prefix == "203.0.113.0/24" else scenario != "no-route"
+    print(json.dumps([{"prefix": prefix, "best": True, "peer_address": "10.96.0.20"}]
+                     if present else []))
+elif "receiver" in sys.argv:
+    if scenario == "stopped": sys.exit(1)
+    print("" if scenario == "empty" else Path(os.environ["CAPTURE"]).read_text())
+else:
+    sys.exit(99)
+''')
+    docker.chmod(0o755)
+    sleep = temporary / "sleep"
+    sleep.write_text("#!/bin/sh\nexit 0\n")
+    sleep.chmod(0o755)
+    calls = temporary / "calls"
+    environment = os.environ | {"PATH": f"{temporary}:{os.environ['PATH']}",
+                                "CALLS": str(calls), "CAPTURE": str(capture)}
+    for scenario in ("healthy", "idle", "no-route", "stopped", "empty"):
+        result = subprocess.run(["bash", str(DIRECTORY / "lab.sh"), "verify"], cwd=ROOT,
+                                env=environment | {"SCENARIO": scenario}, capture_output=True)
+        assert (result.returncode == 0) == (scenario == "healthy"), (scenario, result.stderr)
+    for scenario in ("healthy", "ignored-probe", "stuck-probe"):
+        result = subprocess.run(["bash", str(DIRECTORY / "lab.sh"), "break"], cwd=ROOT,
+                                env=environment | {"SCENARIO": scenario}, capture_output=True)
+        assert (result.returncode == 0) == (scenario == "healthy"), (scenario, result.stderr)
+    calls.unlink()
+    for args in ([], ["../up"], ["verify", "extra"], ["$(touch unexpected)"]):
+        result = subprocess.run(["bash", str(DIRECTORY / "lab.sh"), *args], cwd=ROOT,
+                                env=environment, capture_output=True)
+        assert result.returncode == 2 and not calls.exists(), result.stderr
+print("Monitoring snapshot, verification, and argument checks passed.")

--- a/labs/monitoring/vtysh.conf
+++ b/labs/monitoring/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config


### PR DESCRIPTION
Add `just lab monitoring up|verify|break|explain|down` to demonstrate a BMP collector outage while the BGP session and selected route remain live. The isolated Compose topology reuses the interoperability raw receiver and enables Loc-RIB monitoring; verification decodes the expected IPv4 prefix before End-of-RIB on the newest collector connection. Repeating `up` replaces the receiver while preserving the daemon and peer.

The guide explains replay-attempt and drop-counter limits, the doctor's CLI network vantage, recovery, and cleanup. No daemon or protocol behavior changes.

Validation:
- Fresh current-source Docker lifecycle: healthy verification, stopped receiver causing verification failure, diagnostics, restored receiver with decoded replay, and repeated cleanup.
- Recovery preserved daemon and FRR container identities, kept BGP flap count at zero, and increased BMP replay attempts from 1 to 2. No lab containers, networks, or volumes remained after cleanup.
- Negative parser, lifecycle, routing, and argument checks; all existing operator-lab companion checks after rebasing.
- Shell syntax, Compose configuration, strict daemon configuration, Ruff, offline documentation links, public-document contract, and diff checks passed.

Rust files are unchanged; the broad Rust gate was not rerun.
