### PR TITLE
fix(wire): implement shutdown communication error traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `rustbgpd-wire` shutdown communication errors now implement `Display` and
+  `std::error::Error` for downstream error propagation, with bounded static
+  descriptions. Decoding and structured log categories are unchanged.
+
 - Withdraw every IPv4/IPv6 FlowSpec path immediately when a restarting
   peer's Graceful Restart capability omits that family. Recompute the best
   rule and downstream advertisements, selecting an alternate source when

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -7,6 +7,10 @@ and workspace changes remain in the repository-level `CHANGELOG.md`.
 
 ## 0.19.1 - Unreleased
 
+- `ShutdownCommunicationError` now implements `Display` and
+  `std::error::Error`, allowing `extract_shutdown_communication` failures to
+  propagate into standard error containers. Descriptions are bounded static
+  text; variants, category labels, and decoding behavior are unchanged.
 - `FlowSpecRule::destination_prefix` returns `None` for an IPv6 destination
   component with a non-zero offset. RFC 8956 §3.1 matches the address
   shifted right by `offset` bits, so the component names no routable prefix,

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -485,7 +485,14 @@ tunnel enums, `BgpRole`, and `AspaValidation` are `#[non_exhaustive]`.
 The five public error enums are also non-exhaustive: `DecodeError`,
 `EncodeError`, `RouteDistinguisherParseError`,
 `ShutdownCommunicationError`, and `BgpCodecError` (available with the
-`tokio-codec` feature). Downstream matches on any of these enums must include
+`tokio-codec` feature).
+
+All implement `Display` and `std::error::Error` for
+use with standard error propagation. `ShutdownCommunicationError` displays
+bounded descriptions without malformed input bytes; `category()` retains
+its stable machine-readable labels.
+
+Downstream matches on any of these enums must include
 a wildcard arm:
 
 ```rust

--- a/crates/wire/src/notification.rs
+++ b/crates/wire/src/notification.rs
@@ -176,14 +176,17 @@ pub fn encode_shutdown_communication(reason: &str) -> bytes::Bytes {
 ///
 /// The variants intentionally classify malformed input without retaining or
 /// formatting attacker-controlled bytes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ShutdownCommunicationError {
     /// The length octet is absent or does not consume the complete data field.
+    #[error("invalid shutdown communication length")]
     InvalidLength,
     /// The declared communication is not valid UTF-8.
+    #[error("shutdown communication is not valid UTF-8")]
     InvalidUtf8,
     /// An RFC 8538 Hard Reset does not contain its inner code and subcode.
+    #[error("malformed Hard Reset notification envelope")]
     MalformedHardResetEnvelope,
 }
 

--- a/crates/wire/tests/shutdown_error.rs
+++ b/crates/wire/tests/shutdown_error.rs
@@ -1,0 +1,50 @@
+use std::error::Error;
+
+use rustbgpd_wire::NotificationMessage;
+use rustbgpd_wire::notification::{
+    NotificationCode, ShutdownCommunicationError, cease_subcode, extract_shutdown_communication,
+};
+
+fn extract(notification: &NotificationMessage) -> Result<Option<&str>, Box<dyn Error>> {
+    Ok(extract_shutdown_communication(notification)?)
+}
+
+#[test]
+fn shutdown_errors_propagate_to_downstream_error_handlers() {
+    let valid = NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+        vec![2, b'o', b'k'].into(),
+    );
+    assert_eq!(extract(&valid).unwrap(), Some("ok"));
+
+    for (subcode, data, expected, text) in [
+        (
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            vec![2, b'x'],
+            ShutdownCommunicationError::InvalidLength,
+            "invalid shutdown communication length",
+        ),
+        (
+            cease_subcode::ADMINISTRATIVE_RESET,
+            vec![1, 0xff],
+            ShutdownCommunicationError::InvalidUtf8,
+            "shutdown communication is not valid UTF-8",
+        ),
+        (
+            cease_subcode::HARD_RESET,
+            vec![6],
+            ShutdownCommunicationError::MalformedHardResetEnvelope,
+            "malformed Hard Reset notification envelope",
+        ),
+    ] {
+        let notification = NotificationMessage::new(NotificationCode::Cease, subcode, data.into());
+        let error = extract(&notification).unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<ShutdownCommunicationError>(),
+            Some(&expected)
+        );
+        assert_eq!(error.to_string(), text);
+        assert!(error.source().is_none());
+    }
+}


### PR DESCRIPTION
`extract_shutdown_communication` returned an error that could not propagate with `?` into a standard error container. Implement `Display` and `std::error::Error` for `ShutdownCommunicationError` using the existing `thiserror` dependency. Its three descriptions are static and contain no malformed input bytes; variants, category strings, decoding, and transport logging stay unchanged.

An external integration test proves `?` conversion into `Box<dyn Error>`, typed downcasting, bounded messages, and the absence of a nested source for all three variants. The same test fails to compile against the prior implementation. The wire README and both changelogs describe the additive behavior; versions and dependencies are unchanged.

Validation: wire package tests and strict Clippy, semver checks against published 0.19.0, `just gate`, and normal commit/push hooks.
