### PR TITLE
fix(rib): withdraw FlowSpec families omitted from graceful restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Withdraw every IPv4/IPv6 FlowSpec path immediately when a restarting
+  peer's Graceful Restart capability omits that family. Recompute the best
+  rule and downstream advertisements, selecting an alternate source when
+  available, while keeping GR-covered families stale.
+
 - **Operator-visible:** an IPv6 FlowSpec rule whose destination component
   carries a non-zero offset no longer presents the unshifted address as its
   destination prefix. RFC 8956 §3.1 matches the address shifted right by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,7 +440,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Withdraw every IPv4/IPv6 FlowSpec path immediately when a restarting
   peer's Graceful Restart capability omits that family. Recompute the best
   rule and downstream advertisements, selecting an alternate source when
-  available, while keeping GR-covered families stale.
+  available, while keeping GR-covered families stale. Keep the FlowSpec
+  Adj-RIB-In gauge current through GR/LLGR expiry, End-of-RIB cleanup, and
+  peer teardown.
 
 - **Operator-visible:** an IPv6 FlowSpec rule whose destination component
   carries a non-zero offset no longer presents the unshifted address as its

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -712,6 +712,11 @@ impl RibManager {
                     bgpls_affected.extend(rib.sweep_stale_family_bgpls(family));
                     rtc_affected.extend(rib.sweep_stale_family_rtc(family));
                 }
+                self.metrics.set_rib_prefixes(
+                    &peer_label,
+                    "flowspec",
+                    gauge_val(rib.flowspec_len()),
+                );
                 rib_len = rib.len();
                 evpn_len = rib.evpn_len();
                 // First GC catches interned sets made unreachable by direct
@@ -839,6 +844,8 @@ impl RibManager {
             self.attr_intern.gc();
             self.metrics
                 .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
+            self.metrics
+                .set_rib_prefixes(&peer_label, "flowspec", gauge_val(rib.flowspec_len()));
             rib_len = rib.len();
             evpn_len = rib.evpn_len();
         }
