### PR TITLE
docs(policy): clarify comparisons with absent fields

### DIFF
--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -1692,6 +1692,7 @@ fn absent_route_attribute_matches_neither_eq_nor_ne() {
         ("peer.address", "192.0.2.1"),
         ("peer.asn", "65010"),
         ("peer.group", "\"leaf\""),
+        ("route.origin-as", "64500"),
     ];
     let absent = absent_ctx();
     for (field, literal) in fields {
@@ -1703,6 +1704,13 @@ fn absent_route_attribute_matches_neither_eq_nor_ne() {
                 "absent `{field}` must not match `{field} {op} {literal}`"
             );
         }
+        let negated = reject_if(&format!("!({field} == {literal})"));
+        let (result, evaluation) = negated.evaluate_with_attribution(&absent);
+        assert_eq!(result.action, PolicyAction::Deny, "explicit ! for {field}");
+        assert!(
+            evaluation.eval_error.is_none(),
+            "Boolean negation is a match"
+        );
     }
 }
 
@@ -2923,35 +2931,45 @@ fn eval_error_denies_discards_mods_and_counts() {
 
 /// An absent operand without a documented default (origin-as on an
 /// AS_SET-only path, unknown peer.asn) is unresolvable → the same
-/// eval-error rail. Plain (arithmetic-free) comparisons keep their
+/// eval-error rail. Plain field/literal comparisons keep their
 /// legacy never-match semantics — the two deliberately diverge.
 #[test]
 fn absent_operand_is_an_eval_error_not_a_non_match() {
-    // Arithmetic form: absent origin denies the route.
-    let arith = reject_if("route.origin-as * 1 == 64500");
-    assert_eq!(
-        arith.evaluate(&absent_ctx()).action,
-        PolicyAction::Deny,
-        "absent origin in arithmetic fails closed"
-    );
-    // Plain form: absent origin matches neither == nor != and the
-    // route falls through to the accepting term.
-    let plain = reject_if("route.origin-as == 64500");
-    assert_eq!(
-        plain.evaluate(&absent_ctx()).action,
-        PolicyAction::Permit,
-        "plain comparison keeps never-match-on-absent semantics"
-    );
-    // peer.asn as an operand behaves the same.
-    let peer = reject_if("peer.asn + 0 == 65010");
-    assert_eq!(peer.evaluate(&absent_ctx()).action, PolicyAction::Deny);
-    let mut ctx = absent_ctx();
-    ctx.peer_asn = Some(65010);
-    assert_eq!(
-        peer.evaluate(&ctx).action,
-        PolicyAction::Deny,
-        "matches → reject term fires"
-    );
+    use crate::eval::EvalErrorKind;
+    use crate::ir::ValueField;
+    use PolicyAction::{Deny, Permit};
+
+    // Verdicts are ordered: absent, present/equal, present/different.
+    let cases = [
+        ("FIELD == 64500", [Permit, Deny, Permit], false),
+        ("FIELD != 64500", [Permit, Permit, Deny], false),
+        ("!(FIELD == 64500)", [Deny, Permit, Deny], false),
+        ("(FIELD == 64500)", [Permit, Deny, Permit], false),
+        ("FIELD * 1 == 64500", [Deny, Deny, Permit], true),
+        ("FIELD + 0 == 64500", [Deny, Deny, Permit], true),
+        ("FIELD == (64500)", [Deny, Deny, Permit], true),
+        ("!(FIELD == (64500))", [Deny, Permit, Deny], true),
+    ];
+    for field in [ValueField::OriginAs, ValueField::PeerAsn] {
+        for (template, actions, absent_error) in cases {
+            let guard = template.replace("FIELD", field.as_str());
+            let chain = reject_if(&guard);
+            for (index, value) in [None, Some(64500), Some(64501)].into_iter().enumerate() {
+                let ctx = RouteContext {
+                    origin_asn: value,
+                    peer_asn: value,
+                    ..absent_ctx()
+                };
+                let (result, evaluation) = chain.evaluate_with_attribution(&ctx);
+                assert_eq!(result.action, actions[index], "{guard}, field={value:?}");
+                assert_eq!(
+                    evaluation.eval_error.map(|error| error.kind),
+                    (absent_error && value.is_none()).then_some(EvalErrorKind::AbsentField(field)),
+                    "{guard}, field={value:?}"
+                );
+            }
+        }
+    }
 }
 
 /// min/max/clamp evaluate per route with checked operand evaluation;

--- a/docs/reference/rpol-language.md
+++ b/docs/reference/rpol-language.md
@@ -446,7 +446,20 @@ absent on empty and `AS_SET`-only paths and then matches neither `==`
 nor `!=` nor `in` (`!(... in ...)` negates plainly, matching the
 prefix-set precedent).
 
-`==` on u32 fields lowers to `>= v && <= v`; `!=` is its negation.
+For plain comparisons on optional attributes, `!=` and explicit Boolean
+negation are different. With an optional field `x` and a literal `y`:
+
+| Field state | `x == y` | `x != y` | `!(x == y)` |
+|---|---|---|---|
+| Present, equal | true | false | false |
+| Present, different | false | true | true |
+| Absent, without an implicit default | false | false | true |
+
+For example, an ungrouped peer matches `!(peer.group == "leaf")`, but
+does not match `peer.group != "leaf"`. Include fixtures with omitted
+attributes when testing guards over optional fields. `route.local-pref`
+and `route.med` use their implicit defaults, so they do not have the
+absent-field behavior in the last row.
 
 ### Checked u32 value expressions
 
@@ -495,12 +508,21 @@ policy/term retained, surfaced by `rbgp policy stats`), a
 rate-limited WARN names the failing policy and term, and explain
 traces render the error in place of a verdict. `route.local-pref` and `route.med` read their
 implicit defaults (100 / 0) when absent, consistent with comparisons.
-Note the deliberate divergence from plain comparisons: an
-arithmetic-free `route.origin-as == 64500` on an origin-less route
+Note the deliberate divergence from plain comparisons:
+`route.origin-as == 64500` on an origin-less route
 matches neither `==` nor `!=` (never-match), while
 `route.origin-as * 1 == 64500` is unresolvable and **denies** — the
 computed form has no non-verdict to fall back to, exactly like
 computed prepend operands.
+
+A value comparison does not need arithmetic: `route.origin-as == (64500)`
+also reads a checked value and denies an absent origin with
+`absent-operand`. A runtime `let` binding on the right has the same
+behavior. Grouping the whole condition, `(route.origin-as == 64500)`,
+keeps the plain comparison's no-match behavior. Explicit `!` does not
+suppress an evaluation error: `!(route.origin-as == (64500))` still
+denies an absent origin. Test errors with `expect … == error absent-operand`;
+a plain `reject` expectation does not count an evaluation error as a pass.
 
 **Update-group note.** `peer.asn` as an operand (guard or computed
 `set` value) reads peer identity and keeps its peers out of shared


### PR DESCRIPTION
Clarify how optional policy fields behave under `!=`, explicit Boolean negation, and checked value comparisons. The language reference now shows absent/present outcomes and explains why grouping the right-hand literal can produce an `absent-operand` error while grouping the whole condition retains a plain comparison.

Expand existing regressions across absent, equal, and different values for `route.origin-as` and `peer.asn`, including typed evaluation-error assertions. Runtime behavior is unchanged.

Validation: policy package tests and strict all-target Clippy passed; all 11 absent-field tests passed after integrating main. Documentation links, public-content checks, and `git diff --check` passed.
