### PR TITLE
feat(policy): add explicit rpol default actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   valid `--coverage-min` semantics remain unchanged. Matched coverage does not
   guarantee branch coverage or detect every widened guard.
 
+- Opt-in `.rpol` policy fallbacks with `default-action accept|reject`,
+  declared before terms. Omission keeps accept-and-continue behavior;
+  a rejecting fallback stops the chain and discards staged changes.
+  Defaults also apply to parameterized policies and `apply` predicates.
+
 ### Changed
 
 - `rbgp rib add` uses `--next-hop` as the canonical flag, retaining
@@ -1025,6 +1030,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fit: shorten chains in a separate reload before loading larger definitions
   when that intermediate combination would exceed the cap.
   See [policy bounds](docs/reference/rpol-language.md#loops--for).
+
+- **Policy language:** `default-action` is optional; existing `.rpol` files
+  retain their behavior. Upgrade readers before adding the new declaration,
+  since older releases reject its syntax. `default-action accept` continues
+  the policy chain; `reject` affects only fallthrough and does not diagnose
+  widened guards. Keep negative route assertions when adopting it.
 
 ## [0.68.0] — 2026-08-30
 

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 
 use rustbgpd_wire::{LargeCommunity, Prefix};
 
-use crate::engine::CommunityMatch;
+use crate::engine::{CommunityMatch, PolicyAction};
 
 use super::diag::{Span, Spanned};
 
@@ -226,13 +226,15 @@ impl CommunityLit {
     }
 }
 
-/// `policy NAME(params) { terms }`.
+/// `policy NAME(params) { [default-action accept|reject] terms }`.
 #[derive(Debug)]
 pub struct PolicyDef {
     /// Policy name.
     pub name: Spanned<String>,
     /// Declared parameters (all `u32` in V1).
     pub params: Vec<Spanned<String>>,
+    /// Optional policy fallback; omission preserves accept-and-continue.
+    pub default_action: Option<Spanned<PolicyAction>>,
     /// Named terms, in source order.
     pub terms: Vec<TermDef>,
 }

