### PR TITLE
feat(cli): stream versioned unicast RIB JSON lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Explicit `rbgp --json-lines` output for accepted unicast best, received,
+  and advertised routes. The versioned stream emits routes page by page and
+  ends with matching-row counts and completeness; ordinary JSON arrays and
+  limited envelopes retain their existing output and failure behavior.
+
 - Website ingest manifest in `docs/site-manifest.json`, checked in the public
   docs workflow so moving a consumed page without updating its source mapping
   fails CI. Site destinations remain independent of repository page paths.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -30,8 +30,9 @@ rbgp top          # live terminal dashboard
 
 Lightweight one-shot reads have a 30-second deadline for the complete RPC
 response, including its body, on TCP and Unix sockets. Each automatically
-fetched RIB page gets its own deadline; a failed later page exits with an
-error before printing an incomplete listing. Timeout errors name the RPC
+fetched RIB page gets its own deadline. Human and ordinary JSON listings print
+nothing if a later page fails; explicit `--json-lines` output retains emitted
+routes but omits the terminal end record. Timeout errors name the RPC
 and its budget. Config status and history are lightweight snapshots with the
 same limit. The CLI does not retry these reads automatically.
 
@@ -194,6 +195,43 @@ rbgp fib-table set edge --table-id 1000 --metric 200 --families ipv4_unicast,ipv
 ```
 
 `rib add --nexthop` remains a compatibility alias for `--next-hop`.
+
+For large accepted unicast listings, use `rbgp --json-lines rib`,
+`rbgp --json-lines rib received 192.0.2.1`, or
+`rbgp --json-lines rib advertised 192.0.2.1`. Routes are written as each
+page arrives, retaining only one response page. Existing `--json` arrays
+and `--json --limit` envelopes keep their shapes and print nothing if
+fetching a later page fails.
+
+The JSON-lines format starts with a header, contains one nested `route`
+record per path (including Add-Path identities), and ends with counts:
+
+```json
+{"type":"header","format":"rbgp-rib","format_version":"1.0","view":"best"}
+{"type":"route","route":{"prefix":"203.0.113.0/24","path_id":7}}
+{"type":"end","returned_count":1,"total_count":42,"complete":false}
+```
+
+The route above is abbreviated; real records use the same curated fields
+as ordinary route JSON. This is a daemon RIB view, not a wire-complete
+`rbgp-ribsnap/1` export. `format_version` is independent of daemon and
+protobuf versions: additive optional fields increment the minor version;
+incompatible field types, meaning, or removal require a major version.
+Consumers must ignore unknown fields within a supported major version.
+
+An `end` record means the requested walk succeeded. With `--limit`,
+`complete: false` means more matching routes exist; `total_count` counts
+all matching routes and `returned_count` counts emitted route records.
+An empty successful view emits a header and an end with zero counts.
+A failed continuation or timeout exits 1 without an end record: previously
+emitted routes do not constitute a completed result. The CLI does not
+restart the walk or retry stale tokens. A closed pipe exits 1 quietly and
+stops fetching. Check both process status and the end record before
+accepting a complete result.
+
+JSON-lines supports the existing accepted-unicast filters and `--limit`.
+It cannot be combined with `--json`, `--count`, `--explain`, `--age`,
+`--rejected`, other RIB families, or `--pager always`.
 
 Complete human `rib`, `rib received`, and `rib advertised` unicast listings
 use `--pager auto` by default: a pager starts only when stdout is a terminal,

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -219,11 +219,33 @@ struct RouteListing {
 async fn fetch_route_listing(
     client: &mut RibClient,
     rpc: &RouteListRpc,
-    mut req: ListRoutesRequest,
+    req: ListRoutesRequest,
     limit: Option<u32>,
 ) -> Result<RouteListing, CliError> {
-    req.page_size = limit.unwrap_or(ROUTE_PAGE_SIZE);
     let mut routes = Vec::new();
+    let (total_count, complete) = walk_route_pages(client, rpc, req, limit, |page| {
+        routes.extend(page);
+        Ok(())
+    })
+    .await?;
+    Ok(RouteListing {
+        routes,
+        total_count,
+        complete,
+        limit,
+    })
+}
+
+/// Consume each page before requesting its continuation. A failed consumer or
+/// RPC stops the walk without retrying an opaque continuation token.
+async fn walk_route_pages(
+    client: &mut RibClient,
+    rpc: &RouteListRpc,
+    mut req: ListRoutesRequest,
+    limit: Option<u32>,
+    mut consume: impl FnMut(Vec<Route>) -> Result<(), CliError>,
+) -> Result<(u64, bool), CliError> {
+    req.page_size = limit.unwrap_or(ROUTE_PAGE_SIZE);
     loop {
         let resp = match rpc {
             RouteListRpc::Best => {
@@ -246,18 +268,105 @@ async fn fetch_route_listing(
         }
         .into_inner();
         let total_count = resp.total_count;
-        routes.extend(resp.routes);
+        consume(resp.routes)?;
         let complete = resp.next_page_token.is_empty();
         if limit.is_some() || complete {
-            return Ok(RouteListing {
-                routes,
-                total_count,
-                complete,
-                limit,
-            });
+            return Ok((total_count, complete));
         }
         req.page_token = resp.next_page_token;
     }
+}
+
+#[derive(Serialize)]
+struct JsonLinesHeader {
+    r#type: &'static str,
+    format: &'static str,
+    format_version: &'static str,
+    view: &'static str,
+}
+
+#[derive(Serialize)]
+struct JsonLinesRoute<'a> {
+    r#type: &'static str,
+    route: JsonRouteRef<'a>,
+}
+
+#[derive(Serialize)]
+struct JsonLinesEnd {
+    r#type: &'static str,
+    returned_count: u64,
+    total_count: u64,
+    complete: bool,
+}
+
+async fn write_route_json_lines(
+    writer: &mut impl Write,
+    client: &mut RibClient,
+    rpc: RouteListRpc,
+    request: ListRoutesRequest,
+    limit: Option<u32>,
+    peer: Option<&str>,
+) -> Result<(), CliError> {
+    output::write_json_line(
+        writer,
+        &JsonLinesHeader {
+            r#type: "header",
+            format: "rbgp-rib",
+            format_version: "1.0",
+            view: match rpc {
+                RouteListRpc::Best => "best",
+                RouteListRpc::Received => "received",
+                RouteListRpc::Advertised => "advertised",
+            },
+        },
+    )?;
+    let mut returned_count = 0;
+    let (total_count, complete) = walk_route_pages(client, &rpc, request, limit, |page| {
+        for mut route in page {
+            restore_matching_scoped_address(peer, &mut route.peer_address);
+            output::write_json_line(
+                writer,
+                &JsonLinesRoute {
+                    r#type: "route",
+                    route: JsonRouteRef(&route),
+                },
+            )?;
+            returned_count += 1;
+        }
+        Ok(())
+    })
+    .await?;
+    output::write_json_line(
+        writer,
+        &JsonLinesEnd {
+            r#type: "end",
+            returned_count,
+            total_count,
+            complete,
+        },
+    )
+}
+
+/// Stream the accepted unicast view, retaining at most one response page.
+pub(crate) async fn json_lines(
+    connection: Connection,
+    rpc: RouteListRpc,
+    peer: Option<&str>,
+    family: Option<i32>,
+    filters: &RouteFilterOpts,
+) -> Result<(), CliError> {
+    let mut client =
+        RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let request = make_route_request(peer, family, filters)?;
+    write_route_json_lines(
+        &mut std::io::stdout().lock(),
+        &mut client,
+        rpc,
+        request,
+        filters.limit,
+        peer,
+    )
+    .await
 }
 
 /// Fetch only the backend's exact matching-row count for one route
@@ -2426,6 +2535,259 @@ mod tests {
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
     use prost::Message;
+
+    fn json_lines_records(bytes: &[u8]) -> Vec<serde_json::Value> {
+        std::str::from_utf8(bytes)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    fn assert_json_lines_inventory_shape(value: &serde_json::Value, shape: &serde_json::Value) {
+        for (key, expected) in shape["required_json_types"].as_object().unwrap() {
+            assert!(value.get(key).is_some(), "missing {key}");
+            assert_json_lines_field_type(&value[key], expected);
+        }
+        for (key, expected) in shape["optional_json_types"].as_object().unwrap() {
+            if let Some(value) = value.get(key) {
+                assert_json_lines_field_type(value, expected);
+            }
+        }
+    }
+
+    fn assert_json_lines_field_type(value: &serde_json::Value, expected: &serde_json::Value) {
+        let actual = match value {
+            serde_json::Value::Null => "null",
+            serde_json::Value::Bool(_) => "boolean",
+            serde_json::Value::Number(_) => "number",
+            serde_json::Value::String(_) => "string",
+            serde_json::Value::Array(_) => "array",
+            serde_json::Value::Object(_) => "object",
+        };
+        assert!(
+            expected.as_str() == Some(actual)
+                || expected
+                    .as_array()
+                    .is_some_and(|types| types.iter().any(|value| value == actual)),
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn json_lines_inventory_contract_pins_record_and_route_types() {
+        let inventory: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../../docs/reference/v1-stable-surface.json"
+        ))
+        .unwrap();
+        let contract = inventory["cli"]["versioned_json_contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["id"] == "rbgp-rib/1.0")
+            .unwrap();
+        let shapes = &contract["record_json_contracts"];
+        let header = serde_json::to_value(JsonLinesHeader {
+            r#type: "header",
+            format: "rbgp-rib",
+            format_version: "1.0",
+            view: "received",
+        })
+        .unwrap();
+        assert_json_lines_inventory_shape(&header, &shapes["header"]);
+        let mut route = route_for_json(7, "Valid");
+        route.local_pref_attr = Some(100);
+        route.stale = true;
+        route.llgr_stale = true;
+        route.aggregator = Some(crate::proto::RouteAggregator {
+            asn: 64512,
+            router_id: "192.0.2.9".into(),
+        });
+        route.atomic_aggregate = true;
+        let record = serde_json::to_value(JsonLinesRoute {
+            r#type: "route",
+            route: JsonRouteRef(&route),
+        })
+        .unwrap();
+        assert_json_lines_inventory_shape(&record, &shapes["route"]);
+        assert_json_lines_inventory_shape(&record["route"], &contract["nested_json_contracts"][0]);
+        assert_json_lines_inventory_shape(
+            &record["route"]["aggregator"],
+            &contract["nested_json_contracts"][1],
+        );
+        let end = serde_json::to_value(JsonLinesEnd {
+            r#type: "end",
+            returned_count: 1,
+            total_count: 2,
+            complete: false,
+        })
+        .unwrap();
+        assert_json_lines_inventory_shape(&end, &shapes["end"]);
+        // The nested route is exactly the existing curated projection.
+        assert_eq!(
+            record["route"],
+            serde_json::to_value(JsonRouteRef(&route)).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn json_lines_preserves_views_filters_paths_and_limits() {
+        for rpc in [
+            RouteListRpc::Best,
+            RouteListRpc::Received,
+            RouteListRpc::Advertised,
+        ] {
+            for limit in [None, Some(1)] {
+                let server = spawn_mock_server(None).await;
+                let route = rustbgpd_api::proto::Route {
+                    prefix: "2001:db8::".into(),
+                    prefix_length: 32,
+                    peer_address: "fe80::1".into(),
+                    path_id: 7,
+                    ..Default::default()
+                };
+                *server.state.list_route_pages.lock().await = vec![
+                    rustbgpd_api::proto::ListRoutesResponse {
+                        routes: vec![route.clone()],
+                        next_page_token: "opaque-second".into(),
+                        total_count: 2,
+                        page_version: None,
+                    },
+                    rustbgpd_api::proto::ListRoutesResponse {
+                        routes: vec![rustbgpd_api::proto::Route {
+                            path_id: 8,
+                            ..route
+                        }],
+                        next_page_token: String::new(),
+                        total_count: 2,
+                        page_version: None,
+                    },
+                ];
+                let connection = connect(&server.addr, None).await.unwrap();
+                let mut client = RibServiceClient::with_interceptor(
+                    connection.channel(),
+                    connection.interceptor(),
+                );
+                let peer = (rpc != RouteListRpc::Best).then_some("fe80::1%eth0");
+                let filters = count_filters();
+                let request =
+                    make_route_request(peer, Some(AddressFamily::Ipv6Unicast as i32), &filters)
+                        .unwrap();
+                let mut bytes = Vec::new();
+                write_route_json_lines(&mut bytes, &mut client, rpc, request, limit, peer)
+                    .await
+                    .unwrap();
+                let records = json_lines_records(&bytes);
+                assert_eq!(records[0]["format"], "rbgp-rib");
+                assert_eq!(records[0]["format_version"], "1.0");
+                assert_eq!(
+                    records[0]["view"],
+                    match rpc {
+                        RouteListRpc::Best => "best",
+                        RouteListRpc::Received => "received",
+                        RouteListRpc::Advertised => "advertised",
+                    }
+                );
+                assert_eq!(records[1]["route"]["path_id"], 7);
+                assert_eq!(
+                    records[1]["route"]["peer_address"],
+                    peer.unwrap_or("fe80::1")
+                );
+                let returned = if limit.is_some() { 1 } else { 2 };
+                assert_eq!(
+                    records.last().unwrap(),
+                    &serde_json::json!({
+                        "type": "end", "returned_count": returned, "total_count": 2,
+                        "complete": limit.is_none(),
+                    })
+                );
+                if limit.is_none() {
+                    assert_eq!(records[2]["route"]["path_id"], 8);
+                }
+                let requests = server.state.list_route_requests.lock().await;
+                assert_eq!(requests.len(), returned);
+                for request in requests.iter() {
+                    assert_eq!(request.neighbor_address, peer.map_or("", |_| "fe80::1"));
+                    assert_eq!(request.page_size, limit.unwrap_or(ROUTE_PAGE_SIZE));
+                    let mut count_request = request.clone();
+                    count_request.page_size = 1;
+                    count_request.page_token.clear();
+                    assert_count_request(&count_request, peer.map_or("", |_| "fe80::1"));
+                }
+                assert!(requests[0].page_token.is_empty());
+                if limit.is_none() {
+                    assert_eq!(requests[1].page_token, "opaque-second");
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn json_lines_empty_table_has_successful_end() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut client =
+            RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+        let mut bytes = Vec::new();
+        write_route_json_lines(
+            &mut bytes,
+            &mut client,
+            RouteListRpc::Best,
+            make_route_request(None, None, &no_route_filters()).unwrap(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let records = json_lines_records(&bytes);
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records[1],
+            serde_json::json!({"type":"end", "returned_count":0, "total_count":0, "complete":true})
+        );
+    }
+
+    #[tokio::test]
+    async fn json_lines_write_failure_stops_before_continuation() {
+        struct FailAfterHeader {
+            lines: usize,
+        }
+        impl Write for FailAfterHeader {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if self.lines != 0 {
+                    return Err(std::io::ErrorKind::BrokenPipe.into());
+                }
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.lines += 1;
+                Ok(())
+            }
+        }
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .list_route_pages
+            .lock()
+            .await
+            .push(count_page(2));
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut client =
+            RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+        let result = write_route_json_lines(
+            &mut FailAfterHeader { lines: 0 },
+            &mut client,
+            RouteListRpc::Best,
+            make_route_request(None, None, &no_route_filters()).unwrap(),
+            None,
+            None,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(CliError::Io(error)) if error.kind() == std::io::ErrorKind::BrokenPipe)
+        );
+        assert_eq!(server.state.list_route_requests.lock().await.len(), 1);
+    }
 
     fn legacy_route_to_json(r: &Route) -> output::JsonRoute {
         output::JsonRoute {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -143,7 +143,7 @@ struct Cli {
     token_file: Option<String>,
 
     /// Output in JSON format
-    #[arg(long, short = 'j', global = true)]
+    #[arg(long, short = 'j', global = true, conflicts_with = "json_lines")]
     json: bool,
 
     /// Stream accepted unicast RIB routes as versioned JSON lines
@@ -5060,6 +5060,42 @@ printf '%s\n' "${COMPREPLY[@]}"
             let mut output = Vec::new();
             generate_completions(shell, BINARY_NAME, &mut output).unwrap();
             assert!(!output.is_empty(), "{shell} completions are empty");
+        }
+    }
+
+    #[test]
+    fn json_lines_completion_conflicts_are_reciprocal() {
+        let mut command = cli_command(BINARY_NAME);
+        command.build();
+        for path in [
+            vec![],
+            vec!["rib"],
+            vec!["rib", "received"],
+            vec!["rib", "advertised"],
+        ] {
+            let mut view = &command;
+            for name in &path {
+                view = view.find_subcommand(name).unwrap();
+            }
+            for (flag, conflict) in [("json", "json_lines"), ("json_lines", "json")] {
+                let arg = view
+                    .get_arguments()
+                    .find(|arg| arg.get_id() == flag)
+                    .unwrap();
+                assert!(
+                    view.get_arg_conflicts_with(arg)
+                        .iter()
+                        .any(|arg| arg.get_id() == conflict),
+                    "{path:?}: {flag} must exclude {conflict} from completions"
+                );
+            }
+        }
+        let mut generated = Vec::new();
+        generate_completions(Shell::Zsh, BINARY_NAME, &mut generated).unwrap();
+        let generated = String::from_utf8(generated).unwrap();
+        for flag in ["-j", "--json"] {
+            assert!(generated.contains(&format!("'(--json-lines){flag}[")));
+            assert!(!generated.contains(&format!("'{flag}[")));
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -146,6 +146,10 @@ struct Cli {
     #[arg(long, short = 'j', global = true)]
     json: bool,
 
+    /// Stream accepted unicast RIB routes as versioned JSON lines
+    #[arg(long, global = true, conflicts_with = "json")]
+    json_lines: bool,
+
     /// Disable colored output
     ///
     /// The `NO_COLOR` environment variable is handled at runtime so its
@@ -2451,7 +2455,7 @@ async fn main() {
     let mut cli = parse_cli(binary_name);
 
     cli.no_color |= std::env::var_os("NO_COLOR").is_some();
-    if cli.no_color || cli.json {
+    if cli.no_color || cli.json || cli.json_lines {
         owo_colors::set_override(false);
     }
 
@@ -2933,8 +2937,65 @@ fn pager_supported(command: &Command) -> bool {
     }
 }
 
+fn validate_json_lines(cli: &Cli) -> Result<(), CliError> {
+    if !cli.json_lines {
+        return Ok(());
+    }
+    let unsupported = || {
+        CliError::Argument(
+        "--json-lines supports only accepted unicast rib, rib received, and rib advertised listings; it cannot be combined with --count, --explain, or --age".into(),
+    )
+    };
+    let Command::Rib {
+        action,
+        family,
+        count,
+        explain,
+        age,
+        ..
+    } = &cli.command
+    else {
+        return Err(unsupported());
+    };
+    if *count || *explain || *age {
+        return Err(unsupported());
+    }
+    let view_family = match action {
+        None => None,
+        Some(RibAction::Received {
+            family,
+            count: false,
+            age: false,
+            rejected: false,
+            ..
+        })
+        | Some(RibAction::Advertised {
+            family,
+            count: false,
+            age: false,
+            explain: false,
+            ..
+        }) => family.as_deref(),
+        _ => return Err(unsupported()),
+    };
+    for family in [family.as_deref(), view_family].into_iter().flatten() {
+        match parse_family(family) {
+            Some(value)
+                if value == proto::AddressFamily::Ipv4Unicast as i32
+                    || value == proto::AddressFamily::Ipv6Unicast as i32 => {}
+            _ => return Err(unsupported()),
+        }
+    }
+    Ok(())
+}
+
 async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
-    pager::validate_request(cli.pager, cli.json, pager_supported(&cli.command))?;
+    validate_json_lines(&cli)?;
+    pager::validate_request(
+        cli.pager,
+        cli.json || cli.json_lines,
+        pager_supported(&cli.command),
+    )?;
 
     // Shell completions don't need a gRPC connection.
     if let Command::Completions { shell } = cli.command {
@@ -3595,6 +3656,15 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         .await
                     } else if count {
                         commands::rib::count_best(connection, family_val, &filters, json).await
+                    } else if cli.json_lines {
+                        commands::rib::json_lines(
+                            connection,
+                            commands::rib::RouteListRpc::Best,
+                            None,
+                            family_val,
+                            &filters,
+                        )
+                        .await
                     } else {
                         commands::rib::best(connection, family_val, &filters, age, json, cli.pager)
                             .await
@@ -3638,6 +3708,15 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     let f = resolve_family(&fam.or(family))?;
                     if count {
                         commands::rib::count_received(connection, &address, f, &filters, json).await
+                    } else if cli.json_lines {
+                        commands::rib::json_lines(
+                            connection,
+                            commands::rib::RouteListRpc::Received,
+                            Some(&address),
+                            f,
+                            &filters,
+                        )
+                        .await
                     } else {
                         commands::rib::received(
                             connection, &address, f, &filters, age, json, cli.pager,
@@ -3714,6 +3793,15 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         }
                         commands::rib::count_advertised(connection, &address, f, &filters, json)
                             .await
+                    } else if cli.json_lines {
+                        commands::rib::json_lines(
+                            connection,
+                            commands::rib::RouteListRpc::Advertised,
+                            Some(&address),
+                            f,
+                            &filters,
+                        )
+                        .await
                     } else {
                         commands::rib::advertised(
                             connection, &address, f, &filters, age, json, cli.pager,
@@ -4289,6 +4377,80 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn json_lines_mode_parses_and_rejects_incompatible_views() {
+        for args in [
+            vec!["rbgp", "--json-lines", "rib"],
+            vec![
+                "rbgp",
+                "rib",
+                "received",
+                "fe80::1%eth0",
+                "--json-lines",
+                "--limit",
+                "1",
+            ],
+            vec![
+                "rbgp",
+                "rib",
+                "advertised",
+                "192.0.2.1",
+                "--family",
+                "ipv6",
+                "--json-lines",
+            ],
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            assert!(cli.json_lines);
+            validate_json_lines(&cli).unwrap();
+        }
+        for args in [
+            vec!["rbgp", "--json-lines", "rib", "lookup", "192.0.2.1"],
+            vec![
+                "rbgp",
+                "--json-lines",
+                "rib",
+                "--prefix",
+                "192.0.2.0/24",
+                "--explain",
+            ],
+            vec![
+                "rbgp",
+                "--json-lines",
+                "rib",
+                "--prefix",
+                "192.0.2.0/24",
+                "advertised",
+                "192.0.2.1",
+                "--explain",
+            ],
+            vec![
+                "rbgp",
+                "--json-lines",
+                "rib",
+                "received",
+                "192.0.2.1",
+                "--count",
+            ],
+            vec![
+                "rbgp",
+                "--json-lines",
+                "rib",
+                "received",
+                "192.0.2.1",
+                "--family",
+                "bgpls",
+            ],
+            vec!["rbgp", "--json-lines", "rib", "delete", "192.0.2.0/24"],
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            assert!(validate_json_lines(&cli).is_err());
+        }
+        assert!(Cli::try_parse_from(["rbgp", "--json", "--json-lines", "rib"]).is_err());
+        // The new mode must not tighten the existing JSON age behavior.
+        validate_json_lines(&Cli::try_parse_from(["rbgp", "--json", "rib", "--age"]).unwrap())
+            .unwrap();
+    }
     use super::*;
     use crate::test_support::spawn_mock_server;
     use clap::Parser;

--- a/crates/cli/src/pager.rs
+++ b/crates/cli/src/pager.rs
@@ -32,7 +32,7 @@ fn validate_request_with_tty(
     }
     if json {
         return Err(CliError::Argument(
-            "--pager always cannot be combined with --json".into(),
+            "--pager always cannot be combined with --json or --json-lines".into(),
         ));
     }
     if !stdout_is_tty {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -147,6 +147,7 @@ pub(crate) struct MockState {
     // (received/best/advertised) — drives the CLI pagination loop.
     // Empty = every call returns an empty final page.
     pub(crate) list_route_pages: Mutex<Vec<server_proto::ListRoutesResponse>>,
+    pub(crate) list_route_continuation_error: Mutex<Option<(Code, String)>>,
     pub(crate) list_route_requests: Mutex<Vec<server_proto::ListRoutesRequest>>,
     pub(crate) list_best_route_calls: AtomicUsize,
     pub(crate) list_received_route_calls: AtomicUsize,
@@ -1422,9 +1423,19 @@ impl MockRibService {
     async fn next_route_page(
         &self,
         request: server_proto::ListRoutesRequest,
-    ) -> server_proto::ListRoutesResponse {
+    ) -> Result<server_proto::ListRoutesResponse, Status> {
         let continuation = !request.page_token.is_empty();
         self.state.list_route_requests.lock().await.push(request);
+        if continuation
+            && let Some((code, message)) = self
+                .state
+                .list_route_continuation_error
+                .lock()
+                .await
+                .clone()
+        {
+            return Err(Status::new(code, message));
+        }
         if continuation
             && self
                 .state
@@ -1434,7 +1445,7 @@ impl MockRibService {
             std::future::pending::<()>().await;
         }
         let mut pages = self.state.list_route_pages.lock().await;
-        if pages.is_empty() {
+        Ok(if pages.is_empty() {
             server_proto::ListRoutesResponse {
                 routes: vec![],
                 next_page_token: String::new(),
@@ -1443,7 +1454,7 @@ impl MockRibService {
             }
         } else {
             pages.remove(0)
-        }
+        })
     }
 }
 
@@ -1807,7 +1818,7 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
             .list_received_route_calls
             .fetch_add(1, Ordering::SeqCst);
         Ok(Response::new(
-            self.next_route_page(request.into_inner()).await,
+            self.next_route_page(request.into_inner()).await?,
         ))
     }
 
@@ -1826,7 +1837,7 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         }
         let response = self.next_route_page(request.into_inner()).await;
         active.complete();
-        Ok(Response::new(response))
+        response.map(Response::new)
     }
 
     async fn list_advertised_routes(
@@ -1837,7 +1848,7 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
             .list_advertised_route_calls
             .fetch_add(1, Ordering::SeqCst);
         Ok(Response::new(
-            self.next_route_page(request.into_inner()).await,
+            self.next_route_page(request.into_inner()).await?,
         ))
     }
 

--- a/crates/cli/tests/read_deadlines.rs
+++ b/crates/cli/tests/read_deadlines.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 use rustbgpd_api::proto;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 
 #[path = "../src/test_support.rs"]
@@ -232,6 +232,188 @@ async fn later_page_stalls(json: bool) {
 #[tokio::test]
 async fn later_rib_page_timeout_never_prints_a_partial_listing() {
     tokio::join!(later_page_stalls(false), later_page_stalls(true));
+}
+
+async fn seed_first_route_page(server: &test_support::MockServerHandle) {
+    server
+        .state
+        .list_route_pages
+        .lock()
+        .await
+        .push(proto::ListRoutesResponse {
+            routes: vec![proto::Route {
+                prefix: "203.0.113.0".into(),
+                prefix_length: 24,
+                peer_address: "192.0.2.1".into(),
+                path_id: 7,
+                ..Default::default()
+            }],
+            next_page_token: "second-page".into(),
+            total_count: 2,
+            page_version: None,
+        });
+}
+
+#[tokio::test]
+async fn json_lines_emits_route_before_stalled_page_and_omits_end_on_timeout() {
+    let server = test_support::spawn_mock_server(None).await;
+    seed_first_route_page(&server).await;
+    server
+        .state
+        .list_route_continuation_stall
+        .store(true, Ordering::SeqCst);
+    let mut child = start(
+        &server.addr,
+        &["--json-lines", "rib", "received", "192.0.2.1"],
+    );
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+    let mut first_records = String::new();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        reader.read_line(&mut first_records).await.unwrap();
+        reader.read_line(&mut first_records).await.unwrap();
+    })
+    .await
+    .expect("header AND first route must arrive before the continuation finishes");
+    let records: Vec<serde_json::Value> = first_records
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["type"], "header");
+    assert_eq!(records[1]["type"], "route");
+    assert_eq!(records[1]["route"]["prefix"], "203.0.113.0/24");
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "route arrived only after process exit"
+    );
+    let output = finish(child).await;
+    assert_read_timeout(&output, "ListReceivedRoutes");
+    let mut remaining = String::new();
+    reader.read_to_string(&mut remaining).await.unwrap();
+    assert!(
+        remaining.is_empty(),
+        "failed stream must not emit an end record"
+    );
+    assert_eq!(server.state.list_route_requests.lock().await.len(), 2);
+}
+
+#[tokio::test]
+async fn later_page_abort_preserves_legacy_atomicity_and_leaves_stream_unfinished() {
+    for view in [
+        vec!["rib"],
+        vec!["rib", "received", "192.0.2.1"],
+        vec!["rib", "advertised", "192.0.2.1"],
+    ] {
+        for mode in ["--json", "--json-lines"] {
+            let server = test_support::spawn_mock_server(None).await;
+            seed_first_route_page(&server).await;
+            *server.state.list_route_continuation_error.lock().await =
+                Some((tonic::Code::Aborted, "RIB changed".into()));
+            let mut args = vec![mode];
+            args.extend(view.iter().copied());
+            let output = finish(start(&server.addr, &args)).await;
+            assert_eq!(output.status.code(), Some(1));
+            assert!(String::from_utf8_lossy(&output.stderr).contains("RIB changed"));
+            if mode == "--json" {
+                assert!(output.stdout.is_empty());
+            } else {
+                let records: Vec<serde_json::Value> = std::str::from_utf8(&output.stdout)
+                    .unwrap()
+                    .lines()
+                    .map(|line| serde_json::from_str(line).unwrap())
+                    .collect();
+                assert_eq!(records.len(), 2);
+                assert_eq!(records[1]["type"], "route");
+            }
+            assert_eq!(
+                server.state.list_route_requests.lock().await.len(),
+                2,
+                "no restart or retry"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn legacy_json_array_and_limited_envelope_keep_their_shapes() {
+    for limited in [false, true] {
+        let server = test_support::spawn_mock_server(None).await;
+        seed_first_route_page(&server).await;
+        server
+            .state
+            .list_route_pages
+            .lock()
+            .await
+            .push(proto::ListRoutesResponse {
+                routes: vec![proto::Route {
+                    prefix: "203.0.113.0".into(),
+                    prefix_length: 24,
+                    peer_address: "192.0.2.1".into(),
+                    path_id: 8,
+                    ..Default::default()
+                }],
+                next_page_token: String::new(),
+                total_count: 2,
+                page_version: None,
+            });
+        let mut args = vec!["--json", "rib", "received", "192.0.2.1"];
+        if limited {
+            args.extend(["--limit", "1"]);
+        }
+        let output = finish(start(&server.addr, &args)).await;
+        assert!(output.status.success(), "{output:?}");
+        let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        if limited {
+            let keys: Vec<_> = value
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect();
+            assert_eq!(
+                keys,
+                ["complete", "returned_count", "routes", "total_count"]
+            );
+            assert_eq!(value["returned_count"], 1);
+            assert_eq!(value["total_count"], 2);
+            assert_eq!(value["complete"], false);
+            assert_eq!(value["routes"][0]["path_id"], 7);
+        } else {
+            let routes = value
+                .as_array()
+                .expect("ordinary JSON must remain an array");
+            assert_eq!(routes.len(), 2);
+            assert_eq!(routes[0]["path_id"], 7);
+            assert_eq!(routes[1]["path_id"], 8);
+        }
+        assert_eq!(
+            server.state.list_route_requests.lock().await.len(),
+            if limited { 1 } else { 2 }
+        );
+    }
+}
+
+#[tokio::test]
+async fn json_lines_rejects_unsupported_offline_and_route_commands_before_connect() {
+    for args in [
+        vec!["--json-lines", "completions", "bash"],
+        vec!["--json-lines", "man"],
+        vec!["--json-lines", "doctor"],
+        vec!["--json-lines", "global"],
+        vec!["--json-lines", "rib", "--count"],
+        vec!["--json-lines", "rib", "--age"],
+        vec!["--json-lines", "rib", "received", "192.0.2.1", "--rejected"],
+        vec!["--json-lines", "rib", "advertised", "192.0.2.1", "--age"],
+        vec!["--json-lines", "rib", "--family", "ipv4_flowspec"],
+        vec!["--json-lines", "--pager", "always", "rib"],
+    ] {
+        let output = finish(start("unix:///nonexistent/rbgp-json-lines.sock", &args)).await;
+        assert_eq!(output.status.code(), Some(1), "{args:?}: {output:?}");
+        assert!(output.stdout.is_empty());
+        let error = String::from_utf8_lossy(&output.stderr);
+        assert!(!error.contains("cannot reach"), "{args:?}: {error}");
+        assert!(!error.is_empty());
+    }
 }
 
 #[tokio::test]

--- a/crates/cli/tests/read_deadlines.rs
+++ b/crates/cli/tests/read_deadlines.rs
@@ -413,6 +413,12 @@ async fn json_lines_rejects_unsupported_offline_and_route_commands_before_connec
         let error = String::from_utf8_lossy(&output.stderr);
         assert!(!error.contains("cannot reach"), "{args:?}: {error}");
         assert!(!error.is_empty());
+        if args.contains(&"--pager") {
+            assert!(
+                error.contains("--pager always cannot be combined with --json or --json-lines"),
+                "{error}"
+            );
+        }
     }
 }
 

--- a/crates/cli/tests/stdout_closed.rs
+++ b/crates/cli/tests/stdout_closed.rs
@@ -4,10 +4,36 @@ use std::os::fd::OwnedFd;
 use std::os::unix::net::UnixStream;
 use std::process::{Command, Stdio};
 
+use rustbgpd_api::proto;
 use rustbgpd_api::proto::global_service_server::{GlobalService, GlobalServiceServer};
 use rustbgpd_api::proto::{GetGlobalRequest, GlobalState};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
+
+#[path = "../src/test_support.rs"]
+#[allow(
+    dead_code,
+    reason = "shared CLI mock includes services unused by this contract"
+)]
+mod test_support;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn json_lines_closed_stdout_is_quiet_and_fetches_no_routes() {
+    let server = test_support::spawn_mock_server(None).await;
+    let (reader, writer) = UnixStream::pair().unwrap();
+    drop(reader);
+    let writer: OwnedFd = writer.into();
+    let output = Command::new(env!("CARGO_BIN_EXE_rbgp"))
+        .args(["--addr", &server.addr, "--json-lines", "rib"])
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .env_remove("RUSTBGPD_TOKEN_FILE")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stderr.is_empty(), "{output:?}");
+    assert!(server.state.list_route_requests.lock().await.is_empty());
+}
 
 struct MockGlobalService;
 

--- a/docs/reference/v1-stable-contract.md
+++ b/docs/reference/v1-stable-contract.md
@@ -72,7 +72,15 @@ The stable CLI set is also explicit. For an inventoried command, the v1 promise
 covers only its command path and command name. Flags, positional arguments,
 defaults, exit behavior, and human-readable output remain outside v1 unless a
 separate inventory entry explicitly pins them. The versioned machine formats
-currently include `rbgp-ribdiff/1` and `rbgp-ribsnap/1`. The ribdiff report may
+currently include `rbgp-rib/1.0` (explicit `--json-lines` accepted-unicast
+listings), `rbgp-ribdiff/1`, and `rbgp-ribsnap/1`. The RIB JSON-lines header
+declares `format: "rbgp-rib"` and `format_version: "1.0"`; additive optional
+fields increment the minor version, while incompatible types, meaning, or
+removal require a major version. Its header, route, and terminal count records
+have executable key/type floors. Ordinary `--json` arrays and bounded
+envelopes retain their existing contracts. See the [CLI guide](../../crates/cli/README.md)
+for successful limited walks versus streams missing their terminal record.
+The ribdiff report may
 gain additive fields, but removing or reinterpreting existing fields is not
 compatible. The ribsnap parser is intentionally closed and rejects unknown
 fields; changing its record schema requires a new format version rather than an

--- a/docs/reference/v1-stable-surface.json
+++ b/docs/reference/v1-stable-surface.json
@@ -163,6 +163,24 @@
     "scoped_rr_only_command_paths": ["orr", "rib bgpls", "rib labeled", "rib rtc", "rib vpn", "topology links", "topology nodes"],
     "versioned_json_contracts": [
       {
+        "id": "rbgp-rib/1.0",
+        "command_paths": ["rib", "rib advertised", "rib received"],
+        "source": "crates/cli/src/commands/rib.rs",
+        "test": "json_lines_inventory_contract_pins_record_and_route_types",
+        "test_linkage": "assert_json_lines_inventory_shape",
+        "evolution": "additive_fields_only",
+        "executable_type_floor": true,
+        "record_json_contracts": {
+          "end": {"required_json_types": {"complete": "boolean", "returned_count": "number", "total_count": "number", "type": "string"}, "optional_json_types": {}},
+          "header": {"required_json_types": {"format": "string", "format_version": "string", "type": "string", "view": "string"}, "optional_json_types": {}},
+          "route": {"required_json_types": {"route": "object", "type": "string"}, "optional_json_types": {}}
+        },
+        "nested_json_contracts": [
+          {"path": "route", "required_json_types": {"as_path": "array", "best": "boolean", "communities": "array", "extended_communities": "array", "large_communities": "array", "local_pref": "number", "med": ["null", "number"], "next_hop": "string", "origin": "string", "peer_address": "string", "prefix": "string", "received_at_epoch_seconds": "number"}, "optional_json_types": {"aggregator": "object", "aspa_state": "string", "atomic_aggregate": "boolean", "llgr_stale": "boolean", "local_pref_attr": "number", "path_id": "number", "stale": "boolean", "validation_state": "string"}},
+          {"path": "route.aggregator", "required_json_types": {"asn": "number", "router_id": "string"}, "optional_json_types": {}}
+        ]
+      },
+      {
         "id": "rbgp-ribdiff/1",
         "command_paths": ["diff advertised"],
         "source": "crates/cli/src/ribdiff.rs",

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -21,6 +21,7 @@ _rbgp() {
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -43,6 +44,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -56,6 +58,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -77,6 +80,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -92,6 +96,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -112,6 +117,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -126,6 +132,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -140,6 +147,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -154,6 +162,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -167,6 +176,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -185,6 +195,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -199,6 +210,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -214,6 +226,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -294,6 +307,7 @@ _arguments "${_arguments_options[@]}" : \
 '()--wide[Append summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (\`!\` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -339,6 +353,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-add-path[Explicitly disable the complete inherited Add-Path block]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -352,6 +367,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -365,6 +381,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -379,6 +396,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -393,6 +411,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -408,6 +427,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -421,6 +441,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -488,6 +509,7 @@ _arguments "${_arguments_options[@]}" : \
 '()--wide[Append summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (\`!\` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -533,6 +555,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-add-path[Explicitly disable the complete inherited Add-Path block]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -546,6 +569,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -559,6 +583,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -573,6 +598,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -587,6 +613,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -602,6 +629,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -615,6 +643,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -680,6 +709,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -701,6 +731,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -743,6 +774,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -764,6 +796,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -777,6 +810,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -842,6 +876,7 @@ _arguments "${_arguments_options[@]}" : \
 '(--explain)--age[Append the original route receive age to best, received, or advertised rows]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -863,6 +898,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -894,6 +930,7 @@ _arguments "${_arguments_options[@]}" : \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -925,6 +962,7 @@ _arguments "${_arguments_options[@]}" : \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -960,6 +998,7 @@ _arguments "${_arguments_options[@]}" : \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -995,6 +1034,7 @@ _arguments "${_arguments_options[@]}" : \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1009,6 +1049,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1030,6 +1071,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1048,6 +1090,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1066,6 +1109,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1083,6 +1127,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1100,6 +1145,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1115,6 +1161,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1137,6 +1184,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1152,6 +1200,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1234,6 +1283,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1255,6 +1305,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1268,6 +1319,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1313,6 +1365,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1326,6 +1379,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1357,6 +1411,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1370,6 +1425,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1396,6 +1452,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1413,6 +1470,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1513,6 +1571,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1538,6 +1597,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1554,6 +1614,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1603,6 +1664,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1628,6 +1690,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1646,6 +1709,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1660,6 +1724,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1687,6 +1752,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1705,6 +1771,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1723,6 +1790,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1741,6 +1809,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1758,6 +1827,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1776,6 +1846,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1846,6 +1917,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-vxlan-encap[Disable the RFC 8365 VXLAN encapsulation ext community]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1865,6 +1937,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-vxlan-encap[]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1887,6 +1960,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-vxlan-encap[]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1904,6 +1978,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1920,6 +1995,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1936,6 +2012,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1951,6 +2028,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1964,6 +2042,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1977,6 +2056,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -1998,6 +2078,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2012,6 +2093,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2026,6 +2108,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2076,6 +2159,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2089,6 +2173,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2102,6 +2187,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2115,6 +2201,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2128,6 +2215,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2142,6 +2230,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2313,6 +2402,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2333,6 +2423,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2362,6 +2453,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2379,6 +2471,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2396,6 +2489,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2415,6 +2509,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2468,6 +2563,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2483,6 +2579,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2496,6 +2593,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2510,6 +2608,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2523,6 +2622,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2539,6 +2639,7 @@ _arguments "${_arguments_options[@]}" : \
 '--clear[Clear instead of enabling]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2554,6 +2655,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2567,6 +2669,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2588,6 +2691,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2606,6 +2710,7 @@ _arguments "${_arguments_options[@]}" : \
 '--coverage[Report which policy terms the in-language tests exercised (evaluated vs. matched, per term) plus static lints (unused sets/datasets/fns, unreachable terms, unreferenced policies). A report only — it never changes the exit code by itself]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2621,6 +2726,7 @@ _arguments "${_arguments_options[@]}" : \
 '--check[Rewrite nothing; print a diff and exit 1 when any file is not canonically formatted (CI mode)]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2643,6 +2749,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2657,6 +2764,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2672,6 +2780,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2686,6 +2795,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2700,6 +2810,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2723,6 +2834,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2738,6 +2850,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2754,6 +2867,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2770,6 +2884,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2785,6 +2900,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2845,6 +2961,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2861,6 +2978,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2879,6 +2997,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -2988,6 +3107,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3009,6 +3129,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3022,6 +3143,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3037,6 +3159,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3051,6 +3174,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3105,6 +3229,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3126,6 +3251,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3139,6 +3265,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3154,6 +3281,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3168,6 +3296,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3183,6 +3312,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3197,6 +3327,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3259,6 +3390,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3280,6 +3412,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3297,6 +3430,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3311,6 +3445,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3361,6 +3496,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3382,6 +3518,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3404,6 +3541,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3418,6 +3556,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3468,6 +3607,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -3482,6 +3622,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
+'(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -19,8 +19,8 @@ _rbgp() {
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -42,8 +42,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -56,8 +56,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -78,8 +78,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -94,8 +94,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -115,8 +115,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -130,8 +130,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -145,8 +145,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -160,8 +160,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -174,8 +174,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -193,8 +193,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -208,8 +208,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -224,8 +224,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -305,8 +305,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '()--wide[Append summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (\`!\` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -351,8 +351,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--no-add-path)--add-path-receive[Enable Add-Path receive]' \
 '(--no-add-path)--add-path-send[Enable Add-Path send]' \
 '--no-add-path[Explicitly disable the complete inherited Add-Path block]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -365,8 +365,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -379,8 +379,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -394,8 +394,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -409,8 +409,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -425,8 +425,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -439,8 +439,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -507,8 +507,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '()--wide[Append summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (\`!\` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -553,8 +553,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--no-add-path)--add-path-receive[Enable Add-Path receive]' \
 '(--no-add-path)--add-path-send[Enable Add-Path send]' \
 '--no-add-path[Explicitly disable the complete inherited Add-Path block]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -567,8 +567,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -581,8 +581,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -596,8 +596,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -611,8 +611,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -627,8 +627,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -641,8 +641,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -707,8 +707,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -729,8 +729,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -772,8 +772,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -794,8 +794,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -808,8 +808,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -874,8 +874,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--count)--explain[Show why the best route was selected (requires --prefix)]' \
 '(--age)--count[Print only the number of matching best, received, or advertised routes]' \
 '(--explain)--age[Append the original route receive age to best, received, or advertised rows]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -896,8 +896,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -928,8 +928,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-l[Show longer (more specific) prefixes matching --prefix]' \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -960,8 +960,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-l[Show longer (more specific) prefixes matching --prefix]' \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -996,8 +996,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-l[Show longer (more specific) prefixes matching --prefix]' \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1032,8 +1032,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-l[Show longer (more specific) prefixes matching --prefix]' \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1047,8 +1047,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1069,8 +1069,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1088,8 +1088,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1107,8 +1107,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1125,8 +1125,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1143,8 +1143,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1159,8 +1159,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1182,8 +1182,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1198,8 +1198,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1281,8 +1281,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1303,8 +1303,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1317,8 +1317,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1363,8 +1363,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1377,8 +1377,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1409,8 +1409,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1423,8 +1423,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1450,8 +1450,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1468,8 +1468,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1569,8 +1569,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1595,8 +1595,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1612,8 +1612,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1662,8 +1662,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1688,8 +1688,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1707,8 +1707,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1722,8 +1722,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1750,8 +1750,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1769,8 +1769,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1788,8 +1788,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1807,8 +1807,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1825,8 +1825,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1844,8 +1844,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1915,8 +1915,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--no-vxlan-encap[Disable the RFC 8365 VXLAN encapsulation ext community]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1935,8 +1935,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--no-vxlan-encap[]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1958,8 +1958,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--no-vxlan-encap[]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1976,8 +1976,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -1993,8 +1993,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2010,8 +2010,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2026,8 +2026,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2040,8 +2040,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2054,8 +2054,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2076,8 +2076,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2091,8 +2091,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2106,8 +2106,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2157,8 +2157,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2171,8 +2171,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2185,8 +2185,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2199,8 +2199,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2213,8 +2213,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2228,8 +2228,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2400,8 +2400,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2421,8 +2421,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2451,8 +2451,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2469,8 +2469,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2487,8 +2487,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2507,8 +2507,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2561,8 +2561,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2577,8 +2577,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2591,8 +2591,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2606,8 +2606,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2620,8 +2620,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2637,8 +2637,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--clear[Clear instead of enabling]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2653,8 +2653,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2667,8 +2667,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2689,8 +2689,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2708,8 +2708,8 @@ _arguments "${_arguments_options[@]}" : \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--list-deps[Print the resolved import graph — each module'\''s path, SHA-256 content hash, and imports — instead of running tests (audit/packaging aid)]' \
 '--coverage[Report which policy terms the in-language tests exercised (evaluated vs. matched, per term) plus static lints (unused sets/datasets/fns, unreachable terms, unreferenced policies). A report only — it never changes the exit code by itself]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2724,8 +2724,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
 '--check[Rewrite nothing; print a diff and exit 1 when any file is not canonically formatted (CI mode)]' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2747,8 +2747,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2762,8 +2762,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2778,8 +2778,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2793,8 +2793,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2808,8 +2808,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2832,8 +2832,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2848,8 +2848,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2865,8 +2865,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2882,8 +2882,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2898,8 +2898,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2959,8 +2959,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2976,8 +2976,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -2995,8 +2995,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3105,8 +3105,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3127,8 +3127,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3141,8 +3141,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3157,8 +3157,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3172,8 +3172,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3227,8 +3227,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3249,8 +3249,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3263,8 +3263,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3279,8 +3279,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3294,8 +3294,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3310,8 +3310,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3325,8 +3325,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3388,8 +3388,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3410,8 +3410,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3428,8 +3428,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3443,8 +3443,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3494,8 +3494,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3516,8 +3516,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3539,8 +3539,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3554,8 +3554,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3605,8 +3605,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -3620,8 +3620,8 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--pager=[Page complete human unicast RIB listings]:PAGER:(auto always never)' \
-'-j[Output in JSON format]' \
-'--json[Output in JSON format]' \
+'(--json-lines)-j[Output in JSON format]' \
+'(--json-lines)--json[Output in JSON format]' \
 '(-j --json)--json-lines[Stream accepted unicast RIB routes as versioned JSON lines]' \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -1277,7 +1277,7 @@ _rbgp() {
 
     case "${cmd}" in
         rbgp)
-            opts="-s -j -h -V --addr --token-file --json --no-color --pager --help --version global config neighbor summary bfd rpki rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help"
+            opts="-s -j -h -V --addr --token-file --json --json-lines --no-color --pager --help --version global config neighbor summary bfd rpki rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1307,7 +1307,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__bfd)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help show help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help show help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1379,7 +1379,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__bfd__subcmd__show)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1409,7 +1409,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__completions)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help bash elvish fish powershell zsh"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help bash elvish fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1439,7 +1439,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help diff plan apply confirm abort status history rollback effective import help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help diff plan apply confirm abort status history rollback effective import help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1469,7 +1469,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__abort)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1499,7 +1499,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__apply)
-            opts="-s -j -h --expected-runtime-snapshot-token --plan-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --plan-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1561,7 +1561,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__confirm)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1591,7 +1591,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__diff)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1629,7 +1629,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__effective)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1827,7 +1827,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__history)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1857,7 +1857,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__import)
-            opts="-s -j -h --format --out --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --format --out --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1903,7 +1903,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__plan)
-            opts="-s -j -h --expected-runtime-snapshot-token --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1945,7 +1945,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__rollback)
-            opts="-s -j -h --expected-runtime-snapshot-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1995,7 +1995,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__status)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2025,7 +2025,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help advertised snapshot help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help advertised snapshot help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2055,7 +2055,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__advertised)
-            opts="-a -s -j -h --peer --neighbor --against --family --max-routes --max-input-bytes --ignore-attribute --detail --deadline --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --peer --neighbor --against --family --max-routes --max-input-bytes --ignore-attribute --detail --deadline --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2209,7 +2209,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__snapshot)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help from-mrt from-bmp help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help from-mrt from-bmp help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2239,7 +2239,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__bmp)
-            opts="-s -j -h --peer --source --generation --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --source --generation --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2289,7 +2289,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__mrt)
-            opts="-s -j -h --view --peer --peer-asn --source --generation --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --view --peer --peer-asn --source --generation --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2403,7 +2403,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__doctor)
-            opts="-s -j -h --output --log-file --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --output --log-file --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2441,7 +2441,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help list add delete help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help list add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2471,7 +2471,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --peer-group --asn --remote-asn --description --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer-group --asn --remote-asn --description --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2517,7 +2517,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2617,7 +2617,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2647,7 +2647,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events)
-            opts="-a -l -s -j -h --address --family --prefix --limit --addr --token-file --json --no-color --pager --help watch sessions policy evpn help"
+            opts="-a -l -s -j -h --address --family --prefix --limit --addr --token-file --json --json-lines --no-color --pager --help watch sessions policy evpn help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2701,7 +2701,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__evpn)
-            opts="-l -s -j -h --address --route-type --rd --type --limit --addr --token-file --json --no-color --pager --help"
+            opts="-l -s -j -h --address --route-type --rd --type --limit --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2839,7 +2839,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__policy)
-            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --pager --help"
+            opts="-l -s -j -h --address --type --limit --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2885,7 +2885,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__sessions)
-            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --pager --help"
+            opts="-l -s -j -h --address --type --limit --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2931,7 +2931,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__events__subcmd__watch)
-            opts="-a -s -j -h --category --address --family --prefix --type --backfill --from-event-id --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --category --address --family --prefix --type --backfill --from-event-id --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2993,7 +2993,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn)
-            opts="-s -j -h --route-type --peer --neighbor --rd --addr --token-file --json --no-color --pager --help received advertised explain add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help"
+            opts="-s -j -h --route-type --peer --neighbor --rd --addr --token-file --json --json-lines --no-color --pager --help received advertised explain add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3039,7 +3039,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__add__subcmd__imet)
-            opts="-s -j -h --rd --ethernet-tag --ip --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --ethernet-tag --ip --next-hop --rt --no-vxlan-encap --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3089,7 +3089,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__add__subcmd__ip__subcmd__prefix)
-            opts="-s -j -h --rd --ethernet-tag --prefix --label --next-hop --gateway --router-mac --rt --no-vxlan-encap --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --ethernet-tag --prefix --label --next-hop --gateway --router-mac --rt --no-vxlan-encap --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3151,7 +3151,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__add__subcmd__mac__subcmd__ip)
-            opts="-s -j -h --rd --ethernet-tag --mac --ip --label --label2 --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --ethernet-tag --mac --ip --label --label2 --next-hop --rt --no-vxlan-encap --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3213,7 +3213,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__advertised)
-            opts="-s -j -h --route-type --rd --page-size --page-token --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --route-type --rd --page-size --page-token --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3259,7 +3259,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__clear__subcmd__duplicate__subcmd__mac)
-            opts="-s -j -h --vni --mac --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --vni --mac --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3297,7 +3297,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__delete__subcmd__imet)
-            opts="-s -j -h --rd --ethernet-tag --ip --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --ethernet-tag --ip --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3339,7 +3339,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__delete__subcmd__ip__subcmd__prefix)
-            opts="-s -j -h --rd --ethernet-tag --prefix --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --ethernet-tag --prefix --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3381,7 +3381,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__delete__subcmd__mac__subcmd__ip)
-            opts="-s -j -h --rd --ethernet-tag --mac --ip --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --ethernet-tag --mac --ip --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3427,7 +3427,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__diagnose)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3457,7 +3457,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__duplicate__subcmd__mac__subcmd__quarantines)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3487,7 +3487,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help list drain undrain help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help list drain undrain help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3517,7 +3517,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__drain)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3617,7 +3617,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3647,7 +3647,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__undrain)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3677,7 +3677,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__explain)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help mac-ip imet es ip-prefix ead-per-es ead-per-evi help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help mac-ip imet es ip-prefix ead-per-es ead-per-evi help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3707,7 +3707,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__explain__subcmd__ead__subcmd__per__subcmd__es)
-            opts="-s -j -h --rd --received-from --advertised-to --esi --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --received-from --advertised-to --esi --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3753,7 +3753,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__explain__subcmd__ead__subcmd__per__subcmd__evi)
-            opts="-s -j -h --rd --received-from --advertised-to --esi --ethernet-tag --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --received-from --advertised-to --esi --ethernet-tag --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3803,7 +3803,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__explain__subcmd__es)
-            opts="-s -j -h --rd --received-from --advertised-to --esi --originator-ip --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --received-from --advertised-to --esi --originator-ip --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3965,7 +3965,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__explain__subcmd__imet)
-            opts="-s -j -h --rd --received-from --advertised-to --ethernet-tag --originator-ip --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --received-from --advertised-to --ethernet-tag --originator-ip --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4015,7 +4015,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__explain__subcmd__ip__subcmd__prefix)
-            opts="-s -j -h --rd --received-from --advertised-to --ethernet-tag --prefix --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --received-from --advertised-to --ethernet-tag --prefix --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4065,7 +4065,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__explain__subcmd__mac__subcmd__ip)
-            opts="-s -j -h --rd --received-from --advertised-to --ethernet-tag --mac --ip --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --rd --received-from --advertised-to --ethernet-tag --mac --ip --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4525,7 +4525,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__instances)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4555,7 +4555,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__managed__subcmd__netdevs)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4585,7 +4585,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__nexthops)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4615,7 +4615,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__received)
-            opts="-s -j -h --route-type --rd --page-size --page-token --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --route-type --rd --page-size --page-token --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4661,7 +4661,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__runtime)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4691,7 +4691,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__vrfs)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4721,7 +4721,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help list set delete help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help list set delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4751,7 +4751,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4851,7 +4851,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4881,7 +4881,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__set)
-            opts="-s -j -h --table-id --metric --families --allowed-peer-group --allowed-neighbor --max-routes --maximum-paths --maximum-paths-ebgp --maximum-paths-ibgp --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --table-id --metric --families --allowed-peer-group --allowed-neighbor --max-routes --maximum-paths --maximum-paths-ebgp --maximum-paths-ibgp --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4947,7 +4947,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__flowspec)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --pager --help add delete help"
+            opts="-a -s -j -h --family --addr --token-file --json --json-lines --no-color --pager --help add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4985,7 +4985,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__flowspec__subcmd__add)
-            opts="-a -s -j -h --family --match --action --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --family --match --action --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5031,7 +5031,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__flowspec__subcmd__delete)
-            opts="-a -s -j -h --family --match --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --family --match --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5129,7 +5129,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__global)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5159,7 +5159,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__gshut)
-            opts="-s -j -h --peer --neighbor --clear --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --clear --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5197,7 +5197,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__health)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7047,7 +7047,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__man)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7077,7 +7077,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__metrics)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7107,7 +7107,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__mrt__subcmd__dump)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7137,7 +7137,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor)
-            opts="-s -j -h --wide --compare --addr --token-file --json --no-color --pager --help add delete enable disable reset softreset refresh-out help"
+            opts="-s -j -h --wide --compare --addr --token-file --json --json-lines --no-color --pager --help add delete enable disable reset softreset refresh-out help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7171,7 +7171,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help list get set delete help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help list get set delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7201,7 +7201,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7231,7 +7231,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7345,7 +7345,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7375,7 +7375,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --from-file --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7409,7 +7409,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --peer-group --max-prefix-restart-seconds --families --required-families --route-server-client --no-route-server-client --per-client-best --no-per-client-best --role --strict-role --no-strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --no-add-path --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --peer-group --max-prefix-restart-seconds --families --required-families --route-server-client --no-route-server-client --per-client-best --no-per-client-best --role --strict-role --no-strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --no-add-path --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7495,7 +7495,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7525,7 +7525,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__disable)
-            opts="-s -j -h --reason --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --reason --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7559,7 +7559,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__enable)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7715,7 +7715,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__refresh__subcmd__out)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7745,7 +7745,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__reset)
-            opts="-s -j -h --reason --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --reason --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7779,7 +7779,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__softreset)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --family --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7817,7 +7817,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__orr)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7847,7 +7847,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help list get set delete attach detach help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help list get set delete attach detach help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7877,7 +7877,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__attach)
-            opts="-s -j -h --group --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --group --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7911,7 +7911,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7941,7 +7941,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__detach)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7971,7 +7971,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8113,7 +8113,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8143,7 +8143,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --from-file --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8177,7 +8177,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help list check fmt test get set delete chain stats counters explain help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help list check fmt test get set delete chain stats counters explain help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8207,7 +8207,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help show set-import set-export clear-import clear-export help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help show set-import set-export clear-import clear-export help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8237,7 +8237,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8275,7 +8275,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__import)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8411,7 +8411,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__export)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8449,7 +8449,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__import)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8487,7 +8487,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__show)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8525,7 +8525,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__check)
-            opts="-s -j -h --root --max-graph-bytes --list-deps --coverage --coverage-min --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --root --max-graph-bytes --list-deps --coverage --coverage-min --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8575,7 +8575,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8605,7 +8605,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__explain)
-            opts="-s -j -h --peer --neighbor --prefix --path-id --direction --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --prefix --path-id --direction --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8655,7 +8655,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__fmt)
-            opts="-s -j -h --check --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --check --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8693,7 +8693,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8961,7 +8961,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8991,7 +8991,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --from-file --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9025,7 +9025,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__stats)
-            opts="-s -j -h --peer --neighbor --direction --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --direction --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9067,7 +9067,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__test)
-            opts="-a -s -j -h --policy --direction --peer --neighbor --family --limit --show-changes --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --policy --direction --peer --neighbor --family --limit --show-changes --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9137,7 +9137,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib)
-            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --age --explain-peer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --limit --addr --token-file --json --no-color --pager --help lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
+            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --age --explain-peer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --limit --addr --token-file --json --json-lines --no-color --pager --help lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9219,7 +9219,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__add)
-            opts="-s -j -h --nexthop --next-hop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --nexthop --next-hop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9285,7 +9285,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -p -l -c -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --no-color --pager --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9375,7 +9375,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__bgpls)
-            opts="-a -s -j -h --family --peer --neighbor --nlri-type --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --family --peer --neighbor --nlri-type --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9425,7 +9425,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__blackholes)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9455,7 +9455,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__delete)
-            opts="-s -j -h --path-id --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --path-id --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9489,7 +9489,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__fib)
-            opts="-s -j -h --table --state --reason --prefix --peer --neighbor --page-size --page-token --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --table --state --reason --prefix --peer --neighbor --page-size --page-token --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9733,7 +9733,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__labeled)
-            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9779,7 +9779,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__lookup)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9809,7 +9809,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__received)
-            opts="-a -p -l -c -s -j -h --family --count --age --rejected --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --no-color --pager --help"
+            opts="-a -p -l -c -s -j -h --family --count --age --rejected --limit --prefix --longer --origin-asn --community --large-community --rpki-state --aspa-state --as-path-contains --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9887,7 +9887,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__rtc)
-            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9925,7 +9925,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__vpn)
-            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -9971,7 +9971,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rpki)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help caches validate help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help caches validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10001,7 +10001,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rpki__subcmd__caches)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10087,7 +10087,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rpki__subcmd__validate)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10117,7 +10117,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__shutdown)
-            opts="-s -j -h --reason --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --reason --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10151,7 +10151,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__top)
-            opts="-i -s -j -h --interval --addr --token-file --json --no-color --pager --help"
+            opts="-i -s -j -h --interval --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10189,7 +10189,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__topology)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help nodes links help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help nodes links help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10275,7 +10275,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__topology__subcmd__links)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10305,7 +10305,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__topology__subcmd__nodes)
-            opts="-s -j -h --addr --token-file --json --no-color --pager --help"
+            opts="-s -j -h --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -10335,7 +10335,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__watch)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --pager --help"
+            opts="-a -s -j -h --family --addr --token-file --json --json-lines --no-color --pager --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_rbgp_global_optspecs
-    string join \n s/addr= token-file= j/json no-color pager= h/help V/version
+    string join \n s/addr= token-file= j/json json-lines no-color pager= h/help V/version
 end
 
 function __fish_rbgp_needs_command
@@ -30,6 +30,7 @@ complete -c rbgp -n "__fish_rbgp_needs_command" -l pager -d 'Page complete human
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_needs_command" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_needs_command" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_needs_command" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_needs_command" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_needs_command" -s V -l version -d 'Print version'
@@ -68,6 +69,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l pager -d 'Page comp
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -76,6 +78,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
@@ -95,6 +98,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l expected-runtime-snapshot-token -d 'Optional runtime snapshot token to check while planning' -r
@@ -104,6 +108,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l expected-runtime-snapshot-token -d 'Runtime snapshot token returned by config plan' -r
@@ -118,6 +123,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -126,6 +132,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -134,6 +141,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -142,6 +150,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -150,6 +159,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from history" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -l expected-runtime-snapshot-token -d 'Optional runtime snapshot token to guard against concurrent changes' -r
@@ -163,6 +173,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from rollback" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -171,6 +182,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -l format -d 'Source format (default: auto-detect from content)' -r -f -a "bird\t''
@@ -183,6 +195,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from import" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
@@ -204,6 +217,7 @@ always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -l wide -d 'Append summary columns to the list: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (`!` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -a "add" -d 'Add a new neighbor'
@@ -242,6 +256,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-send -d 'Enable Add-Path send'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-add-path -d 'Explicitly disable the complete inherited Add-Path block'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -250,6 +265,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -258,6 +274,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l reason -d 'Disable reason' -r
@@ -267,6 +284,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from reset" -l reason -d 'Shutdown communication sent with the reset (RFC 9003)' -r
@@ -276,6 +294,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from reset" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from reset" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from reset" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from reset" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s a -l family -d 'Address family to refresh' -r
@@ -285,6 +304,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -293,6 +313,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from refresh-out" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a new neighbor'
@@ -311,6 +332,7 @@ always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -l wide -d 'Append summary columns to the list: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), Slow (`!` marks a slow peer), and State/PfxRcd (prefix count when Established). Display-only; JSON is unaffected by --wide and may omit optional false healthy-state fields'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable reset softreset refresh-out help" -a "add" -d 'Add a new neighbor'
@@ -349,6 +371,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l add-path-send -d 'Enable Add-Path send'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-add-path -d 'Explicitly disable the complete inherited Add-Path block'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -357,6 +380,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -365,6 +389,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l reason -d 'Disable reason' -r
@@ -374,6 +399,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from reset" -l reason -d 'Shutdown communication sent with the reset (RFC 9003)' -r
@@ -383,6 +409,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from reset" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from reset" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from reset" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from reset" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s a -l family -d 'Address family to refresh' -r
@@ -392,6 +419,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -400,6 +428,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from refresh-out" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a new neighbor'
@@ -416,6 +445,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subco
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from show help" -f -a "show" -d 'Show a single BFD session by peer address'
@@ -426,6 +456,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "show" -d 'Show a single BFD session by peer address'
@@ -436,6 +467,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and not __fish_seen_subcommand_from caches validate help" -f -a "caches" -d 'List configured RTR caches and accepted validation epochs'
@@ -447,6 +479,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from caches" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -455,6 +488,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from validate" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rpki; and __fish_seen_subcommand_from help" -f -a "caches" -d 'List configured RTR caches and accepted validation epochs'
@@ -484,6 +518,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l count -d 'Print only the number of matching best, received, or advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l age -d 'Append the original route receive age to best, received, or advertised rows'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from lookup received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "lookup" -d 'Find the longest-prefix match in the global best-route table'
@@ -507,6 +542,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from lookup" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s a -l family -d 'Address family filter' -r
@@ -532,6 +568,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s a -l family -d 'Address family filter' -r
@@ -557,6 +594,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s a -l family -d 'Address family filter' -r
@@ -586,6 +624,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s a -l family -d 'Address family filter' -r
@@ -615,6 +654,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -623,6 +663,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l table -d 'FIB table-name filter' -r
@@ -638,6 +679,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s a -l family -d 'BGP-LS family filter: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)' -r
@@ -649,6 +691,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s a -l family -d 'BGP-LS family filter: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)' -r
@@ -660,6 +703,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s a -l family -d 'VPN family filter: l3vpn_ipv4_unicast (alias vpnv4) or l3vpn_ipv6_unicast (alias vpnv6)' -r
@@ -670,6 +714,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s a -l family -d 'Labeled family filter: ipv4_labeled_unicast (alias labeled-v4) or ipv6_labeled_unicast (alias labeled-v6)' -r
@@ -680,6 +725,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l neighbor -l peer -d 'Neighbor IP address filter' -r
@@ -689,6 +735,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l next-hop -l nexthop -d 'Next hop address' -r
@@ -705,6 +752,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l path-id -d 'Path ID for Add-Path' -r
@@ -714,6 +762,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "lookup" -d 'Find the longest-prefix match in the global best-route table'
@@ -734,6 +783,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -f -a "nodes" -d 'List topology nodes (BGP-LS node identities across all peers)'
@@ -745,6 +795,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -753,6 +804,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from help" -f -a "nodes" -d 'List topology nodes (BGP-LS node identities across all peers)'
@@ -764,6 +816,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l pager -d 'Page complet
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -772,6 +825,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -f -a "advertised" -d 'Compare the live Adj-RIB-Out against an incumbent NDJSON snapshot'
@@ -791,6 +845,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -799,6 +854,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -f -a "from-mrt" -d 'Convert an RFC 6396 TABLE_DUMP_V2 MRT dump into a snapshot'
@@ -814,6 +870,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -f -a "add" -d 'Add a FlowSpec rule'
@@ -828,6 +885,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s a -l family -d 'Address family (required: ipv4_flowspec or ipv6_flowspec)' -r
@@ -838,6 +896,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a FlowSpec rule'
@@ -852,6 +911,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subc
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from received advertised explain add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from received advertised explain add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from received advertised explain add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from received advertised explain add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from received advertised explain add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac duplicate-mac-quarantines es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "received" -d 'Accepted post-policy EVPN routes from a peer; absence does not prove it sent none'
@@ -883,6 +943,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from received" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from received" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from advertised" -l route-type -d 'Only this route type (1..=5)' -r
@@ -895,6 +956,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from advertised" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from explain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -903,6 +965,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from explain" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from explain" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from explain" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from explain" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from explain" -f -a "mac-ip" -d 'Type 2: omitted IP selects the MAC-only key, not all host IPs'
@@ -927,6 +990,7 @@ always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l no-vxlan-encap -d 'Disable the RFC 8365 VXLAN encapsulation ext community'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l rd -r
@@ -941,6 +1005,7 @@ always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l no-vxlan-encap
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l rd -r
@@ -958,6 +1023,7 @@ always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l no-vxlan-encap
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l rd -r
@@ -970,6 +1036,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l rd -r
@@ -981,6 +1048,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l rd -r
@@ -992,6 +1060,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l vni -d 'L2VNI containing the quarantined MAC' -r
@@ -1002,6 +1071,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1010,6 +1080,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from duplicate-mac-quarantines" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1018,6 +1089,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "list" -d 'List configured Ethernet Segments'
@@ -1030,6 +1102,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1038,6 +1111,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1046,6 +1120,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1054,6 +1129,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from managed-netdevs" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1062,6 +1138,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1070,6 +1147,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "received" -d 'Accepted post-policy EVPN routes from a peer; absence does not prove it sent none'
@@ -1098,6 +1176,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l pager -d 'Page compl
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l address -d 'Neighbor address filter' -r
@@ -1110,6 +1189,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -f -a "watch" -d 'Watch the unified live event stream'
@@ -1130,6 +1210,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l address -d 'Neighbor address filter' -r
@@ -1141,6 +1222,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l address -d 'Neighbor address filter. Only peer-scoped policy events match' -r
@@ -1152,6 +1234,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l address -d 'Neighbor address filter. Matches current and previous best-path peer' -r
@@ -1165,6 +1248,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from help" -f -a "watch" -d 'Watch the unified live event stream'
@@ -1178,6 +1262,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l pager -d 'Page comp
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l output -d 'Output tarball path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz` in the first writable of: the working directory, the daemon\'s runtime state dir, the temp dir' -r -F
@@ -1188,6 +1273,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l pager -d 'Page comp
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1196,6 +1282,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l pager -d 'Page com
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l reason -d 'Shutdown reason' -r
@@ -1205,6 +1292,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l pager -d 'Page co
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1213,6 +1301,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l pager -d 'Page co
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l neighbor -l peer -d 'Neighbor address; omit to toggle for all peers' -r
@@ -1223,6 +1312,7 @@ always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l clear -d 'Clear instead of enabling'
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s i -l interval -d 'Poll interval in seconds (1-60)' -r
@@ -1232,6 +1322,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l pager -d 'Page complet
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1240,6 +1331,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "list" -d 'List configured policies (names + statement counts)'
@@ -1260,6 +1352,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l root -d 'Additional policy root for `import` resolution (repeatable; the main file\'s directory is always a root) — mirror of the daemon\'s `[policy] rpol_roots`' -r
@@ -1273,6 +1366,7 @@ never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l list-deps -d 'Print the resolved import graph — each module\'s path, SHA-256 content hash, and imports — instead of running tests (audit/packaging aid)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l coverage -d 'Report which policy terms the in-language tests exercised (evaluated vs. matched, per term) plus static lints (unused sets/datasets/fns, unreachable terms, unreferenced policies). A report only — it never changes the exit code by itself'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1282,6 +1376,7 @@ always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l check -d 'Rewrite nothing; print a diff and exit 1 when any file is not canonically formatted (CI mode)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l policy -d 'Policy to evaluate: a name, or a call-form with u32 arguments for parameterized policies, e.g. "customer-in(200)"' -r
@@ -1296,6 +1391,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1304,6 +1400,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l from-file -d 'JSON file containing the PolicyDefinition shape' -r
@@ -1313,6 +1410,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1321,6 +1419,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1329,6 +1428,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "show" -d 'Show the global or per-neighbor chains'
@@ -1347,6 +1447,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l neighbor -l peer -d 'Restrict to one neighbor\'s installed chain' -r
@@ -1359,6 +1460,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l neighbor -l peer -d 'Neighbor (peer) address whose decision to explain' -r
@@ -1372,6 +1474,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured policies (names + statement counts)'
@@ -1391,6 +1494,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_s
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -f -a "list" -d 'List configured neighbor sets'
@@ -1404,6 +1508,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1412,6 +1517,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l from-file -r
@@ -1421,6 +1527,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1429,6 +1536,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured neighbor sets'
@@ -1442,6 +1550,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_see
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "list" -d 'List configured peer groups'
@@ -1457,6 +1566,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1465,6 +1575,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l from-file -r
@@ -1474,6 +1585,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1482,6 +1594,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l group -d 'Peer-group name' -r
@@ -1491,6 +1604,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1499,6 +1613,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_su
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured peer groups'
@@ -1514,6 +1629,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fi
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -f -a "list" -d 'List configured dynamic neighbor ranges'
@@ -1526,6 +1642,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_s
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l peer-group -d 'Peer group the dynamic peers inherit' -r
@@ -1537,6 +1654,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_s
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1545,6 +1663,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_s
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured dynamic neighbor ranges'
@@ -1557,6 +1676,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -f -a "list" -d 'List the configured FIB tables and runtime availability'
@@ -1569,6 +1689,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_sub
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l table-id -d 'Linux route table id' -r
@@ -1586,6 +1707,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_sub
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1594,6 +1716,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_sub
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from help" -f -a "list" -d 'List the configured FIB tables and runtime availability'
@@ -1606,6 +1729,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l pager -d 'Page
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -1614,6 +1738,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l pager -d 'Page complet
 always\t''
 never\t''"
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l json-lines -d 'Stream accepted unicast RIB routes as versioned JSON lines'
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rpki rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "global" -d 'Show daemon global configuration'


### PR DESCRIPTION
Large unicast RIB listings can now use `--json-lines` to emit routes as pages arrive, with a versioned header and a terminal record containing counts and completeness. Best, received, and advertised views share the existing page walk and route projection; ordinary JSON arrays and limited envelopes keep their shapes and failure-atomic behavior.

Failed continuations leave the stream without an end record, and closed pipes stop fetching quietly. Unsupported combinations fail before connecting. Documentation, scoped JSON contract tests, and shell completions cover the new mode.

Validation: full `just gate` passed before integrating the help-grouping change; affected help, JSON-lines, parser, man, and completion checks passed after integration. Process regressions cover early route output, timeout and ABORTED without terminal success, legacy JSON shapes, and BrokenPipe termination.
