### PR TITLE
test(interop): drain CLI output before matching

### DIFF
--- a/tests/interop/scripts/test-m102-routeserver-openbgpd92.sh
+++ b/tests/interop/scripts/test-m102-routeserver-openbgpd92.sh
@@ -1092,7 +1092,7 @@ assert_policy() {
  import_explain_names_m102_import && ok "import explain names m102-import" || fail "import explain missing"
  rs_loc "$EXPORT_DENY" && ok "export-denied route remains in Loc-RIB" || fail "export source missing"
  rs_advertised_absent "$FRR_ADDR" ipv4 "$EXPORT_DENY" && ok "FRR advertised view omits export deny" || fail "export deny advertised"
- rs_ctl rib --prefix "$EXPORT_DENY" advertised "$FRR_ADDR" --explain | grep -q m102-export-to-frr && ok "export explain names m102-export-to-frr" || fail "export explain missing"
+ rs_ctl rib --prefix "$EXPORT_DENY" advertised "$FRR_ADDR" --explain | grep m102-export-to-frr >/dev/null && ok "export explain names m102-export-to-frr" || fail "export explain missing"
  frr_has ipv4 "$OPEN_V4" && open_has "$FRR_V4" && ok "policy positive controls pass both directions" || fail "policy positive control missing"
 }
 assert_wire() {

--- a/tests/interop/scripts/test-m104-arouteserver-current-rs-differential.sh
+++ b/tests/interop/scripts/test-m104-arouteserver-current-rs-differential.sh
@@ -283,7 +283,7 @@ bird_filtered_has_tags() {
                 && grep -Eq "\\(64496,[[:space:]]*65521,[[:space:]]*3\\)" <<<"$output"; }; }
 }
 
-rs_accepted_has() { rs_ctl rib received "${1:?}" | grep -qF "${2:?}"; }
+rs_accepted_has() { rs_ctl rib received "${1:?}" | grep -F "${2:?}" >/dev/null; }
 rs_accepted_lacks() { ! rs_accepted_has "$1" "$2"; }
 
 rs_rejected_has() {

--- a/tests/interop/scripts/test-m106-rs-white-list-control-differential.sh
+++ b/tests/interop/scripts/test-m106-rs-white-list-control-differential.sh
@@ -104,7 +104,7 @@ bird_filtered_has_tags() {
                 && grep -Eq "\\(64496,[[:space:]]*65521,[[:space:]]*3\\)" <<<"$output"; }; }
 }
 
-rs_accepted_has()   { rs_ctl rib received "${1:?}" | grep -qF "${2:?}"; }
+rs_accepted_has()   { rs_ctl rib received "${1:?}" | grep -F "${2:?}" >/dev/null; }
 rs_accepted_lacks() { ! rs_accepted_has "$1" "$2"; }
 
 # True if the member's rejected-route store retains the prefix with the

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -12,6 +12,67 @@ fn repo_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
 }
 
+#[test]
+fn route_server_cli_predicates_drain_output_and_preserve_errors() {
+    for script in [
+        "scripts/test-m102-routeserver-openbgpd92.sh",
+        "scripts/test-m104-arouteserver-current-rs-differential.sh",
+        "scripts/test-m106-rs-white-list-control-differential.sh",
+    ] {
+        let source = fs::read_to_string(interop_path(script)).unwrap();
+        let line = source
+            .lines()
+            .find(|line| line.contains("rs_ctl ") && line.contains("| grep "))
+            .expect("live route-server CLI predicate");
+        let predicate = &line[line.find("rs_ctl ").unwrap()..];
+        let predicate = predicate
+            .split(" && ")
+            .next()
+            .unwrap()
+            .trim_end_matches("; }");
+        let output = Command::new("bash")
+            .args([
+                "-c",
+                r#"
+set -euo pipefail
+FRR_ADDR=192.0.2.1 EXPORT_DENY=203.0.113.0/24
+set -- "$FRR_ADDR" m102-export-to-frr
+rs_ctl() {
+    printf '%s\n' "$reply" || return $?
+    # More than a pipe buffer after the matching first line makes early
+    # consumer exit fail the producer deterministically, without sleeps.
+    printf '%*s\n' 1048576 '' || return $?
+    return "$producer_exit"
+}
+reply=m102-export-to-frr producer_exit=0
+old=${PREDICATE/grep /grep -q }
+if eval "$old" >/dev/null 2>&1; then
+    echo 'early-closing negative control unexpectedly passed' >&2
+    exit 1
+fi
+eval "$PREDICATE"
+reply=unrelated-output
+if eval "$PREDICATE"; then
+    echo 'nonmatching output was accepted' >&2
+    exit 1
+fi
+reply=m102-export-to-frr producer_exit=7
+status=0
+eval "$PREDICATE" || status=$?
+test "$status" -eq 7
+"#,
+            ])
+            .env("PREDICATE", predicate)
+            .output()
+            .expect("run offline CLI predicate regression");
+        assert!(
+            output.status.success(),
+            "{script}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
 fn topology(relative: &str) -> serde_yaml::Value {
     let path = interop_path(relative);
     let source = fs::read_to_string(&path)


### PR DESCRIPTION
Route-server interop predicates could report a false failure when `grep -q` found a match and closed the pipe while the CLI was still writing. Under `pipefail`, the producer's broken-pipe exit then failed the assertion. The three live predicates now use draining `grep`, preserving the match rules, single attempt, and producer failure status.

The offline regression exercises the actual script predicates with output larger than a pipe buffer. It proves the original early-closing form fails, matching output succeeds, nonmatching output fails, and a producer error still propagates. Historical driver fixtures remain unchanged. This demonstrates and removes a harness hazard; the original failing CI run did not retain enough output to establish its cause.

Validation: all 17 topology-command tests passed, Bash syntax checks and relevant CI-primer companion tests passed, and ShellCheck diagnostics are unchanged from the base. Normal commit and push hooks passed. Full diff and commit reviewed; no daemon behavior or public compatibility surface changes.
