### PR TITLE
fix(evpn): preserve local evi scope in ead forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -719,6 +719,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   mobility, duplicate accounting, or Type 5 gateway-IP recursion. Global RIB
   retention and reflection are unchanged.
 
+- Scope EVPN EAD-per-EVI alias and single-active backup selection to the
+  local VNI as well as ESI and Ethernet Tag. Local EAD consumption now
+  requires a matching Route Target and zero Ethernet Tag, including Type 5
+  ESI overlay resolution. The backup-window gauge counts each VNI separately.
+
 ### Documentation
 
 - Publish a descriptive raw bridge event-skew receipt across six pinned Jammy
@@ -933,6 +938,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or nonzero Ethernet Tags, no longer contribute local forwarding or mobility
   state. Check remote advertisements and configured `route_targets` before
   upgrading; see [local Type 2 import](docs/how-to/evpn-vtep-setup.md#local-type-2-import).
+
+- **EVPN EAD import scope:** alias or backup paths previously admitted from
+  another VNI, a nonmatching or missing Route Target, or a nonzero Ethernet
+  Tag are removed from local forwarding intent. Check remote EAD labels and
+  Route Targets if a path disappears after upgrading. Global EVPN RIB
+  retention, reflection, and export are unchanged. The
+  `evpn_single_active_backup_active` gauge may increase when multiple VNIs
+  share an ESI and tag because each forwarding group is now counted.
 
 ## [0.68.0] — 2026-08-30
 

--- a/crates/evpn/src/aliasing.rs
+++ b/crates/evpn/src/aliasing.rs
@@ -3,7 +3,7 @@
 //! When a peer announces a Type 2 MAC/IP route with a non-zero
 //! Ethernet Segment Identifier, the multi-homed CE the route names
 //! is reachable via *all* PEs that announce a Type 1 EAD-per-EVI
-//! route for the same `(ESI, Ethernet Tag)`. The receiver should
+//! route for the same `(VNI, ESI, Ethernet Tag)`. The receiver should
 //! treat those PE next-hops as alternative paths for the MAC, both
 //! for ECMP load balancing and for fast failover when the primary
 //! path goes away.
@@ -12,9 +12,9 @@
 //!
 //! Pure-logic indexing and portable-intent shaping for aliasing:
 //!
-//! - Given a stream of `(ESI, EthTag, PE_IP)` tuples extracted
+//! - Given a stream of `(VNI, ESI, EthTag, PE_IP)` tuples extracted
 //!   from the receiver's RIB best-path EAD-per-EVI routes, build
-//!   an [`AliasIndex`] that answers `vtep_ips_for(esi, eth_tag)`
+//!   an [`AliasIndex`] that answers `vtep_ips_for(vni, esi, eth_tag)`
 //!   in O(log n). Self-originated routes are filtered at the
 //!   caller (the resolver doesn't know which PE *we* are).
 //! - [`alias_resolved_next_hops`] combines a Type 2 route's
@@ -32,7 +32,7 @@
 //!   `RTM_NEWNEXTHOP` + `NHA_FDB`.
 //! - [`SingleActiveEligibleIndex`] derives the ADR-0083
 //!   single-active eligible-PE set and backup PE per
-//!   `(ESI, EthTag)` — the receive-side backup-path companion to
+//!   `(VNI, ESI, EthTag)` — the receive-side backup-path companion to
 //!   the all-active index above. The projection
 //!   ([`crate::projection::project_evpn_routes_with_backup_paths`])
 //!   consumes it (ADR-0083 slice 2) to give single-active MAC
@@ -63,6 +63,7 @@ use std::net::IpAddr;
 
 use rustbgpd_wire::{EthernetSegmentIdentifier, EthernetTagId};
 
+use crate::EvpnInstanceId;
 use crate::mac::RemoteMacEntry;
 
 /// One EAD-per-EVI advertisement, trimmed to the fields the resolver
@@ -70,10 +71,11 @@ use crate::mac::RemoteMacEntry;
 /// `EvpnRoute::EadPerEvi` and the resolver here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AliasEadPerEvi {
+    /// Local VNI whose import policy admitted this advertisement.
+    pub vni: EvpnInstanceId,
     /// Ethernet Segment Identifier the EAD-per-EVI route names.
     pub esi: EthernetSegmentIdentifier,
-    /// Ethernet Tag identifying the EVI. Always paired with `esi`
-    /// because RFC 7432 §14 aliasing is `(ESI, EthTag)`-keyed.
+    /// Ethernet Tag within the local VNI and Ethernet Segment.
     pub ethernet_tag: EthernetTagId,
     /// Next-hop / VTEP IP advertised on the EAD-per-EVI route. The
     /// resolver dedupes by IP before returning, so the caller
@@ -81,15 +83,15 @@ pub struct AliasEadPerEvi {
     pub vtep_ip: IpAddr,
 }
 
-/// Built index of `(ESI, EthTag) -> [VTEP IP]` for fast lookup.
+/// Built index of `(VNI, ESI, EthTag) -> [VTEP IP]` for fast lookup.
 ///
 /// Construction is O(n log n) on the input length; lookups are
-/// O(log m) where m is the number of distinct `(ESI, EthTag)`
-/// pairs. The index is read-only after `build`; rebuild on every
+/// O(log m) where m is the number of distinct `(VNI, ESI, EthTag)`
+/// keys. The index is read-only after `build`; rebuild on every
 /// projection pass to stay aligned with the RIB best-path snapshot.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct AliasIndex {
-    by_key: BTreeMap<(EthernetSegmentIdentifier, EthernetTagId), Vec<IpAddr>>,
+    by_key: BTreeMap<(EvpnInstanceId, EthernetSegmentIdentifier, EthernetTagId), Vec<IpAddr>>,
 }
 
 impl AliasIndex {
@@ -102,15 +104,15 @@ impl AliasIndex {
     /// Build from a stream of EAD-per-EVI advertisements. Single-
     /// homed entries (`ESI == ZERO`) are filtered out — they'd
     /// never resolve aliasing alternatives even if the caller
-    /// somehow surfaced them. Duplicate `(ESI, EthTag, VTEP IP)`
-    /// triples are deduped to keep the result list minimal.
+    /// somehow surfaced them. Duplicate `(VNI, ESI, EthTag, VTEP IP)`
+    /// rows are deduped to keep the result list minimal.
     #[must_use]
     pub fn build<I>(rows: I) -> Self
     where
         I: IntoIterator<Item = AliasEadPerEvi>,
     {
         let mut staged: BTreeMap<
-            (EthernetSegmentIdentifier, EthernetTagId),
+            (EvpnInstanceId, EthernetSegmentIdentifier, EthernetTagId),
             std::collections::BTreeSet<IpAddr>,
         > = BTreeMap::new();
 
@@ -119,7 +121,7 @@ impl AliasIndex {
                 continue;
             }
             staged
-                .entry((row.esi, row.ethernet_tag))
+                .entry((row.vni, row.esi, row.ethernet_tag))
                 .or_default()
                 .insert(row.vtep_ip);
         }
@@ -131,19 +133,20 @@ impl AliasIndex {
         Self { by_key }
     }
 
-    /// VTEP IPs that advertise an EAD-per-EVI for `(esi, eth_tag)`.
+    /// VTEP IPs that advertise an EAD-per-EVI for `(vni, esi, eth_tag)`.
     /// Returns `None` if there are no aliasing alternatives — the
     /// caller treats that as "use the Type 2's own next-hop only."
     #[must_use]
     pub fn vtep_ips_for(
         &self,
+        vni: EvpnInstanceId,
         esi: EthernetSegmentIdentifier,
         eth_tag: EthernetTagId,
     ) -> Option<&[IpAddr]> {
-        self.by_key.get(&(esi, eth_tag)).map(Vec::as_slice)
+        self.by_key.get(&(vni, esi, eth_tag)).map(Vec::as_slice)
     }
 
-    /// Number of `(ESI, EthTag)` pairs with at least one
+    /// Number of `(VNI, ESI, EthTag)` keys with at least one
     /// aliasing alternative.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -164,6 +167,7 @@ impl AliasIndex {
 /// ready.
 #[must_use]
 pub fn alias_resolved_next_hops(
+    vni: EvpnInstanceId,
     primary_next_hop: IpAddr,
     esi: EthernetSegmentIdentifier,
     eth_tag: EthernetTagId,
@@ -173,7 +177,7 @@ pub fn alias_resolved_next_hops(
     if esi == EthernetSegmentIdentifier::ZERO {
         return out;
     }
-    if let Some(aliases) = index.vtep_ips_for(esi, eth_tag) {
+    if let Some(aliases) = index.vtep_ips_for(vni, esi, eth_tag) {
         for &ip in aliases {
             if ip != primary_next_hop && !out.contains(&ip) {
                 out.push(ip);
@@ -230,7 +234,7 @@ pub struct EadPerEsMode {
     pub single_active: bool,
 }
 
-/// The portable single-active backup view for one `(ESI, EthTag)`
+/// The portable single-active backup view for one `(VNI, ESI, EthTag)`
 /// given a primary PE — what ADR-0083 slice 2 consumes to decide
 /// whether to program the NHG indirection (eligible set beyond the
 /// primary?) and which per-VTEP nexthop object to pre-create (the
@@ -250,12 +254,12 @@ pub struct SingleActiveBackupView {
     pub backup_pe: Option<IpAddr>,
 }
 
-/// Built index of single-active `(ESI, EthTag) -> eligible-PE set`
+/// Built index of single-active `(VNI, ESI, EthTag) -> eligible-PE set`
 /// for the ADR-0083 receive-side backup path.
 ///
-/// The eligible set for `(ESI, EthTag)` is every PE (VTEP IP)
+/// The eligible set for `(VNI, ESI, EthTag)` is every PE (VTEP IP)
 /// advertising *both* an EAD-per-ES with the Single-Active bit set
-/// *and* an EAD-per-EVI for that `(ESI, EthTag)` — RFC 7432 §8.4's
+/// *and* an EAD-per-EVI for that `(VNI, ESI, EthTag)` — RFC 7432 §8.4's
 /// "reachable via any PE" set (ADR-0083 decision
 /// 2). All-active segments never appear here; they stay on the
 /// [`AliasIndex`] ECMP path.
@@ -268,7 +272,7 @@ pub struct SingleActiveBackupView {
 /// ordering dependence.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct SingleActiveEligibleIndex {
-    by_key: BTreeMap<(EthernetSegmentIdentifier, EthernetTagId), Vec<IpAddr>>,
+    by_key: BTreeMap<(EvpnInstanceId, EthernetSegmentIdentifier, EthernetTagId), Vec<IpAddr>>,
     /// `(VTEP, ESI)` pairs whose EAD-per-ES rows OR-fold to
     /// single-active. Retained from the build's mode fold so the
     /// projection can ask "is this MAC route's origin pair
@@ -317,8 +321,10 @@ impl SingleActiveEligibleIndex {
             *entry = *entry || row.single_active;
         }
 
-        let mut staged: BTreeMap<(EthernetSegmentIdentifier, EthernetTagId), BTreeSet<IpAddr>> =
-            BTreeMap::new();
+        let mut staged: BTreeMap<
+            (EvpnInstanceId, EthernetSegmentIdentifier, EthernetTagId),
+            BTreeSet<IpAddr>,
+        > = BTreeMap::new();
         for row in ead_per_evi {
             if row.esi == EthernetSegmentIdentifier::ZERO {
                 continue;
@@ -332,7 +338,7 @@ impl SingleActiveEligibleIndex {
                 continue;
             }
             staged
-                .entry((row.esi, row.ethernet_tag))
+                .entry((row.vni, row.esi, row.ethernet_tag))
                 .or_default()
                 .insert(row.vtep_ip);
         }
@@ -382,20 +388,21 @@ impl SingleActiveEligibleIndex {
         self.pairs_with_ead_per_es.contains(&(vtep_ip, esi))
     }
 
-    /// Eligible PEs for `(esi, eth_tag)`, sorted by `IpAddr` natural
+    /// Eligible PEs for `(vni, esi, eth_tag)`, sorted by `IpAddr` natural
     /// order; the current primary is present only while its own EAD pair
     /// is advertised. Returns `None` when no PE qualifies
     /// — the key is not a single-active segment we know a path for.
     #[must_use]
     pub fn eligible_pes(
         &self,
+        vni: EvpnInstanceId,
         esi: EthernetSegmentIdentifier,
         eth_tag: EthernetTagId,
     ) -> Option<&[IpAddr]> {
-        self.by_key.get(&(esi, eth_tag)).map(Vec::as_slice)
+        self.by_key.get(&(vni, esi, eth_tag)).map(Vec::as_slice)
     }
 
-    /// Backup PE for `(esi, eth_tag)` given the primary (the MAC
+    /// Backup PE for `(vni, esi, eth_tag)` given the primary (the MAC
     /// routes' advertising next-hop): the numerically lowest VTEP IP
     /// in the eligible set excluding the primary (ADR-0083 decision
     /// 2 — the `BTreeSet<IpAddr>` total order, IPv4 before IPv6; an
@@ -409,35 +416,37 @@ impl SingleActiveEligibleIndex {
     #[must_use]
     pub fn backup_pe(
         &self,
+        vni: EvpnInstanceId,
         esi: EthernetSegmentIdentifier,
         eth_tag: EthernetTagId,
         primary: IpAddr,
     ) -> Option<IpAddr> {
-        self.eligible_pes(esi, eth_tag)?
+        self.eligible_pes(vni, esi, eth_tag)?
             .iter()
             .copied()
             .find(|&ip| ip != primary)
     }
 
-    /// Combined [`SingleActiveBackupView`] for `(esi, eth_tag)`
+    /// Combined [`SingleActiveBackupView`] for `(vni, esi, eth_tag)`
     /// given the primary. Returns `None` when the key has no
     /// eligible set at all (not single-active, or no PE advertises
     /// both route types).
     #[must_use]
     pub fn backup_view(
         &self,
+        vni: EvpnInstanceId,
         esi: EthernetSegmentIdentifier,
         eth_tag: EthernetTagId,
         primary: IpAddr,
     ) -> Option<SingleActiveBackupView> {
-        let eligible = self.eligible_pes(esi, eth_tag)?;
+        let eligible = self.eligible_pes(vni, esi, eth_tag)?;
         Some(SingleActiveBackupView {
             eligible_pes: eligible.to_vec(),
             backup_pe: eligible.iter().copied().find(|&ip| ip != primary),
         })
     }
 
-    /// Number of `(ESI, EthTag)` pairs with a non-empty eligible set.
+    /// Number of `(VNI, ESI, EthTag)` keys with a non-empty eligible set.
     #[must_use]
     pub fn len(&self) -> usize {
         self.by_key.len()
@@ -454,6 +463,10 @@ impl SingleActiveEligibleIndex {
 mod tests {
     use super::*;
 
+    fn vni(value: u32) -> EvpnInstanceId {
+        EvpnInstanceId::new(value).unwrap()
+    }
+
     fn esi(seed: u8) -> EthernetSegmentIdentifier {
         EthernetSegmentIdentifier::new([seed; 10])
     }
@@ -465,18 +478,23 @@ mod tests {
     fn empty_index_resolves_nothing() {
         let idx = AliasIndex::new();
         assert!(idx.is_empty());
-        assert!(idx.vtep_ips_for(esi(1), EthernetTagId(0)).is_none());
+        assert!(
+            idx.vtep_ips_for(vni(100), esi(1), EthernetTagId(0))
+                .is_none()
+        );
     }
 
     #[test]
     fn build_filters_zero_esi() {
         let idx = AliasIndex::build([
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: EthernetSegmentIdentifier::ZERO,
                 ethernet_tag: EthernetTagId(0),
                 vtep_ip: ip("10.0.0.1"),
             },
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(0),
                 vtep_ip: ip("10.0.0.2"),
@@ -484,7 +502,9 @@ mod tests {
         ]);
         assert_eq!(idx.len(), 1);
         assert_eq!(
-            idx.vtep_ips_for(esi(1), EthernetTagId(0)).unwrap().to_vec(),
+            idx.vtep_ips_for(vni(100), esi(1), EthernetTagId(0))
+                .unwrap()
+                .to_vec(),
             vec![ip("10.0.0.2")],
         );
     }
@@ -493,18 +513,22 @@ mod tests {
     fn build_dedups_identical_triples() {
         let idx = AliasIndex::build([
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(0),
                 vtep_ip: ip("10.0.0.2"),
             },
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(0),
                 vtep_ip: ip("10.0.0.2"),
             },
         ]);
         assert_eq!(
-            idx.vtep_ips_for(esi(1), EthernetTagId(0)).unwrap().to_vec(),
+            idx.vtep_ips_for(vni(100), esi(1), EthernetTagId(0))
+                .unwrap()
+                .to_vec(),
             vec![ip("10.0.0.2")],
         );
     }
@@ -513,18 +537,20 @@ mod tests {
     fn build_groups_distinct_pes_under_same_key() {
         let idx = AliasIndex::build([
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(100),
                 vtep_ip: ip("10.0.0.2"),
             },
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(100),
                 vtep_ip: ip("10.0.0.3"),
             },
         ]);
         let ips = idx
-            .vtep_ips_for(esi(1), EthernetTagId(100))
+            .vtep_ips_for(vni(100), esi(1), EthernetTagId(100))
             .unwrap()
             .to_vec();
         assert_eq!(ips.len(), 2);
@@ -536,24 +562,26 @@ mod tests {
     fn build_keeps_eth_tags_separate() {
         let idx = AliasIndex::build([
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(100),
                 vtep_ip: ip("10.0.0.2"),
             },
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(200),
                 vtep_ip: ip("10.0.0.3"),
             },
         ]);
         assert_eq!(
-            idx.vtep_ips_for(esi(1), EthernetTagId(100))
+            idx.vtep_ips_for(vni(100), esi(1), EthernetTagId(100))
                 .unwrap()
                 .to_vec(),
             vec![ip("10.0.0.2")],
         );
         assert_eq!(
-            idx.vtep_ips_for(esi(1), EthernetTagId(200))
+            idx.vtep_ips_for(vni(100), esi(1), EthernetTagId(200))
                 .unwrap()
                 .to_vec(),
             vec![ip("10.0.0.3")],
@@ -563,11 +591,13 @@ mod tests {
     #[test]
     fn resolved_next_hops_zero_esi_returns_primary_only() {
         let idx = AliasIndex::build([AliasEadPerEvi {
+            vni: vni(100),
             esi: esi(1),
             ethernet_tag: EthernetTagId(0),
             vtep_ip: ip("10.0.0.5"),
         }]);
         let nhs = alias_resolved_next_hops(
+            vni(100),
             ip("10.0.0.1"),
             EthernetSegmentIdentifier::ZERO,
             EthernetTagId(0),
@@ -580,17 +610,20 @@ mod tests {
     fn resolved_next_hops_appends_unique_alias_ips() {
         let idx = AliasIndex::build([
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(0),
                 vtep_ip: ip("10.0.0.2"),
             },
             AliasEadPerEvi {
+                vni: vni(100),
                 esi: esi(1),
                 ethernet_tag: EthernetTagId(0),
                 vtep_ip: ip("10.0.0.3"),
             },
         ]);
-        let nhs = alias_resolved_next_hops(ip("10.0.0.2"), esi(1), EthernetTagId(0), &idx);
+        let nhs =
+            alias_resolved_next_hops(vni(100), ip("10.0.0.2"), esi(1), EthernetTagId(0), &idx);
         // Primary first, then aliases minus the primary.
         assert_eq!(nhs[0], ip("10.0.0.2"));
         assert_eq!(nhs.len(), 2);
@@ -601,18 +634,21 @@ mod tests {
     fn resolved_next_hops_dedupes_primary_against_alias() {
         // Primary is also in the alias list; result must dedupe.
         let idx = AliasIndex::build([AliasEadPerEvi {
+            vni: vni(100),
             esi: esi(1),
             ethernet_tag: EthernetTagId(0),
             vtep_ip: ip("10.0.0.2"),
         }]);
-        let nhs = alias_resolved_next_hops(ip("10.0.0.2"), esi(1), EthernetTagId(0), &idx);
+        let nhs =
+            alias_resolved_next_hops(vni(100), ip("10.0.0.2"), esi(1), EthernetTagId(0), &idx);
         assert_eq!(nhs, vec![ip("10.0.0.2")]);
     }
 
     #[test]
     fn resolved_next_hops_no_aliases_returns_primary_only() {
         let idx = AliasIndex::new();
-        let nhs = alias_resolved_next_hops(ip("10.0.0.2"), esi(1), EthernetTagId(0), &idx);
+        let nhs =
+            alias_resolved_next_hops(vni(100), ip("10.0.0.2"), esi(1), EthernetTagId(0), &idx);
         assert_eq!(nhs, vec![ip("10.0.0.2")]);
     }
 
@@ -665,6 +701,7 @@ mod tests {
 
     fn evi_row(seed: u8, tag: u32, vtep: &str) -> AliasEadPerEvi {
         AliasEadPerEvi {
+            vni: vni(100),
             esi: esi(seed),
             ethernet_tag: EthernetTagId(tag),
             vtep_ip: ip(vtep),
@@ -675,13 +712,16 @@ mod tests {
     fn eligible_set_empty_index_resolves_nothing() {
         let idx = SingleActiveEligibleIndex::new();
         assert!(idx.is_empty());
-        assert!(idx.eligible_pes(esi(1), EthernetTagId(0)).is_none());
         assert!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("10.0.0.2"))
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(0))
                 .is_none()
         );
         assert!(
-            idx.backup_view(esi(1), EthernetTagId(0), ip("10.0.0.2"))
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.2"))
+                .is_none()
+        );
+        assert!(
+            idx.backup_view(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.2"))
                 .is_none()
         );
     }
@@ -695,7 +735,8 @@ mod tests {
             [evi_row(1, 100, "10.0.0.3"), evi_row(1, 100, "10.0.0.4")],
         );
         assert_eq!(
-            idx.eligible_pes(esi(1), EthernetTagId(100)).unwrap(),
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(100))
+                .unwrap(),
             &[ip("10.0.0.4")],
         );
     }
@@ -704,14 +745,20 @@ mod tests {
     fn eligible_set_ead_per_es_alone_yields_no_key() {
         let idx = SingleActiveEligibleIndex::build([es_row(1, "10.0.0.2", true)], []);
         assert!(idx.is_empty());
-        assert!(idx.eligible_pes(esi(1), EthernetTagId(0)).is_none());
+        assert!(
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                .is_none()
+        );
     }
 
     #[test]
     fn eligible_set_ead_per_evi_alone_yields_no_key() {
         let idx = SingleActiveEligibleIndex::build([], [evi_row(1, 0, "10.0.0.2")]);
         assert!(idx.is_empty());
-        assert!(idx.eligible_pes(esi(1), EthernetTagId(0)).is_none());
+        assert!(
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                .is_none()
+        );
     }
 
     #[test]
@@ -724,7 +771,8 @@ mod tests {
             [evi_row(1, 0, "10.0.0.2"), evi_row(1, 0, "10.0.0.3")],
         );
         assert_eq!(
-            idx.eligible_pes(esi(1), EthernetTagId(0)).unwrap(),
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                .unwrap(),
             &[ip("10.0.0.3")],
         );
     }
@@ -741,7 +789,8 @@ mod tests {
         ] {
             let idx = SingleActiveEligibleIndex::build(rows, [evi_row(1, 0, "10.0.0.2")]);
             assert_eq!(
-                idx.eligible_pes(esi(1), EthernetTagId(0)).unwrap(),
+                idx.eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                    .unwrap(),
                 &[ip("10.0.0.2")],
                 "single-active must win the (VTEP, ESI) fold",
             );
@@ -757,6 +806,7 @@ mod tests {
                 single_active: true,
             }],
             [AliasEadPerEvi {
+                vni: vni(100),
                 esi: EthernetSegmentIdentifier::ZERO,
                 ethernet_tag: EthernetTagId(0),
                 vtep_ip: ip("10.0.0.2"),
@@ -784,7 +834,7 @@ mod tests {
     fn backup_pe_is_lowest_excluding_primary_when_primary_is_lowest() {
         let idx = three_pe_index();
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("10.0.0.2")),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.2")),
             Some(ip("10.0.0.3")),
         );
     }
@@ -793,11 +843,11 @@ mod tests {
     fn backup_pe_is_lowest_excluding_primary_when_primary_is_not_lowest() {
         let idx = three_pe_index();
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("10.0.0.3")),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.3")),
             Some(ip("10.0.0.2")),
         );
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("10.0.0.4")),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.4")),
             Some(ip("10.0.0.2")),
         );
     }
@@ -812,7 +862,7 @@ mod tests {
             [evi_row(1, 0, "10.0.0.3"), evi_row(1, 0, "10.0.0.4")],
         );
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("10.0.0.2")),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.2")),
             Some(ip("10.0.0.3")),
         );
     }
@@ -824,11 +874,11 @@ mod tests {
             [evi_row(1, 0, "10.0.0.2")],
         );
         assert!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("10.0.0.2"))
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.2"))
                 .is_none()
         );
         let view = idx
-            .backup_view(esi(1), EthernetTagId(0), ip("10.0.0.2"))
+            .backup_view(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.2"))
             .unwrap();
         assert_eq!(view.eligible_pes, vec![ip("10.0.0.2")]);
         assert_eq!(view.backup_pe, None);
@@ -838,7 +888,7 @@ mod tests {
     fn backup_view_carries_eligible_set_and_backup() {
         let idx = three_pe_index();
         let view = idx
-            .backup_view(esi(1), EthernetTagId(0), ip("10.0.0.3"))
+            .backup_view(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.3"))
             .unwrap();
         assert_eq!(
             view.eligible_pes,
@@ -860,19 +910,21 @@ mod tests {
             ],
         );
         assert_eq!(
-            idx.eligible_pes(esi(1), EthernetTagId(100)).unwrap(),
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(100))
+                .unwrap(),
             &[ip("10.0.0.2"), ip("10.0.0.3")],
         );
         assert_eq!(
-            idx.eligible_pes(esi(1), EthernetTagId(200)).unwrap(),
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(200))
+                .unwrap(),
             &[ip("10.0.0.2")],
         );
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(100), ip("10.0.0.2")),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(100), ip("10.0.0.2")),
             Some(ip("10.0.0.3")),
         );
         assert!(
-            idx.backup_pe(esi(1), EthernetTagId(200), ip("10.0.0.2"))
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(200), ip("10.0.0.2"))
                 .is_none()
         );
     }
@@ -887,7 +939,8 @@ mod tests {
             [evi_row(1, 0, "10.0.0.2"), evi_row(1, 0, "10.0.0.3")],
         );
         assert_eq!(
-            full.eligible_pes(esi(1), EthernetTagId(0)).unwrap(),
+            full.eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                .unwrap(),
             &[ip("10.0.0.2"), ip("10.0.0.3")],
         );
 
@@ -896,7 +949,9 @@ mod tests {
             [evi_row(1, 0, "10.0.0.2"), evi_row(1, 0, "10.0.0.3")],
         );
         assert_eq!(
-            without_es.eligible_pes(esi(1), EthernetTagId(0)).unwrap(),
+            without_es
+                .eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                .unwrap(),
             &[ip("10.0.0.2")],
         );
 
@@ -905,7 +960,9 @@ mod tests {
             [evi_row(1, 0, "10.0.0.2")],
         );
         assert_eq!(
-            without_evi.eligible_pes(esi(1), EthernetTagId(0)).unwrap(),
+            without_evi
+                .eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                .unwrap(),
             &[ip("10.0.0.2")],
         );
     }
@@ -1000,13 +1057,13 @@ mod tests {
         );
         let dead_primary = ip("10.0.0.2");
         let member = idx
-            .backup_pe(esi(1), EthernetTagId(0), dead_primary)
+            .backup_pe(vni(100), esi(1), EthernetTagId(0), dead_primary)
             .expect("survivors exist");
         assert_eq!(member, ip("10.0.0.3"));
         // New standby for the swapped group: lowest excluding the
         // new member (the dead primary is not eligible anyway).
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(0), member),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), member),
             Some(ip("10.0.0.4")),
         );
     }
@@ -1028,17 +1085,18 @@ mod tests {
             ],
         );
         assert_eq!(
-            idx.eligible_pes(esi(1), EthernetTagId(0)).unwrap(),
+            idx.eligible_pes(vni(100), esi(1), EthernetTagId(0))
+                .unwrap(),
             &[ip("10.0.0.9"), ip("2001:db8::1"), ip("2001:db8::2")],
         );
         // IPv4 primary: backup is the lowest IPv6.
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("10.0.0.9")),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("10.0.0.9")),
             Some(ip("2001:db8::1")),
         );
         // IPv6 primary: the IPv4 PE is the lowest non-primary.
         assert_eq!(
-            idx.backup_pe(esi(1), EthernetTagId(0), ip("2001:db8::1")),
+            idx.backup_pe(vni(100), esi(1), EthernetTagId(0), ip("2001:db8::1")),
             Some(ip("10.0.0.9")),
         );
     }

