### PR TITLE
test(config): fix policy budget bench test boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,9 @@ jobs:
       # LAN-198: `config` referenced binary-only modules, so the lib
       # failed to build under `--all-features` while the bin stayed green.
       - run: cargo check --locked -p rustbgpd --all-features --lib
+      # Bench targets also compile config's tests; keep their binary-module
+      # boundary checked in addition to the production library surface.
+      - run: cargo check --locked -p rustbgpd --features bench-internals --benches
       # The root `Config` API is exported only by `bench-internals`, so the
       # normal workspace test cannot compile this cheap allocation gate.
       - name: Gate eager policy-set sharing allocation shape

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -25,7 +25,7 @@ WORKFLOWS = tuple(
                  "release-install-contract", "release", "update-group-fault")
 )
 EXPECTED_ROOT_COMMANDS = {
-    WORKFLOWS[0]: Counter(build=1, check=6, clippy=2, doc=4, test=7),
+    WORKFLOWS[0]: Counter(build=1, check=7, clippy=2, doc=4, test=7),
     WORKFLOWS[1]: Counter(test=1),
     WORKFLOWS[2]: Counter(test=6),
     WORKFLOWS[3]: Counter(build=1, test=2),

--- a/src/config/tests/rpol.rs
+++ b/src/config/tests/rpol.rs
@@ -761,10 +761,7 @@ fn chain_node_budget_named_mixed_unused_and_implicit_tails() {
         .push("toml-pass".to_string());
     let error = config.validate().unwrap_err();
     assert!(error.to_string().contains("MAX_CHAIN_NODES"), "{error}");
-    assert!(matches!(
-        crate::policy_admin::catalog_config_error(error),
-        rustbgpd_api::peer_types::CatalogMutationError::Invalid(_)
-    ));
+    assert!(matches!(error, ConfigError::PolicyChainTooLarge { .. }));
     let path = dir.path().join("config.toml");
     let text = fs::read_to_string(&path).unwrap();
     let refs = serde_json::to_string(&config.neighbors[0].import_policy_chain).unwrap();

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -971,6 +971,18 @@ remote_asn = 65002
     }
 
     #[test]
+    fn chain_node_budget_config_error_maps_to_invalid_catalog_request() {
+        let error = ConfigError::PolicyChainTooLarge {
+            reason: "chain exceeds node budget".to_string(),
+        };
+        let expected = error.to_string();
+        assert!(matches!(
+            catalog_config_error(error),
+            CatalogMutationError::Invalid(message) if message == expected
+        ));
+    }
+
+    #[test]
     fn raw_neighbor_persists_canonical_family_labels() {
         let families = rustbgpd_wire::CONFIGURED_FAMILIES
             .iter()


### PR DESCRIPTION
The root `bench-internals` build failed because a config test called `policy_admin`, which exists only in the daemon binary. Keep the typed chain-overflow assertion in config tests and move the catalog error mapping assertion into `policy_admin`'s test module, preserving both rejection and diagnostic coverage.

Add the exact root bench check to CI alongside the existing all-features library check. The latter does not compile config's test module and missed this failure. Update the existing CI command inventory accordingly. Production behavior and module visibility are unchanged.

Validation: reproduced the original bench check failure, then passed `just gate-rib`, both feature-gated library config regressions, all five binary chain-budget regressions, 61 CI contract companion tests, both CI contract checkers, and developer-tooling syntax checks. No release-note change is needed for this test/build-boundary repair.
