### PR TITLE
fix(cli): retain communities in evpn route json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -527,6 +527,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- EVPN best, received, and advertised JSON route rows now retain standard and
+  extended communities returned by the daemon. Standard communities use the
+  existing display strings and extended communities retain raw unsigned
+  64-bit values, matching exact-explain JSON.
+
 - IXP Manager lifecycle requests now abort slow control-response bodies when
   the global request budget expires. Uncertain update-lock acquisition stays
   in manual recovery instead of continuing the lifecycle.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -401,6 +401,11 @@ destination neighbor; each row's `peer` remains its source. Older daemons
 report that the new views are unsupported. Plain `rbgp evpn` retains its
 existing best-route listing.
 
+Best, received, advertised, and exact-explain JSON route rows include
+`communities` as strings (`65000:100`, `NO_EXPORT`) and `extended_communities`
+as raw unsigned 64-bit integers, preserving route-target and other extended
+community values. Both fields are empty arrays when the route has none.
+
 `evpn explain` selects one exact `mac-ip`, `imet`, `es`, `ip-prefix`,
 `ead-per-es`, or `ead-per-evi` key. Omit Type 2 `--ip` for MAC-only;
 Type 3/4 require `--originator-ip`, and Type 1/4 require `--esi`.

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -84,6 +84,12 @@ fn routes_to_json(routes: &[crate::proto::EvpnRouteEntry]) -> Vec<serde_json::Va
                 "next_hop": r.next_hop,
                 "peer": r.peer_address,
                 "as_path": r.as_path,
+                "communities": r
+                    .communities
+                    .iter()
+                    .map(|c| output::format_community(*c))
+                    .collect::<Vec<_>>(),
+                "extended_communities": r.extended_communities,
             });
             if let Some(view) = &r.prefix_sid {
                 row["prefix_sid"] = output::prefix_sid_json(view);
@@ -311,16 +317,7 @@ fn selector_to_json(key: &crate::proto::EvpnRouteSelector) -> serde_json::Value 
 
 fn explain_route_to_json(route: &crate::proto::EvpnRouteEntry) -> serde_json::Value {
     let mut rows = routes_to_json(std::slice::from_ref(route));
-    let mut row = rows.remove(0);
-    row["communities"] = serde_json::json!(
-        route
-            .communities
-            .iter()
-            .map(|c| output::format_community(*c))
-            .collect::<Vec<_>>()
-    );
-    row["extended_communities"] = serde_json::json!(route.extended_communities);
-    row
+    rows.remove(0)
 }
 
 fn export_decision(decision: i32) -> &'static str {
@@ -1627,6 +1624,32 @@ mod tests {
     use crate::proto::ListEvpnInstancesRequest;
     use crate::proto::evpn_service_client::EvpnServiceClient;
     use crate::test_support::spawn_mock_server;
+
+    #[test]
+    fn route_json_preserves_communities_and_empty_arrays() {
+        let routes = [
+            crate::proto::EvpnRouteEntry {
+                communities: vec![(65000 << 16) | 100, rustbgpd_wire::COMMUNITY_NO_EXPORT],
+                extended_communities: vec![0x0002_fde8_0000_0064, u64::MAX],
+                ..Default::default()
+            },
+            crate::proto::EvpnRouteEntry::default(),
+        ];
+        let rows = super::routes_to_json(&routes);
+        assert_eq!(
+            rows[0]["communities"],
+            serde_json::json!(["65000:100", "NO_EXPORT"])
+        );
+        assert_eq!(
+            rows[0]["extended_communities"],
+            serde_json::json!([0x0002_fde8_0000_0064_u64, u64::MAX])
+        );
+        assert_eq!(rows[1]["communities"], serde_json::json!([]));
+        assert_eq!(rows[1]["extended_communities"], serde_json::json!([]));
+        for (route, row) in routes.iter().zip(rows) {
+            assert_eq!(super::explain_route_to_json(route), row);
+        }
+    }
 
     /// Build a realistic `EvpnInstanceTable` covering the field surface
     /// operators actually use: minimal instance, instance with bridge,

--- a/crates/cli/tests/evpn_explain.rs
+++ b/crates/cli/tests/evpn_explain.rs
@@ -136,6 +136,8 @@ async fn explain_distinguishes_fresh_selection_retained_source_and_committed_exp
         mac: "aa:bb:cc:dd:ee:ff".into(),
         peer_address: peer.into(),
         next_hop: peer.into(),
+        communities: vec![(65000 << 16) | 100, rustbgpd_wire::COMMUNITY_NO_EXPORT],
+        extended_communities: vec![0x0002_fde8_0000_0064, u64::MAX],
         prefix_sid: Some(Box::new(test_support::mock_prefix_sid())),
         ..Default::default()
     };
@@ -215,6 +217,14 @@ async fn explain_distinguishes_fresh_selection_retained_source_and_committed_exp
         &value["compared"],
         &value["export"]["advertised"],
     ] {
+        assert_eq!(
+            row["communities"],
+            serde_json::json!(["65000:100", "NO_EXPORT"])
+        );
+        assert_eq!(
+            row["extended_communities"],
+            serde_json::json!([0x0002_fde8_0000_0064_u64, u64::MAX])
+        );
         assert_eq!(row["prefix_sid"]["raw_value"], "deadbeef");
         assert_eq!(
             row["prefix_sid"]["services"][0]["sids"][0]["endpoint_behavior"],

--- a/crates/cli/tests/evpn_peer_views.rs
+++ b/crates/cli/tests/evpn_peer_views.rs
@@ -29,6 +29,8 @@ async fn peer_evpn_output_and_rpc_errors() {
             rd: "65000:100".into(),
             next_hop: "192.0.2.1".into(),
             peer_address: "192.0.2.1".into(),
+            communities: vec![(65000 << 16) | 100, rustbgpd_wire::COMMUNITY_NO_EXPORT],
+            extended_communities: vec![0x0002_fde8_0000_0064, u64::MAX],
             ..Default::default()
         }],
         next_page_token: "opaque-next-page".into(),
@@ -53,18 +55,29 @@ async fn peer_evpn_output_and_rpc_errors() {
         )
     );
     server.state.list_peer_evpn_response.lock().await.routes[0].peer_address = "fe80::2".into();
