### PR TITLE
fix(evpn): enforce local type 2 import eligibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -709,6 +709,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `rbgp top` honors `--no-color` and the presence of `NO_COLOR` with a
   monochrome theme that preserves bold emphasis and selection markers.
 
+- Local EVPN Type 2 consumption now requires a matching instance VNI and
+  Route Target, Ethernet Tag 0, and a nonlocal next hop before forwarding,
+  mobility, duplicate accounting, or Type 5 gateway-IP recursion. Global RIB
+  retention and reflection are unchanged.
+
 ### Documentation
 
 - Publish a descriptive raw bridge event-skew receipt across six pinned Jammy
@@ -913,6 +918,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and marks timed-out sections incomplete, with a separate allowance for
   large effective-config exports. A failed health collection no longer
   leaves the system section marked collected.
+
+- **EVPN local VTEP upgrades:** Type 2 routes with missing or mismatched RTs,
+  or nonzero Ethernet Tags, no longer contribute local forwarding or mobility
+  state. Check remote advertisements and configured `route_targets` before
+  upgrading; see [local Type 2 import](docs/how-to/evpn-vtep-setup.md#local-type-2-import).
 
 ## [0.68.0] — 2026-08-30
 

--- a/crates/evpn/src/instance.rs
+++ b/crates/evpn/src/instance.rs
@@ -18,7 +18,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::net::IpAddr;
 
-use rustbgpd_wire::{MacAddress, RouteDistinguisher};
+use rustbgpd_wire::{EvpnMacIp, MacAddress, PathAttribute, RouteDistinguisher};
 
 use crate::duplicate_ip::DuplicateIpConfig;
 use crate::duplicate_mac::DuplicateMacConfig;
@@ -239,6 +239,28 @@ impl EvpnInstance {
             duplicate_mac_detection: DuplicateMacConfig::default(),
             duplicate_ip_detection: DuplicateIpConfig::default(),
         })
+    }
+
+    /// Whether a remote Type 2 is eligible for this local VLAN-based service.
+    ///
+    /// Call before discarding path attributes for forwarding, mobility, or
+    /// gateway-IP recursion. This does not filter global RIB retention or export.
+    #[must_use]
+    pub fn imports_mac_ip(
+        &self,
+        route: &EvpnMacIp,
+        next_hop: IpAddr,
+        attributes: &[PathAttribute],
+    ) -> bool {
+        route.label1.as_vni() == self.id.as_u32()
+            && route.ethernet_tag.0 == 0
+            && next_hop != self.local_vtep_ip
+            && attributes
+                .iter()
+                .filter_map(PathAttribute::extended_communities)
+                .flatten()
+                .filter_map(|ec| RouteTarget::from_extended_community(*ec))
+                .any(|rt| self.route_targets.contains(&rt))
     }
 
     /// Replace the sticky-MAC set on this instance. Used by the config
