### PR TITLE
ci(interop): share the verified bird3 source cache

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -276,8 +276,8 @@ jobs:
       - name: Restore exact BIRD 3.3.2 archive cache
         uses: actions/cache@v6
         with:
-          path: ${{ runner.temp }}/bird332-cache/bird-3.3.2.tar.gz
-          key: bird332-v3.3.2-source-21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c
+          path: ${{ runner.temp }}/bird3-cache/bird-3.3.2.tar.gz
+          key: bird3-v3.3.2-source-21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c
       - name: Prepare exact BIRD 3.3.2 archive
         run: |
           set -euo pipefail
@@ -286,12 +286,12 @@ jobs:
             --sha256 21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c \
             --coverage-label "M101 BIRD 3.3.2 image blocked" \
             --prepare-archive \
-            "$RUNNER_TEMP/bird332-cache/bird-3.3.2.tar.gz"
+            "$RUNNER_TEMP/bird3-cache/bird-3.3.2.tar.gz"
       - name: Upload verified BIRD 3.3.2 archive
         uses: actions/upload-artifact@v7
         with:
           name: bird332-v3.3.2-source
-          path: ${{ runner.temp }}/bird332-cache/bird-3.3.2.tar.gz
+          path: ${{ runner.temp }}/bird3-cache/bird-3.3.2.tar.gz
           if-no-files-found: error
           retention-days: 1
           compression-level: 0

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -131,7 +131,8 @@ BIRD332_VERSION = "3.3.2"
 BIRD332_SHA256 = "21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c"
 BIRD332_ARCHIVE = f"bird-{BIRD332_VERSION}.tar.gz"
 BIRD332_ARTIFACT = f"bird332-v{BIRD332_VERSION}-source"
-BIRD332_CACHE_KEY = f"{BIRD332_ARTIFACT}-{BIRD332_SHA256}"
+BIRD332_CACHE_KEY = BIRD3_CACHE_KEY
+BIRD332_CACHE_DIR = "bird3-cache"
 FRR1070_IMAGE = (
     "quay.io/frrouting/frr@sha256:"
     "a0ed0e4f8727631c8303dd9a4e8199b47464a17a5253135a2c622286aeaec46b"
@@ -725,7 +726,7 @@ def check(root: Path) -> list[str]:
                     BIRD332_ARCHIVE,
                     BIRD332_ARTIFACT,
                     BIRD332_CACHE_KEY,
-                    "bird332-cache",
+                    BIRD332_CACHE_DIR,
                     "M101 BIRD 3.3.2 image blocked",
                 ),
             )

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -1118,18 +1118,20 @@ class PrimerContractTests(unittest.TestCase):
                 "aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660",
                 "bird2192-cache",
                 "bird2192-v2.19.2-source",
+                "bird2192-v2.19.2-source",
             ),
             (
                 "bird332_archive",
                 "3.3.2",
                 "21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c",
-                "bird332-cache",
+                "bird3-cache",
                 "bird332-v3.3.2-source",
+                "bird3-v3.3.2-source",
             ),
         )
-        for job, version, checksum, cache_dir, artifact in specs:
+        for job, version, checksum, cache_dir, artifact, cache_artifact in specs:
             archive = f"bird-{version}.tar.gz"
-            cache_key = f"{artifact}-{checksum}"
+            cache_key = f"{cache_artifact}-{checksum}"
             for old, new in (
                 (f"  {job}:\n", f"  removed_{job}:\n"),
                 (f"key: {cache_key}", "key: bird-latest"),


### PR DESCRIPTION
The Interop BIRD 3.3.2 producer now restores the immutable cache written by Kernel Dataplane, using the same key and cache path. It still publishes M101's separate same-run `bird332-v3.3.2-source` artifact, and all checksum, source-version, and offline staging checks remain in place.

The image-primer contract checker and destructive tests now make the shared cache key/path load-bearing.

Validation:

- `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py` (55 passed)
- `python3 scripts/check_ci_image_primer_contract.py`
- `actionlint .github/workflows/interop.yml`
- `git diff --check`
- normal commit and push hooks
