### PR TITLE
build(deps): refresh http stack and extend update coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
 # Dependabot config — keeps Cargo dependencies and GitHub Actions
-# pinned versions current. The single workspace-root Cargo entry
-# covers the daemon and every workspace crate, including the
+# pinned versions current. The primary workspace-root Cargo entry
+# covers the daemon and its workspace crates, including the
 # published ones, through the shared Cargo.lock. Member manifests
 # inherit workspace fields, so a per-crate directory entry cannot
-# resolve them and must not be added.
+# replace the workspace entry. The independent scale workspace has
+# its own entry and lockfile; its path dependencies share root fields.
 #
 # Cadence: weekly. The Cargo ecosystem tends to produce a steady
 # trickle of patch releases (tonic, prost, tokio); weekly avoids
@@ -23,6 +24,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Keep direct updates and admit the HTTP stack's lock-only dependencies.
+    allow:
+      - dependency-type: "direct"
+      - dependency-name: "hyper*"
+        dependency-type: "indirect"
+      - dependency-name: "h2"
+        dependency-type: "indirect"
     groups:
       netlink-stack:
         patterns:
@@ -64,6 +72,15 @@ updates:
         update-types: ["version-update:semver-major"]
       # Workspace-internal crates are path deps; updates land via the
       # release process, not Dependabot.
+      - dependency-name: "rustbgpd-*"
+
+  # Independent scale workspace, including profiling and load harnesses.
+  - package-ecosystem: "cargo"
+    directory: "/bench/scale"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
       - dependency-name: "rustbgpd-*"
 
   # GitHub Actions versions in workflows/. Catches deprecation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Refreshed the transitive HTTP/gRPC stack: `hyper` 1.8.1 → 1.11.1 and `h2`
+  0.4.16 → 0.4.19. This lockfile-only update applies upstream HTTP/2 trailer
+  handling and frame-budget hardening to the tonic gRPC and gNMI listeners.
+
 - `rbgp rib add` uses `--next-hop` as the canonical flag, retaining
   `--nexthop` as a visible compatibility alias. The default RIB pager now
   wraps long lines (`less -FRX` in auto mode, `less -RX` in always mode);

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,9 +1268,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1425,7 +1425,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2360,12 +2359,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"


### PR DESCRIPTION
Refresh Hyper 1.8.1 → 1.11.1 and h2 0.4.16 → 0.4.19 for the tonic gRPC/gNMI listeners and CLI clients. The update brings upstream HTTP/2 trailer handling and frame-budget fixes, removes the unused pin-utils package, and preserves other resolved dependencies and the Rust version requirement.

Enable indirect `hyper*` and `h2` updates in the existing root Cargo job while retaining all direct updates and existing groups/ignores. The family pattern deliberately includes `hyper-util` and `hyper-timeout`, matching the existing tokio-stack group. Group membership alone did not admit these lock-only dependencies under Dependabot's [default direct-only version-update policy](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#allow). Add a weekly job for the separate `bench/scale` workspace, preserving the GitHub Actions job. An anonymous local run of the official Dependabot Cargo updater successfully proposed a pprof update for the scale workspace; its proposed files passed locked metadata resolution. The updater can follow path dependencies into shared root requirements, so future proposals still require the affected root and scale checks.

Validation: full `just gate`, standalone scale tests (`just gate-deps`), and every benchmark smoke target (`just gate-contract`) pass. Fresh `cargo audit` and `cargo deny` advisories/bans/licenses/sources checks pass. Locked metadata resolves, and YAML object checks confirm the intended admission rules while preserving existing groups, ignores, cadence, and the Actions job.
