### PR TITLE
feat(config): name changed rpol terms in config diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Config diff impact reasons now name directly changed `.rpol` policy terms
+  for static neighbors and dynamic ranges. Text and JSON preserve the existing
+  reasons and reload classifications; ambiguous structural changes retain
+  broader attribution.
+
 - Native gRPC TLS expiry visibility through
   `bgp_grpc_tls_certificate_not_after_seconds{kind}` for the active server leaf,
   supplied server bundle minimum, and supplied client CA bundle minimum.

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -504,6 +504,14 @@ effective-impact view:
   policy definition edit picked up via the global `import_chain`
   (chain list itself unchanged) or via a peer-group's chain
   (peer-group record unchanged) still flags every affected member.
+  Direct `.rpol` term edits also append reasons such as
+  `import rpol policy "customer-in(200)" term "customer-routes" changed`
+  for static neighbors and dynamic ranges, in both text and JSON output.
+  These name changed compiled terms when policy calls, ordered term names,
+  defaults, and shared match tables still align. Compiler-generated `.1` /
+  `.2` term suffixes are preserved. Changed sets, call arguments, term order,
+  or other ambiguous structural edits retain the broader reasons; this is
+  structural attribution, not a proof of changed route outcomes.
 
 Exit codes: 0 = no actionable changes, 1 = actionable changes found,
 2 = error (bad config, missing file).

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4946,18 +4946,22 @@ fn compute_effective_neighbor_impact(
             );
         }
 
