### PR TITLE
test(interop): reject failed accepted-route absence reads

### DIFF
--- a/tests/interop/scripts/test-m104-arouteserver-current-rs-differential.sh
+++ b/tests/interop/scripts/test-m104-arouteserver-current-rs-differential.sh
@@ -284,7 +284,11 @@ bird_filtered_has_tags() {
 }
 
 rs_accepted_has() { rs_ctl rib received "${1:?}" | grep -F "${2:?}" >/dev/null; }
-rs_accepted_lacks() { ! rs_accepted_has "$1" "$2"; }
+rs_accepted_lacks() {
+    local output
+    output=$(rs_ctl rib received "${1:?}") || return $?
+    ! grep -qF "${2:?}" <<<"$output"
+}
 
 rs_rejected_has() {
     rs_ctl rib received "${1:?}" --rejected -j \

--- a/tests/interop/scripts/test-m104-arouteserver-current-rs-differential.sh
+++ b/tests/interop/scripts/test-m104-arouteserver-current-rs-differential.sh
@@ -287,7 +287,7 @@ rs_accepted_has() { rs_ctl rib received "${1:?}" | grep -F "${2:?}" >/dev/null; 
 rs_accepted_lacks() {
     local output
     output=$(rs_ctl rib received "${1:?}") || return $?
-    ! grep -qF "${2:?}" <<<"$output"
+    [[ "$output" != *"${2:?}"* ]]
 }
 
 rs_rejected_has() {

--- a/tests/interop/scripts/test-m106-rs-white-list-control-differential.sh
+++ b/tests/interop/scripts/test-m106-rs-white-list-control-differential.sh
@@ -105,7 +105,11 @@ bird_filtered_has_tags() {
 }
 
 rs_accepted_has()   { rs_ctl rib received "${1:?}" | grep -F "${2:?}" >/dev/null; }
-rs_accepted_lacks() { ! rs_accepted_has "$1" "$2"; }
+rs_accepted_lacks() {
+    local output
+    output=$(rs_ctl rib received "${1:?}") || return $?
+    ! grep -qF "${2:?}" <<<"$output"
+}
 
 # True if the member's rejected-route store retains the prefix with the
 # canonical policy_reject reason token.

--- a/tests/interop/scripts/test-m106-rs-white-list-control-differential.sh
+++ b/tests/interop/scripts/test-m106-rs-white-list-control-differential.sh
@@ -108,7 +108,7 @@ rs_accepted_has()   { rs_ctl rib received "${1:?}" | grep -F "${2:?}" >/dev/null
 rs_accepted_lacks() {
     local output
     output=$(rs_ctl rib received "${1:?}") || return $?
-    ! grep -qF "${2:?}" <<<"$output"
+    [[ "$output" != *"${2:?}"* ]]
 }
 
 # True if the member's rejected-route store retains the prefix with the

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -13,6 +13,55 @@ fn repo_path(relative: &str) -> PathBuf {
 }
 
 #[test]
+fn route_server_accepted_absence_requires_successful_snapshot() {
+    for script in [
+        "scripts/test-m104-arouteserver-current-rs-differential.sh",
+        "scripts/test-m106-rs-white-list-control-differential.sh",
+    ] {
+        let source = fs::read_to_string(interop_path(script)).unwrap();
+        let (_, helpers) = source.split_once("rs_accepted_has()").unwrap();
+        let (helpers, _) = helpers.split_once("\n\n").unwrap();
+        let output = Command::new("bash")
+            .args([
+                "-c",
+                r#"
+set -euo pipefail
+eval "rs_accepted_has()$HELPERS"
+peer=192.0.2.1 prefix=203.0.113.0/24
+rs_ctl() {
+    [[ "$*" == "rib received $peer" ]] || return 99
+    printf '%s' "$reply"
+    return "$producer_exit"
+}
+for producer_exit in 0 42; do
+    for reply in '' '192.0.2.0/24' '203.0.113.' "$prefix"; do
+        expected=$producer_exit
+        if [ "$producer_exit" -eq 0 ] && [ "$reply" = "$prefix" ]; then
+            expected=1
+        fi
+        status=0
+        rs_accepted_lacks "$peer" "$prefix" || status=$?
+        if [ "$status" -ne "$expected" ]; then
+            printf 'producer=%s reply=%q: expected status %s, got %s\n' \
+                "$producer_exit" "$reply" "$expected" "$status" >&2
+            exit 1
+        fi
+    done
+done
+"#,
+            ])
+            .env("HELPERS", helpers)
+            .output()
+            .expect("run offline accepted-route absence regression");
+        assert!(
+            output.status.success(),
+            "{script}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
 fn route_server_cli_predicates_drain_output_and_preserve_errors() {
     for script in [
         "scripts/test-m102-routeserver-openbgpd92.sh",

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -28,6 +28,8 @@ fn route_server_accepted_absence_requires_successful_snapshot() {
 set -euo pipefail
 eval "rs_accepted_has()$HELPERS"
 peer=192.0.2.1 prefix=203.0.113.0/24
+# Absence matching must not turn a failed external matcher into success.
+grep() { return 127; }
 rs_ctl() {
     [[ "$*" == "rib received $peer" ]] || return 99
     printf '%s' "$reply"


### PR DESCRIPTION
M104 and M106 could report an accepted route absent when the CLI query failed. Both absence helpers now require a successfully completed snapshot before matching, preserving the query's error status. Matching uses Bash's literal substring comparison, so a failed external matcher cannot produce a successful absence verdict.

The change keeps the existing commands, ledger counts, and immutable M90 evidence. It adds no retries or production behavior changes.

Validation:

- The new source-extracted regression failed before the fix and passes for both drivers with successful empty, nonmatching, and matching output, plus failed queries with empty, partial, or matching output. It also simulates an unavailable grep; the matching-route case failed before the Bash comparison refinement and now passes.
- The complete topology command test target, Bash syntax, formatting, and normal commit/push hooks passed.
- M104 ShellCheck is clean; M106 retains its five pre-existing diagnostics, verified against the base revision.

M106 completed a fresh single-attempt local run at `ce4c9f577` with 142 passed and 0 failed; image build, deployment, driver, and teardown all succeeded. The subsequent Bash matcher refinement is covered offline and has not yet been replayed live. M104 has a hosted interop job; M106 has no named job in the current workflows. No changelog or roadmap update is needed for this test-harness correction.
