### PR TITLE
test(evpn): prove same-segment sequence adoption on the wire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
             tests/interop/scripts/test-m1-frr.sh
           bash tests/interop/scripts/test-test-operator-auth-helper.sh
           bash tests/interop/scripts/test-test-vtep-route-oracles.sh
+          python3 tests/interop/scripts/test_evpn_peer_sync_oracle.py
       - run: python3 scripts/check-v1-stable-surface.py
       - run: python3 scripts/reflow-release-notes.py --selftest
       - run: cargo clippy --locked --workspace --all-targets -- -D warnings

--- a/tests/interop/peer-sync/README.md
+++ b/tests/interop/peer-sync/README.md
@@ -21,6 +21,11 @@ from a MAC-only peer route, and children synchronized from a MAC/IP peer route.
 A peer-only MAC shares another local host's IPs but must never acquire local
 ownership. Wrong-RT and nonzero-tag controls must retain local sequence zero.
 Removing one local host and replaying its remote route must not resurrect it.
+The peer also withdraws its routes while keeping BGP established. A successful
+received-route positive control and empty complete page establish that boundary.
+After two originator polls, new IPv4/IPv6 children must inherit the retained MAC
+sequence 9; removing the last IP from an IP-first host must create MAC-only at
+sequence 9. Wire history proves that host had no earlier MAC-only advertisement.
 
 All four duplicate-MAC/IP counter families are summed across every label set.
 A missing lazy counter is recorded explicitly as `present: false`, `series: 0`,

--- a/tests/interop/peer-sync/README.md
+++ b/tests/interop/peer-sync/README.md
@@ -1,0 +1,78 @@
+# Same-ESI sequence adoption wire proof
+
+This isolated lab checks exact local Type-2 sequence adoption with a controlled
+BGP source and independent wire receiver. It is not interoperability evidence
+between two independent EVPN implementations, a performance benchmark, or a churn
+soak.
+
+The DUT uses the existing Gate 8b bridge, VXLAN, and CE veth setup. Its peer sends
+same-ESI, matching-RT, Ethernet-tag-zero routes at sequence 3 before local hosts
+are learned, then raises the sequence directly to 9. The receiver checks the
+DUT's own RD, ESI, MAC, IP, tag, VNI, next hop, route target, and MAC Mobility
+community. It requires fresh exports at exactly 3 and 9, rejects transient 4/10
+exports, and checks that equal/lower replays produce no local Type-2 changes over
+two originator poll periods. The topology fixes the encapsulation to VXLAN. In
+accordance with RFC 8365 sections 5.1.3 and 6, absent Encapsulation communities use
+that local profile; a present community must identify VXLAN. This proof does not
+validate automatic encapsulation discovery between different implementations.
+
+The cases include a MAC-only local host, local IPv4 and IPv6 children synchronized
+from a MAC-only peer route, and children synchronized from a MAC/IP peer route.
+A peer-only MAC shares another local host's IPs but must never acquire local
+ownership. Wrong-RT and nonzero-tag controls must retain local sequence zero.
+Removing one local host and replaying its remote route must not resurrect it.
+
+All four duplicate-MAC/IP counter families are summed across every label set.
+A missing lazy counter is recorded explicitly as `present: false`, `series: 0`,
+`total: 0`; an unsuccessful scrape, malformed value, or missing process sample
+fails. A changed process-start sample also fails. Duplicate-IP diagnostics are
+enabled; duplicate-MAC detection retains its default detect-only action.
+
+Run from a clean checkout containing the runtime behavior being tested. Build the
+standard development image with an exact source label, and prepare the existing
+Python-equipped raw-peer image if it is not already available:
+
+```sh
+proof_revision=$(git rev-parse HEAD)
+docker build --target dev \
+  --label "org.opencontainers.image.revision=$proof_revision" \
+  -t rustbgpd:peer-sync-proof .
+docker build -f tests/interop/Dockerfile.bmpsink -t bmpsink:m102 tests/interop
+python3 tests/interop/scripts/run-evpn-peer-sync-proof.py \
+  --image rustbgpd:peer-sync-proof --source-revision "$proof_revision" \
+  --raw-image bmpsink:m102 --output /tmp/evpn-peer-sync-proof
+```
+
+The output directory must not exist. The runner rejects a mismatched DUT source
+label, resolves both images to immutable local IDs, records image IDs/digests and
+source/harness revisions, and uses `--pull never`. A build label is a local build
+receipt, not cryptographic source attestation. Keep the build log with the run.
+When using a separately built DUT image, pass its actual source revision rather
+than the harness checkout revision.
+
+Docker Compose and Linux bridge/VXLAN support are required. The DUT is privileged
+inside its owned container, with no host network namespace or host socket mount.
+The runner rejects an existing Docker network overlapping `10.99.0.0/24`, starts
+a unique Compose project, and applies neighbor-lifetime settings only inside the
+DUT container. Allow about two minutes for the single attempt. Run it separately
+from tests that require an idle host or no running daemon.
+
+Every command's output and exit status, source UPDATE bytes, received BGP message
+bodies, decoded wire events, raw metric scrapes, daemon logs, and the final result
+are retained in the receipt directory. A fresh run ID, command acknowledgements,
+and peer heartbeat prevent a previous capture from satisfying a new phase. The
+runner always attempts project teardown twice and checks for remaining owned
+containers/networks; it never removes another project's resources. If teardown
+fails, the result fails and names the unique project for manual cleanup. Preserve
+failed setup receipts as well as successful runs.
+
+Offline oracle and orchestration-contract checks require only Python:
+
+```sh
+python3 tests/interop/scripts/test_evpn_peer_sync_oracle.py
+```
+
+A fresh Gate 8b churn run is separate evidence. Record its actual duration, source,
+images, restart epochs, raw metrics, and terminal recovery. A short FDB churn run
+does not establish long-term memory stability or MAC/IP churn behavior. Dated soak
+receipts and their missing metric samples remain unchanged.

--- a/tests/interop/peer-sync/compose.yml
+++ b/tests/interop/peer-sync/compose.yml
@@ -1,0 +1,27 @@
+# Images are resolved to immutable local IDs by the runner before deployment.
+services:
+  dut:
+    image: ${PEER_SYNC_DUT_IMAGE:?required}
+    privileged: true
+    entrypoint: ["sleep", "infinity"]
+    volumes:
+      - ./rustbgpd.toml:/etc/rustbgpd/config.toml:ro
+      - ../../soak/scripts/start-rustbgpd-soak-gate8b.sh:/start.sh:ro
+    networks:
+      proof:
+        ipv4_address: 10.99.0.1
+  peer:
+    image: ${PEER_SYNC_RAW_IMAGE:?required}
+    entrypoint: ["python3", "/scripts/evpn_peer_sync_peer.py", "/receipt", "${PEER_SYNC_RUN_ID:?required}"]
+    volumes:
+      - ../scripts:/scripts:ro
+      - ${PEER_SYNC_RECEIPT:?required}:/receipt
+    networks:
+      proof:
+        ipv4_address: 10.99.0.2
+networks:
+  proof:
+    ipam:
+      config:
+        - subnet: 10.99.0.0/24
+          gateway: 10.99.0.254

--- a/tests/interop/peer-sync/rustbgpd.toml
+++ b/tests/interop/peer-sync/rustbgpd.toml
@@ -1,0 +1,33 @@
+apply_bum_enforcement = true
+
+[global]
+asn = 65000
+router_id = "10.99.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+prometheus_addr = "0.0.0.0:9179"
+
+[[evpn_instances]]
+vni = 100
+rd = "10.99.0.1:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.99.0.1"
+bridge = "br100"
+advertise_svi_mac = false
+duplicate_ip_detection = { enabled = true, window_seconds = 180, threshold = 2 }
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+df_preference = 32768
+df_algorithm = "default-modulo"
+originator_ip = "10.99.0.1"
+
+[[neighbors]]
+address = "10.99.0.2"
+remote_asn = 65000
+description = "controlled EVPN wire peer"
+hold_time = 30
+families = ["l2vpn_evpn"]

