### PR TITLE
fix(cli): align operator input and output behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `rbgp rib add` uses `--next-hop` as the canonical flag, retaining
+  `--nexthop` as a visible compatibility alias. The default RIB pager now
+  wraps long lines (`less -FRX` in auto mode, `less -RX` in always mode);
+  explicit `RBGP_PAGER` and `PAGER` arguments remain unchanged.
+
 - The three example programs (`event-bridge`, `peer-loop`, `birdwatcher-adapter`)
   now build under the same lint policy as the workspace crates
   (`deny(unsafe_code)`, `deny(clippy::all)`, `warn(clippy::pedantic)`).
@@ -679,6 +684,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - EVPN Linux route withdrawal treats an already-absent kernel route as
   successfully removed, including single-path and ECMP IP-VRF routes. This
   clears owned state instead of retrying the deletion indefinitely.
+
+- Unicast CLI JSON now includes AGGREGATOR and ATOMIC_AGGREGATE when present,
+  including best-route and candidate rows in best-path explanations. Routes
+  without either attribute retain their existing JSON shape.
+
+- `rbgp neighbor` rejects malformed addresses before connecting, including
+  accidental `neighbor list` invocations. Valid scoped IPv6 peer addresses
+  remain supported. Help and man pages now distinguish parser/usage exit `2`
+  from argument-validation and execution exit `1`, preserving detailed
+  per-command exit codes.
+
+- `rbgp top` honors `--no-color` and the presence of `NO_COLOR` with a
+  monochrome theme that preserves bold emphasis and selection markers.
 
 ### Documentation
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -5,6 +5,12 @@ surface with human-readable and JSON output modes.
 
 Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
+Parser and usage errors, such as an unknown flag or malformed neighbor address,
+exit with code `2` before connecting. Argument validation after parsing, such as
+an out-of-range `top --interval` or an empty policy-chain list, keeps exit code
+`1`, as do connection and execution failures. Commands with detailed exit codes
+document them in `--help`; those codes apply after parsing.
+
 ## Commands
 
 ### Runtime Snapshot
@@ -105,6 +111,10 @@ rbgp rpki validate 192.0.2.0/24 64496       # complete verdict + bounded coverin
 rbgp rpki caches                             # configured caches + accepted RTR epochs
 ```
 
+Neighbor addresses accept IPv4, IPv6, and scoped link-local IPv6 such as
+`fe80::1%eth0` or `fe80::1%7`. Omit the address to list neighbors; `list` is
+not a neighbor subcommand.
+
 `rpki validate` requires the daemon's first authoritative VRP snapshot. Before
 that snapshot it fails with `FAILED_PRECONDITION`; an authoritative empty
 snapshot returns `not_found`. JSON reports the canonical prefix, origin ASN,
@@ -152,7 +162,7 @@ rbgp rib bgpls    # BGP-LS routes learned from peers (RFC 9552)
 rbgp rib vpn      # VPNv4/VPNv6 routes (RFC 4364/4659, SAFI 128)
 rbgp rib labeled  # labeled-unicast routes (RFC 8277, SAFI 4)
 rbgp rib rtc      # RT-Constrain membership NLRI (RFC 4684, SAFI 132)
-rbgp rib add <prefix> --nexthop <ip> [--origin <0|1|2>] [--local-pref <n>] [--med <n>] [--as-path "<asn> <asn>..."] [--communities <c1,c2,...>] [--large-communities <c1,c2,...>] [--path-id <n>]
+rbgp rib add <prefix> --next-hop <ip> [--origin <0|1|2>] [--local-pref <n>] [--med <n>] [--as-path "<asn> <asn>..."] [--communities <c1,c2,...>] [--large-communities <c1,c2,...>] [--path-id <n>]
 rbgp rib delete <prefix> [--path-id <n>]
 rbgp diff advertised   # compare live Adj-RIB-Out against an incumbent NDJSON snapshot (read-only; own 0/1/2 exit contract)
 rbgp diff snapshot from-mrt <file> --view adj-rib-out-capture --peer <addr> --peer-asn <asn>   # offline: produce an rbgp-ribsnap/1 snapshot from an incumbent MRT dump (see docs/how-to/ribdiff.md; from-bmp for BMP captures)
@@ -178,6 +188,8 @@ rbgp fib-table list
 rbgp fib-table set edge --table-id 1000 --metric 200 --families ipv4_unicast,ipv6_unicast
 ```
 
+`rib add --nexthop` remains a compatibility alias for `--next-hop`.
+
 Complete human `rib`, `rib received`, and `rib advertised` unicast listings
 use `--pager auto` by default: a pager starts only when stdout is a terminal,
 the terminal height is known, and the complete rendered table plus any
@@ -187,7 +199,9 @@ listings; JSON and all other commands are rejected before connecting.
 
 The pager command is the first non-empty value of `RBGP_PAGER`, then `PAGER`,
 split on ASCII whitespace without a shell. With neither set, auto mode uses
-`less -FRSX` and always mode uses `less -RSX`. If auto mode cannot find the
+`less -FRX` and always mode uses `less -RX`, allowing long lines to wrap.
+Custom pager arguments are unchanged; set `RBGP_PAGER='less -FRSX'` to opt
+back into horizontal scrolling. If auto mode cannot find the
 pager executable, it writes the same rendered bytes directly; other pager
 startup failures and unsuccessful exits are errors.
 
