### PR TITLE
fix(mrt): correct Add-Path encoding and import boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,6 +625,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   different or zero ESI are contenders as before, and the receive-side
   tiebreak is unchanged.
 
+- Correct MRT Add-Path entry ordering to Peer Index, Originated Time, then
+  Path Identifier, and use subtype 10 for IPv6 unicast. Snapshot encoders
+  and the reader now follow RFC 8050; subtype 9 is treated as unsupported IPv4
+  multicast. Legacy non-Add-Path encoding is unchanged.
+
 ### Documentation
 
 - Publish a descriptive raw bridge event-skew receipt across six pinned Jammy
@@ -815,6 +820,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   peer's advertisement no longer counts as a move or raises the local
   sequence. Re-baseline alerts keyed on that counter for multihomed VNIs;
   single-homed VNIs are unaffected.
+
+- **MRT Add-Path snapshots and warm checkpoints:** regenerate historical
+  Add-Path dumps, whose peer, time, and path-ID fields could be misread by
+  external tools. Warm manifests now use format version 2 and reject all
+  version-1 bundles before decoding, without automatic conversion. The next
+  coordinated shutdown can replace an old checkpoint; the daemon still does
+  not restore routes from these artifacts at boot.
 
 ## [0.68.0] — 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -633,9 +633,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tiebreak is unchanged.
 
 - Correct MRT Add-Path entry ordering to Peer Index, Originated Time, then
-  Path Identifier, and use subtype 10 for IPv6 unicast. Snapshot encoders
-  and the reader now follow RFC 8050; subtype 9 is treated as unsupported IPv4
-  multicast. Legacy non-Add-Path encoding is unchanged.
+  Path Identifier, and use subtype 10 for IPv6 unicast. Snapshot encoders,
+  the reader, and the CLI MRT adapter now follow RFC 8050; subtype 9 is
+  treated as unsupported IPv4 multicast. The CLI adapter also rejects
+  trailing bytes after a RIB record's declared entries without emitting
+  a partial snapshot. Legacy non-Add-Path encoding is unchanged.
 
 ### Documentation
 

--- a/crates/cli/src/commands/ribsnap.rs
+++ b/crates/cli/src/commands/ribsnap.rs
@@ -24,7 +24,7 @@
 //! shapes (bad next-hop length, truncation, AFI/length mismatch,
 //! trailing octets) are refused. The link-local half of a 32-octet next
 //! hop is not part of the snapshot format and is dropped. RFC 8050
-//! Add-Path subtypes (8/9) carry a path identifier per entry, emitted as
+//! Add-Path unicast subtypes (8/10) carry a path identifier per entry, emitted as
 //! `path_id`.
 
 use std::fmt::Write as _;
@@ -45,12 +45,12 @@ const TABLE_DUMP_V2: u16 = 13;
 /// Subtypes ingested (plus RFC 8050 Add-Path variants). Everything else
 /// — `PEER_INDEX_TABLE`, multicast, `RIB_GENERIC` — is skipped. These are
 /// RFC 6396 / RFC 8050 registry values, duplicated from `rustbgpd-mrt` on
-/// purpose: constants cannot drift, and the CLI must not link the daemon's
-/// MRT manager (which pulls in the RIB).
+/// purpose: independent RFC byte vectors pin them, and the CLI must not
+/// link the daemon's MRT manager (which pulls in the RIB).
 const RIB_IPV4_UNICAST: u16 = 2;
 const RIB_IPV6_UNICAST: u16 = 4;
 const RIB_IPV4_UNICAST_ADDPATH: u16 = 8;
-const RIB_IPV6_UNICAST_ADDPATH: u16 = 9;
+const RIB_IPV6_UNICAST_ADDPATH: u16 = 10;
 
 /// Options for `rbgp diff snapshot from-mrt`.
 pub struct FromMrtOpts<'a> {
@@ -344,6 +344,9 @@ fn parse_rib_record(
         let mut route = parse_attributes(attrs)?;
         route.path_id = path_id;
         routes.push((addr, prefix_len, route));
+    }
+    if !cur.is_empty() {
+        return Err("trailing bytes after declared RIB entries".to_string());
     }
     Ok(())
 }
@@ -715,6 +718,92 @@ mod tests {
         }
         let golden = std::fs::read_to_string(golden_path).unwrap();
         assert_eq!(rendered, golden);