-        attribute_rpol_term_changes(
-            &mut reasons,
-            "import",
-            old_resolved.import_policy.as_ref(),
-            new_resolved.import_policy.as_ref(),
-        );
-        attribute_rpol_term_changes(
-            &mut reasons,
-            "export",
-            old_resolved.export_policy.as_ref(),
-            new_resolved.export_policy.as_ref(),
-        );
+        if import_moved {
+            attribute_rpol_term_changes(
+                &mut reasons,
+                "import",
+                old_resolved.import_policy.as_ref(),
+                new_resolved.import_policy.as_ref(),
+            );
+        }
+        if export_moved {
+            attribute_rpol_term_changes(
+                &mut reasons,
+                "export",
+                old_resolved.export_policy.as_ref(),
+                new_resolved.export_policy.as_ref(),
+            );
+        }
 
         if !reasons.is_empty() {
             let kind =
@@ -4981,8 +4985,9 @@ fn compute_effective_neighbor_impact(
     out
 }
 
-/// Name direct compiled term edits only when the configured calls and their
-/// indexed match data still align. Structural changes retain the coarse reason.
+/// Name direct compiled term edits in a changed resolved chain only when its
+/// configured calls and indexed match data still align. Structural changes
+/// retain the coarse reason.
 fn attribute_rpol_term_changes(
     reasons: &mut Vec<String>,
     direction: &str,
@@ -4992,9 +4997,6 @@ fn attribute_rpol_term_changes(
     let (Some(old), Some(new)) = (old, new) else {
         return;
     };
-    if old == new {
-        return;
-    }
     if !old
         .policies
         .iter()
@@ -5149,18 +5151,22 @@ fn dynamic_range_effective_impact(
         if pg_changed.contains(old_range.peer_group.as_str()) {
             reasons.push(format!("peer_group {:?} changed", old_range.peer_group));
         }
-        attribute_rpol_term_changes(
-            &mut reasons,
-            "import",
-            old_resolved.import_policy.as_ref(),
-            new_resolved.import_policy.as_ref(),
-        );
-        attribute_rpol_term_changes(
-            &mut reasons,
-            "export",
-            old_resolved.export_policy.as_ref(),
-            new_resolved.export_policy.as_ref(),
-        );
+        if import_moved {
+            attribute_rpol_term_changes(
+                &mut reasons,
+                "import",
+                old_resolved.import_policy.as_ref(),
+                new_resolved.import_policy.as_ref(),
+            );
+        }
+        if export_moved {
+            attribute_rpol_term_changes(
+                &mut reasons,
+                "export",
+                old_resolved.export_policy.as_ref(),
+                new_resolved.export_policy.as_ref(),
+            );
+        }
 
         if !reasons.is_empty() {
             let kind =

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4946,6 +4946,19 @@ fn compute_effective_neighbor_impact(
             );
         }
 
+        attribute_rpol_term_changes(
+            &mut reasons,
+            "import",
+            old_resolved.import_policy.as_ref(),
+            new_resolved.import_policy.as_ref(),
+        );
+        attribute_rpol_term_changes(
+            &mut reasons,
+            "export",
+            old_resolved.export_policy.as_ref(),
+            new_resolved.export_policy.as_ref(),
+        );
+
         if !reasons.is_empty() {
             let kind =
                 if (import_moved || export_moved) && !transport_changed && !peer_group_reassigned {
@@ -4966,6 +4979,76 @@ fn compute_effective_neighbor_impact(
 
     out.sort_by(|a, b| a.address.cmp(&b.address));
     out
+}
+
+/// Name direct compiled term edits only when the configured calls and their
+/// indexed match data still align. Structural changes retain the coarse reason.
+fn attribute_rpol_term_changes(
+    reasons: &mut Vec<String>,
+    direction: &str,
+    old: Option<&PolicyChain>,
+    new: Option<&PolicyChain>,
+) {
+    let (Some(old), Some(new)) = (old, new) else {
+        return;
+    };
+    if old == new {
+        return;
+    }
+    if !old
+        .policies
+        .iter()
+        .map(|p| &p.name)
+        .eq(new.policies.iter().map(|p| &p.name))
+    {
+        return;
+    }
+    let mut seen = HashSet::new();
+    for (old, new) in old.policies.iter().zip(&new.policies) {
+        let (Some(name), Some(old), Some(new)) =
+            (&new.name, old.rpol.as_deref(), new.rpol.as_deref())
+        else {
+            continue;
+        };
+        // IDs in a term index these tables. A changed table can alter behavior
+        // without changing the term, or renumber otherwise unchanged operands.
+        if old.prefix_sets != new.prefix_sets
+            || old.community_sets != new.community_sets
+            || old.asn_sets != new.asn_sets
+            || old.as_path_regexes != new.as_path_regexes
+            || old.prefix_set_names != new.prefix_set_names
+            || old.community_set_names != new.community_set_names
+            || old.asn_set_names != new.asn_set_names
+            || old.datasets != new.datasets
+            || old.local_asn != new.local_asn
+        {
+            continue;
+        }
+        let ([old], [new]) = (old.policies.as_slice(), new.policies.as_slice()) else {
+            continue;
+        };
+        if old.name != new.name
+            || old.source != new.source
+            || old.default_action != new.default_action
+            || !old
+                .terms
+                .iter()
+                .map(|t| &t.name)
+                .eq(new.terms.iter().map(|t| &t.name))
+        {
+            continue;
+        }
+        for (old, new) in old.terms.iter().zip(&new.terms) {
+            if old != new
+                && let Some(term) = &new.name
+                && seen.insert((name.as_str(), term.as_str()))
+            {
+                reasons.push(format!(
+                    "{direction} rpol policy {name:?} term {term:?} changed"
+                ));
+            }
+        }
+    }
 }
 
 /// Surface `[[dynamic_neighbors]]` ranges whose resolved effective policy moves
@@ -5066,6 +5149,19 @@ fn dynamic_range_effective_impact(
         if pg_changed.contains(old_range.peer_group.as_str()) {
             reasons.push(format!("peer_group {:?} changed", old_range.peer_group));
         }
+        attribute_rpol_term_changes(
+            &mut reasons,
+            "import",
+            old_resolved.import_policy.as_ref(),
+            new_resolved.import_policy.as_ref(),
+        );
+        attribute_rpol_term_changes(
+            &mut reasons,
+            "export",
+            old_resolved.export_policy.as_ref(),
+            new_resolved.export_policy.as_ref(),
+        );
+
         if !reasons.is_empty() {
             let kind =
                 if (import_moved || export_moved) && !transport_changed && !peer_group_reassigned {

--- a/src/config/tests/rpol.rs
+++ b/src/config/tests/rpol.rs
@@ -806,6 +806,197 @@ fn rpol_edit_classifies_policy_chain_impact_for_referencing_peers_only() {
 }
 
 #[test]
+fn rpol_term_diff_names_direct_action_and_guard_edits_in_both_formats() {
+    let source = "policy customer-in(lp: u32) {
+        term customer-routes { if route.med == 10 { set local-pref lp; accept } }
+        term other { if route.med == 20 { reject } }
+    }";
+    // Repeated calls still produce each term reason only once, in first-seen order.
+    let dir = rpol_config_dir(source, r#""customer-in(200)", "customer-in(200)""#);
+    let old = load_dir(&dir).unwrap();
+    for edited in [
+        source.replace("set local-pref lp", "set local-pref 300"),
+        source.replace("route.med == 10", "route.med == 11"),
+    ] {
+        fs::write(dir.path().join("policies/core.rpol"), edited).unwrap();
+        let diff = diff_config(&old, &load_dir(&dir).unwrap());
+        assert_eq!(diff.effective_neighbor_impact.len(), 1);
+        let impact = &diff.effective_neighbor_impact[0];
+        let reason = "import rpol policy \"customer-in(200)\" term \"customer-routes\" changed";
+        assert_eq!(impact.address, "192.0.2.1");
+        assert!(impact.kind.is_policy_chain());
+        assert_eq!(
+            impact.reasons,
+            vec![
+                "import policy resolved differently",
+                "rpol policy file changed",
+                reason,
+            ]
+        );
+        assert!(format_config_diff(&diff).contains(reason));
+        let json = config_diff_json_value(&diff);
+        assert_eq!(
+            json["reload_applied"]["effective_neighbor_impact"][0]["reasons"][2],
+            reason
+        );
+        assert_eq!(
+            json["reload_applied"]["effective_neighbor_impact"][0]["kind"],
+            "policy_chain"
+        );
+        assert!(!classify_config_transaction_v1(&diff).is_committable());
+    }
+}
+
+#[test]
+fn rpol_term_diff_keeps_coarse_reasons_for_ambiguous_changes() {
+    let source = "prefix-set customers { 10.10.0.0/16 ge 24 le 28 }
+    policy customer-in(lp: u32) {
+        default-action accept
+        term customer-routes { if route.prefix in customers { set local-pref lp; accept } }
+        term other { if route.med == 20 { reject } }
+    }";
+    let dir = rpol_config_dir(source, r#""customer-in(200)""#);
+    let old = load_dir(&dir).unwrap();
+    for edited in [
+        source.replace("ge 24 le 28", "ge 24 le 32"),
+        source.replace("default-action accept", "default-action reject"),
+        source.replace("term customer-routes", "term renamed"),
+        source.replace("term other { if route.med == 20 { reject } }", ""),
+        source.replace(
+            "term other",
+            "term added { if route.med == 30 { reject } } term other",
+        ),
+        source.replace(
+            "term customer-routes { if route.prefix in customers { set local-pref lp; accept } }
+        term other { if route.med == 20 { reject } }",
+            "term other { if route.med == 20 { reject } }
+        term customer-routes { if route.prefix in customers { set local-pref lp; accept } }",
+        ),
+    ] {
+        fs::write(dir.path().join("policies/core.rpol"), edited).unwrap();
+        let diff = diff_config(&old, &load_dir(&dir).unwrap());
+        assert_eq!(diff.effective_neighbor_impact.len(), 1, "{diff:?}");
+        assert_eq!(
+            diff.effective_neighbor_impact[0].reasons,
+            vec![
+                "import policy resolved differently",
+                "rpol policy file changed",
+            ]
+        );
+    }
+    // A changed call argument changes compiled terms but is not a source term edit.
+    fs::write(dir.path().join("policies/core.rpol"), source).unwrap();
+    let mut new = load_dir(&dir).unwrap();
+    new.neighbors[0].import_policy_chain = vec!["customer-in(300)".into()];
+    let diff = diff_config(&old, &new);
+    assert_eq!(
+        diff.effective_neighbor_impact[0].reasons,
+        vec!["import policy resolved differently"]
+    );
+}
+
+#[test]
+fn rpol_term_diff_preserves_generated_names_and_requires_the_same_expansion() {
+    let source = "policy shape {
+        term edits { set med 10; if route.local-pref >= 500 { add community 65000:1 } }
+        term decide { accept }
+    }";
+    let dir = rpol_config_dir(source, r#""shape""#);
+    let old = load_dir(&dir).unwrap();
+    for (before, after, term) in [
+        ("set med 10", "set med 11", "edits.1"),
+        ("local-pref >= 500", "local-pref >= 501", "edits.2"),
+    ] {
+        fs::write(
+            dir.path().join("policies/core.rpol"),
+            source.replace(before, after),
+        )
+        .unwrap();
+        let diff = diff_config(&old, &load_dir(&dir).unwrap());
+        assert_eq!(
+            diff.effective_neighbor_impact[0].reasons.last().unwrap(),
+            &format!("import rpol policy \"shape\" term {term:?} changed")
+        );
+    }
+    fs::write(
+        dir.path().join("policies/core.rpol"),
+        source.replace("set med 10;", ""),
+    )
+    .unwrap();
+    let diff = diff_config(&old, &load_dir(&dir).unwrap());
+    assert_eq!(diff.effective_neighbor_impact[0].reasons.len(), 2);
+}
+
+#[test]
+fn rpol_term_diff_names_export_edits_for_static_and_dynamic_peers() {
+    let source = "policy outbound { term export-routes { if route.med == 10 { accept } } }";
+    let dir = rpol_config_dir(source, r#""toml-pass""#);
+    let path = dir.path().join("config.toml");
+    let config = fs::read_to_string(&path).unwrap().replace(
+        "remote_asn = 65002",
+        "remote_asn = 65002\nexport_policy_chain = [\"outbound\"]",
+    );
+    fs::write(
+        &path,
+        format!(
+            "{config}
+[peer_groups.dynamic]
+import_policy_chain = [\"outbound\"]
+export_policy_chain = [\"outbound\"]
+[[dynamic_neighbors]]
+prefix = \"10.30.0.0/16\"
+peer_group = \"dynamic\"
+remote_asn = 65030
+"
+        ),
+    )
+    .unwrap();
+    let old = load_dir(&dir).unwrap();
+    fs::write(
+        dir.path().join("policies/core.rpol"),
+        source.replace("== 10", "== 11"),
+    )
+    .unwrap();
+    let diff = diff_config(&old, &load_dir(&dir).unwrap());
+    assert_eq!(diff.effective_neighbor_impact.len(), 2);
+    for impact in &diff.effective_neighbor_impact {
+        assert!(impact.kind.is_policy_chain());
+        assert_eq!(
+            impact.reasons.last().unwrap(),
+            "export rpol policy \"outbound\" term \"export-routes\" changed"
+        );
+    }
+    assert_eq!(diff.effective_neighbor_impact[0].address, "10.30.0.0/16");
+    assert!(diff.effective_neighbor_impact[0].is_dynamic_range);
+    assert_eq!(
+        diff.effective_neighbor_impact[0].reasons[0],
+        "dynamic-range import policy resolved differently"
+    );
+    assert!(
+        diff.effective_neighbor_impact[0].reasons.contains(
+            &"import rpol policy \"outbound\" term \"export-routes\" changed".to_string()
+        )
+    );
+    assert!(!diff.effective_neighbor_impact[1].is_dynamic_range);
+
+    // Diagnostics do not turn a combined session/policy edit into a live-policy refresh.
+    let mut new = load_dir(&dir).unwrap();
+    new.peer_groups.get_mut("dynamic").unwrap().hold_time = Some(45);
+    let diff = diff_config(&old, &new);
+    assert_eq!(
+        diff.effective_neighbor_impact[0].kind,
+        EffectiveNeighborImpactKind::SessionReshape
+    );
+    assert!(
+        diff.effective_neighbor_impact[0]
+            .reasons
+            .last()
+            .unwrap()
+            .contains("term \"export-routes\" changed")
+    );
+}
+
+#[test]
 fn chain_node_budget_named_mixed_unused_and_implicit_tails() {
     use std::fmt::Write as _;
     let mut source = String::from("policy bulk(x: u32) {\n");


### PR DESCRIPTION
Config diff now appends the changed `.rpol` policy and term to impact reasons for static neighbors and dynamic ranges. A direct edit can report `import rpol policy "customer-in(200)" term "customer-routes" changed` in both text and JSON.

Attribution requires matching calls, ordered term names, defaults, and shared match data. Ambiguous structural changes keep the existing broader reasons, and reload classifications stay unchanged. Compiler-generated term suffixes are preserved; this reports structural changes without claiming different route outcomes.

Validation: `just gate` and `just gate-rib` passed before the final change to reuse existing policy change flags. That change passed the rpol configuration and transaction suites, rpol configuration tests under `bench-internals`, and normal commit/push hooks. Focused coverage includes direct guard/action edits, repeated-call deduplication, ambiguous-change fallback, generated term suffixes, text/JSON output, and static/dynamic reload classifications.