@@ -254,6 +268,18 @@ N of the exact matching total. JSON uses
 This is the bounded inspection path for a live full table. Without `--limit`,
 the CLI still follows every page and fails closed if the table changes; it
 never labels a torn multi-page walk complete.
+
+Unicast JSON route rows expose `aggregator` as `{"asn":65551,"router_id":"192.0.2.9"}`
+when AGGREGATOR is present, and `atomic_aggregate: true` only when
+ATOMIC_AGGREGATE is present. Best-route and candidate rows in best-path
+explanations use the same projection. Rows remain separate for each Add-Path
+path identifier, even when their prefixes match.
+
+The projection combines API `prefix` and `prefix_length` into a CIDR `prefix`.
+JSON `med` comes from optional API `med_attr`: absent is `null`, and explicit
+zero is `0`; the obsolete scalar API `med` is not authoritative. `local_pref`
+is the effective value, while optional `local_pref_attr` records attribute
+presence. This is an API route view, not a complete copy of wire attributes.
 
 In JSON route rows, `validation_state` is the route's recorded RPKI
 origin-validation verdict, not an indicator that `[rpki]` is enabled.

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -258,15 +258,6 @@ pub(crate) fn parse_esi(value: &str) -> Result<String, String> {
     parse_hex_octets(value, 10)
 }
 
-pub(crate) fn parse_explain_peer(value: &str) -> Result<String, String> {
-    bare_ip_rpc_address(value)
-        .parse::<std::net::IpAddr>()
-        .map_err(|_| {
-            "expected a peer IP address (optionally scoped link-local IPv6)".to_string()
-        })?;
-    Ok(value.to_string())
-}
-
 pub(crate) fn parse_exact_prefix(value: &str) -> Result<String, String> {
     if !value.contains('/') {
         return Err("exact EVPN prefix must include a CIDR length".into());
@@ -2389,7 +2380,8 @@ evpn_duplicate_mac_moves_total{vni="100",mac="02:aa:bb:cc:dd:01"} 2
     }
     #[test]
     fn exact_selector_parser_boundaries() {
-        use super::{parse_esi, parse_exact_prefix, parse_explain_peer, parse_mac, parse_rd};
+        use super::{parse_esi, parse_exact_prefix, parse_mac, parse_rd};
+        use crate::commands::neighbor::parse_peer_address;
         for value in [
             "0.0.0.0/0",
             "192.0.2.1/32",
@@ -2421,9 +2413,9 @@ evpn_duplicate_mac_moves_total{vni="100",mac="02:aa:bb:cc:dd:01"} 2
         assert!(parse_esi("00:11:22:33:44:55:66:77:88:9z").is_err());
         assert_eq!(parse_rd("65000:100").unwrap(), "65000:100");
         assert!(parse_rd("65536:65536").is_err());
-        assert!(parse_explain_peer("fe80::1%eth0").is_ok());
+        assert!(parse_peer_address("fe80::1%eth0").is_ok());
         for value in ["fe80::1%", "fe80::1%eth0%eth1", "192.0.2.1%eth0", "invalid"] {
-            assert!(parse_explain_peer(value).is_err(), "{value}");
+            assert!(parse_peer_address(value).is_err(), "{value}");
         }
     }
 }

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -29,6 +29,15 @@ pub(super) fn bare_ip_rpc_address(address: &str) -> &str {
     }
 }
 
+pub(crate) fn parse_peer_address(value: &str) -> Result<String, String> {
+    bare_ip_rpc_address(value)
+        .parse::<std::net::IpAddr>()
+        .map_err(|_| {
+            "expected a peer IP address (optionally scoped link-local IPv6)".to_string()
+        })?;
+    Ok(value.to_string())
+}
+
 pub(super) fn restore_matching_scoped_address(requested: Option<&str>, response: &mut String) {
     let Some(address) = requested else {
         return;

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -984,6 +984,12 @@ fn hex_lower(bytes: &[u8]) -> String {
 
 struct JsonRouteRef<'a>(&'a Route);
 
+#[derive(Serialize)]
+struct JsonRouteAggregator<'a> {
+    asn: u32,
+    router_id: &'a str,
+}
+
 impl Serialize for JsonRouteRef<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1007,6 +1013,12 @@ impl Serialize for JsonRouteRef<'_> {
             len += 1;
         }
         if route.local_pref_attr.is_some() {
+            len += 1;
+        }
+        if route.aggregator.is_some() {
+            len += 1;
+        }
+        if route.atomic_aggregate {
             len += 1;
         }
 
@@ -1043,6 +1055,18 @@ impl Serialize for JsonRouteRef<'_> {
         }
         if route.llgr_stale {
             map.serialize_entry("llgr_stale", &route.llgr_stale)?;
+        }
+        if let Some(aggregator) = &route.aggregator {
+            map.serialize_entry(
+                "aggregator",
+                &JsonRouteAggregator {
+                    asn: aggregator.asn,
+                    router_id: &aggregator.router_id,
+                },
+            )?;
+        }
+        if route.atomic_aggregate {
+            map.serialize_entry("atomic_aggregate", &route.atomic_aggregate)?;
         }
         map.end()
     }