+    }
+
+    #[test]
+    fn rfc8050_unicast_vectors_preserve_path_ids_and_refuse_truncation() {
+        for (subtype, prefix_len, prefix_bytes, prefix) in [
+            (8, 24, &[192, 0, 2][..], "192.0.2.0/24"),
+            (10, 32, &[0x20, 1, 0x0d, 0xb8][..], "2001:db8::/32"),
+        ] {
+            for path_id in [0, 0x5566_7788_u32] {
+                // RFC 8050 sections 4.1 and 5.2, without the production
+                // subtype constants or the shared RIB-entry fixture helper.
+                let mut payload = vec![0, 0, 0, 1, prefix_len];
+                payload.extend_from_slice(prefix_bytes);
+                payload.extend_from_slice(&[0, 1]); // entry count
+                let entry_offset = payload.len();
+                payload.extend_from_slice(&[1, 2, 0x11, 0x22, 0x33, 0x44]);
+                payload.extend_from_slice(&path_id.to_be_bytes());
+                payload.extend_from_slice(&[0, 4, 0x40, 1, 1, 0]); // ORIGIN IGP
+                let valid = mrt_record(subtype, &payload);
+                let dump = write_dump(&valid);
+                let rendered = run(&opts(dump.path(), "adj-rib-out-capture")).unwrap();
+                let records: Vec<serde_json::Value> = rendered
+                    .lines()
+                    .map(|line| serde_json::from_str(line).unwrap())
+                    .collect();
+                assert_eq!(records.len(), 3);
+                assert_eq!(
+                    records[1],
+                    serde_json::json!({
+                        "record": "route", "peer": "192.0.2.9", "peer_asn": 64501,
+                        "prefix": prefix, "path_id": path_id, "origin": 0,
+                    })
+                );
+                assert_eq!(
+                    records[2],
+                    serde_json::json!({"record": "trailer", "routes": 1})
+                );
+
+                for length in entry_offset..payload.len() {
+                    // A complete first record must not escape to stdout when
+                    // a later entry is truncated at any field/attribute byte.
+                    let mut bytes = valid.clone();
+                    bytes.extend_from_slice(&mrt_record(subtype, &payload[..length]));
+                    let dump = write_dump(&bytes);
+                    let result = run(&opts(dump.path(), "adj-rib-out-capture"));
+                    assert!(result.as_ref().unwrap_err().contains("truncated"));
+                    let mut output = Vec::new();
+                    assert_eq!(emit_mrt_snapshot(result, &mut output), EXIT_REFUSED);
+                    assert!(output.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rfc8050_ipv4_multicast_is_skipped_not_decoded_as_ipv6() {
+        let multicast = mrt_record(9, &[0xAB; 10]);
+        assert!(matches!(parse_mrt(&multicast), Err(error) if error.contains("no TABLE_DUMP_V2")));
+        let mut mixed = sample_dump();
+        mixed.extend_from_slice(&multicast);
+        let dump = write_dump(&mixed);
+        let baseline = write_dump(&sample_dump());
+        assert_eq!(
+            run(&opts(dump.path(), "adj-rib-out-capture")).unwrap(),
+            run(&opts(baseline.path(), "adj-rib-out-capture")).unwrap()
+        );
+    }
+
+    #[test]
+    fn rib_record_trailing_bytes_refuse_the_entire_snapshot() {
+        for (subtype, path_id) in [(2, None), (4, None), (8, Some(0)), (10, Some(0))] {
+            let entry = (path_id, attr(attr_type::ORIGIN, &[0]));
+            let valid = mrt_record(subtype, &rib_payload(0, &[], std::slice::from_ref(&entry)));
+            for entries in [vec![], vec![entry.clone()]] {
+                let mut payload = rib_payload(0, &[], &entries);
+                payload.push(0xff); // outside the declared zero or one entries
+                let mut bytes = valid.clone();
+                bytes.extend_from_slice(&mrt_record(subtype, &payload));
+                let dump = write_dump(&bytes);
+                let result = run(&opts(dump.path(), "adj-rib-out-capture"));
+                assert!(result.as_ref().unwrap_err().contains("trailing bytes"));
+                let mut output = Vec::new();
+                assert_eq!(emit_mrt_snapshot(result, &mut output), EXIT_REFUSED);
+                assert!(output.is_empty());
+            }
+        }
     }
 
     #[test]

--- a/crates/mrt/README.md
+++ b/crates/mrt/README.md
@@ -13,7 +13,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
   - `RIB_GENERIC` (subtype 6) for L2VPN/EVPN (AFI 25 / SAFI 70), following
     RFC 6396 section 4.3.5
   - `RIB_IPV4_UNICAST_ADDPATH` (subtype 8), following RFC 8050
-  - `RIB_IPV6_UNICAST_ADDPATH` (subtype 9), following RFC 8050
+  - `RIB_IPV6_UNICAST_ADDPATH` (subtype 10), following RFC 8050
 - **Periodic + on-demand** — configurable dump interval or gRPC
   `TriggerMrtDump` for immediate snapshots
 - **Optional gzip** compression via flate2
@@ -59,12 +59,18 @@ Public entry points:
   directory as a file descriptor; every subsequent read, create, rename,
   unlink, and fsync is descriptor-relative, so path replacement and symlink
   races cannot redirect publication or loading.
-- `write_warm_bundle` / `write_warm_bundle_bounded` — atomically publish a V1
+- `write_warm_bundle` / `write_warm_bundle_bounded` — atomically publish a format-version-2
   bundle (the bounded form additionally observes a shutdown cancellation
   token and deadline, safe to cancel at any point before the manifest
   rename).
 - `load_warm_bundle` — loads only an exact, fresh, byte- and
   semantically-valid bundle against an independently derived expectation.
+
+Format version 2 requires RFC 8050 Add-Path encoding. All version-1
+manifests are rejected before snapshot decoding, including non-Add-Path
+bundles. Regenerate checkpoints with this version; there is no automatic
+conversion of historical malformed Add-Path artifacts. The existing directory
+name, Rust type names, and resolved-policy digest framing remain unchanged.
 
 Warm bundles remain lossless and fail closed: publication and loading reject
 snapshots whose reader reports any discarded path attributes or BGP-LS NLRIs,

--- a/crates/mrt/fuzz/fuzz_targets/warm_bundle_manifest.rs
+++ b/crates/mrt/fuzz/fuzz_targets/warm_bundle_manifest.rs
@@ -14,7 +14,7 @@ use rustbgpd_mrt::warm_bundle::{
 
 const SHA256: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const CREATED_AT_UTC_SECONDS: i64 = 1_800_000_000;
-const CANONICAL_MANIFEST: &[u8] = include_bytes!("../seeds/warm_bundle_manifest/canonical-v1.json");
+const CANONICAL_MANIFEST: &[u8] = include_bytes!("../seeds/warm_bundle_manifest/canonical-v2.json");
 
 fn expected() -> WarmBundleExpectedV1 {
     WarmBundleExpectedV1 {

--- a/crates/mrt/fuzz/seeds/warm_bundle_manifest/canonical-v2.json
+++ b/crates/mrt/fuzz/seeds/warm_bundle_manifest/canonical-v2.json
@@ -1,5 +1,5 @@
 {
-  "format_version": 1,
+  "format_version": 2,
   "identity": {
     "checkpoint_generation": "fuzz-generation-1",
     "created_at_utc_seconds": 1800000000,

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -24,7 +24,7 @@ pub(crate) const RIB_IPV6_UNICAST: u16 = 4;
 /// Used here for L2VPN/EVPN (AFI 25 / SAFI 70).
 pub(crate) const RIB_GENERIC: u16 = 6;
 pub(crate) const RIB_IPV4_UNICAST_ADDPATH: u16 = 8;
-pub(crate) const RIB_IPV6_UNICAST_ADDPATH: u16 = 9;
+pub(crate) const RIB_IPV6_UNICAST_ADDPATH: u16 = 10;
 /// An individual RIB entry within a RIB_* record.
 pub struct RibEntry {
     /// Index into the `PEER_INDEX_TABLE`.
@@ -713,11 +713,11 @@ fn encode_rib_entry(
     entry: &RibEntry,
     add_path: bool,
 ) -> Result<(), EncodeError> {
+    buf.extend_from_slice(&entry.peer_index.to_be_bytes())?;
+    buf.extend_from_slice(&entry.originated_time.to_be_bytes())?;
     if add_path {
         buf.extend_from_slice(&entry.path_id.to_be_bytes())?;
     }
-    buf.extend_from_slice(&entry.peer_index.to_be_bytes())?;
-    buf.extend_from_slice(&entry.originated_time.to_be_bytes())?;
     let mut attr_buf = Vec::new();
     {
         let mut checked_attrs = EncodeBuffer::child(
@@ -748,11 +748,11 @@ fn encode_route_rib_entry(
     originated_time: u32,
     add_path: bool,
 ) -> Result<(), EncodeError> {
+    buf.extend_from_slice(&peer_index.to_be_bytes())?;
+    buf.extend_from_slice(&originated_time.to_be_bytes())?;
     if add_path {
         buf.extend_from_slice(&route.path_id.to_be_bytes())?;
     }
-    buf.extend_from_slice(&peer_index.to_be_bytes())?;
-    buf.extend_from_slice(&originated_time.to_be_bytes())?;
     let attr_len_offset = buf.len();
     buf.extend_from_slice(&0u16.to_be_bytes())?;
     let attr_start = buf.len();
@@ -2157,6 +2157,107 @@ mod tests {
         // 4 bytes for /32 prefix
         assert_eq!(&buf[17..21], &[0x20, 0x01, 0x0d, 0xb8]);
     }
+    #[test]
+    fn rib_entry_encoders_match_rfc8050_field_order() {
+        let mut route = make_route(
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
+            "192.0.2.1".parse().unwrap(),
+            "192.0.2.9".parse().unwrap(),
+        );
+        route.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Igp)]);
+        for add_path in [false, true] {
+            for path_id in [0, 0x5566_7788_u32] {
+                route.path_id = path_id;
+                // RFC 6396 legacy header, then RFC 8050's inserted path ID,
+                // then literal ORIGIN and synthesized NEXT_HOP attributes.
+                let mut expected = vec![0x01, 0x02, 0x11, 0x22, 0x33, 0x44];
+                if add_path {
+                    expected.extend_from_slice(&path_id.to_be_bytes());
+                }
+                expected.extend_from_slice(&[0, 11, 0x40, 1, 1, 0, 0x40, 3, 4, 192, 0, 2, 9]);
+                let entry = RibEntry {
+                    peer_index: 0x0102,
+                    originated_time: 0x1122_3344,
+                    path_id,
+                    attributes: synthesize_attributes(&route),
+                };
+                let mut owned = Vec::new();
+                encode_rib_entry(&mut EncodeBuffer::new(&mut owned, None), &entry, add_path)
+                    .unwrap();
+                assert_eq!(owned, expected);
+                let mut borrowed = Vec::new();
+                encode_route_rib_entry(
+                    &mut EncodeBuffer::new(&mut borrowed, None),
+                    &route,
+                    entry.peer_index,
+                    entry.originated_time,
+                    add_path,
+                )
+                .unwrap();
+                assert_eq!(borrowed, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn unicast_subtypes_match_rfc8050_assignments() {
+        let entry = RibEntry {
+            peer_index: 1,
+            originated_time: 0x1122_3344,
+            path_id: 0,
+            attributes: vec![],
+        };
+        for (prefix, legacy, addpath) in [
+            (Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0)), 2, 8),
+            (Prefix::V6(Ipv6Prefix::new(Ipv6Addr::UNSPECIFIED, 0)), 4, 10),
+        ] {
+            for (add_path, subtype) in [(false, legacy), (true, addpath)] {
+                let mut bytes = Vec::new();
+                encode_rib_entries_profile(
+                    &mut EncodeBuffer::new(&mut bytes, None),
+                    0,
+                    0,
+                    &prefix,
+                    std::slice::from_ref(&entry),
+                    add_path,
+                )
+                .unwrap();
+                let mut expected = vec![
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    13,
+                    0,
+                    subtype,
+                    0,
+                    0,
+                    0,
+                    if add_path { 19 } else { 15 },
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    1,
+                    0x11,
+                    0x22,
+                    0x33,
+                    0x44,
+                ];
+                if add_path {
+                    expected.extend_from_slice(&[0; 4]);
+                }
+                expected.extend_from_slice(&[0, 0]);
+                assert_eq!(bytes, expected);
+            }
+        }
+    }
+
     #[test]
     fn addpath_subtype_used_when_path_id_nonzero() {
         let entry = RibEntry {

--- a/crates/mrt/src/reader.rs
+++ b/crates/mrt/src/reader.rs
@@ -136,7 +136,7 @@ fn malformed(offset: usize, context: impl Into<String>) -> ReadError {
 /// NLRI of a decoded RIB entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SnapshotNlri {
-    /// IPv4/IPv6 unicast prefix (subtypes 2, 4, 8, 9).
+    /// IPv4/IPv6 unicast prefix (subtypes 2, 4, 8, 10).
     Unicast(Prefix),
     /// `RIB_GENERIC` NLRI, kept as raw bytes. The writer only emits
     /// L2VPN/EVPN here; the bytes are the canonical EVPN route TLV
@@ -606,11 +606,6 @@ impl<'a> SnapshotReader<'a> {
         add_path: bool,
         nlri: &SnapshotNlri,
     ) -> Result<(), ReadError> {
-        let path_id = if add_path {
-            cur.u32("path identifier")?
-        } else {
-            0
-        };
         let peer_index = cur.u16("peer index")?;
         let Some(peer) = self.peers.get(usize::from(peer_index)) else {
             return Err(ReadError::BadPeerIndex {
@@ -619,6 +614,11 @@ impl<'a> SnapshotReader<'a> {
             });
         };
         let originated_time = cur.u32("originated time")?;
+        let path_id = if add_path {
+            cur.u32("path identifier")?
+        } else {
+            0
+        };
         let attr_len = cur.u16("attribute length")?;
         let attr_base = cur.offset();
         let attrs = cur.take(usize::from(attr_len), "attribute bytes")?;
@@ -1054,6 +1054,69 @@ mod tests {
     }
 
     #[test]
+    fn rfc8050_independent_entries_and_truncated_boundaries() {
+        let peers = [
+            make_peer("192.0.2.1".parse().unwrap(), 65001),
+            make_peer("192.0.2.2".parse().unwrap(), 65002),
+        ];
+        let pit = encode_snapshot(COLLECTOR, &peers, &[], &[], TS).unwrap();
+        // Entry bytes are authored directly from RFC 8050 section 4.1,
+        // independent of both production entry encoders.
+        for subtype in [8, 10] {
+            for path_id in [0, 0x5566_7788_u32] {
+                let mut entry = vec![0, 1, 0x11, 0x22, 0x33, 0x44];
+                entry.extend_from_slice(&path_id.to_be_bytes());
+                entry.extend_from_slice(&[0, 4, 0x40, 1, 1, 0]);
+                for length in 0..=entry.len() {
+                    // Sequence=0, default prefix, one entry.
+                    let mut payload = vec![0, 0, 0, 0, 0, 0, 1];
+                    payload.extend_from_slice(&entry[..length]);
+                    let mut data = pit.clone();
+                    data.extend_from_slice(&raw_record(13, subtype, &payload));
+                    let mut reader = SnapshotReader::new(&data).unwrap();
+                    let row = reader.next().unwrap();
+                    if length < entry.len() {
+                        assert!(
+                            matches!(row, Err(ReadError::Truncated { .. })),
+                            "length={length}: {row:?}"
+                        );
+                    } else {
+                        let row = row.unwrap();
+                        assert_eq!(row.peer_index, 1);
+                        assert_eq!(row.peer.peer_addr, peers[1].peer_addr);
+                        assert_eq!(row.peer.peer_bgp_id, peers[1].peer_bgp_id);
+                        assert_eq!(row.peer.peer_asn, peers[1].peer_asn);
+                        assert_eq!(row.originated_time, 0x1122_3344);
+                        assert_eq!(row.path_id, path_id);
+                        assert!(row.add_path);
+                        let prefix = if subtype == 8 {
+                            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))
+                        } else {
+                            Prefix::V6(Ipv6Prefix::new(Ipv6Addr::UNSPECIFIED, 0))
+                        };
+                        assert_eq!(row.nlri, SnapshotNlri::Unicast(prefix));
+                        assert_eq!(row.attributes, vec![PathAttribute::Origin(Origin::Igp)]);
+                    }
+                    assert!(reader.next().is_none());
+                }
+                // Invalid peer index must be read from the first two bytes.
+                entry[..2].copy_from_slice(&2_u16.to_be_bytes());
+                let mut payload = vec![0, 0, 0, 0, 0, 0, 1];
+                payload.extend_from_slice(&entry);
+                let mut data = pit.clone();
+                data.extend_from_slice(&raw_record(13, subtype, &payload));
+                assert!(matches!(
+                    SnapshotReader::new(&data).unwrap().next(),
+                    Some(Err(ReadError::BadPeerIndex {
+                        index: 2,
+                        peer_count: 2
+                    }))
+                ));
+            }
+        }
+    }
+
+    #[test]
     fn roundtrip_addpath_v4_and_v6() {
         let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let nh = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9));
@@ -1272,6 +1335,8 @@ mod tests {
         .unwrap();
         // Unknown TABLE_DUMP_V2 subtype (3 = RIB_IPV4_MULTICAST).
         data.extend_from_slice(&raw_record(13, 3, &[0xAB; 10]));
+        // RFC 8050 subtype 9 is IPv4 multicast Add-Path, never IPv6 unicast.
+        data.extend_from_slice(&raw_record(13, 9, &[0xAB; 10]));
         // Foreign MRT type (16 = BGP4MP).
         data.extend_from_slice(&raw_record(16, 4, &[0xCD; 10]));
         // RIB_GENERIC with a non-EVPN AFI/SAFI (IPv4 FlowSpec).
@@ -1285,7 +1350,7 @@ mod tests {
         let (entries, err) = drain(&mut reader);
         assert!(err.is_none(), "skips must not error: {err:?}");
         assert_eq!(entries.len(), 1);
-        assert_eq!(reader.skipped_records(), 3);
+        assert_eq!(reader.skipped_records(), 4);
     }
 
     #[test]

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -43,22 +43,24 @@ use tracing::{debug, warn};
 use crate::codec::{WarmSnapshotBudget, WarmSnapshotBudgetError};
 use crate::{ReadError, SnapshotNlri, SnapshotReader};
 
-/// On-disk format understood by this implementation.
-pub const WARM_BUNDLE_FORMAT_VERSION: u32 = 1;
+/// On-disk format understood by this implementation. Version 2 requires
+/// RFC 8050 Add-Path entry ordering and subtype assignments; version 1
+/// artifacts cannot safely distinguish historical misencoded path IDs.
+pub const WARM_BUNDLE_FORMAT_VERSION: u32 = 2;
 /// Version of the deterministic resolved import-policy digest framing.
 pub const WARM_BUNDLE_POLICY_DIGEST_VERSION: u32 = 1;
 /// Fixed manifest file name within a bundle directory.
 pub const WARM_BUNDLE_MANIFEST_FILE: &str = "manifest.json";
 /// Maximum manifest bytes accepted before JSON parsing (8 MiB).
 ///
-/// Compact V1 manifests use about 250 bytes per peer/family view. This cap
+/// Compact manifests use about 250 bytes per peer/family view. This cap
 /// leaves room for more than 10,000 dual-stack RR peers while bounding boot
 /// allocation and rejecting unreasonable JSON before parsing.
 pub const MAX_WARM_BUNDLE_MANIFEST_BYTES: u64 = 8 * 1024 * 1024;
-/// Maximum MRT artifact bytes accepted by V1 (512 MiB).
+/// Maximum MRT artifact bytes accepted by the loader (512 MiB).
 ///
-/// V1 currently hands verified bytes to the later restore coordinator as one
-/// allocation. Keep that allocation operationally bounded; raising this cap
+/// The loader returns verified bytes as one allocation for a future restore
+/// consumer. Keep that allocation operationally bounded; raising this cap
 /// requires a fully streaming restore consumer rather than reusing the much
 /// larger decompression-format ceiling from [`crate::reader`].
 pub const MAX_WARM_BUNDLE_SNAPSHOT_BYTES: u64 = 512 * 1024 * 1024;
@@ -259,7 +261,8 @@ pub struct WarmBundleArtifactV1 {
     pub sha256: String,
 }
 
-/// V1 on-disk manifest.
+/// Manifest schema retained under its original Rust name. The on-disk
+/// `format_version` independently identifies the MRT encoding contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WarmBundleManifestV1 {
@@ -565,7 +568,7 @@ pub enum WarmBundleError {
     },
 }
 
-/// Atomically publish a V1 warm-checkpoint bundle.
+/// Atomically publish a warm-checkpoint bundle in the current format.
 ///
 /// The directory must already be pinned by [`WarmBundleDirectory::open`].
 /// The snapshot is semantically validated before any filesystem mutation.
@@ -581,7 +584,7 @@ pub fn write_warm_bundle(
     write_warm_bundle_inner(directory, identity, snapshot, FaultPoint::None, None)
 }
 
-/// Atomically publish a V1 bundle while observing the shutdown work budget.
+/// Atomically publish a bundle while observing the shutdown work budget.
 ///
 /// Semantic validation, hashing, chunked writes, fsync boundaries, and the
 /// final manifest commit all recheck the same cancellation token and monotonic
@@ -2445,7 +2448,7 @@ mod tests {
                 WarmBundleFamilyV1::Ipv6Unicast => {
                     payload.push(48);
                     payload.extend_from_slice(&Ipv6Addr::LOCALHOST.octets()[..6]);
-                    if view.add_path_receive { 9 } else { 4 }
+                    if view.add_path_receive { 10 } else { 4 }
                 }
                 WarmBundleFamilyV1::L2vpnEvpn => {
                     payload.extend_from_slice(&25_u16.to_be_bytes());
@@ -2460,11 +2463,11 @@ mod tests {
                 }
             };
             payload.extend_from_slice(&1_u16.to_be_bytes());
+            payload.extend_from_slice(&peer_index.to_be_bytes());
+            payload.extend_from_slice(&u32::try_from(NOW).unwrap().to_be_bytes());
             if view.add_path_receive {
                 payload.extend_from_slice(&u32::try_from(sequence + 1).unwrap().to_be_bytes());
             }
-            payload.extend_from_slice(&peer_index.to_be_bytes());
-            payload.extend_from_slice(&u32::try_from(NOW).unwrap().to_be_bytes());
             payload.extend_from_slice(&0_u16.to_be_bytes());
             record(&mut output, subtype, &payload);
         }
@@ -2605,6 +2608,86 @@ mod tests {
             serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
         mutate(&mut manifest);
         fs::write(path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn historical_v1_addpath_is_rejected_before_ambiguous_decoding() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let id = identity_with(vec![v4_view(1, true)]);
+        let mut corrected = valid_snapshot(&id);
+        // /24 record: common header + sequence + prefix length/address + count.
+        let entry = last_record_offset(&corrected) + 12 + 4 + 1 + 3 + 2;
+        corrected[entry + 6..entry + 10].fill(0); // negotiated Add-Path ID zero
+        let manifest = write_warm_bundle(&dir, id.clone(), &corrected).unwrap();
+        assert_eq!(manifest.format_version, 2);
+        let loaded = load_warm_bundle(&dir, &expected(&id), freshness()).unwrap();
+        let row = SnapshotReader::new(&loaded.snapshot)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.path_id, 0);
+        assert_eq!(row.originated_time, u32::try_from(NOW).unwrap());
+        assert!(row.add_path);
+
+        // Historical writer order: path ID zero, peer index zero, originated time.
+        let mut historical = corrected.clone();
+        historical[entry..entry + 6].fill(0);
+        historical[entry + 6..entry + 10]
+            .copy_from_slice(&u32::try_from(NOW).unwrap().to_be_bytes());
+        let row = SnapshotReader::new(&historical)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.peer_index, 0);
+        assert_eq!(row.originated_time, 0);
+        assert_eq!(row.path_id, u32::try_from(NOW).unwrap());
+        // Even all existing semantic checks would accept the swapped metadata.
+        assert_eq!(
+            validate_snapshot_semantics(&historical, &id, None).unwrap(),
+            vec![1]
+        );
+        install_raw_bundle(&temp, id.clone(), &historical, vec![1]);
+        rewrite_manifest(&temp, |manifest| manifest.format_version = 1);
+        assert!(matches!(
+            load_warm_bundle(&dir, &expected(&id), freshness()),
+            Err(WarmBundleError::UnsupportedVersion {
+                found: 1,
+                expected: 2
+            })
+        ));
+        // The version fence precedes opening or decoding the snapshot.
+        let snapshot_sha = sha256_hex(&historical);
+        fs::remove_file(temp.path().join(snapshot_name(&snapshot_sha))).unwrap();
+        assert!(matches!(
+            load_warm_bundle(&dir, &expected(&id), freshness()),
+            Err(WarmBundleError::UnsupportedVersion {
+                found: 1,
+                expected: 2
+            })
+        ));
+    }
+
+    #[test]
+    fn v1_legacy_bundles_are_also_invalidated_and_new_publication_recovers() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let id = identity_with(vec![v4_view(1, false)]);
+        publish(&dir, &id);
+        rewrite_manifest(&temp, |manifest| manifest.format_version = 1);
+        assert!(matches!(
+            load_warm_bundle(&dir, &expected(&id), freshness()),
+            Err(WarmBundleError::UnsupportedVersion {
+                found: 1,
+                expected: 2
+            })
+        ));
+        publish(&dir, &id);
+        let loaded = load_warm_bundle(&dir, &expected(&id), freshness()).unwrap();
+        assert_eq!(loaded.manifest.format_version, 2);
+        assert_eq!(loaded.snapshot, valid_snapshot(&id));
     }
 
     #[test]
@@ -2909,10 +2992,10 @@ mod tests {
         ));
 
         publish(&dir, &id);
-        rewrite_manifest(&temp, |manifest| manifest.format_version = 2);
+        rewrite_manifest(&temp, |manifest| manifest.format_version = 3);
         assert!(matches!(
             load_warm_bundle(&dir, &expected(&id), freshness()),
-            Err(WarmBundleError::UnsupportedVersion { found: 2, .. })
+            Err(WarmBundleError::UnsupportedVersion { found: 3, .. })
         ));
 
         publish(&dir, &id);

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -3417,7 +3417,7 @@ Each dump contains a complete `TABLE_DUMP_V2` snapshot:
 | `RIB_IPV6_UNICAST` (subtype 4) | IPv6 routes from Adj-RIB-In per peer |
 | `RIB_GENERIC` (subtype 6) | L2VPN/EVPN routes (AFI 25 / SAFI 70) per RFC 6396 section 4.3.5 |
 | `RIB_IPV4_UNICAST_ADDPATH` (subtype 8) | IPv4 routes with path IDs (RFC 8050) |
-| `RIB_IPV6_UNICAST_ADDPATH` (subtype 9) | IPv6 routes with path IDs (RFC 8050) |
+| `RIB_IPV6_UNICAST_ADDPATH` (subtype 10) | IPv6 routes with path IDs (RFC 8050) |
 
 Routes are sourced from Adj-RIB-In (not Loc-RIB) to avoid duplicate entries
 for the best-path winner. Next-hop attributes are synthesized per the MP-BGP

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -657,6 +657,13 @@ orphan cleanup; and an invalid or changed manifest deletes nothing. Cleanup
 errors are warnings and do not disable the next coordinated-shutdown
 publication attempt.
 
+Warm checkpoint manifests now use format version 2, which requires corrected
+RFC 8050 Add-Path encoding. Version-1 manifests are rejected before snapshot
+decoding, including bundles without Add-Path. Regenerate them through a new
+coordinated shutdown; the `warm-bundle-v1` directory name remains unchanged.
+An old manifest can make startup cleanup skip work until the next successful
+checkpoint replaces it.
+
 **Not restored:** routing state, policy evaluation state, RPKI VRP tables, and
 BMP client state. The optional warm checkpoint persists only eligible
 post-import-policy Adj-RIB-In views as a future-use artifact; the daemon does


### PR DESCRIPTION
Correct TABLE_DUMP_V2 Add-Path entries to encode and decode Peer Index, Originated Time, then Path Identifier, as specified by RFC 8050. Both the snapshot reader and CLI MRT adapter recognize IPv6 unicast subtype 10; subtype 9 follows the unsupported IPv4 multicast path. Non-Add-Path encoding is unchanged.

The CLI adapter also rejects bytes left after a RIB record's declared entries. A malformed later record now refuses the entire conversion without emitting partial routes or a misleading completion trailer.

Warm manifests now use format version 2 and reject all version-1 bundles before opening their snapshot. Old malformed entries can otherwise pass semantic validation with silently swapped metadata. Regenerate checkpoints with a new coordinated shutdown; directory names, Rust type names, and policy-digest framing remain unchanged. The daemon does not restore these artifacts at boot.

Independent byte-vector regressions cover both entry encoders and readers, IPv4 and IPv6, zero and nonzero path IDs, truncated entries, invalid peer indexes, and unchanged legacy bytes. CLI record-boundary tests cover zero and nonzero entry counts across ordinary and Add-Path IPv4/IPv6 records, including no partial output after a valid preceding record. Bundle tests cover historical malformed input, version rejection before artifact access, and fresh publication. The canonical fuzz seed and current upgrade documentation are updated.

Validation: full workspace tests, strict workspace Clippy, all rustdoc targets, formatting, offline links, repository contracts, fuzz inventory, the canonical manifest seed replay, and both CI MRT snapshot benchmark smoke modes pass.
