### PR TITLE
fix(config): enforce ixp manager request body deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -517,6 +517,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- IXP Manager lifecycle requests now abort slow control-response bodies when
+  the global request budget expires. Uncertain update-lock acquisition stays
+  in manual recovery instead of continuing the lifecycle.
+
 - VPNv4 sessions now advertise RFC 8950 IPv6 next-hop receive support,
   including VPN-only configurations. Reflection preserves the IPv6 next hop
   and exports it only to recipients advertising the matching capability.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,9 +4588,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
  "base64 0.23.1",
  "log",
@@ -4605,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
 dependencies = [
  "base64 0.23.1",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 # Daemon boot ID stamping for restart detection (ADR-0072).
 uuid = { version = "1", features = ["v4"] }
 zeroize = "1"
-ureq = { version = "=3.4.0", default-features = false, features = ["rustls", "platform-verifier"] }
+ureq = { version = "3.4.1", default-features = false, features = ["rustls", "platform-verifier"] }
 
 [package]
 name = "rustbgpd"

--- a/tools/rs-config-render/tests/ixp_manager_lifecycle.rs
+++ b/tools/rs-config-render/tests/ixp_manager_lifecycle.rs
@@ -48,6 +48,7 @@ struct Response {
     location: Option<String>,
     expected_state: Option<(PathBuf, &'static str)>,
     delay: Option<Duration>,
+    body_byte_delay: Option<Duration>,
     chmod_before_reply: Option<(PathBuf, u32)>,
 }
 
@@ -60,6 +61,7 @@ impl Response {
             location: None,
             expected_state: None,
             delay: None,
+            body_byte_delay: None,
             chmod_before_reply: None,
         }
     }
@@ -72,6 +74,7 @@ impl Response {
             location: None,
             expected_state: None,
             delay: None,
+            body_byte_delay: None,
             chmod_before_reply: None,
         }
     }
@@ -161,7 +164,17 @@ impl Server {
                         let _ = write!(stream, "Location: {location}\r\n");
                     }
                     let _ = write!(stream, "\r\n");