--- a/crates/evpn/src/instance.rs
+++ b/crates/evpn/src/instance.rs
@@ -18,7 +18,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::net::IpAddr;
 
-use rustbgpd_wire::{EvpnMacIp, MacAddress, PathAttribute, RouteDistinguisher};
+use rustbgpd_wire::{EthernetTagId, EvpnMacIp, MacAddress, PathAttribute, RouteDistinguisher};
 
 use crate::duplicate_ip::DuplicateIpConfig;
 use crate::duplicate_mac::DuplicateMacConfig;
@@ -252,9 +252,22 @@ impl EvpnInstance {
         next_hop: IpAddr,
         attributes: &[PathAttribute],
     ) -> bool {
-        route.label1.as_vni() == self.id.as_u32()
-            && route.ethernet_tag.0 == 0
-            && next_hop != self.local_vtep_ip
+        next_hop != self.local_vtep_ip
+            && self.imports_evi(route.label1.as_vni(), route.ethernet_tag, attributes)
+    }
+
+    /// Whether a route belongs to this local VLAN-based EVI: matching VNI,
+    /// zero Ethernet Tag, and at least one configured Route Target.
+    /// This gates local consumption, not global RIB retention or export.
+    #[must_use]
+    pub fn imports_evi(
+        &self,
+        vni: u32,
+        ethernet_tag: EthernetTagId,
+        attributes: &[PathAttribute],
+    ) -> bool {
+        vni == self.id.as_u32()
+            && ethernet_tag.0 == 0
             && attributes
                 .iter()
                 .filter_map(PathAttribute::extended_communities)

--- a/crates/evpn/src/origination_es.rs
+++ b/crates/evpn/src/origination_es.rs
@@ -720,12 +720,13 @@ mod tests {
         // All-active aliasing: the EAD-per-EVI row must resolve under
         // the Type 2's (ESI, tag) lookup key.
         let alias_index = AliasIndex::build([AliasEadPerEvi {
+            vni: vni(100),
             esi: ead_esi,
             ethernet_tag: ead_tag,
             vtep_ip: remote_pe,
         }]);
         assert_eq!(
-            alias_index.vtep_ips_for(segment, mac_tag),
+            alias_index.vtep_ips_for(vni(100), segment, mac_tag),
             Some(&[remote_pe][..]),
             "EAD-per-EVI tag {ead_tag:?} must join the Type 2 tag {mac_tag:?}",
         );
@@ -739,13 +740,14 @@ mod tests {
                 single_active: true,
             }],
             [AliasEadPerEvi {
+                vni: vni(100),
                 esi: ead_esi,
                 ethernet_tag: ead_tag,
                 vtep_ip: remote_pe,
             }],
         );
         assert_eq!(
-            eligible.eligible_pes(segment, mac_tag),
+            eligible.eligible_pes(vni(100), segment, mac_tag),
             Some(&[remote_pe][..]),
             "EAD-per-EVI tag {ead_tag:?} must make the eligible set for the Type 2 tag {mac_tag:?}",
         );

