### PR TITLE
fix(config): validate tls credential content during checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -805,6 +805,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   GSHUT/BLACKHOLE tails. Reject oversized candidates before installation;
   `compile_rpol` enforces the same cap when composing zero-parameter policies.
 
+- `rustbgpd --check` and `--check --strict` validate TLS credential content
+  through the same staging path as startup, rejecting invalid certificates,
+  keys, client CA bundles, and mismatched cert/key pairs before reporting
+  success. Neither mode binds listeners.
+
 ### Documentation
 
 - Publish a descriptive raw bridge event-skew receipt across six pinned Jammy

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -84,9 +84,20 @@ daemon presents the server certificate, requires every client to
 present a certificate signed by `tls_client_ca_file`, and rejects
 unverified clients at the TLS layer before any gRPC handler runs.
 
-PEM material is pre-flight-validated at config load and `--check`
-time, so a successful `--check` rules out cert-rotation surprises
-at startup. Valid credential bytes behind unchanged TLS paths rotate on SIGHUP.
+Config loading checks file readability and PEM framing. Both `--check` and
+`--check --strict` also run startup credential staging: they parse the server
+certificate, private key, and client CA bundle and check the cert/key match
+without binding listeners. After staging replacement files at the configured
+paths, run `rustbgpd --check --strict /etc/rustbgpd/config.toml` before SIGHUP
+or restart. This checks the files at that moment, not certificate
+expiry, client trust, hostname matching, or subsequent file changes.
+
+Native mTLS accepts TLS 1.2 and TLS 1.3 using the rustls/ring default cipher
+suites; protocol versions and cipher suites have no configuration overrides.
+A client whose certificate is trusted can complete TLS without a mapped
+principal, but its RPCs receive `PERMISSION_DENIED` from role authorization.
+
+Valid credential bytes behind unchanged TLS paths rotate on SIGHUP.
 Adding or removing TLS, changing a configured TLS path, or changing TLS/auth
 mode remains **restart-required**; runtime config pins that drift to the live
 values until the daemon is restarted.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -712,7 +712,9 @@ rejected at `Config::load`. There is no "TLS-without-mTLS" half-mode by
 design. When enabled, the daemon presents the server certificate, requires
 every client to present a certificate signed by `tls_client_ca_file`, and
 rejects unverified clients at the TLS layer before any gRPC handler runs.
-PEM material is pre-flight-validated at config load and `--check` time. SIGHUP
+Config loading checks file readability and PEM framing. Both `--check` modes
+also run startup credential staging to parse the TLS material and check the
+cert/key match without binding listeners. SIGHUP
 re-reads the bytes behind the three unchanged paths, validates the complete
 server identity and client CA for every listener, then atomically publishes one
 process-wide credential generation. A malformed or partial rotation leaves the

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -51,8 +51,11 @@ resolved.
   also reads each PEM file at config load / `--check` time and
   rejects missing, unreadable, empty, non-PEM, or wrong-kind files
   (e.g., a key path swapped with a cert path) before the daemon
-  starts — a successful `--check` proves the listed TLS material
-  is at least structurally usable. UDS listeners stay
+  starts. Both `--check` modes also run startup credential staging, rejecting
+  invalid certificate/key content, mismatched cert/key pairs, and client CA
+  bundles rejected by rustls without binding listeners. This checks the files
+  at that moment; it does not verify expiry, client trust, or hostname matching.
+  UDS listeners stay
   file-system-permission-authenticated, unchanged.
 
 - **BMP drop / replay Prometheus counters (resolved).** Four new

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -81,9 +81,17 @@ Preferred posture:
   the server certificate, requires every client to present a
   certificate signed by `tls_client_ca_file`, and rejects unverified
   clients at the TLS layer before any gRPC handler runs. There is
-  no "TLS-without-mTLS" half-mode by design. PEM material is
-  pre-flight-validated at load and `--check` time so a successful
-  `--check` rules out cert-rotation surprises at startup.
+  no "TLS-without-mTLS" half-mode by design. Config loading checks file
+  readability and PEM framing. After staging replacement files at the
+  configured paths, run `rustbgpd --check --strict /etc/rustbgpd/config.toml`
+  before SIGHUP or restart: both `--check`
+  modes also run startup credential staging, parsing the certificates,
+  private key, and client CA bundle and checking the cert/key match without
+  binding listeners. This validates the files at check time, not certificate
+  expiry, client trust, hostname matching, or subsequent file changes.
+- Native mTLS accepts TLS 1.2 and TLS 1.3 with the rustls/ring default cipher
+  suites. There is no configuration setting for a different protocol-version
+  floor or cipher list.
 - For multi-host fan-out, off-host TLS termination, or richer
   authorization fan-out, an Envoy / nginx mTLS sidecar in front of
   the daemon is still a valid pattern; see
@@ -111,6 +119,11 @@ Preferred posture:
   Legacy migration mode (roles as audit context only) was removed in v0.63.0;
   v0.65 accepts only `tier` in the typed schema and gives the exact retired
   value an actionable load diagnostic.