--- a/crates/policy/src/rpol/fmt.rs
+++ b/crates/policy/src/rpol/fmt.rs
@@ -235,7 +235,7 @@ enum Ctx {
     /// The file: imports, dataset declarations, sets, fns, policies,
     /// tests.
     Top,
-    /// A `policy` body: `term` statements.
+    /// A `policy` body: an optional `default-action`, then `term` statements.
     Policy,
     /// A `test` body: `dataset` overrides, `route`/`peer` fixtures,
     /// `expect` lines.
@@ -406,7 +406,15 @@ fn is_starter(children: &[Node<'_>], i: usize, ctx: Ctx, prev: Tok, expr_head: b
             },
             _ => false,
         },
-        Ctx::Policy => *kind == Tok::TermKw,
+        Ctx::Policy => {
+            *kind == Tok::TermKw
+                || (*kind == Tok::Ident
+                    && *text == "default-action"
+                    && matches!(
+                        peek_kind(children, i, 1),
+                        Some(Tok::AcceptKw | Tok::RejectKw)
+                    ))
+        }
         Ctx::Test => match kind {
             Tok::RouteKw | Tok::PeerKw | Tok::ExpectKw => true,
             Tok::Ident => {
@@ -779,6 +787,33 @@ mod tests {
 
     fn fmt(source: &str) -> String {
         format_rpol(source).expect("formats cleanly")
+    }
+
+    #[test]
+    fn default_action_layout_preserves_comments_tokens_and_compiled_identity() {
+        for separator in ["", ";"] {
+            let source = format!(
+                "policy p{{# fallback\n default-action reject{separator} # keep this\n\
+                 term default-action{{if route.med==7{{accept}}}}}}"
+            );
+            let formatted = fmt(&source);
+            assert_eq!(
+                formatted,
+                format!(
+                    "policy p {{\n    # fallback\n    default-action reject{separator} # keep this\n\
+                     \x20   term default-action {{ if route.med == 7 {{ accept }} }}\n}}\n"
+                )
+            );
+            assert_eq!(fmt(&formatted), formatted);
+            assert_eq!(
+                super::super::compile_rpol(&source, &mut SetStore::new()).unwrap(),
+                super::super::compile_rpol(&formatted, &mut SetStore::new()).unwrap()
+            );
+        }
+        assert_eq!(
+            fmt("policy p{default-action accept}"),
+            "policy p {\n    default-action accept\n}\n"
+        );
     }
 
     #[test]

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -20,9 +20,9 @@
 //!   `<term>.<n>` (1-based); a single IR term keeps the plain term
 //!   name. Explain surfaces (PR-4) render these names.
 //!
-//! End of policy without a verdict is `default_action: Permit` — the
-//! policy raises no objection and chain evaluation continues, matching
-//! `GoBGP` chain semantics (an empty chain permits).
+//! End of policy uses its declared `default-action`, or `Permit` when
+//! omitted. Permit raises no objection and chain evaluation continues;
+//! Deny stops the chain and discards staged modifications.
 //!
 //! ## Parameters
 //!
@@ -549,7 +549,10 @@ impl<'a> Lowerer<'a> {
         CompiledPolicy {
             name: Some(Arc::from(def.name.node.clone())),
             terms,
-            default_action: PolicyAction::Permit,
+            default_action: def
+                .default_action
+                .as_ref()
+                .map_or(PolicyAction::Permit, |action| action.node),
             source: PolicySource::Rpol,
         }
     }

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -10,7 +10,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, LargeCommunity, Prefix};
 
-use crate::engine::{CommunityMatch, parse_community_match};
+use crate::engine::{CommunityMatch, PolicyAction, parse_community_match};
 
 use crate::ir::ArithOp;
 
@@ -708,11 +708,38 @@ impl Parser<'_> {
             self.expect(Tok::RParen, "`)`")?;
         }
         self.expect(Tok::LBrace, "`{`")?;
+        let mut default_action = None;
         let mut terms = Vec::new();
         while !self.at(Tok::RBrace) {
-            if let Ok(term) = self.term_def() {
-                terms.push(term);
+            let item = if self
+                .peek()
+                .is_some_and(|t| t.kind == Tok::Ident && self.text(t) == "default-action")
+            {
+                let span = self.bump().expect("peeked").span;
+                if default_action.is_some() || !terms.is_empty() {
+                    self.diags.push(Diagnostic::new(
+                        span,
+                        "`default-action` is allowed at most once, before all terms",
+                        "move a single default declaration before the first term",
+                    ));
+                }
+                let action = match self.peek().map(|t| t.kind) {
+                    Some(Tok::AcceptKw) => Some(PolicyAction::Permit),
+                    Some(Tok::RejectKw) => Some(PolicyAction::Deny),
+                    _ => None,
+                };
+                if let Some(action) = action {
+                    self.bump();
+                    self.eat(Tok::Semi);
+                    default_action.get_or_insert(Spanned::new(action, span));
+                    Ok(())
+                } else {
+                    Err(self.error_expected("`accept` or `reject` after `default-action`"))
+                }
             } else {
+                self.term_def().map(|term| terms.push(term))
+            };
+            if item.is_err() {
                 self.recover_to(&[Tok::TermKw, Tok::RBrace], false);
                 if self.peek().is_none() {
                     return Err(Fail);
@@ -723,6 +750,7 @@ impl Parser<'_> {
         Ok(PolicyDef {
             name,
             params,
+            default_action,
             terms,
         })
     }

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -295,6 +295,147 @@ fn diagnostics_of(source: &str) -> (super::Diagnostics, String) {
 // ── compile + IR shape goldens ─────────────────────────────────────
 
 #[test]
+fn default_action_preserves_omission_and_controls_fallback() {
+    let source = "policy p {
+        term shape { set med 17 }
+        term authorized { if route.prefix == 192.0.2.0/24 { accept } }
+    }";
+    let omitted = compile_ok(source);
+    let explicit_accept = compile_ok(&source.replacen('{', "{ default-action accept;", 1));
+    assert_eq!(omitted, explicit_accept);
+    assert_eq!(
+        compile_ok("policy empty {}"),
+        compile_ok("policy empty { default-action accept }")
+    );
+    let reject = compile_ok(&source.replacen('{', "{ default-action reject", 1));
+    assert_eq!(reject.policies[0].terms, omitted.policies[0].terms);
+    assert_eq!(reject.policies[0].default_action, PolicyAction::Deny);
+
+    let accepted = route_ctx(v4(192, 0, 2, 0, 24), &[], RpkiValidation::NotFound);
+    let result = reject.evaluate(&accepted);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(17));
+    let unmatched = route_ctx(v4(198, 51, 100, 0, 24), &[], RpkiValidation::NotFound);
+    assert_eq!(omitted.evaluate(&unmatched).action, PolicyAction::Permit);
+    let denied = reject.evaluate(&unmatched);
+    assert_eq!(denied.action, PolicyAction::Deny);
+    assert!(
+        denied.modifications.is_empty(),
+        "fallback drops staged changes"
+    );
+    assert_eq!(
+        compile_ok("policy empty { default-action reject }")
+            .evaluate(&accepted)
+            .action,
+        PolicyAction::Deny
+    );
+}
+
+#[test]
+fn default_action_composes_with_parameters_apply_and_later_policies() {
+    let source = r"
+policy authorized(lp: u32) {
+    default-action reject
+    term match { if route.local-pref == lp { accept } }
+}
+policy caller {
+    default-action reject;
+    term match { if apply(authorized(200)) { accept } }
+}
+test matched {
+    route { local-pref 200 }
+    expect authorized(200) == accept
+    expect caller == accept
+}
+test unmatched {
+    route { local-pref 100 }
+    expect authorized(200) == reject
+    expect caller == reject
+}
+";
+    let report = run_rpol_tests(source).expect("defaults compile at every use site");
+    assert_eq!(report.total, 2);
+    assert!(report.all_passed(), "{:?}", report.failures);
+
+    let chain = compile_ok(
+        "policy first { default-action accept term shape { set med 17 } }
+         policy last { term deny { reject } }",
+    );
+    let ctx = route_ctx(v4(192, 0, 2, 0, 24), &[], RpkiValidation::NotFound);
+    let (result, attribution) = chain.evaluate_with_attribution(&ctx);
+    assert_eq!(result.action, PolicyAction::Deny);
+    assert_eq!(attribution.matched_policy.as_deref(), Some("last"));
+    assert!(result.modifications.is_empty());
+}
+
+#[test]
+fn default_action_has_default_explain_attribution_and_no_coverage_term() {
+    let source = r"
+policy p {
+    default-action reject
+    term authorized { if route.prefix == 192.0.2.0/24 { accept } }
+}
+test matched { route { prefix 192.0.2.0/24 } expect p == accept }
+test unmatched { route { prefix 198.51.100.0/24 } expect p == reject }
+";
+    let file = RpolFile::parse(source).expect("default declaration parses");
+    let (report, coverage) = file.run_tests_with_coverage();
+    assert!(report.all_passed(), "{:?}", report.failures);
+    assert_eq!(coverage.terms_total(), 1);
+    let term = &coverage.policies[0].terms[0];
+    assert_eq!(term.name, "authorized");
+    assert_eq!((term.evaluated, term.matched), (2, 1));
+
+    let chain = crate::PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "p".into(),
+        Arc::new(compile_ok(source)),
+    )]);
+    let ctx = route_ctx(v4(198, 51, 100, 0, 24), &[], RpkiValidation::NotFound);
+    let trace = crate::explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(trace.action, PolicyAction::Deny);
+    assert_eq!(trace.steps.len(), 1);
+    let step = &trace.steps[0];
+    assert_eq!(step.policy_name.as_deref(), Some("p"));
+    assert_eq!(step.statement_index, None);
+    assert_eq!(step.term_name, None);
+    assert!(step.modifications.is_empty());
+}
+
+#[test]
+fn default_action_rejects_invalid_duplicate_and_misplaced_declarations() {
+    for source in [
+        "policy p { default-action }",
+        "policy p { default-action",
+        "policy p { default-action deny }",
+        "policy p { default-action = reject }",
+        "policy p { default-action accept default-action reject }",
+        "policy p { default-action accept; default-action accept; }",
+        "policy p { term t {} default-action reject }",
+        "policy p { term t { default-action reject } }",
+        "default-action reject policy p {}",
+    ] {
+        let (diagnostics, rendered) = diagnostics_of(source);
+        assert!(!diagnostics.is_empty(), "{source}");
+        assert!(rendered.contains("default-action"), "{rendered}");
+    }
+
+    // Recovery must progress through bad declarations and still find a later
+    // independent policy. No new reserved word steals existing identifiers.
+    let (file, diagnostics) = super::parser::parse(
+        "policy bad { default-action deny term t { accept } }
+         policy later { term t { accept } }",
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert!(file.policies.iter().any(|p| p.name.node == "later"));
+    compile_ok(
+        "policy default-action(default-action: u32) {
+            term default-action { if route.local-pref == default-action { accept } }
+        }
+        policy caller { term t { if apply(default-action(200)) { reject } } }",
+    );
+}
+
+#[test]
 fn adr_example_compiles_zero_param_policies_only() {
     let chain = compile_ok(ADR_EXAMPLE);
     // `customer-in` takes a parameter → template only; `bogon-filter`

--- a/docs/reference/rpol-language.md
+++ b/docs/reference/rpol-language.md
@@ -346,6 +346,7 @@ the daemon config's bindings.
 
 ```rpol
 policy NAME[(param: u32, ...)] {
+    [default-action accept|reject]
     term NAME { statement... }
     ...
 }
@@ -364,14 +365,34 @@ policy NAME[(param: u32, ...)] {
   without a verdict, evaluation continues to the next term.
   Modifications executed along the way (Junos-style
   modify-and-continue) are kept and merged into the eventual accept.
-- **End of policy without a verdict = accept** (with any accumulated
-  modifications). In chain terms: the policy raises no objection and
-  the chain continues — this matches the GoBGP-style chain semantics
-  the daemon already uses (each policy's permit accumulates and
-  continues; a deny terminates the chain).
+- **End of policy without a verdict** uses the policy's `default-action`.
+  When omitted, it remains `accept`, with accumulated modifications.
+  An accepting policy continues the chain; a rejecting policy stops it
+  and discards staged modifications.
 - Statements after a bare `accept`/`reject` in the same term (or
   actions after a verdict in the same `if` body) are **unreachable
   and a compile error**.
+
+An optional `default-action accept|reject` declaration must appear at most
+once, before the first term. Its semicolon is optional. For example:
+
+```rpol
+prefix-set customers { 192.0.2.0/24 }
+
+policy authorized-customers {
+    default-action reject
+    term authorized {
+        if route.prefix in customers { accept }
+    }
+}
+```
+
+The default decides only when no term has returned a verdict. Explicit
+`default-action accept` has the same behavior as omission, including continuing
+to later policies in a chain. Existing unconditional terms, such as
+`term reject-rest { reject }`, remain valid. A default declaration does not
+detect an accidentally removed guard or conjunct: include negative route
+assertions that would fail if the allowed set widened.
 
 ### Lowering into the IR (normative)
 
@@ -1010,10 +1031,10 @@ Two consequences worth internalizing:
 
 - Policy composition must form a **DAG** — recursion through `apply`
   (including self-application) is a compile error naming the cycle.
-- Since end-of-policy defaults to accept, a policy that never
-  `reject`s is constant-true under `apply`. Predicate policies should
-  decide both ways (see `bogon-filter` above: match → `accept`,
-  final term → `reject`).
+- With an accepting default, a policy that never `reject`s is
+  constant-true under `apply`. Predicate policies should decide both
+  ways: use `default-action reject` with guarded `accept` terms, or
+  retain a final rejecting term (as in `bogon-filter` above).
 - A policy that declares `let` bindings cannot be applied:
   the inlined predicate has no term walk to execute bindings in. The
   compile error names the target's first `let`. The same rule covers
@@ -1197,6 +1218,11 @@ unconditional term (`term catch-all { accept }`) matches whenever it
 is reached. Parameterized policies aggregate across instantiations
 (`expect p(200)` and `expect p(300)` both count toward `p`). With
 imports, each policy is attributed to its defining file.
+
+A policy's `default-action` is a fallback, not a source term: it adds no
+term to coverage or hit counters. Explain reports a default verdict without
+a matched term name. Test the unmatched case explicitly to exercise the
+fallback; a coverage percentage does not prove that case ran.
 
 Two boundaries, both deliberate:
 

--- a/src/config/tests/rpol.rs
+++ b/src/config/tests/rpol.rs
@@ -1,6 +1,69 @@
 use super::*;
 
 #[test]
+fn rpol_default_action_survives_imported_parameterized_chain_splicing() {
+    use rustbgpd_policy::{PolicyAction, RouteContext};
+
+    let imported = "policy customer-in(lp: u32) {
+        default-action reject
+        term shape { set med 23 }
+        term authorized { if route.local-pref == lp { accept } }
+    }
+    policy deny-tail { default-action reject }";
+    for (references, accepted_action) in [
+        (
+            r#""continue-default", "customer-in(200)", "toml-pass""#,
+            PolicyAction::Permit,
+        ),
+        (
+            r#""continue-default", "customer-in(200)", "deny-tail""#,
+            PolicyAction::Deny,
+        ),
+    ] {
+        let dir = rpol_config_dir(
+            "import \"defaults.rpol\"\npolicy continue-default { default-action accept }",
+            references,
+        );
+        fs::write(dir.path().join("policies/defaults.rpol"), imported).unwrap();
+        let config = load_dir(&dir).expect("imported default declarations load");
+        let (chain, _) = config
+            .effective_policy_chains_for_neighbor(&config.neighbors[0])
+            .expect("parameterized defaults resolve");
+        let chain = chain.expect("configured chain");
+        assert_eq!(
+            chain.compiled().policies[1].default_action,
+            PolicyAction::Deny
+        );
+        let ctx = RouteContext {
+            local_pref: Some(200),
+            ..route_server_test_context(
+                route_server_test_prefix("192.0.2.0/24"),
+                rustbgpd_wire::RpkiValidation::NotFound,
+                rustbgpd_wire::AspaValidation::Unknown,
+            )
+        };
+        let accepted = chain.evaluate(&ctx);
+        assert_eq!(accepted.action, accepted_action);
+        assert_eq!(
+            accepted.modifications.set_med,
+            (accepted_action == PolicyAction::Permit).then_some(23)
+        );
+        let unmatched = RouteContext {
+            local_pref: Some(100),
+            ..ctx
+        };
+        let (denied, attribution) =
+            rustbgpd_policy::evaluate_chain_with_attribution(Some(&chain), &unmatched);
+        assert_eq!(denied.action, PolicyAction::Deny);
+        assert!(denied.modifications.is_empty());
+        assert_eq!(
+            attribution.matched_policy.as_deref(),
+            Some("customer-in(200)")
+        );
+    }
+}
+
+#[test]
 fn rpol_files_load_resolve_and_evaluate_in_chains() {
     let dir = rpol_config_dir(
         RPOL_SOURCE,


### PR DESCRIPTION
## Summary

Policies can opt into rejecting fallthrough with `default-action reject` before their terms. Omitting the declaration, or declaring `default-action accept`, preserves accept-and-continue behavior.

## Changes

- Parse and format the optional declaration, rejecting duplicates and declarations after terms without reserving a new keyword.
- Lower into the existing policy fallback field, including parameterized policies, imports, chain splicing, and `apply` predicates.
- Cover fallback verdicts, discarded modifications, explain attribution, coverage, diagnostics, and formatting; document syntax and upgrade behavior.

## Testing

- [x] `just gate` (formatting, links, contracts, strict workspace Clippy, workspace tests, library and binary docs)
- [x] `just gate-rib`
- [x] Full policy package tests and focused daemon configuration regression
- [x] Existing corpus comparison: 23 fixtures retained the same results, 22 formatted outputs and 18 compiled standalone policy representations were byte-identical
- Interop and performance receipts: not applicable; the evaluator and wire behavior are unchanged.

## Docs / release notes

- [x] Language reference and changelog updated, including older-reader compatibility and negative-test guidance.
- Roadmap update: not needed for this bounded additive language feature.
