### PR TITLE
fix(evpn): converge deletion of absent kernel routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,6 +625,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   different or zero ESI are contenders as before, and the receive-side
   tiebreak is unchanged.
 
+- EVPN Linux route withdrawal treats an already-absent kernel route as
+  successfully removed, including single-path and ECMP IP-VRF routes. This
+  clears owned state instead of retrying the deletion indefinitely.
+
 ### Documentation
 
 - Publish a descriptive raw bridge event-skew receipt across six pinned Jammy

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -565,16 +565,17 @@ pub(super) fn is_einval(err: &rtnetlink::Error) -> bool {
 }
 
 /// Variant of [`classify_apply_error`] for **remove** ops:
-/// `ENOENT` is idempotent success.
+/// `ENOENT` and `ESRCH` are idempotent success. Linux route deletion
+/// reports `ESRCH` when the matching route or FIB table is absent.
 ///
 /// Remove ops have a post-condition of "the kernel row is absent
 /// when this returns Ok". If the row was already absent — manual
 /// `ip route del`, prior partial drain, kernel cleanup, foreign
-/// removal — the desired state already holds, so surfacing ENOENT
+/// removal — the desired state already holds, so surfacing either errno
 /// as an error would wedge `L3OwnedState` convergence: the actor
 /// would never call `record_l3_success`, the owned row would stay
 /// indefinitely, and every reconcile pass would re-emit the same
-/// failing remove. Mapping ENOENT to Ok(()) lets owned state
+/// failing remove. Mapping absence to Ok(()) lets owned state
 /// advance and matches the "idempotent delete" semantic operators
 /// expect.
 ///