-    let output = run(
-        &server.addr,
-        &["--json", "evpn", "received", "fe80::2%eth0"],
-    );
-    assert!(output.status.success(), "{output:?}");
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(value["view"], "received");
-    assert_eq!(value["neighbor"], "fe80::2%eth0");
-    assert_eq!(value["routes"][0]["peer"], "fe80::2%eth0");
-    assert_eq!(value["total_count"], 2);
-    assert_eq!(value["next_page_token"], "opaque-next-page");
-    assert_eq!(value["page_version"]["generation"], 2);
+    for (view, neighbor, source) in [
+        ("received", "fe80::2%eth0", "fe80::2%eth0"),
+        ("advertised", "192.0.2.2", "fe80::2"),
+    ] {
+        let output = run(&server.addr, &["--json", "evpn", view, neighbor]);
+        assert!(output.status.success(), "{output:?}");
+        let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(value["view"], view);
+        assert_eq!(value["neighbor"], neighbor);
+        assert_eq!(value["routes"][0]["peer"], source);
+        assert_eq!(
+            value["routes"][0]["communities"],
+            serde_json::json!(["65000:100", "NO_EXPORT"])
+        );
+        assert_eq!(
+            value["routes"][0]["extended_communities"],
+            serde_json::json!([0x0002_fde8_0000_0064_u64, u64::MAX])
+        );
+        assert_eq!(value["total_count"], 2);
+        assert_eq!(value["next_page_token"], "opaque-next-page");
+        assert_eq!(value["page_version"]["epoch"], 1);
+        assert_eq!(value["page_version"]["generation"], 2);
+    }
     assert_eq!(
         server
             .state


### PR DESCRIPTION
EVPN best, received, and advertised JSON rows dropped communities already present in the daemon response. The shared route formatter now includes standard community display strings and raw unsigned 64-bit extended communities, matching exact-explain output. Empty values remain arrays.

The change reuses the existing formatter and removes the duplicate explain-only enrichment. Regression coverage checks populated and empty rows, unsigned 64-bit boundaries, and received/advertised/explain process output. The CLI reference and changelog document the fields.

Validation passed: `just gate` (repository contracts, strict workspace Clippy, all workspace tests, and library/binary rustdoc), one focused JSON unit test, all six EVPN peer-view/explain process tests, strict CLI all-target Clippy, and normal commit/push hooks.
