### PR TITLE
chore(config): adopt renderer binary clippy policy

### DIFF
--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -2,6 +2,8 @@
 //! refresh loop (`render → rustbgpd --check --strict → swap → SIGHUP`).
 
 #![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
 
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
@@ -171,7 +173,7 @@ struct RollbackArgs {
     #[arg(long, allow_hyphen_values = true)]
     activation_arg: Vec<OsString>,
     /// Generation to re-stage (`generations/<digest>`); defaults to the
-    /// activation receipt's previous_generation when that receipt describes
+    /// activation receipt's `previous_generation` when that receipt describes
     /// the current attempt
     #[arg(long)]
     to: Option<String>,
@@ -315,7 +317,7 @@ struct Cli {
     /// Abort when a client's generated origin asn-set has fewer members
     #[arg(long)]
     min_origins: Option<u32>,
-    /// RTR cache endpoint (host:port) for [[rpki.cache_servers]]; repeatable.
+    /// RTR cache endpoint (host:port) for `[[rpki.cache_servers]]`; repeatable.
     /// Required when the context enables RPKI origin validation.
     #[arg(long = "rtr-cache")]
     rtr_cache: Vec<String>,
@@ -519,6 +521,10 @@ fn lifecycle_exit(
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "the entrypoint keeps subcommand dispatch, argument validation, and exit-code mapping together"
+)]
 fn main() -> ExitCode {
     if let Some(args) = parse_status() {
         let binding = match args.host.binding() {


### PR DESCRIPTION
The renderer binary now applies the existing crate-root Clippy policy. Two help literals gain code markup, and the command-dispatch entrypoint keeps a function-scoped `too_many_lines` expectation with an explicit reason.

Validation: all 131 renderer tests, strict renderer all-target Clippy, the Clippy-reason checker, formatting, and diff checks passed. Help comparisons show only the two literal backtick additions. Normal commit/push hooks passed, including workspace Clippy, library tests, and rustdoc. The complete one-commit diff was reviewed; this lint-policy change needs no changelog or roadmap update.
