### PR TITLE
fix(cli): reject conflicting explain families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -465,6 +465,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   while a re-established peer's initial outbound registration is deferred.
   Stale routes still expire, and the pending registration completes normally.
 
+- `rbgp rib` best-path and advertised explanations reject conflicting or
+  unsupported `--family` selectors before connecting, instead of silently
+  returning an explanation for the prefix's family. Matching IPv4/IPv6 aliases
+  and omitted-family inference remain supported.
+
 - `rustbgpd-wire` shutdown communication errors now implement `Display` and
   `std::error::Error` for downstream error propagation, with bounded static
   descriptions. Decoding and structured log categories are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -465,10 +465,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   while a re-established peer's initial outbound registration is deferred.
   Stale routes still expire, and the pending registration completes normally.
 
-- `rbgp rib` best-path and advertised explanations reject conflicting or
-  unsupported `--family` selectors before connecting, instead of silently
-  returning an explanation for the prefix's family. Matching IPv4/IPv6 aliases
-  and omitted-family inference remain supported.
+- `rbgp rib` best-path and advertised explanations reject missing prefixes and
+  conflicting or unsupported `--family` selectors before connecting. A conflicting
+  family no longer produces a successful explanation for the prefix's family.
+  Matching IPv4/IPv6 aliases and omitted-family inference remain supported.
 
 - `rustbgpd-wire` shutdown communication errors now implement `Display` and
   `std::error::Error` for downstream error propagation, with bounded static

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2119,7 +2119,10 @@ fn reject_duplicate_route_view_option<T>(
 }
 
 fn validate_explain_family(family: Option<&str>, prefix: Option<&str>) -> Result<(), CliError> {
-    let (Some(family), Some(prefix)) = (family, prefix) else {
+    let prefix = prefix.ok_or_else(|| {
+        CliError::Argument("--explain requires --prefix with an exact CIDR".into())
+    })?;
+    let Some(family) = family else {
         return Ok(());
     };
     let ipv4 = match parse_family(family) {
@@ -7497,6 +7500,14 @@ printf '%s\n' "${COMPREPLY[@]}"
             (
                 "rib --family ipv6 --prefix 203.0.113.0/24 --explain",
                 "--family ipv6 does not match prefix 203.0.113.0/24",
+            ),
+            (
+                "rib advertised 192.0.2.1 --explain",
+                "--explain requires --prefix with an exact CIDR",
+            ),
+            (
+                "rib advertised 192.0.2.1 --family ipv4 --explain",
+                "--explain requires --prefix with an exact CIDR",
             ),
             (
                 "rib --family ipv4 --prefix 2001:db8::/32 --explain",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2118,6 +2118,33 @@ fn reject_duplicate_route_view_option<T>(
     Ok(())
 }
 
+fn validate_explain_family(family: Option<&str>, prefix: Option<&str>) -> Result<(), CliError> {
+    let (Some(family), Some(prefix)) = (family, prefix) else {
+        return Ok(());
+    };
+    let ipv4 = match parse_family(family) {
+        Some(value) if value == proto::AddressFamily::Ipv4Unicast as i32 => true,
+        Some(value) if value == proto::AddressFamily::Ipv6Unicast as i32 => false,
+        Some(_) => {
+            return Err(CliError::Argument(format!(
+                "--explain does not support address family: {family}"
+            )));
+        }
+        None => {
+            return Err(CliError::Argument(format!(
+                "unknown address family: {family}"
+            )));
+        }
+    };
+    let (address, _) = output::parse_prefix_addr(prefix).map_err(CliError::Argument)?;
+    if address.is_ipv4() != ipv4 {
+        return Err(CliError::Argument(format!(
+            "--family {family} does not match prefix {prefix}"
+        )));
+    }
+    Ok(())
+}
+
 /// Reject route-view combinations before opening the gRPC transport.
 ///
 /// Clap catches conflicts within one argument scope, but parent-compatible
@@ -2146,6 +2173,9 @@ fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
 
     match action {
         None => {
+            if *parent_explain {
+                validate_explain_family(family.as_deref(), prefix.as_deref())?;
+            }
             if limit.is_some() && *parent_explain {
                 return Err(CliError::Argument(
                     "--explain cannot be combined with --limit".into(),
@@ -2246,6 +2276,12 @@ fn validate_rib_route_view_action(command: &Command) -> Result<(), CliError> {
                 return Err(CliError::Argument(
                     "--explain cannot be combined with --limit".into(),
                 ));
+            }
+            if *explain {
+                validate_explain_family(
+                    family.as_deref().or(view_family.as_deref()),
+                    prefix.as_deref().or(filters.prefix.as_deref()),
+                )?;
             }
         }
         Some(_) if limit.is_some() => {
@@ -7395,6 +7431,46 @@ printf '%s\n' "${COMPREPLY[@]}"
         }
     }
 
+    #[test]
+    fn rib_explain_family_preserves_matching_aliases_and_selectors() {
+        for (prefix, families) in [
+            ("203.0.113.0/24", ["ipv4", "ipv4_unicast", "ipv4-unicast"]),
+            ("2001:db8::/32", ["ipv6", "ipv6_unicast", "ipv6-unicast"]),
+        ] {
+            for family in std::iter::once("").chain(families) {
+                let family = if family.is_empty() {
+                    String::new()
+                } else {
+                    format!("--family {family}")
+                };
+                for command in [
+                    format!("rib {family} --prefix {prefix} --explain"),
+                    format!("rib {family} --prefix {prefix} advertised 192.0.2.1 --explain"),
+                    format!("rib advertised 192.0.2.1 {family} --prefix {prefix} --explain"),
+                ] {
+                    let cli = Cli::try_parse_from(
+                        std::iter::once("rbgp").chain(command.split_whitespace()),
+                    )
+                    .unwrap();
+                    validate_rib_route_view_action(&cli.command).unwrap();
+                    validate_local_command(&cli.command).unwrap();
+                }
+                for selector in [
+                    "--rd 65000:100",
+                    "--labeled",
+                    "--source-peer 198.51.100.2 --source-path-id 0",
+                ] {
+                    let command = format!(
+                        "rbgp rib advertised 192.0.2.1 {family} --prefix {prefix} --explain {selector}"
+                    );
+                    let cli = Cli::try_parse_from(command.split_whitespace()).unwrap();
+                    validate_rib_route_view_action(&cli.command).unwrap();
+                    validate_local_command(&cli.command).unwrap();
+                }
+            }
+        }
+    }
+
     #[tokio::test]
     async fn local_argument_errors_fail_before_transport() {
         for (args, expected) in [
@@ -7417,6 +7493,30 @@ printf '%s\n' "${COMPREPLY[@]}"
             (
                 "policy explain --neighbor 10.0.0.2 --prefix 10.0.0.0/24 --path-id 3 --direction export",
                 commands::policy::EXPLAIN_EXPORT_PATH_ID_ERROR,
+            ),
+            (
+                "rib --family ipv6 --prefix 203.0.113.0/24 --explain",
+                "--family ipv6 does not match prefix 203.0.113.0/24",
+            ),
+            (
+                "rib --family ipv4 --prefix 2001:db8::/32 --explain",
+                "--family ipv4 does not match prefix 2001:db8::/32",
+            ),
+            (
+                "rib --family ipv6 --prefix 203.0.113.0/24 advertised 192.0.2.1 --explain",
+                "--family ipv6 does not match prefix 203.0.113.0/24",
+            ),
+            (
+                "rib advertised 192.0.2.1 --family ipv4 --prefix 2001:db8::/32 --explain",
+                "--family ipv4 does not match prefix 2001:db8::/32",
+            ),
+            (
+                "rib --family ipv4_flowspec --prefix 203.0.113.0/24 --explain",
+                "--explain does not support address family: ipv4_flowspec",
+            ),
+            (
+                "rib advertised 192.0.2.1 --family bgpls --prefix 203.0.113.0/24 --explain",
+                "--explain does not support address family: bgpls",
             ),
             ("watch --family bogus", "unknown address family: bogus"),
             (

--- a/docs/how-to/explain.md
+++ b/docs/how-to/explain.md
@@ -44,8 +44,8 @@ translates the usual show-commands into these.
 
 Best-path and export explanations infer IPv4 or IPv6 from the exact prefix.
 An optional `--family` must be a matching IPv4/IPv6 unicast alias; conflicting
-or unsupported families fail before connecting. Export `--rd` and `--labeled`
-selectors continue to choose VPN and labeled-unicast explanations.
+or unsupported families fail before connecting. The `--rd` and `--labeled`
+selectors on `rib advertised --explain` choose VPN and labeled-unicast explanations.
 
 Why did this path win? Every losing candidate is annotated with the
 decisive comparison step (`only_path`, `higher_local_pref`,

--- a/docs/how-to/explain.md
+++ b/docs/how-to/explain.md
@@ -42,6 +42,11 @@ translates the usual show-commands into these.
 <a id="best-path-explain--decisive-comparison-attribution"></a>
 ## Best-path explain
 
+Best-path and export explanations infer IPv4 or IPv6 from the exact prefix.
+An optional `--family` must be a matching IPv4/IPv6 unicast alias; conflicting
+or unsupported families fail before connecting. Export `--rd` and `--labeled`
+selectors continue to choose VPN and labeled-unicast explanations.
+
 Why did this path win? Every losing candidate is annotated with the
 decisive comparison step (`only_path`, `higher_local_pref`,
 `shorter_as_path`, `lower_origin`, `lower_med`, ... down to


### PR DESCRIPTION
Best-path and advertised route explanations now reject conflicting or unsupported `--family` selectors before connecting. Previously, `--family ipv6 --prefix 203.0.113.0/24` could return an IPv4 answer with exit 0. Advertised explanations also reject a missing prefix before transport, so an unavailable daemon cannot hide that argument error.

Matching IPv4/IPv6 aliases, omitted-family inference, parent-scope prefixes, and existing RD, labeled-route, and source-path selectors remain supported. Changes are limited to CLI validation, regression tests, and operator documentation.

Validation: regressions failed before each fix; focused tests, strict CLI Clippy, real-binary diagnostics, formatting, and links passed. The full `just gate` passed on the normal filesystem. Initial publication hooks passed with memory-backed temporary test files and four threads after a confirmed host storage stall; that retry is not disk-durability evidence. Follow-up publication hooks passed on the normal filesystem. The complete diff and both dispatch paths were reviewed.