--- a/tests/interop/scripts/evpn_peer_sync_oracle.py
+++ b/tests/interop/scripts/evpn_peer_sync_oracle.py
@@ -229,28 +229,40 @@ def send_announcement(connection, routes: list[Route], sequence: int, *, next_ho
     send_message(connection, 2, announcement(routes, sequence, next_hop=next_hop))
 
 
+def _metric_values(scrape: str, family: str) -> list[float]:
+    boundary = re.compile(re.escape(family) + r"(?=$|[\s{])")
+    pattern = re.compile(re.escape(family) + r"(?:\{[^}]*\})?\s+(\S+)(?:\s+[0-9]+)?$")
+    values = []
+    for line in scrape.splitlines():
+        if not boundary.match(line):
+            continue
+        match = pattern.fullmatch(line)
+        if not match:
+            raise ValueError(f"malformed sample for {family}")
+        value = float(match[1])
+        if not math.isfinite(value) or value < 0:
+            raise ValueError(f"invalid metric value for {family}")
+        values.append(value)
+    return values
+
+
+def process_start_time(scrape: str) -> float:
+    """Return one positive finite process identity, regardless of sample labels."""
+    values = _metric_values(scrape, "process_start_time_seconds")
+    if len(values) != 1 or values[0] <= 0:
+        raise ValueError("missing or ambiguous process identity in metrics scrape")
+    return values[0]
+
+
 def duplicate_totals(scrape: str) -> dict[str, dict]:
     """Aggregate all label sets. Missing lazy series is explicit, never NaN.
 
     Caller must obtain a complete successful scrape. A required process sample
     rejects empty/error bodies; HTTP failures must propagate before this call.
     """
+    process_start_time(scrape)
     result = {}
-    for family in ("process_start_time_seconds", *COUNTERS):
-        values = []
-        pattern = re.compile(r"^" + re.escape(family) + r"(?:\{[^}]*\})?\s+(\S+)(?:\s+[0-9]+)?$")
-        for line in scrape.splitlines():
-            match = pattern.fullmatch(line)
-            if match:
-                value = float(match[1])
-                if not math.isfinite(value) or value < 0:
-                    raise ValueError(f"invalid counter value for {family}")
-                values.append(value)
-            elif line.startswith((family + " ", family + "{")):
-                raise ValueError(f"malformed sample for {family}")
-        if family == "process_start_time_seconds":
-            if len(values) != 1 or values[0] <= 0:
-                raise ValueError("missing or ambiguous process identity in metrics scrape")
-        else:
-            result[family] = {"present": bool(values), "series": len(values), "total": sum(values)}
+    for family in COUNTERS:
+        values = _metric_values(scrape, family)
+        result[family] = {"present": bool(values), "series": len(values), "total": sum(values)}
     return result

--- a/tests/interop/scripts/evpn_peer_sync_oracle.py
+++ b/tests/interop/scripts/evpn_peer_sync_oracle.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Bounded Type-2 wire helpers for the controlled same-ESI peer proof.
+
+Uses the existing independent BGP framing/attribute reader. This is a test
+peer/oracle, not a second EVPN implementation or a general EVPN decoder.
+RFC 7432 sections 7.2/7.7 define Type 2 and MAC Mobility; RFC 8365 section
+5.1.3 puts the unshifted 24-bit VNI in the label field for VXLAN.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import math
+import re
+import struct
+from dataclasses import asdict, dataclass
+
+from m94_as4_oracle import BgpReader, parse_update, send_message
+
+ESI = bytes.fromhex("00000000000000000001")
+RT = bytes.fromhex("0002fde800000064")
+VXLAN = bytes.fromhex("030c000000000008")
+FAMILY = bytes.fromhex("001946")  # AFI 25, SAFI 70
+COUNTERS = (
+    "evpn_duplicate_mac_moves_total",
+    "evpn_duplicate_mac_threshold_exceeded_total",
+    "evpn_duplicate_ip_moves_total",
+    "evpn_duplicate_ip_threshold_exceeded_total",
+)
+
+
+@dataclass(frozen=True)
+class Route:
+    rd: str
+    mac: str
+    ip: str = ""
+    tag: int = 0
+    esi: str = ESI.hex(":")
+    vni: int = 100
+
+    def key(self) -> tuple[str, int, str, str]:
+        return self.rd, self.tag, self.mac, self.ip
+
+
+def type2(route: Route) -> bytes:
+    """Encode this lab's IPv4-admin RD and one-label VXLAN Type 2."""
+    administrator, assigned = route.rd.split(":")
+    rd = b"\x00\x01" + ipaddress.IPv4Address(administrator).packed
+    rd += struct.pack("!H", int(assigned))
+    mac = bytes.fromhex(route.mac.replace(":", ""))
+    esi = bytes.fromhex(route.esi.replace(":", ""))
+    if len(mac) != 6 or len(esi) != 10 or not 1 <= route.vni <= 0xFFFFFF:
+        raise ValueError("invalid MAC, ESI, or VNI")
+    ip = ipaddress.ip_address(route.ip).packed if route.ip else b""
+    body = rd + esi + struct.pack("!I", route.tag) + b"\x30" + mac
+    body += bytes([len(ip) * 8]) + ip + route.vni.to_bytes(3, "big")
+    return bytes([2, len(body)]) + body
+
+
+def attribute(code: int, value: bytes, flags: int = 0x80) -> bytes:
+    if len(value) > 255:
+        return bytes([flags | 0x10, code]) + struct.pack("!H", len(value)) + value
+    return bytes([flags, code, len(value)]) + value
+
+
+def announcement(routes: list[Route], sequence: int, *, next_hop: str,
+                 route_target: bytes = RT) -> bytes:
+    """Return an UPDATE body; only the source chooses the sequence."""
+    if len(route_target) != 8:
+        raise ValueError("route target must be eight bytes")
+    mobility = b"\x06\x00\x00\x00" + struct.pack("!I", sequence)
+    reach = FAMILY + b"\x04" + ipaddress.IPv4Address(next_hop).packed + b"\x00"
+    reach += b"".join(type2(route) for route in routes)
+    attrs = attribute(1, b"\x00", 0x40) + attribute(2, b"", 0x40)
+    attrs += attribute(16, route_target + VXLAN + mobility, 0xC0)
+    attrs += attribute(14, reach)
+    if 23 + len(attrs) > 4096:
+        raise ValueError("test UPDATE exceeds ordinary BGP frame size")
+    return b"\x00\x00" + struct.pack("!H", len(attrs)) + attrs
+
+
+def withdrawal(routes: list[Route]) -> bytes:
+    attrs = attribute(15, FAMILY + b"".join(type2(route) for route in routes))
+    if 23 + len(attrs) > 4096:
+        raise ValueError("test UPDATE exceeds ordinary BGP frame size")
+    return b"\x00\x00" + struct.pack("!H", len(attrs)) + attrs
+
+
+def decode_type2s(nlri: bytes) -> list[Route]:
+    """Frame every EVPN NLRI; decode only the proof's one-label Type 2s."""
+    routes = []
+    while nlri:
+        if len(nlri) < 2 or len(nlri) < 2 + nlri[1]:
+            raise ValueError("truncated EVPN NLRI")
+        kind, length = nlri[:2]
+        body, nlri = nlri[2:2 + length], nlri[2 + length:]
+        if kind != 2:
+            continue
+        if len(body) < 33 or body[22] != 48 or body[29] not in (0, 32, 128):
+            raise ValueError("invalid Type-2 MAC/IP lengths")
+        ip_length = body[29] // 8
+        if len(body) != 33 + ip_length or body[:2] != b"\x00\x01":
+            raise ValueError("unexpected Type-2 length or RD encoding in proof")
+        rd = f"{ipaddress.IPv4Address(body[2:6])}:{int.from_bytes(body[6:8], 'big')}"
+        ip = str(ipaddress.ip_address(body[30:30 + ip_length])) if ip_length else ""
+        routes.append(Route(rd, body[23:29].hex(":"), ip,
+                            int.from_bytes(body[18:22], "big"), body[8:18].hex(":"),
+                            int.from_bytes(body[-3:], "big")))
+    return routes
+
+
+class Oracle:
+    """Track received wire state, retaining exact announcements for replay proof."""
+
+    def __init__(self) -> None:
+        self.live: dict[tuple[str, int, str, str], dict] = {}
+        self.events: list[dict] = []
+
+    def apply(self, body: bytes) -> None:
+        update = parse_update(body)
+        if update.nlri or update.withdrawn:
+            raise ValueError("unexpected classic IPv4 NLRI on EVPN test session")
+        changes = []
+        for code in (15, 14):
+            values = update.attrs.get(code, [])
+            if len(values) > 1:
+                raise ValueError("duplicate MP attribute")
+            if not values:
+                continue
+            value = values[0]
+            if value[:3] != FAMILY:
+                raise ValueError("unexpected MP family")
+            next_hop = ""
+            if code == 14:
+                if len(value) < 9 or value[3] != 4 or value[8] != 0:
+                    raise ValueError("invalid test MP_REACH next hop/reserved byte")
+                next_hop = str(ipaddress.IPv4Address(value[4:8]))
+                value = value[9:]
+            else:
+                value = value[3:]
+            for route in decode_type2s(value):
+                changes.append((code, route, next_hop))
+        # Validate the whole UPDATE before publishing any state from it.
+        communities = update.attrs.get(16, [])
+        if len(communities) > 1 or any(len(value) % 8 for value in communities):
+            raise ValueError("malformed extended communities")
+        ecs = [value[i:i + 8] for value in communities for i in range(0, len(value), 8)]
+        mobility = [ec for ec in ecs if ec[:2] == b"\x06\x00"]
+        if len(mobility) > 1:
+            raise ValueError("ambiguous duplicate MAC Mobility community")
+        sequence = int.from_bytes(mobility[0][4:], "big") if mobility else 0
+        sticky = bool(mobility and mobility[0][2] & 1)
+        for code, route, next_hop in changes:
+            event = {"action": "announce" if code == 14 else "withdraw", **asdict(route)}
+            if code == 14:
+                event.update(sequence=sequence, sticky=sticky, next_hop=next_hop,
+                             communities=[ec.hex() for ec in ecs])
+                self.live[route.key()] = event
+            else:
+                self.live.pop(route.key(), None)
+            self.events.append(event)
+
+    def expect(self, routes: list[Route], sequence: int, *, next_hop: str) -> None:
+        for route in routes:
+            row = self.live.get(route.key())
+            if row is None or any(row[name] != value for name, value in asdict(route).items()):
+                raise AssertionError(f"missing or mismatched route: {route}")
+            if (row["sequence"], row["sticky"], row["next_hop"]) != (sequence, False, next_hop):
+                raise AssertionError(f"wrong mobility/next hop: {row}")
+            mobility = [ec for ec in row["communities"] if ec.startswith("0600")]
+            if mobility and mobility != ["06000000" + sequence.to_bytes(4, "big").hex()]:
+                raise AssertionError(f"noncanonical MAC Mobility community: {row}")
+            if RT.hex() not in row["communities"]:
+                raise AssertionError(f"missing required RT community: {row}")
+            # RFC 8365 sections 5.1.3/6 permit locally configured encapsulation
+            # when this EC is absent. This proof fixes that profile to VXLAN.
+            encapsulations = [ec for ec in row["communities"] if ec.startswith("030c")]
+            if encapsulations and encapsulations != [VXLAN.hex()]:
+                raise AssertionError(f"unexpected encapsulation for fixed VXLAN profile: {row}")
+
+    def expect_owned_keys(self, routes: list[Route], *, rd: str) -> None:
+        actual = {key for key in self.live if key[0] == rd}
+        if actual != {route.key() for route in routes}:
+            raise AssertionError(f"unexpected set of locally owned Type-2 keys: {actual}")
+
+    def expect_absent(self, *, rd: str, mac: str) -> None:
+        if any(row["rd"] == rd and row["mac"] == mac for row in self.live.values()):
+            raise AssertionError(f"unexpected local ownership: {rd}/{mac}")
+
+    def expect_transition(self, routes: list[Route], sequence: int, *, next_hop: str,
+                          after: int) -> None:
+        """Require fresh correct announcements, including intermediate wire states."""
+        self.expect(routes, sequence, next_hop=next_hop)
+        if not 0 <= after <= len(self.events):
+            raise AssertionError("invalid event checkpoint")
+        expected = {route.key(): route for route in routes}
+        seen = set()
+        for row in self.events[after:]:
+            key = row["rd"], row["tag"], row["mac"], row["ip"]
+            if key in expected and row["action"] == "announce":
+                check = Oracle()
+                check.live[key] = row
+                check.expect([expected[key]], sequence, next_hop=next_hop)
+                seen.add(key)
+        if seen != expected.keys():
+            raise AssertionError("missing fresh announcement after phase checkpoint")
+
+    def expect_quiet(self, *, after: int, rd: str) -> None:
+        if not 0 <= after <= len(self.events):
+            raise AssertionError("invalid event checkpoint")
+        if any(row["rd"] == rd for row in self.events[after:]):
+            raise AssertionError("unexpected local route change during replay")
+
+    def expect_never_owned(self, *, rd: str, mac: str) -> None:
+        self.expect_absent(rd=rd, mac=mac)
+        if any(row["rd"] == rd and row["mac"] == mac and row["action"] == "announce"
+               for row in self.events):
+            raise AssertionError("transient peer-only local ownership")
+
+    def read(self, reader: BgpReader) -> None:
+        kind, body = reader.read_message()
+        if kind == 2:
+            self.apply(body)
+        elif kind != 4:
+            raise ValueError(f"unexpected established BGP message type {kind}")
+
+
+def send_announcement(connection, routes: list[Route], sequence: int, *, next_hop: str) -> None:
+    send_message(connection, 2, announcement(routes, sequence, next_hop=next_hop))
+
+
+def duplicate_totals(scrape: str) -> dict[str, dict]:
+    """Aggregate all label sets. Missing lazy series is explicit, never NaN.
+
+    Caller must obtain a complete successful scrape. A required process sample
+    rejects empty/error bodies; HTTP failures must propagate before this call.
+    """
+    result = {}
+    for family in ("process_start_time_seconds", *COUNTERS):
+        values = []
+        pattern = re.compile(r"^" + re.escape(family) + r"(?:\{[^}]*\})?\s+(\S+)(?:\s+[0-9]+)?$")
+        for line in scrape.splitlines():
+            match = pattern.fullmatch(line)
+            if match:
+                value = float(match[1])
+                if not math.isfinite(value) or value < 0:
+                    raise ValueError(f"invalid counter value for {family}")
+                values.append(value)
+            elif line.startswith((family + " ", family + "{")):
+                raise ValueError(f"malformed sample for {family}")
+        if family == "process_start_time_seconds":
+            if len(values) != 1 or values[0] <= 0:
+                raise ValueError("missing or ambiguous process identity in metrics scrape")
+        else:
+            result[family] = {"present": bool(values), "series": len(values), "total": sum(values)}
+    return result

--- a/tests/interop/scripts/evpn_peer_sync_peer.py
+++ b/tests/interop/scripts/evpn_peer_sync_peer.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Controlled EVPN source and independent wire receiver for one bounded proof."""
+
+import argparse
+import ipaddress
+import json
+import socket
+import struct
+import time
+from pathlib import Path
+
+from evpn_peer_sync_oracle import FAMILY, Oracle, Route, announcement
+from m94_as4_oracle import BgpReader, parse_open, send_message, write_receipt
+
+DUT = "10.99.0.1"
+SOURCE = "10.99.0.2"
+DUT_RD = DUT + ":100"
+SOURCE_RD = SOURCE + ":100"
+MACS = {name: "02:aa:bb:cc:dd:" + suffix for name, suffix in
+        zip("abcdef", ("11", "22", "33", "44", "55", "66"), strict=True)}
+IPS = {"b": ("192.0.2.22", "2001:db8::22"), "c": ("192.0.2.33", "2001:db8::33")}
+LOCAL = [Route(DUT_RD, MACS["a"])] + [
+    Route(DUT_RD, MACS[name], ip) for name in ("b", "c") for ip in IPS[name]]
+CONTROLS = [Route(DUT_RD, MACS[name]) for name in ("e", "f")]
+SOURCES = [Route(SOURCE_RD, MACS["a"]), Route(SOURCE_RD, MACS["b"]),
+           Route(SOURCE_RD, MACS["c"], IPS["c"][0]),
+           # Peer-only D shares B's IPs: it must not become a local IP owner.
+           *(Route(SOURCE_RD, MACS["d"], ip) for ip in IPS["b"]),
+           Route(SOURCE_RD, MACS["f"], tag=1)]
+
+
+def open_body() -> bytes:
+    caps = b"\x01\x04\x00\x19\x00\x46\x41\x04" + struct.pack("!I", 65000)
+    optional = bytes([2, len(caps)]) + caps
+    return struct.pack("!BHH4sB", 4, 65000, 30, ipaddress.IPv4Address(SOURCE).packed,
+                       len(optional)) + optional
+
+
+def validate_open(body: bytes) -> None:
+    parsed = parse_open(body)
+    if (parsed["my_as"], parsed["router_id"], parsed["hold_time"],
+            parsed["advertised_as4"]) != (65000, DUT, 30, True):
+        raise ValueError(f"unexpected DUT OPEN: {parsed}")
+    if len(body) != 10 + body[9]:
+        raise ValueError("trailing OPEN bytes")
+    optional, found = body[10:], False
+    while optional:
+        if len(optional) < 2 or len(optional) < 2 + optional[1]:
+            raise ValueError("truncated OPEN parameter")
+        kind, size = optional[:2]
+        value, optional = optional[2:2 + size], optional[2 + size:]
+        if kind != 2:
+            continue
+        while value:
+            if len(value) < 2 or len(value) < 2 + value[1]:
+                raise ValueError("truncated OPEN capability")
+            code, size = value[:2]
+            capability, value = value[2:2 + size], value[2 + size:]
+            found |= code == 1 and capability == FAMILY[:2] + b"\0" + FAMILY[2:]
+    if not found:
+        raise ValueError("DUT did not negotiate EVPN")
+
+
+def serve(directory: Path, run_id: str) -> None:
+    receipt = {"run_id": run_id, "established": False, "ack": 0, "checkpoint": 0,
+               "events": [], "live": [], "sent": [], "received": []}
+    path = str(directory / "peer.json")
+    try:
+        with socket.socket() as listener:
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listener.bind((SOURCE, 179))
+            listener.listen(1)
+            listener.settimeout(45)
+            connection, address = listener.accept()
+            with connection:
+                if address[0] != DUT:
+                    raise ValueError(f"unexpected source: {address}")
+                connection.settimeout(10)
+                reader, oracle = BgpReader(connection), Oracle()
+                send_message(connection, 1, open_body())
+                kind, body = reader.read_message()
+                if kind != 1:
+                    raise ValueError("expected OPEN")
+                validate_open(body)
+                send_message(connection, 4)
+                if reader.read_message() != (4, b""):
+                    raise ValueError("expected initial KEEPALIVE")
+                receipt["established"] = True
+                connection.settimeout(0.2)
+                deadline, last_send, last_receive = time.monotonic() + 240, time.monotonic(), time.monotonic()
+                while time.monotonic() < deadline:
+                    command_path = directory / "command.json"
+                    if command_path.exists():
+                        command = json.loads(command_path.read_text())
+                        if command["run_id"] != run_id:
+                            raise ValueError("command belongs to another run")
+                        if command["id"] > receipt["ack"]:
+                            if command["id"] != receipt["ack"] + 1:
+                                raise ValueError("nonsequential command")
+                            receipt["checkpoint"] = len(oracle.events)
+                            if command["sequence"] not in (3, 9):
+                                raise ValueError("unsupported proof sequence")
+                            for routes, rt in ((SOURCES, bytes.fromhex("0002fde800000064")),
+                                               ([Route(SOURCE_RD, MACS["e"])],
+                                                bytes.fromhex("0002fde8000000c8"))):
+                                update = announcement(routes, command["sequence"], next_hop=SOURCE,
+                                                      route_target=rt)
+                                send_message(connection, 2, update)
+                                receipt["sent"].append({"command": command["id"], "body": update.hex()})
+                            receipt["ack"] = command["id"]
+                    try:
+                        kind, body = reader.read_message()
+                        receipt["received"].append({"type": kind, "body": body.hex()})
+                        if kind == 2:
+                            oracle.apply(body)
+                        elif (kind, body) != (4, b""):
+                            raise ValueError(f"unexpected established BGP message: {kind}")
+                        last_receive = time.monotonic()
+                    except socket.timeout:
+                        pass
+                    if time.monotonic() - last_receive > 30:
+                        raise TimeoutError("DUT hold timer expired")
+                    if time.monotonic() - last_send > 10:
+                        send_message(connection, 4)
+                        last_send = time.monotonic()
+                    receipt.update(events=oracle.events, live=list(oracle.live.values()),
+                                   heartbeat=time.time())
+                    write_receipt(path, receipt)
+                raise TimeoutError("proof exceeded bounded peer lifetime")
+    except Exception as error:
+        receipt.update(established=False, error=str(error), heartbeat=time.time())
+        write_receipt(path, receipt)
+        raise
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path)
+    parser.add_argument("run_id")
+    args = parser.parse_args()
+    serve(args.directory, args.run_id)

--- a/tests/interop/scripts/evpn_peer_sync_peer.py
+++ b/tests/interop/scripts/evpn_peer_sync_peer.py
@@ -9,7 +9,7 @@ import struct
 import time
 from pathlib import Path
 
-from evpn_peer_sync_oracle import FAMILY, Oracle, Route, announcement
+from evpn_peer_sync_oracle import FAMILY, Oracle, Route, announcement, withdrawal
 from m94_as4_oracle import BgpReader, parse_open, send_message, write_receipt
 
 DUT = "10.99.0.1"
@@ -27,6 +27,18 @@ SOURCES = [Route(SOURCE_RD, MACS["a"]), Route(SOURCE_RD, MACS["b"]),
            # Peer-only D shares B's IPs: it must not become a local IP owner.
            *(Route(SOURCE_RD, MACS["d"], ip) for ip in IPS["b"]),
            Route(SOURCE_RD, MACS["f"], tag=1)]
+
+
+def command_updates(sequence: int | None) -> list[bytes]:
+    """The fixed proof supports two announcement values and a complete withdrawal."""
+    wrong_rt = [Route(SOURCE_RD, MACS["e"])]
+    if sequence is None:
+        return [withdrawal(SOURCES + wrong_rt)]
+    if sequence not in (3, 9):
+        raise ValueError("unsupported proof sequence")
+    return [announcement(routes, sequence, next_hop=SOURCE, route_target=rt)
+            for routes, rt in ((SOURCES, bytes.fromhex("0002fde800000064")),
+                               (wrong_rt, bytes.fromhex("0002fde8000000c8")))]
 
 
 def open_body() -> bytes:
@@ -98,13 +110,7 @@ def serve(directory: Path, run_id: str) -> None:
                             if command["id"] != receipt["ack"] + 1:
                                 raise ValueError("nonsequential command")
                             receipt["checkpoint"] = len(oracle.events)
-                            if command["sequence"] not in (3, 9):
-                                raise ValueError("unsupported proof sequence")
-                            for routes, rt in ((SOURCES, bytes.fromhex("0002fde800000064")),
-                                               ([Route(SOURCE_RD, MACS["e"])],
-                                                bytes.fromhex("0002fde8000000c8"))):
-                                update = announcement(routes, command["sequence"], next_hop=SOURCE,
-                                                      route_target=rt)
+                            for update in command_updates(command["sequence"]):
                                 send_message(connection, 2, update)
                                 receipt["sent"].append({"command": command["id"], "body": update.hex()})
                             receipt["ack"] = command["id"]

--- a/tests/interop/scripts/run-evpn-peer-sync-proof.py
+++ b/tests/interop/scripts/run-evpn-peer-sync-proof.py
@@ -13,7 +13,7 @@ from dataclasses import asdict
 from pathlib import Path
 
 from evpn_peer_sync_oracle import Oracle, Route, duplicate_totals
-from evpn_peer_sync_peer import CONTROLS, DUT, DUT_RD, IPS, LOCAL, MACS
+from evpn_peer_sync_peer import CONTROLS, DUT, DUT_RD, IPS, LOCAL, MACS, SOURCE, SOURCE_RD
 from m94_as4_oracle import write_receipt
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -31,6 +31,23 @@ def receipt_oracle(receipt: dict, run_id: str, command: int) -> Oracle:
         route = Route(**{name: row[name] for name in asdict(LOCAL[0])})
         oracle.live[route.key()] = row
     return oracle
+
+
+def received_routes(raw: str) -> list[dict]:
+    """Validate the complete bounded CLI page before testing route absence."""
+    page = json.loads(raw)
+    if (not isinstance(page, dict) or page.get("view") != "received"
+            or page.get("neighbor") != SOURCE or page.get("next_page_token") != ""
+            or not isinstance(page.get("routes"), list)
+            or type(page.get("total_count")) is not int
+            or page["total_count"] != len(page["routes"])):
+        raise ValueError("malformed, incomplete, or wrong-source received-route page")
+    for row in page["routes"]:
+        if (not isinstance(row, dict) or row.get("rd") != SOURCE_RD
+                or row.get("peer") != SOURCE or row.get("route_type") != 2
+                or not isinstance(row.get("mac"), str) or not isinstance(row.get("ip"), str)):
+            raise ValueError("unexpected row in received-route page")
+    return page["routes"]
 
 
 def main() -> None:
@@ -87,10 +104,22 @@ def main() -> None:
                     raise TimeoutError(f"wire condition failed: {error}") from error
                 time.sleep(0.2)
 
-    def send(command: int, sequence: int) -> tuple[dict, Oracle]:
+    def send(command: int, sequence: int | None) -> tuple[dict, Oracle]:
         write_receipt(str(output / "command.json"),
                       {"run_id": run_id, "id": command, "sequence": sequence})
         return wait(command, lambda _receipt, _oracle: None)
+
+    def source_view(name: str, present: bool) -> None:
+        raw = run([*compose, "exec", "-T", "dut", "rbgp", "-j", "evpn", "received",
+                   SOURCE, "--route-type", "2", "--rd", SOURCE_RD])
+        (output / f"{name}.json").write_text(raw)
+        rows = received_routes(raw)
+        if present:
+            keys = {(row["mac"], row["ip"]) for row in rows}
+            if not {(MACS["a"], ""), (MACS["b"], "")} <= keys:
+                raise AssertionError("positive control is missing the eligible source MAC routes")
+        elif rows:
+            raise AssertionError("accepted peer routes have not been withdrawn")
 
     def metrics(name: str) -> None:
         # HTTP status/read errors propagate from the existing Python-equipped peer.
@@ -136,17 +165,24 @@ def main() -> None:
         metrics("baseline")
         first, _ = send(1, 3)
         time.sleep(12)  # At least two default originator polls before local observation.
+        # B must enter through pending IP bindings, without a prior MAC-only
+        # advertisement. Netlink delivers these earlier neighbor events before
+        # the later FDB learn; the wire history below verifies that shape.
+        for address in IPS["b"]:
+            dut("ip", "neigh", "replace", address, "lladdr", MACS["b"], "dev", "br100", "nud", "reachable")
         for name in "abcef":
             dut("bridge", "fdb", "replace", MACS[name], "dev", "ce100a", "master", "static")
-        for name, addresses in IPS.items():
-            for address in addresses:
-                dut("ip", "neigh", "replace", address, "lladdr", MACS[name], "dev", "br100", "nud", "reachable")
+        for address in IPS["c"]:
+            dut("ip", "neigh", "replace", address, "lladdr", MACS["c"], "dev", "br100", "nud", "reachable")
 
         def adopted(receipt, oracle, sequence, checkpoint):
             oracle.expect_transition(LOCAL, sequence, next_hop=DUT, after=checkpoint)
             oracle.expect(CONTROLS, 0, next_hop=DUT)
             oracle.expect_owned_keys(LOCAL + CONTROLS, rd=DUT_RD)
             oracle.expect_never_owned(rd=DUT_RD, mac=MACS["d"])
+            if any(row["rd"] == DUT_RD and row["mac"] == MACS["b"] and not row["ip"]
+                   and row["action"] == "announce" for row in oracle.events):
+                raise AssertionError("B was not learned through the IP-first path")
 
         wait(1, lambda receipt, oracle: adopted(receipt, oracle, 3, first["checkpoint"]))
         time.sleep(12)
@@ -170,16 +206,55 @@ def main() -> None:
             oracle.expect_quiet(after=sent["checkpoint"], rd=DUT_RD)
             oracle.expect_never_owned(rd=DUT_RD, mac=MACS["d"])
             metrics(f"replay-{sequence}")
+        # Remove eligible peers without resetting the BGP session. Prove the
+        # input existed and is now absent before allowing two originator polls.
+        source_view("peer-before-withdrawal", True)
+        withdrawn, _ = send(5, None)
+        wait(5, lambda _receipt, _oracle: source_view("peer-withdrawn", False))
+        time.sleep(12)
+        _, oracle = state(5)
+        source_view("peer-withdrawn-settled", False)
+        oracle.expect(LOCAL, 9, next_hop=DUT)
+        oracle.expect(CONTROLS, 0, next_hop=DUT)
+        oracle.expect_quiet(after=withdrawn["checkpoint"], rd=DUT_RD)
+        metrics("peer-withdrawn")
+
+        # A only has a MAC route. New children must inherit its retained sequence 9 even
+        # though the current peer view is empty.
+        children = [Route(DUT_RD, MACS["a"], ip) for ip in ("192.0.2.11", "2001:db8::11")]
+        checkpoint = len(oracle.events)
+        for route in children:
+            dut("ip", "neigh", "replace", route.ip, "lladdr", route.mac, "dev", "br100", "nud", "reachable")
+        _, oracle = wait(5, lambda _receipt, oracle: oracle.expect_transition(
+            children, 9, next_hop=DUT, after=checkpoint))
+        retained_local = [route for route in LOCAL if route.mac != MACS["a"]] + children
+        oracle.expect_owned_keys(retained_local + CONTROLS, rd=DUT_RD)
+        metrics("retained-new-children")
+
+        # B began IP-first. Removing its last child must create MAC-only at 9,
+        # rather than initializing a new MAC-only tracker at zero.
+        checkpoint = len(oracle.events)
+        for address in IPS["b"]:
+            dut("ip", "neigh", "del", address, "dev", "br100")
+        mac_only = Route(DUT_RD, MACS["b"])
+        _, oracle = wait(5, lambda _receipt, oracle: oracle.expect_transition(
+            [mac_only], 9, next_hop=DUT, after=checkpoint))
+        retained_local = [route for route in retained_local if route.mac != MACS["b"]] + [mac_only]
+        oracle.expect(retained_local, 9, next_hop=DUT)
+        oracle.expect(CONTROLS, 0, next_hop=DUT)
+        oracle.expect_owned_keys(retained_local + CONTROLS, rd=DUT_RD)
+        oracle.expect_never_owned(rd=DUT_RD, mac=MACS["d"])
+        metrics("retained-mac-only")
         # Remove C's actual local ownership, then replay the remote owner.
         for address in IPS["c"]:
             dut("ip", "neigh", "del", address, "dev", "br100")
         dut("bridge", "fdb", "del", MACS["c"], "dev", "ce100a", "master")
-        wait(4, lambda _receipt, oracle: oracle.expect_absent(rd=DUT_RD, mac=MACS["c"]))
-        sent, _ = send(5, 9)
+        wait(5, lambda _receipt, oracle: oracle.expect_absent(rd=DUT_RD, mac=MACS["c"]))
+        sent, _ = send(6, 9)
         time.sleep(12)
-        final, oracle = state(5)
+        final, oracle = state(6)
         oracle.expect_absent(rd=DUT_RD, mac=MACS["c"])
-        oracle.expect_owned_keys([route for route in LOCAL if route.mac != MACS["c"]] + CONTROLS,
+        oracle.expect_owned_keys([route for route in retained_local if route.mac != MACS["c"]] + CONTROLS,
                                  rd=DUT_RD)
         oracle.expect_never_owned(rd=DUT_RD, mac=MACS["d"])
         oracle.expect_quiet(after=sent["checkpoint"], rd=DUT_RD)

--- a/tests/interop/scripts/run-evpn-peer-sync-proof.py
+++ b/tests/interop/scripts/run-evpn-peer-sync-proof.py
@@ -12,7 +12,7 @@ import uuid
 from dataclasses import asdict
 from pathlib import Path
 
-from evpn_peer_sync_oracle import Oracle, Route, duplicate_totals
+from evpn_peer_sync_oracle import Oracle, Route, duplicate_totals, process_start_time
 from evpn_peer_sync_peer import CONTROLS, DUT, DUT_RD, IPS, LOCAL, MACS, SOURCE, SOURCE_RD
 from m94_as4_oracle import write_receipt
 
@@ -130,7 +130,7 @@ def main() -> None:
         totals = duplicate_totals(scrape)
         if any(row["total"] != 0 for row in totals.values()):
             raise AssertionError(f"duplicate accounting changed: {totals}")
-        process = next(line for line in scrape.splitlines() if line.startswith("process_start_time_seconds "))
+        process = process_start_time(scrape)
         if "process_start" in ledger and ledger["process_start"] != process:
             raise AssertionError("DUT restarted during proof")
         ledger["process_start"] = process

--- a/tests/interop/scripts/run-evpn-peer-sync-proof.py
+++ b/tests/interop/scripts/run-evpn-peer-sync-proof.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Run one isolated controlled-peer sequence-adoption proof; always tear it down."""
+
+import argparse
+import ipaddress
+import json
+import os
+import re
+import subprocess
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+
+from evpn_peer_sync_oracle import Oracle, Route, duplicate_totals
+from evpn_peer_sync_peer import CONTROLS, DUT, DUT_RD, IPS, LOCAL, MACS
+from m94_as4_oracle import write_receipt
+
+ROOT = Path(__file__).resolve().parents[3]
+COMPOSE = ROOT / "tests/interop/peer-sync/compose.yml"
+
+
+def receipt_oracle(receipt: dict, run_id: str, command: int) -> Oracle:
+    if (receipt.get("run_id") != run_id or not receipt.get("established")
+            or receipt.get("error") or receipt.get("ack") != command
+            or not 0 <= time.time() - receipt.get("heartbeat", 0) < 5):
+        raise AssertionError("missing, stale, failed, or wrong-phase peer receipt")
+    oracle = Oracle()
+    oracle.events = receipt["events"]
+    for row in receipt["live"]:
+        route = Route(**{name: row[name] for name in asdict(LOCAL[0])})
+        oracle.live[route.key()] = row
+    return oracle
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True, help="local DUT image with OCI revision label")
+    parser.add_argument("--source-revision", required=True, help="exact DUT source commit")
+    parser.add_argument("--raw-image", default="bmpsink:m102", help="existing Dockerfile.bmpsink image")
+    parser.add_argument("--output", type=Path, required=True, help="new receipt directory")
+    args = parser.parse_args()
+    if not re.fullmatch("[0-9a-f]{40}", args.source_revision):
+        parser.error("--source-revision must be a full commit SHA")
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    run_id = uuid.uuid4().hex
+    project = "evpn-peer-sync-" + run_id[:12]
+    environment = {**os.environ, "PEER_SYNC_RECEIPT": str(output), "PEER_SYNC_RUN_ID": run_id}
+    compose = ["docker", "compose", "-p", project, "-f", str(COMPOSE)]
+    ledger = {"run_id": run_id, "project": project, "source_revision": args.source_revision,
+              "harness_revision": subprocess.check_output(
+                  ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip(), "passed": False}
+
+    def run(command: list[str], *, check: bool = True) -> str:
+        try:
+            result = subprocess.run(command, cwd=ROOT, env=environment, text=True,
+                                    capture_output=True, timeout=60, check=False)
+        except subprocess.TimeoutExpired as error:
+            with (output / "commands.jsonl").open("a") as log:
+                log.write(json.dumps({"command": command, "timeout": 60,
+                                      "stdout": str(error.stdout), "stderr": str(error.stderr)}) + "\n")
+            raise
+        with (output / "commands.jsonl").open("a") as log:
+            log.write(json.dumps({"command": command, "exit": result.returncode,
+                                  "stdout": result.stdout, "stderr": result.stderr}) + "\n")
+        if check and result.returncode:
+            raise RuntimeError(f"command exited {result.returncode}: {command}; see commands.jsonl")
+        return result.stdout
+
+    def dut(*command: str) -> None:
+        run([*compose, "exec", "-T", "dut", *command])
+
+    def state(command: int) -> tuple[dict, Oracle]:
+        receipt = json.loads((output / "peer.json").read_text())
+        return receipt, receipt_oracle(receipt, run_id, command)
+
+    def wait(command: int, assertion) -> tuple[dict, Oracle]:
+        deadline = time.monotonic() + 35
+        while True:
+            try:
+                receipt, oracle = state(command)
+                assertion(receipt, oracle)
+                return receipt, oracle
+            except (FileNotFoundError, AssertionError) as error:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(f"wire condition failed: {error}") from error
+                time.sleep(0.2)
+
+    def send(command: int, sequence: int) -> tuple[dict, Oracle]:
+        write_receipt(str(output / "command.json"),
+                      {"run_id": run_id, "id": command, "sequence": sequence})
+        return wait(command, lambda _receipt, _oracle: None)
+
+    def metrics(name: str) -> None:
+        # HTTP status/read errors propagate from the existing Python-equipped peer.
+        scrape = run([*compose, "exec", "-T", "peer", "python3", "-c",
+                      "import urllib.request; "
+                      f"print(urllib.request.urlopen('http://{DUT}:9179/metrics', timeout=5).read().decode(), end='')"])
+        (output / f"{name}.prom").write_text(scrape)
+        totals = duplicate_totals(scrape)
+        if any(row["total"] != 0 for row in totals.values()):
+            raise AssertionError(f"duplicate accounting changed: {totals}")
+        process = next(line for line in scrape.splitlines() if line.startswith("process_start_time_seconds "))
+        if "process_start" in ledger and ledger["process_start"] != process:
+            raise AssertionError("DUT restarted during proof")
+        ledger["process_start"] = process
+        ledger.setdefault("metrics", {})[name] = totals
+
+    ledger["harness_dirty"] = bool(run(["git", "status", "--porcelain"]))
+    started = False
+    try:
+        for name, reference in (("dut", args.image), ("raw", args.raw_image)):
+            image = json.loads(run(["docker", "image", "inspect", reference]))[0]
+            ledger[name + "_image"] = {key: image.get(key) for key in ("Id", "RepoDigests", "Created")}
+            environment["PEER_SYNC_" + ("DUT" if name == "dut" else "RAW") + "_IMAGE"] = image["Id"]
+            if name == "dut" and (image["Config"].get("Labels") or {}).get(
+                    "org.opencontainers.image.revision") != args.source_revision:
+                raise ValueError("DUT image OCI revision does not match --source-revision")
+        network_ids = run(["docker", "network", "ls", "-q"]).split()
+        if network_ids:
+            for network in json.loads(run(["docker", "network", "inspect", *network_ids])):
+                for config in network.get("IPAM", {}).get("Config") or []:
+                    subnet = config.get("Subnet")
+                    if subnet and ipaddress.ip_network(subnet).overlaps(ipaddress.ip_network("10.99.0.0/24")):
+                        raise ValueError("proof subnet overlaps an existing Docker network")
+        run([*compose, "config", "--quiet"])
+        started = True
+        run([*compose, "up", "-d", "--pull", "never"])
+        dut("sh", "/start.sh", DUT, "10.99.0.2", "100")
+        dut("bridge", "link", "set", "dev", "vxlan100", "neigh_suppress", "on")
+        # Keep the deliberately installed reachable neighbors stable throughout the proof.
+        dut("sh", "-ec", "echo 600000 > /proc/sys/net/ipv4/neigh/br100/base_reachable_time_ms; "
+            "echo 600000 > /proc/sys/net/ipv6/neigh/br100/base_reachable_time_ms")
+        wait(0, lambda _receipt, _oracle: None)
+        metrics("baseline")
+        first, _ = send(1, 3)
+        time.sleep(12)  # At least two default originator polls before local observation.
+        for name in "abcef":
+            dut("bridge", "fdb", "replace", MACS[name], "dev", "ce100a", "master", "static")
+        for name, addresses in IPS.items():
+            for address in addresses:
+                dut("ip", "neigh", "replace", address, "lladdr", MACS[name], "dev", "br100", "nud", "reachable")
+
+        def adopted(receipt, oracle, sequence, checkpoint):
+            oracle.expect_transition(LOCAL, sequence, next_hop=DUT, after=checkpoint)
+            oracle.expect(CONTROLS, 0, next_hop=DUT)
+            oracle.expect_owned_keys(LOCAL + CONTROLS, rd=DUT_RD)
+            oracle.expect_never_owned(rd=DUT_RD, mac=MACS["d"])
+
+        wait(1, lambda receipt, oracle: adopted(receipt, oracle, 3, first["checkpoint"]))
+        time.sleep(12)
+        receipt, oracle = state(1)
+        adopted(receipt, oracle, 3, first["checkpoint"])
+        metrics("sequence-3")
+        raised, _ = send(2, 9)
+        wait(2, lambda receipt, oracle: adopted(receipt, oracle, 9, raised["checkpoint"]))
+        time.sleep(12)
+        receipt, oracle = state(2)
+        adopted(receipt, oracle, 9, raised["checkpoint"])
+        metrics("sequence-9")
+        # Exact replay and lower sequence must not cause even a transient export.
+        for command, sequence in ((3, 9), (4, 3)):
+            sent, _ = send(command, sequence)
+            time.sleep(12)
+            receipt, oracle = state(command)
+            oracle.expect(LOCAL, 9, next_hop=DUT)
+            oracle.expect(CONTROLS, 0, next_hop=DUT)
+            oracle.expect_owned_keys(LOCAL + CONTROLS, rd=DUT_RD)
+            oracle.expect_quiet(after=sent["checkpoint"], rd=DUT_RD)
+            oracle.expect_never_owned(rd=DUT_RD, mac=MACS["d"])
+            metrics(f"replay-{sequence}")
+        # Remove C's actual local ownership, then replay the remote owner.
+        for address in IPS["c"]:
+            dut("ip", "neigh", "del", address, "dev", "br100")
+        dut("bridge", "fdb", "del", MACS["c"], "dev", "ce100a", "master")
+        wait(4, lambda _receipt, oracle: oracle.expect_absent(rd=DUT_RD, mac=MACS["c"]))
+        sent, _ = send(5, 9)
+        time.sleep(12)
+        final, oracle = state(5)
+        oracle.expect_absent(rd=DUT_RD, mac=MACS["c"])
+        oracle.expect_owned_keys([route for route in LOCAL if route.mac != MACS["c"]] + CONTROLS,
+                                 rd=DUT_RD)
+        oracle.expect_never_owned(rd=DUT_RD, mac=MACS["d"])
+        oracle.expect_quiet(after=sent["checkpoint"], rd=DUT_RD)
+        metrics("after-age")
+        ledger.update(passed=True, final_event_count=len(final["events"]))
+    except BaseException as error:
+        ledger["error"] = str(error)
+        raise
+    finally:
+        cleanup_errors = []
+        if started:
+            for command in ([*compose, "logs", "--no-color"],
+                            [*compose, "exec", "-T", "dut", "cat", "/var/log/rustbgpd.log"],
+                            [*compose, "down", "--volumes", "--remove-orphans"],
+                            [*compose, "down", "--volumes", "--remove-orphans"]):
+                try:
+                    run(command)
+                except Exception as error:
+                    cleanup_errors.append(str(error))
+            for kind in ("container", "network"):
+                try:
+                    owned = run(["docker", kind, "ls", "-q", "--filter",
+                                 f"label=com.docker.compose.project={project}",
+                                 *(["-a"] if kind == "container" else [])])
+                    if owned.strip():
+                        cleanup_errors.append(f"owned {kind} remains: {owned.strip()}")
+                except Exception as error:
+                    cleanup_errors.append(str(error))
+        ledger["cleanup_errors"] = cleanup_errors
+        ledger["passed"] &= not cleanup_errors
+        write_receipt(str(output / "result.json"), ledger)
+        if cleanup_errors:
+            raise RuntimeError(f"cleanup or log capture failed: {cleanup_errors}")
+    print(f"PASS: controlled peer sequence adoption; receipt {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/interop/scripts/test_evpn_peer_sync_oracle.py
+++ b/tests/interop/scripts/test_evpn_peer_sync_oracle.py
@@ -14,7 +14,7 @@ import unittest
 
 from evpn_peer_sync_oracle import (
     BgpReader, COUNTERS, ESI, FAMILY, Oracle, RT, Route, VXLAN,
-    announcement, attribute, decode_type2s, duplicate_totals, type2, withdrawal,
+    announcement, attribute, decode_type2s, duplicate_totals, process_start_time, type2, withdrawal,
 )
 
 
@@ -339,6 +339,34 @@ class PeerSyncOracleTests(unittest.TestCase):
                 oracle.expect_transition(replacement, 9, next_hop=DUT,
                                          after=len(oracle.events) - len(replacement))
                 oracle.expect_owned_keys(replacement, rd=parent.rd)
+
+    def test_malformed_exact_metric_samples_never_count_as_missing(self):
+        for family in COUNTERS:
+            for malformed in (family, family + "\tbroken extra junk", family + "\t",
+                              family + "{broken", family + "\tNaN", family + "\t-1"):
+                with self.subTest(sample=malformed), self.assertRaises(ValueError):
+                    duplicate_totals("process_start_time_seconds 123\n" + malformed + "\n")
+        valid = duplicate_totals("process_start_time_seconds 123\n" + COUNTERS[0] + "_other\tbroken extra junk\n")
+        self.assertEqual(valid[COUNTERS[0]], {"present": False, "series": 0, "total": 0})
+
+    def test_process_start_uses_shared_numeric_identity_for_valid_sample_shapes(self):
+        for sample in ("process_start_time_seconds 123", "process_start_time_seconds\t123",
+                       'process_start_time_seconds{instance="dut"} 123',
+                       'process_start_time_seconds{instance="dut"}\t123.0 1000'):
+            with self.subTest(sample=sample):
+                scrape = sample + "\n" + COUNTERS[0] + "\t2\n"
+                self.assertEqual(process_start_time(scrape), 123.0)
+                self.assertEqual(duplicate_totals(scrape)[COUNTERS[0]],
+                                 {"present": True, "series": 1, "total": 2})
+        self.assertNotEqual(process_start_time("process_start_time_seconds 123\n"),
+                            process_start_time("process_start_time_seconds 124\n"))
+        for sample in ("", "process_start_time_seconds", "process_start_time_seconds\tbroken extra junk",
+                       "process_start_time_seconds NaN", "process_start_time_seconds Inf",
+                       "process_start_time_seconds 0", "process_start_time_seconds -1",
+                       "process_start_time_seconds_other 123",
+                       'process_start_time_seconds 123\nprocess_start_time_seconds{instance="dut"} 123'):
+            with self.subTest(sample=sample), self.assertRaises(ValueError):
+                process_start_time(sample + "\n")
 
     def test_encoder_rejects_out_of_range_and_oversized_inputs(self):
         for route in (Route("10.0.0.2:100", "00"), Route("10.0.0.2:100", MAC, vni=0),

--- a/tests/interop/scripts/test_evpn_peer_sync_oracle.py
+++ b/tests/interop/scripts/test_evpn_peer_sync_oracle.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Offline independent vectors and false-positive controls for peer-sync proof."""
+
+import copy
+import socket
+import subprocess
+import sys
+import tempfile
+import tomllib
+import runpy
+import time
+from pathlib import Path
+import unittest
+
+from evpn_peer_sync_oracle import (
+    BgpReader, COUNTERS, ESI, FAMILY, Oracle, RT, Route, VXLAN,
+    announcement, attribute, decode_type2s, duplicate_totals, type2, withdrawal,
+)
+
+
+from evpn_peer_sync_peer import open_body, validate_open
+
+
+SOURCE = "10.0.0.2"
+DUT = "10.0.0.1"
+MAC = "02:aa:bb:cc:dd:11"
+# RFC 7432 Type2: route type/length, RD, ESI, tag, MAClen/MAC,
+# IPlen/IP, and RFC 8365's unshifted VNI100. These are literal byte vectors,
+# not expected data reconstructed by the encoder under test.
+PREFIX = "00010a0000020064" + "00000000000000000001" + "00000000" + "3002aabbccdd11"
+VECTORS = (
+    ("", "0221" + PREFIX + "00" + "000064"),
+    ("192.0.2.17", "0225" + PREFIX + "20c0000211" + "000064"),
+    ("2001:db8::17", "0231" + PREFIX + "8020010db8000000000000000000000017" + "000064"),
+)
+
+
+class PeerSyncOracleTests(unittest.TestCase):
+    def test_literal_type2_and_complete_update_vectors(self):
+        for ip, expected in VECTORS:
+            route = Route("10.0.0.2:100", MAC, ip)
+            with self.subTest(ip=ip):
+                self.assertEqual(type2(route).hex(), expected)
+                self.assertEqual(decode_type2s(bytes.fromhex(expected)), [route])
+        expected = (
+            "00000051" "40010100" "400200" "c01018"
+            "0002fde800000064" "030c000000000008" "0600000000000003"
+            "800e2c" "001946040a00000200" + VECTORS[0][1]
+        )
+        self.assertEqual(announcement([Route("10.0.0.2:100", MAC)], 3,
+                                      next_hop=SOURCE).hex(), expected)
+
+    def test_direct_three_to_nine_and_wrong_increment_rejected(self):
+        routes = [Route("10.0.0.1:100", MAC, ip) for ip, _ in VECTORS]
+        oracle = Oracle()
+        oracle.apply(announcement(routes, 3, next_hop=DUT))
+        oracle.expect(routes, 3, next_hop=DUT)
+        with self.assertRaises(AssertionError):
+            oracle.expect(routes, 4, next_hop=DUT)
+        oracle.apply(announcement(routes, 9, next_hop=DUT))
+        oracle.expect(routes, 9, next_hop=DUT)
+        with self.assertRaises(AssertionError):
+            oracle.expect(routes, 10, next_hop=DUT)
+        oracle.apply(withdrawal(routes))
+        oracle.expect_absent(rd="10.0.0.1:100", mac=MAC)
+
+    def test_source_route_cannot_satisfy_local_ownership(self):
+        oracle = Oracle()
+        source = Route("10.0.0.2:100", MAC)
+        local = Route("10.0.0.1:100", MAC)
+        oracle.apply(announcement([source], 9, next_hop=SOURCE))
+        oracle.expect_absent(rd=local.rd, mac=MAC)
+        with self.assertRaises(AssertionError):
+            oracle.expect([local], 9, next_hop=DUT)
+        oracle.apply(announcement([local], 9, next_hop=DUT))
+        with self.assertRaises(AssertionError):
+            oracle.expect_absent(rd=local.rd, mac=MAC)
+
+    def test_exact_esi_tag_vni_nexthop_and_rt_are_load_bearing(self):
+        expected = Route("10.0.0.1:100", MAC)
+        for changed in (Route(expected.rd, MAC, tag=1), Route(expected.rd, MAC, vni=200),
+                        Route(expected.rd, MAC, esi=(b"\0" * 10).hex(":"))):
+            oracle = Oracle()
+            oracle.apply(announcement([changed], 3, next_hop=DUT))
+            with self.assertRaises(AssertionError):
+                oracle.expect([expected], 3, next_hop=DUT)
+        for next_hop, rt in ((SOURCE, RT), (DUT, bytes.fromhex("0002fde8000000c8"))):
+            oracle = Oracle()
+            oracle.apply(announcement([expected], 3, next_hop=next_hop, route_target=rt))
+            with self.assertRaises(AssertionError):
+                oracle.expect([expected], 3, next_hop=DUT)
+
+    def test_truncation_and_bad_lengths_never_publish_partial_state(self):
+        route = Route("10.0.0.1:100", MAC)
+        body = announcement([route], 3, next_hop=DUT)
+        oracle = Oracle()
+        oracle.apply(body)
+        before = copy.deepcopy((oracle.live, oracle.events))
+        malformed = [body[:length] for length in range(len(body))]
+        # A complete valid Type2 followed by an incomplete Type2 in one MP_REACH.
+        reach = FAMILY + b"\x04" + bytes([10, 0, 0, 1]) + b"\0" + type2(route) + b"\x02"
+        attrs = attribute(14, reach)
+        malformed.append(b"\0\0" + len(attrs).to_bytes(2, "big") + attrs)
+        for value in malformed:
+            with self.subTest(length=len(value)), self.assertRaises(ValueError):
+                oracle.apply(value)
+            self.assertEqual((oracle.live, oracle.events), before)
+        for position, value in ((1, 34), (24, 47), (31, 31)):
+            nlri = bytearray(type2(route))
+            nlri[position] = value
+            with self.assertRaises(ValueError):
+                decode_type2s(bytes(nlri))
+
+    def test_duplicate_communities_and_mp_attributes_are_rejected(self):
+        route = Route("10.0.0.1:100", MAC)
+        reach = attribute(14, FAMILY + b"\4" + bytes([10, 0, 0, 1]) + b"\0" + type2(route))
+        mobility = bytes.fromhex("0600000000000003")
+        for attrs in (reach + reach,
+                      reach + attribute(16, RT + VXLAN + mobility * 2, 0xC0),
+                      reach + attribute(16, RT + b"\0", 0xC0)):
+            with self.assertRaises(ValueError):
+                Oracle().apply(b"\0\0" + len(attrs).to_bytes(2, "big") + attrs)
+
+    def test_existing_reader_retains_fragment_across_timeout(self):
+        body = announcement([Route("10.0.0.1:100", MAC)], 9, next_hop=DUT)
+        frame = b"\xff" * 16 + (19 + len(body)).to_bytes(2, "big") + b"\x02" + body
+
+        class Stream:
+            chunks = iter((frame[:10], socket.timeout(), frame[10:23], frame[23:]))
+
+            def recv(self, _):
+                result = next(self.chunks)
+                if isinstance(result, Exception):
+                    raise result
+                return result
+
+        reader, oracle = BgpReader(Stream()), Oracle()
+        with self.assertRaises(socket.timeout):
+            oracle.read(reader)
+        oracle.read(reader)
+        oracle.expect([Route("10.0.0.1:100", MAC)], 9, next_hop=DUT)
+
+    def test_metrics_sum_all_series_without_prefix_collisions(self):
+        family = COUNTERS[0]
+        scrape = (f'process_start_time_seconds 123\n{family}{{vni="100",mac="a"}} 2\n'
+                  f'{family}{{vni="100",mac="b"}} 3\n{family}_wrong 100\n')
+        result = duplicate_totals(scrape)
+        self.assertEqual(result[family], {"present": True, "series": 2, "total": 5})
+        self.assertEqual(result[COUNTERS[-1]], {"present": False, "series": 0, "total": 0})
+        for bad in ("", "HTTP error", "process_start_time_seconds NaN\n",
+                    scrape + f"{COUNTERS[1]} NaN\n", scrape + f"{COUNTERS[1]} -1\n",
+                    scrape + f"{COUNTERS[1]}{{broken\n"):
+            with self.subTest(bad=bad), self.assertRaises(ValueError):
+                duplicate_totals(bad)
+
+    def test_combined_withdraw_reannounce_leaves_replacement_installed(self):
+        old = Route("10.0.0.1:100", MAC, vni=200)
+        new = Route("10.0.0.1:100", MAC)
+        oracle = Oracle()
+        oracle.apply(announcement([old], 3, next_hop=DUT))
+        # Attribute order intentionally puts REACH first, as batching may do.
+        attrs = announcement([new], 9, next_hop=DUT)[4:] + withdrawal([old])[4:]
+        combined = b"\0\0" + len(attrs).to_bytes(2, "big") + attrs
+        before = copy.deepcopy((oracle.live, oracle.events))
+        with self.assertRaises(ValueError):
+            oracle.apply(combined[:-1])
+        self.assertEqual((oracle.live, oracle.events), before)
+        oracle.apply(combined)
+        oracle.expect([new], 9, next_hop=DUT)
+        self.assertEqual([row["action"] for row in oracle.events[-2:]],
+                         ["withdraw", "announce"])
+
+    def test_old_capture_and_transient_wrong_sequences_are_rejected(self):
+        route = Route("10.0.0.1:100", MAC)
+        oracle = Oracle()
+        oracle.apply(announcement([route], 9, next_hop=DUT))
+        oracle.expect_transition([route], 9, next_hop=DUT, after=0)
+        with self.assertRaises(AssertionError):
+            oracle.expect_transition([route], 9, next_hop=DUT, after=1)
+        oracle.apply(announcement([route], 10, next_hop=DUT))
+        oracle.apply(announcement([route], 9, next_hop=DUT))
+        with self.assertRaises(AssertionError):
+            oracle.expect_transition([route], 9, next_hop=DUT, after=1)
+        with self.assertRaises(AssertionError):
+            oracle.expect_quiet(after=1, rd=route.rd)
+        oracle.apply(withdrawal([route]))
+        with self.assertRaises(AssertionError):
+            oracle.expect_never_owned(rd=route.rd, mac=MAC)
+        oracle.expect_quiet(after=len(oracle.events), rd=route.rd)
+
+    def test_process_identity_must_be_one_valid_sample(self):
+        for bad in ("123bogus", "NaN", "Inf", "0", "-1", "123 garbage"):
+            with self.subTest(bad=bad), self.assertRaises(ValueError):
+                duplicate_totals(f"process_start_time_seconds {bad}\n")
+        with self.assertRaises(ValueError):
+            duplicate_totals("process_start_time_seconds 123\n" * 2)
+
+    def test_open_requires_exact_peer_and_evpn_capability(self):
+        body = bytearray(open_body())
+        body[5:9] = bytes([10, 99, 0, 1])
+        validate_open(bytes(body))
+        for malformed in (bytes(body) + b"x", bytes(body[:-1]), open_body(),
+                          bytes(body).replace(bytes.fromhex("00190046"), bytes.fromhex("00010001"))):
+            with self.subTest(body=malformed.hex()), self.assertRaises(ValueError):
+                validate_open(malformed)
+
+    def test_receipt_rejects_old_run_phase_error_and_heartbeat(self):
+        module = runpy.run_path(str(Path(__file__).with_name("run-evpn-peer-sync-proof.py")))
+        load = module["receipt_oracle"]
+        valid = {"run_id": "fresh", "established": True, "ack": 2,
+                 "heartbeat": time.time(), "events": [], "live": []}
+        load(valid, "fresh", 2)
+        for mutation in ({"run_id": "old"}, {"ack": 1}, {"established": False},
+                         {"error": "disconnected"}, {"heartbeat": time.time() - 10},
+                         {"heartbeat": time.time() + 10}):
+            with self.subTest(mutation=mutation), self.assertRaises(AssertionError):
+                load({**valid, **mutation}, "fresh", 2)
+
+    def test_runner_rejects_bad_revision_before_docker_or_output_creation(self):
+        runner = Path(__file__).with_name("run-evpn-peer-sync-proof.py")
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "receipt"
+            result = subprocess.run([sys.executable, str(runner), "--image", "unused",
+                                     "--source-revision", "not-a-sha", "--output", str(output)],
+                                    capture_output=True, text=True, check=False)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("full commit SHA", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_live_config_matches_wire_fixture_and_enables_ip_diagnostics(self):
+        from evpn_peer_sync_peer import DUT, DUT_RD, SOURCE
+        config = tomllib.loads((Path(__file__).resolve().parents[1] /
+                                "peer-sync/rustbgpd.toml").read_text())
+        self.assertEqual(config["global"]["router_id"], DUT)
+        self.assertEqual(config["neighbors"][0]["address"], SOURCE)
+        self.assertEqual(config["neighbors"][0]["families"], ["l2vpn_evpn"])
+        instance = config["evpn_instances"][0]
+        self.assertEqual((instance["rd"], instance["vni"], instance["route_targets"]),
+                         (DUT_RD, 100, ["65000:100"]))
+        self.assertTrue(instance["duplicate_ip_detection"]["enabled"])
+        self.assertEqual(config["ethernet_segments"][0]["esi"], ESI.hex(":"))
+
+    def test_unexpected_local_key_and_reserved_mobility_bits_fail(self):
+        route = Route("10.0.0.1:100", MAC)
+        oracle = Oracle()
+        oracle.apply(announcement([route], 3, next_hop=DUT))
+        oracle.expect_owned_keys([route], rd=route.rd)
+        oracle.apply(announcement([Route(route.rd, MAC, "192.0.2.1")], 3, next_hop=DUT))
+        with self.assertRaises(AssertionError):
+            oracle.expect_owned_keys([route], rd=route.rd)
+        malformed = announcement([route], 3, next_hop=DUT).replace(
+            bytes.fromhex("0600000000000003"), bytes.fromhex("0600020000000003"))
+        oracle.apply(malformed)
+        with self.assertRaises(AssertionError):
+            oracle.expect([route], 3, next_hop=DUT)
+
+    def test_static_vxlan_allows_absent_but_not_conflicting_encapsulation(self):
+        route = Route("10.0.0.1:100", MAC)
+        mobility = bytes.fromhex("0600000000000003")
+        reach = attribute(14, FAMILY + b"\4" + bytes([10, 0, 0, 1]) + b"\0" + type2(route))
+        for communities, accepted in ((RT + mobility, True),
+                                      (RT + mobility + VXLAN, True),
+                                      (RT + mobility + bytes.fromhex("030c000000000009"), False),
+                                      (RT + mobility + VXLAN * 2, False),
+                                      (mobility + VXLAN, False)):
+            attrs = reach + attribute(16, communities, 0xC0)
+            oracle = Oracle()
+            oracle.apply(b"\0\0" + len(attrs).to_bytes(2, "big") + attrs)
+            if accepted:
+                oracle.expect([route], 3, next_hop=DUT)
+            else:
+                with self.assertRaises(AssertionError):
+                    oracle.expect([route], 3, next_hop=DUT)
+
+    def test_encoder_rejects_out_of_range_and_oversized_inputs(self):
+        for route in (Route("10.0.0.2:100", "00"), Route("10.0.0.2:100", MAC, vni=0),
+                      Route("10.0.0.2:100", MAC, esi="00")):
+            with self.assertRaises(ValueError):
+                type2(route)
+        with self.assertRaises(ValueError):
+            announcement([Route("10.0.0.2:100", MAC)] * 150, 3, next_hop=SOURCE)
+        self.assertEqual(ESI.hex(), "00000000000000000001")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/interop/scripts/test_evpn_peer_sync_oracle.py
+++ b/tests/interop/scripts/test_evpn_peer_sync_oracle.py
@@ -18,7 +18,7 @@ from evpn_peer_sync_oracle import (
 )
 
 
-from evpn_peer_sync_peer import open_body, validate_open
+from evpn_peer_sync_peer import command_updates, open_body, validate_open
 
 
 SOURCE = "10.0.0.2"
@@ -271,6 +271,74 @@ class PeerSyncOracleTests(unittest.TestCase):
             else:
                 with self.assertRaises(AssertionError):
                     oracle.expect([route], 3, next_hop=DUT)
+
+    def test_withdraw_command_removes_every_announced_source_key(self):
+        oracle = Oracle()
+        for body in command_updates(9):
+            oracle.apply(body)
+        announced = set(oracle.live)
+        self.assertEqual(len(announced), 7)
+        updates = command_updates(None)
+        self.assertEqual(len(updates), 1)
+        # Independent UPDATE prefix: no classic withdrawals, a single optional
+        # MP_UNREACH attribute, AFI25/SAFI70, with no announcement attribute.
+        # Seven NLRIs total 269 bytes; AFI/SAFI makes a 272-byte extended-
+        # length MP_UNREACH value and 276-byte attributes block.
+        self.assertEqual(updates[0][:11].hex(), "00000114900f0110001946")
+        before = len(oracle.events)
+        oracle.apply(updates[0])
+        self.assertEqual(oracle.live, {})
+        self.assertEqual({(row["rd"], row["tag"], row["mac"], row["ip"])
+                          for row in oracle.events[before:]}, announced)
+        self.assertTrue(all(row["action"] == "withdraw" for row in oracle.events[before:]))
+        for bad in (0, 4, "withdraw", False):
+            with self.subTest(sequence=bad), self.assertRaises(ValueError):
+                command_updates(bad)
+
+    def test_received_page_requires_complete_success_shape_before_absence(self):
+        from evpn_peer_sync_peer import SOURCE, SOURCE_RD
+        module = runpy.run_path(str(Path(__file__).with_name("run-evpn-peer-sync-proof.py")))
+        parse = module["received_routes"]
+        empty = {"view": "received", "neighbor": SOURCE, "routes": [],
+                 "next_page_token": "", "total_count": 0}
+        import json
+        self.assertEqual(parse(json.dumps(empty)), [])
+        route = {"rd": SOURCE_RD, "peer": SOURCE, "route_type": 2, "mac": MAC, "ip": ""}
+        positive = {**empty, "routes": [route], "total_count": 1}
+        self.assertEqual(parse(json.dumps(positive)), [route])
+        malformed = [[], None, {}, {**empty, "view": "advertised"},
+                     {**empty, "neighbor": DUT}, {**empty, "next_page_token": "more"},
+                     {**empty, "total_count": 1}, {**empty, "total_count": False},
+                     {**positive, "routes": [{}]}, {**positive, "routes": [None]},
+                     {**positive, "routes": [{**route, "peer": DUT}]}]
+        for value in malformed:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                parse(json.dumps(value))
+        for raw in ("", "not JSON", json.dumps(empty) + json.dumps(empty)):
+            with self.subTest(raw=raw), self.assertRaises(ValueError):
+                parse(raw)
+
+    def test_cross_shape_transitions_require_fresh_nine_not_retained_other_key(self):
+        parent = Route("10.0.0.1:100", MAC)
+        children = [Route(parent.rd, MAC, ip) for ip, _ in VECTORS if ip]
+        for original, replacement in (([parent], children), (children, [parent])):
+            with self.subTest(replacement=replacement):
+                oracle = Oracle()
+                oracle.apply(announcement(original, 9, next_hop=DUT))
+                checkpoint = len(oracle.events)
+                with self.assertRaises(AssertionError):
+                    oracle.expect_transition(replacement, 9, next_hop=DUT, after=checkpoint)
+                oracle.apply(withdrawal(original))
+                oracle.apply(announcement(replacement, 0, next_hop=DUT))
+                with self.assertRaises(AssertionError):
+                    oracle.expect_transition(replacement, 9, next_hop=DUT, after=checkpoint)
+                oracle.apply(announcement(replacement, 9, next_hop=DUT))
+                # A later correction cannot hide a transient zero export.
+                with self.assertRaises(AssertionError):
+                    oracle.expect_transition(replacement, 9, next_hop=DUT, after=checkpoint)
+                oracle.expect_transition(replacement, 9, next_hop=DUT,
+                                         after=len(oracle.events) - len(replacement))
+                oracle.expect_owned_keys(replacement, rd=parent.rd)
 
     def test_encoder_rejects_out_of_range_and_oversized_inputs(self):
         for route in (Route("10.0.0.2:100", "00"), Route("10.0.0.2:100", MAC, vni=0),


### PR DESCRIPTION
Add a reproducible controlled BGP peer proof for local same-ESI Type-2 sequence adoption. It checks exact 3→9 adoption for MAC-only and IPv4/IPv6 routes, replay stability, peer-only ownership exclusion, RT/tag eligibility, and removal without resurrection. After confirmed peer withdrawal, new IP children and the last-IP-to-MAC-only transition must retain sequence 9.

The isolated Compose topology uses a fixed VXLAN profile, pinned local image IDs and source revision, complete wire/metric receipts, and verified cleanup. The existing offline interop CI step runs the oracle and runner regression suite. This is a bounded controlled-peer proof, not vendor interoperability, general encapsulation discovery, or a churn soak.

Validation: 23 offline tests, the complete offline interop CI step, Ruff, Compose configuration, links, and metric-consumer/public-document companion checks passed. Normal commit and push hooks passed; the push ran the documentation hooks and skipped file-filtered Rust tests for this harness-only diff. The expanded live proof passed with runtime source `f80f94ad916396a2cf412cf98fbf4d2f227c6032` and harness `2ab1f1392f3778ee4b61c8dd8ea5ae9d6b3b28fd`. The final shared metric parser also passed replay of all nine saved live scrapes, including unchanged process identity and counter totals. All four duplicate-counter totals stayed zero across successful scrapes, with missing lazy series recorded explicitly; the process-start sample stayed unchanged. Teardown left no owned containers or networks.