-                    let _ = stream.write_all(&response.body);
+                    if let Some(delay) = response.body_byte_delay {
+                        stream.set_nodelay(true).unwrap();
+                        for byte in response.body {
+                            if stream.write_all(&[byte]).is_err() {
+                                break;
+                            }
+                            thread::sleep(delay);
+                        }
+                    } else {
+                        let _ = stream.write_all(&response.body);
+                    }
                 }));
             }
             for writer in writers {
@@ -551,6 +564,7 @@ fn redirects_and_unsafe_origins_or_key_files_are_refused_without_key_forwarding(
         location: Some(format!("http://{}/stolen", sink.local_addr().unwrap())),
         expected_state: None,
         delay: None,
+        body_byte_delay: None,
         chmod_before_reply: None,
     }]);
     assert_eq!(
@@ -601,6 +615,23 @@ fn redirects_and_unsafe_origins_or_key_files_are_refused_without_key_forwarding(
 }
 
 #[test]
+fn control_body_cannot_continue_past_the_global_deadline() {
+    let _lifecycle_guard = lifecycle_test_guard();
+    let rig = Rig::new();
+    let mut response = Response::json(200);
+    response.body.splice(0..0, vec![b' '; 1_500]);
+    response.body_byte_delay = Some(Duration::from_millis(1));
+    let server = Server::start(vec![response]);
+    let mut options = rig.options(&server.origin);
+    options.timeout = Duration::from_secs(1);
+    let result = lifecycle::run(&options);
+    let requests = server.finish();
+    assert_eq!(result, Err(Error::ManualRecovery));
+    assert_eq!(requests.len(), 1);
+    assert_request(&requests[0], "POST", "get-update-lock");
+}
+
+#[test]
 fn control_and_configuration_body_caps_fail_closed() {
     let _lifecycle_guard = lifecycle_test_guard();
     let rig = Rig::new();
@@ -620,6 +651,7 @@ fn control_and_configuration_body_caps_fail_closed() {
         location: None,
         expected_state: None,
         delay: None,
+        body_byte_delay: None,
         chmod_before_reply: None,
     }]);
     assert_eq!(
@@ -636,6 +668,7 @@ fn control_and_configuration_body_caps_fail_closed() {
         location: None,
         expected_state: None,
         delay: None,
+        body_byte_delay: None,
         chmod_before_reply: None,
     }]);
     assert_eq!(
@@ -1207,6 +1240,6 @@ fn every_lifecycle_test_acquires_the_process_guard_first() {
         .collect::<Vec<_>>();
     assert_eq!(
         tests.join(","),
-        "noop_lifecycle_uses_exact_authenticated_order_and_acknowledges,definite_lock_and_render_failures_have_bounded_release_semantics,failed_callback_is_durable_and_resume_never_refetches_or_activates,started_activation_uncertainty_retains_remote_lock_for_manual_recovery,redirects_and_unsafe_origins_or_key_files_are_refused_without_key_forwarding,control_and_configuration_body_caps_fail_closed,in_memory_renderer_is_byte_identical_to_private_file_entry_point,host_lock_is_exclusive_before_any_network_request,guard_clear_is_bound_to_the_claimed_host,per_handle_state_lock_refuses_before_publishing_host_fence,topology_mismatches_are_refused_before_network_effects,killed_run_retains_owner_fence_and_foreign_resume_cannot_bypass_it,journal_write_failure_after_lock_acquisition_fences_without_activation,callback_cleanup_failure_retains_fence_until_matching_resume,additive_cli_help_pins_run_and_callback_only_resume,poisoned_proxy_is_ignored_and_cli_reports_the_exact_terminal_status,only_the_pinned_definite_lock_statuses_clear_the_intent,corrupt_or_contradictory_durable_state_never_sends_a_callback,release_resume_preserves_the_original_refusal_or_rollback_exit,every_lifecycle_test_acquires_the_process_guard_first"
+        "noop_lifecycle_uses_exact_authenticated_order_and_acknowledges,definite_lock_and_render_failures_have_bounded_release_semantics,failed_callback_is_durable_and_resume_never_refetches_or_activates,started_activation_uncertainty_retains_remote_lock_for_manual_recovery,redirects_and_unsafe_origins_or_key_files_are_refused_without_key_forwarding,control_body_cannot_continue_past_the_global_deadline,control_and_configuration_body_caps_fail_closed,in_memory_renderer_is_byte_identical_to_private_file_entry_point,host_lock_is_exclusive_before_any_network_request,guard_clear_is_bound_to_the_claimed_host,per_handle_state_lock_refuses_before_publishing_host_fence,topology_mismatches_are_refused_before_network_effects,killed_run_retains_owner_fence_and_foreign_resume_cannot_bypass_it,journal_write_failure_after_lock_acquisition_fences_without_activation,callback_cleanup_failure_retains_fence_until_matching_resume,additive_cli_help_pins_run_and_callback_only_resume,poisoned_proxy_is_ignored_and_cli_reports_the_exact_terminal_status,only_the_pinned_definite_lock_statuses_clear_the_intent,corrupt_or_contradictory_durable_state_never_sends_a_callback,release_resume_preserves_the_original_refusal_or_rollback_exit,every_lifecycle_test_acquires_the_process_guard_first"
     );
 }


### PR DESCRIPTION
Slowly streaming a successful update-lock response could outlive the global request timeout and let the IXP Manager lifecycle continue. Require ureq 3.4.1 or a compatible newer release, with 3.4.1 and ureq-proto 0.6.2 resolved, so expiration during the body read follows the existing ambiguous-acquisition path to manual recovery before another request is sent.

The regression uses the existing loopback server to stream valid acquisition JSON. It fails with the old dependency, which advances to `CallbackPending`, and passes with the update, which returns `ManualRecovery` after only the acquisition request. It checks outcomes without a narrow wall-clock assertion. All other resolved packages and HTTP/TLS features are preserved. The existing renderer documentation already describes bounded requests and manual recovery; no RPC, configuration schema, or roadmap boundary changes.

Validation: all 132 renderer tests, strict package Clippy, `just gate`, `just gate-deps`, `just gate-contract`, `cargo audit`, and `cargo deny check` passed on the combined branch. The full diff and dependency scope were reviewed.
