### PR TITLE
chore(repo): enforce library unsafe-code denial

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 #![cfg_attr(
     feature = "bench-internals",
     allow(dead_code, unfulfilled_lint_expectations, unused_imports)


### PR DESCRIPTION
The daemon binary's crate-level unsafe-code denial did not apply to its separate library target. Add the same denial to `src/lib.rs` so library-only and feature-enabled builds enforce the existing project policy.

Validation: `cargo check --locked -p rustbgpd --all-features --lib`, formatting, and normal strict Clippy, workspace library-test and rustdoc hooks.
