### PR TITLE
feat(mcp): add a read-only MCP server over the explain surfaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,22 @@ updates:
           - "serde*"
       test-deps:
         dependency-type: "development"
+      # The MCP SDK gets its own group and never rides along with an
+      # unrelated batch: rmcp majors have carried breaking API changes,
+      # and `schemars` must stay compatible with the version rmcp itself
+      # resolves so its `Json<T>` trait bounds keep unifying.
+      mcp-sdk:
+        patterns:
+          - "rmcp*"
+          - "schemars*"
     ignore:
+      # An rmcp major is a deliberate, separately reviewed change — the
+      # server is not shipped in any release artifact, so an unattended
+      # major bump costs more review than it buys.
+      - dependency-name: "rmcp"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "schemars"
+        update-types: ["version-update:semver-major"]
       # Workspace-internal crates are path deps; updates land via the
       # release process, not Dependabot.
       - dependency-name: "rustbgpd-*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Read-only Model Context Protocol server (`rustbgpd-mcp`) exposing the
+  explain surfaces to an MCP host over stdio: export-gate ladder, import
+  decision, best-path selection, retained rejections, neighbors, and health.
+  It runs on the operator's workstation as a gRPC client, adds no process to
+  the daemon host, and ships in no release artifact — build it with
+  `cargo build -p rustbgpd-mcp`. Read-only rests on two controls: no write
+  tool exists in the binary (fenced by a contract test against the gRPC
+  method inventory) and a listener capped at `max_tier = "sensitive_read"`.
+  Neither is sufficient alone. See the
+  [how-to](docs/how-to/mcp-server.md) and
+  [ADR-0131](docs/adr/0131-read-only-mcp-server.md).
+
 - Per-neighbor EVPN received and advertised route views through additive
   `ListReceivedEvpnRoutes` / `ListAdvertisedEvpnRoutes` RPCs and
   `rbgp evpn received|advertised PEER`. Type/RD filters and bounded pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `cargo build -p rustbgpd-mcp`. Read-only rests on two controls: no write
   tool exists in the binary (fenced by a contract test against the gRPC
   method inventory) and a listener capped at `max_tier = "sensitive_read"`.