--- a/crates/evpn/src/projection.rs
+++ b/crates/evpn/src/projection.rs
@@ -86,6 +86,8 @@ pub struct ProjectedEvpnRoute {
 /// keeps this struct purely declarative.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProjectedEvpnEadPerEvi {
+    /// Local VNI whose import policy admitted this advertisement.
+    pub vni: EvpnInstanceId,
     /// Ethernet Segment Identifier the EAD-per-EVI route names.
     pub esi: rustbgpd_wire::EthernetSegmentIdentifier,
     /// Ethernet Tag identifying the EVI.
@@ -224,6 +226,7 @@ where
     // single-homed Type 2 routes resolve to no alternatives even if
     // the index has rows for unrelated ESIs.
     let alias_rows = ead_per_evi.into_iter().map(|e| crate::AliasEadPerEvi {
+        vni: e.vni,
         esi: e.esi,
         ethernet_tag: e.ethernet_tag,
         vtep_ip: e.next_hop,
@@ -270,7 +273,7 @@ where
         // arm). `Some(entry)` means the route is governed by the
         // single-active machinery; `None` falls through to the
         // all-active aliasing path.
-        if let Some(entry) = single_active_entry(&route, single_active) {
+        if let Some(entry) = single_active_entry(vni, &route, single_active) {
             builder
                 .insert(vni, mac, entry)
                 .expect("staged BTreeMap already deduped (VNI, MAC) keys");
@@ -292,6 +295,7 @@ where
                 Vec::new()
             } else {
                 let resolved = crate::alias_resolved_next_hops(
+                    vni,
                     route.next_hop,
                     route.esi,
                     route.ethernet_tag,
@@ -377,6 +381,7 @@ where
 ///   segment) does NOT take this arm: its own mode stays
 ///   authoritative (slice-2 pinned behavior).
 fn single_active_entry(
+    vni: EvpnInstanceId,
     route: &ProjectedEvpnRoute,
     single_active: &crate::SingleActiveEligibleIndex,
 ) -> Option<RemoteMacEntry> {
@@ -384,7 +389,7 @@ fn single_active_entry(
         return None;
     }
     if single_active.pair_is_single_active(route.next_hop, route.esi) {
-        let backup = single_active.backup_pe(route.esi, route.ethernet_tag, route.next_hop);
+        let backup = single_active.backup_pe(vni, route.esi, route.ethernet_tag, route.next_hop);
         return Some(RemoteMacEntry {
             remote_vtep_ip: route.next_hop,
             mobility_sequence: route.mobility_sequence,
@@ -395,12 +400,13 @@ fn single_active_entry(
         });
     }
     if !single_active.pair_has_ead_per_es(route.next_hop, route.esi)
-        && let Some(member) = single_active.backup_pe(route.esi, route.ethernet_tag, route.next_hop)
+        && let Some(member) =
+            single_active.backup_pe(vni, route.esi, route.ethernet_tag, route.next_hop)
     {
         // The swap window. New standby: the lowest eligible PE
         // excluding the new member (the withdrawn primary is not in
         // the eligible set — eligibility requires its EAD pair).
-        let standby = single_active.backup_pe(route.esi, route.ethernet_tag, member);
+        let standby = single_active.backup_pe(vni, route.esi, route.ethernet_tag, member);
         return Some(RemoteMacEntry {
             remote_vtep_ip: member,
             mobility_sequence: route.mobility_sequence,
@@ -659,6 +665,7 @@ mod tests {
         dst: &str,
     ) -> ProjectedEvpnEadPerEvi {
         ProjectedEvpnEadPerEvi {
+            vni: vni(100),
             esi,
             ethernet_tag: rustbgpd_wire::EthernetTagId(eth_tag),
             next_hop: ipa(dst),
@@ -818,6 +825,7 @@ mod tests {
             evi_rows
                 .iter()
                 .map(|&(seed, tag, vtep)| crate::AliasEadPerEvi {
+                    vni: vni(100),
                     esi: esi_seed(seed),
                     ethernet_tag: rustbgpd_wire::EthernetTagId(tag),
                     vtep_ip: ipa(vtep),

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -2321,7 +2321,7 @@ impl BgpMetrics {
 
         let evpn_single_active_backup_active = IntGauge::new(
             "evpn_single_active_backup_active",
-            "Number of (ESI, EthernetTag) single-active groups currently retargeted at \
+            "Number of (VNI, ESI, EthernetTag) single-active groups currently retargeted at \
              their backup PE (the ADR-0083 post-failover window: the origin VTEP \
              withdrew its EAD-per-ES, eligible survivors remain, and the new active \
              PE has not yet re-advertised the MACs). Non-zero values are expected \
@@ -5650,7 +5650,7 @@ impl BgpMetrics {
     }
 
     /// Set the ADR-0083 backup-window gauge: how many
-    /// `(ESI, EthernetTag)` single-active groups are currently
+    /// `(VNI, ESI, EthernetTag)` single-active groups are currently
     /// retargeted at their backup PE.
     pub fn set_evpn_single_active_backup_active(&self, value: i64) {
         self.0.evpn_single_active_backup_active.set(value);

--- a/docs/how-to/evpn-vtep-troubleshooting.md
+++ b/docs/how-to/evpn-vtep-troubleshooting.md
@@ -370,9 +370,13 @@ nexthop **group**, not a single-dst `dst <ip>` row.
    parked in a range is quarantined (left untouched, never adopted or
    deleted) and surfaces on `evpn_foreign_nhid_range_conflicts_total`.
 3. Confirm rustbgpd actually observed both alias VTEPs' Type 1
-   EAD-per-EVI routes for the shared ESI — check
-   `rbgp evpn instances` or the gRPC `ListEvpnInstances`,
-   and verify peer sessions are Established.
+   EAD-per-EVI routes for the shared ESI in the same local VNI. The label
+   must name that VNI, at least one Route Target must match its configured
+   `route_targets`, and Ethernet Tag must be zero. An EAD for another
+   configured VNI cannot supply an alias or single-active backup. The same
+   admission rule applies to EAD inputs for Type 5 ESI overlay resolution.
+   Check `rbgp evpn instances` or gRPC `ListEvpnInstances`, inspect the
+   received routes, and verify peer sessions are Established.
 4. If the FDB row has `dst <ip>` (not `nhid`), the entry is in
    the single-dst fallback path. Common causes:
    - Mixed address-family alias members: one FDB nexthop group

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -1841,7 +1841,7 @@ per-cache readiness metrics and RTR logs for those questions.
 | `evpn_fdb_nhg_drift_groups_replaced_total` | FDB nexthop groups re-created or replaced after kernel drift. Investigate sustained increases alongside member repairs for competing kernel writers. |
 | `evpn_fdb_nhg_orphans_cleaned_total` | Unreferenced rustbgpd-tagged FDB nexthops removed by ownership-aware garbage collection. Sustained growth outside restart recovery indicates unstable group membership or cleanup churn. |
 | `evpn_fdb_nhg_drift_disabled_total` | Permanent dump failures that disabled FDB-NHG drift recovery for this daemon lifetime. Any increase means automatic repair is unavailable; use the accompanying error to correct kernel support, privilege, or netlink-message failures, then restart the daemon. |
-| `evpn_single_active_backup_active` | Single-active groups currently retargeted to a backup PE during the post-failover window |
+| `evpn_single_active_backup_active` | Distinct (VNI, ESI, Ethernet Tag) single-active groups currently retargeted to a backup PE during the post-failover window |
 
 For an instance with `duplicate_ip_detection.enabled = true`, investigate an
 increase in `evpn_duplicate_ip_threshold_exceeded_total` alongside the

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1324,7 +1324,7 @@ fn project_intent_tables(
             ),
         routes
             .iter()
-            .filter_map(|r| project_ead_per_evi_unfiltered(r, &local_vtep_ips)),
+            .filter_map(|r| project_ead_per_evi_unfiltered(r, &local_vtep_ips, instances)),
     );
 
     let projected: Vec<ProjectedEvpnRoute> = routes
@@ -1342,10 +1342,10 @@ fn project_intent_tables(
         .collect();
     let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
         .iter()
-        .filter_map(|r| project_ead_per_evi(r, &local_vtep_ips, &ead_per_es_modes))
+        .filter_map(|r| project_ead_per_evi(r, &local_vtep_ips, instances, &ead_per_es_modes))
         .collect();
 
-    // ADR-0083 slice 3 observability: the number of (ESI, EthernetTag)
+    // ADR-0083 slice 3 observability: the number of (VNI, ESI, EthernetTag)
     // groups currently in the post-failover backup window — i.e. with
     // at least one locally-relevant Type 2 kept by the swap arm of
     // the mass-withdraw gate. Drives the
@@ -1421,7 +1421,7 @@ fn project_intent_tables(
     }
 }
 
-/// ADR-0083 slice 3: returns the `(ESI, EthernetTag)` group key when
+/// ADR-0083 slice 3: returns the `(VNI, ESI, EthernetTag)` group key when
 /// `route` is a Type 2 in the post-failover swap window — its origin
 /// VTEP advertises NO EAD-per-ES for the segment (the RFC 7432 §8.2
 /// mass-withdraw condition that used to flush the MAC) but the
@@ -1438,6 +1438,7 @@ fn single_active_swap_window_key(
     )>,
     single_active_index: &rustbgpd_evpn::SingleActiveEligibleIndex,
 ) -> Option<(
+    rustbgpd_evpn::EvpnInstanceId,
     rustbgpd_wire::EthernetSegmentIdentifier,
     rustbgpd_wire::EthernetTagId,
 )> {
@@ -1449,9 +1450,10 @@ fn single_active_swap_window_key(
     {
         return None;
     }
+    let vni = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni()).ok()?;
     single_active_index
-        .backup_pe(macip.esi, macip.ethernet_tag, route.next_hop)
-        .map(|_| (macip.esi, macip.ethernet_tag))
+        .backup_pe(vni, macip.esi, macip.ethernet_tag, route.next_hop)
+        .map(|_| (vni, macip.esi, macip.ethernet_tag))
 }
 
 fn projected_route_is_quarantined(
@@ -1622,22 +1624,19 @@ fn ead_per_es_is_single_active(attrs: &[PathAttribute]) -> bool {
 fn project_ead_per_evi(
     route: &EvpnRibRoute,
     local_vtep_ips: &std::collections::BTreeSet<std::net::IpAddr>,
+    instances: &EvpnInstanceTable,
     ead_per_es_modes: &std::collections::BTreeMap<
         (std::net::IpAddr, rustbgpd_wire::EthernetSegmentIdentifier),
         bool,
     >,
 ) -> Option<ProjectedEvpnEadPerEvi> {
-    let EvpnRoute::EadPerEvi(ead) = &route.route else {
-        return None;
-    };
-    if local_vtep_ips.contains(&route.next_hop) {
-        return None;
-    }
+    let ead = project_ead_per_evi_unfiltered(route, local_vtep_ips, instances)?;
     let single_active = ead_per_es_modes.get(&(route.next_hop, ead.esi)).copied()?;
     if single_active {
         return None;
     }
     Some(ProjectedEvpnEadPerEvi {
+        vni: ead.vni,
         esi: ead.esi,
         ethernet_tag: ead.ethernet_tag,
         next_hop: route.next_hop,
@@ -1647,10 +1646,9 @@ fn project_ead_per_evi(
 /// Translate a Type 1 EAD-per-EVI [`EvpnRibRoute`] into the scoped
 /// resolver input used by ESI overlay-index Type 5 receive. The row is
 /// usable only when it is remote, its label names a configured local
-/// L2VNI, and a matching EAD-per-ES row supplied the ES redundancy
-/// mode. Both single-active and all-active rows are passed through so
-/// the Type 5 projection can import the former and fail closed on the
-/// latter with a precise drop reason.
+/// L2VNI with a matching Route Target and zero Ethernet Tag, and a matching
+/// EAD-per-ES row supplied the ES redundancy mode. Both single-active and
+/// all-active rows retain their mode for the Type 5 resolver.
 fn project_esi_overlay_ead_per_evi(
     route: &EvpnRibRoute,
     local_vtep_ips: &std::collections::BTreeSet<std::net::IpAddr>,
@@ -1660,14 +1658,8 @@ fn project_esi_overlay_ead_per_evi(
         rustbgpd_evpn::ip_vrf::EsiOverlayRedundancyMode,
     >,
 ) -> Option<rustbgpd_evpn::ip_vrf::ProjectedEsiOverlayEadPerEvi> {
-    let EvpnRoute::EadPerEvi(ead) = &route.route else {
-        return None;
-    };
-    if local_vtep_ips.contains(&route.next_hop) {
-        return None;
-    }
-    let l2vni = rustbgpd_evpn::EvpnInstanceId::new(ead.label.as_vni()).ok()?;
-    instances.get(l2vni)?;
+    let ead = project_ead_per_evi_unfiltered(route, local_vtep_ips, instances)?;
+    let l2vni = ead.vni;
     let mode = ead_per_es_modes.get(&(route.next_hop, ead.esi)).copied()?;
     Some(rustbgpd_evpn::ip_vrf::ProjectedEsiOverlayEadPerEvi {
         l2vni,
@@ -1684,10 +1676,12 @@ fn project_esi_overlay_ead_per_evi(
 /// the `SingleActiveEligibleIndex` build performs the
 /// "single-active EAD-per-ES AND EAD-per-EVI" join itself (decision
 /// 2's both-route-types rule). Self-originated rows are still
-/// filtered: we are never our own backup path.
+/// filtered: we are never our own backup path. All consumers require a
+/// configured VNI, matching Route Target, and zero Ethernet Tag.
 fn project_ead_per_evi_unfiltered(
     route: &EvpnRibRoute,
     local_vtep_ips: &std::collections::BTreeSet<std::net::IpAddr>,
+    instances: &EvpnInstanceTable,
 ) -> Option<rustbgpd_evpn::AliasEadPerEvi> {
     let EvpnRoute::EadPerEvi(ead) = &route.route else {
         return None;
@@ -1695,7 +1689,15 @@ fn project_ead_per_evi_unfiltered(
     if local_vtep_ips.contains(&route.next_hop) {
         return None;
     }
+    let vni = rustbgpd_evpn::EvpnInstanceId::new(ead.label.as_vni()).ok()?;
+    if !instances
+        .get(vni)?
+        .imports_evi(ead.label.as_vni(), ead.ethernet_tag, &route.attributes)
+    {
+        return None;
+    }
     Some(rustbgpd_evpn::AliasEadPerEvi {
+        vni,
         esi: ead.esi,
         ethernet_tag: ead.ethernet_tag,
         vtep_ip: route.next_hop,
@@ -2074,7 +2076,7 @@ mod tests {
         ethernet_tag: u32,
         next_hop: &str,
     ) -> EvpnRibRoute {
-        evpn_ead_per_evi_route_with_label(esi, ethernet_tag, ethernet_tag, next_hop)
+        evpn_ead_per_evi_route_with_label(esi, ethernet_tag, 100, next_hop)
     }
 
     fn evpn_ead_per_evi_route_with_label(
@@ -2093,7 +2095,13 @@ mod tests {
             next_hop: ipa(next_hop),
             link_local_next_hop: None,
             peer: ipa("10.0.0.99"),
-            attributes: Arc::new(vec![]),
+            attributes: Arc::new(vec![PathAttribute::ExtendedCommunities(vec![
+                RouteTarget::TwoOctetAs {
+                    asn: 65001,
+                    value: label,
+                }
+                .to_extended_community(),
+            ])]),
             received_at: std::time::Instant::now(),
             origin_type: rustbgpd_rib::route::RouteOrigin::Ebgp,
             peer_router_id: std::net::Ipv4Addr::new(10, 0, 0, 99),
@@ -2683,23 +2691,24 @@ mod tests {
     fn project_ead_per_evi_requires_all_active_ead_per_es_reachability() {
         let esi = EthernetSegmentIdentifier::new([8; 10]);
         let local_vteps = BTreeSet::new();
-        let ead = evpn_ead_per_evi_route(esi, 100, "10.0.0.2");
+        let instances = local_instance_table(100, None);
+        let ead = evpn_ead_per_evi_route(esi, 0, "10.0.0.2");
 
         let no_ead_per_es = BTreeMap::new();
         assert!(
-            project_ead_per_evi(&ead, &local_vteps, &no_ead_per_es).is_none(),
+            project_ead_per_evi(&ead, &local_vteps, &instances, &no_ead_per_es).is_none(),
             "EAD-per-EVI without EAD-per-ES reachability must not create aliasing input"
         );
 
         let all_active = BTreeMap::from([((ipa("10.0.0.2"), esi), false)]);
         assert!(
-            project_ead_per_evi(&ead, &local_vteps, &all_active).is_some(),
+            project_ead_per_evi(&ead, &local_vteps, &instances, &all_active).is_some(),
             "all-active EAD-per-ES reachability allows aliasing input"
         );
 
         let single_active = BTreeMap::from([((ipa("10.0.0.2"), esi), true)]);
         assert!(
-            project_ead_per_evi(&ead, &local_vteps, &single_active).is_none(),
+            project_ead_per_evi(&ead, &local_vteps, &instances, &single_active).is_none(),
             "single-active EAD-per-ES reachability must suppress all-active alias ECMP"
         );
     }
@@ -2711,7 +2720,7 @@ mod tests {
         let esi = EthernetSegmentIdentifier::new([8; 10]);
         let local_vteps = BTreeSet::new();
         let instances = local_instance_table(100, Some("br100"));
-        let ead = evpn_ead_per_evi_route_with_label(esi, 42, 100, "10.0.0.2");
+        let ead = evpn_ead_per_evi_route_with_label(esi, 0, 100, "10.0.0.2");
         let all_active = BTreeMap::from([((ipa("10.0.0.2"), esi), AllActive)]);
         let single_active = BTreeMap::from([((ipa("10.0.0.2"), esi), SingleActive)]);
 
@@ -2719,7 +2728,7 @@ mod tests {
             project_esi_overlay_ead_per_evi(&ead, &local_vteps, &instances, &all_active)
                 .expect("all-active still feeds the fail-closed Type 5 resolver");
         assert_eq!(all_active_projected.l2vni, vni(100));
-        assert_eq!(all_active_projected.ethernet_tag, EthernetTagId(42));
+        assert_eq!(all_active_projected.ethernet_tag, EthernetTagId(0));
         assert_eq!(all_active_projected.next_hop, ipa("10.0.0.2"));
         assert_eq!(all_active_projected.mode, AllActive);
 
@@ -2900,6 +2909,164 @@ mod tests {
             macip.esi = esi;
         }
         route
+    }
+
+    #[test]
+    fn ead_evi_scope_is_preserved_for_aliases_backups_and_swaps() {
+        let instances = local_instance_table_many(&[(100, None), (200, None)]);
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let valid = evpn_ead_per_evi_route(esi, 0, "10.0.0.3");
+        let foreign = evpn_ead_per_evi_route_with_label(esi, 0, 200, "10.0.0.3");
+        let mut wrong_rt = valid.clone();
+        wrong_rt.attributes = foreign.attributes.clone();
+        let mut missing_rt = valid.clone();
+        missing_rt.attributes = Arc::new(vec![]);
+        let unsupported_tag = evpn_ead_per_evi_route(esi, 42, "10.0.0.3");
+        for (name, candidate, eligible) in [
+            ("same EVI", valid, true),
+            ("other configured EVI", foreign, false),
+            ("wrong RT", wrong_rt, false),
+            ("missing RT", missing_rt, false),
+            ("unsupported tag", unsupported_tag, false),
+        ] {
+            for single_active in [false, true] {
+                for primary_reachable in [false, true] {
+                    let mut routes = vec![
+                        evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                        evpn_ead_per_es_route(esi, "10.0.0.3", single_active),
+                        candidate.clone(),
+                    ];
+                    if primary_reachable {
+                        routes.push(evpn_ead_per_es_route(esi, "10.0.0.2", single_active));
+                    }
+                    let tables = project_intent_tables(
+                        &routes,
+                        &instances,
+                        &IpVrfTable::new(),
+                        &BTreeSet::new(),
+                        &no_bias(),
+                    );
+                    let entry = tables.remote_macs.get(vni(100), mac(1));
+                    let swapped = !primary_reachable && single_active && eligible;
+                    assert_eq!(entry.is_some(), primary_reachable || swapped, "{name}");
+                    assert_eq!(
+                        tables.single_active_backup_active,
+                        usize::from(swapped),
+                        "{name}"
+                    );
+                    if let Some(entry) = entry {
+                        assert_eq!(
+                            entry.remote_vtep_ip,
+                            ipa(if swapped { "10.0.0.3" } else { "10.0.0.2" }),
+                            "{name}"
+                        );
+                        assert_eq!(
+                            entry.alias_vtep_ips,
+                            if !single_active && eligible {
+                                vec![ipa("10.0.0.3")]
+                            } else {
+                                vec![]
+                            },
+                            "{name}"
+                        );
+                        assert_eq!(
+                            entry.single_active_backup_vtep_ip,
+                            (single_active && primary_reachable && eligible)
+                                .then(|| ipa("10.0.0.3")),
+                            "{name}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ead_evi_scope_counts_each_vni_backup_window() {
+        let instances = local_instance_table_many(&[(100, None), (200, None)]);
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let routes = vec![
+            evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+            evpn_macip_route_with_esi(200, 1, "10.0.0.2", esi),
+            evpn_ead_per_es_route(esi, "10.0.0.3", true),
+            evpn_ead_per_es_route(esi, "10.0.0.4", true),
+            evpn_ead_per_evi_route_with_label(esi, 0, 100, "10.0.0.3"),
+            evpn_ead_per_evi_route_with_label(esi, 0, 200, "10.0.0.4"),
+        ];
+        let tables = project_intent_tables(
+            &routes,
+            &instances,
+            &IpVrfTable::new(),
+            &BTreeSet::new(),
+            &no_bias(),
+        );
+        assert_eq!(tables.single_active_backup_active, 2);
+        for (id, peer) in [(100, "10.0.0.3"), (200, "10.0.0.4")] {
+            let entry = tables.remote_macs.get(vni(id), mac(1)).unwrap();
+            assert_eq!(entry.remote_vtep_ip, ipa(peer));
+            assert_eq!(entry.single_active_backup_vtep_ip, None);
+        }
+    }
+
+    #[test]
+    fn ead_evi_scope_gates_esi_overlay_type5_resolution() {
+        let instances = local_instance_table_many(&[(100, None), (200, None)]);
+        let mut ip_vrfs = ip_vrf_table_one("blue", 5000, 5000);
+        ip_vrfs.mark_referenced_by_l2vni("blue".to_string(), vni(100));
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let valid = evpn_ead_per_evi_route(esi, 0, "10.0.0.3");
+        let foreign = evpn_ead_per_evi_route_with_label(esi, 0, 200, "10.0.0.3");
+        let mut wrong_rt = valid.clone();
+        wrong_rt.attributes = foreign.attributes.clone();
+        let mut missing_rt = valid.clone();
+        missing_rt.attributes = Arc::new(vec![]);
+        for (name, ead, tag, accepted) in [
+            ("same EVI", valid, 0, true),
+            ("other configured EVI", foreign, 0, false),
+            ("wrong RT", wrong_rt, 0, false),
+            ("missing RT", missing_rt, 0, false),
+            (
+                "unsupported tag",
+                evpn_ead_per_evi_route(esi, 42, "10.0.0.3"),
+                42,
+                false,
+            ),
+        ] {
+            for single_active in [false, true] {
+                let routes = vec![
+                    ead.clone(),
+                    evpn_ead_per_es_route(esi, "10.0.0.3", single_active),
+                    type5_with_esi_and_router_mac(
+                        "10.58.0.0/24",
+                        "10.0.0.9",
+                        5000,
+                        esi,
+                        tag,
+                        [2; 6],
+                    ),
+                ];
+                let tables = project_intent_tables(
+                    &routes,
+                    &instances,
+                    &ip_vrfs,
+                    &BTreeSet::new(),
+                    &no_bias(),
+                );
+                assert_eq!(
+                    tables
+                        .remote_ip_prefixes
+                        .for_vrf(IpVrfId::new(5000).unwrap())
+                        .count(),
+                    usize::from(accepted),
+                    "{name}"
+                );
+                assert_eq!(
+                    tables.remote_ip_prefixes.drops().is_empty(),
+                    accepted,
+                    "{name}"
+                );
+            }
+        }
     }
 
     // ─── ADR-0083 slice 2: single-active projection wiring ───
@@ -3422,13 +3589,13 @@ mod tests {
             if let Some(RibUpdate::QueryEvpnRoutes { reply, .. }) = rib_rx.recv().await {
                 let routes = vec![
                     evpn_ead_per_es_route(esi, "10.0.0.2", true),
-                    evpn_ead_per_evi_route_with_label(esi, 42, 100, "10.0.0.2"),
+                    evpn_ead_per_evi_route_with_label(esi, 0, 100, "10.0.0.2"),
                     type5_with_esi_and_router_mac(
                         "10.58.0.0/24",
                         "10.0.0.9",
                         5000,
                         esi,
-                        42,
+                        0,
                         overlay_mac,
                     ),
                 ];


### PR DESCRIPTION
Keep EAD-per-EVI alias and single-active backup selection within the local VNI. Previously, an EAD for VNI 200 could supply a forwarding path to VNI 100 sharing the same ESI and Ethernet Tag; a missing or mismatched Route Target could also supply Type 5 ESI overlay recursion.

Carry VNI through both forwarding indexes and require matching local VNI/Route Target plus Ethernet Tag zero before consuming EAD routes. Type 2 and EAD admission share the existing import predicate. Count backup windows per VNI and document the resulting upgrade behavior. Global EVPN RIB retention, reflection, export, and EAD-per-ES reachability semantics remain unchanged.

Validation: before/after regressions cover cross-VNI aliases and backups, mass-withdraw swaps, ESI overlay recursion, and per-VNI backup-window counting. Focused Type 2 and EAD checks and `just gate` passed, including strict workspace/all-target Clippy, workspace tests, and rustdoc. The subsequent main integration changed CLI examples and contribution guidance; the EVPN and telemetry Rust files remained byte-identical. Normal commit and push hooks passed on the final head.