@@ -2478,6 +2502,8 @@ mod tests {
     }
 
     fn route_for_json(path_id: u32, validation_state: &str) -> Route {
+        // Keep this generated message exhaustive: adding an API field must prompt
+        // a projection decision and an update to route_json_covers_proto_fields.
         Route {
             prefix: "203.0.113.0".to_string(),
             prefix_length: 24,
@@ -2496,7 +2522,11 @@ mod tests {
             validation_state: validation_state.to_string(),
             aspa_state: "valid".to_string(),
             received_at_epoch_seconds: 1_750_000_000,
-            ..Default::default()
+            local_pref_attr: None,
+            stale: false,
+            llgr_stale: false,
+            aggregator: None,
+            atomic_aggregate: false,
         }
     }
 
@@ -3538,6 +3568,89 @@ mod tests {
         assert_eq!(sampling.len(), 2);
         assert_eq!(sampling[0].table_name, "edge");
         assert_eq!(sampling[1].table_name, "core");
+    }
+
+    #[test]
+    fn route_json_covers_proto_fields() {
+        let mut route = route_for_json(7, "valid");
+        route.local_pref_attr = Some(200);
+        // The legacy scalar is deliberately not authoritative.
+        route.med = 999;
+        route.stale = true;
+        route.llgr_stale = true;
+        // This nested generated message must also remain exhaustive.
+        route.aggregator = Some(crate::proto::RouteAggregator {
+            asn: 65551,
+            router_id: "192.0.2.9".to_string(),
+        });
+        route.atomic_aggregate = true;
+        let expected = serde_json::json!({
+            "prefix": "203.0.113.0/24",
+            "next_hop": "198.51.100.1",
+            "as_path": [64512, 64496],
+            "local_pref": 200,
+            "local_pref_attr": 200,
+            "med": 50,
+            "origin": "igp",
+            "best": true,
+            "peer_address": "192.0.2.1",
+            "communities": ["NO_EXPORT", "64512:100"],
+            "extended_communities": [0x0002_fc00_0000_0064_u64, 0x4004_c000_0201_0032_u64],
+            "large_communities": ["64512:1:100"],
+            "path_id": 7,
+            "validation_state": "valid",
+            "aspa_state": "valid",
+            "received_at_epoch_seconds": 1_750_000_000,
+            "stale": true,
+            "llgr_stale": true,
+            "aggregator": {"asn": 65551, "router_id": "192.0.2.9"},
+            "atomic_aggregate": true,
+        });
+        assert_eq!(
+            serde_json::to_value(JsonRouteRef(&route)).unwrap(),
+            expected
+        );
+
+        // Two paths for the same prefix stay separate, including their own
+        // attribute presence. An aggregate need not carry ATOMIC_AGGREGATE.
+        let mut second = route.clone();
+        second.path_id = 8;
+        second.best = false;
+        second.atomic_aggregate = false;
+        let routes = [route.clone(), second];
+        let value = serde_json::to_value(JsonRoutes(&routes)).unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 2);
+        assert_eq!(value[0], expected);
+        assert_eq!(value[1]["prefix"], expected["prefix"]);
+        assert_eq!(value[1]["path_id"], 8);
+        assert_eq!(value[1]["aggregator"], expected["aggregator"]);
+        assert!(value[1].get("atomic_aggregate").is_none());
+
+        let resp = ExplainBestPathResponse {
+            best_route: Some(route.clone()),
+            candidates: vec![crate::proto::BestPathCandidate {
+                route: Some(route),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let value = serde_json::to_value(explain_best_path_to_json(&resp)).unwrap();
+        assert_eq!(value["best_route"], expected);
+        assert_eq!(value["candidates"][0]["route"], expected);
+    }
+
+    #[test]
+    fn route_json_omits_absent_aggregate_attributes() {
+        let mut route = route_for_json(0, "");
+        let value = serde_json::to_value(JsonRouteRef(&route)).unwrap();
+        assert!(value.get("aggregator").is_none());
+        assert!(value.get("atomic_aggregate").is_none());
+
+        // The two attributes have independent presence semantics.
+        route.atomic_aggregate = true;
+        let value = serde_json::to_value(JsonRouteRef(&route)).unwrap();
+        assert!(value.get("aggregator").is_none());
+        assert_eq!(value["atomic_aggregate"], true);
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -80,6 +80,8 @@ pub enum RouteAspaState {
 //   `visible_alias = "peer"` so both spellings work; commands that
 //   take the address as a positional (`rbgp neighbor <ADDRESS>`)
 //   keep it positional.
+// - Next-hop address: use `--next-hop`; `rib add` keeps `--nexthop` as
+//   a visible compatibility alias.
 // - ASNs: a remote AS flag is `--remote-asn` (visible alias
 //   `--asn`); an unqualified "ASN" in output means the local AS.
 // - TOML and policy-program file arguments are positional (`policy check
@@ -94,9 +96,9 @@ pub enum RouteAspaState {
 // - Empty results: JSON list output prints `[]` (or `{}` for
 //   objects), never nothing; human list output prints a one-line
 //   empty state ("No ... recorded/configured").
-// - Exit codes: 0 success / 1 error everywhere, with detailed
-//   contracts only where documented. Any new detailed contract must
-//   be added to EXIT_CODES_HELP and the subcommand's after_help.
+// - Exit codes: parser/usage failures are 2; after parsing, 0 success /
+//   1 error by default, with detailed contracts only where documented. Any
+//   new detailed contract must be added to EXIT_CODES_HELP and after_help.
 // - Help text: list entries (`about`) are one terse line; details go
 //   in `long_about` (the doc-comment paragraph after a blank line).
 // ===============================================================
@@ -105,8 +107,9 @@ pub enum RouteAspaState {
 /// and in the EXTRA section of `rbgp man`.
 const EXIT_CODES_HELP: &str = "Exit codes:\n  \
     0  success\n  \
-    1  error (argument, connection, daemon, or runtime failure)\n\n\
-    Detailed contracts (also in each subcommand's --help):\n  \
+    1  error (argument validation, connection, daemon, or runtime failure)\n  \
+    2  parser or usage error\n\n\
+    Detailed contracts after parsing (also in each subcommand's --help):\n  \
     diff advertised      0 no differences / 1 differences / 2 non-comparable input or error\n  \
     diff snapshot ...    0 snapshot emitted / 2 refused or malformed input\n  \
     config diff, plan    0 no changes / 1 error / 2 changes present\n  \
@@ -173,6 +176,7 @@ enum Command {
     #[command(visible_alias = "summary")]
     Neighbor {
         /// Neighbor address (omit to list all)
+        #[arg(value_parser = commands::neighbor::parse_peer_address)]
         address: Option<String>,
 
         #[command(subcommand)]
@@ -1449,7 +1453,7 @@ enum RibAction {
         /// Prefix (e.g., 10.0.0.0/24)
         prefix: String,
         /// Next hop address
-        #[arg(long)]
+        #[arg(long = "next-hop", visible_alias = "nexthop", value_name = "NEXT_HOP")]
         nexthop: String,
         /// Origin (0=igp, 1=egp, 2=incomplete)
         #[arg(long)]
@@ -1810,10 +1814,10 @@ struct EvpnExplainArgs {
     #[arg(long, value_parser = commands::evpn::parse_rd)]
     rd: String,
     /// Look up this accepted source; absence does not explain import rejection.
-    #[arg(long, value_parser = commands::evpn::parse_explain_peer)]
+    #[arg(long, value_parser = commands::neighbor::parse_peer_address)]
     received_from: Option<String>,
     /// Evaluate current export gates and committed local state for this peer.
-    #[arg(long, value_parser = commands::evpn::parse_explain_peer)]
+    #[arg(long, value_parser = commands::neighbor::parse_peer_address)]
     advertised_to: Option<String>,
 }
 
@@ -2444,10 +2448,10 @@ fn parse_community_str(s: &str) -> Result<u32, String> {
 #[tokio::main]
 async fn main() {
     let binary_name = invoked_binary_name();
-    let cli = parse_cli(binary_name);
+    let mut cli = parse_cli(binary_name);
 
-    let no_color = cli.no_color || std::env::var_os("NO_COLOR").is_some();
-    if no_color || cli.json {
+    cli.no_color |= std::env::var_os("NO_COLOR").is_some();
+    if cli.no_color || cli.json {
         owo_colors::set_override(false);
     }
 
@@ -4028,7 +4032,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             if json {
                 eprintln!("warning: --json has no effect on `top`; it is an interactive TUI");
             }
-            tui::run(connection, interval).await
+            tui::run(connection, interval, cli.no_color).await
         }
         Command::Policy { action } => match action {
             PolicyAction::Check { .. } | PolicyAction::Fmt { .. } => {
@@ -4898,6 +4902,30 @@ printf '%s\n' "${COMPREPLY[@]}"
                 compare: None,
             }
         ));
+    }
+
+    #[test]
+    fn test_parse_neighbor_address_preserves_scoped_inputs() {
+        for address in [
+            "192.0.2.1",
+            "2001:DB8::1",
+            "fe80::1",
+            "fe80::1%eth0",
+            "fe80::1%7",
+        ] {
+            for noun in ["neighbor", "summary"] {
+                let cli = Cli::try_parse_from(["rbgp", noun, address, "reset"]).unwrap();
+                let Command::Neighbor {
+                    address: Some(parsed),
+                    action: Some(NeighborAction::Reset { .. }),
+                    ..
+                } = cli.command
+                else {
+                    panic!("expected neighbor reset");
+                };
+                assert_eq!(parsed, address);
+            }
+        }
     }
 
     #[test]
@@ -6916,21 +6944,78 @@ printf '%s\n' "${COMPREPLY[@]}"
 
     #[test]
     fn test_parse_rib_add() {
-        let cli =
-            Cli::try_parse_from(["rbgp", "rib", "add", "10.0.0.0/24", "--nexthop", "10.0.0.1"])
+        for flag in ["--next-hop", "--nexthop"] {
+            for (expected_prefix, expected_next_hop) in [
+                ("10.0.0.0/24", "10.0.0.1"),
+                ("2001:db8::/32", "2001:db8::1"),
+            ] {
+                let cli = Cli::try_parse_from([
+                    "rbgp",
+                    "rib",
+                    "add",
+                    expected_prefix,
+                    flag,
+                    expected_next_hop,
+                ])
                 .unwrap();
-        if let Command::Rib {
-            action: Some(RibAction::Add {
-                prefix, nexthop, ..
-            }),
-            ..
-        } = cli.command
-        {
-            assert_eq!(prefix, "10.0.0.0/24");
-            assert_eq!(nexthop, "10.0.0.1");
-        } else {
-            panic!("expected Rib Add command");
+                if let Command::Rib {
+                    action:
+                        Some(RibAction::Add {
+                            prefix, nexthop, ..
+                        }),
+                    ..
+                } = cli.command
+                {
+                    assert_eq!(prefix, expected_prefix);
+                    assert_eq!(nexthop, expected_next_hop);
+                } else {
+                    panic!("expected Rib Add command");
+                }
+            }
         }
+    }
+
+    #[test]
+    fn rib_add_next_hop_alias_rejects_duplicate_values() {
+        let error = Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "add",
+            "10.0.0.0/24",
+            "--next-hop",
+            "10.0.0.1",
+            "--nexthop",
+            "10.0.0.2",
+        ])
+        .err()
+        .expect("both spellings name the same argument");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn rib_add_next_hop_help_and_man_use_canonical_spelling() {
+        let mut command = cli_command(BINARY_NAME);
+        let help = command
+            .find_subcommand_mut("rib")
+            .unwrap()
+            .find_subcommand_mut("add")
+            .unwrap()
+            .render_long_help()
+            .to_string();
+        assert!(help.contains("--next-hop <NEXT_HOP>"), "{help}");
+        assert!(help.contains("[alias: --nexthop]"), "{help}");
+
+        let mut output = Vec::new();
+        generate_man(BINARY_NAME, &mut output).unwrap();
+        let man = String::from_utf8(output).unwrap();
+        let add_section = man
+            .split(".SH \"RBGP RIB ADD\"")
+            .nth(1)
+            .unwrap()
+            .split(".SH \"RBGP ")
+            .next()
+            .unwrap();
+        assert!(add_section.contains("next\\-hop"), "{add_section}");
     }
 
     #[test]
@@ -7603,6 +7688,14 @@ printf '%s\n' "${COMPREPLY[@]}"
         let mut command = cli_command(BINARY_NAME);
         let help = command.render_long_help().to_string();
         assert!(help.contains("Exit codes:"), "help was: {help}");
+        assert!(
+            help.contains("1  error (argument validation,"),
+            "help was: {help}"
+        );
+        assert!(
+            help.contains("2  parser or usage error"),
+            "help was: {help}"
+        );
         assert!(help.contains("config diff, plan"), "help was: {help}");
         assert!(help.contains("policy fmt"), "help was: {help}");
     }
@@ -7616,6 +7709,11 @@ printf '%s\n' "${COMPREPLY[@]}"
             man.contains("Exit codes:"),
             "man page must carry the exit-code list"
         );
+        assert!(
+            man.contains("1  error (argument validation,"),
+            "man was: {man}"
+        );
+        assert!(man.contains("2  parser or usage error"), "man was: {man}");
     }
 
     /// LAN-329 noun standardization: `--neighbor` is canonical,

--- a/crates/cli/src/pager.rs
+++ b/crates/cli/src/pager.rs
@@ -88,8 +88,8 @@ fn pager_argv_from(mode: PagerMode, rbgp_pager: Option<&str>, pager: Option<&str
         .or_else(|| pager.filter(|value| !value.trim_ascii().is_empty()))
         .map(|value| value.split_ascii_whitespace().map(str::to_owned).collect())
         .unwrap_or_else(|| match mode {
-            PagerMode::Auto => vec!["less".into(), "-FRSX".into()],
-            PagerMode::Always => vec!["less".into(), "-RSX".into()],
+            PagerMode::Auto => vec!["less".into(), "-FRX".into()],
+            PagerMode::Always => vec!["less".into(), "-RX".into()],
             PagerMode::Never => unreachable!("never mode writes directly"),
         })
 }
@@ -203,13 +203,20 @@ mod tests {
             pager_argv_from(PagerMode::Always, Some("cat -n"), Some("more")),
             ["cat", "-n"]
         );
+        for mode in [PagerMode::Auto, PagerMode::Always] {
+            assert_eq!(
+                pager_argv_from(mode, Some("less -S"), Some("more -f")),
+                ["less", "-S"]
+            );
+            assert_eq!(pager_argv_from(mode, None, Some("less -S")), ["less", "-S"]);
+        }
         assert_eq!(
             pager_argv_from(PagerMode::Auto, None, None),
-            ["less", "-FRSX"]
+            ["less", "-FRX"]
         );
         assert_eq!(
             pager_argv_from(PagerMode::Always, None, None),
-            ["less", "-RSX"]
+            ["less", "-RX"]
         );
     }
 

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -60,7 +60,7 @@ impl Drop for TerminalGuard {
     }
 }
 
-pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> {
+pub async fn run(connection: Connection, interval: u64, no_color: bool) -> Result<(), CliError> {
     let (signal_tx, mut signal_rx) = mpsc::channel(1);
     spawn_signal_forwarder(signal_tx)?;
     enable_raw_mode()?;
@@ -71,7 +71,11 @@ pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> 
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
 
-    let theme = Theme::default();
+    let theme = if no_color {
+        Theme::monochrome()
+    } else {
+        Theme::default()
+    };
     let mut app = App::new();
 
     let (data_tx, mut data_rx) = mpsc::channel(4);

--- a/crates/cli/src/tui/theme.rs
+++ b/crates/cli/src/tui/theme.rs
@@ -35,6 +35,23 @@ impl Default for Theme {
 }
 
 impl Theme {
+    pub fn monochrome() -> Self {
+        Self {
+            border: Color::Reset,
+            header_fg: Color::Reset,
+            text: Color::Reset,
+            text_dim: Color::Reset,
+            highlight: Color::Reset,
+            state_established: Color::Reset,
+            state_connecting: Color::Reset,
+            state_down: Color::Reset,
+            event_added: Color::Reset,
+            event_withdrawn: Color::Reset,
+            error: Color::Reset,
+            accent: Color::Reset,
+        }
+    }
+
     pub fn state_color(&self, state: i32) -> Color {
         match state {
             6 => self.state_established,

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -1309,6 +1309,29 @@ mod tests {
     use ratatui::backend::TestBackend;
 
     #[test]
+    fn monochrome_retains_text_bold_and_selection() {
+        let mut app = App::new();
+        app.on_data(snapshot(vec![safety_neighbor()], Freshness::Fresh));
+        app.peer_table_state.select(Some(0));
+        let mut terminal = Terminal::new(TestBackend::new(160, 24)).unwrap();
+        terminal
+            .draw(|frame| draw(frame, &mut app, &Theme::monochrome()))
+            .unwrap();
+        let cells = &terminal.backend().buffer().content;
+        assert!(cells.iter().all(|cell| {
+            cell.fg == ratatui::style::Color::Reset && cell.bg == ratatui::style::Color::Reset
+        }));
+        assert!(
+            cells
+                .iter()
+                .any(|cell| { cell.symbol() == "N" && cell.modifier.contains(Modifier::BOLD) })
+        );
+        let text = cells.iter().map(|cell| cell.symbol()).collect::<String>();
+        assert!(text.contains("Neighbor"));
+        assert!(text.contains("> "), "selected row remains identifiable");
+    }
+
+    #[test]
     fn test_format_number() {
         assert_eq!(format_number(0), "0");
         assert_eq!(format_number(1), "1");

--- a/crates/cli/tests/argument_errors.rs
+++ b/crates/cli/tests/argument_errors.rs
@@ -1,0 +1,93 @@
+//! Parser errors and semantic validation keep distinct process exit codes.
+
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    let directory = tempfile::tempdir().unwrap();
+    let address = format!("unix://{}/absent.sock", directory.path().display());
+    Command::new(env!("CARGO_BIN_EXE_rbgp"))
+        .args(["--addr", &address, "--no-color"])
+        .args(args)
+        .output()
+        .expect("run rbgp against an absent socket")
+}
+
+#[test]
+fn parser_and_neighbor_usage_errors_exit_two_before_transport() {
+    for args in [
+        vec!["--unknown-flag"],
+        vec!["unknown-command"],
+        vec!["--addr"],
+        vec!["top", "--interval", "not-a-number"],
+        vec!["neighbor", "lst"],
+        vec!["neighbor", "list"],
+        vec!["neighbor", "999.999.999.999"],
+        vec!["neighbor", "fe80::1%"],
+        vec!["neighbor", "fe80::1%eth0%eth1"],
+        vec!["neighbor", "192.0.2.1%eth0"],
+    ] {
+        let output = run(&args);
+        assert_eq!(output.status.code(), Some(2), "{args:?}: {output:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+        let error = String::from_utf8(output.stderr).unwrap();
+        assert!(error.contains("error:"), "{args:?}: {error}");
+        assert!(
+            !error.contains("cannot reach rustbgpd"),
+            "{args:?}: {error}"
+        );
+    }
+}
+
+#[test]
+fn semantic_argument_errors_keep_exit_one_before_transport() {
+    for (args, message) in [
+        (vec!["top", "--interval", "0"], "interval must be between"),
+        (vec!["top", "--interval", "61"], "interval must be between"),
+        (vec!["policy", "chain", "set-import"], "set-import requires"),
+        (vec!["policy", "chain", "set-export"], "set-export requires"),
+    ] {
+        let output = run(&args);
+        assert_eq!(output.status.code(), Some(1), "{args:?}: {output:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+        let error = String::from_utf8(output.stderr).unwrap();
+        assert!(error.contains(message), "{args:?}: {error}");
+        assert!(
+            !error.contains("cannot reach rustbgpd"),
+            "{args:?}: {error}"
+        );
+    }
+}
+
+#[test]
+fn valid_neighbor_addresses_and_list_mode_reach_transport() {
+    for args in [
+        vec!["neighbor"],
+        vec!["summary"],
+        vec!["neighbor", "192.0.2.1"],
+        vec!["neighbor", "2001:db8::1"],
+        vec!["neighbor", "fe80::1%eth0"],
+        vec!["neighbor", "fe80::1%7", "reset"],
+    ] {
+        let output = run(&args);
+        assert_eq!(output.status.code(), Some(1), "{args:?}: {output:?}");
+        let error = String::from_utf8(output.stderr).unwrap();
+        assert!(error.contains("cannot reach rustbgpd"), "{args:?}: {error}");
+    }
+}
+
+#[test]
+fn help_and_man_distinguish_parsing_from_argument_validation() {
+    for args in [vec!["--help"], vec!["man"]] {
+        let output = run(&args);
+        assert!(output.status.success(), "{args:?}: {output:?}");
+        let text = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            text.contains("1  error (argument validation,"),
+            "{args:?}: {text}"
+        );
+        assert!(
+            text.contains("2  parser or usage error"),
+            "{args:?}: {text}"
+        );
+    }
+}

--- a/crates/cli/tests/tui_signal_restore.rs
+++ b/crates/cli/tests/tui_signal_restore.rs
@@ -7,7 +7,7 @@
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -32,8 +32,77 @@ fn count(haystack: &[u8], needle: &[u8]) -> usize {
         .count()
 }
 
+struct ScriptGuard {
+    child: Child,
+    reader: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for ScriptGuard {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let children = format!("/proc/{0}/task/{0}/children", self.child.id());
+            for pid in std::fs::read_to_string(children)
+                .unwrap_or_default()
+                .split_whitespace()
+                .filter_map(|pid| pid.parse().ok())
+            {
+                let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+            }
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+fn sgr_codes(output: &[u8]) -> Vec<u16> {
+    String::from_utf8_lossy(output)
+        .split("\x1b[")
+        .skip(1)
+        .filter_map(|sequence| sequence.split_once('m').map(|(codes, _)| codes))
+        .filter(|codes| {
+            codes
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || byte == b';')
+        })
+        .flat_map(|codes| codes.split(';').map(|code| code.parse().unwrap_or(0)))
+        .collect()
+}
+
 #[test]
-fn sigterm_restores_the_terminal() {
+fn sigterm_restores_the_terminal_and_color_policy_preserves_emphasis() {
+    for (flag, no_color, colored) in [
+        ("", None, true),
+        ("--no-color", None, false),
+        ("", Some("1"), false),
+        ("", Some(""), false),
+    ] {
+        let output = run_tui(flag, no_color);
+        let has_color = sgr_codes(&output)
+            .into_iter()
+            .any(|code| matches!(code, 30..=38 | 40..=48 | 58 | 90..=97 | 100..=107));
+        assert_eq!(
+            has_color,
+            colored,
+            "flag={flag:?} NO_COLOR={no_color:?}: {:?}",
+            String::from_utf8_lossy(&output)
+        );
+        let heading = find(&output, b"Dashboard").expect("help heading rendered");
+        let mut bold = false;
+        for code in sgr_codes(&output[..heading]) {
+            match code {
+                0 | 22 => bold = false,
+                1 => bold = true,
+                _ => {}
+            }
+        }
+        assert!(bold, "help heading must retain bold emphasis");
+    }
+}
+
+fn run_tui(flag: &str, no_color: Option<&str>) -> Vec<u8> {
     // A bare listener completes the TCP handshake, which is all the CLI's
     // connect step needs. The TUI's RPCs then stay in flight, which keeps it
     // on screen with a visible error and no daemon to run.
@@ -41,20 +110,32 @@ fn sigterm_restores_the_terminal() {
     let addr = format!("http://{}", listener.local_addr().expect("local addr"));
 
     // `exec` makes rbgp the direct child of `script`, so /proc names its pid.
-    let command = format!("exec {} -s {addr} top", env!("CARGO_BIN_EXE_rbgp"));
-    let mut script = Command::new("script")
-        .args(["-qec", &command, "/dev/null"])
+    let command_line = format!(
+        "stty rows 24 cols 160 && exec {} -s {addr} {flag} top",
+        env!("CARGO_BIN_EXE_rbgp")
+    );
+    let mut command = Command::new("script");
+    command.env_remove("NO_COLOR").env("TERM", "xterm-256color");
+    if let Some(value) = no_color {
+        command.env("NO_COLOR", value);
+    }
+    let child = command
+        .args(["-qec", &command_line, "/dev/null"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn script(1)");
+    let mut script = ScriptGuard {
+        child,
+        reader: None,
+    };
     // Held open so `script` never sees EOF on its stdin; it is also the
     // TUI's keyboard.
-    let mut stdin = script.stdin.take().expect("script stdin");
-    let mut stdout = script.stdout.take().expect("script stdout");
+    let mut stdin = script.child.stdin.take().expect("script stdin");
+    let mut stdout = script.child.stdout.take().expect("script stdout");
     let output = Arc::new(Mutex::new(Vec::new()));
-    let reader = {
+    script.reader = Some({
         let output = Arc::clone(&output);
         std::thread::spawn(move || {
             let mut buf = [0u8; 4096];
@@ -64,11 +145,12 @@ fn sigterm_restores_the_terminal() {
                 output.lock().unwrap().extend_from_slice(&buf[..n]);
             }
         })
-    };
+    });
 
-    let children = format!("/proc/{0}/task/{0}/children", script.id());
+    let children = format!("/proc/{0}/task/{0}/children", script.child.id());
     let deadline = Instant::now() + Duration::from_secs(30);
     let mut answered = 0;
+    let mut help_requested = false;
     let tui = loop {
         // Nothing emulates a terminal behind the pty, so answer the cursor
         // position query ratatui sends while setting up; unanswered, setup
@@ -81,12 +163,19 @@ fn sigterm_restores_the_terminal() {
             stdin.flush().expect("flush cursor report");
             answered += 1;
         }
+        if !help_requested && find(&output.lock().unwrap(), b"rustbgpd").is_some() {
+            stdin.write_all(b"h").expect("open help");
+            stdin.flush().expect("flush help key");
+            help_requested = true;
+        }
         let child = std::fs::read_to_string(&children).unwrap_or_default();
-        // A hidden cursor means a frame was drawn, so the event loop is
-        // running when the signal arrives.
-        if find(&output.lock().unwrap(), HIDE_CURSOR).is_some()
-            && let Some(pid) = child.split_whitespace().next()
-        {
+        // Require actual content: a zero-sized terminal can hide its cursor
+        // without rendering any cells, which cannot prove the color policy.
+        let frame_ready = {
+            let bytes = output.lock().unwrap();
+            find(&bytes, HIDE_CURSOR).is_some() && find(&bytes, b"Dashboard").is_some()
+        };
+        if frame_ready && let Some(pid) = child.split_whitespace().next() {
             break Pid::from_raw(pid.parse().expect("child pid"));
         }
         assert!(
@@ -98,8 +187,15 @@ fn sigterm_restores_the_terminal() {
     };
 
     kill(tui, Signal::SIGTERM).expect("deliver SIGTERM");
-    let status = script.wait().expect("wait for script");
-    reader.join().expect("reader thread");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        if let Some(status) = script.child.try_wait().expect("wait for script") {
+            break status;
+        }
+        assert!(Instant::now() < deadline, "TUI did not exit after SIGTERM");
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    script.reader.take().unwrap().join().expect("reader thread");
     let output = output.lock().unwrap();
 
     let enter = find(&output, ENTER_ALTERNATE_SCREEN).expect("alternate screen entered");
@@ -118,4 +214,5 @@ fn sigterm_restores_the_terminal() {
         Some(0),
         "a signal-driven quit exits like `q`; status: {status:?}"
     );
+    output.clone()
 }

--- a/docs/explanation/use-cases.md
+++ b/docs/explanation/use-cases.md
@@ -335,10 +335,10 @@ families = ["ipv4_unicast", "ipv6_unicast"]
 
 ```bash
 # Customer buys 203.0.113.0/24 — announce it
-rbgp rib add 203.0.113.0/24 --nexthop 192.0.2.1
+rbgp rib add 203.0.113.0/24 --next-hop 192.0.2.1
 
 # Customer buys an IPv6 block
-rbgp rib add 2001:db8:1000::/36 --nexthop 2001:db8::1
+rbgp rib add 2001:db8:1000::/36 --next-hop 2001:db8::1
 
 # Customer cancels — withdraw
 rbgp rib delete 203.0.113.0/24

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -1122,7 +1122,8 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (add)
 _arguments "${_arguments_options[@]}" : \
-'--nexthop=[Next hop address]:NEXTHOP:_default' \
+'--next-hop=[Next hop address]:NEXT_HOP:_default' \
+'--nexthop=[Next hop address]:NEXT_HOP:_default' \
 '--origin=[Origin (0=igp, 1=egp, 2=incomplete)]:ORIGIN:_default' \
 '--local-pref=[Local preference]:LOCAL_PREF:_default' \
 '--med=[MED]:MED:_default' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -9219,12 +9219,16 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__add)
-            opts="-s -j -h --nexthop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --nexthop --next-hop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --next-hop)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --nexthop)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -691,7 +691,7 @@ never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l nexthop -d 'Next hop address' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l next-hop -l nexthop -d 'Next hop address' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l origin -d 'Origin (0=igp, 1=egp, 2=incomplete)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l local-pref -d 'Local preference' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l med -d 'MED' -r


### PR DESCRIPTION
CLI corrections make operator output match the supplied data and selected options:

- Unicast JSON includes AGGREGATOR and ATOMIC_AGGREGATE when present, including best-route and candidate explanations. An exhaustive generated Route fixture guards field coverage while preserving optional MED semantics and Add-Path multiplicity.
- Malformed neighbor addresses fail before connecting, while scoped IPv6 addresses remain supported. Help and man pages distinguish parser/usage exit 2 from semantic argument and execution exit 1.
- The TUI honors `--no-color` and the presence of `NO_COLOR`, retaining bold emphasis and selection markers.
- `rib add --next-hop` matches the other route commands, with `--nexthop` retained as a visible compatibility alias. Shell completions include both spellings.
- The default pager wraps long lines so long AS paths and communities remain visible. Explicit `RBGP_PAGER` and `PAGER` arguments remain unchanged.

Regression evidence covers actual process exit codes, terminal output and restoration, and exact semantic JSON. Routes without the new attributes retain their JSON shape; no JSON envelope or streaming format changes are included.

Validation: full `just gate` passed before integrating the independently validated explain-family fix from main. On the combined tree, focused family/neighbor validation, argument exit-code integration, TUI terminal integration, and completion checks passed. The aggregate-field, next-hop, and pager regressions were each demonstrated against their prior behavior. Documentation and changelog describe the observable changes; this maintenance batch changes no roadmap milestone.
