### PR TITLE
build(deps): refresh internal tls stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,6 +331,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   0.4.16 → 0.4.19. This lockfile-only update applies upstream HTTP/2 trailer
   handling and frame-budget hardening to the tonic gRPC and gNMI listeners.
 
+- Refreshed internal TLS dependencies to tokio-rustls 0.26.5, rustls 0.23.43,
+  rustls-webpki 0.103.15, and rustls-pki-types 1.15.1. tokio-rustls can return
+  more data from a stream read; provider selection and TLS configuration remain
+  unchanged.
+
 - `rbgp rib add` uses `--next-hop` as the canonical flag, retaining
   `--nexthop` as a visible compatibility alias. The default RIB pager now
   wraps long lines (`less -FRX` in auto mode, `less -RX` in always mode);

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -3536,9 +3536,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4247,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",


### PR DESCRIPTION
Refreshes the internal TLS dependencies to tokio-rustls 0.26.5, rustls 0.23.43, rustls-webpki 0.103.15, and rustls-pki-types 1.15.1. This includes tokio-rustls's improved stream-read handling while retaining the configured ring provider and TLS 1.2/1.3 behavior.

The lockfile changes only those four packages. Focused validation passed all nine credential tests, the live TLS handshake/rejection/metrics regression, and all 19 configuration-preflight tests, including expiry warnings and failed-rotation retention.

Validation passed: `just gate`, `just gate-deps`, `just gate-contract`, fresh `cargo audit` and `cargo deny check`, and normal repository commit/push hooks.
