### PR TITLE
feat(cli): add practical help and man page examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -748,6 +748,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   from draft-ietf-sidrops-avoid-rpki-state-in-bgp and RFC 9736; the
   rs-config-render README corrects the RTT-community refusal rationale.
 
+- Root, neighbor, and RIB CLI help include practical inspection examples.
+  The man page includes subcommand help footers, including examples and
+  detailed exit codes. Contributor guidance defines verbs by operation
+  semantics without renaming existing commands.
+
 ### Upgrade notes
 
 - **EVPN RPCs apply the configuration MAC and ESI grammar:** `AddEvpnRoute`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,15 @@ the same offline boundary; a weekly lane checks external destinations.
 - Keep lines under 100 characters when possible
 - `#![deny(unsafe_code)]` on every crate — this is enforced, not advisory
 
+For CLI commands, use verbs by meaning: `list` inspects a collection, `get`
+inspects one named object, `set` creates or replaces a full definition, `add`
+creates a resource or injects a route, `delete` removes it, and `explain`
+diagnoses a decision. Do not make a create-only `add` an alias for a replacing
+`set`. Preserve existing bare-noun inspection shortcuts and EVPN mutation
+names such as `add-mac-ip`; their existing paths remain compatible. Keep
+help examples close to the command definition and parse-test the displayed
+invocations. The detailed flag conventions live in `crates/cli/src/main.rs`.
+
 ### Postmortem artifacts
 
 Any postmortem doc that cites raw data — soak runs, scale tests,

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -18,6 +18,16 @@ Diagnostics, and Reference. `rbgp man` uses the same groups in its command
 index. Existing command paths and aliases are unchanged; use
 `rbgp <command> --help` for each command's flags and subcommands.
 
