### PR TITLE
docs(release): align prepared wire version notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,12 +362,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   now build under the same lint policy as the workspace crates
   (`deny(unsafe_code)`, `deny(clippy::all)`, `warn(clippy::pedantic)`).
 
-- `rustbgpd-wire` 0.19.0 → 0.19.1 (additive): a new `mrt` module adds
-  `decode_table_dump_v2_mp_reach_next_hop`, the RFC 6396 §4.3.4 `TABLE_DUMP_V2`
-  RIB-entry `MP_REACH_NLRI` next-hop decoder now shared by the daemon's
-  warm-checkpoint reader and `rbgp diff snapshot from-mrt`. `rustbgpd-fsm`
-  stays at 0.6.0 and `rustbgpd-rpki` at 0.1.0; their wire requirement follows
-  the workspace pin to `^0.19.1`, which the patch satisfies.
+- `rustbgpd-wire` 0.19.0 → prepared 0.20.0 compatibility line. Its additive
+  `mrt` API adds `decode_table_dump_v2_mp_reach_next_hop`, the RFC 6396 §4.3.4
+  `TABLE_DUMP_V2` RIB-entry `MP_REACH_NLRI` next-hop decoder, now shared by
+  the daemon's warm-checkpoint reader and `rbgp diff snapshot from-mrt`.
+  `rustbgpd-fsm` is prepared at 0.7.0 and `rustbgpd-rpki` at 0.2.0; their
+  public signatures expose wire types, so the wire requirement follows the
+  prepared workspace pin to `^0.20.0`.
 
 - **Operator-visible:** the EVPN MAC and ESI text forms are parsed by one
   grammar shared by the configuration loader and the gRPC services: exactly
@@ -917,7 +918,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the session when NLRI can be recovered. Unusable NLRI retains session reset;
   malformed snapshot entries fail admission. Generic Prefix-SID errors retain
   attribute-discard, and valid opaque reflection is unchanged. Embedders using
-  prepared wire `0.19.1` can receive `DecodeError::MalformedSrv6ServiceTlv`.
+  prepared wire `0.20.0` can receive `DecodeError::MalformedSrv6ServiceTlv`.
 
 - **EVPN IP ownership sequence:** a newly learned local MAC/IP binding can
   now carry a higher MAC Mobility sequence when another eligible remote MAC

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -3,8 +3,6 @@
 This changelog covers the independently published `rustbgpd-wire` crate. Daemon
 and workspace changes remain in the repository-level `CHANGELOG.md`.
 
-## Unreleased
-
 ## 0.20.0 - Unreleased
 
 - Added `decode_prefix_sid_services` and the `Srv6Service`,

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1283,6 +1283,10 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   service encapsulation (including RFC 9252 SRv6 BGP overlay services), EVPN
   VPWS / E-Tree service models, and BGP Add-Path (RFC 7911) for L2VPN EVPN.
   Service-provider EVPN use cases.
+  RFC 9252 reflection with an unchanged next hop and scoped
+  [framing](../reference/path-attribute-registry.md#srv6-service-framing-within-prefix-sid)
+  and [eligibility](../reference/path-attribute-registry.md#srv6-service-eligibility)
+  checks is implemented; service encapsulation and forwarding remain deferred.
 - **Evaluate buffa for protobuf codegen.** Anthropic's
   [buffa](https://github.com/anthropics/buffa) is a pure-Rust protobuf
   implementation with editions-first design, zero-copy views, and `no_std`

--- a/docs/reference/v1-stable-contract.md
+++ b/docs/reference/v1-stable-contract.md
@@ -177,21 +177,10 @@ to a later release line, keep the chain contiguous, and end at the workspace
 anchor. An unannotated gap remains an error, and the annotation is rejected on
 an exercise that is actually between consecutive release lines.
 
-The v0.51.0 route-server example is staged byte-for-byte under
-`tests/fixtures/v1-stable/v0.51.0/` and exercised by the current parser. The
-v0.60.0 release records that fixture as the accepted v0.51.0-to-v0.60.0
-milestone-jump upgrade exercise, extending the inventory's accepted release
-chain to the v0.60.0 anchor. The v0.60.0 route-server example is likewise
-archived under `tests/fixtures/v1-stable/v0.60.0/`; the v0.61.0 release records
-it as the accepted consecutive v0.60.0-to-v0.61.0 exercise and proves it with
-the current parser. The v0.61.0 route-server example continues the chain under
-`tests/fixtures/v1-stable/v0.61.0/` as the accepted consecutive
-v0.61.0-to-v0.62.0 exercise, proven the same way. The v0.62.0 route-server
-example continues the chain under `tests/fixtures/v1-stable/v0.62.0/` as the
-accepted consecutive v0.62.0-to-v0.63.0 exercise, proven the same way. The
-v0.63.0 route-server example continues the chain under
-`tests/fixtures/v1-stable/v0.63.0/` as the accepted consecutive
-v0.63.0-to-v0.64.0 exercise, proven the same way.
+The accepted source/target pairs and archived fixture paths are listed in
+[`v1-stable-surface.json`](v1-stable-surface.json). Run the fixture parser tests
+below as a set. Staging a future source fixture alone does not advance the
+accepted release chain; the workspace version and inventory move together.
 
 ## Release gate
 
@@ -200,12 +189,7 @@ Run:
 ```bash
 python3 scripts/check-v1-stable-surface.py
 cargo test -p rustbgpctl v1_stable_cli_command_inventory_matches_clap_tree
-cargo test -p rustbgpd v1_stable_v0_50_route_server_fixture_parses
-cargo test -p rustbgpd v1_stable_v0_51_route_server_fixture_parses
-cargo test -p rustbgpd v1_stable_v0_60_route_server_fixture_parses
-cargo test -p rustbgpd v1_stable_v0_61_route_server_fixture_parses
-cargo test -p rustbgpd v1_stable_v0_62_route_server_fixture_parses
-cargo test -p rustbgpd v1_stable_v0_63_route_server_fixture_parses
+cargo test -p rustbgpd route_server_fixture_parses
 cargo test -p rustbgpd v1_stable_effective_defaults_match_runtime_resolution
 ```
 


### PR DESCRIPTION
## Summary

- Align the root and wire changelogs on the published `rustbgpd-wire 0.19.0` to prepared `0.20.0` boundary, with prepared FSM `0.7.0` and RPKI `0.2.0`.
- Remove the empty crate-level `Unreleased` heading before `0.20.0`.
- Keep the roadmap's RFC 9252 reflection claim scoped to unchanged-next-hop reflection with framing and eligibility checks; service encapsulation and forwarding remain deferred.
- Make the v1-stable upgrade guidance follow the canonical inventory and current parser, including all 11 fixture parser tests through v0.68.

## Validation

- `git diff --check`
- `python3 scripts/check_embedding_versions.py`
- `python3 scripts/check_public_tracker_ids.py`
- `cargo test -p rustbgpd route_server_fixture_parses` — 11 passed
- Pre-commit documentation hook completed; Rust hooks skipped because no Rust files changed.
- Pre-push documentation hooks passed: workspace library docs, `rustbgpd` binary docs, and `rbgp` binary docs.
- `just links`
- Release-notes preview retained the upgrade notes and corrected entries.

No version bump, tag roll, or runtime behavior change.

