### PR TITLE
fix(rib): preserve live peers during retention expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,6 +461,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Preserve fresh routes and live peer state when GR or LLGR retention expires
+  while a re-established peer's initial outbound registration is deferred.
+  Stale routes still expire, and the pending registration completes normally.
+
 - `rustbgpd-wire` shutdown communication errors now implement `Display` and
   `std::error::Error` for downstream error propagation, with bounded static
   descriptions. Decoding and structured log categories are unchanged.

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -1104,15 +1104,17 @@ impl RibManager {
     /// already removed the GR/LLGR maps (its abort arms no-op), the ribs
     /// entry holds only swept-empty state, and the outbound state was
     /// cleared at GR entry (`clear_outbound_peer_state` no-ops). If the
-    /// peer DID re-establish (`outbound_peers` is re-inserted by
-    /// `handle_peer_up`) and only its End-of-RIB is late, identity and RIB
-    /// state must survive the sweep — hence the guard. Retention expiry is
-    /// a timer decision, not a session event, so it calls the
-    /// unconditional teardown rather than the session-identity-gated
-    /// `handle_peer_down` (there is no registered session to match here
-    /// anyway — the guard just established that).
+    /// peer DID re-establish and only its End-of-RIB is late, identity and
+    /// fresh RIB state must survive the sweep. A busy actor may defer its
+    /// outbound registration, so a nonempty live-session record also proves
+    /// the peer is present before that registration completes. Retention
+    /// expiry is a timer decision without a session identity; once departure
+    /// is established it can use unconditional teardown rather than the
+    /// session-identity-gated `handle_peer_down`.
     fn release_peer_state_if_departed(&mut self, peer: IpAddr) {
-        if !self.outbound_peers.contains_key(&peer) {
+        if !self.outbound_peers.contains_key(&peer)
+            && self.live_sessions.get(&peer).is_none_or(Vec::is_empty)
+        {
             info!(%peer, "GR retention expired without re-establishment — releasing per-peer state");
             self.peer_down_teardown(peer);
         }

--- a/crates/rib/src/manager/tests/gr_llgr.rs
+++ b/crates/rib/src/manager/tests/gr_llgr.rs
@@ -1204,6 +1204,8 @@ async fn gr_expiry_without_reestablish_releases_peer_state() {
         peer_llgr_families: vec![],
         llgr_stale_time: 0,
     });
+    // An empty session-list entry must not keep a departed peer alive.
+    manager.live_sessions.insert(peer, Vec::new());
     manager.sweep_gr_stale(peer);
 
     assert!(
@@ -2135,5 +2137,142 @@ mod deadline_map {
         assert_eq!(map.min(), Some(at(7)));
         map.retain(|_| false);
         assert_eq!(map.min(), None);
+    }
+}
+
+// Build the same busy-actor deferral window as the lifecycle tests, with
+// retained FlowSpec and fresh input from the re-established session.
+fn deferred_retention_peer(
+    llgr: bool,
+) -> (
+    mpsc::Sender<RibUpdate>,
+    RibManager,
+    mpsc::Receiver<OutboundRouteUpdate>,
+) {
+    let (tx, mut manager) = direct_manager(None);
+    let source = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(source);
+    let _old_rx = establish_peer(&mut manager, peer);
+    let mut old_route = make_flowspec_route(source);
+    old_route.rule.components = vec![rustbgpd_wire::FlowSpecComponent::DestinationPrefix(
+        rustbgpd_wire::FlowSpecPrefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+    )];
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![old_route],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    drain_route_chunks(&mut manager);
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer,
+        restart_time: 2,
+        stale_routes_time: 5,
+        gr_families: vec![(Afi::Ipv4, Safi::FlowSpec)],
+        peer_llgr_capable: llgr,
+        peer_llgr_families: if llgr {
+            vec![rustbgpd_wire::LlgrFamily {
+                afi: Afi::Ipv4,
+                safi: Safi::FlowSpec,
+                forwarding_preserved: false,
+                stale_time: 10,
+            }]
+        } else {
+            vec![]
+        },
+        llgr_stale_time: if llgr { 10 } else { 0 },
+    });
+    manager.initial_dump_defer_min_routes = 0;
+    tx.try_send(RibUpdate::SetPeerPolicyContext {
+        peer,
+        session_id: 0,
+        peer_group: Some("edge".to_string()),
+    })
+    .unwrap();
+    let new_rx = establish_peer(&mut manager, peer);
+    // Consume the queued context while leaving the initial registration pending.
+    manager.drain_ready_updates();
+    if llgr {
+        // The GR timer can expire before the deferred dump. Promotion is
+        // nonterminal; the original LLGR timer then owns terminal cleanup.
+        manager.sweep_gr_stale(peer);
+        assert!(!manager.gr_peers.contains_key(&peer));
+        assert!(manager.llgr_peers.contains_key(&peer));
+    }
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![make_flowspec_route(source)],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    drain_route_chunks(&mut manager);
+    assert_eq!(manager.loc_rib.flowspec_len(), 2);
+    assert!(manager.pending_initial_registrations.contains(&peer));
+    assert!(!manager.outbound_peers.contains_key(&peer));
+    assert!(manager.live_sessions.contains_key(&peer));
+    (tx, manager, new_rx)
+}
+
+#[tokio::test]
+async fn retention_expiry_spares_deferred_reestablished_peer() {
+    for llgr in [false, true] {
+        let (_tx, mut manager, _new_rx) = deferred_retention_peer(llgr);
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        if llgr {
+            manager.sweep_llgr_stale(peer, &[(Afi::Ipv4, Safi::FlowSpec)]);
+        } else {
+            manager.sweep_gr_stale(peer);
+        }
+        let fresh_key = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1)).selection_key();
+        assert!(
+            manager.loc_rib.get_flowspec(&fresh_key).is_some(),
+            "retention expiry must preserve fresh FlowSpec from the live deferred session (LLGR={llgr})"
+        );
+        assert_eq!(manager.loc_rib.flowspec_len(), 1, "stale route must expire");
+        assert_eq!(manager.ribs[&peer].flowspec_len(), 1);
+        assert!(manager.live_sessions.contains_key(&peer));
+        assert!(manager.peer_asn.contains_key(&peer));
+        assert!(manager.peer_bgp_id.contains_key(&peer));
+        assert_eq!(
+            manager.peer_group.get(&peer).map(String::as_str),
+            Some("edge")
+        );
+        assert!(manager.pending_initial_registrations.contains(&peer));
+        assert!(!manager.gr_peers.contains_key(&peer));
+        assert!(!manager.llgr_peers.contains_key(&peer));
+        manager.advance_pending_initial_registration();
+        assert!(manager.outbound_peers.contains_key(&peer));
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn run_loop_retention_expiry_precedes_deferred_registration() {
+    for llgr in [false, true] {
+        let (tx, manager, mut new_rx) = deferred_retention_peer(llgr);
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        // Start the actual actor with a due timer and a pending registration.
+        // Virtual time makes the ordering deterministic without a bulk table.
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        let handle = tokio::spawn(manager.run());
+        let dump = tokio::time::timeout(std::time::Duration::from_secs(1), new_rx.recv()).await;
+        let best = query_flowspec_routes(&tx).await;
+        drop(tx);
+        handle.await.unwrap();
+        assert_eq!(best.len(), 1, "only the fresh route survives (LLGR={llgr})");
+        assert!(!best[0].is_stale && !best[0].is_llgr_stale);
+        assert_eq!(best[0].peer, peer);
+        let dump = dump
+            .expect("deferred registration must complete")
+            .expect("the live session's sender must survive expiry");
+        assert!(!dump.end_of_rib.is_empty());
     }
 }


### PR DESCRIPTION
A re-established peer can send fresh routes while a busy RIB actor defers its initial outbound registration. If GR or terminal LLGR retention expires in that interval, cleanup previously mistook the missing registration for a departed session, removed fresh routes, and canceled the pending registration.

The shared departure check now also considers live sessions. Stale routes still expire, while fresh routes, peer identity, and pending registration survive until the initial dump completes. An empty session list still permits departed-peer cleanup.

Validation:

- Direct and paused-time actor regressions reproduced fresh FlowSpec loss before the fix for both GR and terminal LLGR; all four cases pass afterward.
- Existing GR/LLGR and peer-lifecycle suites passed, including departed-peer cleanup and session-down-before-registration controls.
- Strict RIB package Clippy and normal commit/push hooks passed.
- `just gate` and `just gate-rib` passed before integrating the independent documentation-manifest change; the runtime diff is unchanged.

Self-review covered the complete diff, both expiry callers, session-record teardown, stale-route cleanup, and deferred registration completion. No public API, wire format, configuration, or retention-duration changes.
