### PR TITLE
feat(api): expose native tls certificate expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Native gRPC TLS expiry visibility through
+  `bgp_grpc_tls_certificate_not_after_seconds{kind}` for the active server leaf,
+  supplied server bundle minimum, and supplied client CA bundle minimum.
+  Successful client handshakes log observed leaf expiry. The restart-required
+  `tls_expiry_warning_seconds` setting defaults to `0` (warnings off); a
+  positive window adds startup, reload, client-handshake, and config-check
+  warnings. Plain `--check` retains exit 0 for warnings and `--strict` returns
+  1. Bundle dates are metadata, not effective handshake cutoffs, and expiry
+  visibility does not introduce date-based startup rejection.
+
 - VPN and EVPN route views now expose optional Prefix-SID raw bytes and flags,
   advertised SRv6 SID values, numeric endpoint behavior, and SID Structure
   fields. EVPN explain and current/previous event snapshots retain the same

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -5,10 +5,14 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
+use prometheus::core::{Collector, Desc};
+use prometheus::proto::MetricFamily;
+use prometheus::{IntGaugeVec, Opts, Registry};
 use tokio_rustls::rustls::pki_types::pem::PemObject;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig};
+use x509_parser::prelude::{FromDer, X509Certificate};
 use zeroize::Zeroizing;
 
 use crate::authz_runtime::BearerAuthSecret;
@@ -30,6 +34,100 @@ pub struct TlsSource {
 pub struct ListenerCredentials {
     pub(crate) bearer: Option<BearerAuthSecret>,
     pub(crate) tls: Option<Arc<ServerConfig>>,
+    tls_expiry: Option<TlsExpiry>,
+}
+
+/// Raw certificate notAfter metadata, in signed Unix seconds. Bundle minima
+/// include every supplied certificate; they are not effective path cutoffs.
+/// A value is absent when metadata cannot be parsed, without changing rustls
+/// credential acceptance. An incomplete bundle has no reported minimum.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TlsExpiry {
+    pub server_leaf: Option<i64>,
+    pub server_bundle_min: Option<i64>,
+    pub client_ca_bundle_min: Option<i64>,
+}
+
+impl TlsExpiry {
+    pub fn values(self) -> impl Iterator<Item = (&'static str, i64)> {
+        [
+            ("server_leaf", self.server_leaf),
+            ("server_bundle_min", self.server_bundle_min),
+            ("client_ca_bundle_min", self.client_ca_bundle_min),
+        ]
+        .into_iter()
+        .filter_map(|(kind, value)| value.map(|value| (kind, value)))
+    }
+
+    /// Available expiry values inside the opt-in warning window, using the
+    /// current wall clock. This includes dates already in the past.
+    pub fn warnings(self, warning_seconds: u32) -> impl Iterator<Item = (&'static str, i64)> {
+        let now = x509_parser::time::ASN1Time::now().timestamp();
+        self.values()
+            .filter(move |(_, not_after)| tls_expiry_warning_due(*not_after, now, warning_seconds))
+    }
+}
+
+/// Zero disables warnings, including for past dates. Signed subtraction keeps
+/// expired certificates inside every positive warning window.
+#[must_use]
+pub fn tls_expiry_warning_due(not_after: i64, now: i64, warning_seconds: u32) -> bool {
+    warning_seconds != 0 && not_after.saturating_sub(now) <= i64::from(warning_seconds)
+}
+
+pub(crate) fn certificate_not_after(cert: &CertificateDer<'_>) -> Option<i64> {
+    X509Certificate::from_der(cert.as_ref())
+        .ok()
+        .map(|(_, certificate)| certificate.validity().not_after.timestamp())
+}
+
+struct TlsExpiryCollector {
+    store: CredentialStore,
+    listener: usize,
+    desc: Desc,
+}
+
+const TLS_EXPIRY_METRIC: &str = "bgp_grpc_tls_certificate_not_after_seconds";
+const TLS_EXPIRY_HELP: &str = "Active native gRPC TLS certificate notAfter in Unix seconds. Bundle minima cover supplied certificates, not effective peer path cutoffs.";
+
+impl TlsExpiryCollector {
+    fn new(store: CredentialStore, listener: usize) -> Result<Self, prometheus::Error> {
+        Ok(Self {
+            store,
+            listener,
+            desc: Desc::new(
+                TLS_EXPIRY_METRIC.into(),
+                TLS_EXPIRY_HELP.into(),
+                vec!["kind".into()],
+                std::collections::HashMap::new(),
+            )?,
+        })
+    }
+}
+
+impl Collector for TlsExpiryCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.desc]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let generation = self.store.load();
+        let Some(expiry) = generation.tls_expiry(self.listener) else {
+            return Vec::new();
+        };
+        let gauges = IntGaugeVec::new(
+            Opts::new(
+                "bgp_grpc_tls_certificate_not_after_seconds",
+                "Active native gRPC TLS certificate notAfter in Unix seconds. Bundle minima cover supplied certificates, not effective peer path cutoffs.",
+            ),
+            &["kind"],
+        )
+        .expect("valid metric definition");
+        for (kind, not_after) in expiry.values() {
+            gauges.with_label_values(&[kind]).set(not_after);
+        }
+        gauges.collect()
+    }
 }
 
 impl std::fmt::Debug for ListenerCredentials {
@@ -37,6 +135,7 @@ impl std::fmt::Debug for ListenerCredentials {
         f.debug_struct("ListenerCredentials")
             .field("bearer", &self.bearer.is_some())
             .field("tls", &self.tls.is_some())
+            .field("tls_expiry", &self.tls_expiry)
             .finish()
     }
 }
