### PR TITLE
fix(cli): bound unary read response deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -816,6 +816,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sequence. Re-baseline alerts keyed on that counter for multihomed VNIs;
   single-homed VNIs are unaffected.
 
+- Lightweight native CLI reads now bound the complete RPC response to
+  30 seconds per call or page, so stalled TCP or Unix-socket endpoints
+  cannot hang scripts indefinitely. Doctor preserves successful evidence
+  and marks timed-out sections incomplete, with a separate allowance for
+  large effective-config exports. A failed health collection no longer
+  leaves the system section marked collected.
+
 ## [0.68.0] — 2026-08-30
 
 > **Release framing — broader control surfaces, faster route-server release.**

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -17,6 +17,22 @@ rbgp metrics      # Prometheus metrics snapshot
 rbgp top          # live terminal dashboard
 ```
 
+Lightweight one-shot reads have a 30-second deadline for the complete RPC
+response, including its body, on TCP and Unix sockets. Each automatically
+fetched RIB page gets its own deadline; a failed later page exits with an
+error before printing an incomplete listing. Timeout errors name the RPC
+and its budget. Config status and history are lightweight snapshots with the
+same limit. The CLI does not retry these reads automatically.
+
+Doctor keeps successfully collected evidence when a read times out and marks
+the affected bundle section incomplete. Its effective-config export has a
+separate 30-minute-and-30-second allowance for the server's supported large
+configuration operation and response transfer. This is a per-call limit, not
+a 30-second limit on the whole doctor command. Long-running config diff,
+plan, and effective export, config mutations and streams, advertised diff's
+aggregate deadline, TUI refresh limits, live watches, MRT dump completion,
+and other mutations retain their existing behavior.
+
 In `rbgp top`, select a peer and open its detail, then press `r` to open the
 on-demand route explorer. `v` cycles the global unicast Best table and the
 peer's Received, Advertised, and Rejected tables, `f` toggles IPv4/IPv6

--- a/crates/cli/src/commands/bfd.rs
+++ b/crates/cli/src/commands/bfd.rs
@@ -1,6 +1,6 @@
 //! `rbgp bfd` — BFD session inspection (ADR-0067; single-hop and multihop).
 
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::bfd_service_client::BfdServiceClient;
@@ -64,12 +64,14 @@ fn human_diagnostic(session: &BfdSession) -> String {
 async fn fetch(connection: Connection, peer: Option<&str>) -> Result<Vec<BfdSession>, CliError> {
     let mut client =
         BfdServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .get_bfd_sessions(GetBfdSessionsRequest {
+    let resp = read_rpc(
+        "GetBfdSessions",
+        client.get_bfd_sessions(GetBfdSessionsRequest {
             peer_address: peer.unwrap_or_default().to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     Ok(resp.sessions)
 }
 

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -1,4 +1,4 @@
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::config_service_client::ConfigServiceClient;
@@ -568,10 +568,12 @@ pub async fn abort(connection: Connection, confirm_id: &str, json: bool) -> Resu
 pub async fn status(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .get_config_transaction_status(GetConfigTransactionStatusRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "GetConfigTransactionStatus",
+        client.get_config_transaction_status(GetConfigTransactionStatusRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         print_json(status_to_json(&resp))?;
@@ -588,10 +590,12 @@ pub async fn status(connection: Connection, json: bool) -> Result<(), CliError> 
 pub async fn history(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_config_history(ListConfigHistoryRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListConfigHistory",
+        client.list_config_history(ListConfigHistoryRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         print_json(history_to_json(&resp))?;

--- a/crates/cli/src/commands/control.rs
+++ b/crates/cli/src/commands/control.rs
@@ -1,4 +1,4 @@
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, JsonHealth, outln};
 use crate::proto::control_service_client::ControlServiceClient;
@@ -93,7 +93,9 @@ pub(crate) fn rpki_cache_end_of_data_readiness(
 pub async fn health(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client.get_health(HealthRequest {}).await?.into_inner();
+    let resp = read_rpc("GetHealth", client.get_health(HealthRequest {}))
+        .await?
+        .into_inner();
 
     if json {
         let out = JsonHealth {
@@ -115,7 +117,9 @@ pub async fn health(connection: Connection, json: bool) -> Result<(), CliError> 
 pub async fn metrics(connection: Connection) -> Result<(), CliError> {
     let mut client =
         ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client.get_metrics(MetricsRequest {}).await?.into_inner();
+    let resp = read_rpc("GetMetrics", client.get_metrics(MetricsRequest {}))
+        .await?
+        .into_inner();
     output::print_text(&resp.prometheus_text)?;
     Ok(())
 }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -11,12 +11,14 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
 use crate::commands::watch::bgp_event_json_value;
-use crate::connection::Connection;
+use crate::connection::{
+    Connection, EFFECTIVE_CONFIG_RPC_TIMEOUT, READ_RPC_TIMEOUT, rpc_with_timeout,
+};
 use crate::error::CliError;
 use crate::output::{self, JsonNeighbor, outln};
 use crate::proto::bfd_service_client::BfdServiceClient;
@@ -1918,6 +1920,21 @@ pub(crate) async fn run(
     connection: Result<Connection, CliError>,
     opts: &DoctorOptions<'_>,
 ) -> Result<i32, CliError> {
+    run_with_deadlines(
+        connection,
+        opts,
+        READ_RPC_TIMEOUT,
+        EFFECTIVE_CONFIG_RPC_TIMEOUT,
+    )
+    .await
+}
+
+async fn run_with_deadlines(
+    connection: Result<Connection, CliError>,
+    opts: &DoctorOptions<'_>,
+    read_budget: Duration,
+    effective_config_budget: Duration,
+) -> Result<i32, CliError> {
     let now = now_unix_seconds();
     let mut reporter = Reporter {
         json: opts.json,
@@ -1963,10 +1980,13 @@ pub(crate) async fn run(
                 connection.interceptor(),
             );
 
-            let posture = policy
-                .get_validation_policy_posture(GetValidationPolicyPostureRequest {})
-                .await
-                .map(|response| response.into_inner());
+            let posture = rpc_with_timeout(
+                "GetValidationPolicyPosture",
+                read_budget,
+                policy.get_validation_policy_posture(GetValidationPolicyPostureRequest {}),
+            )
+            .await
+            .map(|response| response.into_inner());
             for check in validation_policy_posture_checks(posture) {
                 reporter.record(check.name, check.status, check.detail)?;
             }
@@ -1974,7 +1994,12 @@ pub(crate) async fn run(
             // system/health.json + the healthy check. The same probe outcome
             // feeds the daemon.authz.* triage: a PERMISSION_DENIED here is an
             // authorization finding, not a health one.
-            let health_result = control.get_health(HealthRequest {}).await;
+            let health_result = rpc_with_timeout(
+                "GetHealth",
+                read_budget,
+                control.get_health(HealthRequest {}),
+            )
+            .await;
             if let Some(check) = authz_reachable_check(health_result.as_ref().err()) {
                 reporter.record(check.name, check.status, check.detail)?;
             }
@@ -2022,11 +2047,18 @@ pub(crate) async fn run(
                         CheckStatus::Fail,
                         format!("health RPC failed: {e}"),
                     )?;
+                    sections.insert("system", format!("partial: health RPC failed: {e}"));
                 }
             }
 
             // system/global.json.
-            match global.get_global(GetGlobalRequest {}).await {
+            match rpc_with_timeout(
+                "GetGlobal",
+                read_budget,
+                global.get_global(GetGlobalRequest {}),
+            )
+            .await
+            {
                 Ok(resp) => {
                     let global_state = resp.into_inner();
                     tcp_ao_support = global_state.tcp_ao_support;
@@ -2048,7 +2080,13 @@ pub(crate) async fn run(
             }
 
             // system/metrics.prom.
-            match control.get_metrics(MetricsRequest {}).await {
+            match rpc_with_timeout(
+                "GetMetrics",
+                read_budget,
+                control.get_metrics(MetricsRequest {}),
+            )
+            .await
+            {
                 Ok(resp) => {
                     let text = resp.into_inner().prometheus_text;
                     bundle.add("system/metrics.prom", redact_text(&text).into_bytes());
@@ -2062,9 +2100,12 @@ pub(crate) async fn run(
             // config/effective.toml: the daemon's own redacted, normalized
             // dump (same RPC as `rbgp config effective`). Never the raw file.
             let mut config_client = connection.effective_config_client();
-            match config_client
-                .get_effective_config(GetEffectiveConfigRequest {})
-                .await
+            match rpc_with_timeout(
+                "GetEffectiveConfig",
+                effective_config_budget,
+                config_client.get_effective_config(GetEffectiveConfigRequest {}),
+            )
+            .await
             {
                 Ok(resp) => {
                     let toml_text = resp.into_inner().toml;
@@ -2098,11 +2139,14 @@ pub(crate) async fn run(
             // red/yellow/green checks. The RPC is bounded by the same tonic
             // request path as the other daemon snapshots; no packet probing is
             // performed by doctor.
-            let bfd_collected = match bfd
-                .get_bfd_sessions(GetBfdSessionsRequest {
+            let bfd_collected = match rpc_with_timeout(
+                "GetBfdSessions",
+                read_budget,
+                bfd.get_bfd_sessions(GetBfdSessionsRequest {
                     peer_address: String::new(),
-                })
-                .await
+                }),
+            )
+            .await
             {
                 Ok(resp) => {
                     let snapshots: Vec<BfdSnapshot> = resp
@@ -2129,10 +2173,18 @@ pub(crate) async fn run(
             // remains harmless; if the snapshot already shows the resulting
             // non-Established state, the later history query includes the
             // disable evidence.
-            let neighbor_snapshot = neighbor.list_neighbors(ListNeighborsRequest {}).await;
-            let dynamic_neighbor_snapshot = match neighbor
-                .list_dynamic_neighbors(ListDynamicNeighborsRequest {})
-                .await
+            let neighbor_snapshot = rpc_with_timeout(
+                "ListNeighbors",
+                read_budget,
+                neighbor.list_neighbors(ListNeighborsRequest {}),
+            )
+            .await;
+            let dynamic_neighbor_snapshot = match rpc_with_timeout(
+                "ListDynamicNeighbors",
+                read_budget,
+                neighbor.list_dynamic_neighbors(ListDynamicNeighborsRequest {}),
+            )
+            .await
             {
                 Ok(resp) => {
                     let snapshots: Vec<DynamicNeighborSnapshot> = resp
@@ -2156,13 +2208,16 @@ pub(crate) async fn run(
                     None
                 }
             };
-            let (session_events, session_history_available) = match events
-                .list_session_events(ListSessionEventsRequest {
+            let (session_events, session_history_available) = match rpc_with_timeout(
+                "ListSessionEvents",
+                read_budget,
+                events.list_session_events(ListSessionEventsRequest {
                     neighbor_address: String::new(),
                     event_types: Vec::new(),
                     limit: EVENT_HISTORY_LIMIT,
-                })
-                .await
+                }),
+            )
+            .await
             {
                 Ok(resp) => (
                     resp.into_inner()
@@ -2186,13 +2241,16 @@ pub(crate) async fn run(
             sections
                 .entry("session_events")
                 .or_insert_with(|| "collected".to_string());
-            let policy_events = match events
-                .list_policy_events(ListPolicyEventsRequest {
+            let policy_events = match rpc_with_timeout(
+                "ListPolicyEvents",
+                read_budget,
+                events.list_policy_events(ListPolicyEventsRequest {
                     neighbor_address: String::new(),
                     event_types: Vec::new(),
                     limit: EVENT_HISTORY_LIMIT,
-                })
-                .await
+                }),
+            )
+            .await
             {
                 Ok(resp) => resp
                     .into_inner()
@@ -2341,13 +2399,6 @@ pub(crate) async fn run(
                             .map(|record| &record.support)
                             .collect::<Vec<_>>(),
                     )?;
-                    bundle.add_json(
-                        "peers/events.json",
-                        &EventsSnapshot {
-                            session: session_events,
-                            policy: policy_events,
-                        },
-                    )?;
                     if bfd_collected {
                         sections.insert("peers", "collected".to_string());
                     }
@@ -2363,6 +2414,15 @@ pub(crate) async fn run(
                     );
                 }
             }
+            // Event history was collected independently of the neighbor snapshot.
+            // Keep it even when that snapshot failed or timed out.
+            bundle.add_json(
+                "peers/events.json",
+                &EventsSnapshot {
+                    session: session_events,
+                    policy: policy_events,
+                },
+            )?;
             sections
                 .entry("system")
                 .or_insert_with(|| "collected".to_string());
@@ -4371,6 +4431,135 @@ paths = ["x"]
             flap_count: flaps,
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn read_deadline_retains_partial_bundle_and_separate_effective_config_budget() {
+        let server = spawn_mock_server(None).await;
+        server.state.health_read_stall.store(true, Ordering::SeqCst);
+        server
+            .state
+            .neighbor_read_stall
+            .store(true, Ordering::SeqCst);
+        server
+            .state
+            .session_events
+            .lock()
+            .await
+            .push(rustbgpd_api::proto::BgpEvent {
+                event_type: rustbgpd_api::proto::BgpEventType::SessionLost as i32,
+                summary: "retained session history".into(),
+                ..Default::default()
+            });
+        server
+            .state
+            .effective_config_delay_ms
+            .store(500, Ordering::SeqCst);
+        let dir = tempfile::tempdir().unwrap();
+        *server.state.config_effective_toml.lock().await = Some(format!(
+            "[global]\nasn = 65000\nruntime_state_dir = \"{}\"\n",
+            dir.path().display()
+        ));
+        let bundle_path = dir.path().join("bundle.tar.gz");
+        let code = run_with_deadlines(
+            connect(&server.addr, None).await,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+            Duration::from_millis(250),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 2);
+        let files = extract_bundle(&bundle_path);
+        assert!(!files.iter().any(|(name, _)| name == "system/health.json"));
+        for retained in [
+            "system/global.json",
+            "system/metrics.prom",
+            "config/effective.toml",
+            "peers/events.json",
+        ] {
+            find(&files, retained);
+        }
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert!(
+            manifest["sections"]["system"]
+                .as_str()
+                .unwrap()
+                .contains("partial: health RPC failed")
+        );
+        assert!(
+            manifest_check(&manifest, "daemon.healthy")["detail"]
+                .as_str()
+                .unwrap()
+                .contains("GetHealth response timed out after 250ms")
+        );
+        assert_eq!(
+            manifest["sections"]["config"],
+            "collected (daemon-redacted effective config)"
+        );
+        assert!(
+            manifest["sections"]["peers"]
+                .as_str()
+                .unwrap()
+                .contains("partial: BFD collected")
+        );
+        assert_eq!(manifest["sections"]["session_events"], "collected");
+        assert!(
+            manifest["sections"]["peers"]
+                .as_str()
+                .unwrap()
+                .contains("ListNeighbors response timed out after 250ms")
+        );
+        assert!(find(&files, "peers/events.json").contains("retained session history"));
+    }
+
+    #[tokio::test]
+    async fn effective_config_deadline_keeps_successful_lightweight_evidence() {
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .effective_config_delay_ms
+            .store(500, Ordering::SeqCst);
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+        run_with_deadlines(
+            connect(&server.addr, None).await,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+            Duration::from_secs(1),
+            Duration::from_millis(20),
+        )
+        .await
+        .unwrap();
+        let files = extract_bundle(&bundle_path);
+        find(&files, "system/health.json");
+        find(&files, "peers/neighbors.json");
+        assert!(
+            !files
+                .iter()
+                .any(|(name, _)| name == "config/effective.toml")
+        );
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert_eq!(manifest["sections"]["system"], "collected");
+        assert!(
+            manifest["sections"]["config"]
+                .as_str()
+                .unwrap()
+                .contains("GetEffectiveConfig response timed out after 20ms")
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -4498,7 +4498,7 @@ paths = ["x"]
             manifest_check(&manifest, "daemon.healthy")["detail"]
                 .as_str()
                 .unwrap()
-                .contains("GetHealth response timed out after 250ms")
+                .contains("GetHealth response timed out after 0.25s")
         );
         assert_eq!(
             manifest["sections"]["config"],
@@ -4515,7 +4515,7 @@ paths = ["x"]
             manifest["sections"]["peers"]
                 .as_str()
                 .unwrap()
-                .contains("ListNeighbors response timed out after 250ms")
+                .contains("ListNeighbors response timed out after 0.25s")
         );
         assert!(find(&files, "peers/events.json").contains("retained session history"));
     }
@@ -4558,7 +4558,7 @@ paths = ["x"]
             manifest["sections"]["config"]
                 .as_str()
                 .unwrap()
-                .contains("GetEffectiveConfig response timed out after 20ms")
+                .contains("GetEffectiveConfig response timed out after 0.02s")
         );
     }
 

--- a/crates/cli/src/commands/dynamic_neighbor.rs
+++ b/crates/cli/src/commands/dynamic_neighbor.rs
@@ -7,7 +7,7 @@
 
 use serde::Serialize;
 
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::neighbor_service_client::NeighborServiceClient;
@@ -27,10 +27,12 @@ struct JsonDynamicRange {
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_dynamic_neighbors(ListDynamicNeighborsRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListDynamicNeighbors",
+        client.list_dynamic_neighbors(ListDynamicNeighborsRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let out: Vec<JsonDynamicRange> = resp

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -1,5 +1,5 @@
 use crate::commands::neighbor::{bare_ip_rpc_address, restore_matching_scoped_address};
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::control_service_client::ControlServiceClient;
@@ -43,8 +43,9 @@ pub async fn list(
     json: bool,
 ) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let mut resp = client
-        .list_evpn_routes(ListEvpnRequest {
+    let mut resp = read_rpc(
+        "ListEvpnRoutes",
+        client.list_evpn_routes(ListEvpnRequest {
             route_type_filter: route_type.unwrap_or(0),
             peer_filter: peer
                 .as_deref()
@@ -52,9 +53,10 @@ pub async fn list(
                 .unwrap_or_default()
                 .to_string(),
             rd_filter: rd.unwrap_or_default(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     for route in &mut resp.routes {
         restore_matching_scoped_address(peer.as_deref(), &mut route.peer_address);
     }
@@ -176,9 +178,17 @@ pub async fn list_peer(
     request.neighbor_address = bare_ip_rpc_address(&peer).to_string();
     let mut client = connection.rib_listing_client();
     let mut response = if received {
-        client.list_received_evpn_routes(request).await?
+        read_rpc(
+            "ListReceivedEvpnRoutes",
+            client.list_received_evpn_routes(request),
+        )
+        .await?
     } else {
-        client.list_advertised_evpn_routes(request).await?
+        read_rpc(
+            "ListAdvertisedEvpnRoutes",
+            client.list_advertised_evpn_routes(request),
+        )
+        .await?
     }
     .into_inner();
     for route in &mut response.routes {
@@ -389,11 +399,12 @@ pub async fn explain(
     let advertised_to = request.advertised_to.clone();
     request.received_from = bare_ip_rpc_address(&received_from).to_string();
     request.advertised_to = bare_ip_rpc_address(&advertised_to).to_string();
-    let mut response = connection
-        .rib_listing_client()
-        .explain_evpn_route(request)
-        .await?
-        .into_inner();
+    let mut response = read_rpc(
+        "ExplainEvpnRoute",
+        connection.rib_listing_client().explain_evpn_route(request),
+    )
+    .await?
+    .into_inner();
     restore_matching_scoped_address(Some(&received_from), &mut response.received_from);
     for route in [
         &mut response.received,
@@ -749,10 +760,12 @@ pub async fn list_duplicate_mac_quarantines(
 ) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_duplicate_mac_quarantines(ListDuplicateMacQuarantinesRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListDuplicateMacQuarantines",
+        client.list_duplicate_mac_quarantines(ListDuplicateMacQuarantinesRequest {}),
+    )
+    .await?
+    .into_inner();
     if json {
         output::print_json_pretty(&serde_json::json!({
             "quarantines": resp.quarantines.iter().map(|row| serde_json::json!({
@@ -826,12 +839,14 @@ pub async fn list_ethernet_segments(
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let filter = esi.unwrap_or_default();
-    let resp = client
-        .list_ethernet_segments(ListEthernetSegmentsRequest {
+    let resp = read_rpc(
+        "ListEthernetSegments",
+        client.list_ethernet_segments(ListEthernetSegmentsRequest {
             esi: filter.clone(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if json {
         output::print_json_pretty(&ethernet_segments_to_json(&resp))?;
@@ -853,10 +868,12 @@ pub async fn list_ethernet_segments(
 pub async fn runtime(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let state = client
-        .get_evpn_runtime(GetEvpnRuntimeRequest {})
-        .await?
-        .into_inner();
+    let state = read_rpc(
+        "GetEvpnRuntime",
+        client.get_evpn_runtime(GetEvpnRuntimeRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         output::print_json_pretty(&runtime_to_json(&state))?;
@@ -887,10 +904,12 @@ pub async fn runtime(connection: Connection, json: bool) -> Result<(), CliError>
 pub async fn list_instances(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_evpn_instances(ListEvpnInstancesRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListEvpnInstances",
+        client.list_evpn_instances(ListEvpnInstancesRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let out: Vec<serde_json::Value> =
@@ -966,10 +985,12 @@ fn evpn_instance_to_json(instance: &EvpnInstanceState) -> serde_json::Value {
 pub async fn list_managed_netdevs(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_managed_netdevs(ListManagedNetdevsRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListManagedNetdevs",
+        client.list_managed_netdevs(ListManagedNetdevsRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let out: Vec<serde_json::Value> = resp.netdevs.iter().map(managed_netdev_to_json).collect();
@@ -1138,10 +1159,12 @@ fn managed_netdev_to_json(row: &ManagedNetdevState) -> serde_json::Value {
 pub async fn list_nexthops(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_evpn_nexthops(ListEvpnNexthopsRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListEvpnNexthops",
+        client.list_evpn_nexthops(ListEvpnNexthopsRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         output::print_json_pretty(&fdb_nexthops_to_json(&resp))?;
@@ -1348,8 +1371,7 @@ fn runtime_mutation_label(state: i32) -> &'static str {
 pub async fn list_ip_vrfs(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_ip_vrfs(ListIpVrfsRequest {})
+    let resp = read_rpc("ListIpVrfs", client.list_ip_vrfs(ListIpVrfsRequest {}))
         .await?
         .into_inner();
 
@@ -1371,8 +1393,7 @@ pub async fn list_ip_vrfs(connection: Connection, json: bool) -> Result<(), CliE
 pub async fn get_ip_vrf(connection: Connection, name: String, json: bool) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let vrf = client
-        .get_ip_vrf(GetIpVrfRequest { name })
+    let vrf = read_rpc("GetIpVrf", client.get_ip_vrf(GetIpVrfRequest { name }))
         .await?
         .into_inner();
 
@@ -1468,36 +1489,41 @@ fn format_ip_vrf_human(vrf: &IpVrfState) -> String {
 pub async fn diagnose(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut evpn_client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let instances = evpn_client
-        .list_evpn_instances(ListEvpnInstancesRequest {})
-        .await?
-        .into_inner()
-        .instances;
+    let instances = read_rpc(
+        "ListEvpnInstances",
+        evpn_client.list_evpn_instances(ListEvpnInstancesRequest {}),
+    )
+    .await?
+    .into_inner()
+    .instances;
 
     let mut rib_client = connection.rib_listing_client();
-    let type2_routes = rib_client
-        .list_evpn_routes(ListEvpnRequest {
+    let type2_routes = read_rpc(
+        "ListEvpnRoutes",
+        rib_client.list_evpn_routes(ListEvpnRequest {
             route_type_filter: 2,
             peer_filter: String::new(),
             rd_filter: String::new(),
-        })
-        .await?
-        .into_inner()
-        .routes;
-    let type3_routes = rib_client
-        .list_evpn_routes(ListEvpnRequest {
+        }),
+    )
+    .await?
+    .into_inner()
+    .routes;
+    let type3_routes = read_rpc(
+        "ListEvpnRoutes",
+        rib_client.list_evpn_routes(ListEvpnRequest {
             route_type_filter: 3,
             peer_filter: String::new(),
             rd_filter: String::new(),
-        })
-        .await?
-        .into_inner()
-        .routes;
+        }),
+    )
+    .await?
+    .into_inner()
+    .routes;
 
     let mut control_client =
         ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let metrics = control_client
-        .get_metrics(MetricsRequest {})
+    let metrics = read_rpc("GetMetrics", control_client.get_metrics(MetricsRequest {}))
         .await?
         .into_inner()
         .prometheus_text;

--- a/crates/cli/src/commands/fib_table.rs
+++ b/crates/cli/src/commands/fib_table.rs
@@ -8,7 +8,7 @@
 
 use serde::Serialize;
 
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::rib_service_client::RibServiceClient;
@@ -104,10 +104,12 @@ fn render(resp: &ListFibTablesResponse, json: bool) -> Result<(), CliError> {
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_fib_tables(ListFibTablesRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListFibTables",
+        client.list_fib_tables(ListFibTablesRequest {}),
+    )
+    .await?
+    .into_inner();
     render(&resp, json)
 }
 

--- a/crates/cli/src/commands/flowspec.rs
+++ b/crates/cli/src/commands/flowspec.rs
@@ -1,4 +1,4 @@
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::injection_service_client::InjectionServiceClient;
@@ -62,12 +62,14 @@ fn format_action(a: &FlowSpecAction) -> String {
 
 pub async fn list(connection: Connection, family: Option<i32>, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
-        .list_flow_spec_routes(ListFlowSpecRequest {
+    let resp = read_rpc(
+        "ListFlowSpecRoutes",
+        client.list_flow_spec_routes(ListFlowSpecRequest {
             afi_safi: family.unwrap_or(0),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let out: Vec<serde_json::Value> = resp

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -1,4 +1,4 @@
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, JsonGlobal, outln};
 use crate::proto::GetGlobalRequest;
@@ -16,7 +16,9 @@ fn tcp_ao_support_label(value: i32) -> &'static str {
 pub async fn run(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         GlobalServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client.get_global(GetGlobalRequest {}).await?.into_inner();
+    let resp = read_rpc("GetGlobal", client.get_global(GetGlobalRequest {}))
+        .await?
+        .into_inner();
 
     if json {
         let out = JsonGlobal {

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{
     self, JsonEffectiveNeighborPosture, JsonInboundPrefixLimit, JsonNegotiatedGracefulRestart,
@@ -92,21 +92,25 @@ async fn neighbor_list_view(
 ) -> Result<NeighborListView, CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_neighbors(ListNeighborsRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListNeighbors",
+        client.list_neighbors(ListNeighborsRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let out: Vec<JsonNeighbor> = resp.neighbors.iter().map(json_neighbor).collect();
         Ok(NeighborListView::Json(out))
     } else if resp.neighbors.is_empty() {
-        let dynamic_range_count = client
-            .list_dynamic_neighbors(ListDynamicNeighborsRequest {})
-            .await?
-            .into_inner()
-            .ranges
-            .len();
+        let dynamic_range_count = read_rpc(
+            "ListDynamicNeighbors",
+            client.list_dynamic_neighbors(ListDynamicNeighborsRequest {}),
+        )
+        .await?
+        .into_inner()
+        .ranges
+        .len();
         Ok(NeighborListView::Empty(empty_neighbor_list_message(
             dynamic_range_count,
         )))
@@ -197,15 +201,17 @@ async fn query_neighbor(
     let (address_only, interface) = split_scoped_address(address);
     let (compare_address, compare_interface) =
         compare.map(split_scoped_address).unwrap_or_default();
-    let state = client
-        .get_neighbor_state(GetNeighborStateRequest {
+    let state = read_rpc(
+        "GetNeighborState",
+        client.get_neighbor_state(GetNeighborStateRequest {
             address: address_only,
             interface,
             compare_address,
             compare_interface,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     match compare {
         Some(comparison) => json_update_group_comparison(
             address,

--- a/crates/cli/src/commands/neighbor_set.rs
+++ b/crates/cli/src/commands/neighbor_set.rs
@@ -7,7 +7,7 @@
 use serde::Serialize;
 
 use crate::commands::policy_input::{JsonNeighborSetDefinition, load_json};
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::policy_service_client::PolicyServiceClient;
@@ -34,10 +34,12 @@ struct JsonNeighborSetDetail {
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_neighbor_sets(ListNeighborSetsRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListNeighborSets",
+        client.list_neighbor_sets(ListNeighborSetsRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let out: Vec<JsonNeighborSetSummary> = resp
@@ -80,12 +82,14 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
 pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .get_neighbor_set(GetNeighborSetRequest {
+    let resp = read_rpc(
+        "GetNeighborSet",
+        client.get_neighbor_set(GetNeighborSetRequest {
             name: name.to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     let def = resp.definition.unwrap_or_default();
     if json {

--- a/crates/cli/src/commands/orr.rs
+++ b/crates/cli/src/commands/orr.rs
@@ -1,7 +1,7 @@
 //! `rbgp orr` — RFC 9107 ORR per-vantage status (resolution, SPF reach,
 //! bound peers) plus topology totals.
 
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::{
@@ -15,10 +15,12 @@ const NO_ACTIVE_VANTAGES: &str = "No active ORR vantages (none registered by liv
 
 pub async fn status(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
-        .list_orr_status(ListOrrStatusRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListOrrStatus",
+        client.list_orr_status(ListOrrStatusRequest {}),
+    )
+    .await?
+    .into_inner();
     print_orr_status(&resp, json)
 }
 

--- a/crates/cli/src/commands/peer_group.rs
+++ b/crates/cli/src/commands/peer_group.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::commands::neighbor::bare_ip_rpc_address;
 use crate::commands::policy_input::{JsonPeerGroupDefinition, load_json};
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::peer_group_service_client::PeerGroupServiceClient;
@@ -126,10 +126,12 @@ fn json_peer_group_detail(
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         PeerGroupServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_peer_groups(ListPeerGroupsRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListPeerGroups",
+        client.list_peer_groups(ListPeerGroupsRequest {}),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let out: Vec<JsonPeerGroupSummary> = resp
@@ -173,12 +175,14 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
 pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         PeerGroupServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .get_peer_group(GetPeerGroupRequest {
+    let resp = read_rpc(
+        "GetPeerGroup",
+        client.get_peer_group(GetPeerGroupRequest {
             name: name.to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     let def = resp.definition.unwrap_or_default();
     if json {

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 
 use crate::commands::neighbor::bare_ip_rpc_address;
 use crate::commands::policy_input::{JsonPolicyDefinition, load_json};
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::policy_service_client::PolicyServiceClient;
@@ -767,8 +767,9 @@ pub async fn test(
     };
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .test_policy(proto::TestPolicyRequest {
+    let resp = read_rpc(
+        "TestPolicy",
+        client.test_policy(proto::TestPolicyRequest {
             rpol_source,
             policy: opts.policy.to_string(),
             direction: opts.direction.to_string(),
@@ -780,9 +781,10 @@ pub async fn test(
             afi_safi: afi_safi as i32,
             limit: opts.limit,
             show_changes: opts.show_changes,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if json {
         #[derive(Serialize)]
@@ -943,16 +945,18 @@ pub async fn stats(
 ) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .get_policy_stats(GetPolicyStatsRequest {
+    let resp = read_rpc(
+        "GetPolicyStats",
+        client.get_policy_stats(GetPolicyStatsRequest {
             peer_address: peer
                 .map(bare_ip_rpc_address)
                 .unwrap_or_default()
                 .to_string(),
             direction: direction.to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if json {
         let chains: Vec<JsonPolicyStats> = resp
@@ -1079,8 +1083,7 @@ pub async fn stats(
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_policies(ListPoliciesRequest {})
+    let resp = read_rpc("ListPolicies", client.list_policies(ListPoliciesRequest {}))
         .await?
         .into_inner();
 
@@ -1120,12 +1123,14 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
 pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .get_policy(GetPolicyRequest {
+    let resp = read_rpc(
+        "GetPolicy",
+        client.get_policy(GetPolicyRequest {
             name: name.to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     let def = resp.definition.unwrap_or_default();
     if json {
@@ -1384,16 +1389,18 @@ pub async fn explain_import(
     let (addr, prefix_length, afi_safi) = parse_cidr(prefix)?;
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .explain_import_policy(ExplainImportPolicyRequest {
+    let resp = read_rpc(
+        "ExplainImportPolicy",
+        client.explain_import_policy(ExplainImportPolicyRequest {
             peer_address: bare_ip_rpc_address(neighbor).to_string(),
             afi_safi: afi_safi as i32,
             prefix: addr,
             prefix_length,
             path_id,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     // LAN-320: cache-disabled / no-session mean the daemon could not
     // evaluate the question — surface an error (nonzero exit) instead
@@ -1644,12 +1651,14 @@ pub async fn chain_show(
 
     let (import, export, address) = match neighbor {
         Some(addr) => {
-            let resp = client
-                .get_neighbor_policy_chains(GetNeighborPolicyChainsRequest {
+            let resp = read_rpc(
+                "GetNeighborPolicyChains",
+                client.get_neighbor_policy_chains(GetNeighborPolicyChainsRequest {
                     address: bare_ip_rpc_address(addr).to_string(),
-                })
-                .await?
-                .into_inner();
+                }),
+            )
+            .await?
+            .into_inner();
             (
                 resp.import_policy_names,
                 resp.export_policy_names,
@@ -1657,10 +1666,12 @@ pub async fn chain_show(
             )
         }
         None => {
-            let resp = client
-                .get_global_policy_chains(GetGlobalPolicyChainsRequest {})
-                .await?
-                .into_inner();
+            let resp = read_rpc(
+                "GetGlobalPolicyChains",
+                client.get_global_policy_chains(GetGlobalPolicyChainsRequest {}),
+            )
+            .await?
+            .into_inner();
             (resp.import_policy_names, resp.export_policy_names, None)
         }
     };

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -1,5 +1,5 @@
 use crate::commands::neighbor::{bare_ip_rpc_address, restore_matching_scoped_address};
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{
     self, JsonExplainAdvertisedRoute, JsonExplainModifications, JsonExplainReason,
@@ -226,9 +226,23 @@ async fn fetch_route_listing(
     let mut routes = Vec::new();
     loop {
         let resp = match rpc {
-            RouteListRpc::Best => client.list_best_routes(req.clone()).await?,
-            RouteListRpc::Received => client.list_received_routes(req.clone()).await?,
-            RouteListRpc::Advertised => client.list_advertised_routes(req.clone()).await?,
+            RouteListRpc::Best => {
+                read_rpc("ListBestRoutes", client.list_best_routes(req.clone())).await?
+            }
+            RouteListRpc::Received => {
+                read_rpc(
+                    "ListReceivedRoutes",
+                    client.list_received_routes(req.clone()),
+                )
+                .await?
+            }
+            RouteListRpc::Advertised => {
+                read_rpc(
+                    "ListAdvertisedRoutes",
+                    client.list_advertised_routes(req.clone()),
+                )
+                .await?
+            }
         }
         .into_inner();
         let total_count = resp.total_count;
@@ -258,9 +272,13 @@ async fn fetch_route_count(
     req.page_size = 1;
     req.page_token.clear();
     let resp = match rpc {
-        RouteListRpc::Best => client.list_best_routes(req).await?,
-        RouteListRpc::Received => client.list_received_routes(req).await?,
-        RouteListRpc::Advertised => client.list_advertised_routes(req).await?,
+        RouteListRpc::Best => read_rpc("ListBestRoutes", client.list_best_routes(req)).await?,
+        RouteListRpc::Received => {
+            read_rpc("ListReceivedRoutes", client.list_received_routes(req)).await?
+        }
+        RouteListRpc::Advertised => {
+            read_rpc("ListAdvertisedRoutes", client.list_advertised_routes(req)).await?
+        }
     }
     .into_inner();
     Ok(resp.total_count)
@@ -1855,17 +1873,19 @@ pub async fn explain_best_path(
     let (addr, len) = output::parse_prefix(prefix).map_err(CliError::Argument)?;
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut resp = client
-        .explain_best_path(ExplainBestPathRequest {
+    let mut resp = read_rpc(
+        "ExplainBestPath",
+        client.explain_best_path(ExplainBestPathRequest {
             prefix: addr,
             prefix_length: len,
             peer_address: peer
                 .map(bare_ip_rpc_address)
                 .unwrap_or_default()
                 .to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     restore_matching_scoped_address(peer, &mut resp.peer_address);
     print_explain_best_path(&resp, json)
 }
@@ -1883,13 +1903,15 @@ pub async fn lookup_best_path(
     let (addr, len) = output::parse_prefix(target).map_err(CliError::Argument)?;
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .lookup_best_path(LookupBestPathRequest {
+    let resp = read_rpc(
+        "LookupBestPath",
+        client.lookup_best_path(LookupBestPathRequest {
             prefix: addr,
             prefix_length: len,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     print_explain_best_path(&resp, json)
 }
 
@@ -1924,10 +1946,12 @@ pub async fn count_best(
 
 pub async fn blackholes(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
-        .list_blackhole_discards(ListBlackholeDiscardsRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListBlackholeDiscards",
+        client.list_blackhole_discards(ListBlackholeDiscardsRequest {}),
+    )
+    .await?
+    .into_inner();
     print_blackhole_discards(&resp.discards, json)
 }
 
@@ -1937,10 +1961,12 @@ pub async fn fib(
     json: bool,
 ) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let mut resp = client
-        .list_fib_routes(make_fib_request(&filters)?)
-        .await?
-        .into_inner();
+    let mut resp = read_rpc(
+        "ListFibRoutes",
+        client.list_fib_routes(make_fib_request(&filters)?),
+    )
+    .await?
+    .into_inner();
     for route in &mut resp.routes {
         restore_matching_scoped_address(filters.peer.as_deref(), &mut route.peer_address);
     }
@@ -1956,10 +1982,12 @@ pub async fn bgpls(
 ) -> Result<(), CliError> {
     let requested_peer = peer.clone();
     let mut client = connection.rib_listing_client();
-    let mut resp = client
-        .list_bgp_ls_routes(make_bgpls_request(family, peer, nlri_type)?)
-        .await?
-        .into_inner();
+    let mut resp = read_rpc(
+        "ListBgpLsRoutes",
+        client.list_bgp_ls_routes(make_bgpls_request(family, peer, nlri_type)?),
+    )
+    .await?
+    .into_inner();
     for route in &mut resp.routes {
         restore_matching_scoped_address(requested_peer.as_deref(), &mut route.peer_address);
     }
@@ -1974,10 +2002,12 @@ pub async fn vpn(
 ) -> Result<(), CliError> {
     let requested_peer = peer.clone();
     let mut client = connection.rib_listing_client();
-    let mut resp = client
-        .list_vpn_routes(make_vpn_request(family, peer)?)
-        .await?
-        .into_inner();
+    let mut resp = read_rpc(
+        "ListVpnRoutes",
+        client.list_vpn_routes(make_vpn_request(family, peer)?),
+    )
+    .await?
+    .into_inner();
     for route in &mut resp.routes {
         restore_matching_scoped_address(requested_peer.as_deref(), &mut route.peer_address);
     }
@@ -1992,10 +2022,12 @@ pub async fn labeled(
 ) -> Result<(), CliError> {
     let requested_peer = peer.clone();
     let mut client = connection.rib_listing_client();
-    let mut resp = client
-        .list_labeled_routes(make_labeled_request(family, peer)?)
-        .await?
-        .into_inner();
+    let mut resp = read_rpc(
+        "ListLabeledRoutes",
+        client.list_labeled_routes(make_labeled_request(family, peer)?),
+    )
+    .await?
+    .into_inner();
     for route in &mut resp.routes {
         restore_matching_scoped_address(requested_peer.as_deref(), &mut route.peer_address);
     }
@@ -2004,16 +2036,18 @@ pub async fn labeled(
 
 pub async fn rtc(connection: Connection, peer: Option<String>, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let mut resp = client
-        .list_rtc_routes(ListRtcRoutesRequest {
+    let mut resp = read_rpc(
+        "ListRtcRoutes",
+        client.list_rtc_routes(ListRtcRoutesRequest {
             peer_filter: peer
                 .as_deref()
                 .map(bare_ip_rpc_address)
                 .unwrap_or_default()
                 .to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     for route in &mut resp.routes {
         restore_matching_scoped_address(peer.as_deref(), &mut route.peer_address);
     }
@@ -2069,12 +2103,14 @@ pub async fn count_received(
 pub async fn rejected(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut resp = client
-        .list_rejected_routes(ListRejectedRoutesRequest {
+    let mut resp = read_rpc(
+        "ListRejectedRoutes",
+        client.list_rejected_routes(ListRejectedRoutesRequest {
             peer_address: bare_ip_rpc_address(address).to_string(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     restore_matching_scoped_address(Some(address), &mut resp.peer_address);
     print_rejected_routes(&resp, json)
 }
@@ -2272,8 +2308,9 @@ pub async fn explain_advertised(
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let requested_source = source_peer.filter(|_| source_path_id.is_some());
-    let mut resp = client
-        .explain_advertised_route(ExplainAdvertisedRouteRequest {
+    let mut resp = read_rpc(
+        "ExplainAdvertisedRoute",
+        client.explain_advertised_route(ExplainAdvertisedRouteRequest {
             peer_address: bare_ip_rpc_address(address).to_string(),
             prefix: addr,
             prefix_length: len,
@@ -2285,9 +2322,10 @@ pub async fn explain_advertised(
                     path_id,
                 }
             }),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
     restore_matching_scoped_address(Some(address), &mut resp.peer_address);
     restore_matching_scoped_address(requested_source, &mut resp.route_peer_address);
     if let Some(source) = &mut resp.source {

--- a/crates/cli/src/commands/rpki.rs
+++ b/crates/cli/src/commands/rpki.rs
@@ -5,7 +5,7 @@ use std::net::IpAddr;
 
 use serde::Serialize;
 
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output;
 use crate::proto::rpki_service_client::RpkiServiceClient;
@@ -164,14 +164,16 @@ async fn fetch(
     let (prefix, prefix_length) = split_prefix(prefix)?;
     let mut client =
         RpkiServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    Ok(client
-        .validate_route_origin(ValidateRouteOriginRequest {
+    Ok(read_rpc(
+        "ValidateRouteOrigin",
+        client.validate_route_origin(ValidateRouteOriginRequest {
             prefix,
             prefix_length: Some(prefix_length),
             origin_asn,
-        })
-        .await?
-        .into_inner())
+        }),
+    )
+    .await?
+    .into_inner())
 }
 
 /// Validate one route prefix and origin against the daemon's current VRPs.
@@ -274,8 +276,7 @@ fn caches_json(response: &ListRpkiCachesResponse) -> serde_json::Value {
 pub async fn caches(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         RpkiServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let response = client
-        .list_caches(ListRpkiCachesRequest {})
+    let response = read_rpc("ListCaches", client.list_caches(ListRpkiCachesRequest {}))
         .await?
         .into_inner();
     if json {

--- a/crates/cli/src/commands/topology.rs
+++ b/crates/cli/src/commands/topology.rs
@@ -1,7 +1,7 @@
 //! `rbgp topology nodes|links` — RFC 9107 ORR topology derived from the
 //! BGP-LS Adj-RIB-In union across peers.
 
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, outln};
 use crate::proto::{
@@ -12,19 +12,23 @@ use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 
 pub async fn nodes(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
-        .list_topology_nodes(ListTopologyNodesRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListTopologyNodes",
+        client.list_topology_nodes(ListTopologyNodesRequest {}),
+    )
+    .await?
+    .into_inner();
     print_topology_nodes(&resp.nodes, json)
 }
 
 pub async fn links(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
-        .list_topology_links(ListTopologyLinksRequest {})
-        .await?
-        .into_inner();
+    let resp = read_rpc(
+        "ListTopologyLinks",
+        client.list_topology_links(ListTopologyLinksRequest {}),
+    )
+    .await?
+    .into_inner();
     print_topology_links(&resp.links, json)
 }
 

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -1,4 +1,4 @@
-use crate::connection::Connection;
+use crate::connection::{Connection, read_rpc};
 use crate::error::CliError;
 use crate::output::{self, JsonRouteEvent, outln};
 use crate::proto::event_service_client::EventServiceClient;
@@ -1194,8 +1194,9 @@ pub async fn events_watch(
     if backfill > 0 {
         let mut rib_client =
             RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-        let response = rib_client
-            .list_route_events(ListRouteEventsRequest {
+        let response = read_rpc(
+            "ListRouteEvents",
+            rib_client.list_route_events(ListRouteEventsRequest {
                 neighbor_address: neighbor.unwrap_or_default(),
                 afi_safi: family.unwrap_or(0),
                 // Ask for the full bounded ring only when local type
@@ -1203,9 +1204,10 @@ pub async fn events_watch(
                 limit: route_history_request_limit(backfill, &event_types),
                 prefix,
                 prefix_length,
-            })
-            .await?
-            .into_inner();
+            }),
+        )
+        .await?
+        .into_inner();
         let mut events = response
             .events
             .into_iter()
@@ -1261,16 +1263,18 @@ pub async fn history(
 
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let response = client
-        .list_route_events(ListRouteEventsRequest {
+    let response = read_rpc(
+        "ListRouteEvents",
+        client.list_route_events(ListRouteEventsRequest {
             neighbor_address: neighbor.unwrap_or_default(),
             afi_safi: family.unwrap_or(0),
             limit,
             prefix,
             prefix_length,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if response.events.is_empty() {
         print_empty_history(json, "route")?;
@@ -1296,14 +1300,16 @@ pub async fn session_history(
         .collect::<Result<Vec<_>, _>>()?;
     let mut client =
         EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let response = client
-        .list_session_events(ListSessionEventsRequest {
+    let response = read_rpc(
+        "ListSessionEvents",
+        client.list_session_events(ListSessionEventsRequest {
             neighbor_address: neighbor.unwrap_or_default(),
             event_types,
             limit,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if response.events.is_empty() {
         print_empty_history(json, "session")?;
@@ -1329,14 +1335,16 @@ pub async fn policy_history(
         .collect::<Result<Vec<_>, _>>()?;
     let mut client =
         EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let response = client
-        .list_policy_events(ListPolicyEventsRequest {
+    let response = read_rpc(
+        "ListPolicyEvents",
+        client.list_policy_events(ListPolicyEventsRequest {
             neighbor_address: neighbor.unwrap_or_default(),
             event_types,
             limit,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if response.events.is_empty() {
         print_empty_history(json, "policy")?;
@@ -1364,16 +1372,18 @@ pub async fn evpn_history(
         .collect::<Result<Vec<_>, _>>()?;
     let mut client =
         EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let response = client
-        .list_evpn_events(ListEvpnEventsRequest {
+    let response = read_rpc(
+        "ListEvpnEvents",
+        client.list_evpn_events(ListEvpnEventsRequest {
             neighbor_address: neighbor.unwrap_or_default(),
             event_types,
             limit,
             route_type_filter: route_type.unwrap_or(0),
             rd_filter: rd.unwrap_or_default(),
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     if response.events.is_empty() {
         print_empty_history(json, "EVPN")?;

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -5,6 +5,7 @@
 //! loaded from a file.
 
 use std::fs;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -22,8 +23,32 @@ use crate::proto::config_service_client::ConfigServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Budget for one completed lightweight read, including the response body.
+pub(crate) const READ_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+/// Allow the server's 30-minute effective-config operation plus response transfer.
+pub(crate) const EFFECTIVE_CONFIG_RPC_TIMEOUT: Duration = Duration::from_secs(30 * 60 + 30);
 const AUTHORIZATION_HEADER: &str = "authorization";
 const BEARER_PREFIX: &str = "Bearer ";
+
+/// Bound a generated unary read future through decoding its full response.
+/// Connection and response-header timeouts alone do not bound a stalled body.
+pub(crate) async fn read_rpc<T>(
+    name: &str,
+    future: impl Future<Output = Result<T, Status>>,
+) -> Result<T, Status> {
+    rpc_with_timeout(name, READ_RPC_TIMEOUT, future).await
+}
+
+/// Method-specific budget for reads with a separate supported allowance.
+pub(crate) async fn rpc_with_timeout<T>(
+    name: &str,
+    budget: Duration,
+    future: impl Future<Output = Result<T, Status>>,
+) -> Result<T, Status> {
+    tokio::time::timeout(budget, future).await.map_err(|_| {
+        Status::deadline_exceeded(format!("{name} response timed out after {budget:?}"))
+    })?
+}
 
 /// Decode ceiling for full unary listing responses, replacing tonic's
 /// 4 MiB client default on the clients built by
@@ -268,6 +293,43 @@ mod tests {
     use tonic::metadata::MetadataValue;
 
     use super::*;
+
+    #[tokio::test]
+    async fn read_deadline_cancels_pending_response_and_names_method_and_budget() {
+        struct Cancelled<'a>(&'a std::sync::atomic::AtomicBool);
+        impl Drop for Cancelled<'_> {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let cancelled = std::sync::atomic::AtomicBool::new(false);
+        let error = rpc_with_timeout("GetGlobal", Duration::from_millis(20), async {
+            let _guard = Cancelled(&cancelled);
+            std::future::pending::<Result<(), Status>>().await
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(error.code(), tonic::Code::DeadlineExceeded);
+        assert_eq!(error.message(), "GetGlobal response timed out after 20ms");
+        assert!(cancelled.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn read_deadline_preserves_success_and_server_errors() {
+        assert_eq!(read_rpc("GetGlobal", async { Ok(42) }).await.unwrap(), 42);
+        let expected = Status::permission_denied("principal observer cannot perform this read");
+        let error = read_rpc("GetGlobal", async { Err::<(), _>(expected.clone()) })
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), expected.code());
+        assert_eq!(error.message(), expected.message());
+    }
+
+    #[test]
+    fn effective_config_keeps_its_supported_server_budget() {
+        assert_eq!(READ_RPC_TIMEOUT, Duration::from_secs(30));
+        assert!(EFFECTIVE_CONFIG_RPC_TIMEOUT > Duration::from_secs(30 * 60));
+    }
 
     #[test]
     fn parse_endpoint_target_accepts_plain_tcp_address() {

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -46,7 +46,10 @@ pub(crate) async fn rpc_with_timeout<T>(
     future: impl Future<Output = Result<T, Status>>,
 ) -> Result<T, Status> {
     tokio::time::timeout(budget, future).await.map_err(|_| {
-        Status::deadline_exceeded(format!("{name} response timed out after {budget:?}"))
+        Status::deadline_exceeded(format!(
+            "{name} response timed out after {}s",
+            budget.as_secs_f64()
+        ))
     })?
 }
 
@@ -310,7 +313,7 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(error.code(), tonic::Code::DeadlineExceeded);
-        assert_eq!(error.message(), "GetGlobal response timed out after 20ms");
+        assert_eq!(error.message(), "GetGlobal response timed out after 0.02s");
         assert!(cancelled.load(std::sync::atomic::Ordering::SeqCst));
     }
 

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -43,6 +43,11 @@ pub(crate) struct MockState {
     pub(crate) health_failures_remaining: AtomicUsize,
     pub(crate) metrics_calls: AtomicUsize,
     pub(crate) global_calls: AtomicUsize,
+    pub(crate) global_read_stall: AtomicBool,
+    pub(crate) health_read_stall: AtomicBool,
+    pub(crate) neighbor_read_stall: AtomicBool,
+    pub(crate) effective_config_delay_ms: AtomicUsize,
+    pub(crate) list_route_continuation_stall: AtomicBool,
     pub(crate) validation_policy_posture_calls: AtomicUsize,
     pub(crate) metrics_failures_remaining: AtomicUsize,
     pub(crate) global_failures_remaining: AtomicUsize,
@@ -84,6 +89,7 @@ pub(crate) struct MockState {
     pub(crate) config_abort_calls: AtomicUsize,
     pub(crate) add_neighbor_calls: AtomicUsize,
     pub(crate) config_status_calls: AtomicUsize,
+    pub(crate) config_snapshot_read_stall: AtomicBool,
     pub(crate) config_history_calls: AtomicUsize,
     pub(crate) config_rollback_calls: AtomicUsize,
     pub(crate) config_rollback_error: Mutex<Option<(Code, String)>>,
@@ -177,6 +183,7 @@ pub(crate) struct MockState {
     pub(crate) last_explain_evpn: Mutex<Option<server_proto::ExplainEvpnRouteRequest>>,
     pub(crate) explain_evpn_response: Mutex<server_proto::ExplainEvpnRouteResponse>,
     pub(crate) explain_evpn_error: Mutex<Option<(Code, String)>>,
+    pub(crate) explain_evpn_read_stall: AtomicBool,
     pub(crate) last_list_rejected: Mutex<Option<server_proto::ListRejectedRoutesRequest>>,
     pub(crate) last_list_topology_nodes: Mutex<Option<server_proto::ListTopologyNodesRequest>>,
     pub(crate) last_list_topology_links: Mutex<Option<server_proto::ListTopologyLinksRequest>>,
@@ -752,6 +759,9 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
         self.state
             .config_status_calls
             .fetch_add(1, Ordering::SeqCst);
+        if self.state.config_snapshot_read_stall.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
         if let Some((code, message)) = self.state.config_status_error.lock().await.clone() {
             return Err(Status::new(code, message));
         }
@@ -778,6 +788,9 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
         self.state
             .config_history_calls
             .fetch_add(1, Ordering::SeqCst);
+        if self.state.config_snapshot_read_stall.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
         Ok(Response::new(server_proto::ListConfigHistoryResponse {
             entries: vec![
                 server_proto::ConfigHistoryEntry {
@@ -833,6 +846,10 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
         self.state
             .config_effective_calls
             .fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(std::time::Duration::from_millis(
+            self.state.effective_config_delay_ms.load(Ordering::SeqCst) as u64,
+        ))
+        .await;
         if let Some((code, message)) = self.state.config_effective_error.lock().await.clone() {
             return Err(Status::new(code, message));
         }
@@ -852,6 +869,9 @@ impl rustbgpd_api::proto::global_service_server::GlobalService for MockGlobalSer
         _request: Request<server_proto::GetGlobalRequest>,
     ) -> Result<Response<server_proto::GlobalState>, Status> {
         self.state.global_calls.fetch_add(1, Ordering::SeqCst);
+        if self.state.global_read_stall.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
         if self
             .state
             .global_failures_remaining
@@ -910,6 +930,9 @@ impl rustbgpd_api::proto::control_service_server::ControlService for MockControl
         _request: Request<server_proto::HealthRequest>,
     ) -> Result<Response<server_proto::HealthResponse>, Status> {
         self.state.health_calls.fetch_add(1, Ordering::SeqCst);
+        if self.state.health_read_stall.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
         if consume_failure(&self.state.health_failures_remaining) {
             return Err(Status::unavailable("transient health failure"));
         }
@@ -1005,6 +1028,9 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
         self.state
             .list_neighbors_calls
             .fetch_add(1, Ordering::SeqCst);
+        if self.state.neighbor_read_stall.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
         if consume_failure(&self.state.list_neighbors_failures_remaining) {
             return Err(Status::unavailable("transient neighbor-list failure"));
         }
@@ -1397,7 +1423,16 @@ impl MockRibService {
         &self,
         request: server_proto::ListRoutesRequest,
     ) -> server_proto::ListRoutesResponse {
+        let continuation = !request.page_token.is_empty();
         self.state.list_route_requests.lock().await.push(request);
+        if continuation
+            && self
+                .state
+                .list_route_continuation_stall
+                .load(Ordering::SeqCst)
+        {
+            std::future::pending::<()>().await;
+        }
         let mut pages = self.state.list_route_pages.lock().await;
         if pages.is_empty() {
             server_proto::ListRoutesResponse {
@@ -2255,6 +2290,9 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
     ) -> Result<Response<server_proto::ExplainEvpnRouteResponse>, Status> {
         let request = request.into_inner();
         *self.state.last_explain_evpn.lock().await = Some(request.clone());
+        if self.state.explain_evpn_read_stall.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
         if let Some((code, message)) = self.state.explain_evpn_error.lock().await.clone() {
             return Err(Status::new(code, message));
         }

--- a/crates/cli/tests/read_deadlines.rs
+++ b/crates/cli/tests/read_deadlines.rs
@@ -1,0 +1,260 @@
+//! Real-process response deadlines, including a response whose headers already arrived.
+
+#![cfg(unix)]
+
+use std::process::{Output, Stdio};
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use rustbgpd_api::proto;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::process::{Child, Command};
+
+#[path = "../src/test_support.rs"]
+#[allow(
+    dead_code,
+    reason = "shared CLI mock includes services unused by this contract"
+)]
+mod test_support;
+
+fn start(addr: &str, args: &[&str]) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_rbgp"))
+        .args(["--addr", addr])
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env_remove("RUSTBGPD_TOKEN_FILE")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("start rbgp")
+}
+
+async fn finish(mut child: Child) -> Output {
+    if tokio::time::timeout(Duration::from_secs(45), child.wait())
+        .await
+        .is_err()
+    {
+        child
+            .kill()
+            .await
+            .expect("kill CLI after regression timeout");
+        let output = child.wait_with_output().await.expect("reap killed CLI");
+        panic!("CLI exceeded its 30-second response deadline: {output:?}");
+    }
+    child.wait_with_output().await.expect("collect CLI output")
+}
+
+fn assert_read_timeout(output: &Output, rpc: &str) {
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(output.stdout.is_empty(), "partial stdout: {output:?}");
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(error.contains("deadline exceeded"), "{error}");
+    assert!(error.contains(rpc), "{error}");
+    assert!(error.contains("response timed out"), "{error}");
+}
+
+#[tokio::test]
+async fn evpn_explain_stops_at_response_deadline() {
+    let server = test_support::spawn_mock_server(None).await;
+    server
+        .state
+        .explain_evpn_read_stall
+        .store(true, Ordering::SeqCst);
+    let output = finish(start(
+        &server.addr,
+        &[
+            "evpn",
+            "explain",
+            "mac-ip",
+            "--rd",
+            "65000:100",
+            "--mac",
+            "02:00:00:00:00:01",
+        ],
+    ))
+    .await;
+    assert_read_timeout(&output, "ExplainEvpnRoute");
+    assert!(server.state.last_explain_evpn.lock().await.is_some());
+    assert!(server.state.last_list_evpn.lock().await.is_none());
+}
+
+#[tokio::test]
+async fn config_status_and_history_have_lightweight_read_deadlines() {
+    let server = test_support::spawn_mock_server(None).await;
+    server
+        .state
+        .config_snapshot_read_stall
+        .store(true, Ordering::SeqCst);
+    let (status, history) = tokio::join!(
+        finish(start(&server.addr, &["--json", "config", "status"])),
+        finish(start(&server.addr, &["config", "history"])),
+    );
+    assert_read_timeout(&status, "GetConfigTransactionStatus");
+    assert_read_timeout(&history, "ListConfigHistory");
+    assert_eq!(server.state.config_status_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(server.state.config_history_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(server.state.config_apply_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn established_tcp_and_unix_requests_stop_at_response_deadline() {
+    let tcp = test_support::spawn_mock_server(None).await;
+    let directory = tempfile::tempdir().unwrap();
+    let uds = test_support::spawn_mock_uds_server(&directory.path().join("read.sock"), None).await;
+    tcp.state.global_read_stall.store(true, Ordering::SeqCst);
+    uds.state.global_read_stall.store(true, Ordering::SeqCst);
+    let started = Instant::now();
+    let (tcp_output, uds_output) = tokio::join!(
+        finish(start(&tcp.addr, &["global"])),
+        finish(start(&uds.addr, &["global"])),
+    );
+    assert_read_timeout(&tcp_output, "GetGlobal");
+    assert_read_timeout(&uds_output, "GetGlobal");
+    assert!(started.elapsed() >= Duration::from_secs(25));
+    assert_eq!(tcp.state.global_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(uds.state.global_calls.load(Ordering::SeqCst), 1);
+}
+
+// Minimal HTTP/2 fixture for the one boundary tonic's unary service cannot
+// expose: successful response headers followed by an incomplete gRPC body.
+async fn stall_response_body<S: AsyncRead + AsyncWrite + Unpin>(mut stream: S) {
+    stream
+        .write_all(&[0, 0, 0, 4, 0, 0, 0, 0, 0])
+        .await
+        .unwrap(); // SETTINGS
+    let mut preface = [0; 24];
+    stream.read_exact(&mut preface).await.unwrap();
+    assert_eq!(&preface, b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+    let mut saw_headers = false;
+    let stream_id = loop {
+        let mut header = [0; 9];
+        stream.read_exact(&mut header).await.unwrap();
+        let length =
+            usize::from(header[0]) << 16 | usize::from(header[1]) << 8 | usize::from(header[2]);
+        let mut payload = vec![0; length];
+        stream.read_exact(&mut payload).await.unwrap();
+        let kind = header[3];
+        let flags = header[4];
+        let id: [u8; 4] = header[5..9].try_into().unwrap();
+        if kind == 4 && flags & 1 == 0 {
+            stream
+                .write_all(&[0, 0, 0, 4, 1, 0, 0, 0, 0])
+                .await
+                .unwrap(); // SETTINGS ACK
+        }
+        saw_headers |= kind == 1 && id != [0; 4];
+        if id != [0; 4] && matches!(kind, 0 | 1) && flags & 1 != 0 {
+            break id;
+        }
+    };
+    assert!(saw_headers, "complete RPC request must reach the fixture");
+    // HPACK: indexed :status=200, literal content-type=application/grpc.
+    // END_HEADERS deliberately omits END_STREAM.
+    let mut headers = vec![0, 0, 20, 1, 4];
+    headers.extend_from_slice(&stream_id);
+    headers.extend_from_slice(b"\x88\x0f\x10\x10application/grpc");
+    stream.write_all(&headers).await.unwrap();
+    // An uncompressed 32-byte gRPC message is promised but never delivered.
+    let mut data = vec![0, 0, 5, 0, 0];
+    data.extend_from_slice(&stream_id);
+    data.extend_from_slice(&[0, 0, 0, 0, 32]);
+    stream.write_all(&data).await.unwrap();
+    // Hold the response open until the CLI deadline closes the connection.
+    let mut buffer = [0; 256];
+    while let Ok(length) = stream.read(&mut buffer).await {
+        if length == 0 {
+            break;
+        }
+    }
+}
+
+#[tokio::test]
+async fn response_headers_do_not_end_tcp_or_unix_deadline() {
+    let tcp = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let tcp_addr = format!("http://{}", tcp.local_addr().unwrap());
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("body.sock");
+    let uds = tokio::net::UnixListener::bind(&path).unwrap();
+    let uds_addr = format!("unix://{}", path.display());
+    let tcp_server = tokio::spawn(async move {
+        stall_response_body(tcp.accept().await.unwrap().0).await;
+    });
+    let uds_server = tokio::spawn(async move {
+        stall_response_body(uds.accept().await.unwrap().0).await;
+    });
+    let (tcp_output, uds_output) = tokio::join!(
+        finish(start(&tcp_addr, &["global"])),
+        finish(start(&uds_addr, &["global"])),
+    );
+    // Both child processes have exited; the socket readers must now finish.
+    tcp_server.await.unwrap();
+    uds_server.await.unwrap();
+    assert_read_timeout(&tcp_output, "GetGlobal");
+    assert_read_timeout(&uds_output, "GetGlobal");
+}
+
+async fn later_page_stalls(json: bool) {
+    let server = test_support::spawn_mock_server(None).await;
+    server
+        .state
+        .list_route_continuation_stall
+        .store(true, Ordering::SeqCst);
+    server
+        .state
+        .list_route_pages
+        .lock()
+        .await
+        .push(proto::ListRoutesResponse {
+            routes: vec![proto::Route {
+                prefix: "203.0.113.0".into(),
+                prefix_length: 24,
+                peer_address: "192.0.2.1".into(),
+                ..Default::default()
+            }],
+            next_page_token: "second-page".into(),
+            total_count: 2,
+            page_version: None,
+        });
+    let mut args = vec!["rib", "received", "192.0.2.1"];
+    if json {
+        args.push("--json");
+    }
+    let output = finish(start(&server.addr, &args)).await;
+    assert_read_timeout(&output, "ListReceivedRoutes");
+    let requests = server.state.list_route_requests.lock().await;
+    assert_eq!(requests.len(), 2, "no retries after the stalled page");
+    assert!(requests[0].page_token.is_empty());
+    assert_eq!(requests[1].page_token, "second-page");
+}
+
+#[tokio::test]
+async fn later_rib_page_timeout_never_prints_a_partial_listing() {
+    tokio::join!(later_page_stalls(false), later_page_stalls(true));
+}
+
+#[tokio::test]
+async fn successful_authenticated_read_keeps_its_output() {
+    let server = test_support::spawn_mock_server(Some("read-secret")).await;
+    let directory = tempfile::tempdir().unwrap();
+    let token = directory.path().join("token");
+    std::fs::write(&token, "read-secret\n").unwrap();
+    let output = finish(start(
+        &server.addr,
+        &["--token-file", token.to_str().unwrap(), "--json", "global"],
+    ))
+    .await;
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "asn": 65001,
+            "router_id": "10.0.0.1",
+            "listen_port": 179,
+            "tcp_ao_support": "supported",
+        })
+    );
+    assert_eq!(server.state.global_calls.load(Ordering::SeqCst), 1);
+}

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -1973,6 +1973,17 @@ directional policy presence, daemon `nofile` rlimits, recent panic reports)
 plus first-deploy environment probes, and writes one redacted
 `rustbgpd-doctor-<ts>.tar.gz`:
 
+Each lightweight gRPC collection call has a 30-second response deadline,
+including response-body transfer, for both TCP and Unix sockets. A timeout
+names the RPC and budget, preserves successful evidence, and marks the
+affected section incomplete. The effective-config collection has a separate
+30-minute-and-30-second allowance; doctor can therefore take longer than
+30 seconds overall. No timeout triggers an automatic retry. Native one-shot
+CLI reads, including config status and history, use the same 30-second limit
+per call or RIB page. Long-running config diff, plan, and effective export,
+config mutations and streams, and live watches keep their existing budgets
+and lifetimes.
+
 `peer.<addr>.rfc8212_policy` is the ADR-0112 check. It is green for
 `not_required` — the compatibility default, so it never turns an existing
 deployment yellow — and for `present`. It is **red** when a direction reports


### PR DESCRIPTION
An established endpoint could leave native CLI reads waiting indefinitely for a response. Bound lightweight reads to 30 seconds per complete RPC, including body transfer over TCP and Unix sockets. Each listing page has its own allowance; a failed later page exits before printing a partial listing.

Coverage includes config status/history, finite event history, and EVPN explain. Doctor retains successful evidence and marks incomplete sections accurately, with a separate 30-minute-and-30-second allowance for effective-config collection. Long-running config operations, mutations, streams, TUI refresh limits, and advertised-diff deadlines retain their existing behavior.

Validation: the complete local gate baseline, normal commit/push hooks, and real CLI regressions for withheld responses, stalled bodies, pagination, config snapshots, EVPN explain, and authenticated success. Doctor tests cover partial evidence and the separate effective-config budget. The CLI and operator references and changelog document the new limits.