@@ -979,6 +986,8 @@ impl RibManager {
             self.attr_intern.gc();
             self.metrics
                 .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
+            self.metrics
+                .set_rib_prefixes(&peer_label, "flowspec", gauge_val(rib.flowspec_len()));
             rib_len = rib.len();
             evpn_len = rib.evpn_len();
             llgr_stale_remaining = rib.iter().filter(|r| r.is_llgr_stale).count()

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -220,6 +220,18 @@ impl RibManager {
             // advertised GR capability are retained. A negotiated typed
             // family whose tuple is absent from `gr_families` is withdrawn
             // outright — mirroring the EVPN not-in-gr arm below.
+            let keys: Vec<_> = rib
+                .iter_flowspec()
+                .filter(|route| !gr_families.contains(&(route.afi, Safi::FlowSpec)))
+                .map(crate::route::FlowSpecRoute::key)
+                .collect();
+            for key in keys {
+                rib.withdraw_flowspec(&key);
+                fs_affected.insert(crate::route::FlowSpecKey {
+                    afi: key.afi,
+                    rule: key.rule,
+                });
+            }
             for &family in &[(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv6, Safi::MplsVpn)] {
                 if !gr_families.contains(&family) {
                     let keys: Vec<crate::route::VpnRibRouteKey> = rib
@@ -338,6 +350,11 @@ impl RibManager {
             }
             self.metrics
                 .set_rib_prefixes(&peer.to_string(), "all", gauge_val(rib.len()));
+            self.metrics.set_rib_prefixes(
+                &peer.to_string(),
+                "flowspec",
+                gauge_val(rib.flowspec_len()),
+            );
             self.metrics
                 .set_rib_prefixes(&peer.to_string(), "evpn", gauge_val(rib.evpn_len()));
         }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -472,6 +472,8 @@ impl RibManager {
         debug!(%peer, cleared = count, "peer adj-rib-in cleared");
         self.metrics.set_rib_prefixes(&peer.to_string(), "all", 0);
         self.metrics.set_rib_prefixes(&peer.to_string(), "evpn", 0);
+        self.metrics
+            .set_rib_prefixes(&peer.to_string(), "flowspec", 0);
         let changed = self.recompute_best(&affected);
         self.distribute_changes(&changed, &affected);
         if !fs_affected.is_empty() {

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -223,6 +223,11 @@ impl RibManager {
                 rib.sweep_stale_flowspec_family((afi, safi));
                 rib.sweep_llgr_stale_flowspec_family((afi, safi));
                 rib.clear_stale_flowspec((afi, safi));
+                self.metrics.set_rib_prefixes(
+                    &peer.to_string(),
+                    "flowspec",
+                    gauge_val(rib.flowspec_len()),
+                );
                 rib.sweep_stale_family_evpn((afi, safi));
                 rib.sweep_llgr_stale_family_evpn((afi, safi));
                 rib.clear_stale_evpn((afi, safi));
@@ -403,6 +408,11 @@ impl RibManager {
                 rib.clear_llgr_stale((afi, safi));
                 rib.sweep_llgr_stale_flowspec_family((afi, safi));
                 rib.clear_llgr_stale_flowspec((afi, safi));
+                self.metrics.set_rib_prefixes(
+                    &peer.to_string(),
+                    "flowspec",
+                    gauge_val(rib.flowspec_len()),
+                );
                 rib.sweep_llgr_stale_family_evpn((afi, safi));
                 rib.clear_llgr_stale_evpn((afi, safi));
                 rib.sweep_llgr_stale_family_vpn((afi, safi));

--- a/crates/rib/src/manager/tests/flowspec.rs
+++ b/crates/rib/src/manager/tests/flowspec.rs
@@ -199,14 +199,144 @@ async fn dirty_resync_retries_flowspec_updates() {
 
 // --- Graceful Restart tests ---
 
+#[expect(
+    clippy::float_cmp,
+    reason = "the exported gauge contains exact integer route counts"
+)]
+fn assert_flowspec_gauge(manager: &RibManager, peer: IpAddr, expected: u32) {
+    let metrics = manager.metrics.registry().gather();
+    let gauge = metrics
+        .iter()
+        .find(|metric| metric.name() == "bgp_rib_prefixes")
+        .unwrap();
+    let sample = gauge
+        .metric
+        .iter()
+        .find(|metric| {
+            metric
+                .label
+                .iter()
+                .any(|label| label.name() == "peer" && label.value() == peer.to_string())
+                && metric
+                    .label
+                    .iter()
+                    .any(|label| label.name() == "afi_safi" && label.value() == "flowspec")
+        })
+        .unwrap();
+    assert_eq!(sample.gauge.value(), f64::from(expected));
+}
+
+#[tokio::test]
+async fn flowspec_gauge_tracks_gr_llgr_expiry_and_end_of_rib() {
+    for llgr in [false, true] {
+        for end_of_rib in [false, true] {
+            let source = Ipv4Addr::new(10, 0, 0, 1);
+            let peer = IpAddr::V4(source);
+            let (_tx, rx) = mpsc::channel(64);
+            let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+            let mut routes = Vec::new();
+            for afi in [Afi::Ipv4, Afi::Ipv6] {
+                for path_id in [0, 7] {
+                    let mut route = make_destless_flowspec_route(afi, source, 6);
+                    route.path_id = path_id;
+                    routes.push(route);
+                }
+            }
+            let mut refreshed = routes[1].clone();
+            let mut no_llgr = make_destless_flowspec_route(Afi::Ipv4, source, 17);
+            no_llgr.attributes.push(PathAttribute::Communities(vec![
+                rustbgpd_wire::COMMUNITY_NO_LLGR,
+            ]));
+            routes.push(no_llgr);
+            manager.handle_update(RibUpdate::RoutesReceived {
+                session_id: 0,
+                peer,
+                announced: vec![],
+                withdrawn: vec![],
+                flowspec_announced: routes,
+                flowspec_withdrawn: vec![],
+                evpn_announced: vec![],
+                evpn_withdrawn: vec![],
+            });
+            drain_route_chunks(&mut manager);
+            assert_flowspec_gauge(&manager, peer, 5);
+            assert!(manager.handle_peer_graceful_restart(
+                peer,
+                0,
+                120,
+                360,
+                vec![(Afi::Ipv4, Safi::FlowSpec), (Afi::Ipv6, Safi::FlowSpec)],
+                llgr,
+                vec![rustbgpd_wire::LlgrFamily {
+                    afi: Afi::Ipv4,
+                    safi: Safi::FlowSpec,
+                    forwarding_preserved: true,
+                    stale_time: 300
+                }],
+                if llgr { 300 } else { 0 },
+            ));
+            assert_flowspec_gauge(&manager, peer, 5);
+            if llgr {
+                manager.sweep_gr_stale(peer);
+                // IPv6 is outside LLGR; the IPv4 NO_LLGR rule is also purged.
+                assert_eq!(manager.ribs[&peer].flowspec_len(), 2);
+                assert!(
+                    manager.ribs[&peer]
+                        .iter_flowspec()
+                        .all(|route| route.is_llgr_stale)
+                );
+                assert_flowspec_gauge(&manager, peer, 2);
+            }
+            // Keep an active outbound registration so timer cleanup retains the
+            // re-advertised path instead of tearing down a departed peer.
+            let (out_tx, _out_rx) = mpsc::channel(64);
+            manager.outbound_peers.insert(peer, out_tx);
+            // One re-advertised path survives either EOR or timer cleanup.
+            refreshed.is_stale = false;
+            manager.handle_update(RibUpdate::RoutesReceived {
+                session_id: 0,
+                peer,
+                announced: vec![],
+                withdrawn: vec![],
+                flowspec_announced: vec![refreshed],
+                flowspec_withdrawn: vec![],
+                evpn_announced: vec![],
+                evpn_withdrawn: vec![],
+            });
+            drain_route_chunks(&mut manager);
+            assert_flowspec_gauge(&manager, peer, if llgr { 2 } else { 5 });
+            if end_of_rib {
+                manager.handle_end_of_rib(peer, Afi::Ipv4, Safi::FlowSpec);
+                assert_flowspec_gauge(&manager, peer, if llgr { 1 } else { 3 });
+                if !llgr {
+                    assert!(
+                        manager.ribs[&peer]
+                            .iter_flowspec()
+                            .filter(|route| route.afi == Afi::Ipv6)
+                            .all(|route| route.is_stale)
+                    );
+                    manager.handle_end_of_rib(peer, Afi::Ipv6, Safi::FlowSpec);
+                }
+            } else if llgr {
+                manager.sweep_llgr_stale(peer, &[(Afi::Ipv4, Safi::FlowSpec)]);
+            } else {
+                manager.sweep_gr_stale(peer);
+            }
+            assert_eq!(manager.ribs[&peer].flowspec_len(), 1);
+            assert_flowspec_gauge(&manager, peer, 1);
+            manager.peer_down_teardown(peer);
+            assert!(!manager.ribs.contains_key(&peer));
+            assert_flowspec_gauge(&manager, peer, 0);
+            manager.peer_down_teardown(peer);
+            assert_flowspec_gauge(&manager, peer, 0);
+        }
+    }
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
     reason = "one GR-entry matrix checks exact path removal, retained families, fallback, and committed downstream state"
-)]
-#[expect(
-    clippy::float_cmp,
-    reason = "the exported integer gauge must contain exactly zero or three routes"
 )]
 async fn flowspec_gr_omitted_families_withdraw_all_paths_and_redistribute() {
     for omitted_afi in [Afi::Ipv4, Afi::Ipv6] {
@@ -377,26 +507,10 @@ async fn flowspec_gr_omitted_families_withdraw_all_paths_and_redistribute() {
                     assert_eq!(withdrawn, vec![key.clone()]);
                     assert!(announced.iter().all(|route| route.selection_key() != key));
                 }
-                let metrics = manager.metrics.registry().gather();
-                let gauge = metrics
-                    .iter()
-                    .find(|metric| metric.name() == "bgp_rib_prefixes")
-                    .unwrap();
-                let sample = gauge
-                    .metric
-                    .iter()
-                    .find(|metric| {
-                        metric.label.iter().any(|label| {
-                            label.name() == "peer" && label.value() == source.to_string()
-                        }) && metric
-                            .label
-                            .iter()
-                            .any(|label| label.name() == "afi_safi" && label.value() == "flowspec")
-                    })
-                    .unwrap();
-                assert_eq!(
-                    sample.gauge.value(),
-                    if preserve_other_flowspec { 3.0 } else { 0.0 }
+                assert_flowspec_gauge(
+                    &manager,
+                    source,
+                    if preserve_other_flowspec { 3 } else { 0 },
                 );
             }
         }

--- a/crates/rib/src/manager/tests/flowspec.rs
+++ b/crates/rib/src/manager/tests/flowspec.rs
@@ -202,6 +202,210 @@ async fn dirty_resync_retries_flowspec_updates() {
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
+    reason = "one GR-entry matrix checks exact path removal, retained families, fallback, and committed downstream state"
+)]
+#[expect(
+    clippy::float_cmp,
+    reason = "the exported integer gauge must contain exactly zero or three routes"
+)]
+async fn flowspec_gr_omitted_families_withdraw_all_paths_and_redistribute() {
+    for omitted_afi in [Afi::Ipv4, Afi::Ipv6] {
+        for preserve_other_flowspec in [false, true] {
+            for fallback in [false, true] {
+                let other_afi = if omitted_afi == Afi::Ipv4 {
+                    Afi::Ipv6
+                } else {
+                    Afi::Ipv4
+                };
+                let source_v4 = Ipv4Addr::new(10, 0, 0, 1);
+                let source = IpAddr::V4(source_v4);
+                let alternate_v4 = Ipv4Addr::new(10, 0, 0, 2);
+                let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 100));
+                let (_tx, rx) = mpsc::channel(64);
+                let mut manager =
+                    RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+                // The same destination-less rule is legal in both AFIs. Remove every
+                // Add-Path identity of the omitted family without touching the other.
+                let omitted = make_destless_flowspec_route(omitted_afi, source_v4, 6);
+                let retained = make_destless_flowspec_route(other_afi, source_v4, 6);
+                let mut routes = Vec::new();
+                for route in [&omitted, &retained] {
+                    if route.afi == other_afi && !preserve_other_flowspec {
+                        continue;
+                    }
+                    for path_id in [0, 7, 19] {
+                        let mut route = route.clone();
+                        route.path_id = path_id;
+                        route.attributes.push(PathAttribute::LocalPref(200));
+                        routes.push(route);
+                    }
+                }
+                let unicast =
+                    make_route(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24), source_v4);
+                let prefix = unicast.prefix;
+                manager.handle_update(RibUpdate::RoutesReceived {
+                    session_id: 0,
+                    peer: source,
+                    announced: vec![unicast],
+                    withdrawn: vec![],
+                    flowspec_announced: routes,
+                    flowspec_withdrawn: vec![],
+                    evpn_announced: vec![],
+                    evpn_withdrawn: vec![],
+                });
+                drain_route_chunks(&mut manager);
+                if fallback {
+                    let mut route = make_destless_flowspec_route(omitted_afi, alternate_v4, 6);
+                    route.path_id = 31;
+                    route.attributes.push(PathAttribute::LocalPref(100));
+                    let alternate = IpAddr::V4(alternate_v4);
+                    manager.handle_update(RibUpdate::RoutesReceived {
+                        session_id: 0,
+                        peer: alternate,
+                        announced: vec![],
+                        withdrawn: vec![],
+                        flowspec_announced: vec![route],
+                        flowspec_withdrawn: vec![],
+                        evpn_announced: vec![],
+                        evpn_withdrawn: vec![],
+                    });
+                    drain_route_chunks(&mut manager);
+                }
+                let key = omitted.selection_key();
+                assert_eq!(manager.loc_rib.get_flowspec(&key).unwrap().peer, source);
+                let (out_tx, mut out_rx) = mpsc::channel(64);
+                manager.handle_update(RibUpdate::PeerUp {
+                    per_client_best: false,
+                    interpret_rfc1997: true,
+                    session_id: 0,
+                    peer: target,
+                    peer_asn: 65000,
+                    peer_router_id: Ipv4Addr::UNSPECIFIED,
+                    outbound_tx: out_tx,
+                    export_policy: None,
+                    sendable_families: vec![
+                        (Afi::Ipv4, Safi::Unicast),
+                        (Afi::Ipv4, Safi::FlowSpec),
+                        (Afi::Ipv6, Safi::FlowSpec),
+                    ],
+                    is_ebgp: true,
+                    route_reflector_client: false,
+                    orr_vantage: None,
+                    add_path_send_families: vec![],
+                    add_path_send_max: 0,
+                    negotiated_orf_recv: vec![],
+                    negotiated_llgr_families: vec![],
+                });
+                assert_eq!(
+                    manager.adj_ribs_out[&target]
+                        .get_flowspec(&key)
+                        .unwrap()
+                        .peer,
+                    source
+                );
+                while out_rx.try_recv().is_ok() {}
+                let mut gr_families = vec![(Afi::Ipv4, Safi::Unicast)];
+                if preserve_other_flowspec {
+                    gr_families.push((other_afi, Safi::FlowSpec));
+                }
+                assert!(manager.handle_peer_graceful_restart(
+                    source,
+                    0,
+                    120,
+                    360,
+                    gr_families,
+                    false,
+                    vec![],
+                    0,
+                ));
+                let rib = &manager.ribs[&source];
+                assert!(
+                    rib.iter_flowspec().all(|route| route.afi != omitted_afi),
+                    "all paths must be removed for {omitted_afi:?}"
+                );
+                assert_eq!(
+                    rib.flowspec_len(),
+                    if preserve_other_flowspec { 3 } else { 0 }
+                );
+                assert!(rib.iter_flowspec().all(|route| route.is_stale));
+                assert!(rib.iter().all(|route| route.is_stale));
+                assert!(manager.loc_rib.get(&prefix).unwrap().is_stale);
+                if preserve_other_flowspec {
+                    assert!(
+                        manager
+                            .loc_rib
+                            .get_flowspec(&retained.selection_key())
+                            .unwrap()
+                            .is_stale
+                    );
+                    assert!(
+                        manager.adj_ribs_out[&target]
+                            .get_flowspec(&retained.selection_key())
+                            .is_some()
+                    );
+                }
+                let mut withdrawn = Vec::new();
+                let mut announced = Vec::new();
+                while let Ok(update) = out_rx.try_recv() {
+                    assert!(
+                        update.withdraw.is_empty(),
+                        "preserved unicast must not be withdrawn"
+                    );
+                    withdrawn.extend(update.flowspec_withdraw);
+                    announced.extend(update.flowspec_announce);
+                }
+                if fallback {
+                    let best = manager.loc_rib.get_flowspec(&key).unwrap();
+                    assert_eq!(best.peer, IpAddr::V4(alternate_v4));
+                    assert!(!best.is_stale);
+                    assert_eq!(
+                        manager.adj_ribs_out[&target]
+                            .get_flowspec(&key)
+                            .unwrap()
+                            .peer,
+                        best.peer
+                    );
+                    assert!(withdrawn.is_empty());
+                    assert!(
+                        announced
+                            .iter()
+                            .any(|route| route.selection_key() == key && route.peer == best.peer)
+                    );
+                } else {
+                    assert!(manager.loc_rib.get_flowspec(&key).is_none());
+                    assert!(manager.adj_ribs_out[&target].get_flowspec(&key).is_none());
+                    assert_eq!(withdrawn, vec![key.clone()]);
+                    assert!(announced.iter().all(|route| route.selection_key() != key));
+                }
+                let metrics = manager.metrics.registry().gather();
+                let gauge = metrics
+                    .iter()
+                    .find(|metric| metric.name() == "bgp_rib_prefixes")
+                    .unwrap();
+                let sample = gauge
+                    .metric
+                    .iter()
+                    .find(|metric| {
+                        metric.label.iter().any(|label| {
+                            label.name() == "peer" && label.value() == source.to_string()
+                        }) && metric
+                            .label
+                            .iter()
+                            .any(|label| label.name() == "afi_safi" && label.value() == "flowspec")
+                    })
+                    .unwrap();
+                assert_eq!(
+                    sample.gauge.value(),
+                    if preserve_other_flowspec { 3.0 } else { 0.0 }
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
     reason = "covers the stale demotion, RFC 4724 §4.1 re-advertise-before-EoR, and best-path flip-back in one scenario"
 )]
 async fn gr_flowspec_eor_recomputes_and_redistributes() {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1677,10 +1677,11 @@ Operational note:
 Graceful Restart is enabled by default. rustbgpd implements:
 
 - **Helper mode (receiving speaker):** when a peer with GR capability
-  restarts, its routes are preserved as stale during the restart window
-  instead of being immediately withdrawn. End-of-RIB markers from the peer
-  clear stale flags per address family; if the timer expires before all
-  End-of-RIB markers arrive, remaining stale routes are swept.
+  restarts, routes for families listed in its GR capability are preserved as
+  stale during the restart window. Routes for omitted families, including
+  IPv4/IPv6 FlowSpec, are immediately withdrawn. Re-advertisements replace
+  stale routes; each End-of-RIB marker removes the remaining stale routes
+  for that family. If the timer expires first, remaining stale routes are swept.
 - **Minimal restarting-speaker mode:** after a coordinated daemon restart,
   rustbgpd can temporarily advertise `restart_state = true` to static peers
   restored from config, using a marker file under `runtime_state_dir`.


### PR DESCRIPTION
A peer restarting with Graceful Restart coverage for unicast but not FlowSpec previously left its FlowSpec rules active. Remove every path for an omitted IPv4/IPv6 FlowSpec family at GR entry, then use the existing selection and distribution path to advertise an alternate source or withdraw the rule downstream. Covered families remain stale.

Keep the peer FlowSpec Adj-RIB-In gauge accurate after GR entry, GR/LLGR promotion and expiry, End-of-RIB cleanup, and hard peer teardown. The configuration reference describes family-scoped retention and stale-route cleanup.

Regression coverage includes identical destination-less rules across AFIs, multiple path IDs, mixed GR coverage, alternate-source selection, committed downstream withdrawals, NO_LLGR cleanup, fresh-path survival, and repeated teardown. Both the route-retention and stale-gauge regressions fail against their prior implementations.

Validation: the original fix passed focused FlowSpec tests, strict RIB Clippy, `just gate`, `just gate-rib`, `just gate-deps`, and `just gate-contract`. The metric follow-up passed focused lifecycle and withdrawal regressions, strict RIB Clippy, formatting and lint-reason checks, and normal commit/push hooks, including workspace library tests and rustdoc.