@@ -67,6 +166,13 @@ impl PinnedCredentialGeneration {
 }
 
 impl CredentialGeneration {
+    #[must_use]
+    pub fn tls_expiry(&self, index: usize) -> Option<TlsExpiry> {
+        self.listeners
+            .get(index)
+            .and_then(|listener| listener.tls_expiry)
+    }
+
     #[must_use]
     pub const fn sequence(&self) -> u64 {
         self.sequence
@@ -105,6 +211,18 @@ impl PartialEq for CredentialStore {
 impl Eq for CredentialStore {}
 
 impl CredentialStore {
+    /// Register the single native TCP listener's active credential metadata.
+    ///
+    /// # Errors
+    /// Returns a Prometheus registration error, including duplicate registration.
+    pub fn register_tls_expiry_metrics(
+        &self,
+        registry: &Registry,
+        listener: usize,
+    ) -> Result<(), prometheus::Error> {
+        registry.register(Box::new(TlsExpiryCollector::new(self.clone(), listener)?))
+    }
+
     /// Load and validate the initial immutable generation.
     ///
     /// # Errors
@@ -189,7 +307,15 @@ fn stage_listener(index: usize, source: &CredentialSource) -> Result<ListenerCre
         .as_ref()
         .map(|source| build_tls(index, source))
         .transpose()?;
-    Ok(ListenerCredentials { bearer, tls })
+    let (tls, tls_expiry) = match tls {
+        Some((config, expiry)) => (Some(config), Some(expiry)),
+        None => (None, None),
+    };
+    Ok(ListenerCredentials {
+        bearer,
+        tls,
+        tls_expiry,
+    })
 }
 
 /// Read a credential file into a buffer that is scrubbed on drop (the TLS
@@ -210,7 +336,7 @@ fn read_file(index: usize, label: &str, path: &Path) -> Result<Zeroizing<Vec<u8>
     Ok(bytes)
 }
 
-fn build_tls(index: usize, source: &TlsSource) -> Result<Arc<ServerConfig>, String> {
+fn build_tls(index: usize, source: &TlsSource) -> Result<(Arc<ServerConfig>, TlsExpiry), String> {
     let cert_bytes = read_file(index, "certificate", &source.cert_file)?;
     let key_bytes = read_file(index, "private key", &source.key_file)?;
     let ca_bytes = read_file(index, "client CA", &source.client_ca_file)?;
@@ -227,6 +353,20 @@ fn build_tls(index: usize, source: &TlsSource) -> Result<Arc<ServerConfig>, Stri
     let ca_certs = CertificateDer::pem_slice_iter(&ca_bytes)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("listener {index}: invalid client-CA PEM: {e}"))?;
+    // Metadata is observational. A parser difference must not reject TLS
+    // material accepted by rustls. Never publish a partial bundle minimum.
+    let bundle_min = |certs: &[CertificateDer<'_>]| {
+        certs
+            .iter()
+            .map(certificate_not_after)
+            .collect::<Option<Vec<_>>>()
+            .and_then(|dates| dates.into_iter().min())
+    };
+    let tls_expiry = TlsExpiry {
+        server_leaf: certificate_not_after(&certs[0]),
+        server_bundle_min: bundle_min(&certs),
+        client_ca_bundle_min: bundle_min(&ca_certs),
+    };
     let mut roots = RootCertStore::empty();
     let (accepted, rejected) = roots.add_parsable_certificates(ca_certs);
     if accepted == 0 || rejected != 0 {
@@ -245,7 +385,7 @@ fn build_tls(index: usize, source: &TlsSource) -> Result<Arc<ServerConfig>, Stri
     // rustls config must do the same, or ALPN-strict gRPC clients
     // (grpc-go: gnmic, gobgp) refuse to negotiate h2 on the TLS session.
     config.alpn_protocols = vec![b"h2".to_vec()];
-    Ok(Arc::new(config))
+    Ok((Arc::new(config), tls_expiry))
 }
 
 #[cfg(test)]
@@ -351,6 +491,163 @@ mod tests {
         TlsConnector::from(config)
             .connect("localhost".to_string().try_into().unwrap(), stream)
             .await
+    }
+
+    fn dated_certificate(year: i32, ca: bool) -> (Certificate, KeyPair) {
+        let mut params = CertificateParams::new(vec!["localhost".into()]).unwrap();
+        params.not_before = rcgen::date_time_ymd(1960, 1, 1);
+        params.not_after = rcgen::date_time_ymd(year, 1, 1);
+        if ca {
+            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+            params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+        }
+        let key = KeyPair::generate().unwrap();
+        (params.self_signed(&key).unwrap(), key)
+    }
+
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "test fixtures use whole Unix seconds exactly representable by Prometheus doubles"
+    )]
+    fn expiry_metrics(registry: &Registry) -> std::collections::BTreeMap<String, i64> {
+        registry
+            .gather()
+            .into_iter()
+            .filter(|family| family.name() == TLS_EXPIRY_METRIC)
+            .flat_map(|family| family.get_metric().to_vec())
+            .map(|metric| {
+                assert_eq!(metric.get_label().len(), 1);
+                assert_eq!(metric.get_label()[0].name(), "kind");
+                (
+                    metric.get_label()[0].value().into(),
+                    metric.get_gauge().value() as i64,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn tls_expiry_warning_boundaries_are_signed_and_opt_in() {
+        for not_after in [i64::MIN, -1, 0, 100, i64::MAX] {
+            assert!(!tls_expiry_warning_due(not_after, 100, 0));
+        }
+        assert!(tls_expiry_warning_due(-1, 100, 10));
+        assert!(tls_expiry_warning_due(100, 100, 10));
+        assert!(tls_expiry_warning_due(110, 100, 10));
+        assert!(!tls_expiry_warning_due(111, 100, 10));
+        assert!(tls_expiry_warning_due(i64::MIN, i64::MAX, 1));
+        assert!(!tls_expiry_warning_due(i64::MAX, i64::MIN, u32::MAX));
+    }
+
+    #[test]
+    fn tls_expiry_metrics_are_absent_without_tls() {
+        let store = CredentialStore::stage(vec![CredentialSource::default()]).unwrap();
+        let registry = Registry::new();
+        store.register_tls_expiry_metrics(&registry, 0).unwrap();
+        assert!(registry.gather().is_empty());
+        assert_eq!(store.load().tls_expiry(0), None);
+    }
+
+    #[test]
+    fn tls_expiry_unparseable_extra_chain_preserves_tls_acceptance() {
+        let bundle = tls_bundle("observational metadata");
+        let cert = token_file(&format!(
+            "{}-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n",
+            bundle.server_pem
+        ));
+        let key = token_file(&bundle.server_key_pem);
+        let ca = token_file(&bundle.ca_pem);
+        let store = CredentialStore::stage(vec![CredentialSource {
+            token_file: None,
+            tls: Some(TlsSource {
+                cert_file: cert.path().into(),
+                key_file: key.path().into(),
+                client_ca_file: ca.path().into(),
+            }),
+        }])
+        .unwrap();
+        assert!(store.load().listener(0).tls.is_some());
+        let expiry = store.load().tls_expiry(0).unwrap();
+        assert!(expiry.server_leaf.is_some());
+        assert_eq!(expiry.server_bundle_min, None);
+        assert!(expiry.client_ca_bundle_min.is_some());
+        let registry = Registry::new();
+        store.register_tls_expiry_metrics(&registry, 0).unwrap();
+        assert_eq!(expiry_metrics(&registry).len(), 2);
+    }
+
+    #[test]
+    fn tls_expiry_metrics_follow_atomic_generation_and_ignore_old_snapshots() {
+        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+        let (leaf, key) = dated_certificate(2032, false);
+        let (chain, _) = dated_certificate(2029, true);
+        let (ca, _) = dated_certificate(2030, true);
+        let (other_ca, _) = dated_certificate(2031, true);
+        let mut cert_file = token_file(&format!("{}{}", leaf.pem(), chain.pem()));
+        let mut key_file = token_file(&key.serialize_pem());
+        let mut ca_file = token_file(&format!("{}{}", other_ca.pem(), ca.pem()));
+        let store = CredentialStore::stage(vec![CredentialSource {
+            token_file: None,
+            tls: Some(TlsSource {
+                cert_file: cert_file.path().into(),
+                key_file: key_file.path().into(),
+                client_ca_file: ca_file.path().into(),
+            }),
+        }])
+        .unwrap();
+        let old = store.load();
+        let expected = TlsExpiry {
+            server_leaf: Some(rcgen::date_time_ymd(2032, 1, 1).unix_timestamp()),
+            server_bundle_min: Some(rcgen::date_time_ymd(2029, 1, 1).unix_timestamp()),
+            client_ca_bundle_min: Some(rcgen::date_time_ymd(2030, 1, 1).unix_timestamp()),
+        };
+        assert_eq!(old.tls_expiry(0), Some(expected));
+        let registry = Registry::new();
+        store.register_tls_expiry_metrics(&registry, 0).unwrap();
+        let old_metrics = expiry_metrics(&registry);
+        assert_eq!(
+            old_metrics,
+            expected.values().map(|(k, v)| (k.into(), v)).collect()
+        );
+
+        // File edits cannot alter a scrape before staging succeeds. An expired
+        // certificate remains observable without imposing a new startup policy.
+        let (new_leaf, new_key) = dated_certificate(1965, false);
+        let (new_ca, _) = dated_certificate(2040, true);
+        overwrite(&mut cert_file, new_leaf.pem().as_bytes());
+        overwrite(&mut ca_file, new_ca.pem().as_bytes());
+        assert!(store.reload().is_err()); // The old private key does not match.
+        assert_eq!(store.load().sequence(), 1);
+        assert_eq!(expiry_metrics(&registry), old_metrics);
+        overwrite(&mut key_file, new_key.serialize_pem().as_bytes());
+        assert_eq!(expiry_metrics(&registry), old_metrics);
+        assert_eq!(store.reload().unwrap(), 2);
+        let new_expiry = store.load().tls_expiry(0).unwrap();
+        assert_eq!(
+            new_expiry.server_leaf,
+            Some(rcgen::date_time_ymd(1965, 1, 1).unix_timestamp())
+        );
+        assert_eq!(new_expiry.server_bundle_min, new_expiry.server_leaf);
+        assert_eq!(
+            new_expiry.client_ca_bundle_min,
+            Some(rcgen::date_time_ymd(2040, 1, 1).unix_timestamp())
+        );
+        assert_eq!(new_expiry.warnings(0).count(), 0);
+        assert!(
+            new_expiry
+                .warnings(1)
+                .any(|(kind, _)| kind == "server_leaf")
+        );
+        assert_eq!(
+            expiry_metrics(&registry),
+            new_expiry.values().map(|(k, v)| (k.into(), v)).collect()
+        );
+        assert_eq!(old.tls_expiry(0), Some(expected));
+        drop(old);
+        assert_eq!(
+            expiry_metrics(&registry)["server_leaf"],
+            new_expiry.server_leaf.unwrap()
+        );
     }
 
     #[test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -74,9 +74,42 @@ use rustbgpd_telemetry::reason_labels::GrpcTlsHandshakeFailureReason;
 const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
 const GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 const GRPC_LISTENER_SHUTDOWN_GRACE: Duration = Duration::from_secs(1);
+
 const FULLY_COMPENSATED_STATUS_PREFIX: &str =
     "runtime effects were fully compensated; retry may repeat transient runtime changes:";
 const RUNTIME_CONFIG_OUTCOME_METADATA: &str = "rustbgpd-runtime-config-outcome";
+
+fn log_tls_client_expiry(
+    stream: &tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
+    warning_seconds: u32,
+) {
+    let (tcp, session) = stream.get_ref();
+    let certificate_not_after_seconds = session
+        .peer_certificates()
+        .and_then(|certificates| certificates.first())
+        .and_then(crate::credentials::certificate_not_after);
+    info!(
+        event = "grpc_tls_client_certificate",
+        peer_addr = ?tcp.peer_addr().ok(),
+        certificate_not_after_seconds,
+        "accepted gRPC mTLS client certificate"
+    );
+    if certificate_not_after_seconds.is_some_and(|not_after| {
+        crate::credentials::tls_expiry_warning_due(
+            not_after,
+            x509_parser::time::ASN1Time::now().timestamp(),
+            warning_seconds,
+        )
+    }) {
+        warn!(
+            event = "grpc_tls_client_certificate_expiry",
+            peer_addr = ?tcp.peer_addr().ok(),
+            certificate_not_after_seconds,
+            tls_expiry_warning_seconds = warning_seconds,
+            "observed gRPC client leaf notAfter is within the configured warning window"
+        );
+    }
+}
 
 /// Mark a runtime-config error whose forward effects were fully compensated.
 ///
@@ -238,6 +271,7 @@ async fn accept_tls(
     stream: tokio::net::TcpStream,
     tls: Arc<tokio_rustls::rustls::ServerConfig>,
     metrics: &BgpMetrics,
+    warning_seconds: u32,
 ) -> Option<RustbgpdTcpStream> {
     match tokio::time::timeout(
         GRPC_TLS_HANDSHAKE_TIMEOUT,
@@ -245,7 +279,10 @@ async fn accept_tls(
     )
     .await
     {
-        Ok(Ok(stream)) => Some(RustbgpdTcpStream::from_tls(stream)),
+        Ok(Ok(stream)) => {
+            log_tls_client_expiry(&stream, warning_seconds);
+            Some(RustbgpdTcpStream::from_tls(stream))
+        }
         Ok(Err(error)) => {
             let reason = tls_handshake_failure_reason(&error);
             metrics.record_grpc_tls_handshake_failure(reason);
@@ -1204,6 +1241,8 @@ pub struct ListenerConfig {
     pub roles: Arc<BTreeMap<String, PrincipalRole>>,
     pub credential_store: CredentialStore,
     pub credential_index: usize,
+    /// Restart-pinned opt-in TLS expiry warning window; zero disables warnings.
+    pub tls_expiry_warning_seconds: u32,
     /// Optional stable principal label for audit records. Bearer-token
     /// and UDS listeners may use it to avoid placeholder identities in
     /// `grpc_authz` logs; mTLS listeners derive their audit principal
@@ -1698,6 +1737,7 @@ async fn run_listener(
         roles,
         credential_store,
         credential_index,
+        tls_expiry_warning_seconds,
         principal,
     } = listener;
 
@@ -1710,6 +1750,7 @@ async fn run_listener(
                 roles,
                 credential_store,
                 credential_index,
+                tls_expiry_warning_seconds,
                 principal,
                 rib_tx,
                 rib_query_tx,
@@ -1848,6 +1889,7 @@ async fn run_tcp_listener(
     roles: Arc<BTreeMap<String, PrincipalRole>>,
     credential_store: CredentialStore,
     credential_index: usize,
+    tls_expiry_warning_seconds: u32,
     principal: Option<String>,
     rib_tx: mpsc::Sender<RibUpdate>,
     rib_query_tx: mpsc::Sender<RibUpdate>,
@@ -1950,7 +1992,9 @@ async fn run_tcp_listener(
                 Err(error) => return Some(Err(error)),
             };
             if let Some(tls) = generation.listener(credential_index).tls.clone() {
-                accept_tls(stream, tls, &metrics).await.map(Ok)
+                accept_tls(stream, tls, &metrics, tls_expiry_warning_seconds)
+                    .await
+                    .map(Ok)
             } else {
                 Some(Ok(RustbgpdTcpStream::new(stream)))
             }
@@ -3698,7 +3742,7 @@ mod tests {
                     let metrics = incoming_metrics.clone();
                     async move {
                         match accepted {
-                            Ok(stream) => accept_tls(stream, tls, &metrics).await.map(Ok),
+                            Ok(stream) => accept_tls(stream, tls, &metrics, 0).await.map(Ok),
                             Err(error) => Some(Err(error)),
                         }
                     }

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -89,8 +89,12 @@ Config loading checks file readability and PEM framing. Both `--check` and
 certificate, private key, and client CA bundle and check the cert/key match
 without binding listeners. After staging replacement files at the configured
 paths, run `rustbgpd --check --strict /etc/rustbgpd/config.toml` before SIGHUP
-or restart. This checks the files at that moment, not certificate
-expiry, client trust, hostname matching, or subsequent file changes.
+or restart. This checks the files at that moment; it does not prove client
+trust or hostname matching, or cover subsequent file changes. A positive
+`tls_expiry_warning_seconds` adds expiry warnings from that staged generation;
+the default `0` disables those warnings. See
+[native gRPC certificate expiry](operations.md#native-grpc-certificate-expiry)
+for metrics, successful-client metadata logs, and bundle-date limits.
 
 Native mTLS accepts TLS 1.2 and TLS 1.3 using the rustls/ring default cipher
 suites; protocol versions and cipher suites have no configuration overrides.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -705,6 +705,7 @@ container/network exposure.
 | `tls_cert_file` | string | no   | --      | PEM-encoded server certificate (mTLS — requires the two siblings below) |
 | `tls_key_file`  | string | no   | --      | PEM-encoded server private key |
 | `tls_client_ca_file` | string | no | --   | PEM-encoded CA bundle that must sign every client certificate |
+| `tls_expiry_warning_seconds` | integer (`u32`) | no | `0` | Opt-in certificate expiry warning window in seconds, including past dates; `0` disables warnings only. Restart-required. |
 
 **Native gRPC mTLS.** Setting any of `tls_cert_file` / `tls_key_file` /
 `tls_client_ca_file` requires *all three* together; a partial config is
@@ -720,6 +721,15 @@ server identity and client CA for every listener, then atomically publishes one
 process-wide credential generation. A malformed or partial rotation leaves the
 last-known-good generation active. Changing a path or TLS/auth mode remains
 **restart-required** and stays visible as drift until restart.
+
+Expiry metrics and successful-client metadata logs are available independently
+of `tls_expiry_warning_seconds`. A positive window adds warnings at startup,
+after successful credential reload, during `--check`, and for observed client
+leaves after successful TLS handshakes. Plain `--check` keeps exit 0 for these
+warnings; `--check --strict` returns 1. No new date-based startup rejection is
+introduced. Bundle minima describe supplied certificate metadata, not an
+effective path or trust-anchor cutoff. See
+[native gRPC certificate expiry](operations.md#native-grpc-certificate-expiry).
 
 Native gNMI / OpenConfig telemetry (`gnmi.gNMI`) is registered on TCP only when
 this native mTLS config is present. Plaintext or bearer-token-only TCP listeners

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -54,7 +54,10 @@ resolved.
   starts. Both `--check` modes also run startup credential staging, rejecting
   invalid certificate/key content, mismatched cert/key pairs, and client CA
   bundles rejected by rustls without binding listeners. This checks the files
-  at that moment; it does not verify expiry, client trust, or hostname matching.
+  at that moment; it does not prove client trust or hostname matching. A
+  positive `tls_expiry_warning_seconds` adds expiry warnings; the default `0`
+  disables warnings. [Expiry visibility](operations.md#native-grpc-certificate-expiry)
+  does not add date-based startup rejection or imply an effective bundle cutoff.
   UDS listeners stay
   file-system-permission-authenticated, unchanged.
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -706,6 +706,13 @@ the stop, stops rustbgpd cleanly so the restart marker is written, checks the
 package manager's preserved-config files, and verifies the restarted daemon.
 The package hooks do not stop or restart a running service.
 
+Native TLS expiry warnings remain off on upgrade unless
+`tls_expiry_warning_seconds` is positive. Enabling the setting requires a
+restart and makes matching expiry warnings fail `--check --strict`; ordinary
+`--check` still returns 0. Before rolling back to a binary without this field,
+remove it from the configuration, including a default `0` written by a newer
+configuration edit.
+
 Finish any pending confirmed transaction before any upgrade. Before upgrading
 past v0.64.0, also clear retired v1/v2 authority — v0.65.0 and every later
 release refuse to boot while it is present. The candidate binary's `--check`
@@ -1494,6 +1501,52 @@ What to do when it fires:
    guards, not this feature: the RFC 9687 send-hold timer tears down a
    wedged socket, and outbound-buffer saturation tears the session
    down with `Cease/Out of Resources`.
+
+## Native gRPC certificate expiry
+
+`bgp_grpc_tls_certificate_not_after_seconds{kind}` reports certificate
+`notAfter` as Unix seconds from the active credential generation. Its only
+label is `kind`:
+
+| Kind | Meaning |
+|------|---------|
+| `server_leaf` | First certificate in the configured server PEM bundle |
+| `server_bundle_min` | Earliest date across every certificate supplied in that bundle, including an optional root |
+| `client_ca_bundle_min` | Earliest date across every certificate supplied in the client trust bundle |
+
+These are raw certificate dates. A bundle minimum does not determine the
+effective peer certification path or its handshake cutoff. In particular,
+the client CA bundle is not an inventory of client leaf certificates, and a
+trust anchor's date is not an automatic rustls handshake cutoff.
+
+```promql
+# Active server leaf is within seven days of notAfter, including past dates.
+bgp_grpc_tls_certificate_not_after_seconds{kind="server_leaf"} - time() <= 604800
+```
+
+Without native TLS, the family has no series. Unavailable metadata is omitted;
+if any supplied bundle member cannot be inspected, that bundle minimum is
+omitted rather than calculated over an incomplete subset. Metadata parsing
+does not add a credential rejection rule. File changes alone do not alter
+these gauges: successful SIGHUP credential publication replaces the snapshot,
+while failed reloads retain the prior snapshot. Existing connections cannot
+overwrite the active values.
+
+Set `tls_expiry_warning_seconds = 604800` in
+`[global.telemetry.grpc_tcp]` to request warnings within seven days, including
+past dates. The default `0` disables expiry warnings while preserving metrics
+and successful-client metadata logs. The setting requires a restart. Warnings
+appear at startup, after successful credential reload, and during `--check`;
+ordinary `--check` returns 0 for warnings, while `--check --strict` returns 1.
+The setting does not reject startup solely because a certificate date is past.
+
+After each successful native TLS handshake, the `grpc_tls_client_certificate`
+log event reports the observed client's leaf `certificate_not_after_seconds`
+when available. A positive warning window also enables the
+`grpc_tls_client_certificate_expiry` warning event. These records describe
+clients that completed a handshake, not unseen clients or a guarantee about
+future connections. RPC role authorization remains a separate check. There
+is no per-client expiry metric or client certificate inventory.
 
 <a id="grpc-authorization-audit-and-resource-guardrails"></a>
 ## gRPC audit and resource guardrails

--- a/docs/reference/rustbgpd.schema.json
+++ b/docs/reference/rustbgpd.schema.json
@@ -1426,6 +1426,13 @@
             "null"
           ]
         },
+        "tls_expiry_warning_seconds": {
+          "description": "Warn when a TLS certificate notAfter is within this many seconds,\nincluding past dates. Default 0 disables warnings only; expiry metrics\nand successful client handshake metadata remain available. Restart-required.",
+          "type": "integer",
+          "format": "uint32",
+          "default": 0,
+          "minimum": 0
+        },
         "tls_key_file": {
           "description": "Server private key (PEM file path). Required when `tls_cert_file`\nis set.",
           "type": [

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -87,8 +87,10 @@ Preferred posture:
   before SIGHUP or restart: both `--check`
   modes also run startup credential staging, parsing the certificates,
   private key, and client CA bundle and checking the cert/key match without
-  binding listeners. This validates the files at check time, not certificate
-  expiry, client trust, hostname matching, or subsequent file changes.
+  binding listeners. This validates the files at check time; it does not prove
+  client trust or hostname matching, or cover subsequent file changes.
+  A positive `tls_expiry_warning_seconds` adds expiry warnings from the same
+  staged bytes; the default `0` disables those warnings.
 - Native mTLS accepts TLS 1.2 and TLS 1.3 with the rustls/ring default cipher
   suites. There is no configuration setting for a different protocol-version
   floor or cipher list.
@@ -603,3 +605,6 @@ the roadmap:
   all-listener generation. Alert on
   `bgp_grpc_credential_reloads_total{outcome="failure"}`; failures retain the
   last-known-good generation and logs never include secret bytes.
+  [Native gRPC expiry visibility](operations.md#native-grpc-certificate-expiry)
+  exposes active certificate dates and opt-in warning windows. Supplied bundle
+  minima are metadata, not effective peer-path cutoffs or client leaf inventories.

--- a/scripts/check-metric-consumers.py
+++ b/scripts/check-metric-consumers.py
@@ -17,6 +17,7 @@ from types import ModuleType
 ROOT = Path(__file__).resolve().parents[1]
 TELEMETRY = "crates/telemetry/src/metrics.rs"
 SETTLEMENT = "crates/api/src/runtime_config_settlement.rs"
+CREDENTIALS = "crates/api/src/credentials.rs"
 DASHBOARD = ROOT / "docs/grafana/rustbgpd-overview.json"
 ALERT_RULES = ROOT / "examples/prometheus/rustbgpd-alerts.yml"
 CARGO_LOCK = ROOT / "Cargo.lock"
@@ -42,13 +43,14 @@ HISTORICAL_DOCUMENT_PREFIXES = (
     "docs/soaks/",
 )
 
-EMITTER_FILES = frozenset({TELEMETRY, SETTLEMENT})
+EMITTER_FILES = frozenset({TELEMETRY, SETTLEMENT, CREDENTIALS})
 CUSTOM_COLLECTORS = frozenset(
     {
         (TELEMETRY, "JemallocCollector"),
         (TELEMETRY, "SessionNotificationDepthCollector"),
         (TELEMETRY, "EventOutboxQueueDepthCollector"),
         (SETTLEMENT, "RuntimeConfigSettlementCollector"),
+        (CREDENTIALS, "TlsExpiryCollector"),
     }
 )
 CUSTOM_COLLECTOR_PREFIXES = {
@@ -56,8 +58,10 @@ CUSTOM_COLLECTOR_PREFIXES = {
     (TELEMETRY, "SessionNotificationDepthCollector"): "bgp_session_notification_",
     (TELEMETRY, "EventOutboxQueueDepthCollector"): "bgp_event_outbox_queue_depth",
     (SETTLEMENT, "RuntimeConfigSettlementCollector"): "bgp_runtime_config_settlement_",
+    (CREDENTIALS, "TlsExpiryCollector"): "bgp_grpc_tls_certificate_not_after_seconds",
 }
 SPECIAL_REGISTRATIONS = {
+    CREDENTIALS: ("TlsExpiryCollector::new(self.clone(),listener)?",),
     TELEMETRY: (
         "prometheus::process_collector::ProcessCollector::for_self()",
         "jemalloc_stats::JemallocCollector::new()",
@@ -409,25 +413,25 @@ def session_notification_depth_inventory(source: str) -> tuple[dict[str, str], s
     return {name: kind for name, kind in emitted.values()}, set(emitted)
 
 
-def event_outbox_queue_depth_inventory(
-    source: str,
+def local_gauge_vector_inventory(
+    source: str, collector: str, expected_name: str, label: str,
 ) -> tuple[dict[str, str], set[str]]:
-    """Validate the local gauge vector emitted by the queue-depth collector."""
+    """Validate one scrape-time local gauge vector and its named label."""
     source = production_source(source)
     syntax, strings = DASHBOARD_CHECK.rust_lex(source)
     collector_impl = braced_body(
         syntax,
-        r"\bimpl\s+Collector\s+for\s+EventOutboxQueueDepthCollector\s*\{",
-        "Collector impl for EventOutboxQueueDepthCollector",
+        rf"\bimpl\s+Collector\s+for\s+{re.escape(collector)}\s*\{{",
+        f"Collector impl for {collector}",
     )
     collect_body = braced_body(
         collector_impl,
         r"\bfn\s+collect\s*\(\s*&self\s*\)\s*->\s*Vec\s*<\s*MetricFamily\s*>\s*\{",
-        "collect method for EventOutboxQueueDepthCollector",
+        f"collect method for {collector}",
     )
     if "MetricFamily" in collect_body:
         raise ValueError(
-            "EventOutboxQueueDepthCollector constructs MetricFamily values directly"
+            f"{collector} constructs MetricFamily values directly"
         )
     unexpected_returns = [
         expression
@@ -436,9 +440,8 @@ def event_outbox_queue_depth_inventory(
     ]
     if unexpected_returns:
         raise ValueError(
-            "EventOutboxQueueDepthCollector returns families outside its local gauge vector"
+            f"{collector} returns families outside its local gauge vector"
         )
-    expected_name = CUSTOM_COLLECTOR_PREFIXES[(TELEMETRY, "EventOutboxQueueDepthCollector")]
     constructors = re.findall(
         r"\blet\s+(\w+)\s*=\s*IntGaugeVec::new\(\s*"
         r"Opts::new\(\s*__RUST_STRING_(\d+)__\s*,\s*"
@@ -448,7 +451,7 @@ def event_outbox_queue_depth_inventory(
     )
     if len(constructors) != 1:
         raise ValueError(
-            "EventOutboxQueueDepthCollector must construct exactly one local IntGaugeVec"
+            f"{collector} must construct exactly one local IntGaugeVec"
         )
     variable, name_index, label_index = constructors[0]
     definitions = static_metric_definitions(source)
@@ -458,28 +461,48 @@ def event_outbox_queue_depth_inventory(
         or definitions.get(variable) != expected_definition
     ):
         raise ValueError(
-            "EventOutboxQueueDepthCollector must construct exactly one uniquely "
+            f"{collector} must construct exactly one uniquely "
             f"named local gauge vector for {expected_name}"
         )
-    if strings[int(label_index)] != "category":
+    if strings[int(label_index)] != label:
         raise ValueError(
-            "EventOutboxQueueDepthCollector must construct its local IntGaugeVec "
-            "with the category label"
+            f"{collector} must construct its local IntGaugeVec "
+            f"with the {label} label"
         )
 
     compact = re.sub(r"\s+", "", collect_body)
-    population = f"{variable}.with_label_values(&[category]).set("
+    population = f"{variable}.with_label_values(&[{label}]).set("
     if compact.count(population) != 1:
         raise ValueError(
-            "EventOutboxQueueDepthCollector must populate its local gauge vector "
-            "through the category label exactly once"
+            f"{collector} must populate its local gauge vector "
+            f"through the {label} label exactly once"
         )
     collect_calls = re.findall(r"\b(\w+)\.collect\(\)", compact)
     if collect_calls != [variable] or not compact.endswith(f"{variable}.collect()"):
         raise ValueError(
-            "EventOutboxQueueDepthCollector must return its local gauge vector exactly once"
+            f"{collector} must return its local gauge vector exactly once"
         )
     return {expected_name: "ordinary"}, {variable}
+
+
+def event_outbox_queue_depth_inventory(source: str) -> tuple[dict[str, str], set[str]]:
+    return local_gauge_vector_inventory(
+        source, "EventOutboxQueueDepthCollector",
+        CUSTOM_COLLECTOR_PREFIXES[(TELEMETRY, "EventOutboxQueueDepthCollector")],
+        "category",
+    )
+
+
+def tls_expiry_metric_inventory(source: str) -> dict[str, str]:
+    definitions = static_metric_definitions(source)
+    registered = registered_metric_variables(CREDENTIALS, source, definitions)
+    emitted, variables = local_gauge_vector_inventory(
+        source, "TlsExpiryCollector",
+        CUSTOM_COLLECTOR_PREFIXES[(CREDENTIALS, "TlsExpiryCollector")], "kind",
+    )
+    if registered or set(definitions) != variables:
+        raise ValueError("TLS expiry definitions must match its sole collector")
+    return emitted
 
 
 def candidate_emitter_sources(root: Path = ROOT) -> dict[str, str]:
@@ -629,19 +652,20 @@ def workspace_metric_inventory(
     telemetry.update(event_outbox_depth)
 
     settlement = settlement_metric_inventory(sources[SETTLEMENT])
-    overlap = sorted(set(telemetry) & set(settlement))
+    expiry = tls_expiry_metric_inventory(sources[CREDENTIALS])
+    overlap = sorted((set(telemetry) & set(settlement)) | ((set(telemetry) | set(settlement)) & set(expiry)))
     if overlap:
         raise ValueError(f"duplicate workspace metric families: {overlap}")
 
     process_dependency_version(lock_text or CARGO_LOCK.read_text(encoding="utf-8"))
 
-    inventory = {**telemetry, **settlement}
+    inventory = {**telemetry, **settlement, **expiry}
     for name in PROCESS_FAMILIES:
         if name in inventory:
             raise ValueError(f"process family duplicates workspace family {name}")
         inventory[name] = "ordinary"
-    if len(inventory) != 212:
-        raise ValueError(f"emitted metric roster changed: expected 212, got {len(inventory)}")
+    if len(inventory) != 213:
+        raise ValueError(f"emitted metric roster changed: expected 213, got {len(inventory)}")
     return dict(sorted(inventory.items()))
 
 

--- a/scripts/test_check_metric_consumers.py
+++ b/scripts/test_check_metric_consumers.py
@@ -47,7 +47,7 @@ class MetricConsumerContractTests(unittest.TestCase):
 
     def test_live_inventory_and_consumer_counts_are_exact(self):
         self.assertEqual(set(self.sources), set(CHECK.EMITTER_FILES))
-        self.assertEqual(len(self.inventory), 212)
+        self.assertEqual(len(self.inventory), 213)
         self.assertEqual(
             len(CHECK.DASHBOARD_CHECK.rust_metric_inventory(self.sources[CHECK.TELEMETRY])),
             199,
@@ -58,10 +58,10 @@ class MetricConsumerContractTests(unittest.TestCase):
         self.assertEqual(len(CHECK.PROCESS_FAMILIES), 7)
         self.assertEqual(len(self.dashboard_refs), 98)
         self.assertEqual(len(self.rule_refs), 44)
-        self.assertEqual(len(self.public_doc_refs), 201)
-        self.assertEqual(len(self.doc_refs), 201)
+        self.assertEqual(len(self.public_doc_refs), 202)
+        self.assertEqual(len(self.doc_refs), 202)
         consumers = self.dashboard_refs | self.rule_refs | self.doc_refs
-        self.assertEqual(len(consumers), 206)
+        self.assertEqual(len(consumers), 207)
         self.assertEqual(set(self.inventory) - consumers, set(CHECK.ALLOWLIST))
         self.assertEqual(
             set(CHECK.ALLOWLIST), CHECK.PROCESS_FAMILIES - {"process_start_time_seconds"}
@@ -72,9 +72,9 @@ class MetricConsumerContractTests(unittest.TestCase):
         stdout = io.StringIO()
         with redirect_stdout(stdout):
             self.assertEqual(CHECK.main(), 0)
-        self.assertIn("212 emitted families", stdout.getvalue())
-        self.assertIn("201 normative-doc families", stdout.getvalue())
-        self.assertIn("206 consumed, 6 justified raw diagnostics", stdout.getvalue())
+        self.assertIn("213 emitted families", stdout.getvalue())
+        self.assertIn("202 normative-doc families", stdout.getvalue())
+        self.assertIn("207 consumed, 6 justified raw diagnostics", stdout.getvalue())
 
     def test_blackhole_metric_inventory_has_one_operations_row_per_family(self):
         prefix = "bgp_blackhole_discard_"
@@ -360,6 +360,26 @@ fn alias_metric(registry: &Registry) {
         )
         with self.assertRaisesRegex(ValueError, "special collector registrations changed"):
             CHECK.workspace_metric_inventory(sources, self.lock_text)
+
+    def test_tls_expiry_collector_shape_and_registration_are_fail_closed(self):
+        source = self.sources[CHECK.CREDENTIALS]
+        emitted = CHECK.tls_expiry_metric_inventory(source)
+        self.assertEqual(emitted, {"bgp_grpc_tls_certificate_not_after_seconds": "ordinary"})
+        mutations = [
+            (source.replace('"bgp_grpc_tls_certificate_not_after_seconds"', '"bgp_other_seconds"'),
+             "uniquely named local gauge"),
+            (source.replace('&["kind"],', '&["identity"],'), "with the kind label"),
+            (source.replace("gauges.collect()", "Vec::new()", 1), "return its local gauge vector"),
+            (source.replace("return Vec::new();", "return self.hidden.collect();", 1),
+             "returns families outside"),
+            (source.replace("TlsExpiryCollector::new(", "UnknownCollector::new(", 1),
+             "special collector registrations changed"),
+        ]
+        for mutated, diagnostic in mutations:
+            with self.subTest(diagnostic=diagnostic):
+                self.assertNotEqual(mutated, source)
+                with self.assertRaisesRegex(ValueError, diagnostic):
+                    CHECK.tls_expiry_metric_inventory(mutated)
 
     def test_process_dependency_drift_is_rejected(self):
         drifted = self.lock_text.replace(

--- a/scripts/test_check_metric_release_notes.py
+++ b/scripts/test_check_metric_release_notes.py
@@ -31,6 +31,7 @@ class MetricReleaseNoteContractTests(unittest.TestCase):
             {
                 "bgp_evpn_nlri_discarded_by_type_total",
                 "bgp_grpc_tls_handshake_failures_total",
+                "bgp_grpc_tls_certificate_not_after_seconds",
                 "bgp_max_prefix_blocked_total",
                 "bgp_max_prefix_blocking",
                 "bgp_max_prefix_warning_total",

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1033,6 +1033,11 @@ pub struct GrpcTcpListenerConfig {
     /// always enforces client-cert auth when TLS is on (no
     /// "TLS-without-mTLS" half-mode).
     pub tls_client_ca_file: Option<String>,
+    /// Warn when a TLS certificate notAfter is within this many seconds,
+    /// including past dates. Default 0 disables warnings only; expiry metrics
+    /// and successful client handshake metadata remain available. Restart-required.
+    #[serde(default)]
+    pub tls_expiry_warning_seconds: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/src/config/tests/grpc_security.rs
+++ b/src/config/tests/grpc_security.rs
@@ -42,6 +42,42 @@ fn grpc_tcp_listener_parses_when_enabled() {
 }
 
 #[test]
+fn grpc_tls_expiry_warning_window_defaults_off_and_accepts_u32() {
+    let base = format!(
+        "{}\n[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n",
+        valid_toml()
+    );
+    let config = parse_schema_only(&base).unwrap();
+    assert_eq!(
+        config
+            .global
+            .telemetry
+            .grpc_tcp
+            .unwrap()
+            .tls_expiry_warning_seconds,
+        0
+    );
+    for value in [0, 604_800, u32::MAX] {
+        let config =
+            parse_schema_only(&format!("{base}tls_expiry_warning_seconds = {value}\n")).unwrap();
+        assert_eq!(
+            config
+                .global
+                .telemetry
+                .grpc_tcp
+                .unwrap()
+                .tls_expiry_warning_seconds,
+            value
+        );
+    }
+    for value in ["-1", "4294967296", "1.5", "\"7d\""] {
+        assert!(
+            parse_schema_only(&format!("{base}tls_expiry_warning_seconds = {value}\n")).is_err()
+        );
+    }
+}
+
+#[test]
 fn grpc_explicit_uds_opt_out_disables_the_implicit_listener() {
     let toml_str = format!(
         "{}\n[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n\n[global.telemetry.grpc_uds]\nenabled = false\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1521,6 +1521,12 @@ fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, St
                     roles: Arc::clone(&roles),
                     credential_store: credential_store.clone(),
                     credential_index,
+                    tls_expiry_warning_seconds: config
+                        .global
+                        .telemetry
+                        .grpc_tcp
+                        .as_ref()
+                        .map_or(0, |tcp| tcp.tls_expiry_warning_seconds),
                     principal,
                 })
             }
@@ -1538,10 +1544,53 @@ fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, St
                 roles: Arc::clone(&roles),
                 credential_store: credential_store.clone(),
                 credential_index,
+                tls_expiry_warning_seconds: 0,
                 principal,
             }),
         })
         .collect()
+}
+
+fn check_tls_expiry_warnings(listeners: &[GrpcListenerConfig]) -> usize {
+    let mut warnings = 0;
+    for listener in listeners {
+        let generation = listener.credential_store.load();
+        if let Some(expiry) = generation.tls_expiry(listener.credential_index) {
+            for (kind, not_after) in expiry.warnings(listener.tls_expiry_warning_seconds) {
+                print_framed_warning(
+                    &format!("gRPC TLS {kind} notAfter is within the configured warning window"),
+                    &format!(
+                        "Certificate notAfter: {not_after} Unix seconds. Warning window: {} seconds, including past dates.\n\
+                         Rotate the relevant certificate material and reload credentials with SIGHUP.\n\
+                         Bundle minima describe supplied certificates, not effective peer path cutoffs.",
+                        listener.tls_expiry_warning_seconds,
+                    ),
+                );
+                warnings += 1;
+            }
+        }
+    }
+    warnings
+}
+
+fn warn_grpc_tls_expiry(
+    credentials: &rustbgpd_api::credentials::CredentialStore,
+    index: usize,
+    warning_seconds: u32,
+) {
+    let generation = credentials.load();
+    if let Some(expiry) = generation.tls_expiry(index) {
+        for (kind, not_after) in expiry.warnings(warning_seconds) {
+            warn!(
+                event = "grpc_tls_certificate_expiry",
+                generation = generation.sequence(),
+                kind,
+                certificate_not_after_seconds = not_after,
+                tls_expiry_warning_seconds = warning_seconds,
+                "gRPC TLS certificate notAfter is within the configured warning window, including past dates; bundle minima are supplied metadata, not effective path cutoffs"
+            );
+        }
+    }
 }
 
 const fn warm_bundle_family_v1(afi: Afi, safi: Safi) -> Option<WarmBundleFamilyV1> {
@@ -1938,8 +1987,8 @@ fn family_partitioned_listener_mss(
 /// set on purpose: it reports what this release has not finished building,
 /// not a defect in the operator's config, so gating on it would make a
 /// correct deployment unshippable.
-fn check_warnings(config: &Config) -> usize {
-    let mut warnings = warn_unpoliced_ebgp(config);
+fn check_warnings(config: &Config, listeners: &[GrpcListenerConfig]) -> usize {
+    let mut warnings = warn_unpoliced_ebgp(config) + check_tls_expiry_warnings(listeners);
     for advisory in config.advisories() {
         print_framed_warning(advisory.headline, advisory.detail);
         warnings += 1;
@@ -2743,18 +2792,21 @@ fn main() -> ExitCode {
     let config = accepted.config();
 
     if check_only {
-        // Resolve the same credential generation as startup without binding
-        // listeners, so invalid TLS content cannot pass the preflight check.
-        if let Err(error) = resolve_grpc_listeners(&config) {
-            eprintln!("error: invalid gRPC listener configuration: {error}");
-            return ExitCode::FAILURE;
-        }
+        // Retain the exact staged generation used for credential preflight so
+        // expiry warnings describe those bytes without reading the files again.
+        let grpc_listeners = match resolve_grpc_listeners(&config) {
+            Ok(listeners) => listeners,
+            Err(error) => {
+                eprintln!("error: invalid gRPC listener configuration: {error}");
+                return ExitCode::FAILURE;
+            }
+        };
         // The summary line is the only thing some operators read. When
         // anything was flagged it must not be able to pass for a clean
         // result, so `OK` is spent only on a check with nothing to report
         // and otherwise gives way to the count. Without `--strict` the exit
         // code stays 0 either way — these are warnings, not failures.
-        let warnings = check_warnings(&config);
+        let warnings = check_warnings(&config, &grpc_listeners);
         let output = write_stdout(|writer| {
             if warnings == 0 {
                 writeln!(writer, "config OK: {config_path}")
@@ -3692,6 +3744,20 @@ async fn run<T>(
     let grpc_credentials = grpc_listeners
         .first()
         .map(GrpcListenerConfig::credential_store);
+    let grpc_tls_expiry_warning = grpc_listeners.iter().find_map(|listener| {
+        matches!(listener.endpoint, ListenerEndpoint::Tcp(_)).then_some((
+            listener.credential_index,
+            listener.tls_expiry_warning_seconds,
+        ))
+    });
+    if let (Some(credentials), Some((index, warning_seconds))) =
+        (&grpc_credentials, grpc_tls_expiry_warning)
+    {
+        credentials
+            .register_tls_expiry_metrics(metrics.registry(), index)
+            .expect("gRPC TLS expiry metric registered once at startup");
+        warn_grpc_tls_expiry(credentials, index, warning_seconds);
+    }
 
     // Startup banner — human-friendly topology summary on stderr.
     print_startup_banner(&config, &grpc_listeners);
@@ -5926,6 +5992,9 @@ async fn run<T>(
                                 accepted_effect = true;
                                 reload_metrics.record_grpc_credential_reload("success");
                                 info!(generation, "gRPC credential generation reloaded");
+                                if let Some((index, warning_seconds)) = grpc_tls_expiry_warning {
+                                    warn_grpc_tls_expiry(&credentials, index, warning_seconds);
+                                }
                             }
                             Err(error) => {
                                 reload_metrics.record_grpc_credential_reload("failure");

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1977,8 +1977,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
     if new_config.global.telemetry.grpc_tcp.as_ref() != live_grpc_tcp {
         error!(
             "[global.telemetry.grpc_tcp] differs from the live listener \
-             (address / token / TLS): live listener is unchanged. \
-             Restart rustbgpd to apply path/auth-mode changes. Credential \
+             (address / token / TLS / expiry warning window): live listener is unchanged. \
+             Restart rustbgpd to apply listener setting changes. Credential \
              bytes behind unchanged token/TLS paths rotate independently \
              on SIGHUP."
         );
@@ -4290,6 +4290,7 @@ token_file = {token:?}
 tls_cert_file = {cert:?}
 tls_key_file = {key:?}
 tls_client_ca_file = {ca:?}
+tls_expiry_warning_seconds = 604800
 
 [security.grpc]
 enforcement = "tier"
@@ -4322,6 +4323,27 @@ hold_time = 90
         .await
         .expect("reload should return a config even when grpc_tcp drifts");
         assert_tier_authorized_test_config(&returned);
+        assert_eq!(
+            returned
+                .global
+                .telemetry
+                .grpc_tcp
+                .as_ref()
+                .unwrap()
+                .tls_expiry_warning_seconds,
+            0
+        );
+        assert_eq!(
+            returned
+                .desired
+                .global
+                .telemetry
+                .grpc_tcp
+                .as_ref()
+                .unwrap()
+                .tls_expiry_warning_seconds,
+            604_800
+        );
         assert_eq!(
             returned.desired.security.grpc.enforcement,
             crate::config::GrpcEnforcementConfig::Tier

--- a/tests/check_strict.rs
+++ b/tests/check_strict.rs
@@ -569,3 +569,72 @@ fn check_tls_rejects_invalid_client_ca_der() {
         check_tls_material(CHECK_CERT, CHECK_KEY, &ca, Some("client-CA"));
     }
 }
+
+// Public expired certificate signed by CHECK_KEY; no production trust or identity.
+const EXPIRED_CHECK_CERT: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBfTCCASKgAwIBAgIBATAKBggqhkjOPQQDAjAdMRswGQYDVQQDDBJjaGVjay1v
+bmx5LmludmFsaWQwHhcNOTAwMTAxMDAwMDAwWhcNMDAwMTAxMDAwMDAwWjAdMRsw
+GQYDVQQDDBJjaGVjay1vbmx5LmludmFsaWQwWTATBgcqhkjOPQIBBggqhkjOPQMB
+BwNCAAQXpxOPohjjciNp9QoIOBbMOcfcvfG8HSDVxnJSAh7pMGExMb0MC8eZFIGx
+IzruHB5P4ngSmaL12b53Ulf8LzP2o1MwUTAdBgNVHQ4EFgQUs8OQThYHP98r+3/s
+2vLfUNDj1TEwHwYDVR0jBBgwFoAUs8OQThYHP98r+3/s2vLfUNDj1TEwDwYDVR0T
+AQH/BAUwAwEB/zAKBggqhkjOPQQDAgNJADBGAiEAitu0Kk47oqMvy0h5yJRWN2sq
+mLQpzHQWk5jofogVaVsCIQCwIyGG8Dbh5p+RnM0ktM/TtxbZ+EDqy3UnaIrJYRsp
+wQ==
+-----END CERTIFICATE-----
+"#;
+
+#[test]
+fn check_tls_expiry_warnings_are_opt_in_and_strict_sensitive() {
+    for (cert, window, expected_warning) in [
+        (CHECK_CERT, Some(1), false),
+        (CHECK_CERT, Some(u32::MAX), true),
+        (EXPIRED_CHECK_CERT, None, false),
+        (EXPIRED_CHECK_CERT, Some(0), false),
+        (EXPIRED_CHECK_CERT, Some(1), true),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_file = dir.path().join("server.pem");
+        let key_file = dir.path().join("server.key");
+        let ca_file = dir.path().join("client-ca.pem");
+        std::fs::write(&cert_file, cert).unwrap();
+        std::fs::write(&key_file, CHECK_KEY).unwrap();
+        std::fs::write(&ca_file, cert).unwrap();
+        let window_config = window.map_or_else(String::new, |seconds| {
+            format!("tls_expiry_warning_seconds = {seconds}\n")
+        });
+        let runtime_dir = dir.path().join("not-created");
+        let config = format!(
+            "{}\n[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n\
+             tls_cert_file = {cert_file:?}\ntls_key_file = {key_file:?}\n\
+             tls_client_ca_file = {ca_file:?}\n{window_config}",
+            CLEAN.replace("/tmp/rustbgpd-check-strict", runtime_dir.to_str().unwrap()),
+        );
+        for args in [&["--check"][..], &["--check", "--strict"][..]] {
+            let (code, stdout, stderr) = run(&config, args);
+            let expected_code = i32::from(expected_warning && args.contains(&"--strict"));
+            assert_eq!(
+                code,
+                Some(expected_code),
+                "window={window:?} {args:?}: {stdout}\n{stderr}"
+            );
+            if expected_warning {
+                assert!(stdout.contains("config VALID, 3 WARNINGS"), "{stdout}");
+                for kind in ["server_leaf", "server_bundle_min", "client_ca_bundle_min"] {
+                    assert!(
+                        stderr.contains(&format!("gRPC TLS {kind} notAfter")),
+                        "{stderr}"
+                    );
+                }
+                assert!(
+                    stderr.contains("not effective peer path cutoffs"),
+                    "{stderr}"
+                );
+            } else {
+                assert!(stdout.contains("config OK"), "{stdout}");
+                assert!(stderr.is_empty(), "{stderr}");
+            }
+            assert!(!runtime_dir.exists(), "check created runtime state");
+        }
+    }
+}


### PR DESCRIPTION
Native gRPC mTLS operators can now inspect certificate expiry from the active credential generation. `bgp_grpc_tls_certificate_not_after_seconds{kind}` exposes the server leaf, supplied server-bundle minimum, and supplied client-CA-bundle minimum. Successful TLS handshakes log the observed client's leaf expiry. The restart-required `tls_expiry_warning_seconds` defaults to `0`; a positive window enables startup, successful-reload, config-check, and successful-client warnings, including past dates. Ordinary `--check` keeps exit 0 for warnings, while `--check --strict` returns 1.

Metadata is extracted from the same bytes used to stage TLS and collected from one active snapshot per scrape. Failed rotations preserve prior values; retained old connections cannot overwrite them. Unavailable metadata is omitted without adding credential rejection rules. Documentation distinguishes supplied bundle dates from effective peer-path cutoffs and observed clients from a client certificate inventory, and covers rollback of the new configuration field.

Validation:

- Full `just gate` passes: links, developer tooling, contracts, strict workspace Clippy, workspace tests, and library/binary rustdoc.
- Focused credential and handshake regressions plus all 19 `check_strict` tests pass, including expired/default-off, near-window, strict-exit, failed-rotation, opaque extra-chain, and no-TLS cases.
- Loopback daemon smoke verifies active gauges, successful-client INFO/WARN records, rejected and successful SIGHUP rotation, and zero expiry samples on plaintext TCP. Both temporary daemons exit cleanly.
- Generated configuration schema and stable-surface checks pass; metric-consumer and release-note contracts cover the new collector and preserve the historical baseline.
