### PR TITLE
fix(evpn): reject incompatible local VXLAN encapsulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -495,6 +495,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   duplicate-IP movement. Only matching import RTs, VNI, tag zero, and a
   nonlocal next hop qualify; peer routes alone do not create local ownership.
 
+- Reject explicitly incompatible EVPN encapsulations before local VXLAN
+  forwarding, mobility, and gateway or alias/backup resolution. Absent
+  encapsulation uses the configured VXLAN fallback; advertised sets containing
+  VXLAN remain eligible. Global retention and reflection are unchanged.
+
 - Preserve fresh routes and live peer state when GR or LLGR retention expires
   while a re-established peer's initial outbound registration is deferred.
   Stale routes still expire, and the pending registration completes normally.
@@ -778,6 +783,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Existing higher local sequences never decrease. Withdrawn, quarantined, or
   drained routes stay suppressed until normal local replay permits origination.
   A host learned only from the ES peer is still not originated locally.
+
+- **EVPN VXLAN import:** Type 2, Type 5, and EAD-per-EVI advertisements with
+  explicit encapsulation sets lacking VXLAN no longer contribute local state.
+  Check remote Encapsulation communities before upgrading; absent communities
+  continue to use the configured VXLAN profile. See
+  [encapsulation compatibility](docs/how-to/evpn-vtep-setup.md#vxlan-encapsulation-compatibility).
 
 - **EVPN RPCs apply the configuration MAC and ESI grammar:** `AddEvpnRoute`,
   `DeleteEvpnRoute`, and `ClearDuplicateMacQuarantine` now parse `mac` and

--- a/crates/evpn/src/instance.rs
+++ b/crates/evpn/src/instance.rs
@@ -27,6 +27,26 @@ use crate::route_target::RouteTarget;
 /// Maximum 24-bit VXLAN Network Identifier (RFC 8365 §5).
 pub const MAX_VNI: u32 = (1 << 24) - 1;
 
+/// Whether an advertisement can be consumed by the local VXLAN profile.
+/// RFC 8365 §6 requires a common advertised encapsulation; absence uses the
+/// statically configured VXLAN fallback. Global retention/export is separate.
+#[must_use]
+pub fn vxlan_encapsulation_compatible(attributes: &[PathAttribute]) -> bool {
+    let mut advertised = false;
+    for encapsulation in attributes
+        .iter()
+        .filter_map(PathAttribute::extended_communities)
+        .flatten()
+        .filter_map(|ec| ec.as_bgp_encapsulation())
+    {
+        if encapsulation == 8 {
+            return true;
+        }
+        advertised = true;
+    }
+    !advertised
+}
+
 /// A validated 24-bit VXLAN Network Identifier (RFC 8365 §5).
 ///
 /// Constructed only via [`EvpnInstanceId::new`], which rejects 0 (RFC
@@ -257,7 +277,8 @@ impl EvpnInstance {
     }
 
     /// Whether a route belongs to this local VLAN-based EVI: matching VNI,
-    /// zero Ethernet Tag, and at least one configured Route Target.
+    /// zero Ethernet Tag, at least one configured Route Target, and compatible
+    /// encapsulation for the local VXLAN profile.
     /// This gates local consumption, not global RIB retention or export.
     #[must_use]
     pub fn imports_evi(
@@ -268,6 +289,7 @@ impl EvpnInstance {
     ) -> bool {
         vni == self.id.as_u32()
             && ethernet_tag.0 == 0
+            && vxlan_encapsulation_compatible(attributes)
             && attributes
                 .iter()
                 .filter_map(PathAttribute::extended_communities)
@@ -522,6 +544,30 @@ mod tests {
             false,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn vxlan_encapsulation_uses_exact_decoder_and_all_attributes() {
+        use rustbgpd_wire::ExtendedCommunity;
+        let nvgre = ExtendedCommunity::bgp_encapsulation(9);
+        let vxlan = ExtendedCommunity::bgp_encapsulation(8);
+        assert!(vxlan_encapsulation_compatible(&[]));
+        assert!(!vxlan_encapsulation_compatible(&[
+            PathAttribute::ExtendedCommunities(vec![nvgre]),
+        ]));
+        assert!(vxlan_encapsulation_compatible(&[
+            PathAttribute::ExtendedCommunities(vec![nvgre]),
+            PathAttribute::ExtendedCommunitiesPartial(vec![vxlan]),
+        ]));
+        for type_byte in [0x43_u64, 0x83, 0xc3] {
+            let unassigned = ExtendedCommunity::new((type_byte << 56) | 0x000c_0000_0000_0008);
+            assert!(vxlan_encapsulation_compatible(&[
+                PathAttribute::ExtendedCommunities(vec![unassigned]),
+            ]));
+            assert!(!vxlan_encapsulation_compatible(&[
+                PathAttribute::ExtendedCommunitiesPartial(vec![nvgre, unassigned]),
+            ]));
+        }
     }
 
     #[test]

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -138,7 +138,7 @@ pub use duplicate_mac::{
 };
 pub use instance::{
     BridgeVlan, BridgeVlanError, EvpnInstance, EvpnInstanceId, EvpnInstanceIdError,
-    EvpnInstanceTable, EvpnInstanceTableError,
+    EvpnInstanceTable, EvpnInstanceTableError, vxlan_encapsulation_compatible,
 };
 pub use ip_vrf::{
     IpVrf, IpVrfError, IpVrfId, IpVrfIdError, IpVrfRouteDump, IpVrfTable, IpVrfTableError,

--- a/docs/how-to/evpn-vtep-setup.md
+++ b/docs/how-to/evpn-vtep-setup.md
@@ -136,6 +136,20 @@ by remote VTEPs. Previously installed Type 2 rows that fail these requirements
 are removed from local forwarding and gateway-IP resolution; correct the
 sender's RTs or the intended instance configuration before upgrading.
 
+### VXLAN encapsulation compatibility
+
+Local Type 2, Type 5, and EAD-per-EVI consumers require a compatible
+encapsulation. When a route advertises BGP Encapsulation extended communities,
+at least one must specify VXLAN (`8`). A set containing both VXLAN and NVGRE
+qualifies; NVGRE-only, MPLS-only, or other sets without VXLAN do not. When
+the community is absent, the configured VXLAN profile supplies the fallback,
+as allowed by [RFC 8365 section 6](https://www.rfc-editor.org/rfc/rfc8365.html#section-6).
+
+This check applies to forwarding, mobility, gateway resolution, and alias or
+backup selection. It leaves global EVPN retention and reflection unchanged.
+Before upgrading, correct explicitly incompatible advertisements: their local
+FDB, prefix, or next-hop state is removed when the updated daemon reconciles.
+
 ### MAC+IP origination (ARP/ND suppression)
 
 To originate Type 2 routes carrying the host IP (MAC+IP), enable

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1504,6 +1504,9 @@ fn project_type5(route: &EvpnRibRoute) -> Option<rustbgpd_evpn::ip_vrf::Projecte
     let EvpnRoute::IpPrefix(prefix_route) = &route.route else {
         return None;
     };
+    if !rustbgpd_evpn::vxlan_encapsulation_compatible(&route.attributes) {
+        return None;
+    }
     let ext_comms: Vec<rustbgpd_wire::ExtendedCommunity> = route
         .attributes
         .iter()
@@ -2923,6 +2926,21 @@ mod tests {
         missing_rt.attributes = Arc::new(vec![]);
         let unsupported_tag = evpn_ead_per_evi_route(esi, 42, "10.0.0.3");
         for (name, candidate, eligible) in [
+            (
+                "NVGRE only",
+                with_encapsulations(valid.clone(), &[9], false),
+                false,
+            ),
+            (
+                "MPLS only",
+                with_encapsulations(valid.clone(), &[10], true),
+                false,
+            ),
+            (
+                "VXLAN shared",
+                with_encapsulations(valid.clone(), &[9, 8], true),
+                true,
+            ),
             ("same EVI", valid, true),
             ("other configured EVI", foreign, false),
             ("wrong RT", wrong_rt, false),
@@ -3021,6 +3039,24 @@ mod tests {
         let mut missing_rt = valid.clone();
         missing_rt.attributes = Arc::new(vec![]);
         for (name, ead, tag, accepted) in [
+            (
+                "NVGRE only",
+                with_encapsulations(valid.clone(), &[9], false),
+                0,
+                false,
+            ),
+            (
+                "MPLS only",
+                with_encapsulations(valid.clone(), &[10], true),
+                0,
+                false,
+            ),
+            (
+                "VXLAN shared",
+                with_encapsulations(valid.clone(), &[9, 8], true),
+                0,
+                true,
+            ),
             ("same EVI", valid, 0, true),
             ("other configured EVI", foreign, 0, false),
             ("wrong RT", wrong_rt, 0, false),
@@ -3537,6 +3573,85 @@ mod tests {
                 assert_eq!(route.route, before.route);
                 assert_eq!(route.attributes, before.attributes);
                 assert_eq!(route.next_hop, before.next_hop);
+            }
+        }
+    }
+
+    fn with_encapsulations(mut route: EvpnRibRoute, types: &[u16], partial: bool) -> EvpnRibRoute {
+        let attrs = Arc::make_mut(&mut route.attributes);
+        let ecs = attrs
+            .iter_mut()
+            .find_map(PathAttribute::extended_communities_mut)
+            .unwrap();
+        ecs.extend(
+            types
+                .iter()
+                .copied()
+                .map(ExtendedCommunity::bgp_encapsulation),
+        );
+        if partial {
+            for attr in attrs {
+                if let PathAttribute::ExtendedCommunities(ecs) = attr {
+                    *attr = PathAttribute::ExtendedCommunitiesPartial(std::mem::take(ecs));
+                }
+            }
+        }
+        route
+    }
+
+    #[test]
+    fn encapsulation_eligibility_gates_type2_and_type5_forwarding() {
+        let instances = local_instance_table(100, Some("br100"));
+        let mut ip_vrfs = ip_vrf_table_one("blue", 5000, 5000);
+        ip_vrfs.mark_referenced_by_l2vni("blue".to_string(), vni(100));
+        for (encapsulations, accepted) in [
+            (&[][..], true),
+            (&[8][..], true),
+            (&[9, 8][..], true),
+            (&[9][..], false),
+            (&[10][..], false),
+            (&[12, 65535][..], false),
+        ] {
+            for partial in [false, true] {
+                for subject in [0, 1] {
+                    let mut routes = vec![
+                        evpn_macip_route_with_host_ip(
+                            100,
+                            0xaa,
+                            Some("192.0.2.10"),
+                            "10.0.0.2",
+                            Some(9),
+                        ),
+                        evpn_ip_prefix_route("10.1.0.0/24", "192.0.2.10", "10.0.0.9", 5000),
+                    ];
+                    routes[subject] =
+                        with_encapsulations(routes[subject].clone(), encapsulations, partial);
+                    let retained = routes.clone();
+                    let tables = project_intent_tables(
+                        &routes,
+                        &instances,
+                        &ip_vrfs,
+                        &BTreeSet::new(),
+                        &no_bias(),
+                    );
+                    assert_eq!(
+                        tables.remote_macs.len(),
+                        usize::from(subject == 1 || accepted),
+                        "route index {subject}: {encapsulations:?}, partial={partial}"
+                    );
+                    assert_eq!(
+                        tables
+                            .remote_ip_prefixes
+                            .for_vrf(IpVrfId::new(5000).unwrap())
+                            .count(),
+                        usize::from(accepted),
+                        "route index {subject}: {encapsulations:?}, partial={partial}"
+                    );
+                    for (route, before) in routes.iter().zip(&retained) {
+                        assert_eq!(route.attributes, before.attributes);
+                        assert_eq!(route.route, before.route);
+                    }
+                }
             }
         }
     }

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -5477,10 +5477,26 @@ async fn peer_sync_keeps_higher_local_sequence_across_new_children_and_downgrade
 }
 
 #[tokio::test]
-async fn peer_sync_requires_import_rt_tag_zero_and_nonself_next_hop() {
-    for invalid in ["missing_rt", "wrong_rt", "tag", "self", "vni"] {
+async fn peer_sync_requires_local_import_eligibility() {
+    for (case, eligible) in [
+        ("missing_rt", false),
+        ("wrong_rt", false),
+        ("tag", false),
+        ("self", false),
+        ("vni", false),
+        ("nvgre", false),
+        ("mixed_vxlan", true),
+    ] {
         let mut route = eligible_peer_sync_route(9, None);
-        match invalid {
+        match case {
+            "nvgre" | "mixed_vxlan" => {
+                let mut ecs = vec![ExtendedCommunity::bgp_encapsulation(9)];
+                if eligible {
+                    ecs.push(ExtendedCommunity::bgp_encapsulation(8));
+                }
+                Arc::make_mut(&mut route.attributes)
+                    .push(PathAttribute::ExtendedCommunitiesPartial(ecs));
+            }
             "missing_rt" => {
                 Arc::make_mut(&mut route.attributes).remove(0);
             }
@@ -5500,7 +5516,7 @@ async fn peer_sync_requires_import_rt_tag_zero_and_nonself_next_hop() {
                 let EvpnRoute::MacIp(mac_ip) = &mut route.route else {
                     unreachable!()
                 };
-                if invalid == "tag" {
+                if case == "tag" {
                     mac_ip.ethernet_tag = EthernetTagId(1);
                 } else {
                     mac_ip.label1 = MplsLabel::new(200);
@@ -5514,11 +5530,11 @@ async fn peer_sync_requires_import_rt_tag_zero_and_nonself_next_hop() {
             h.take_log().await,
             vec![RibActionWithSeq::Inject(
                 macip_key_with(100, 0xAA, None),
-                None,
+                eligible.then_some(9),
             )],
-            "ineligible {invalid} route must not seed sequence adoption"
+            "{case} sequence adoption"
         );
-        assert!(h.state.peer_sync_sequences.is_empty());
+        assert_eq!(h.state.peer_sync_sequences.is_empty(), !eligible, "{case}");
     }
 }
 
@@ -6272,7 +6288,15 @@ async fn duplicate_ip_runtime_model_enables_and_disables_without_recounting_cach
 #[tokio::test]
 async fn type2_import_eligibility_gates_contenders_and_duplicate_accounting() {
     for ip in ["192.0.2.10", "2001:db8::10"] {
-        for case in ["missing", "mismatched", "tag", "vni", "self"] {
+        for case in [
+            "missing",
+            "mismatched",
+            "tag",
+            "vni",
+            "self",
+            "nvgre",
+            "mpls",
+        ] {
             let mut h = duplicate_ip_harness(true);
             h.observe(learned_aa()).await;
             h.observe(ip_observation(0xaa, ip, true)).await;
@@ -6283,6 +6307,17 @@ async fn type2_import_eligibility_gates_contenders_and_duplicate_accounting() {
                 .collect();
             for route in &mut routes {
                 match case {
+                    "nvgre" | "mpls" => {
+                        Arc::make_mut(&mut route.attributes).push(
+                            PathAttribute::ExtendedCommunitiesPartial(vec![
+                                ExtendedCommunity::bgp_encapsulation(if case == "nvgre" {
+                                    9
+                                } else {
+                                    10
+                                }),
+                            ]),
+                        );
+                    }
                     "missing" => route.attributes = Arc::new(vec![]),
                     "mismatched" => {
                         route.attributes =
@@ -6323,7 +6358,16 @@ async fn type2_import_eligibility_gates_contenders_and_duplicate_accounting() {
 
             // Restoring eligible routes makes both contender views visible and
             // counts the different remote MAC claiming the local IP exactly once.
-            let valid = evpn_macip_route_with_ip(100, 0xbb, Some(ip), "10.0.0.2", Some(9), false);
+            let mut valid =
+                evpn_macip_route_with_ip(100, 0xbb, Some(ip), "10.0.0.2", Some(9), false);
+            if matches!(case, "nvgre" | "mpls") {
+                Arc::make_mut(&mut valid.attributes).push(
+                    PathAttribute::ExtendedCommunitiesPartial(vec![
+                        ExtendedCommunity::bgp_encapsulation(9),
+                        ExtendedCommunity::bgp_encapsulation(8),
+                    ]),
+                );
+            }
             let views = build_remote_views(&h.instances, std::slice::from_ref(&valid), &h.segments);
             assert_eq!(views.0.len(), 1);
             assert_eq!(views.1.len(), 1);


### PR DESCRIPTION
An otherwise eligible EVPN route advertising only NVGRE or MPLS could become local VXLAN forwarding or mobility state. Check advertised encapsulations before Type 2/EAD-per-EVI admission and before Type 5 projection discards path attributes.

A shared allocation-free predicate accepts the configured VXLAN fallback when the Encapsulation community is absent, and accepts advertised sets containing VXLAN, including VXLAN plus NVGRE. It preserves Partial attributes and the exact existing community decoder. Global retention, reflection, export, and ES discovery remain unchanged.

The existing regression matrices now cover FDB and gateway-IP recursion, Type 5 input, MAC/MAC+IP contenders, peer-sequence adoption and duplicate accounting, and EAD alias/backup/ESI recursion. Maintained setup and upgrade notes describe removal of explicitly incompatible local state.

Validation: the new projection matrix failed against the old behavior with an NVGRE-only FDB present. Corrected focused checks passed: 59 dataplane, 89 originator, and 354 EVPN domain tests, plus strict Clippy, formatting, links and public-document checks.

The literal full `just gate` passed with the patch on base `1fc3a9be2`. After integrating main `aafc6e7ae`, all 101 originator tests passed, including explicit incompatible and shared-VXLAN peer-adoption cases.

Normal commit and push hooks passed on the final integrated head: strict workspace Clippy, workspace library tests, and library/binary rustdoc.
