### PR TITLE
chore(build): remove obsolete rand advisory exception

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,15 +15,6 @@
 
 [advisories]
 ignore = [
-    # RUSTSEC-2026-0097 — rand 0.8.5 + 0.9.2 soundness warning with a
-    # custom logger using `rand::rng()`. Transitive via
-    # phf_generator → phf_macros → phf → termwiz → ratatui-termwiz
-    # (the `rbgp top` command). We do not install a custom rand
-    # logger anywhere in the workspace, so the unsoundness isn't
-    # reachable. Pending a ratatui-termwiz bump that pulls a fixed
-    # rand. Tracked in docs/project/roadmap.md under the "`cargo deny` for
-    # license / dependency / advisory audit" bullet.
-    "RUSTSEC-2026-0097",
     # RUSTSEC-2024-0436 — `paste` 1.0.15 unmaintained (the upstream
     # author archived the repo). Informational, no security
     # vulnerability. The netlink stack no longer carries it; the sole

--- a/deny.toml
+++ b/deny.toml
@@ -8,11 +8,9 @@
 #
 # Advisory ignores broadly mirror .cargo/audit.toml (the local
 # `cargo audit` pre-flight keeps its own copy); every entry MUST carry
-# a tracked follow-up. The two lists are NOT identical by design:
-# cargo-deny treats unsound-class advisories as warnings (they don't
-# fail the check, so no ignore is needed — e.g. the rand RUSTSEC-2026-
-# 0097 entry that audit.toml carries), while unmaintained-class ones
-# fail and need listing here.
+# a tracked follow-up. The lists may differ when cargo-deny treats an
+# advisory class as a warning while cargo-audit reports it; currently
+# both retain only the tracked paste advisory below.
 
 [advisories]
 ignore = [


### PR DESCRIPTION
The lockfile already resolves rand 0.8.6 and 0.9.3, both covered by the patched ranges for [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html). Remove the obsolete cargo-audit exception and update the cargo-deny explanation to reflect the current lists. The tracked paste exception remains.

Validation: TOML parsing, `cargo audit`, `cargo deny check advisories bans licenses sources`, diff checks, and normal repository hooks. No dependency or lockfile changes.