+`rbgp --help`, `rbgp neighbor --help`, and `rbgp rib --help` include examples
+for common inspection tasks. The same examples appear in `rbgp man`.
+
+Named configuration objects use `list` and `get` for inspection, `set` for
+full-definition creation or replacement, and `delete` for removal. `add`
+creates a resource or injects a route; it does not promise replacement of an
+existing definition. Existing bare commands such as `rbgp neighbor` and
+`rbgp rib` keep their inspection defaults. EVPN mutation names such as
+`add-mac-ip` retain their existing syntax.
+
 ### Runtime Snapshot
 
 ```bash

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -101,6 +101,11 @@ pub enum RouteAspaState {
 //   new detailed contract must be added to EXIT_CODES_HELP and after_help.
 // - Help text: list entries (`about`) are one terse line; details go
 //   in `long_about` (the doc-comment paragraph after a blank line).
+// - Verbs describe behavior: list/get inspect collections/one object; set
+//   creates or replaces a full definition; add creates a resource or injects
+//   a route; delete removes it; explain diagnoses a decision. Do not alias
+//   create-only add to replacing set. Keep existing bare-noun inspection
+//   shortcuts and EVPN route-type mutation names compatible.
 // ===============================================================
 
 /// The one authoritative exit-code list: rendered in `rbgp --help`
@@ -119,13 +124,43 @@ const EXIT_CODES_HELP: &str = "Exit codes:\n  \
     policy test          0 ran / 1 compile diagnostics\n  \
     policy fmt           0 clean or formatted / 1 needs formatting (--check) or error";
 
+const ROOT_EXAMPLES: &str = "Examples:
+  # Check the daemon and inspect peers
+  rbgp health
+  rbgp neighbor
+  # Inspect a bounded route page and explain one prefix
+  rbgp rib --limit 20
+  rbgp rib --prefix 203.0.113.0/24 --explain
+  # Preview a configuration change without applying it
+  rbgp config plan config.toml";
+
+const NEIGHBOR_EXAMPLES: &str = "Examples:
+  # List peers, with optional summary columns
+  rbgp neighbor
+  rbgp neighbor --wide
+  # Inspect one peer, including a scoped IPv6 peer
+  rbgp neighbor 192.0.2.1
+  rbgp neighbor fe80::1%eth0
+  # Compare two peers' live update-group membership
+  rbgp neighbor 192.0.2.1 --compare 192.0.2.2";
+
+const RIB_EXAMPLES: &str = "Examples:
+  # Inspect bounded best, received, and advertised views
+  rbgp rib --limit 20
+  rbgp rib received 192.0.2.1 --limit 20
+  rbgp rib advertised 192.0.2.1 --limit 20
+  # Explain best-path selection and export to one peer
+  rbgp rib --prefix 203.0.113.0/24 --explain
+  rbgp rib --prefix 203.0.113.0/24 advertised 192.0.2.1 --explain";
+
 #[derive(Parser)]
 #[command(
     name = "rbgp",
     bin_name = "rbgp",
     about = "CLI for rustbgpd",
     version,
-    after_long_help = EXIT_CODES_HELP
+    after_help = ROOT_EXAMPLES,
+    after_long_help = format!("{ROOT_EXAMPLES}\n\n{EXIT_CODES_HELP}")
 )]
 struct Cli {
     /// gRPC server address or unix:///path/to/socket
@@ -177,7 +212,7 @@ enum Command {
     },
 
     /// Manage BGP neighbors
-    #[command(visible_alias = "summary")]
+    #[command(visible_alias = "summary", after_help = NEIGHBOR_EXAMPLES)]
     Neighbor {
         /// Neighbor address (omit to list all)
         #[arg(value_parser = commands::neighbor::parse_peer_address)]
@@ -217,6 +252,7 @@ enum Command {
     },
 
     /// Query and manage the RIB
+    #[command(after_help = RIB_EXAMPLES)]
     Rib {
         #[command(subcommand)]
         action: Option<RibAction>,
@@ -2898,6 +2934,7 @@ fn render_subcommand_sections(
         man.render_synopsis_section(output)?;
         man.render_description_section(output)?;
         man.render_options_section(output)?;
+        man.render_extra_section(output)?;
         render_subcommand_sections(&sub, &path, global_args, output)?;
     }
     Ok(())
@@ -8111,6 +8148,57 @@ printf '%s\n' "${COMPREPLY[@]}"
         let mut cmd = cli_command(BINARY_NAME);
         cmd.build();
         assert_terse(&cmd, BINARY_NAME);
+    }
+
+    #[test]
+    fn help_examples_are_parseable_and_present_in_man() {
+        let mut output = Vec::new();
+        generate_man(BINARY_NAME, &mut output).unwrap();
+        let man = String::from_utf8(output).unwrap().replace("\\-", "-");
+        for path in ["", "neighbor", "rib"] {
+            for long in [false, true] {
+                let mut command = cli_command(BINARY_NAME);
+                let page = if path.is_empty() {
+                    &mut command
+                } else {
+                    command.find_subcommand_mut(path).unwrap()
+                };
+                let help = if long {
+                    page.render_long_help()
+                } else {
+                    page.render_help()
+                }
+                .to_string();
+                let examples: Vec<_> = help
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| line.starts_with("rbgp "))
+                    .collect();
+                assert_eq!(examples.len(), 5, "{path}: {help}");
+                let section = if path.is_empty() {
+                    man.split(".SH SUBCOMMANDS").next().unwrap()
+                } else {
+                    man.split(&format!(".SH \"RBGP {}\"", path.to_uppercase()))
+                        .nth(1)
+                        .unwrap()
+                        .split(".SH \"RBGP ")
+                        .next()
+                        .unwrap()
+                };
+                for example in examples {
+                    let cli = Cli::try_parse_from(example.split_whitespace()).unwrap();
+                    validate_local_command(&cli.command).unwrap();
+                    validate_rib_route_view_action(&cli.command).unwrap();
+                    validate_neighbor_compare_action(&cli.command).unwrap();
+                    assert!(
+                        section.contains(example),
+                        "{path}: {example} missing from man"
+                    );
+                }
+            }
+        }
+        assert!(man.contains("0  all checks green"));
+        assert!(man.contains("2  bundle written but one or more checks are red"));
     }
 
     #[test]


### PR DESCRIPTION
Root, neighbor, and RIB help now show practical inspection examples. The man page includes subcommand help footers, including those examples and detailed exit codes.

Document command verbs by operation semantics while preserving existing paths and aliases. Regression coverage parses every displayed example and checks its corresponding man section.

Validation: `just gate` passed before integrating current main; affected help, man, completion, parser, JSON-lines, and stable-command inventory checks passed after integration. Normal commit and push hooks passed.