+  A trusted client certificate can complete TLS even when its principal has
+  no role mapping; each RPC then receives `PERMISSION_DENIED`. The
+  handshake-time rejection described in the historical
+  [ADR-0064 role-mapping decision](../adr/0064-grpc-authorization.md) does not
+  describe this per-request authorization boundary.
 - Listener `max_tier` caps are enforced now and should be used to bound remote
   TCP listeners to the smallest required method tier. `access_mode =
   "read_only"` remains a compatibility ceiling equivalent to

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -3319,16 +3319,9 @@ enum PemKind {
 
 /// Validate a PEM-encoded TLS file at config-load / `--check` time.
 ///
-/// Catches the surprises that would otherwise only surface at daemon
-/// startup: missing path, unreadable file, empty file, file with no
-/// PEM markers, file with PEM blocks of the wrong kind (e.g., cert
-/// path pointed at a private key). Tonic's `Identity::from_pem` and
-/// `Certificate::from_pem` only hold the bytes; the actual parser
-/// runs deep inside `ServerTlsConfig::tls_config` at server build
-/// time, well past `--check`. This is a structural pre-flight, not a
-/// full key/cert match — a mismatched cert+key pair will still fail
-/// at server build, but missing-file / wrong-kind errors are caught
-/// before the daemon ever starts.
+/// Checks readability and PEM framing/block kind. Startup and both `--check`
+/// modes additionally resolve the gRPC listeners through credential staging,
+/// which parses the TLS material and checks the certificate/private-key match.
 fn validate_grpc_pem_file(path: &str, field_name: &str, kind: PemKind) -> Result<(), ConfigError> {
     if path.trim().is_empty() {
         return Err(ConfigError::InvalidGrpcConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2743,6 +2743,12 @@ fn main() -> ExitCode {
     let config = accepted.config();
 
     if check_only {
+        // Resolve the same credential generation as startup without binding
+        // listeners, so invalid TLS content cannot pass the preflight check.
+        if let Err(error) = resolve_grpc_listeners(&config) {
+            eprintln!("error: invalid gRPC listener configuration: {error}");
+            return ExitCode::FAILURE;
+        }
         // The summary line is the only thing some operators read. When
         // anything was flagged it must not be able to pass for a clean
         // result, so `OK` is spent only on a check with nothing to report

--- a/tests/check_strict.rs
+++ b/tests/check_strict.rs
@@ -429,3 +429,143 @@ fn help_documents_the_exit_codes() {
         "help does not document exit status:\n{help}"
     );
 }
+
+// Public test-only credentials; no production trust or identity. The self-signed
+// certificate also supplies the parsable trust anchor for credential staging.
+const CHECK_CERT: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBkDCCATegAwIBAgIUWBew9zSvvaMDf6NTvWkDQhnqZMowCgYIKoZIzj0EAwIw
+HTEbMBkGA1UEAwwSY2hlY2stb25seS5pbnZhbGlkMCAXDTI2MDkwNjIwNDczMVoY
+DzIxMjYwODEzMjA0NzMxWjAdMRswGQYDVQQDDBJjaGVjay1vbmx5LmludmFsaWQw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQXpxOPohjjciNp9QoIOBbMOcfcvfG8
+HSDVxnJSAh7pMGExMb0MC8eZFIGxIzruHB5P4ngSmaL12b53Ulf8LzP2o1MwUTAd
+BgNVHQ4EFgQUs8OQThYHP98r+3/s2vLfUNDj1TEwHwYDVR0jBBgwFoAUs8OQThYH
+P98r+3/s2vLfUNDj1TEwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+AiBArx1qm8xKbxXK30JD2jdvMVo+XFwWGNDNzwYCRfb60QIgH3Q55VHUZXHwgysl
+YBFeoacrRlcf4t7VyeI4yAEG1q0=
+-----END CERTIFICATE-----
+"#;
+
+const CHECK_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgkjGF+oW40C122VHs
+dnnXYQmOuXKiyn5YqHW6HXuPO82hRANCAAQXpxOPohjjciNp9QoIOBbMOcfcvfG8
+HSDVxnJSAh7pMGExMb0MC8eZFIGxIzruHB5P4ngSmaL12b53Ulf8LzP2
+-----END PRIVATE KEY-----
+"#;
+
+const CHECK_OTHER_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjeO14atCpqcNqPEa
+Rtlb9nDn67rfual7vOqr+TE+LTOhRANCAARnMjqr0ixHq1wJFlwSaI8/WaZSWjWe
+FWGU7BfKJXFHDCCB80GJVXFyqzevL7nVMaEClgzXRnChIMvy8A6Uzeui
+-----END PRIVATE KEY-----
+"#;
+// These envelopes decode to bytes that are not an X.509 certificate or key.
+const INVALID_CERT_DER: &str =
+    "-----BEGIN CERTIFICATE-----\nbm90LWEtdGxzLWNlcnRpZmljYXRl\n-----END CERTIFICATE-----\n";
+const INVALID_KEY_DER: &str =
+    "-----BEGIN PRIVATE KEY-----\nbm90LWEtdGxzLXByaXZhdGUta2V5\n-----END PRIVATE KEY-----\n";
+
+fn check_tls_material(cert: &str, key: &str, ca: &str, expected_error: Option<&str>) {
+    let dir = tempfile::tempdir().unwrap();
+    let cert_file = dir.path().join("server.pem");
+    let key_file = dir.path().join("server.key");
+    let ca_file = dir.path().join("client-ca.pem");
+    std::fs::write(&cert_file, cert).unwrap();
+    std::fs::write(&key_file, key).unwrap();
+    std::fs::write(&ca_file, ca).unwrap();
+    // A valid check must succeed even when its configured port is occupied,
+    // and must not create the UDS parent or runtime state directory.
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let runtime_dir = dir.path().join("not-created");
+    let config = format!(
+        "{}\n[global.telemetry.grpc_tcp]\naddress = {:?}\n\
+         tls_cert_file = {cert_file:?}\ntls_key_file = {key_file:?}\n\
+         tls_client_ca_file = {ca_file:?}\n",
+        CLEAN.replace("/tmp/rustbgpd-check-strict", runtime_dir.to_str().unwrap()),
+        occupied.local_addr().unwrap().to_string(),
+    );
+    for args in [&["--check"][..], &["--check", "--strict"][..]] {
+        let (code, stdout, stderr) = run(&config, args);
+        if let Some(expected) = expected_error {
+            assert_eq!(
+                code,
+                Some(1),
+                "{args:?}: stdout:\n{stdout}\nstderr:\n{stderr}"
+            );
+            assert!(stdout.is_empty(), "{stdout}");
+            assert!(stderr.contains(expected), "{stderr}");
+            // Neither a parsed credential nor rejected PEM/DER is diagnostic text.
+            for material in [cert, key, ca] {
+                for line in material.lines().filter(|line| !line.starts_with("-----")) {
+                    assert!(!stderr.contains(line), "credential content in stderr");
+                }
+            }
+        } else {
+            assert_eq!(
+                code,
+                Some(0),
+                "{args:?}: stdout:\n{stdout}\nstderr:\n{stderr}"
+            );
+            assert!(stdout.contains("config OK"), "{stdout}");
+            assert!(stderr.is_empty(), "{stderr}");
+        }
+        assert!(
+            !runtime_dir.exists(),
+            "check created runtime or listener state"
+        );
+    }
+}
+
+#[test]
+fn check_tls_accepts_valid_material_without_binding() {
+    check_tls_material(CHECK_CERT, CHECK_KEY, CHECK_CERT, None);
+}
+
+#[test]
+fn check_tls_rejects_mismatched_certificate_and_key() {
+    check_tls_material(
+        CHECK_CERT,
+        CHECK_OTHER_KEY,
+        CHECK_CERT,
+        Some("certificate/private-key"),
+    );
+}
+
+#[test]
+fn check_tls_rejects_invalid_certificate_der() {
+    check_tls_material(
+        INVALID_CERT_DER,
+        CHECK_KEY,
+        CHECK_CERT,
+        Some("certificate/private-key"),
+    );
+}
+
+#[test]
+fn check_tls_rejects_invalid_key_der() {
+    check_tls_material(
+        CHECK_CERT,
+        INVALID_KEY_DER,
+        CHECK_CERT,
+        Some("certificate/private-key"),
+    );
+}
+
+#[test]
+fn check_tls_rejects_invalid_pem_payload() {
+    check_tls_material(
+        "-----BEGIN CERTIFICATE-----\nnot-valid-base64!\n-----END CERTIFICATE-----\n",
+        CHECK_KEY,
+        CHECK_CERT,
+        Some("certificate PEM"),
+    );
+}
+
+#[test]
+fn check_tls_rejects_invalid_client_ca_der() {
+    for ca in [
+        INVALID_CERT_DER.to_string(),
+        format!("{CHECK_CERT}{INVALID_CERT_DER}"),
+    ] {
+        check_tls_material(CHECK_CERT, CHECK_KEY, &ca, Some("client-CA"));
+    }
+}


### PR DESCRIPTION
`rustbgpd --check` previously accepted PEM-shaped credentials that startup rejected, including mismatched certificate/key pairs and invalid DER. Both check modes now resolve the same credential generation as startup before reporting success, without binding listeners or creating runtime state.

Binary regressions cover valid credentials with an occupied TCP port, mismatched keys, invalid certificate/key DER, corrupt PEM payloads, and invalid or partially invalid client CA bundles in both modes. Errors identify the credential kind without exposing its content. The existing startup/reload staging implementation and configuration schema are unchanged.

Maintained references describe the check's limits and the correct rotation order, current TLS 1.2/1.3 and rustls/ring cipher defaults, and per-RPC rejection of unmapped principals. The historical authorization ADR is preserved.

Validation: all 18 `check_strict` integration tests passed; the five new negative cases failed against the prior implementation. The full local gate passed, including workspace tests and rustdoc. Normal commit and push hooks passed after integrating the renderer-only main update.