-  Neither is sufficient alone. See the
+  Remote HTTPS connections verify the server and present a client certificate;
+  every tool bounds the complete gRPC response at 30 seconds. See the
   [how-to](docs/how-to/mcp-server.md) and
   [ADR-0131](docs/adr/0131-read-only-mcp-server.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [how-to](docs/how-to/mcp-server.md) and
   [ADR-0131](docs/adr/0131-read-only-mcp-server.md).
 
+- `rbgp_explain_evpn_route` on the MCP server: exact EVPN route explain
+  (RFC 7432 Types 1-5) carrying the selection story and the export gate ladder
+  from `ExplainEvpnRoute`. The response states in words that an empty retained
+  source is neither an import-rejection explanation nor proof the peer never
+  sent the key, and that a deferred selection means the installed best may
+  differ from fresh selection.
+
 - Per-neighbor EVPN received and advertised route views through additive
   `ListReceivedEvpnRoutes` / `ListAdvertisedEvpnRoutes` RPCs and
   `rbgp evpn received|advertised PEER`. Type/RD filters and bounded pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -783,8 +784,18 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -801,14 +812,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -950,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1492,7 +1527,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1513,7 +1548,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2159,6 +2194,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "peer-loop"
@@ -2919,6 +2960,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
+dependencies = [
+ "chrono",
+ "futures",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
+dependencies = [
+ "darling 0.24.1",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "roff"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3279,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustbgpd-mcp"
+version = "0.68.0"
+dependencies = [
+ "clap",
+ "rmcp",
+ "rustbgpd-api",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "rustbgpd-mrt"
 version = "0.68.0"
 dependencies = [
@@ -3380,7 +3472,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3437,7 +3529,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3505,6 +3597,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
@@ -3920,7 +4013,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4830,7 +4923,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,12 +3283,15 @@ name = "rustbgpd-mcp"
 version = "0.68.0"
 dependencies = [
  "clap",
+ "rcgen",
  "rmcp",
  "rustbgpd-api",
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,34 @@ members = [
     "examples/birdwatcher-adapter",
     "examples/peer-loop",
     "tools/rs-config-render",
+    "tools/mcp",
+]
+# `tools/mcp` is deliberately outside the default set: a plain `cargo build`
+# must not pay the MCP SDK compile cost, and the binary is shipped in no
+# release artifact. CI and the local gates pass `--workspace` or an explicit
+# `-p`, so it stays fully built, linted, and tested.
+default-members = [
+    ".",
+    "crates/wire",
+    "crates/bfd",
+    "crates/fsm",
+    "crates/transport",
+    "crates/rib",
+    "crates/policy",
+    "crates/api",
+    "crates/telemetry",
+    "crates/rpki",
+    "crates/cli",
+    "crates/bmp",
+    "crates/mrt",
+    "crates/evpn",
+    "crates/evpn-linux",
+    "crates/event-history",
+    "bench/evpn-load",
+    "examples/event-bridge",
+    "examples/birdwatcher-adapter",
+    "examples/peer-loop",
+    "tools/rs-config-render",
 ]
 resolver = "2"
 
@@ -76,6 +104,10 @@ libc = "0.2"
 x509-parser = "0.18"
 serde = { version = "1", features = ["derive"] }
 schemars = "1.2"
+# MCP SDK. Kept on a caret requirement within the current major and held out
+# of Dependabot's grouped updates: rmcp majors have carried breaking API
+# changes, so a major bump is a deliberate, separately reviewed change.
+rmcp = { version = "3.2.0", default-features = false, features = ["server", "macros", "transport-io"] }
 toml = "1.1"
 toml_edit = "0.25"
 clap = { version = "4", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,33 +22,6 @@ members = [
     "tools/rs-config-render",
     "tools/mcp",
 ]
-# `tools/mcp` is deliberately outside the default set: a plain `cargo build`
-# must not pay the MCP SDK compile cost, and the binary is shipped in no
-# release artifact. CI and the local gates pass `--workspace` or an explicit
-# `-p`, so it stays fully built, linted, and tested.
-default-members = [
-    ".",
-    "crates/wire",
-    "crates/bfd",
-    "crates/fsm",
-    "crates/transport",
-    "crates/rib",
-    "crates/policy",
-    "crates/api",
-    "crates/telemetry",
-    "crates/rpki",
-    "crates/cli",
-    "crates/bmp",
-    "crates/mrt",
-    "crates/evpn",
-    "crates/evpn-linux",
-    "crates/event-history",
-    "bench/evpn-load",
-    "examples/event-bridge",
-    "examples/birdwatcher-adapter",
-    "examples/peer-loop",
-    "tools/rs-config-render",
-]
 resolver = "2"
 
 [workspace.package]

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Follow a procedure for a specific task.
 | [Kernel dataplane runner](how-to/kernel-dataplane-runner.md) | Run the privileged Linux dataplane checks. |
 | [Fuzzing](how-to/fuzzing.md) | Build and run the parser fuzz targets. |
 | [Add a configuration field](how-to/config-knob-contributor-guide.md) | Cover validation, reload, persistence, and documentation. |
+| [Answer route questions from an AI agent](how-to/mcp-server.md) | Expose the explain surfaces to an MCP host, read-only. |
 | [Scenario cookbook](cookbook/README.md) | Choose a complete deployment recipe. |
 | [iBGP route reflector](cookbook/route-reflector.md) | Deploy a route reflector for an iBGP client fleet. |
 | [L3VPN route reflector](cookbook/l3vpn-route-reflector.md) | Reflect VPN routes with RT-Constrain filtering. |

--- a/docs/adr/0131-read-only-mcp-server.md
+++ b/docs/adr/0131-read-only-mcp-server.md
@@ -136,10 +136,10 @@ reduced to `stopped_at_gate` by the code path the unicast tool uses.
 Three fields on this surface are read wrongly by default, and the responses say
 so in words rather than leaving the inference to a model:
 
-- **`retention_note`** on `rbgp_list_rejected`. An empty list with retention
-  disabled means something completely different from an empty list with
-  retention on, and the tool must never report "no rejected routes" for the
-  first case.
+- **`retention_note`** on `rbgp_list_rejected`. The note identifies whether
+  retention is enabled and reports known capacity evictions separately from
+  occupancy. Acceptance or withdrawal can remove retained entries, so even an
+  enabled, empty store does not prove that nothing was rejected.
 - **`received_note`** on `rbgp_explain_evpn_route`. The proto is explicit that
   absence of retained accepted state is neither an import-rejection explanation
   nor proof the peer never sent the key — EVPN import rejection history is not
@@ -213,6 +213,15 @@ connects to a capped remote listener like any other API client. Colocating it
 on the daemon host is documented as the sharp edge, with the `local-operator`
 tier consequence spelled out.
 
+Remote HTTPS connections use mutual TLS with an explicit server CA and client
+certificate/key. The daemon maps the verified certificate principal to the
+observer role; the MCP client verifies the server identity. Incomplete TLS
+options and TLS options on plaintext or Unix endpoints are rejected.
+
+Every tool bounds the complete unary gRPC response at 30 seconds, including
+connection readiness and body decoding. A stalled response fails the tool
+call without an automatic retry.
+
 ### Packaging: source only, opt-in build, shipped nowhere
 
 The binary is deliberately absent from every release artifact. It is not in
@@ -221,11 +230,11 @@ the release tarball's copy list, not in the deb or rpm payload
 copies binaries by name, so nothing picks it up implicitly — verified against
 the release workflow, the packaging manifest, and the Dockerfile.
 
-The workspace gains a `default-members` list containing every member except
-`tools/mcp`, so a plain `cargo build` does not pay the MCP SDK compile cost.
-CI and the local gates pass `--workspace` or an explicit `-p` everywhere it
-matters, so the crate stays fully built, linted, and tested; the exclusion
-changes only the implicit default set.
+The existing root-package default stays unchanged: a plain `cargo build`
+selects `rustbgpd`, while `cargo build -p rustbgpd-mcp` opts into the MCP
+binary and its SDK dependencies. No `default-members` override is needed.
+CI and the local gates use `--workspace` or an explicit `-p`, so the MCP
+crate is still built, linted, and tested.
 
 The crate stays **in this repository**. Splitting it out would turn the
 inventory contract test into a cross-repo synchronization problem: it reads

--- a/docs/adr/0131-read-only-mcp-server.md
+++ b/docs/adr/0131-read-only-mcp-server.md
@@ -114,22 +114,53 @@ The feature set pulls no HTTP stack: `cargo tree -p rmcp -e normal` shows no
 behind its own `tower` feature. `chrono` enters through rmcp's `schemars`
 feature selection.
 
-### Six tools, `rbgp_`-prefixed
+### Seven tools, `rbgp_`-prefixed
 
 `rbgp_explain_export`, `rbgp_explain_import`, `rbgp_explain_best_path`,
-`rbgp_list_rejected`, `rbgp_list_peers`, `rbgp_get_health`. The prefix matches
-the CLI binary operators already know.
+`rbgp_explain_evpn_route`, `rbgp_list_rejected`, `rbgp_list_peers`,
+`rbgp_get_health`. The prefix matches the CLI binary operators already know.
 
 `rbgp_explain_export` is the headline: it surfaces the whole `gates` ladder in
 evaluation order with each rung's gate name, code, verdict, and detail, plus a
-`stopped_at_gate` field naming the rung that halted the route. `rbgp_list_rejected`
-surfaces `retention_enabled` and `capacity` alongside the listing and states in
-words what an empty list means, because an empty list with retention disabled
-means something completely different from an empty list with retention on.
+`stopped_at_gate` field naming the rung that halted the route.
+
+`rbgp_explain_evpn_route` covers the EVPN equivalent through `ExplainEvpnRoute`,
+and answers more per call than either unicast explain tool: one response carries
+the selection story (installed best, fresh selection, compared candidate,
+candidate count, deciding reason, deferral state) and, when `advertised_to` is
+supplied, the same `ExportGateStep` ladder toward that peer, numbered and
+reduced to `stopped_at_gate` by the code path the unicast tool uses.
+
+#### Stating what a result does not mean
+
+Three fields on this surface are read wrongly by default, and the responses say
+so in words rather than leaving the inference to a model:
+
+- **`retention_note`** on `rbgp_list_rejected`. An empty list with retention
+  disabled means something completely different from an empty list with
+  retention on, and the tool must never report "no rejected routes" for the
+  first case.
+- **`received_note`** on `rbgp_explain_evpn_route`. The proto is explicit that
+  absence of retained accepted state is neither an import-rejection explanation
+  nor proof the peer never sent the key — EVPN import rejection history is not
+  retained. An agent reading a bare empty `received` will state "the peer never
+  advertised it"; the note says the absence supports no such conclusion, and
+  distinguishes it from the case where no lookup was requested at all.
+- **`selection_note`** on `rbgp_explain_evpn_route`. While `selection_deferred`
+  is set, the installed Loc-RIB `best` can differ from fresh selection, so
+  reporting it as current state is reporting something untrue. A boolean beside
+  the data it invalidates is skimmable, so the note names the hazard and points
+  at `selection_best` instead.
+
+Each is unit-tested on the property that matters: that the disclaiming case
+cannot be confused with the ordinary one.
 
 #### Scope corrections
 
 Two tools from the original scope cannot be built and are not faked:
+
+These are unchanged by the EVPN addition — `ExplainEvpnRoute` is an existing
+`sensitive_read` RPC, so the seventh tool needed no new daemon surface.
 
 - **No BMP RPC exists.** BMP is outbound-only export to configured collectors
   (`crates/bmp`); the proto has no BMP service. A BMP tool would require a new
@@ -250,7 +281,14 @@ built for this; `tests/birdwatcher_adapter_smoke.rs` stands up a real daemon
 and a hand-rolled BGP speaker, which is the pattern to reuse if that coverage
 is wanted later.
 
-The six tools are a vertical slice, not a complete operator surface. The
-remaining explain surfaces (`rbgp policy stats`, `rbgp doctor`, RPKI validation,
-EVPN explain) are unaddressed, and whether they belong in an MCP tool list at
-all is a question this ADR does not answer.
+The seven tools are a vertical slice, not a complete operator surface. The
+remaining explain surfaces (`rbgp policy stats`, `rbgp doctor`, RPKI validation)
+are unaddressed, and whether they belong in an MCP tool list at all is a
+question this ADR does not answer.
+
+`rbgp_explain_evpn_route` is the only tool without live evidence. Its unit
+coverage (selector mapping including the MAC-only and MAX_ET forms, both note
+functions, the shared gate-ladder numbering) and the inventory contract hold,
+but no captured transcript exercises it against a running daemon: reaching a
+real EVPN route means an established EVPN session with a carried route, which
+is a lab this slice deliberately does not build.

--- a/docs/adr/0131-read-only-mcp-server.md
+++ b/docs/adr/0131-read-only-mcp-server.md
@@ -1,0 +1,256 @@
+# ADR-0131: Read-Only MCP Server for the Explain Surfaces
+
+**Status:** Proposed
+**Date:** 2026-09-05
+
+## Context
+
+The daemon already answers "why is this prefix not advertised to that peer?"
+from live evaluation. `RibService.ExplainAdvertisedRoute` returns the ordered
+export-gate ladder a route traverses toward a peer, recorded by a dry run of
+the same staging body live distribution executes, so the explanation cannot
+drift from the real decision. `PolicyService.ExplainImportPolicy`,
+`RibService.ExplainBestPath`, and `PolicyService.ListRejectedRoutes` answer the
+neighbouring questions.
+
+Those answers reach operators through `rbgp` and the gRPC API. They do not
+reach an AI agent, which is where a growing share of first-pass network triage
+now happens. An agent asked the same question today answers it by inference
+from route dumps and configuration text — exactly the guesswork the explain
+surfaces exist to replace.
+
+The Model Context Protocol is the interoperable way to close that gap: an MCP
+host spawns a server as a subprocess and calls its declared tools. A read-only
+MCP server over the explain RPCs would let an agent answer the question from
+the daemon's own decision ladder.
+
+Exposing a routing control plane to an agent is the part that needs a decision
+record, not the plumbing. Three constraints shape it.
+
+**There is no read-only tier to bind to.** `docs/reference/grpc-method-inventory.json`
+reports `"read": 0` — of 111 methods, 66 are `sensitive_read`, 21 `mutating`,
+24 `operator_only`. `sensitive_read` is the lowest tier a listener can be
+capped at, and every method this server needs sits in it.
+
+**The convenient local endpoint is the most privileged one.** An owner-only
+Unix socket with no configured principal authorizes as the reserved implicit
+principal `local-operator` at Operator tier — the highest. Filesystem ownership
+is the authentication. Pointing an MCP server at the default local socket
+therefore does not produce a read-only session; it produces the daemon's
+strongest credential.
+
+**Operators will be wary, and should be.** A process that takes instructions
+from a language model is not something a serious network operator wants near a
+production router. Any packaging that makes running it the default is wrong.
+
+## Decision
+
+### Ship a standalone, read-only MCP server as `tools/mcp`
+
+`rustbgpd-mcp` is a `publish = false` workspace member with a lib and a bin
+target, depending on `rustbgpd-api` for the generated gRPC client — the same
+shape as `examples/event-bridge` and `examples/birdwatcher-adapter`. It depends
+on neither `rustbgpctl`, `rustbgpd-rib`, nor `rustbgpd-mrt`. The lib target
+exists so tests can call handler methods and inspect the registered tool router
+directly.
+
+The alternative considered was adding the MCP surface to the `rbgp` CLI. The
+measurement below was run to settle it.
+
+#### Placement measurement
+
+Adding `rmcp 3.2.0` (`default-features = false`, features `server`, `macros`,
+`transport-io`) plus `schemars` to `crates/cli/Cargo.toml` and rebuilding
+`rbgp`, on a warm target directory:
+
+| Measure | Before | After | Delta |
+|---|---|---|---|
+| `target/debug/rbgp` | 227,467,840 B | 227,635,808 B | +167,968 B (+0.07%) |
+| `target/release/rbgp` | 10,695,176 B | 10,697,352 B | +2,176 B (+0.02%) |
+| `cargo build -p rustbgpctl --bin rbgp` (debug) | 21.06 s | 20.50 s | within noise |
+| `cargo build --release -p rustbgpctl --bin rbgp` | 1 m 32 s | 1 m 43 s | +11 s |
+| `cargo tree -p rustbgpctl -e normal \| grep -c rustbgpd-rib` | 0 | 0 | unchanged |
+
+Twenty crates enter the graph: `rmcp`, `rmcp-macros`, `schemars`,
+`schemars_derive`, `serde_derive_internals`, `chrono`, `num-traits`, `futures`,
+`futures-executor`, `futures-io`, `futures-macro`, `darling`, `darling_core`,
+`darling_macro`, `dyn-clone`, `ref-cast`, `ref-cast-impl`, `getrandom`,
+`pastey`, `uuid`.
+
+The binary-size numbers are a floor, not the real cost: the experimental
+`rbgp` never *called* rmcp, so link-time dead-code elimination removed nearly
+all of it. What the measurement does establish is the part that matters for
+this decision — the dependency-graph and build-time cost is paid by every
+`rbgp` build whether or not the operator wants MCP, and `rustbgpd-rib` stays
+out of the CLI either way (the 230 MB → 337 MB regression that rule exists to
+prevent is not in play here).
+
+A separate crate keeps the cost opt-in and keeps the MCP surface out of a
+binary operators run on routers. That is decisive independently of the byte
+counts, which is why the standalone crate is the decision.
+
+#### Dependency pins
+
+`rmcp 3.2.0`, verified against the crates.io registry on 2026-09-05
+(`cargo search rmcp` reported `rmcp = "3.2.0"`). Pinned as a caret requirement
+in `[workspace.dependencies]`, held out of Dependabot's grouped Cargo updates
+in its own `mcp-sdk` group with major versions ignored: rmcp majors have
+carried breaking API changes, so a major bump is a deliberate, separately
+reviewed change rather than something that arrives batched with a tokio patch
+release.
+
+`schemars` needs **no exact pin here.** rmcp's `Json<T>` bound is satisfied
+only by the schemars instance rmcp itself compiles against, which is what
+forces an exact pin in projects on rmcp 1.7. rmcp 3.2.0 requires
+`schemars = "1.0"` as a caret requirement (with the `chrono04` feature), which
+unifies with this workspace's existing `schemars = "1.2"` onto a single
+resolved `schemars 1.2.2` — verified with `cargo tree -p rmcp -e normal`. rmcp
+3.x additionally re-exports the crate as `rmcp::schemars`, so even a future
+divergence has a non-pinning remedy. Copying the `=1.2.1` pin from a project on
+an older rmcp would have been wrong.
+
+The feature set pulls no HTTP stack: `cargo tree -p rmcp -e normal` shows no
+`axum`, no `hyper`, and no `tower` — not even `tower-service`, which rmcp gates
+behind its own `tower` feature. `chrono` enters through rmcp's `schemars`
+feature selection.
+
+### Six tools, `rbgp_`-prefixed
+
+`rbgp_explain_export`, `rbgp_explain_import`, `rbgp_explain_best_path`,
+`rbgp_list_rejected`, `rbgp_list_peers`, `rbgp_get_health`. The prefix matches
+the CLI binary operators already know.
+
+`rbgp_explain_export` is the headline: it surfaces the whole `gates` ladder in
+evaluation order with each rung's gate name, code, verdict, and detail, plus a
+`stopped_at_gate` field naming the rung that halted the route. `rbgp_list_rejected`
+surfaces `retention_enabled` and `capacity` alongside the listing and states in
+words what an empty list means, because an empty list with retention disabled
+means something completely different from an empty list with retention on.
+
+#### Scope corrections
+
+Two tools from the original scope cannot be built and are not faked:
+
+- **No BMP RPC exists.** BMP is outbound-only export to configured collectors
+  (`crates/bmp`); the proto has no BMP service. A BMP tool would require a new
+  read RPC first.
+- **No support-bundle RPC exists.** `rbgp doctor` assembles its bundle
+  client-side from several RPCs plus local file and network probes. Reproducing
+  it in an MCP server means reproducing those local probes, which is a separate
+  decision — a support bundle is a redaction contract, not a query.
+
+### Read-only by two independent controls
+
+Neither control is sufficient alone, and the documentation says so.
+
+**Control 1 — no write tool exists in the binary.** Not hidden, not gated at
+call time: absent. Each tool declares the gRPC method path it calls in
+`TOOL_METHOD_PATHS`, and `tools/mcp/tests/inventory_contract.rs` reads
+`docs/reference/grpc-method-inventory.json` and fails the build if any declared
+path is missing from the inventory, carries a `mutating` or `operator_only`
+tier, or is declared twice. A companion unit test asserts the declared set
+equals the set the tool router actually registers, so a tool cannot be added
+without also entering the contract. The inventory is a machine-readable export
+of the static table in `crates/api/src/authz.rs`, kept in step with it by
+`machine_readable_inventory_matches_method_matrix`. It carries no request or
+response types, so it cannot generate tool schemas — it can only police the
+tool list, which is exactly what it is used for.
+
+The mechanism was negative-controlled during development: adding
+`/rustbgpd.v1.ControlService/Shutdown` to the table failed the contract test
+with the tier named.
+
+**Control 2 — the documented deployment.** The server runs on the operator's
+workstation and connects to a listener capped at `max_tier = "sensitive_read"`
+whose principal maps to the `observer` role. This is a property of one daemon's
+configuration, which the server cannot verify and does not attempt to.
+
+The reason neither suffices: control 2 is absent by default on the endpoint
+most people will reach for. A colocated server on an owner-only UDS with no
+principal gets Operator-tier credentials, and control 1 is the only thing
+between those credentials and a write. Conversely control 1 lives in this
+source tree, not in the daemon — it constrains this binary and nothing else, so
+a correctly capped listener stays worthwhile.
+
+### Deployment posture: workstation, not router
+
+An stdio MCP server is spawned as a subprocess by the MCP host on the machine
+where the operator sits, and it is a gRPC client. The recommended deployment
+therefore adds **no process to the router**: it runs on the workstation and
+connects to a capped remote listener like any other API client. Colocating it
+on the daemon host is documented as the sharp edge, with the `local-operator`
+tier consequence spelled out.
+
+### Packaging: source only, opt-in build, shipped nowhere
+
+The binary is deliberately absent from every release artifact. It is not in
+the release tarball's copy list, not in the deb or rpm payload
+(`packaging/nfpm.yaml`), and not in any container image. Every packaging step
+copies binaries by name, so nothing picks it up implicitly — verified against
+the release workflow, the packaging manifest, and the Dockerfile.
+
+The workspace gains a `default-members` list containing every member except
+`tools/mcp`, so a plain `cargo build` does not pay the MCP SDK compile cost.
+CI and the local gates pass `--workspace` or an explicit `-p` everywhere it
+matters, so the crate stays fully built, linted, and tested; the exclusion
+changes only the implicit default set.
+
+The crate stays **in this repository**. Splitting it out would turn the
+inventory contract test into a cross-repo synchronization problem: it reads
+`docs/reference/grpc-method-inventory.json` and depends on `rustbgpd-api`
+generated from `proto/rustbgpd.proto`, both of which live here. This project
+already carries one open gap of exactly that shape, where CI cannot see a path
+dependency in a sibling repository; deliberately creating a second instance
+would repeat a known failure. An in-repo crate, excluded from the default build
+and from every shipped artifact, is the maximum separation that keeps the
+contract test real.
+
+Building an installable artifact for it — a separate, clearly labelled release
+asset — is a possible follow-on and is explicitly not done here.
+
+## Consequences
+
+**Positive.** The defining question is answered from the daemon's own ladder.
+Captured against a live daemon on 2026-09-05, `rbgp_explain_export` for a
+prefix an export policy blocked returned `"decision": "deny"`, a seven-rung
+ladder (`best_route`, `split_horizon`, `rr_reflection`, `family`, `llgr`,
+`orf`, `export_policy`), `"stopped_at_gate": "export_policy"`, and the deciding
+policy named in the rung's detail. The same query before the policy change
+returned `"advertise"` with a nine-rung all-pass ladder ending at
+`adj_rib_out`. That is the product claim, demonstrated rather than asserted.
+
+The read-only property is mechanical. "A write RPC cannot leak into the tool
+surface" is a failing test, not a promise in a README, and it is checked
+against the same table the daemon authorizes from.
+
+The tool surface is small and honest about what it cannot answer. `rbgp_list_rejected`
+cannot report "no rejected routes" when retention is off; `rbgp_explain_import`
+distinguishes `cache_disabled`, `no_session`, and `evicted` from a rejection.
+
+**Negative.** A twentieth-order dependency surface enters the workspace lock
+file for a binary nobody ships. `chrono` in particular arrives only because
+rmcp selects it through its `schemars` feature.
+
+rmcp is young and its majors break. The Dependabot exclusion means an rmcp
+major sits unpatched until someone picks it up deliberately — the right
+trade for a non-shipped tool, but it is a maintenance obligation, not a
+free win.
+
+The safety model rests partly on documentation. Control 1 holds unconditionally;
+control 2 is advice an operator can ignore by pointing the server at the
+default local socket, which works and gives the process Operator-tier
+credentials. The how-to states this plainly rather than assuming it away.
+
+**Neutral / outstanding.** Unit coverage is the pure mapping logic — request
+construction, response to structured result, error mapping, truncation
+accounting, label rendering — plus the stdio end-to-end handshake against the
+compiled binary and the inventory contract. There is no in-repo mock gRPC
+server harness to drive handler methods against a faked backend, and none was
+built for this; `tests/birdwatcher_adapter_smoke.rs` stands up a real daemon
+and a hand-rolled BGP speaker, which is the pattern to reuse if that coverage
+is wanted later.
+
+The six tools are a vertical slice, not a complete operator surface. The
+remaining explain surfaces (`rbgp policy stats`, `rbgp doctor`, RPKI validation,
+EVPN explain) are unaddressed, and whether they belong in an MCP tool list at
+all is a question this ADR does not answer.

--- a/docs/adr/0131-read-only-mcp-server.md
+++ b/docs/adr/0131-read-only-mcp-server.md
@@ -159,9 +159,6 @@ cannot be confused with the ordinary one.
 
 Two tools from the original scope cannot be built and are not faked:
 
-These are unchanged by the EVPN addition — `ExplainEvpnRoute` is an existing
-`sensitive_read` RPC, so the seventh tool needed no new daemon surface.
-
 - **No BMP RPC exists.** BMP is outbound-only export to configured collectors
   (`crates/bmp`); the proto has no BMP service. A BMP tool would require a new
   read RPC first.
@@ -169,6 +166,10 @@ These are unchanged by the EVPN addition — `ExplainEvpnRoute` is an existing
   client-side from several RPCs plus local file and network probes. Reproducing
   it in an MCP server means reproducing those local probes, which is a separate
   decision — a support bundle is a redaction contract, not a query.
+
+Both stand unchanged after the EVPN addition. `ExplainEvpnRoute` was already a
+`sensitive_read` RPC, so the seventh tool needed no new daemon surface — which
+is exactly why it could be added and the two above still cannot.
 
 ### Read-only by two independent controls
 
@@ -250,6 +251,16 @@ policy named in the rung's detail. The same query before the policy change
 returned `"advertise"` with a nine-rung all-pass ladder ending at
 `adj_rib_out`. That is the product claim, demonstrated rather than asserted.
 
+`rbgp_explain_evpn_route` was exercised against an injected Type 2 route on the
+same lab: the selection story came back with `candidate_count: 1` and installed
+best agreeing with fresh selection, and the export half returned a real
+one-rung ladder stopping at the `family` gate (`family_not_sendable`,
+`"decision": "unsupported_family"`) because the lab peer negotiated IPv4
+unicast only. Both `received_note` branches were exercised, including the one
+that matters: an Established peer that had never sent the key produced the full
+disclaimer rather than an empty field an agent could read as "the peer never
+advertised it".
+
 The read-only property is mechanical. "A write RPC cannot leak into the tool
 surface" is a failing test, not a promise in a README, and it is checked
 against the same table the daemon authorizes from.
@@ -286,9 +297,11 @@ remaining explain surfaces (`rbgp policy stats`, `rbgp doctor`, RPKI validation)
 are unaddressed, and whether they belong in an MCP tool list at all is a
 question this ADR does not answer.
 
-`rbgp_explain_evpn_route` is the only tool without live evidence. Its unit
-coverage (selector mapping including the MAC-only and MAX_ET forms, both note
-functions, the shared gate-ladder numbering) and the inventory contract hold,
-but no captured transcript exercises it against a running daemon: reaching a
-real EVPN route means an established EVPN session with a carried route, which
-is a lab this slice deliberately does not build.
+Two branches of the EVPN tool have unit coverage but no live capture, and both
+are conditions a two-node lab does not produce on demand. `selection_deferred =
+true` needs a real deferral, so the `selection_note` hazard text has never been
+emitted by a running daemon. And no EVPN route was ever *received* from a peer
+in the lab — `examples/peer-loop` negotiates IPv4 unicast only — so `received`
+was null in every capture and the populated-source branch is untested against
+live data. The absent-source branch, which is the one that misleads, was
+exercised live.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -152,6 +152,7 @@ states that the whole decision is Superseded.
 | [0128](0128-route-server-next-hop-translation.md) | Route-server next-hop translation | Accepted (architecture GO if activated; implementation NO-GO, demand-gated) | 2026-08-29 | Active |
 | [0129](0129-prefix-sid-domain-boundary.md) | BGP Prefix-SID administrative-domain boundary | Proposed (no runtime behavior shipped) | 2026-08-29 | Unstated |
 | [0130](0130-identity-conditional-external-policy-fence.md) | Identity-conditional external-policy transaction fence | Accepted | 2026-09-01 | Active |
+| [0131](0131-read-only-mcp-server.md) | Read-only MCP server for the explain surfaces | Proposed | 2026-09-05 | Active |
 
 ## Supporting records
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -152,7 +152,7 @@ states that the whole decision is Superseded.
 | [0128](0128-route-server-next-hop-translation.md) | Route-server next-hop translation | Accepted (architecture GO if activated; implementation NO-GO, demand-gated) | 2026-08-29 | Active |
 | [0129](0129-prefix-sid-domain-boundary.md) | BGP Prefix-SID administrative-domain boundary | Proposed (no runtime behavior shipped) | 2026-08-29 | Unstated |
 | [0130](0130-identity-conditional-external-policy-fence.md) | Identity-conditional external-policy transaction fence | Accepted | 2026-09-01 | Active |
-| [0131](0131-read-only-mcp-server.md) | Read-only MCP server for the explain surfaces | Proposed | 2026-09-05 | Active |
+| [0131](0131-read-only-mcp-server.md) | Read-only MCP server for the explain surfaces | Accepted | 2026-09-05 | Active |
 
 ## Supporting records
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -17,5 +17,6 @@ Follow a procedure for a specific task.
 - [Kernel dataplane runner](kernel-dataplane-runner.md) — Run the privileged Linux dataplane checks.
 - [Fuzzing](fuzzing.md) — Build and run the parser fuzz targets.
 - [Add a configuration field](config-knob-contributor-guide.md) — Cover validation, reload, persistence, and documentation.
+- [Answer route questions from an AI agent](mcp-server.md) — Expose the explain surfaces to an MCP host, read-only.
 
 For complete deployment recipes, browse the [scenario cookbook](../cookbook/README.md).

--- a/docs/how-to/mcp-server.md
+++ b/docs/how-to/mcp-server.md
@@ -74,17 +74,21 @@ rustbgpd-mcp --grpc-addr https://10.0.0.1:50051 \
 {
   "mcpServers": {
     "rustbgpd": {
-      "command": "/usr/local/bin/rustbgpd-mcp",
       "args": [
         "--grpc-addr",
         "https://10.0.0.1:50051",
         "--grpc-token-file",
         "/path/to/rustbgpd-observer.token"
-      ]
+      ],
+      "command": "/usr/local/bin/rustbgpd-mcp"
     }
   }
 }
 ```
+
+Note the token path: the real `--grpc-token-file` value is replaced with a
+placeholder, so a pasted snippet never carries a token. `command` is the
+running binary's own path.
 
 Replace the placeholder path with the real token file before pasting. For
 Claude Code:

--- a/docs/how-to/mcp-server.md
+++ b/docs/how-to/mcp-server.md
@@ -105,6 +105,7 @@ claude mcp add rustbgpd -- /usr/local/bin/rustbgpd-mcp \
 | `rbgp_explain_export` | Why is this prefix advertised, or not advertised, to this peer? |
 | `rbgp_explain_import` | Why did this prefix from this peer get accepted or rejected? |
 | `rbgp_explain_best_path` | Which path won for this prefix, and at which decision step? |
+| `rbgp_explain_evpn_route` | What happened to this exact EVPN route — selection and export? |
 | `rbgp_list_rejected` | What did this peer send that was thrown away? |
 | `rbgp_list_peers` | What sessions exist and what state are they in? |
 | `rbgp_get_health` | Is the daemon up, and how much is in the RIB? |
@@ -136,14 +137,42 @@ on every rung. A `stop` verdict names the gate that halted the route, and the
 ladder is recorded by a dry run of the same staging body live distribution
 executes — it cannot drift from the real decision.
 
-Two surfaces the agent must not be allowed to misread, and which the tools
-label explicitly:
+`rbgp_explain_evpn_route` covers the EVPN side and answers more per call: one
+response carries the selection story (installed best, fresh selection, compared
+candidate, candidate count, deciding reason) and, when `advertised_to` is given,
+the same gate ladder toward that peer. Keys are exact, not filters — a Type 2
+lookup with `ip` omitted selects the MAC-only key, not every host IP under that
+MAC:
+
+```json
+{
+  "rd": "65001:100",
+  "key": { "route_type": "mac_ip", "ethernet_tag": 0, "mac": "aa:bb:cc:dd:ee:01" },
+  "received_from": "192.0.2.1",
+  "advertised_to": "192.0.2.9"
+}
+```
+
+### Results an agent must not over-read
+
+Empty is not the same as absent, and absent is not the same as denied. Four
+fields carry an explicit note so the distinction does not depend on a model
+inferring it:
 
 - `rbgp_list_rejected` returns `retention_enabled` and a `retention_note`. When
   retention is off, an empty list is a configuration fact, not "nothing was
   rejected". When the store is at `capacity`, older rejections were displaced.
 - `rbgp_explain_import` outcomes `cache_disabled`, `no_session`, and `evicted`
   mean the question could not be answered. They are not rejections.
+- `rbgp_explain_evpn_route` returns a `received_note`. EVPN import rejection
+  history is not retained, so an empty `received` for a peer is **not** an
+  import-rejection explanation and **not** proof the peer never sent the key —
+  it supports no conclusion about what the peer sent. The note also separates
+  that case from "no accepted-source lookup was requested".
+- `rbgp_explain_evpn_route` returns a `selection_note`. While
+  `selection_deferred` is set the installed `best` may differ from fresh
+  selection, so reporting it as current state would be wrong; the note says so
+  and points at `selection_best`.
 
 Two tools that might be expected are absent because the RPCs do not exist: BMP
 is outbound-only export to configured collectors with no query surface, and the

--- a/docs/how-to/mcp-server.md
+++ b/docs/how-to/mcp-server.md
@@ -1,0 +1,198 @@
+# Answer route questions from an AI agent
+
+> **Document class: CURRENT.** This maintained page reflects the project as it is now; dated sections remain bounded to their stated scope.
+
+`rustbgpd-mcp` exposes the daemon's explain surfaces to an AI agent over the
+Model Context Protocol, so "why is 203.0.113.0/24 not advertised to AS64502?"
+is answered by the daemon's own export-gate ladder instead of inferred from
+route dumps.
+
+[All documentation](../README.md)
+
+## Where this runs, and why that matters
+
+**It does not run on the router.** An stdio MCP server is a subprocess the MCP
+host spawns on the machine where the operator sits, and it is a plain gRPC
+client. Adopting it adds no process to the daemon host: it runs on the
+workstation and connects to a listener over the network, like `rbgp` or any
+other API client.
+
+That is the honest answer to "do I want an AI-facing process in my production
+environment" — in the recommended deployment, you are not putting one there.
+
+The binary is shipped in no release artifact and is excluded from the default
+workspace build. Build it explicitly when you want it:
+
+```sh
+cargo build --release -p rustbgpd-mcp
+```
+
+## Configure a read-only listener on the daemon
+
+Every tool this server exposes calls a `sensitive_read` gRPC method. Cap the
+listener there and map its principal to the `observer` role:
+
+```toml
+[global.telemetry.grpc_tcp]
+address = "10.0.0.1:50051"
+max_tier = "sensitive_read"
+token_file = "/etc/rustbgpd/mcp-observer.token"
+principal = "mcp.observer"
+
+[security.grpc.roles]
+"mcp.observer" = "observer"
+```
+
+`max_tier` is a hard per-listener ceiling and `observer` is the lowest role
+that reaches `sensitive_read`. A mutating call over this listener is refused by
+the daemon before the handler runs:
+
+```text
+permission denied: listener max_tier sensitive_read does not permit
+operator_only RPC /rustbgpd.v1.InjectionService/AddPath
+```
+
+gRPC authorization is startup configuration. Changing it needs a daemon
+restart, not a reload.
+
+For a TLS deployment, give the listener the `tls_cert_file` / `tls_key_file` /
+`tls_client_ca_file` trio instead of a bearer token and point `--grpc-addr` at
+`https://`. See [configuration](../reference/configuration.md) for the full
+listener contract.
+
+## Register the server with an MCP host
+
+`--print-config` emits paste-ready `mcpServers` JSON. It renders a placeholder
+for the token path and never echoes a token value:
+
+```sh
+rustbgpd-mcp --grpc-addr https://10.0.0.1:50051 \
+  --grpc-token-file /etc/rustbgpd/mcp-observer.token --print-config
+```
+
+```json
+{
+  "mcpServers": {
+    "rustbgpd": {
+      "command": "/usr/local/bin/rustbgpd-mcp",
+      "args": [
+        "--grpc-addr",
+        "https://10.0.0.1:50051",
+        "--grpc-token-file",
+        "/path/to/rustbgpd-observer.token"
+      ]
+    }
+  }
+}
+```
+
+Replace the placeholder path with the real token file before pasting. For
+Claude Code:
+
+```sh
+claude mcp add rustbgpd -- /usr/local/bin/rustbgpd-mcp \
+  --grpc-addr https://10.0.0.1:50051 \
+  --grpc-token-file /etc/rustbgpd/mcp-observer.token
+```
+
+`--grpc-addr` and `--grpc-token-file` also read `RUSTBGPD_GRPC_ADDR` and
+`RUSTBGPD_GRPC_TOKEN_FILE`.
+
+## What the agent can ask
+
+| Tool | Question it answers |
+|------|---------------------|
+| `rbgp_explain_export` | Why is this prefix advertised, or not advertised, to this peer? |
+| `rbgp_explain_import` | Why did this prefix from this peer get accepted or rejected? |
+| `rbgp_explain_best_path` | Which path won for this prefix, and at which decision step? |
+| `rbgp_list_rejected` | What did this peer send that was thrown away? |
+| `rbgp_list_peers` | What sessions exist and what state are they in? |
+| `rbgp_get_health` | Is the daemon up, and how much is in the RIB? |
+
+`rbgp_explain_export` returns the full export-gate ladder in live evaluation
+order. Against a daemon whose export policy blocks the prefix:
+
+```json
+{
+  "decision": "deny",
+  "prefix": "203.0.113.0/24",
+  "peer_address": "192.0.2.2",
+  "stopped_at_gate": "export_policy",
+  "gates": [
+    { "step": 1, "gate": "best_route",     "code": "local_route",     "verdict": "pass" },
+    { "step": 2, "gate": "split_horizon",  "code": "split_horizon",   "verdict": "pass" },
+    { "step": 3, "gate": "rr_reflection",  "code": "rr_reflection",   "verdict": "pass" },
+    { "step": 4, "gate": "family",         "code": "family",          "verdict": "pass" },
+    { "step": 5, "gate": "llgr",           "code": "llgr",            "verdict": "pass" },
+    { "step": 6, "gate": "orf",            "code": "orf",             "verdict": "not_applicable" },
+    { "step": 7, "gate": "export_policy",  "code": "policy_denied",   "verdict": "stop",
+      "detail": "export policy \"block-doc-prefix\" denied this route" }
+  ]
+}
+```
+
+The `detail` fields are elided above for width; the real response carries one
+on every rung. A `stop` verdict names the gate that halted the route, and the
+ladder is recorded by a dry run of the same staging body live distribution
+executes — it cannot drift from the real decision.
+
+Two surfaces the agent must not be allowed to misread, and which the tools
+label explicitly:
+
+- `rbgp_list_rejected` returns `retention_enabled` and a `retention_note`. When
+  retention is off, an empty list is a configuration fact, not "nothing was
+  rejected". When the store is at `capacity`, older rejections were displaced.
+- `rbgp_explain_import` outcomes `cache_disabled`, `no_session`, and `evicted`
+  mean the question could not be answered. They are not rejections.
+
+Two tools that might be expected are absent because the RPCs do not exist: BMP
+is outbound-only export to configured collectors with no query surface, and the
+`rbgp doctor` support bundle is assembled client-side from several RPCs plus
+local probes.
+
+## How "read-only" is actually enforced
+
+Two independent controls. **Neither is sufficient alone.**
+
+**1. No write tool exists in the binary.** Not hidden, not gated at call time —
+absent. Each tool declares the gRPC method it calls, and a contract test reads
+[`grpc-method-inventory.json`](../reference/grpc-method-inventory.json) — the
+machine-readable export of the daemon's own authorization table — and fails the
+build if any declared method carries a `mutating` or `operator_only` tier. A
+companion test asserts the declared set equals what the server actually
+registers, so a tool cannot be added without entering the contract.
+
+**2. The listener configuration above.** This is a property of one daemon's
+config. The server cannot verify it and does not try.
+
+### The colocation sharp edge
+
+If you run the server on the daemon host against the local Unix socket, read
+this. An owner-only UDS with no configured `principal` authorizes as the
+reserved implicit principal `local-operator` **at Operator tier** — the
+daemon's highest. Filesystem ownership is the authentication. So:
+
+```sh
+# Gives this process Operator-tier credentials on the daemon.
+rustbgpd-mcp --grpc-addr unix:///var/lib/rustbgpd/grpc.sock
+```
+
+Control 2 is simply not present in that configuration, and control 1 — the
+absence of any write tool in this binary — is the only thing standing between
+those credentials and a write.
+
+There is no lower tier to fall back to. The daemon publishes **zero**
+`read`-tier methods; `sensitive_read` is the lowest cap a listener can carry,
+and every explain RPC sits in it. Capping a UDS listener at `sensitive_read`
+and giving it an explicit `principal` mapped to `observer` restores control 2
+if colocation is unavoidable.
+
+## Related
+
+- [Explain route decisions](explain.md) — the same answers through `rbgp`.
+- [gRPC method inventory](../reference/grpc-method-inventory.md) — every method
+  and its authorization tier.
+- [Configuration](../reference/configuration.md) — listener, tier, and role
+  contracts.
+- [ADR-0131](../adr/0131-read-only-mcp-server.md) — why this exists and what it
+  deliberately does not do.

--- a/docs/how-to/mcp-server.md
+++ b/docs/how-to/mcp-server.md
@@ -20,8 +20,8 @@ other API client.
 That is the honest answer to "do I want an AI-facing process in my production
 environment" — in the recommended deployment, you are not putting one there.
 
-The binary is shipped in no release artifact and is excluded from the default
-workspace build. Build it explicitly when you want it:
+The binary is shipped in no release artifact. Plain `cargo build` keeps its
+existing root-package default; build the MCP server explicitly when needed:
 
 ```sh
 cargo build --release -p rustbgpd-mcp
@@ -29,18 +29,21 @@ cargo build --release -p rustbgpd-mcp
 
 ## Configure a read-only listener on the daemon
 
-Every tool this server exposes calls a `sensitive_read` gRPC method. Cap the
-listener there and map its principal to the `observer` role:
+Every tool calls a `sensitive_read` gRPC method. For remote access, configure
+mutual TLS, cap the listener there, and map the client certificate's principal
+to the `observer` role. This example uses a client certificate with URI SAN
+`rustbgpd://observer/mcp`:
 
 ```toml
 [global.telemetry.grpc_tcp]
 address = "10.0.0.1:50051"
 max_tier = "sensitive_read"
-token_file = "/etc/rustbgpd/mcp-observer.token"
-principal = "mcp.observer"
+tls_cert_file = "/etc/rustbgpd/pki/server.crt"
+tls_key_file = "/etc/rustbgpd/pki/server.key"
+tls_client_ca_file = "/etc/rustbgpd/pki/client-ca.pem"
 
 [security.grpc.roles]
-"mcp.observer" = "observer"
+"rustbgpd://observer/mcp" = "observer"
 ```
 
 `max_tier` is a hard per-listener ceiling and `observer` is the lowest role
@@ -55,19 +58,27 @@ operator_only RPC /rustbgpd.v1.InjectionService/AddPath
 gRPC authorization is startup configuration. Changing it needs a daemon
 restart, not a reload.
 
-For a TLS deployment, give the listener the `tls_cert_file` / `tls_key_file` /
-`tls_client_ca_file` trio instead of a bearer token and point `--grpc-addr` at
-`https://`. See [configuration](../reference/configuration.md) for the full
-listener contract.
+The MCP client needs the server's CA and its own client certificate/key.
+`https://` requires all three `--grpc-tls-*-file` options below. The endpoint's
+host must match the server certificate; `--grpc-tls-server-name` can select a
+different verification name. TLS options are rejected with `http://` and
+`unix://` endpoints. Do not set `grpc_tcp.principal` on a mutual-TLS listener:
+the daemon derives it from the verified client certificate.
+
+For an existing bearer-token listener, use `--grpc-token-file` with the
+appropriate endpoint. See [configuration](../reference/configuration.md) for
+the listener's token, principal, and role settings.
 
 ## Register the server with an MCP host
 
-`--print-config` emits paste-ready `mcpServers` JSON. It renders a placeholder
-for the token path and never echoes a token value:
+`--print-config` emits `mcpServers` JSON with placeholders for credential-file
+paths. It never echoes token values or certificate/key contents:
 
 ```sh
 rustbgpd-mcp --grpc-addr https://10.0.0.1:50051 \
-  --grpc-token-file /etc/rustbgpd/mcp-observer.token --print-config
+  --grpc-tls-ca-file /etc/rustbgpd/pki/server-ca.pem \
+  --grpc-tls-cert-file /etc/rustbgpd/pki/mcp-client.crt \
+  --grpc-tls-key-file /etc/rustbgpd/pki/mcp-client.key --print-config
 ```
 
 ```json
@@ -77,8 +88,12 @@ rustbgpd-mcp --grpc-addr https://10.0.0.1:50051 \
       "args": [
         "--grpc-addr",
         "https://10.0.0.1:50051",
-        "--grpc-token-file",
-        "/path/to/rustbgpd-observer.token"
+        "--grpc-tls-ca-file",
+        "/path/to/ca.pem",
+        "--grpc-tls-cert-file",
+        "/path/to/client.crt",
+        "--grpc-tls-key-file",
+        "/path/to/client.key"
       ],
       "command": "/usr/local/bin/rustbgpd-mcp"
     }
@@ -86,21 +101,27 @@ rustbgpd-mcp --grpc-addr https://10.0.0.1:50051 \
 }
 ```
 
-Note the token path: the real `--grpc-token-file` value is replaced with a
-placeholder, so a pasted snippet never carries a token. `command` is the
-running binary's own path.
+`command` is the running binary's own path. Replace the credential-file
+placeholders with paths readable by the MCP host before using the snippet.
 
-Replace the placeholder path with the real token file before pasting. For
-Claude Code:
+For Claude Code:
 
 ```sh
 claude mcp add rustbgpd -- /usr/local/bin/rustbgpd-mcp \
   --grpc-addr https://10.0.0.1:50051 \
-  --grpc-token-file /etc/rustbgpd/mcp-observer.token
+  --grpc-tls-ca-file /etc/rustbgpd/pki/server-ca.pem \
+  --grpc-tls-cert-file /etc/rustbgpd/pki/mcp-client.crt \
+  --grpc-tls-key-file /etc/rustbgpd/pki/mcp-client.key
 ```
 
 `--grpc-addr` and `--grpc-token-file` also read `RUSTBGPD_GRPC_ADDR` and
-`RUSTBGPD_GRPC_TOKEN_FILE`.
+`RUSTBGPD_GRPC_TOKEN_FILE`. The TLS options read `RUSTBGPD_GRPC_TLS_CA_FILE`,
+`RUSTBGPD_GRPC_TLS_CERT_FILE`, `RUSTBGPD_GRPC_TLS_KEY_FILE`, and
+`RUSTBGPD_GRPC_TLS_SERVER_NAME`.
+
+Each tool call has a 30-second backend response deadline, including connection
+readiness and the complete decoded response body. A stalled daemon or response
+path returns an error; the MCP server does not retry the call automatically.
 
 ## What the agent can ask
 
@@ -165,7 +186,11 @@ model inferring it:
 
 - `rbgp_list_rejected` returns `retention_enabled` and a `retention_note`. When
   retention is off, an empty list is a configuration fact, not "nothing was
-  rejected". When the store is at `capacity`, older rejections were displaced.
+  rejected". An enabled store describes currently retained entries: subsequent
+  acceptance or withdrawal removes entries, so an empty store does not prove
+  there were no earlier rejections. `evictions_since_reset` reports known
+  displacement; occupancy alone cannot establish whether eviction occurred.
+  `truncated_by_limit` reports entries omitted from this response by `limit`.
 - `rbgp_explain_import` outcomes `cache_disabled`, `no_session`, and `evicted`
   mean the question could not be answered. They are not rejections.
 - `rbgp_explain_evpn_route` returns a `received_note`. EVPN import rejection

--- a/docs/how-to/mcp-server.md
+++ b/docs/how-to/mcp-server.md
@@ -156,8 +156,8 @@ MAC:
 ### Results an agent must not over-read
 
 Empty is not the same as absent, and absent is not the same as denied. Four
-fields carry an explicit note so the distinction does not depend on a model
-inferring it:
+results say which case they are in, so the distinction does not depend on a
+model inferring it:
 
 - `rbgp_list_rejected` returns `retention_enabled` and a `retention_note`. When
   retention is off, an empty list is a configuration fact, not "nothing was

--- a/docs/reference/embedding.md
+++ b/docs/reference/embedding.md
@@ -33,6 +33,7 @@ This document is the contract for embedders: which crate to depend on, what the
 | `rustbgpd-evpn-linux` | Disabled | `rustbgpd-evpn` | Linux netlink EVPN dataplane reconciler. |
 | `rustbgpd-evpn-load` | Disabled | `rustbgpd-wire` | EVPN route-reflector benchmark load generator. |
 | `rustbgpd-fsm` | Enabled | `rustbgpd-wire` | Pure RFC 4271 FSM; no I/O. |
+| `rustbgpd-mcp` | Disabled | `rustbgpd-api` | Read-only Model Context Protocol server over the explain surfaces. |
 | `rustbgpd-mrt` | Disabled | `rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-wire` | RFC 6396 MRT dump export. |
 | `rustbgpd-policy` | Disabled | `rustbgpd-wire` | Import/export policy engine. |
 | `rustbgpd-rib` | Disabled | `rustbgpd-bmp`, `rustbgpd-policy`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-wire` | Adj-RIB and Loc-RIB best-path data structures. |

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+publish = false
+name = "rustbgpd-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Read-only Model Context Protocol server exposing rustbgpd's gRPC explain surfaces over stdio"
+
+[lib]
+name = "rustbgpd_mcp"
+path = "src/lib.rs"
+
+[[bin]]
+name = "rustbgpd-mcp"
+path = "src/main.rs"
+
+[dependencies]
+rustbgpd-api.workspace = true
+rmcp.workspace = true
+# Same major as rmcp's own `schemars` requirement, so Cargo unifies both onto
+# one instance and rmcp's `Json<T>` trait bounds are satisfied by types derived
+# here. rmcp also re-exports `rmcp::schemars` for the same reason.
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-std"] }
+tonic.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -33,3 +33,6 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+rcgen.workspace = true
+tempfile.workspace = true
+tokio-stream.workspace = true

--- a/tools/mcp/src/backend_tests.rs
+++ b/tools/mcp/src/backend_tests.rs
@@ -1,0 +1,324 @@
+//! Real transport regressions without a daemon or privileged networking.
+use super::*;
+use rcgen::{BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tonic::Response;
+use tonic::transport::{Server, ServerTlsConfig};
+
+fn adapter(channel: Channel) -> RustbgpdMcp {
+    let mut adapter = RustbgpdMcp::new(InterceptedService::new(
+        channel,
+        BearerInterceptor::new(None),
+    ));
+    adapter.read_timeout = Duration::from_secs(2);
+    adapter
+}
+
+// Consume the entire request so a body-stall test cannot accidentally pass
+// because connection readiness or request transmission used up the budget.
+async fn stall_response(
+    mut stream: impl AsyncRead + AsyncWrite + Unpin,
+    headers: bool,
+    reached: tokio::sync::oneshot::Sender<()>,
+) {
+    stream
+        .write_all(&[0, 0, 0, 4, 0, 0, 0, 0, 0])
+        .await
+        .unwrap();
+    let mut preface = [0; 24];
+    stream.read_exact(&mut preface).await.unwrap();
+    assert_eq!(&preface, b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+    let stream_id = loop {
+        let mut frame = [0; 9];
+        stream.read_exact(&mut frame).await.unwrap();
+        let length = u32::from_be_bytes([0, frame[0], frame[1], frame[2]]) as usize;
+        stream.read_exact(&mut vec![0; length]).await.unwrap();
+        let stream_id = [frame[5], frame[6], frame[7], frame[8]];
+        if stream_id != [0; 4] && matches!(frame[3], 0 | 1) && frame[4] & 1 != 0 {
+            break stream_id;
+        }
+    };
+    if headers {
+        // HPACK :status=200, content-type=application/grpc; END_HEADERS only.
+        let block = b"\x88\x5f\x10application/grpc";
+        let mut frame = vec![0, 0, 19, 1, 4];
+        frame.extend(stream_id);
+        frame.extend(block);
+        stream.write_all(&frame).await.unwrap();
+    }
+    reached.send(()).unwrap();
+    // The client must terminate the RPC. Keep the socket alive meanwhile.
+    std::future::pending::<()>().await;
+}
+
+#[tokio::test]
+async fn tcp_complete_response_deadline_before_and_after_headers() {
+    for headers in [false, true] {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint =
+            parse_daemon_endpoint(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            stall_response(stream, headers, reached_tx).await;
+        });
+        let mcp = adapter(TlsOptions::default().channel(&endpoint).unwrap());
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            mcp.get_health(Parameters(NoParams {})),
+        )
+        .await
+        .expect("the read deadline must finish before the test watchdog");
+        server.abort();
+        assert!(server.await.unwrap_err().is_cancelled());
+        reached_rx
+            .await
+            .expect("the mock reached the requested response phase before the deadline");
+        assert!(
+            result
+                .err()
+                .expect("stalled RPC must fail")
+                .message
+                .contains("daemon read response timed out")
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn uds_complete_response_deadline_before_and_after_headers() {
+    for headers in [false, true] {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("grpc.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+        let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            stall_response(stream, headers, reached_tx).await;
+        });
+        let mcp = adapter(
+            TlsOptions::default()
+                .channel(&DaemonEndpoint::Uds(path))
+                .unwrap(),
+        );
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            mcp.get_health(Parameters(NoParams {})),
+        )
+        .await
+        .expect("the read deadline must finish before the test watchdog");
+
+        server.abort();
+        assert!(server.await.unwrap_err().is_cancelled());
+        reached_rx
+            .await
+            .expect("the mock reached the requested response phase before the deadline");
+        assert!(
+            result
+                .err()
+                .expect("stalled RPC must fail")
+                .message
+                .contains("daemon read response timed out")
+        );
+    }
+}
+
+#[derive(Default)]
+struct Health;
+
+#[tonic::async_trait]
+impl proto::control_service_server::ControlService for Health {
+    async fn get_health(
+        &self,
+        request: Request<proto::HealthRequest>,
+    ) -> Result<Response<proto::HealthResponse>, Status> {
+        assert!(
+            request.peer_certs().is_some_and(|certs| !certs.is_empty()),
+            "mutual TLS must present a client certificate"
+        );
+        Ok(Response::new(proto::HealthResponse {
+            healthy: true,
+            ..Default::default()
+        }))
+    }
+    async fn get_metrics(
+        &self,
+        _: Request<proto::MetricsRequest>,
+    ) -> Result<Response<proto::MetricsResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+    async fn shutdown(
+        &self,
+        _: Request<proto::ShutdownRequest>,
+    ) -> Result<Response<proto::ShutdownResponse>, Status> {
+        panic!("read-only adapter must never invoke shutdown")
+    }
+    async fn trigger_mrt_dump(
+        &self,
+        _: Request<proto::TriggerMrtDumpRequest>,
+    ) -> Result<Response<proto::TriggerMrtDumpResponse>, Status> {
+        panic!("read-only adapter must never invoke a dump")
+    }
+}
+
+fn authority() -> (rcgen::Certificate, Issuer<'static, KeyPair>) {
+    let mut params = CertificateParams::new(Vec::new()).unwrap();
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let key = KeyPair::generate().unwrap();
+    let cert = params.self_signed(&key).unwrap();
+    (cert, Issuer::new(params, key))
+}
+
+fn leaf(issuer: &Issuer<'static, KeyPair>, usage: ExtendedKeyUsagePurpose) -> (String, String) {
+    let mut params = CertificateParams::new(vec!["localhost".into(), "127.0.0.1".into()]).unwrap();
+    params.extended_key_usages.push(usage);
+    let key = KeyPair::generate().unwrap();
+    (
+        params.signed_by(&key, issuer).unwrap().pem(),
+        key.serialize_pem(),
+    )
+}
+
+#[tokio::test]
+async fn mtls_health_requires_trusted_server_and_client_identity() {
+    let directory = tempfile::tempdir().unwrap();
+    let (ca, issuer) = authority();
+    let (server_cert, server_key) = leaf(&issuer, ExtendedKeyUsagePurpose::ServerAuth);
+    let (client_cert, client_key) = leaf(&issuer, ExtendedKeyUsagePurpose::ClientAuth);
+    let mut options = TlsOptions {
+        ca_file: Some(directory.path().join("ca.pem")),
+        cert_file: Some(directory.path().join("client.pem")),
+        key_file: Some(directory.path().join("client.key")),
+        server_name: Some("localhost".into()),
+    };
+    std::fs::write(options.ca_file.as_ref().unwrap(), ca.pem()).unwrap();
+    std::fs::write(options.cert_file.as_ref().unwrap(), &client_cert).unwrap();
+    std::fs::write(options.key_file.as_ref().unwrap(), &client_key).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint =
+        parse_daemon_endpoint(&format!("https://{}", listener.local_addr().unwrap())).unwrap();
+    let server = tokio::spawn(
+        Server::builder()
+            .tls_config(
+                ServerTlsConfig::new()
+                    .identity(Identity::from_pem(server_cert, server_key))
+                    .client_ca_root(Certificate::from_pem(ca.pem())),
+            )
+            .unwrap()
+            .add_service(proto::control_service_server::ControlServiceServer::new(
+                Health,
+            ))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+    );
+    let result = adapter(options.channel(&endpoint).unwrap())
+        .get_health(Parameters(NoParams {}))
+        .await;
+    assert!(result.unwrap().0.healthy);
+    options.server_name = None;
+    assert!(
+        adapter(options.channel(&endpoint).unwrap())
+            .get_health(Parameters(NoParams {}))
+            .await
+            .unwrap()
+            .0
+            .healthy
+    );
+
+    let (foreign_ca, foreign_issuer) = authority();
+    std::fs::write(options.ca_file.as_ref().unwrap(), foreign_ca.pem()).unwrap();
+    assert!(
+        adapter(options.channel(&endpoint).unwrap())
+            .get_health(Parameters(NoParams {}))
+            .await
+            .is_err()
+    );
+    std::fs::write(options.ca_file.as_ref().unwrap(), ca.pem()).unwrap();
+    let (foreign_cert, foreign_key) = leaf(&foreign_issuer, ExtendedKeyUsagePurpose::ClientAuth);
+    std::fs::write(options.cert_file.as_ref().unwrap(), foreign_cert).unwrap();
+    std::fs::write(options.key_file.as_ref().unwrap(), foreign_key).unwrap();
+    assert!(
+        adapter(options.channel(&endpoint).unwrap())
+            .get_health(Parameters(NoParams {}))
+            .await
+            .is_err()
+    );
+    std::fs::write(options.cert_file.as_ref().unwrap(), client_cert).unwrap();
+    std::fs::write(options.key_file.as_ref().unwrap(), client_key).unwrap();
+    let wrong_name = TlsOptions {
+        server_name: Some("wrong.invalid".into()),
+        ..options
+    };
+    assert!(
+        adapter(wrong_name.channel(&endpoint).unwrap())
+            .get_health(Parameters(NoParams {}))
+            .await
+            .is_err()
+    );
+    server.abort();
+    assert!(server.await.unwrap_err().is_cancelled());
+}
+
+#[test]
+fn tls_options_require_https_and_complete_credentials() {
+    let https = parse_daemon_endpoint("https://localhost:50051").unwrap();
+    for mask in 0..8 {
+        let options = TlsOptions {
+            ca_file: (mask & 1 != 0).then(|| "ca.pem".into()),
+            cert_file: (mask & 2 != 0).then(|| "client.pem".into()),
+            key_file: (mask & 4 != 0).then(|| "client.key".into()),
+            server_name: None,
+        };
+        assert_eq!(options.validate(&https).is_ok(), mask == 7);
+        for endpoint in [
+            DaemonEndpoint::Tcp("http://localhost:50051".into()),
+            DaemonEndpoint::Uds("/tmp/grpc.sock".into()),
+        ] {
+            assert_eq!(options.validate(&endpoint).is_ok(), mask == 0);
+        }
+    }
+    let options = TlsOptions {
+        server_name: Some("localhost".into()),
+        ..Default::default()
+    };
+    assert!(
+        options
+            .validate(&DaemonEndpoint::Tcp("http://localhost:50051".into()))
+            .is_err()
+    );
+    assert!(options.validate(&https).is_err());
+}
+
+#[test]
+fn printed_mtls_config_preserves_options_without_credential_paths() {
+    let mut options = TlsOptions {
+        ca_file: Some("private-ca.pem".into()),
+        cert_file: Some("private-client.pem".into()),
+        key_file: Some("private-client.key".into()),
+        server_name: Some("daemon.example".into()),
+    };
+    let printed = print_config("rustbgpd-mcp", "https://127.0.0.1:50051", false, &options);
+    assert!(!printed.contains("private-"));
+    let config: serde_json::Value = serde_json::from_str(&printed).unwrap();
+    assert_eq!(
+        config["mcpServers"]["rustbgpd"]["args"],
+        serde_json::json!([
+            "--grpc-addr",
+            "https://127.0.0.1:50051",
+            "--grpc-tls-ca-file",
+            "/path/to/ca.pem",
+            "--grpc-tls-cert-file",
+            "/path/to/client.crt",
+            "--grpc-tls-key-file",
+            "/path/to/client.key",
+            "--grpc-tls-server-name",
+            "daemon.example"
+        ])
+    );
+    options.server_name = Some(" ".into());
+    assert!(
+        options
+            .validate(&DaemonEndpoint::Tcp("https://localhost:50051".into()))
+            .is_err()
+    );
+}

--- a/tools/mcp/src/lib.rs
+++ b/tools/mcp/src/lib.rs
@@ -289,7 +289,7 @@ pub fn load_bearer_authorization(
             format!("token file is empty: {}", token_file.display()),
         ));
     }
-    let value = AsciiMetadataValue::try_from(format!("Bearer {token}")).map_err(|_| {
+    let mut value = AsciiMetadataValue::try_from(format!("Bearer {token}")).map_err(|_| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
@@ -298,6 +298,7 @@ pub fn load_bearer_authorization(
             ),
         )
     })?;
+    value.set_sensitive(true);
     Ok(Some(value))
 }
 
@@ -1233,6 +1234,10 @@ impl RustbgpdMcp {
 }
 
 #[allow(
+    unknown_lints,
+    reason = "Clippy at the supported 1.95 MSRV predates this lint"
+)]
+#[allow(
     clippy::unused_async_trait_impl,
     reason = "the #[tool_handler] macro emits the async ServerHandler methods; get_info resolves \
               immediately and has no call to await"
@@ -1246,7 +1251,7 @@ impl ServerHandler for RustbgpdMcp {
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
         info.server_info = Implementation::new("rustbgpd-mcp", env!("CARGO_PKG_VERSION"));
         info.instructions = Some(
-            "Read-only view of a running rustbgpd daemon. Every tool calls a read-tier gRPC \
+            "Read-only view of a running rustbgpd daemon. Every tool calls a sensitive_read gRPC \
              method; this server registers no tool that can change daemon state. Start from \
              rbgp_explain_export for \"why is this prefix not advertised to that peer\" — it \
              returns the daemon's own ordered export-gate ladder, so the answer comes from live \
@@ -1577,6 +1582,21 @@ fn push_list<T: std::fmt::Display>(lines: &mut Vec<String>, label: &str, values:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bearer_file_value_and_sensitivity_survive_interceptor_cloning() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("observer.token");
+        std::fs::write(&path, "dummy-mcp-token\n").unwrap();
+        let authorization = load_bearer_authorization(Some(&path)).unwrap().unwrap();
+        assert_eq!(authorization, "Bearer dummy-mcp-token");
+        assert!(authorization.is_sensitive());
+        let interceptor = BearerInterceptor::new(Some(authorization));
+        let request = interceptor.clone().call(Request::new(())).unwrap();
+        let inserted = request.metadata().get("authorization").unwrap();
+        assert_eq!(inserted, "Bearer dummy-mcp-token");
+        assert!(inserted.is_sensitive());
+    }
 
     #[test]
     fn endpoint_parsing_accepts_the_two_supported_families() {

--- a/tools/mcp/src/lib.rs
+++ b/tools/mcp/src/lib.rs
@@ -73,6 +73,10 @@ pub const TOOL_METHOD_PATHS: &[(&str, &str)] = &[
         "/rustbgpd.v1.NeighborService/ListNeighbors",
     ),
     ("rbgp_get_health", "/rustbgpd.v1.ControlService/GetHealth"),
+    (
+        "rbgp_explain_evpn_route",
+        "/rustbgpd.v1.RibService/ExplainEvpnRoute",
+    ),
 ];
 
 // ---------------------------------------------------------------------------
@@ -525,6 +529,207 @@ pub struct ListRejectedResult {
     pub evictions_since_reset: Option<u64>,
 }
 
+/// Exact EVPN route key, mirroring the `rbgp evpn explain` selector vocabulary.
+///
+/// Every variant is an exact key, not a filter. Type 2 with `ip` omitted
+/// selects the MAC-only key rather than every host IP under that MAC.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(tag = "route_type", rename_all = "snake_case")]
+pub enum EvpnKey {
+    /// Type 2 MAC/IP. Omitting `ip` selects the MAC-only key.
+    MacIp {
+        /// Ethernet Tag; `0` for a single-tag EVI.
+        #[serde(default)]
+        ethernet_tag: u32,
+        /// MAC address, colon-separated.
+        mac: String,
+        /// Exact host address. Omit for the MAC-only key.
+        #[serde(default)]
+        ip: Option<String>,
+    },
+    /// Type 3 inclusive multicast, by exact originator.
+    Imet {
+        /// Ethernet Tag; `0` for a single-tag EVI.
+        #[serde(default)]
+        ethernet_tag: u32,
+        /// Originating VTEP address.
+        originator_ip: String,
+    },
+    /// Type 4 Ethernet Segment route, by exact segment and originator.
+    Es {
+        /// Ethernet Segment Identifier.
+        esi: String,
+        /// Originating VTEP address.
+        originator_ip: String,
+    },
+    /// Type 5 IP prefix. Host bits must be zero.
+    IpPrefix {
+        /// Ethernet Tag; `0` for a single-tag EVI.
+        #[serde(default)]
+        ethernet_tag: u32,
+        /// Canonical CIDR prefix.
+        prefix: String,
+    },
+    /// Type 1 per-ES Ethernet A-D. The Ethernet Tag is always `MAX_ET` and is
+    /// not a caller parameter.
+    EadPerEs {
+        /// Ethernet Segment Identifier.
+        esi: String,
+    },
+    /// Type 1 per-EVI Ethernet A-D. `MAX_ET` is not a per-EVI key.
+    EadPerEvi {
+        /// Ethernet Segment Identifier.
+        esi: String,
+        /// Ethernet Tag; must not be `MAX_ET`.
+        ethernet_tag: u32,
+    },
+}
+
+impl EvpnKey {
+    fn into_selector(self, rd: String) -> proto::EvpnRouteSelector {
+        use proto::evpn_route_selector::Route;
+        let route = match self {
+            Self::MacIp {
+                ethernet_tag,
+                mac,
+                ip,
+            } => Route::MacIp(proto::EvpnMacIpSelector {
+                ethernet_tag,
+                mac,
+                ip: ip.unwrap_or_default(),
+            }),
+            Self::Imet {
+                ethernet_tag,
+                originator_ip,
+            } => Route::Imet(proto::EvpnImetSelector {
+                ethernet_tag,
+                originator_ip,
+            }),
+            Self::Es { esi, originator_ip } => {
+                Route::Es(proto::EvpnEsSelector { esi, originator_ip })
+            }
+            Self::IpPrefix {
+                ethernet_tag,
+                prefix,
+            } => Route::IpPrefix(proto::EvpnIpPrefixSelector {
+                ethernet_tag,
+                prefix,
+            }),
+            // MAX_ET identifies the per-ES form; the caller does not supply it.
+            Self::EadPerEs { esi } => Route::EadPerEs(proto::EvpnEadSelector {
+                esi,
+                ethernet_tag: u32::MAX,
+            }),
+            Self::EadPerEvi { esi, ethernet_tag } => {
+                Route::EadPerEvi(proto::EvpnEadSelector { esi, ethernet_tag })
+            }
+        };
+        proto::EvpnRouteSelector {
+            rd,
+            route: Some(route),
+        }
+    }
+}
+
+/// "What happened to this exact EVPN route?"
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ExplainEvpnRouteParams {
+    /// Route Distinguisher, `asn:nn` or `ip:nn`.
+    pub rd: String,
+    /// The exact route key.
+    pub key: EvpnKey,
+    /// Optional peer whose retained accepted state to look up. Absence of
+    /// retained state is not an import-rejection explanation.
+    #[serde(default)]
+    pub received_from: Option<String>,
+    /// Optional peer to evaluate current export eligibility toward.
+    #[serde(default)]
+    pub advertised_to: Option<String>,
+}
+
+/// One EVPN route as the daemon holds it.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct EvpnRouteLine {
+    /// RFC 7432 route type (1-5).
+    pub route_type: u32,
+    /// Route Distinguisher.
+    pub rd: String,
+    /// Ethernet Segment Identifier; empty when the type carries none.
+    pub esi: String,
+    /// Ethernet Tag as the daemon renders it.
+    pub ethernet_tag: String,
+    /// MAC address; empty for types that carry none.
+    pub mac: String,
+    /// Host IP; empty for types that carry none.
+    pub ip: String,
+    /// Type 5 prefix; empty for other types.
+    pub prefix: String,
+    /// Next hop.
+    pub next_hop: String,
+    /// Peer this route came from; empty when locally originated.
+    pub peer_address: String,
+    /// `AS_PATH` rendering.
+    pub as_path: String,
+    /// MPLS label 1.
+    pub label: u32,
+}
+
+/// Current export evaluation toward one peer.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct EvpnExportResult {
+    /// Peer the export was evaluated toward.
+    pub peer_address: String,
+    /// `advertise`, `deny`, `no_best_route`, or `unsupported_family`.
+    pub decision: String,
+    /// Full gate ladder in live evaluation order.
+    pub gates: Vec<GateStep>,
+    /// The gate that stopped the route, when one did.
+    pub stopped_at_gate: Option<String>,
+    /// Reason codes and messages attached to the decision.
+    pub reasons: Vec<ReasonLine>,
+    /// Attribute modifications export policy would apply.
+    pub modifications: Vec<String>,
+    /// Dry-run staged result from the installed best. No state was changed.
+    pub staged: Option<EvpnRouteLine>,
+    /// Committed local Adj-RIB-Out entry. This is send-side state only: it is
+    /// not proof the peer received or installed the route.
+    pub advertised: Option<EvpnRouteLine>,
+    /// True when an identical route already sits in the advertised state.
+    pub already_advertised: bool,
+    /// True when outbound state for this peer has pending work.
+    pub outbound_dirty: bool,
+}
+
+/// Selection and export story for one exact EVPN route.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ExplainEvpnRouteResult {
+    /// Installed Loc-RIB route. **Read `selection_note` before trusting this**
+    /// — while selection is deferred it can differ from fresh selection.
+    pub best: Option<EvpnRouteLine>,
+    /// Fresh selection winner, recomputed for this query.
+    pub selection_best: Option<EvpnRouteLine>,
+    /// The requested source when it is not the fresh winner, otherwise the
+    /// winner's runner-up.
+    pub compared: Option<EvpnRouteLine>,
+    /// How many candidates the selection considered.
+    pub candidate_count: u64,
+    /// Why `selection_best` beats `compared`. Absent when nothing was compared.
+    pub selection_reason: Option<ReasonLine>,
+    /// True when selection is deferred, so `best` may be stale.
+    pub selection_deferred: bool,
+    /// Plain statement of whether `best` is current. Always populated.
+    pub selection_note: String,
+    /// Peer whose retained accepted state was looked up; empty when none was
+    /// requested.
+    pub received_from: String,
+    /// The retained accepted route from that peer, when one is retained.
+    pub received: Option<EvpnRouteLine>,
+    /// What the `received` field does and does not establish. Always populated.
+    pub received_note: String,
+    /// Current export evaluation, when `advertised_to` was supplied.
+    pub export: Option<EvpnExportResult>,
+}
+
 /// No parameters.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema)]
 pub struct NoParams {}
@@ -572,7 +777,7 @@ pub struct HealthResult {
 // Server
 // ---------------------------------------------------------------------------
 
-/// The MCP server: a gRPC client of one daemon, exposing six read-only tools.
+/// The MCP server: a gRPC client of one daemon, exposing seven read-only tools.
 #[derive(Clone)]
 pub struct RustbgpdMcp {
     upstream: Upstream,
@@ -615,18 +820,7 @@ impl RustbgpdMcp {
             .map_err(|status| map_status(&status))?
             .into_inner();
 
-        let gates: Vec<GateStep> = response
-            .gates
-            .iter()
-            .enumerate()
-            .map(|(index, step)| GateStep {
-                step: u32::try_from(index + 1).unwrap_or(u32::MAX),
-                gate: step.gate.clone(),
-                code: step.code.clone(),
-                verdict: verdict_label(step.verdict),
-                detail: step.detail.clone(),
-            })
-            .collect();
+        let gates = gate_ladder(&response.gates);
 
         Ok(Json(ExplainExportResult {
             decision: decision_label(response.decision),
@@ -634,10 +828,7 @@ impl RustbgpdMcp {
             prefix: format!("{}/{}", response.prefix, response.prefix_length),
             next_hop: response.next_hop,
             route_peer_address: response.route_peer_address,
-            stopped_at_gate: gates
-                .iter()
-                .find(|step| step.verdict == "stop")
-                .map(|step| step.gate.clone()),
+            stopped_at_gate: stopped_at_gate(&gates),
             gates,
             reasons: response
                 .reasons
@@ -869,6 +1060,80 @@ impl RustbgpdMcp {
             daemon_version: response.daemon_version,
         }))
     }
+
+    /// Explain one exact EVPN route: selection story plus current export.
+    #[tool(
+        name = "rbgp_explain_evpn_route",
+        description = "Explain one exact EVPN route (RFC 7432 Types 1-5): the selection story \
+                       (installed best, fresh selection, compared candidate, candidate count, \
+                       deciding reason) and, when `advertised_to` is given, the current export \
+                       gate ladder toward that peer. Every key is exact, not a filter. Two \
+                       results must not be over-read, and the response states both in words: an \
+                       empty `received` for a peer is NOT an import-rejection explanation and NOT \
+                       proof the peer never sent the key — import rejection history is not \
+                       retained, so it supports no conclusion about what the peer sent. And when \
+                       `selection_deferred` is true, the installed `best` may differ from fresh \
+                       selection, so reporting it as current state would be wrong. Read \
+                       `received_note` and `selection_note`."
+    )]
+    pub async fn explain_evpn_route(
+        &self,
+        Parameters(params): Parameters<ExplainEvpnRouteParams>,
+    ) -> Result<Json<ExplainEvpnRouteResult>, ErrorData> {
+        let mut client = proto::rib_service_client::RibServiceClient::new(self.upstream.clone());
+        let received_from = params.received_from.unwrap_or_default();
+        let response = client
+            .explain_evpn_route(proto::ExplainEvpnRouteRequest {
+                key: Some(params.key.into_selector(params.rd)),
+                received_from: received_from.clone(),
+                advertised_to: params.advertised_to.unwrap_or_default(),
+            })
+            .await
+            .map_err(|status| map_status(&status))?
+            .into_inner();
+
+        let received = response.received.as_ref().map(evpn_route_line);
+        Ok(Json(ExplainEvpnRouteResult {
+            selection_note: selection_note(
+                response.selection_deferred,
+                response.selection_best.is_some(),
+            ),
+            received_note: received_note(&response.received_from, received.is_some()),
+            best: response.best.as_ref().map(evpn_route_line),
+            selection_best: response.selection_best.as_ref().map(evpn_route_line),
+            compared: response.compared.as_ref().map(evpn_route_line),
+            candidate_count: response.candidate_count,
+            selection_reason: response.selection_reason.map(|reason| ReasonLine {
+                code: reason.code,
+                message: reason.message,
+            }),
+            selection_deferred: response.selection_deferred,
+            received_from: response.received_from,
+            received,
+            export: response.export.map(|export| {
+                let gates = gate_ladder(&export.gates);
+                EvpnExportResult {
+                    peer_address: export.peer_address,
+                    decision: decision_label(export.decision),
+                    stopped_at_gate: stopped_at_gate(&gates),
+                    gates,
+                    reasons: export
+                        .reasons
+                        .into_iter()
+                        .map(|reason| ReasonLine {
+                            code: reason.code,
+                            message: reason.message,
+                        })
+                        .collect(),
+                    modifications: render_modifications(export.modifications.as_ref()),
+                    staged: export.staged.as_ref().map(evpn_route_line),
+                    advertised: export.advertised.as_ref().map(evpn_route_line),
+                    already_advertised: export.already_advertised,
+                    outbound_dirty: export.outbound_dirty,
+                }
+            }),
+        }))
+    }
 }
 
 #[allow(
@@ -1043,6 +1308,81 @@ fn render_modifications(modifications: Option<&proto::ExplainModifications>) -> 
         lines.push(format!("as_path_prepend = {asn} x{count}"));
     }
     lines
+}
+
+/// Number an export gate ladder in live evaluation order.
+fn gate_ladder(gates: &[proto::ExportGateStep]) -> Vec<GateStep> {
+    gates
+        .iter()
+        .enumerate()
+        .map(|(index, step)| GateStep {
+            step: u32::try_from(index + 1).unwrap_or(u32::MAX),
+            gate: step.gate.clone(),
+            code: step.code.clone(),
+            verdict: verdict_label(step.verdict),
+            detail: step.detail.clone(),
+        })
+        .collect()
+}
+
+/// Name the rung that halted the route, when one did.
+fn stopped_at_gate(gates: &[GateStep]) -> Option<String> {
+    gates
+        .iter()
+        .find(|step| step.verdict == "stop")
+        .map(|step| step.gate.clone())
+}
+
+fn evpn_route_line(entry: &proto::EvpnRouteEntry) -> EvpnRouteLine {
+    EvpnRouteLine {
+        route_type: entry.route_type,
+        rd: entry.rd.clone(),
+        esi: entry.esi.clone(),
+        ethernet_tag: entry.ethernet_tag.clone(),
+        mac: entry.mac.clone(),
+        ip: entry.ip.clone(),
+        prefix: entry.prefix.clone(),
+        next_hop: entry.next_hop.clone(),
+        peer_address: entry.peer_address.clone(),
+        as_path: render_as_path(&entry.as_path),
+        label: entry.label,
+    }
+}
+
+/// State in words whether the installed best is current.
+///
+/// A bare `selection_deferred: true` sitting beside `best` is easy to skim
+/// past, and reporting a deferred `best` as current state is wrong. This says
+/// so in the result itself.
+fn selection_note(deferred: bool, has_fresh: bool) -> String {
+    if deferred {
+        return "SELECTION IS DEFERRED: the installed `best` may be stale and may differ from \
+                `selection_best`. Do not report `best` as current state; `selection_best` is the \
+                fresh winner for this query."
+            .into();
+    }
+    if has_fresh {
+        return "selection is not deferred, so the installed `best` reflects current selection"
+            .into();
+    }
+    "selection is not deferred and no candidate was selected for this key".into()
+}
+
+/// State in words what an absent retained source does and does not establish.
+fn received_note(received_from: &str, present: bool) -> String {
+    if received_from.is_empty() {
+        return "no accepted-source lookup was requested; `received` is empty for that reason \
+                alone"
+            .into();
+    }
+    if present {
+        return format!("retained accepted state from {received_from}");
+    }
+    format!(
+        "no retained accepted state from {received_from}. This is NOT an import-rejection \
+         explanation and NOT proof that the peer never sent this key: import rejection history \
+         is not retained for EVPN, so absence supports no conclusion about what the peer sent."
+    )
 }
 
 /// Render an `AS_PATH` as the space-separated ASN list operators read.
@@ -1259,6 +1599,99 @@ mod tests {
             false,
         );
         assert!(!without.contains("token"), "{without}");
+    }
+
+    #[test]
+    fn a_deferred_selection_says_the_installed_best_may_be_stale() {
+        let deferred = selection_note(true, true);
+        assert!(deferred.contains("DEFERRED"), "{deferred}");
+        assert!(
+            deferred.contains("may be stale") && deferred.contains("Do not report `best`"),
+            "a bare boolean is skimmable; the note must say what not to conclude: {deferred}"
+        );
+
+        let settled = selection_note(false, true);
+        assert!(settled.contains("reflects current selection"), "{settled}");
+        assert!(!settled.contains("DEFERRED"), "{settled}");
+    }
+
+    #[test]
+    fn an_absent_retained_source_is_not_an_import_rejection() {
+        let absent = received_note("192.0.2.1", false);
+        assert!(
+            absent.contains("NOT an import-rejection explanation")
+                && absent.contains("NOT proof that the peer never sent"),
+            "absence must not read as evidence: {absent}"
+        );
+
+        let present = received_note("192.0.2.1", true);
+        assert!(present.contains("retained accepted state"), "{present}");
+        assert!(!present.contains("NOT proof"), "{present}");
+
+        let unrequested = received_note("", false);
+        assert!(
+            unrequested.contains("no accepted-source lookup was requested"),
+            "an unrequested lookup must not read as an absent one: {unrequested}"
+        );
+    }
+
+    #[test]
+    fn evpn_keys_map_onto_the_exact_selector_forms() {
+        use proto::evpn_route_selector::Route;
+
+        // Omitting `ip` selects the MAC-only key, not every host IP.
+        let mac_only = EvpnKey::MacIp {
+            ethernet_tag: 0,
+            mac: "aa:bb:cc:dd:ee:01".into(),
+            ip: None,
+        }
+        .into_selector("65001:100".into());
+        assert_eq!(mac_only.rd, "65001:100");
+        match mac_only.route {
+            Some(Route::MacIp(selector)) => assert!(selector.ip.is_empty()),
+            other => panic!("expected a MAC/IP selector, got {other:?}"),
+        }
+
+        // MAX_ET identifies the per-ES form and is not a caller parameter.
+        match (EvpnKey::EadPerEs { esi: "es-1".into() })
+            .into_selector("65001:100".into())
+            .route
+        {
+            Some(Route::EadPerEs(selector)) => assert_eq!(selector.ethernet_tag, u32::MAX),
+            other => panic!("expected a per-ES A-D selector, got {other:?}"),
+        }
+
+        match (EvpnKey::EadPerEvi {
+            esi: "es-1".into(),
+            ethernet_tag: 7,
+        })
+        .into_selector("65001:100".into())
+        .route
+        {
+            Some(Route::EadPerEvi(selector)) => assert_eq!(selector.ethernet_tag, 7),
+            other => panic!("expected a per-EVI A-D selector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_gate_ladder_is_numbered_and_names_its_stop() {
+        let gates = gate_ladder(&[
+            proto::ExportGateStep {
+                gate: "split_horizon".into(),
+                code: "split_horizon".into(),
+                verdict: proto::ExportGateVerdict::Pass as i32,
+                detail: String::new(),
+            },
+            proto::ExportGateStep {
+                gate: "export_policy".into(),
+                code: "policy_denied".into(),
+                verdict: proto::ExportGateVerdict::Stop as i32,
+                detail: String::new(),
+            },
+        ]);
+        assert_eq!(gates.iter().map(|g| g.step).collect::<Vec<_>>(), vec![1, 2]);
+        assert_eq!(stopped_at_gate(&gates).as_deref(), Some("export_policy"));
+        assert_eq!(stopped_at_gate(&gates[..1]), None);
     }
 
     #[tokio::test]

--- a/tools/mcp/src/lib.rs
+++ b/tools/mcp/src/lib.rs
@@ -30,7 +30,9 @@
 #![warn(clippy::pedantic)]
 
 use std::fmt::Write as _;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
@@ -42,7 +44,7 @@ use serde::{Deserialize, Serialize};
 use tonic::metadata::AsciiMetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use tonic::{Request, Status};
 
 /// Every tool this server registers, paired with the gRPC method it calls.
@@ -153,6 +155,88 @@ pub fn parse_daemon_endpoint(addr: &str) -> Result<DaemonEndpoint, std::io::Erro
         )
     })?;
     Ok(DaemonEndpoint::Tcp(addr.to_string()))
+}
+
+/// Client-side TLS credentials for the daemon's mutual-TLS listener.
+#[derive(clap::Args, Debug, Default)]
+pub struct TlsOptions {
+    /// PEM CA certificate used to verify the daemon.
+    #[arg(long = "grpc-tls-ca-file", env = "RUSTBGPD_GRPC_TLS_CA_FILE")]
+    pub ca_file: Option<PathBuf>,
+    /// PEM client certificate presented to the daemon.
+    #[arg(long = "grpc-tls-cert-file", env = "RUSTBGPD_GRPC_TLS_CERT_FILE")]
+    pub cert_file: Option<PathBuf>,
+    /// PEM private key for the client certificate.
+    #[arg(long = "grpc-tls-key-file", env = "RUSTBGPD_GRPC_TLS_KEY_FILE")]
+    pub key_file: Option<PathBuf>,
+    /// TLS verification name and SNI; defaults to the HTTPS URI host.
+    #[arg(long = "grpc-tls-server-name", env = "RUSTBGPD_GRPC_TLS_SERVER_NAME")]
+    pub server_name: Option<String>,
+}
+
+impl TlsOptions {
+    /// Validate TLS options without reading credential files.
+    ///
+    /// # Errors
+    /// Returns invalid input for incomplete HTTPS credentials or TLS options
+    /// on a plaintext TCP or Unix endpoint.
+    pub fn validate(&self, endpoint: &DaemonEndpoint) -> Result<(), std::io::Error> {
+        let https = matches!(endpoint, DaemonEndpoint::Tcp(uri) if uri.starts_with("https://"));
+        let any = self.ca_file.is_some()
+            || self.cert_file.is_some()
+            || self.key_file.is_some()
+            || self.server_name.is_some();
+        let message = if https
+            && (self.ca_file.is_none() || self.cert_file.is_none() || self.key_file.is_none())
+        {
+            Some(
+                "https:// requires --grpc-tls-ca-file, --grpc-tls-cert-file and --grpc-tls-key-file for mutual TLS",
+            )
+        } else if !https && any {
+            Some("gRPC TLS options require an https:// endpoint")
+        } else if self
+            .server_name
+            .as_ref()
+            .is_some_and(|name| name.trim().is_empty())
+        {
+            Some("--grpc-tls-server-name must not be empty")
+        } else {
+            None
+        };
+        message.map_or(Ok(()), |message| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                message,
+            ))
+        })
+    }
+
+    /// Build a lazy channel, verifying the server and presenting the client identity.
+    ///
+    /// # Errors
+    /// Returns invalid options, unreadable credentials, or invalid TLS configuration.
+    pub fn channel(
+        &self,
+        endpoint: &DaemonEndpoint,
+    ) -> Result<Channel, Box<dyn std::error::Error>> {
+        self.validate(endpoint)?;
+        let mut builder =
+            Endpoint::from_shared(endpoint.channel_uri())?.connect_timeout(Duration::from_secs(5));
+        if let (Some(ca), Some(cert), Some(key)) = (&self.ca_file, &self.cert_file, &self.key_file)
+        {
+            let mut tls = ClientTlsConfig::new()
+                .ca_certificate(Certificate::from_pem(std::fs::read(ca)?))
+                .identity(Identity::from_pem(
+                    std::fs::read(cert)?,
+                    std::fs::read(key)?,
+                ));
+            if let Some(name) = &self.server_name {
+                tls = tls.domain_name(name);
+            }
+            builder = builder.tls_config(tls)?;
+        }
+        Ok(builder.connect_lazy())
+    }
 }
 
 /// Attaches a bearer token to every outbound request when one is configured.
@@ -514,12 +598,11 @@ pub struct ListRejectedResult {
     /// an empty `routes` list is a configuration fact and says nothing about
     /// whether routes were rejected.
     pub retention_enabled: bool,
-    /// The session's retention cap. When the daemon returned exactly this many
-    /// rejections, older ones were displaced.
+    /// The session's retention cap; occupancy alone does not establish eviction.
     pub capacity: u32,
     /// Human-readable statement of what an empty or full listing means here.
     pub retention_note: String,
-    /// The rejections, oldest ordering as the daemon returned them.
+    /// Currently retained rejections, in the order the daemon returned them.
     pub routes: Vec<RejectedRouteLine>,
     /// Rejections the daemon returned that `limit` cut from `routes`. `0` means
     /// the list is complete with respect to what the daemon retained.
@@ -782,6 +865,7 @@ pub struct HealthResult {
 pub struct RustbgpdMcp {
     upstream: Upstream,
     tool_router: ToolRouter<Self>,
+    read_timeout: Duration,
 }
 
 #[tool_router(router = tool_router)]
@@ -792,7 +876,21 @@ impl RustbgpdMcp {
         Self {
             upstream,
             tool_router: Self::tool_router(),
+            read_timeout: Duration::from_secs(30),
         }
+    }
+
+    // Wrap the generated unary future itself: readiness, response headers,
+    // body and protobuf decoding all complete inside this deadline.
+    async fn read<T>(
+        &self,
+        response: impl Future<Output = Result<tonic::Response<T>, Status>>,
+    ) -> Result<T, ErrorData> {
+        tokio::time::timeout(self.read_timeout, response)
+            .await
+            .map_err(|_| map_status(&Status::deadline_exceeded("daemon read response timed out")))?
+            .map(tonic::Response::into_inner)
+            .map_err(|status| map_status(&status))
     }
 
     /// Explain the export decision for one prefix toward one peer, as the full
@@ -809,16 +907,16 @@ impl RustbgpdMcp {
         Parameters(params): Parameters<ExplainExportParams>,
     ) -> Result<Json<ExplainExportResult>, ErrorData> {
         let mut client = proto::rib_service_client::RibServiceClient::new(self.upstream.clone());
-        let response = client
-            .explain_advertised_route(proto::ExplainAdvertisedRouteRequest {
-                peer_address: params.peer_address.clone(),
-                prefix: params.prefix.clone(),
-                prefix_length: params.prefix_length,
-                ..Default::default()
-            })
-            .await
-            .map_err(|status| map_status(&status))?
-            .into_inner();
+        let response = self
+            .read(
+                client.explain_advertised_route(proto::ExplainAdvertisedRouteRequest {
+                    peer_address: params.peer_address.clone(),
+                    prefix: params.prefix.clone(),
+                    prefix_length: params.prefix_length,
+                    ..Default::default()
+                }),
+            )
+            .await?;
 
         let gates = gate_ladder(&response.gates);
 
@@ -858,17 +956,17 @@ impl RustbgpdMcp {
     ) -> Result<Json<ExplainImportResult>, ErrorData> {
         let mut client =
             proto::policy_service_client::PolicyServiceClient::new(self.upstream.clone());
-        let response = client
-            .explain_import_policy(proto::ExplainImportPolicyRequest {
-                peer_address: params.peer_address,
-                afi_safi: params.family.as_proto(),
-                prefix: params.prefix,
-                prefix_length: params.prefix_length,
-                path_id: params.path_id,
-            })
-            .await
-            .map_err(|status| map_status(&status))?
-            .into_inner();
+        let response = self
+            .read(
+                client.explain_import_policy(proto::ExplainImportPolicyRequest {
+                    peer_address: params.peer_address,
+                    afi_safi: params.family.as_proto(),
+                    prefix: params.prefix,
+                    prefix_length: params.prefix_length,
+                    path_id: params.path_id,
+                }),
+            )
+            .await?;
 
         Ok(Json(ExplainImportResult {
             peer_address: response.peer_address,
@@ -904,15 +1002,13 @@ impl RustbgpdMcp {
         Parameters(params): Parameters<ExplainBestPathParams>,
     ) -> Result<Json<ExplainBestPathResult>, ErrorData> {
         let mut client = proto::rib_service_client::RibServiceClient::new(self.upstream.clone());
-        let response = client
-            .explain_best_path(proto::ExplainBestPathRequest {
+        let response = self
+            .read(client.explain_best_path(proto::ExplainBestPathRequest {
                 prefix: params.prefix,
                 prefix_length: params.prefix_length,
                 peer_address: params.peer_address,
-            })
-            .await
-            .map_err(|status| map_status(&status))?
-            .into_inner();
+            }))
+            .await?;
 
         let best = response.best_route.unwrap_or_default();
         Ok(Json(ExplainBestPathResult {
@@ -955,13 +1051,13 @@ impl RustbgpdMcp {
     ) -> Result<Json<ListRejectedResult>, ErrorData> {
         let mut client =
             proto::policy_service_client::PolicyServiceClient::new(self.upstream.clone());
-        let response = client
-            .list_rejected_routes(proto::ListRejectedRoutesRequest {
-                peer_address: params.peer_address,
-            })
-            .await
-            .map_err(|status| map_status(&status))?
-            .into_inner();
+        let response = self
+            .read(
+                client.list_rejected_routes(proto::ListRejectedRoutesRequest {
+                    peer_address: params.peer_address,
+                }),
+            )
+            .await?;
 
         let retained = response.routes.len();
         let limit = params
@@ -972,7 +1068,13 @@ impl RustbgpdMcp {
         let at_capacity = response.capacity > 0 && retained >= response.capacity as usize;
 
         Ok(Json(ListRejectedResult {
-            retention_note: retention_note(response.retention_enabled, at_capacity, retained),
+            retention_note: retention_note(
+                response.retention_enabled,
+                at_capacity,
+                retained,
+                response.evictions_since_reset,
+                truncated_by_limit,
+            ),
             peer_address: response.peer_address,
             retention_enabled: response.retention_enabled,
             capacity: response.capacity,
@@ -1009,11 +1111,9 @@ impl RustbgpdMcp {
     ) -> Result<Json<ListPeersResult>, ErrorData> {
         let mut client =
             proto::neighbor_service_client::NeighborServiceClient::new(self.upstream.clone());
-        let response = client
-            .list_neighbors(proto::ListNeighborsRequest {})
-            .await
-            .map_err(|status| map_status(&status))?
-            .into_inner();
+        let response = self
+            .read(client.list_neighbors(proto::ListNeighborsRequest {}))
+            .await?;
 
         Ok(Json(ListPeersResult {
             peers: response
@@ -1046,11 +1146,9 @@ impl RustbgpdMcp {
     ) -> Result<Json<HealthResult>, ErrorData> {
         let mut client =
             proto::control_service_client::ControlServiceClient::new(self.upstream.clone());
-        let response = client
-            .get_health(proto::HealthRequest {})
-            .await
-            .map_err(|status| map_status(&status))?
-            .into_inner();
+        let response = self
+            .read(client.get_health(proto::HealthRequest {}))
+            .await?;
 
         Ok(Json(HealthResult {
             healthy: response.healthy,
@@ -1082,15 +1180,13 @@ impl RustbgpdMcp {
     ) -> Result<Json<ExplainEvpnRouteResult>, ErrorData> {
         let mut client = proto::rib_service_client::RibServiceClient::new(self.upstream.clone());
         let received_from = params.received_from.unwrap_or_default();
-        let response = client
-            .explain_evpn_route(proto::ExplainEvpnRouteRequest {
+        let response = self
+            .read(client.explain_evpn_route(proto::ExplainEvpnRouteRequest {
                 key: Some(params.key.into_selector(params.rd)),
                 received_from: received_from.clone(),
                 advertised_to: params.advertised_to.unwrap_or_default(),
-            })
-            .await
-            .map_err(|status| map_status(&status))?
-            .into_inner();
+            }))
+            .await?;
 
         let received = response.received.as_ref().map(evpn_route_line);
         Ok(Json(ExplainEvpnRouteResult {
@@ -1170,7 +1266,7 @@ impl ServerHandler for RustbgpdMcp {
 /// The token argument is never echoed: the rendered config names a placeholder
 /// path so a real token value cannot leak into a pasted snippet.
 #[must_use]
-pub fn print_config(command: &str, grpc_addr: &str, uses_token: bool) -> String {
+pub fn print_config(command: &str, grpc_addr: &str, uses_token: bool, tls: &TlsOptions) -> String {
     let mut args = vec![
         serde_json::Value::from("--grpc-addr"),
         serde_json::Value::from(grpc_addr),
@@ -1178,6 +1274,36 @@ pub fn print_config(command: &str, grpc_addr: &str, uses_token: bool) -> String 
     if uses_token {
         args.push(serde_json::Value::from("--grpc-token-file"));
         args.push(serde_json::Value::from("/path/to/rustbgpd-observer.token"));
+    }
+    for (configured, flag, placeholder) in [
+        (
+            tls.ca_file.is_some(),
+            "--grpc-tls-ca-file",
+            "/path/to/ca.pem",
+        ),
+        (
+            tls.cert_file.is_some(),
+            "--grpc-tls-cert-file",
+            "/path/to/client.crt",
+        ),
+        (
+            tls.key_file.is_some(),
+            "--grpc-tls-key-file",
+            "/path/to/client.key",
+        ),
+    ] {
+        if configured {
+            args.extend([
+                serde_json::Value::from(flag),
+                serde_json::Value::from(placeholder),
+            ]);
+        }
+    }
+    if let Some(name) = &tls.server_name {
+        args.extend([
+            serde_json::Value::from("--grpc-tls-server-name"),
+            serde_json::Value::from(name.as_str()),
+        ]);
     }
     let config = serde_json::json!({
         "mcpServers": {
@@ -1238,25 +1364,43 @@ fn session_state_label(value: i32) -> String {
     )
 }
 
-fn retention_note(enabled: bool, at_capacity: bool, retained: usize) -> String {
-    if !enabled {
-        return "reject retention is disabled on this session ([policy.reject_retention]); an \
-                empty list is a configuration fact and does not mean nothing was rejected"
-            .into();
+fn retention_note(
+    enabled: bool,
+    at_capacity: bool,
+    retained: usize,
+    evictions: Option<u64>,
+    truncated: usize,
+) -> String {
+    let mut note = if enabled {
+        format!(
+            "reject retention is enabled; {retained} entries are currently retained. {} ",
+            if at_capacity {
+                "The store is at capacity."
+            } else {
+                "The store is below capacity."
+            }
+        )
+    } else {
+        "reject retention is disabled on this session ([policy.reject_retention]). ".into()
+    };
+    match evictions {
+        Some(0) => note.push_str("No capacity eviction has occurred since the session reset. "),
+        Some(count) => {
+            let _ = write!(
+                note,
+                "{count} capacity evictions have occurred since the session reset. "
+            );
+        }
+        None => note.push_str("Capacity eviction history is unavailable. "),
     }
-    if at_capacity {
-        return "the retention store is at capacity, so this listing shows the most recent \
-                rejections and older ones were displaced"
-            .into();
+    if truncated > 0 {
+        let _ = write!(
+            note,
+            "The output limit omits {truncated} currently retained entries. "
+        );
     }
-    if retained == 0 {
-        return "reject retention is enabled and the store is empty: this session has rejected \
-                nothing since its last reset"
-            .into();
-    }
-    "reject retention is enabled and the store is below capacity, so this listing is complete for \
-     this session"
-        .into()
+    note.push_str("This is current retained state, not a rejection history: acceptance or withdrawal can remove entries. An empty list does not mean nothing was rejected.");
+    note
 }
 
 fn render_modifications(modifications: Option<&proto::ExplainModifications>) -> Vec<String> {
@@ -1496,19 +1640,35 @@ mod tests {
     }
 
     #[test]
-    fn disabled_retention_never_reads_as_nothing_rejected() {
-        let note = retention_note(false, false, 0);
-        assert!(note.contains("disabled"), "{note}");
-        assert!(
-            note.contains("does not mean nothing was rejected"),
-            "{note}"
-        );
-
-        let empty = retention_note(true, false, 0);
-        assert!(empty.contains("rejected nothing"), "{empty}");
-
-        let full = retention_note(true, true, 32);
-        assert!(full.contains("displaced"), "{full}");
+    fn retention_notes_do_not_infer_history_from_occupancy() {
+        for (enabled, full, retained) in [
+            (false, false, 0),
+            (true, false, 0),
+            (true, false, 3),
+            (true, true, 32),
+        ] {
+            for evictions in [None, Some(0), Some(7)] {
+                for truncated in [0, 2] {
+                    let note = retention_note(enabled, full, retained, evictions, truncated);
+                    assert!(
+                        note.contains("An empty list does not mean nothing was rejected"),
+                        "{note}"
+                    );
+                    assert!(
+                        note.contains("acceptance or withdrawal can remove entries"),
+                        "{note}"
+                    );
+                    assert_eq!(note.contains("output limit omits"), truncated > 0, "{note}");
+                    let expected = match evictions {
+                        None => "history is unavailable",
+                        Some(0) => "No capacity eviction has occurred",
+                        Some(_) => "7 capacity evictions have occurred",
+                    };
+                    assert!(note.contains(expected), "{note}");
+                    assert!(!note.contains("listing is complete"), "{note}");
+                }
+            }
+        }
     }
 
     #[test]
@@ -1577,6 +1737,7 @@ mod tests {
             "/usr/local/bin/rustbgpd-mcp",
             "http://rr1.example.net:50051",
             true,
+            &TlsOptions::default(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
         assert_eq!(
@@ -1597,6 +1758,7 @@ mod tests {
             "/usr/local/bin/rustbgpd-mcp",
             "http://127.0.0.1:50051",
             false,
+            &TlsOptions::default(),
         );
         assert!(!without.contains("token"), "{without}");
     }
@@ -1721,3 +1883,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod backend_tests;

--- a/tools/mcp/src/lib.rs
+++ b/tools/mcp/src/lib.rs
@@ -1,0 +1,1290 @@
+//! Read-only Model Context Protocol server over rustbgpd's gRPC explain
+//! surfaces.
+//!
+//! The server speaks MCP over stdio (newline-delimited JSON-RPC on stdin and
+//! stdout) and is a plain gRPC client of a running daemon. An MCP host spawns
+//! it as a subprocess on the operator's own workstation; adopting it adds no
+//! process to the router.
+//!
+//! # Read-only by two independent controls
+//!
+//! 1. **No write tool exists in this binary.** Every tool is registered in
+//!    [`TOOL_METHOD_PATHS`] with the gRPC method it calls, and a contract test
+//!    fails the build if any entry names a method the daemon classifies as
+//!    `mutating` or `operator_only`. There is no call-time gate to bypass and
+//!    no hidden tool to enable.
+//! 2. **The documented deployment** points the server at a listener capped at
+//!    `max_tier = "sensitive_read"` whose principal maps to the `observer`
+//!    role.
+//!
+//! Neither control is sufficient alone. Control 1 is a property of this source
+//! tree, not of the daemon: a daemon serving an owner-only Unix socket with no
+//! configured principal authorizes the reserved implicit principal
+//! `local-operator` at Operator tier, so a colocated deployment hands this
+//! process the daemon's highest credentials and only control 1 stands between
+//! them and a write. Control 2 is a property of one daemon's configuration,
+//! which this process cannot verify and does not attempt to.
+
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::{Json, Parameters};
+use rmcp::model::{ErrorData, Implementation, ServerCapabilities, ServerInfo};
+use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use rustbgpd_api::proto;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tonic::metadata::AsciiMetadataValue;
+use tonic::service::Interceptor;
+use tonic::service::interceptor::InterceptedService;
+use tonic::transport::{Channel, Endpoint};
+use tonic::{Request, Status};
+
+/// Every tool this server registers, paired with the gRPC method it calls.
+///
+/// This is the tool surface's machine-checkable contract. `tests/inventory_contract.rs`
+/// asserts each path exists in `docs/reference/grpc-method-inventory.json` and
+/// carries a `read` or `sensitive_read` tier, so a write RPC cannot reach the
+/// tool surface without failing the build.
+pub const TOOL_METHOD_PATHS: &[(&str, &str)] = &[
+    (
+        "rbgp_explain_export",
+        "/rustbgpd.v1.RibService/ExplainAdvertisedRoute",
+    ),
+    (
+        "rbgp_explain_import",
+        "/rustbgpd.v1.PolicyService/ExplainImportPolicy",
+    ),
+    (
+        "rbgp_explain_best_path",
+        "/rustbgpd.v1.RibService/ExplainBestPath",
+    ),
+    (
+        "rbgp_list_rejected",
+        "/rustbgpd.v1.PolicyService/ListRejectedRoutes",
+    ),
+    (
+        "rbgp_list_peers",
+        "/rustbgpd.v1.NeighborService/ListNeighbors",
+    ),
+    ("rbgp_get_health", "/rustbgpd.v1.ControlService/GetHealth"),
+];
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+/// The two endpoint families the server accepts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DaemonEndpoint {
+    /// A complete `http://` or `https://` URI.
+    Tcp(String),
+    /// An absolute Unix-domain socket path.
+    Uds(PathBuf),
+}
+
+impl DaemonEndpoint {
+    /// The URI handed to tonic's channel builder.
+    #[must_use]
+    pub fn channel_uri(&self) -> String {
+        match self {
+            Self::Tcp(uri) => uri.clone(),
+            Self::Uds(path) => format!("unix://{}", path.display()),
+        }
+    }
+}
+
+/// Parse a daemon endpoint, matching the `birdwatcher-adapter` contract:
+/// complete HTTP(S) TCP URIs, or `unix:///absolute/path`.
+///
+/// # Errors
+///
+/// Returns [`std::io::ErrorKind::InvalidInput`] for a relative socket path, a
+/// bare `unix:` prefix, a scheme this server does not speak, or a URI tonic
+/// itself rejects.
+pub fn parse_daemon_endpoint(addr: &str) -> Result<DaemonEndpoint, std::io::Error> {
+    if let Some(path) = addr.strip_prefix("unix://") {
+        if path.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "invalid gRPC endpoint: unix:// path must not be empty",
+            ));
+        }
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "invalid gRPC endpoint: Unix socket path must be absolute: {}",
+                    path.display()
+                ),
+            ));
+        }
+        return Ok(DaemonEndpoint::Uds(path));
+    }
+
+    if addr.starts_with("unix:") {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid gRPC endpoint: use unix:///absolute/path",
+        ));
+    }
+
+    if !(addr.starts_with("http://") || addr.starts_with("https://")) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid gRPC endpoint: expected http://, https://, or unix:///absolute/path",
+        ));
+    }
+
+    Endpoint::from_shared(addr.to_string()).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid gRPC endpoint: {error}"),
+        )
+    })?;
+    Ok(DaemonEndpoint::Tcp(addr.to_string()))
+}
+
+/// Attaches a bearer token to every outbound request when one is configured.
+#[derive(Clone)]
+pub struct BearerInterceptor {
+    authorization: Option<AsciiMetadataValue>,
+}
+
+impl BearerInterceptor {
+    /// Build an interceptor that attaches `authorization` when a token was
+    /// configured, and nothing otherwise.
+    #[must_use]
+    pub fn new(authorization: Option<AsciiMetadataValue>) -> Self {
+        Self { authorization }
+    }
+}
+
+impl Interceptor for BearerInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if let Some(value) = &self.authorization {
+            request
+                .metadata_mut()
+                .insert("authorization", value.clone());
+        }
+        Ok(request)
+    }
+}
+
+/// The authenticated channel every generated client is built over.
+pub type Upstream = InterceptedService<Channel, BearerInterceptor>;
+
+/// Read a bearer token from `token_file` and render it as an `authorization`
+/// metadata value.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read, is empty, or holds bytes
+/// that are not valid ASCII gRPC metadata.
+pub fn load_bearer_authorization(
+    token_file: Option<&Path>,
+) -> Result<Option<AsciiMetadataValue>, std::io::Error> {
+    let Some(token_file) = token_file else {
+        return Ok(None);
+    };
+    let raw = std::fs::read_to_string(token_file)?;
+    let token = raw.trim_end();
+    if token.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("token file is empty: {}", token_file.display()),
+        ));
+    }
+    let value = AsciiMetadataValue::try_from(format!("Bearer {token}")).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "invalid token file {}: authorization value must be valid ASCII gRPC metadata",
+                token_file.display()
+            ),
+        )
+    })?;
+    Ok(Some(value))
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+/// Map a `tonic::Status` onto an MCP error.
+///
+/// `InvalidArgument` and `NotFound` are caller mistakes and map to
+/// `invalid_params`; everything else is `internal_error`. `PermissionDenied`
+/// names the tier problem explicitly, because that is the failure an operator
+/// hits after wiring this server to a listener capped below `sensitive_read`
+/// or to a principal without the `observer` role.
+#[must_use]
+pub fn map_status(status: &Status) -> ErrorData {
+    let detail = status.message().to_string();
+    match status.code() {
+        tonic::Code::InvalidArgument | tonic::Code::NotFound => {
+            ErrorData::invalid_params(format!("{}: {detail}", status.code().description()), None)
+        }
+        tonic::Code::PermissionDenied => ErrorData::internal_error(
+            format!(
+                "daemon refused the call: {detail}. Every tool here calls a `sensitive_read` \
+                 method, so the configured listener needs `max_tier = \"sensitive_read\"` and a \
+                 principal mapped to a role that grants it (`observer`)."
+            ),
+            None,
+        ),
+        tonic::Code::Unauthenticated => ErrorData::internal_error(
+            format!(
+                "daemon rejected the credential: {detail}. Check `--grpc-token-file` against the \
+                 listener's configured principal."
+            ),
+            None,
+        ),
+        code => ErrorData::internal_error(format!("{}: {detail}", code.description()), None),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tool parameter and result types
+// ---------------------------------------------------------------------------
+
+/// Address family scope accepted by the explain tools.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Family {
+    /// Let the daemon apply its own default for the request.
+    #[default]
+    Unspecified,
+    /// IPv4 unicast.
+    Ipv4Unicast,
+    /// IPv6 unicast.
+    Ipv6Unicast,
+}
+
+impl Family {
+    fn as_proto(self) -> i32 {
+        match self {
+            Self::Unspecified => proto::AddressFamily::Unspecified as i32,
+            Self::Ipv4Unicast => proto::AddressFamily::Ipv4Unicast as i32,
+            Self::Ipv6Unicast => proto::AddressFamily::Ipv6Unicast as i32,
+        }
+    }
+}
+
+/// Render a generated enum name as the `snake_case` token the rest of the tool
+/// surface uses: `ADDRESS_FAMILY_IPV4_UNICAST` becomes `ipv4_unicast`.
+fn strip_enum_prefix(name: &str, prefix: &str) -> String {
+    name.strip_prefix(prefix).unwrap_or(name).to_lowercase()
+}
+
+fn family_label(value: i32) -> String {
+    proto::AddressFamily::try_from(value).map_or_else(
+        |_| format!("unknown({value})"),
+        |family| strip_enum_prefix(family.as_str_name(), "ADDRESS_FAMILY_"),
+    )
+}
+
+/// "Why is this prefix not advertised to that peer?"
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ExplainExportParams {
+    /// IPv4 or IPv6 literal of the peer the route would be advertised to.
+    pub peer_address: String,
+    /// Prefix to explain, without the length (e.g. `203.0.113.0`).
+    pub prefix: String,
+    /// Prefix length in bits.
+    pub prefix_length: u32,
+}
+
+/// One rung of the export decision ladder.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct GateStep {
+    /// Position in live evaluation order, starting at 1.
+    pub step: u32,
+    /// Stable gate name (`split_horizon`, `rr_reflection`, `export_policy`, ...).
+    pub gate: String,
+    /// Reason code for this step.
+    pub code: String,
+    /// `pass`, `stop`, `not_applicable`, or `unspecified`.
+    pub verdict: String,
+    /// Human-readable detail; not a stable machine-parsable grammar.
+    pub detail: String,
+}
+
+/// The export-gate ladder plus the decision it produced.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ExplainExportResult {
+    /// `advertise`, `deny`, `no_best_route`, or `unsupported_family`.
+    pub decision: String,
+    /// Peer the explain was scoped to.
+    pub peer_address: String,
+    /// Prefix explained, in CIDR form.
+    pub prefix: String,
+    /// Next hop the route would carry.
+    pub next_hop: String,
+    /// Adj-RIB-In source peer of the explained route.
+    pub route_peer_address: String,
+    /// Full gate ladder in live evaluation order. A `stop` step names the gate
+    /// that halted the route.
+    pub gates: Vec<GateStep>,
+    /// The gate that stopped the route, when one did.
+    pub stopped_at_gate: Option<String>,
+    /// Reason codes and messages attached to the decision.
+    pub reasons: Vec<ReasonLine>,
+    /// Attribute modifications export policy would apply, rendered as
+    /// `field = value` lines. Empty when policy changes nothing.
+    pub modifications: Vec<String>,
+    /// True when the decision is `advertise` but an identical route already
+    /// sits in the advertised state, so the live path suppresses
+    /// re-announcement. Send-side state only — it never means the peer holds
+    /// the route.
+    pub already_advertised: bool,
+}
+
+/// A decision reason code with its message.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ReasonLine {
+    /// Stable `snake_case` reason code.
+    pub code: String,
+    /// Human-readable message.
+    pub message: String,
+}
+
+/// "Why didn't this prefix come in?"
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ExplainImportParams {
+    /// IPv4 or IPv6 literal of the peer whose import-decision cache to consult.
+    pub peer_address: String,
+    /// Prefix to explain, without the length.
+    pub prefix: String,
+    /// Prefix length in bits.
+    pub prefix_length: u32,
+    /// Address family scope. Defaults to unspecified.
+    #[serde(default)]
+    pub family: Family,
+    /// RFC 7911 path identifier. Omit to return every matching path.
+    #[serde(default)]
+    pub path_id: Option<u32>,
+}
+
+/// One cached import decision.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ImportMatch {
+    /// `permit`, `deny`, `withdrawn`, `evicted`, `stale`, `not_seen`,
+    /// `cache_disabled`, or `no_session`. The last three are configuration or
+    /// session facts, not "the prefix was rejected".
+    pub outcome: String,
+    /// Prefix this match covers, in CIDR form.
+    pub prefix: String,
+    /// RFC 7911 path identifier.
+    pub path_id: u32,
+    /// Deciding chain member, or `chain_default_permit`. Empty for an inline
+    /// deny or an absent chain.
+    pub matched_policy: String,
+    /// RPKI origin-validation state at evaluation time.
+    pub rpki_validation: String,
+    /// ASPA path-verification state at evaluation time.
+    pub aspa_validation: String,
+    /// Attribute modifications applied on import, as `field = value` lines.
+    pub modifications: Vec<String>,
+    /// Per-term rendered trace lines for an rpol member, in walk order. Empty
+    /// for TOML members.
+    pub statements: Vec<String>,
+}
+
+/// Cached import decisions for one prefix on one session.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ExplainImportResult {
+    /// Peer whose cache was consulted.
+    pub peer_address: String,
+    /// Prefix explained, in CIDR form.
+    pub prefix: String,
+    /// Address family the request was scoped to.
+    pub family: String,
+    /// The session's current import-policy generation. A match recorded under
+    /// an older generation reports the `stale` outcome.
+    pub current_policy_generation: u64,
+    /// One entry per cached `(peer, prefix, path_id)` the request resolves to.
+    pub matches: Vec<ImportMatch>,
+}
+
+/// "Which path won for this prefix, and why?"
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ExplainBestPathParams {
+    /// Prefix to explain, without the length.
+    pub prefix: String,
+    /// Prefix length in bits.
+    pub prefix_length: u32,
+    /// Optional peer to scope the explanation to. Empty gives the global view.
+    #[serde(default)]
+    pub peer_address: String,
+}
+
+/// One non-winning path and the step that eliminated it.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct BestPathCandidateLine {
+    /// Adj-RIB-In source peer of this candidate.
+    pub peer_address: String,
+    /// Candidate's next hop.
+    pub next_hop: String,
+    /// `AS_PATH` rendering.
+    pub as_path: String,
+    /// Decisive best-path step against the winner, in the stable `snake_case`
+    /// step vocabulary.
+    pub vs_best_reason: String,
+    /// Compared values behind `vs_best_reason`, candidate's value first.
+    /// Human-oriented text, not a stable grammar.
+    pub vs_best_detail: String,
+    /// Equal-cost multipath eligibility versus the best route.
+    pub multipath: String,
+}
+
+/// The best-path winner and the candidates it beat.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ExplainBestPathResult {
+    /// Prefix explained, in CIDR form.
+    pub prefix: String,
+    /// Peer the explanation was scoped to; empty for the global view.
+    pub peer_address: String,
+    /// Source peer of the winning path.
+    pub best_peer_address: String,
+    /// Next hop of the winning path.
+    pub best_next_hop: String,
+    /// `AS_PATH` of the winning path.
+    pub best_as_path: String,
+    /// The step at which the runner-up was eliminated, or `only_path`.
+    pub best_reason: String,
+    /// Compared values behind `best_reason`, winner's value first.
+    pub best_reason_detail: String,
+    /// Every non-best path the RIB knows for the prefix, in the daemon's order.
+    pub candidates: Vec<BestPathCandidateLine>,
+}
+
+/// "What did this peer send that we threw away?"
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ListRejectedParams {
+    /// IPv4 or IPv6 literal of the peer whose retention store to list.
+    pub peer_address: String,
+    /// Maximum rejections to return. `0` or omitted returns everything the
+    /// daemon retained; a smaller value sets `truncated` when it bites.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// One retained rejection.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RejectedRouteLine {
+    /// Prefix, in CIDR form.
+    pub prefix: String,
+    /// RFC 7911 path identifier.
+    pub path_id: u32,
+    /// Canonical `snake_case` reject-reason token.
+    pub reason: String,
+    /// Sub-mechanism detail: matched policy name, or the gate's sub-reason.
+    pub reason_detail: String,
+    /// Wire next hop the rejected announcement carried.
+    pub next_hop: String,
+    /// `AS_PATH` rendering; truncated with a trailing ellipsis at the retention
+    /// byte budget.
+    pub as_path: String,
+    /// RPKI origin-validation state at rejection time.
+    pub rpki_validation: String,
+    /// ASPA path-verification state at rejection time.
+    pub aspa_validation: String,
+    /// Rejection wall-clock time as Unix nanoseconds.
+    pub rejected_at_unix_ns: i64,
+}
+
+/// Retained rejections for one peer, with the retention state that gives an
+/// empty listing its meaning.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ListRejectedResult {
+    /// Peer whose store was listed.
+    pub peer_address: String,
+    /// Whether the session retains rejected routes at all. When this is false
+    /// an empty `routes` list is a configuration fact and says nothing about
+    /// whether routes were rejected.
+    pub retention_enabled: bool,
+    /// The session's retention cap. When the daemon returned exactly this many
+    /// rejections, older ones were displaced.
+    pub capacity: u32,
+    /// Human-readable statement of what an empty or full listing means here.
+    pub retention_note: String,
+    /// The rejections, oldest ordering as the daemon returned them.
+    pub routes: Vec<RejectedRouteLine>,
+    /// Rejections the daemon returned that `limit` cut from `routes`. `0` means
+    /// the list is complete with respect to what the daemon retained.
+    pub truncated_by_limit: usize,
+    /// Older retained rejections this session's bounded store displaced since
+    /// its last reset. Absent when the daemon predates the field.
+    pub evictions_since_reset: Option<u64>,
+}
+
+/// No parameters.
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema)]
+pub struct NoParams {}
+
+/// One configured neighbor.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PeerLine {
+    /// Neighbor address.
+    pub address: String,
+    /// Peer AS.
+    pub peer_as: u32,
+    /// BGP FSM state.
+    pub state: String,
+    /// Seconds in the current state.
+    pub uptime_seconds: u64,
+    /// Routes accepted from this peer.
+    pub routes_received: u64,
+    /// Routes advertised to this peer.
+    pub routes_advertised: u64,
+}
+
+/// The neighbor table.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ListPeersResult {
+    /// Configured neighbors, ordered numerically by address.
+    pub peers: Vec<PeerLine>,
+}
+
+/// Daemon liveness and headline counters.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HealthResult {
+    /// Whether the daemon reports itself healthy.
+    pub healthy: bool,
+    /// Seconds since daemon start.
+    pub uptime_seconds: u64,
+    /// Established sessions.
+    pub active_peers: u32,
+    /// Routes in the Loc-RIB.
+    pub total_routes: u32,
+    /// Daemon package version. Empty from a daemon predating the field.
+    pub daemon_version: String,
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+/// The MCP server: a gRPC client of one daemon, exposing six read-only tools.
+#[derive(Clone)]
+pub struct RustbgpdMcp {
+    upstream: Upstream,
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router(router = tool_router)]
+impl RustbgpdMcp {
+    /// Build a server over an already-constructed upstream channel.
+    #[must_use]
+    pub fn new(upstream: Upstream) -> Self {
+        Self {
+            upstream,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Explain the export decision for one prefix toward one peer, as the full
+    /// ordered gate ladder the live export path evaluates.
+    #[tool(
+        name = "rbgp_explain_export",
+        description = "Explain why a prefix is or is not advertised to a peer, as the daemon's \
+                       full ordered export-gate ladder (split horizon, RR reflection, family, \
+                       LLGR, ORF, RT membership, export policy, Adj-RIB-Out). A `stop` verdict \
+                       names the gate that halted the route."
+    )]
+    pub async fn explain_export(
+        &self,
+        Parameters(params): Parameters<ExplainExportParams>,
+    ) -> Result<Json<ExplainExportResult>, ErrorData> {
+        let mut client = proto::rib_service_client::RibServiceClient::new(self.upstream.clone());
+        let response = client
+            .explain_advertised_route(proto::ExplainAdvertisedRouteRequest {
+                peer_address: params.peer_address.clone(),
+                prefix: params.prefix.clone(),
+                prefix_length: params.prefix_length,
+                ..Default::default()
+            })
+            .await
+            .map_err(|status| map_status(&status))?
+            .into_inner();
+
+        let gates: Vec<GateStep> = response
+            .gates
+            .iter()
+            .enumerate()
+            .map(|(index, step)| GateStep {
+                step: u32::try_from(index + 1).unwrap_or(u32::MAX),
+                gate: step.gate.clone(),
+                code: step.code.clone(),
+                verdict: verdict_label(step.verdict),
+                detail: step.detail.clone(),
+            })
+            .collect();
+
+        Ok(Json(ExplainExportResult {
+            decision: decision_label(response.decision),
+            peer_address: response.peer_address,
+            prefix: format!("{}/{}", response.prefix, response.prefix_length),
+            next_hop: response.next_hop,
+            route_peer_address: response.route_peer_address,
+            stopped_at_gate: gates
+                .iter()
+                .find(|step| step.verdict == "stop")
+                .map(|step| step.gate.clone()),
+            gates,
+            reasons: response
+                .reasons
+                .into_iter()
+                .map(|reason| ReasonLine {
+                    code: reason.code,
+                    message: reason.message,
+                })
+                .collect(),
+            modifications: render_modifications(response.modifications.as_ref()),
+            already_advertised: response.already_advertised,
+        }))
+    }
+
+    /// Explain the cached import decision for one prefix on one session.
+    #[tool(
+        name = "rbgp_explain_import",
+        description = "Explain why a prefix from a peer was accepted or rejected on import, with \
+                       the matched policy, RPKI and ASPA validation state, applied modifications, \
+                       and the per-term policy trace. Outcomes `cache_disabled`, `no_session`, \
+                       and `evicted` mean the question could not be answered — they are not \
+                       rejections."
+    )]
+    pub async fn explain_import(
+        &self,
+        Parameters(params): Parameters<ExplainImportParams>,
+    ) -> Result<Json<ExplainImportResult>, ErrorData> {
+        let mut client =
+            proto::policy_service_client::PolicyServiceClient::new(self.upstream.clone());
+        let response = client
+            .explain_import_policy(proto::ExplainImportPolicyRequest {
+                peer_address: params.peer_address,
+                afi_safi: params.family.as_proto(),
+                prefix: params.prefix,
+                prefix_length: params.prefix_length,
+                path_id: params.path_id,
+            })
+            .await
+            .map_err(|status| map_status(&status))?
+            .into_inner();
+
+        Ok(Json(ExplainImportResult {
+            peer_address: response.peer_address,
+            prefix: format!("{}/{}", response.prefix, response.prefix_length),
+            family: family_label(response.afi_safi),
+            current_policy_generation: response.current_policy_generation,
+            matches: response
+                .matches
+                .into_iter()
+                .map(|entry| ImportMatch {
+                    outcome: import_outcome_label(entry.outcome),
+                    prefix: format!("{}/{}", entry.prefix, entry.prefix_length),
+                    path_id: entry.path_id,
+                    matched_policy: entry.matched_policy,
+                    rpki_validation: entry.rpki_validation,
+                    aspa_validation: entry.aspa_validation,
+                    modifications: render_modifications(entry.modifications.as_ref()),
+                    statements: render_statements(&entry.statements),
+                })
+                .collect(),
+        }))
+    }
+
+    /// Explain which path won best-path selection for a prefix.
+    #[tool(
+        name = "rbgp_explain_best_path",
+        description = "Explain which path won best-path selection for a prefix and at which \
+                       decision step, listing every losing candidate with the step that \
+                       eliminated it. Optionally scoped to one peer."
+    )]
+    pub async fn explain_best_path(
+        &self,
+        Parameters(params): Parameters<ExplainBestPathParams>,
+    ) -> Result<Json<ExplainBestPathResult>, ErrorData> {
+        let mut client = proto::rib_service_client::RibServiceClient::new(self.upstream.clone());
+        let response = client
+            .explain_best_path(proto::ExplainBestPathRequest {
+                prefix: params.prefix,
+                prefix_length: params.prefix_length,
+                peer_address: params.peer_address,
+            })
+            .await
+            .map_err(|status| map_status(&status))?
+            .into_inner();
+
+        let best = response.best_route.unwrap_or_default();
+        Ok(Json(ExplainBestPathResult {
+            prefix: format!("{}/{}", response.prefix, response.prefix_length),
+            peer_address: response.peer_address,
+            best_as_path: render_as_path(&best.as_path),
+            best_peer_address: best.peer_address,
+            best_next_hop: best.next_hop,
+            best_reason: response.best_reason,
+            best_reason_detail: response.best_reason_detail,
+            candidates: response
+                .candidates
+                .into_iter()
+                .map(|candidate| {
+                    let route = candidate.route.unwrap_or_default();
+                    BestPathCandidateLine {
+                        as_path: render_as_path(&route.as_path),
+                        peer_address: route.peer_address,
+                        next_hop: route.next_hop,
+                        vs_best_reason: candidate.vs_best_reason,
+                        vs_best_detail: candidate.vs_best_detail,
+                        multipath: candidate.multipath,
+                    }
+                })
+                .collect(),
+        }))
+    }
+
+    /// List the rejections one peer's session retained.
+    #[tool(
+        name = "rbgp_list_rejected",
+        description = "List the routes a peer announced that the daemon rejected and retained, \
+                       with the reject-reason token and validation state. Always read \
+                       `retention_enabled`: when it is false the list is empty because retention \
+                       is off, not because nothing was rejected."
+    )]
+    pub async fn list_rejected(
+        &self,
+        Parameters(params): Parameters<ListRejectedParams>,
+    ) -> Result<Json<ListRejectedResult>, ErrorData> {
+        let mut client =
+            proto::policy_service_client::PolicyServiceClient::new(self.upstream.clone());
+        let response = client
+            .list_rejected_routes(proto::ListRejectedRoutesRequest {
+                peer_address: params.peer_address,
+            })
+            .await
+            .map_err(|status| map_status(&status))?
+            .into_inner();
+
+        let retained = response.routes.len();
+        let limit = params
+            .limit
+            .filter(|limit| *limit > 0)
+            .map_or(retained, |limit| limit as usize);
+        let truncated_by_limit = retained.saturating_sub(limit);
+        let at_capacity = response.capacity > 0 && retained >= response.capacity as usize;
+
+        Ok(Json(ListRejectedResult {
+            retention_note: retention_note(response.retention_enabled, at_capacity, retained),
+            peer_address: response.peer_address,
+            retention_enabled: response.retention_enabled,
+            capacity: response.capacity,
+            routes: response
+                .routes
+                .into_iter()
+                .take(limit)
+                .map(|route| RejectedRouteLine {
+                    prefix: format!("{}/{}", route.prefix, route.prefix_length),
+                    path_id: route.path_id,
+                    reason: route.reason,
+                    reason_detail: route.reason_detail,
+                    next_hop: route.next_hop,
+                    as_path: route.as_path,
+                    rpki_validation: route.rpki_validation,
+                    aspa_validation: route.aspa_validation,
+                    rejected_at_unix_ns: route.rejected_at_unix_ns,
+                })
+                .collect(),
+            truncated_by_limit,
+            evictions_since_reset: response.evictions_since_reset,
+        }))
+    }
+
+    /// List configured neighbors and their session state.
+    #[tool(
+        name = "rbgp_list_peers",
+        description = "List the daemon's configured BGP neighbors with session state, peer AS, \
+                       uptime, and received/advertised route counts."
+    )]
+    pub async fn list_peers(
+        &self,
+        Parameters(_): Parameters<NoParams>,
+    ) -> Result<Json<ListPeersResult>, ErrorData> {
+        let mut client =
+            proto::neighbor_service_client::NeighborServiceClient::new(self.upstream.clone());
+        let response = client
+            .list_neighbors(proto::ListNeighborsRequest {})
+            .await
+            .map_err(|status| map_status(&status))?
+            .into_inner();
+
+        Ok(Json(ListPeersResult {
+            peers: response
+                .neighbors
+                .into_iter()
+                .map(|neighbor| {
+                    let config = neighbor.config.unwrap_or_default();
+                    PeerLine {
+                        address: config.address,
+                        peer_as: config.remote_asn,
+                        state: session_state_label(neighbor.state),
+                        uptime_seconds: neighbor.uptime_seconds,
+                        routes_received: neighbor.prefixes_received,
+                        routes_advertised: neighbor.prefixes_sent,
+                    }
+                })
+                .collect(),
+        }))
+    }
+
+    /// Report daemon liveness and headline counters.
+    #[tool(
+        name = "rbgp_get_health",
+        description = "Report daemon liveness, uptime, established-peer count, Loc-RIB route \
+                       count, and package version."
+    )]
+    pub async fn get_health(
+        &self,
+        Parameters(_): Parameters<NoParams>,
+    ) -> Result<Json<HealthResult>, ErrorData> {
+        let mut client =
+            proto::control_service_client::ControlServiceClient::new(self.upstream.clone());
+        let response = client
+            .get_health(proto::HealthRequest {})
+            .await
+            .map_err(|status| map_status(&status))?
+            .into_inner();
+
+        Ok(Json(HealthResult {
+            healthy: response.healthy,
+            uptime_seconds: response.uptime_seconds,
+            active_peers: response.active_peers,
+            total_routes: response.total_routes,
+            daemon_version: response.daemon_version,
+        }))
+    }
+}
+
+#[allow(
+    clippy::unused_async_trait_impl,
+    reason = "the #[tool_handler] macro emits the async ServerHandler methods; get_info resolves \
+              immediately and has no call to await"
+)]
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for RustbgpdMcp {
+    fn get_info(&self) -> ServerInfo {
+        // `ServerInfo` and `Implementation` are `#[non_exhaustive]`, so this
+        // starts from a default and assigns the fields it owns.
+        let mut info = ServerInfo::default();
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.server_info = Implementation::new("rustbgpd-mcp", env!("CARGO_PKG_VERSION"));
+        info.instructions = Some(
+            "Read-only view of a running rustbgpd daemon. Every tool calls a read-tier gRPC \
+             method; this server registers no tool that can change daemon state. Start from \
+             rbgp_explain_export for \"why is this prefix not advertised to that peer\" — it \
+             returns the daemon's own ordered export-gate ladder, so the answer comes from live \
+             evaluation rather than inference."
+                .into(),
+        );
+        info
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host configuration
+// ---------------------------------------------------------------------------
+
+/// Render paste-ready `mcpServers` JSON for an MCP host.
+///
+/// The token argument is never echoed: the rendered config names a placeholder
+/// path so a real token value cannot leak into a pasted snippet.
+#[must_use]
+pub fn print_config(command: &str, grpc_addr: &str, uses_token: bool) -> String {
+    let mut args = vec![
+        serde_json::Value::from("--grpc-addr"),
+        serde_json::Value::from(grpc_addr),
+    ];
+    if uses_token {
+        args.push(serde_json::Value::from("--grpc-token-file"));
+        args.push(serde_json::Value::from("/path/to/rustbgpd-observer.token"));
+    }
+    let config = serde_json::json!({
+        "mcpServers": {
+            "rustbgpd": {
+                "command": command,
+                "args": args,
+            }
+        }
+    });
+    serde_json::to_string_pretty(&config)
+        .unwrap_or_else(|error| format!("{{\"error\": \"{error}\"}}"))
+}
+
+// ---------------------------------------------------------------------------
+// Label helpers
+// ---------------------------------------------------------------------------
+
+fn decision_label(value: i32) -> String {
+    match proto::ExplainDecision::try_from(value) {
+        Ok(proto::ExplainDecision::Advertise) => "advertise".into(),
+        Ok(proto::ExplainDecision::Deny) => "deny".into(),
+        Ok(proto::ExplainDecision::NoBestRoute) => "no_best_route".into(),
+        Ok(proto::ExplainDecision::UnsupportedFamily) => "unsupported_family".into(),
+        Ok(proto::ExplainDecision::Unspecified) => "unspecified".into(),
+        Err(_) => format!("unknown({value})"),
+    }
+}
+
+fn verdict_label(value: i32) -> String {
+    match proto::ExportGateVerdict::try_from(value) {
+        Ok(proto::ExportGateVerdict::Pass) => "pass".into(),
+        Ok(proto::ExportGateVerdict::Stop) => "stop".into(),
+        Ok(proto::ExportGateVerdict::NotApplicable) => "not_applicable".into(),
+        Ok(proto::ExportGateVerdict::Unspecified) => "unspecified".into(),
+        Err(_) => format!("unknown({value})"),
+    }
+}
+
+fn import_outcome_label(value: i32) -> String {
+    match proto::ImportExplainOutcome::try_from(value) {
+        Ok(proto::ImportExplainOutcome::Permit) => "permit".into(),
+        Ok(proto::ImportExplainOutcome::Deny) => "deny".into(),
+        Ok(proto::ImportExplainOutcome::Withdrawn) => "withdrawn".into(),
+        Ok(proto::ImportExplainOutcome::Evicted) => "evicted".into(),
+        Ok(proto::ImportExplainOutcome::Stale) => "stale".into(),
+        Ok(proto::ImportExplainOutcome::NotSeen) => "not_seen".into(),
+        Ok(proto::ImportExplainOutcome::CacheDisabled) => "cache_disabled".into(),
+        Ok(proto::ImportExplainOutcome::NoSession) => "no_session".into(),
+        Ok(proto::ImportExplainOutcome::Unspecified) => "unspecified".into(),
+        Err(_) => format!("unknown({value})"),
+    }
+}
+
+fn session_state_label(value: i32) -> String {
+    proto::SessionState::try_from(value).map_or_else(
+        |_| format!("unknown({value})"),
+        |state| strip_enum_prefix(state.as_str_name(), "SESSION_STATE_"),
+    )
+}
+
+fn retention_note(enabled: bool, at_capacity: bool, retained: usize) -> String {
+    if !enabled {
+        return "reject retention is disabled on this session ([policy.reject_retention]); an \
+                empty list is a configuration fact and does not mean nothing was rejected"
+            .into();
+    }
+    if at_capacity {
+        return "the retention store is at capacity, so this listing shows the most recent \
+                rejections and older ones were displaced"
+            .into();
+    }
+    if retained == 0 {
+        return "reject retention is enabled and the store is empty: this session has rejected \
+                nothing since its last reset"
+            .into();
+    }
+    "reject retention is enabled and the store is below capacity, so this listing is complete for \
+     this session"
+        .into()
+}
+
+fn render_modifications(modifications: Option<&proto::ExplainModifications>) -> Vec<String> {
+    let Some(modifications) = modifications else {
+        return Vec::new();
+    };
+    let mut lines = Vec::new();
+    if let Some(value) = modifications.set_local_pref {
+        lines.push(format!("set_local_pref = {value}"));
+    }
+    if let Some(value) = modifications.set_med {
+        lines.push(format!("set_med = {value}"));
+    }
+    if !modifications.set_next_hop.is_empty() {
+        lines.push(format!("set_next_hop = {}", modifications.set_next_hop));
+    }
+    push_list(
+        &mut lines,
+        "communities_add",
+        &modifications.communities_add,
+    );
+    push_list(
+        &mut lines,
+        "communities_remove",
+        &modifications.communities_remove,
+    );
+    push_list(
+        &mut lines,
+        "extended_communities_add",
+        &modifications.extended_communities_add,
+    );
+    push_list(
+        &mut lines,
+        "extended_communities_remove",
+        &modifications.extended_communities_remove,
+    );
+    push_list(
+        &mut lines,
+        "large_communities_add",
+        &modifications.large_communities_add,
+    );
+    push_list(
+        &mut lines,
+        "large_communities_remove",
+        &modifications.large_communities_remove,
+    );
+    if let Some(asn) = modifications.as_path_prepend_asn {
+        let count = modifications.as_path_prepend_count.unwrap_or(1);
+        lines.push(format!("as_path_prepend = {asn} x{count}"));
+    }
+    lines
+}
+
+/// Render an `AS_PATH` as the space-separated ASN list operators read.
+fn render_as_path(as_path: &[u32]) -> String {
+    as_path
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Flatten the per-term import trace into readable lines.
+///
+/// `.rpol` members carry rendered `term_traces` in walk order; TOML members
+/// carry none, so those fall back to a line naming the deciding statement and
+/// its action.
+fn render_statements(statements: &[proto::ImportExplainStatementStep]) -> Vec<String> {
+    let mut lines = Vec::new();
+    for step in statements {
+        if step.term_traces.is_empty() {
+            let mut line = format!("{}: {}", step.policy_name, step.action);
+            if step.default_action {
+                line.push_str(" (default action)");
+            }
+            if !step.matched_conditions.is_empty() {
+                let _ = write!(line, " [{}]", step.matched_conditions.join(", "));
+            }
+            lines.push(line);
+        } else {
+            lines.extend(
+                step.term_traces
+                    .iter()
+                    .map(|trace| format!("{}: {trace}", step.policy_name)),
+            );
+        }
+    }
+    lines
+}
+
+fn push_list<T: std::fmt::Display>(lines: &mut Vec<String>, label: &str, values: &[T]) {
+    if values.is_empty() {
+        return;
+    }
+    let rendered: Vec<String> = values.iter().map(ToString::to_string).collect();
+    lines.push(format!("{label} = [{}]", rendered.join(", ")));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_parsing_accepts_the_two_supported_families() {
+        assert_eq!(
+            parse_daemon_endpoint("http://127.0.0.1:50051").unwrap(),
+            DaemonEndpoint::Tcp("http://127.0.0.1:50051".into())
+        );
+        assert_eq!(
+            parse_daemon_endpoint("unix:///run/rustbgpd/api.sock").unwrap(),
+            DaemonEndpoint::Uds(PathBuf::from("/run/rustbgpd/api.sock"))
+        );
+        assert_eq!(
+            parse_daemon_endpoint("unix:///run/rustbgpd/api.sock")
+                .unwrap()
+                .channel_uri(),
+            "unix:///run/rustbgpd/api.sock"
+        );
+    }
+
+    #[test]
+    fn endpoint_parsing_rejects_malformed_input() {
+        for addr in [
+            "unix://",
+            "unix://relative/path",
+            "unix:/run/rustbgpd/api.sock",
+            "127.0.0.1:50051",
+            "grpc://127.0.0.1:50051",
+        ] {
+            assert!(
+                parse_daemon_endpoint(addr).is_err(),
+                "{addr} must not parse as an endpoint"
+            );
+        }
+    }
+
+    #[test]
+    fn caller_mistakes_map_to_invalid_params_and_the_rest_to_internal_error() {
+        assert_eq!(
+            map_status(&Status::invalid_argument("bad prefix")).code,
+            rmcp::model::ErrorCode::INVALID_PARAMS
+        );
+        assert_eq!(
+            map_status(&Status::not_found("no such peer")).code,
+            rmcp::model::ErrorCode::INVALID_PARAMS
+        );
+        assert_eq!(
+            map_status(&Status::unavailable("daemon down")).code,
+            rmcp::model::ErrorCode::INTERNAL_ERROR
+        );
+    }
+
+    #[test]
+    fn permission_denied_names_the_tier_problem() {
+        let error = map_status(&Status::permission_denied("tier"));
+        assert_eq!(error.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(
+            error.message.contains("sensitive_read") && error.message.contains("observer"),
+            "operators hitting this need the tier and role named: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn disabled_retention_never_reads_as_nothing_rejected() {
+        let note = retention_note(false, false, 0);
+        assert!(note.contains("disabled"), "{note}");
+        assert!(
+            note.contains("does not mean nothing was rejected"),
+            "{note}"
+        );
+
+        let empty = retention_note(true, false, 0);
+        assert!(empty.contains("rejected nothing"), "{empty}");
+
+        let full = retention_note(true, true, 32);
+        assert!(full.contains("displaced"), "{full}");
+    }
+
+    #[test]
+    fn modifications_render_only_the_fields_policy_set() {
+        assert!(render_modifications(None).is_empty());
+        assert!(
+            render_modifications(Some(&proto::ExplainModifications::default())).is_empty(),
+            "an all-default modifications message means policy changed nothing"
+        );
+
+        let lines = render_modifications(Some(&proto::ExplainModifications {
+            set_local_pref: Some(200),
+            large_communities_add: vec!["64500:1:2".into()],
+            as_path_prepend_asn: Some(64500),
+            as_path_prepend_count: Some(3),
+            ..Default::default()
+        }));
+        assert_eq!(
+            lines,
+            vec![
+                "set_local_pref = 200".to_string(),
+                "large_communities_add = [64500:1:2]".to_string(),
+                "as_path_prepend = 64500 x3".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn enum_labels_are_stable_snake_case_and_survive_unknown_values() {
+        assert_eq!(decision_label(proto::ExplainDecision::Deny as i32), "deny");
+        assert_eq!(verdict_label(proto::ExportGateVerdict::Stop as i32), "stop");
+        assert_eq!(
+            import_outcome_label(proto::ImportExplainOutcome::CacheDisabled as i32),
+            "cache_disabled"
+        );
+        assert_eq!(decision_label(9999), "unknown(9999)");
+        assert_eq!(verdict_label(9999), "unknown(9999)");
+        assert_eq!(import_outcome_label(9999), "unknown(9999)");
+        assert_eq!(session_state_label(9999), "unknown(9999)");
+        assert_eq!(family_label(9999), "unknown(9999)");
+        assert_eq!(
+            session_state_label(proto::SessionState::Established as i32),
+            "established"
+        );
+        assert_eq!(
+            family_label(proto::AddressFamily::Ipv4Unicast as i32),
+            "ipv4_unicast"
+        );
+    }
+
+    #[test]
+    fn families_map_onto_the_v1_unicast_scope() {
+        assert_eq!(
+            Family::Ipv4Unicast.as_proto(),
+            proto::AddressFamily::Ipv4Unicast as i32
+        );
+        assert_eq!(
+            Family::default().as_proto(),
+            proto::AddressFamily::Unspecified as i32
+        );
+    }
+
+    #[test]
+    fn printed_host_config_carries_a_placeholder_not_a_token() {
+        let rendered = print_config(
+            "/usr/local/bin/rustbgpd-mcp",
+            "http://rr1.example.net:50051",
+            true,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(
+            parsed["mcpServers"]["rustbgpd"]["command"],
+            "/usr/local/bin/rustbgpd-mcp"
+        );
+        assert_eq!(
+            parsed["mcpServers"]["rustbgpd"]["args"],
+            serde_json::json!([
+                "--grpc-addr",
+                "http://rr1.example.net:50051",
+                "--grpc-token-file",
+                "/path/to/rustbgpd-observer.token"
+            ])
+        );
+
+        let without = print_config(
+            "/usr/local/bin/rustbgpd-mcp",
+            "http://127.0.0.1:50051",
+            false,
+        );
+        assert!(!without.contains("token"), "{without}");
+    }
+
+    #[tokio::test]
+    async fn every_registered_tool_declares_a_grpc_method() {
+        let server = RustbgpdMcp::new(InterceptedService::new(
+            Endpoint::from_static("http://127.0.0.1:1").connect_lazy(),
+            BearerInterceptor::new(None),
+        ));
+        let mut registered: Vec<String> = server
+            .tool_router
+            .list_all()
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+        registered.sort();
+
+        let mut declared: Vec<String> = TOOL_METHOD_PATHS
+            .iter()
+            .map(|(name, _)| (*name).to_string())
+            .collect();
+        declared.sort();
+
+        assert_eq!(
+            registered, declared,
+            "TOOL_METHOD_PATHS must name exactly the tools the router registers — \
+             an unlisted tool would escape the inventory contract test"
+        );
+    }
+}

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -1,8 +1,9 @@
 //! stdio entry point for the read-only rustbgpd MCP server.
 //!
-//! stdout carries newline-delimited JSON-RPC and nothing else; every log line
-//! goes to stderr. A stray `println!` here corrupts the protocol stream, so
-//! `tests/stdio_e2e.rs` asserts every stdout line parses as JSON.
+//! In normal server mode, stdout carries only newline-delimited JSON-RPC;
+//! every log line goes to stderr. `tests/stdio_e2e.rs` checks this protocol
+//! stream. The `--print-config` and `--help` modes intentionally print their
+//! own output and exit without starting the server.
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -1,0 +1,88 @@
+//! stdio entry point for the read-only rustbgpd MCP server.
+//!
+//! stdout carries newline-delimited JSON-RPC and nothing else; every log line
+//! goes to stderr. A stray `println!` here corrupts the protocol stream, so
+//! `tests/stdio_e2e.rs` asserts every stdout line parses as JSON.
+
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use rmcp::ServiceExt;
+use rustbgpd_mcp::{
+    BearerInterceptor, RustbgpdMcp, load_bearer_authorization, parse_daemon_endpoint, print_config,
+};
+use tonic::service::interceptor::InterceptedService;
+use tonic::transport::Endpoint;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rustbgpd-mcp",
+    about = "Read-only MCP server over a running rustbgpd's gRPC explain surfaces",
+    long_about = "Speaks MCP over stdio and answers from one daemon's live explain RPCs. \
+                  Intended to run on the operator's workstation, spawned by an MCP host, \
+                  against a listener capped at `max_tier = \"sensitive_read\"`."
+)]
+struct Args {
+    /// rustbgpd gRPC endpoint: `http://host:port`, `https://host:port`, or
+    /// `unix:///absolute/path`.
+    #[arg(
+        long,
+        env = "RUSTBGPD_GRPC_ADDR",
+        default_value = "http://127.0.0.1:50051"
+    )]
+    grpc_addr: String,
+
+    /// File holding the bearer token for gRPC authentication.
+    #[arg(long, env = "RUSTBGPD_GRPC_TOKEN_FILE")]
+    grpc_token_file: Option<PathBuf>,
+
+    /// Print paste-ready `mcpServers` JSON for an MCP host and exit. The token
+    /// path is rendered as a placeholder; no token value is ever echoed.
+    #[arg(long)]
+    print_config: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    if args.print_config {
+        let command = std::env::current_exe().map_or_else(
+            |_| "rustbgpd-mcp".to_string(),
+            |path| path.display().to_string(),
+        );
+        println!(
+            "{}",
+            print_config(&command, &args.grpc_addr, args.grpc_token_file.is_some())
+        );
+        return Ok(());
+    }
+
+    // stderr, always: stdout is the JSON-RPC channel.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let endpoint = parse_daemon_endpoint(&args.grpc_addr)?;
+    tracing::info!(grpc_addr = %args.grpc_addr, "connecting to rustbgpd");
+    // Lazy so the server can start before the daemon is reachable; the MCP
+    // host spawns it at its own convenience and tool calls report the
+    // connection failure when it matters.
+    let channel = Endpoint::from_shared(endpoint.channel_uri())?.connect_lazy();
+    let authorization = load_bearer_authorization(args.grpc_token_file.as_deref())?;
+    let upstream = InterceptedService::new(channel, BearerInterceptor::new(authorization));
+
+    let service = RustbgpdMcp::new(upstream)
+        .serve(rmcp::transport::stdio())
+        .await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -13,10 +13,10 @@ use std::path::PathBuf;
 use clap::Parser;
 use rmcp::ServiceExt;
 use rustbgpd_mcp::{
-    BearerInterceptor, RustbgpdMcp, load_bearer_authorization, parse_daemon_endpoint, print_config,
+    BearerInterceptor, RustbgpdMcp, TlsOptions, load_bearer_authorization, parse_daemon_endpoint,
+    print_config,
 };
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::Endpoint;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -40,6 +40,9 @@ struct Args {
     #[arg(long, env = "RUSTBGPD_GRPC_TOKEN_FILE")]
     grpc_token_file: Option<PathBuf>,
 
+    #[command(flatten)]
+    tls: TlsOptions,
+
     /// Print paste-ready `mcpServers` JSON for an MCP host and exit. The token
     /// path is rendered as a placeholder; no token value is ever echoed.
     #[arg(long)]
@@ -49,6 +52,8 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
+    let endpoint = parse_daemon_endpoint(&args.grpc_addr)?;
+    args.tls.validate(&endpoint)?;
 
     if args.print_config {
         let command = std::env::current_exe().map_or_else(
@@ -57,7 +62,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         println!(
             "{}",
-            print_config(&command, &args.grpc_addr, args.grpc_token_file.is_some())
+            print_config(
+                &command,
+                &args.grpc_addr,
+                args.grpc_token_file.is_some(),
+                &args.tls
+            )
         );
         return Ok(());
     }
@@ -71,12 +81,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .init();
 
-    let endpoint = parse_daemon_endpoint(&args.grpc_addr)?;
     tracing::info!(grpc_addr = %args.grpc_addr, "connecting to rustbgpd");
     // Lazy so the server can start before the daemon is reachable; the MCP
     // host spawns it at its own convenience and tool calls report the
     // connection failure when it matters.
-    let channel = Endpoint::from_shared(endpoint.channel_uri())?.connect_lazy();
+    let channel = args.tls.channel(&endpoint)?;
     let authorization = load_bearer_authorization(args.grpc_token_file.as_deref())?;
     let upstream = InterceptedService::new(channel, BearerInterceptor::new(authorization));
 

--- a/tools/mcp/tests/inventory_contract.rs
+++ b/tools/mcp/tests/inventory_contract.rs
@@ -1,0 +1,94 @@
+//! The tool surface is fenced to the daemon's own read tiers.
+//!
+//! `docs/reference/grpc-method-inventory.json` is a machine-readable export of
+//! the authorization matrix in `crates/api/src/authz.rs`, kept in step with it
+//! by tests in that file. It carries no request or response types, so it
+//! cannot generate tool schemas — it can only police the tool list, which is
+//! what it is used for here.
+//!
+//! This is the mechanism behind control 1 of the server's safety model: "no
+//! write tool exists in the binary" is checked, not asserted in prose.
+
+use rustbgpd_mcp::TOOL_METHOD_PATHS;
+use serde_json::Value;
+
+const INVENTORY: &str = include_str!("../../../docs/reference/grpc-method-inventory.json");
+
+fn inventory_tiers() -> Vec<(String, String)> {
+    let parsed: Value =
+        serde_json::from_str(INVENTORY).expect("the method inventory must be valid JSON");
+    parsed["methods"]
+        .as_array()
+        .expect("the method inventory lists methods")
+        .iter()
+        .map(|method| {
+            (
+                method["path"]
+                    .as_str()
+                    .expect("every inventory entry has a path")
+                    .to_string(),
+                method["tier"]
+                    .as_str()
+                    .expect("every inventory entry has a tier")
+                    .to_string(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn every_tool_calls_a_method_the_daemon_publishes() {
+    let inventory = inventory_tiers();
+    for (tool, path) in TOOL_METHOD_PATHS {
+        assert!(
+            inventory.iter().any(|(known, _)| known == path),
+            "tool `{tool}` declares `{path}`, which is not in the gRPC method inventory — \
+             either the path is wrong or the RPC no longer exists"
+        );
+    }
+}
+
+#[test]
+fn no_tool_reaches_a_mutating_or_operator_only_method() {
+    let inventory = inventory_tiers();
+    for (tool, path) in TOOL_METHOD_PATHS {
+        let tier = inventory
+            .iter()
+            .find(|(known, _)| known == path)
+            .map(|(_, tier)| tier.as_str())
+            .unwrap_or_else(|| panic!("tool `{tool}` declares unknown method `{path}`"));
+        assert!(
+            matches!(tier, "read" | "sensitive_read"),
+            "tool `{tool}` calls `{path}`, which the daemon classifies as `{tier}`. \
+             This server is read-only: a `mutating` or `operator_only` method must not be \
+             reachable from any tool."
+        );
+    }
+}
+
+#[test]
+fn declared_paths_are_unique() {
+    let mut paths: Vec<&str> = TOOL_METHOD_PATHS.iter().map(|(_, path)| *path).collect();
+    paths.sort_unstable();
+    let count = paths.len();
+    paths.dedup();
+    assert_eq!(
+        paths.len(),
+        count,
+        "two tools declare the same gRPC method path; each entry must name a distinct method"
+    );
+}
+
+#[test]
+fn the_inventory_publishes_no_read_tier_to_bind_to() {
+    // Documented in the ADR and the how-to: there is no tier below
+    // `sensitive_read` to constrain a listener with, which is why the
+    // deployment control alone cannot make this server read-only.
+    let parsed: Value = serde_json::from_str(INVENTORY).expect("valid JSON");
+    assert_eq!(
+        parsed["tier_counts"]["read"].as_u64(),
+        Some(0),
+        "a `read` tier now exists; the safety model's claim that `sensitive_read` is the \
+         lowest bindable tier needs revisiting in the ADR and how-to"
+    );
+}

--- a/tools/mcp/tests/stdio_e2e.rs
+++ b/tools/mcp/tests/stdio_e2e.rs
@@ -1,0 +1,128 @@
+//! End-to-end stdio JSON-RPC handshake against the real compiled binary.
+//!
+//! Covers the two properties a stdio MCP server must hold before any tool
+//! matters: the handshake completes, and stdout carries JSON-RPC and nothing
+//! else. The second assertion is what catches a stray `println!` added later.
+//!
+//! No daemon is needed — the gRPC channel is lazy, and `initialize` /
+//! `tools/list` never touch it.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+
+/// The tool surface this server is allowed to expose, in sorted order.
+const EXPECTED_TOOLS: &[&str] = &[
+    "rbgp_explain_best_path",
+    "rbgp_explain_export",
+    "rbgp_explain_import",
+    "rbgp_get_health",
+    "rbgp_list_peers",
+    "rbgp_list_rejected",
+];
+
+struct Server(Child);
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn initialize_then_list_tools_over_stdio() {
+    let mut server = Server(
+        Command::new(env!("CARGO_BIN_EXE_rustbgpd-mcp"))
+            // Never connected: the channel is lazy and neither request in this
+            // handshake reaches the daemon.
+            .args(["--grpc-addr", "http://127.0.0.1:1"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("the compiled rustbgpd-mcp binary starts"),
+    );
+
+    let mut stdin = server.0.stdin.take().expect("piped stdin");
+    let mut stdout = BufReader::new(server.0.stdout.take().expect("piped stdout"));
+
+    let send = |stdin: &mut std::process::ChildStdin, line: &str| {
+        writeln!(stdin, "{line}").expect("the server accepts a request line");
+        stdin.flush().expect("request flushes");
+    };
+    let recv = |stdout: &mut BufReader<std::process::ChildStdout>| -> serde_json::Value {
+        let mut line = String::new();
+        let read = stdout.read_line(&mut line).expect("the server answers");
+        assert!(read > 0, "the server closed stdout before answering");
+        // Every stdout line must be JSON-RPC. A stray `println!` anywhere in
+        // the binary fails here rather than silently corrupting the stream.
+        serde_json::from_str(&line)
+            .unwrap_or_else(|error| panic!("stdout line is not JSON ({error}): {line:?}"))
+    };
+
+    send(
+        &mut stdin,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "contract-test", "version": "0" }
+            }
+        })
+        .to_string(),
+    );
+    let initialized = recv(&mut stdout);
+    assert_eq!(initialized["id"], 1, "{initialized}");
+    assert_eq!(
+        initialized["result"]["serverInfo"]["name"], "rustbgpd-mcp",
+        "{initialized}"
+    );
+    assert!(
+        initialized["result"]["capabilities"]["tools"].is_object(),
+        "the server must advertise the tools capability: {initialized}"
+    );
+
+    send(
+        &mut stdin,
+        &serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }).to_string(),
+    );
+
+    send(
+        &mut stdin,
+        &serde_json::json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }).to_string(),
+    );
+    let listed = recv(&mut stdout);
+    assert_eq!(listed["id"], 2, "{listed}");
+
+    let mut names: Vec<String> = listed["result"]["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("tools/list returns an array: {listed}"))
+        .iter()
+        .map(|tool| {
+            tool["name"]
+                .as_str()
+                .unwrap_or_else(|| panic!("every tool has a name: {tool}"))
+                .to_string()
+        })
+        .collect();
+    names.sort();
+
+    let mut expected: Vec<String> = EXPECTED_TOOLS.iter().map(|s| (*s).to_string()).collect();
+    expected.sort();
+    assert_eq!(
+        names, expected,
+        "the stdio tool surface must be exactly the six read-only tools"
+    );
+
+    // Every tool must declare an input schema; a host cannot call one without.
+    for tool in listed["result"]["tools"].as_array().expect("array") {
+        assert!(
+            tool["inputSchema"].is_object(),
+            "tool {} has no input schema: {tool}",
+            tool["name"]
+        );
+    }
+}

--- a/tools/mcp/tests/stdio_e2e.rs
+++ b/tools/mcp/tests/stdio_e2e.rs
@@ -13,6 +13,7 @@ use std::process::{Child, Command, Stdio};
 /// The tool surface this server is allowed to expose, in sorted order.
 const EXPECTED_TOOLS: &[&str] = &[
     "rbgp_explain_best_path",
+    "rbgp_explain_evpn_route",
     "rbgp_explain_export",
     "rbgp_explain_import",
     "rbgp_get_health",
@@ -114,7 +115,7 @@ fn initialize_then_list_tools_over_stdio() {
     expected.sort();
     assert_eq!(
         names, expected,
-        "the stdio tool surface must be exactly the six read-only tools"
+        "the stdio tool surface must be exactly the seven read-only tools"
     );
 
     // Every tool must declare an input schema; a host cannot call one without.


### PR DESCRIPTION
Adds a separate, source-built `rustbgpd-mcp` binary that exposes the daemon's existing explain and observation RPCs over MCP stdio. An operator can ask why a prefix is not advertised to a peer and receive the daemon's ordered export gates and deciding policy.

The seven tools cover export, import, best-path and exact EVPN explanation, retained rejections, peers, and health. They call only `sensitive_read` RPCs; the documented remote listener also enforces that ceiling and maps the client certificate to the observer role. HTTPS uses explicit mutual-TLS credentials and server identity verification. Every complete unary response has a 30-second deadline.

Responses distinguish retained state from history, report capacity evictions independently of occupancy, and explain the limits of missing EVPN input and deferred selection. The CLI dependency graph, ordinary root-package build selection, daemon RPC contracts, and release artifacts stay unchanged. The how-to and ADR document deployment, scope, and the measured placement decision.

Validation:

- Focused tests passed: mapping and retention semantics, real mTLS success and rejected credentials, TCP/Unix response stalls before and after headers, the read-only inventory contract, and stdio JSON framing.
- Strict package Clippy, workspace formatting, and offline documentation links passed.
- Earlier live-daemon evidence exercised the export allow/deny ladder, listener authorization ceiling, and injected EVPN selection/export explanation.
- `just gate` and `just gate-deps` passed; focused wire and MCP tests also passed after the final main integration.

The live transcript is documented evidence rather than a daemon integration test in CI. Received EVPN input and deferred selection have unit coverage; those populated/deferred cases were not observed in the live capture. VPN, labeled-unicast, and Add-Path export selectors are outside this initial tool surface.