@@ -487,6 +509,57 @@ mod tests {
             false,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn imports_mac_ip_requires_local_vni_tag_next_hop_and_matching_rt() {
+        use rustbgpd_wire::{
+            EthernetSegmentIdentifier, EthernetTagId, ExtendedCommunity, MplsLabel,
+        };
+        let mut instance = make_instance(100, "65000:100", "10.0.0.1");
+        let mut route = EvpnMacIp {
+            rd: rd("65001:100"),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(0),
+            mac: MacAddress::new([0xaa; 6]),
+            ip: Some(vtep_ip("192.0.2.10")),
+            label1: MplsLabel::new(100),
+            label2: None,
+        };
+        let remote = vtep_ip("10.0.0.2");
+        let matching = rt("65000:100").to_extended_community();
+        let wrong = rt("65000:999").to_extended_community();
+        let attributes = [PathAttribute::ExtendedCommunities(vec![wrong, matching])];
+        assert!(instance.imports_mac_ip(&route, remote, &attributes));
+        assert!(!instance.imports_mac_ip(&route, remote, &[]));
+        assert!(!instance.imports_mac_ip(
+            &route,
+            remote,
+            &[PathAttribute::ExtendedCommunities(vec![
+                wrong,
+                ExtendedCommunity::mac_mobility(false, 9)
+            ])]
+        ));
+        assert!(!instance.imports_mac_ip(&route, instance.local_vtep_ip, &attributes));
+        route.ethernet_tag = EthernetTagId(77);
+        assert!(!instance.imports_mac_ip(&route, remote, &attributes));
+        route.ethernet_tag = EthernetTagId(0);
+        route.label1 = MplsLabel::new(200);
+        assert!(!instance.imports_mac_ip(&route, remote, &attributes));
+        route.label1 = MplsLabel::new(100);
+        // All supported RT encodings and the Partial attribute use the same
+        // existing decoder; a nonmatching first attribute cannot hide a match.
+        for target in [rt("65000:100"), rt("192.0.2.1:100"), rt("4200000000:100")] {
+            instance.route_targets = vec![rt("65000:200"), target];
+            assert!(instance.imports_mac_ip(
+                &route,
+                remote,
+                &[
+                    PathAttribute::ExtendedCommunities(vec![wrong]),
+                    PathAttribute::ExtendedCommunitiesPartial(vec![target.to_extended_community()]),
+                ]
+            ));
+        }
     }
 
     #[test]

--- a/docs/how-to/evpn-vtep-setup.md
+++ b/docs/how-to/evpn-vtep-setup.md
@@ -122,6 +122,20 @@ the SVD shape, see `[[managed_netdevs.svd_vxlans]]` in
 EAD-per-EVI routes remain Ethernet Tag ID `0`. It is the local Linux VLAN
 selector used for readiness and for `NDA_VLAN` on remote-MAC FDB writes.
 
+### Local Type 2 import
+
+Remote Type 2 routes contribute to local FDB state, MAC/MAC+IP mobility,
+duplicate detection, and Type 5 gateway-IP resolution only when their VNI
+matches a configured instance, Ethernet Tag is `0`, next hop differs from
+that instance's local VTEP, and at least one Route Target matches its
+`route_targets`. Missing or mismatched RTs do not satisfy local import.
+Global EVPN retention and reflection remain independent of this local filter.
+
+When upgrading from a version without this filter, check the RTs advertised
+by remote VTEPs. Previously installed Type 2 rows that fail these requirements
+are removed from local forwarding and gateway-IP resolution; correct the
+sender's RTs or the intended instance configuration before upgrading.
+
 ### MAC+IP origination (ARP/ND suppression)
 
 To originate Type 2 routes carrying the host IP (MAC+IP), enable

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1329,7 +1329,15 @@ fn project_intent_tables(
 
     let projected: Vec<ProjectedEvpnRoute> = routes
         .iter()
-        .filter_map(|r| project_one(r, &active_ead_per_es, &single_active_index, same_esi_bias))
+        .filter_map(|r| {
+            project_one(
+                r,
+                instances,
+                &active_ead_per_es,
+                &single_active_index,
+                same_esi_bias,
+            )
+        })
         .filter(|route| !projected_route_is_quarantined(route, quarantined_macs))
         .collect();
     let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
@@ -1351,7 +1359,10 @@ fn project_intent_tables(
                 return None;
             };
             let vni = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni()).ok()?;
-            instances.get(vni)?;
+            let instance = instances.get(vni)?;
+            if !instance.imports_mac_ip(macip, r.next_hop, &r.attributes) {
+                return None;
+            }
             // Mirror the projection's quarantine + same-ESI bias gates
             // — a route that contributes no desired state must not
             // light the gauge either.
@@ -1694,7 +1705,8 @@ fn project_ead_per_evi_unfiltered(
 /// Translate a single [`EvpnRibRoute`] into the projection input
 /// shape, returning `None` for non-Type-2 routes (Gate 7b L2VNI
 /// dataplane only programs MAC/IP entries) and for Type 2 routes
-/// that fail the RFC 7432 §8.4 mass-withdraw reachability gate
+/// that fail local VNI/RT/tag/next-hop import eligibility or the
+/// RFC 7432 §8.4 mass-withdraw reachability gate
 /// (non-zero ESI without a matching EAD-per-ES from the same
 /// origin VTEP next-hop). ADR-0083 slice 3 reinterprets that gate
 /// for single-active segments: a Type 2 whose origin VTEP lost its
@@ -1722,6 +1734,7 @@ fn project_ead_per_evi_unfiltered(
 /// behavior is the failure path, by design.
 fn project_one(
     route: &EvpnRibRoute,
+    instances: &EvpnInstanceTable,
     active_ead_per_es: &std::collections::BTreeSet<(
         std::net::IpAddr,
         rustbgpd_wire::EthernetSegmentIdentifier,
@@ -1733,13 +1746,20 @@ fn project_one(
         return None;
     };
 
-    // ADR-0085 decision 5 same-ESI local bias: suppress before any
-    // other gate — an eligible (ESI, VNI) has no remote row regardless
+    let vni = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni()).ok()?;
+    if !instances
+        .get(vni)?
+        .imports_mac_ip(macip, route.next_hop, &route.attributes)
+    {
+        return None;
+    }
+
+    // ADR-0085 decision 5 same-ESI local bias: an eligible (ESI, VNI)
+    // has no remote row regardless
     // of the mass-withdraw / swap-window outcome. ESI=0 (single-homed)
     // can never be eligible; the eligibility table only carries
     // configured, bound segments.
     if macip.esi != rustbgpd_wire::EthernetSegmentIdentifier::ZERO
-        && let Ok(vni) = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni())
         && same_esi_bias.is_eligible(macip.esi, vni)
     {
         return None;
@@ -1931,7 +1951,13 @@ mod tests {
             label1: MplsLabel::new(v),
             label2: None,
         };
-        let mut attrs: Vec<PathAttribute> = Vec::new();
+        let mut attrs = vec![PathAttribute::ExtendedCommunities(vec![
+            RouteTarget::TwoOctetAs {
+                asn: 65001,
+                value: v,
+            }
+            .to_extended_community(),
+        ])];
         if let Some(seq) = seq {
             attrs.push(PathAttribute::ExtendedCommunities(vec![
                 ExtendedCommunity::mac_mobility(false, seq),
@@ -2320,7 +2346,14 @@ mod tests {
         // ESI=0 → bypasses the mass-withdraw filter regardless of
         // the active set's contents.
         let active = std::collections::BTreeSet::new();
-        let projected = project_one(&route, &active, &empty_sa_index(), &no_bias()).unwrap();
+        let projected = project_one(
+            &route,
+            &local_instance_table(100, None),
+            &active,
+            &empty_sa_index(),
+            &no_bias(),
+        )
+        .unwrap();
         assert_eq!(projected.mac.octets(), [1; 6]);
         assert_eq!(projected.next_hop, ipa("10.0.0.2"));
         assert_eq!(projected.mobility_sequence, Some(7));
@@ -2345,7 +2378,16 @@ mod tests {
             is_llgr_stale: false,
         };
         let active = std::collections::BTreeSet::new();
-        assert!(project_one(&imet, &active, &empty_sa_index(), &no_bias()).is_none());
+        assert!(
+            project_one(
+                &imet,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &no_bias()
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -2355,39 +2397,46 @@ mod tests {
         // segment reachability (no current EAD-per-ES from the same
         // origin VTEP for the same ESI) fails the receiver-side
         // reachability precondition and is dropped from projection.
-        use rustbgpd_wire::{EthernetSegmentIdentifier, EvpnMacIp, MplsLabel};
         let esi = EthernetSegmentIdentifier::new([1; 10]);
-        let route = EvpnRibRoute {
-            route: EvpnRoute::MacIp(EvpnMacIp {
-                rd: RouteDistinguisher::ZERO,
-                esi,
-                ethernet_tag: EthernetTagId(0),
-                mac: rustbgpd_wire::MacAddress::new([2; 6]),
-                ip: None,
-                label1: MplsLabel::new(100),
-                label2: None,
-            }),
-            next_hop: ipa("10.0.0.2"),
-            link_local_next_hop: None,
-            peer: ipa("10.0.0.99"),
-            attributes: Arc::new(vec![]),
-            received_at: std::time::Instant::now(),
-            origin_type: rustbgpd_rib::route::RouteOrigin::Ebgp,
-            peer_router_id: std::net::Ipv4Addr::new(10, 0, 0, 99),
-            is_stale: false,
-            is_llgr_stale: false,
-        };
+        let route = evpn_macip_route_with_esi(100, 2, "10.0.0.2", esi);
         // No EAD-per-ES from VTEP 10.0.0.2 for this ESI → filter.
         let empty = std::collections::BTreeSet::new();
-        assert!(project_one(&route, &empty, &empty_sa_index(), &no_bias()).is_none());
+        assert!(
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &empty,
+                &empty_sa_index(),
+                &no_bias()
+            )
+            .is_none()
+        );
         // Same route with the active set populated → route survives.
         let mut active = std::collections::BTreeSet::new();
         active.insert((ipa("10.0.0.2"), esi));
-        assert!(project_one(&route, &active, &empty_sa_index(), &no_bias()).is_some());
+        assert!(
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &no_bias()
+            )
+            .is_some()
+        );
         // Different VTEP in the active set doesn't satisfy the gate.
         let mut wrong_vtep = std::collections::BTreeSet::new();
         wrong_vtep.insert((ipa("10.0.0.55"), esi));
-        assert!(project_one(&route, &wrong_vtep, &empty_sa_index(), &no_bias()).is_none());
+        assert!(
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &wrong_vtep,
+                &empty_sa_index(),
+                &no_bias()
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -2415,9 +2464,25 @@ mod tests {
         let mut active = std::collections::BTreeSet::new();
         active.insert((ipa("10.0.0.2"), esi));
 
-        assert!(project_one(&from_vtep_a, &active, &empty_sa_index(), &no_bias()).is_some());
         assert!(
-            project_one(&from_vtep_b, &active, &empty_sa_index(), &no_bias()).is_none(),
+            project_one(
+                &from_vtep_a,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &no_bias()
+            )
+            .is_some()
+        );
+        assert!(
+            project_one(
+                &from_vtep_b,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &no_bias()
+            )
+            .is_none(),
             "EAD-per-ES from VTEP A must not satisfy VTEP B"
         );
     }
@@ -2453,7 +2518,16 @@ mod tests {
         active.insert((ipa("10.0.0.2"), esi));
         // Control: the route passes the mass-withdraw gate and
         // projects without the bias.
-        assert!(project_one(&route, &active, &empty_sa_index(), &no_bias()).is_some());
+        assert!(
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &no_bias()
+            )
+            .is_some()
+        );
 
         // Locally attached (bound), healthy (not drained), all-active
         // — entitled to forward even as non-DF: suppressed.
@@ -2463,7 +2537,14 @@ mod tests {
             &[(esi, RedundancyMode::AllActive, 100, DfRole::NonDf)],
         );
         assert!(
-            project_one(&route, &active, &empty_sa_index(), &bias).is_none(),
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &bias
+            )
+            .is_none(),
             "an all-active member with a healthy local AC must not program a remote row"
         );
 
@@ -2476,7 +2557,14 @@ mod tests {
             inner.esi = esi;
         }
         assert!(
-            project_one(&macip, &active, &empty_sa_index(), &bias).is_none(),
+            project_one(
+                &macip,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &bias
+            )
+            .is_none(),
             "MAC-IP (neighbor) rows follow the MAC's bias"
         );
     }
@@ -2494,7 +2582,14 @@ mod tests {
             &[(esi, RedundancyMode::SingleActive, 100, DfRole::Df)],
         );
         assert!(
-            project_one(&route, &active, &empty_sa_index(), &bias).is_none(),
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &bias
+            )
+            .is_none(),
             "the single-active DF forwards on its own AC; the peer's Type 2 must not usurp it"
         );
     }
@@ -2517,7 +2612,14 @@ mod tests {
             &[(esi, RedundancyMode::SingleActive, 100, DfRole::NonDf)],
         );
         assert!(
-            project_one(&route, &active, &empty_sa_index(), &bias).is_some(),
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &bias
+            )
+            .is_some(),
             "a healthy single-active backup must keep the remote row toward the active PE"
         );
     }
@@ -2538,7 +2640,14 @@ mod tests {
             &[(esi, RedundancyMode::AllActive, 100, DfRole::Df)],
         );
         assert!(
-            project_one(&route, &active, &empty_sa_index(), &bias).is_some(),
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &bias
+            )
+            .is_some(),
             "a drained segment must program remote rows so the peer PE takes over"
         );
     }
@@ -2558,7 +2667,14 @@ mod tests {
             &[(esi, RedundancyMode::AllActive, 100, DfRole::Df)],
         );
         assert!(
-            project_one(&route, &active, &empty_sa_index(), &bias).is_some(),
+            project_one(
+                &route,
+                &local_instance_table(100, None),
+                &active,
+                &empty_sa_index(),
+                &bias
+            )
+            .is_some(),
             "unbound segments must keep today's remote-row behavior"
         );
     }
@@ -2943,10 +3059,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_intent_tables_single_active_swap_is_independent_per_ethernet_tag() {
-        // Groups are keyed per (ESI, EthernetTag): an ES spanning two
-        // tags takes one retarget each, derived from each tag's own
-        // eligible set.
+    async fn build_intent_tables_single_active_swap_rejects_unsupported_ethernet_tag() {
+        // The low-level aliasing algorithm supports distinct tags, but the
+        // local VLAN-based service imports only tag 0, including in a swap.
         let instances = local_instance_table(100, Some("br100"));
         let ip_vrfs = IpVrfTable::new();
         let esi = EthernetSegmentIdentifier::new([7; 10]);
@@ -2979,18 +3094,8 @@ mod tests {
         assert_eq!(tag0.remote_vtep_ip, ipa("10.0.0.3"));
         assert_eq!(tag0.alias_group_key, Some((esi, EthernetTagId(0))));
         assert_eq!(tag0.single_active_backup_vtep_ip, Some(ipa("10.0.0.4")));
-        let tag1 = tables.remote_macs.get(vni(100), mac(2)).unwrap();
-        assert_eq!(
-            tag1.remote_vtep_ip,
-            ipa("10.0.0.4"),
-            "tag 1 retargets from its own eligible set"
-        );
-        assert_eq!(tag1.alias_group_key, Some((esi, EthernetTagId(1))));
-        assert!(tag1.single_active_backup_vtep_ip.is_none());
-        assert_eq!(
-            tables.single_active_backup_active, 2,
-            "two (ESI, EthTag) groups in the backup window"
-        );
+        assert!(tables.remote_macs.get(vni(100), mac(2)).is_none());
+        assert_eq!(tables.single_active_backup_active, 1);
     }
 
     #[tokio::test]
@@ -3182,6 +3287,91 @@ mod tests {
             entry.single_active_backup_vtep_ip.is_none(),
             "all-active entries never carry the backup intent"
         );
+    }
+
+    #[test]
+    fn type2_import_eligibility_gates_fdb_and_gateway_ip_recursion() {
+        let instances = local_instance_table(100, Some("br100"));
+        let mut ip_vrfs = ip_vrf_table_one("blue", 5000, 5000);
+        ip_vrfs.mark_referenced_by_l2vni("blue".to_string(), vni(100));
+        let valid =
+            evpn_macip_route_with_host_ip(100, 0xaa, Some("192.0.2.10"), "10.0.0.2", Some(9));
+        for case in [
+            "matching",
+            "partial",
+            "missing",
+            "mismatched",
+            "tag",
+            "vni",
+            "self",
+        ] {
+            let mut route = valid.clone();
+            match case {
+                "partial" => {
+                    route.attributes =
+                        Arc::new(vec![PathAttribute::ExtendedCommunitiesPartial(vec![
+                            RouteTarget::TwoOctetAs {
+                                asn: 65001,
+                                value: 999,
+                            }
+                            .to_extended_community(),
+                            RouteTarget::TwoOctetAs {
+                                asn: 65001,
+                                value: 100,
+                            }
+                            .to_extended_community(),
+                        ])]);
+                }
+                "missing" => route.attributes = Arc::new(vec![]),
+                "mismatched" => {
+                    route.attributes = Arc::new(vec![PathAttribute::ExtendedCommunities(vec![
+                        RouteTarget::TwoOctetAs {
+                            asn: 65001,
+                            value: 999,
+                        }
+                        .to_extended_community(),
+                    ])]);
+                }
+                "tag" | "vni" => {
+                    let EvpnRoute::MacIp(macip) = &mut route.route else {
+                        unreachable!()
+                    };
+                    if case == "tag" {
+                        macip.ethernet_tag = EthernetTagId(77);
+                    } else {
+                        macip.label1 = MplsLabel::new(200);
+                    }
+                }
+                "self" => route.next_hop = ipa("10.0.0.1"),
+                _ => {}
+            }
+            let routes = vec![
+                route,
+                evpn_ip_prefix_route("10.1.0.0/24", "192.0.2.10", "10.0.0.9", 5000),
+            ];
+            let retained = routes.clone();
+            let tables =
+                project_intent_tables(&routes, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias());
+            let accepted = matches!(case, "matching" | "partial");
+            assert_eq!(
+                tables.remote_macs.get(vni(100), mac(0xaa)).is_some(),
+                accepted,
+                "{case}"
+            );
+            let entries: Vec<_> = tables
+                .remote_ip_prefixes
+                .for_vrf(IpVrfId::new(5000).unwrap())
+                .collect();
+            assert_eq!(entries.len(), usize::from(accepted), "{case}");
+            if accepted {
+                assert_eq!(entries[0].1.next_hop, ipa("10.0.0.2"));
+            }
+            for (route, before) in routes.iter().zip(&retained) {
+                assert_eq!(route.route, before.route);
+                assert_eq!(route.attributes, before.attributes);
+                assert_eq!(route.next_hop, before.next_hop);
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/evpn_originator/rib_polling.rs
+++ b/src/evpn_originator/rib_polling.rs
@@ -348,7 +348,8 @@ fn sticky_and_esi_by_mac_winner(
 }
 
 /// Build both contender maps from a flat set of best-path
-/// `EvpnRibRoute`s. Drops self-NH routes per the module-level
+/// `EvpnRibRoute`s. Requires local Type 2 import eligibility before losing
+/// attributes. Drops self-NH routes per the module-level
 /// "self-origination filter" rule, and drops routes advertised by a PE
 /// on the VNI's own Ethernet Segment (`vni_to_esi`, RFC 9721 §6.4):
 /// those are peer-sync routes, not mobility contenders, so they must
@@ -376,9 +377,12 @@ pub(super) fn build_remote_views(
             let EvpnRoute::MacIp(macip) = &r.route else {
                 return None;
             };
-            let local_esi = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni())
-                .ok()
-                .and_then(|vni| vni_to_esi.get(&vni).copied());
+            let vni = EvpnInstanceId::new(macip.label1.as_vni()).ok()?;
+            let instance = instances.get(vni)?;
+            if !instance.imports_mac_ip(macip, r.next_hop, &r.attributes) {
+                return None;
+            }
+            let local_esi = vni_to_esi.get(&vni).copied();
             if local_esi.is_some_and(|local| is_same_segment_peer(macip.esi, local)) {
                 return None;
             }
@@ -562,8 +566,15 @@ mod partial_extended_community_tests {
     #[test]
     fn partial_mac_mobility_preserves_sticky_sequence_contender_state() {
         let mobility = ExtendedCommunity::mac_mobility(true, 7);
-        let canonical = contender(PathAttribute::ExtendedCommunities(vec![mobility]));
-        let partial = contender(PathAttribute::ExtendedCommunitiesPartial(vec![mobility]));
+        let rt = rustbgpd_evpn::RouteTarget::TwoOctetAs {
+            asn: 65000,
+            value: 100,
+        }
+        .to_extended_community();
+        let canonical = contender(PathAttribute::ExtendedCommunities(vec![rt, mobility]));
+        let partial = contender(PathAttribute::ExtendedCommunitiesPartial(vec![
+            rt, mobility,
+        ]));
         let mut instances = EvpnInstanceTable::new();
         instances
             .insert(evpn_instance(

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -196,7 +196,13 @@ fn evpn_macip_route_with_ip(
         label1: MplsLabel::new(v),
         label2: None,
     };
-    let mut attrs: Vec<PathAttribute> = Vec::new();
+    let mut attrs = vec![PathAttribute::ExtendedCommunities(vec![
+        rustbgpd_evpn::RouteTarget::TwoOctetAs {
+            asn: 65000,
+            value: v,
+        }
+        .to_extended_community(),
+    ])];
     if seq.is_some() || sticky {
         attrs.push(PathAttribute::ExtendedCommunities(vec![
             ExtendedCommunity::mac_mobility(sticky, seq.unwrap_or(0)),
@@ -5673,5 +5679,71 @@ async fn duplicate_ip_runtime_model_enables_and_disables_without_recounting_cach
         h.observe(ip_observation(0xAA, "192.0.2.10", false)).await;
         h.observe(ip_added_aa()).await;
         assert_duplicate_ip_metrics(&h.metrics, 1, 0);
+    }
+}
+
+#[tokio::test]
+async fn type2_import_eligibility_gates_contenders_and_duplicate_accounting() {
+    for ip in ["192.0.2.10", "2001:db8::10"] {
+        for case in ["missing", "mismatched", "tag", "vni", "self"] {
+            let mut h = duplicate_ip_harness(true);
+            h.observe(learned_aa()).await;
+            h.observe(ip_observation(0xaa, ip, true)).await;
+            h.take_log().await;
+            let mut routes: Vec<_> = [0xaa, 0xbb]
+                .into_iter()
+                .map(|m| evpn_macip_route_with_ip(100, m, Some(ip), "10.0.0.2", Some(9), false))
+                .collect();
+            for route in &mut routes {
+                match case {
+                    "missing" => route.attributes = Arc::new(vec![]),
+                    "mismatched" => {
+                        route.attributes =
+                            Arc::new(vec![PathAttribute::ExtendedCommunities(vec![
+                                rustbgpd_evpn::RouteTarget::TwoOctetAs {
+                                    asn: 65000,
+                                    value: 999,
+                                }
+                                .to_extended_community(),
+                                ExtendedCommunity::mac_mobility(false, 9),
+                            ])]);
+                    }
+                    "tag" | "vni" => {
+                        let EvpnRoute::MacIp(macip) = &mut route.route else {
+                            unreachable!()
+                        };
+                        if case == "tag" {
+                            macip.ethernet_tag = EthernetTagId(77);
+                        } else {
+                            macip.label1 = MplsLabel::new(200);
+                        }
+                    }
+                    "self" => route.next_hop = ipa("10.0.0.1"),
+                    _ => unreachable!(),
+                }
+            }
+            let views = build_remote_views(&h.instances, &routes, &h.segments);
+            assert!(views.0.is_empty() && views.1.is_empty(), "{case}, {ip}");
+            h.routes_tx.send(routes).unwrap();
+            h.repoll().await;
+            h.repoll().await;
+            assert!(
+                h.take_log().await.is_empty(),
+                "ineligible contender changed local routes: {case}"
+            );
+            assert_duplicate_ip_metrics(&h.metrics, 0, 0);
+            assert!(!gather_metrics_text(&h.metrics).contains("evpn_duplicate_mac_moves_total{"));
+
+            // Restoring eligible routes makes both contender views visible and
+            // counts the different remote MAC claiming the local IP exactly once.
+            let valid = evpn_macip_route_with_ip(100, 0xbb, Some(ip), "10.0.0.2", Some(9), false);
+            let views = build_remote_views(&h.instances, std::slice::from_ref(&valid), &h.segments);
+            assert_eq!(views.0.len(), 1);
+            assert_eq!(views.1.len(), 1);
+            h.routes_tx.send(vec![valid]).unwrap();
+            h.repoll().await;
+            h.repoll().await;
+            assert_duplicate_ip_metrics(&h.metrics, 1, 0);
+        }
     }
 }


### PR DESCRIPTION
Selected EVPN Type 2 routes could affect local forwarding and mobility even when their Route Targets did not match the configured instance or their Ethernet Tag was unsupported. Require the local VNI, tag 0, a nonlocal next hop, and at least one matching RT before discarding attributes for FDB projection, Type 5 gateway-IP recursion, or MAC/MAC+IP contender views. Apply the same eligibility to backup-window accounting.

Global EVPN retention and reflection remain unchanged. Update the maintained VTEP setup and upgrade notes because previously consumed unmatched routes now leave local forwarding and mobility state. Existing low-level tag-aware algorithms remain intact.

Validation: the missing-RT and unsupported-tag controls fail with the new eligibility terms disabled, then pass with the guard restored. Complete dataplane, originator, and EVPN domain tests pass, including partial/multiple RTs, IPv4/IPv6 duplicate accounting, and gateway-IP recursion. `just gate` passes, including strict workspace Clippy, all workspace tests, and library/binary rustdoc.