@@ -590,7 +591,7 @@ pub(super) fn classify_remove_apply_error(err: &rtnetlink::Error) -> Result<(), 
 }
 
 fn errno_to_remove_apply_result(errno: i32, detail: &str) -> Result<(), DataplaneError> {
-    if errno == libc::ENOENT {
+    if errno == libc::ENOENT || errno == libc::ESRCH {
         return Ok(());
     }
     Err(errno_to_dataplane_error(errno, detail))
@@ -1168,6 +1169,23 @@ mod tests {
     #[test]
     fn remove_errno_enoent_is_idempotent_success() {
         assert!(errno_to_remove_apply_result(libc::ENOENT, "No such file or directory").is_ok());
+    }
+
+    #[test]
+    fn remove_errno_esrch_is_idempotent_success() {
+        assert!(errno_to_remove_apply_result(libc::ESRCH, "No such process").is_ok());
+        let add_error = errno_to_dataplane_error(libc::ESRCH, "No such process");
+        assert!(matches!(add_error, DataplaneError::Other(_)));
+        assert_eq!(add_error.class(), FailureClass::Transient);
+    }
+
+    #[test]
+    fn remove_errno_permission_errors_stay_permanent() {
+        for errno in [libc::EPERM, libc::EACCES] {
+            let error = errno_to_remove_apply_result(errno, "Permission denied").unwrap_err();
+            assert!(matches!(error, DataplaneError::PermissionDenied(_)));
+            assert_eq!(error.class(), FailureClass::Permanent);
+        }
     }
 
     #[test]

--- a/crates/evpn-linux/src/linux/l3.rs
+++ b/crates/evpn-linux/src/linux/l3.rs
@@ -116,7 +116,7 @@ pub(crate) async fn apply_add_ip_route(
 ///
 /// Returns [`DataplaneError::InvalidArgument`] on family mismatch.
 /// Other failures classify per [`classify_remove_apply_error`],
-/// which treats `ENOENT` as idempotent success — if the kernel
+/// which treats `ENOENT` and `ESRCH` as idempotent success — if the kernel
 /// row is already absent the post-condition holds and the actor
 /// should advance `L3OwnedState` rather than retry forever.
 pub(crate) async fn apply_remove_ip_route(
@@ -164,7 +164,7 @@ pub(crate) async fn apply_add_ip_route_ecmp(
 ///
 /// Returns [`DataplaneError::InvalidArgument`] on invalid target set
 /// shape. Other failures classify per [`classify_remove_apply_error`],
-/// which treats `ENOENT` as idempotent success.
+/// which treats `ENOENT` and `ESRCH` as idempotent success.
 pub(crate) async fn apply_remove_ip_route_ecmp(
     handle: &Handle,
     prefix: EvpnIpPrefixValue,

--- a/crates/evpn-linux/tests/netns_l3_install.rs
+++ b/crates/evpn-linux/tests/netns_l3_install.rs
@@ -645,6 +645,129 @@ async fn linux_reconcile_actor_installs_and_withdraws_all_active_l3_writer() {
         .expect("actor join");
 }
 
+/// Missing single-path and ECMP routes must release ownership without
+/// retrying, even when an operator removed the kernel row first.
+#[tokio::test]
+async fn linux_reconcile_actor_withdraws_already_absent_l3_routes() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged L3 absent-route proof");
+        return;
+    }
+    let local_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0xdd]);
+    let remote_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0xee]);
+    let prefix = "203.0.113.0/24";
+    let foreign_prefix = "198.51.100.0/24";
+    let foreign_gw = "10.0.0.99";
+    if !is_inner() {
+        let ns = NetnsFixture::create("absent-l3");
+        setup_topology(&ns, TABLE_ID, L3VNI, LOCAL_VTEP, local_mac);
+        ns.exec(
+            "ip",
+            &[
+                "route",
+                "add",
+                foreign_prefix,
+                "via",
+                foreign_gw,
+                "dev",
+                "l3vxlan-test",
+                "table",
+                &TABLE_ID.to_string(),
+                "proto",
+                "static",
+                "onlink",
+            ],
+        );
+        run_inner(
+            &ns,
+            "linux_reconcile_actor_withdraws_already_absent_l3_routes",
+        );
+        return;
+    }
+
+    let vrf_id = IpVrfId::new(L3VNI).unwrap();
+    let ip_vrfs = actor_ip_vrfs(local_mac);
+    let (intent_tx, mut reports, shutdown, actor_join) =
+        spawn_reconcile_actor(ReconcileActorConfig::for_tests()).await;
+    for (base, ecmp) in [(1, false), (4, true)] {
+        let mut routes = RemoteIpPrefixTable::new();
+        if ecmp {
+            routes = actor_all_active_prefixes(remote_mac);
+        } else {
+            routes.insert_resolved(
+                vrf_id,
+                RemoteIpPrefixEntry::single(
+                    v4_prefix([203, 0, 113, 0], 24),
+                    "10.0.0.2".parse().unwrap(),
+                    L3VNI,
+                    remote_mac,
+                ),
+            );
+        }
+        intent_tx
+            .send(actor_intent(base, ip_vrfs.clone(), routes))
+            .unwrap();
+        let installed = wait_for_report_generation(&mut reports, base).await;
+        assert!(
+            installed.failed.is_empty(),
+            "install: {:?}",
+            installed.failed
+        );
+        assert_eq!(installed.ip_vrf_installed_routes.get(&vrf_id), Some(&1));
+
+        // No await between the external deletion and the withdrawal intent:
+        // the actor must observe the absent row with withdrawal already pending.
+        run(
+            "ip",
+            &["route", "del", prefix, "table", &TABLE_ID.to_string()],
+        );
+        intent_tx
+            .send(actor_intent(
+                base + 1,
+                ip_vrfs.clone(),
+                RemoteIpPrefixTable::new(),
+            ))
+            .unwrap();
+        let withdrawn = wait_for_report_generation(&mut reports, base + 1).await;
+        assert!(
+            withdrawn.failed.is_empty(),
+            "withdraw: {:?}",
+            withdrawn.failed
+        );
+        assert_eq!(
+            withdrawn
+                .ip_vrf_installed_routes
+                .get(&vrf_id)
+                .copied()
+                .unwrap_or(0),
+            0
+        );
+
+        intent_tx
+            .send(actor_intent(
+                base + 2,
+                ip_vrfs.clone(),
+                RemoteIpPrefixTable::new(),
+            ))
+            .unwrap();
+        let settled = wait_for_report_generation(&mut reports, base + 2).await;
+        assert!(settled.failed.is_empty(), "settled: {:?}", settled.failed);
+        assert!(
+            settled.applied.is_empty(),
+            "withdrawal must not be retried: {:?}",
+            settled.applied
+        );
+        let dump = shell_capture("ip", &["route", "show", "table", &TABLE_ID.to_string()]);
+        assert_route_absent(&dump, prefix);
+        assert_route_present(&dump, foreign_prefix, foreign_gw, "l3vxlan-test");
+    }
+    shutdown.cancel();
+    tokio::time::timeout(std::time::Duration::from_secs(2), actor_join)
+        .await
+        .expect("actor shutdown timeout")
+        .expect("actor join");
+}
+
 /// LAN-77 restart-adoption proof: a fresh actor in the same netns
 /// reclaims the crash-leftover all-active L3 writer state instead of
 /// treating the Router-MAC FDB-NHG row as a scalar FDB entry or


### PR DESCRIPTION
Deleting an EVPN IP-VRF route that the kernel has already removed currently leaves the reconciler retrying with stale ownership. Treat `ESRCH`, like `ENOENT`, as successful removal so single-path and ECMP withdrawals clear owned state. Add-operation errors and permission/invalid-argument failures retain their existing behavior.

The regression drives the real Linux reconciler after an external route deletion, verifies ownership clears and the next pass settles, and checks that a foreign static route survives. Both the errno assertion and kernel ownership assertion failed against the original code.

Validation:

- Workspace tests, strict all-target Clippy, and library/binary rustdoc.
- Developer tooling, fast checks, and repository contracts.
- EVPN Linux unit suite and the complete privileged L3 netns suite, including single-path, ECMP, restart adoption, and foreign-route preservation.
