### PR TITLE
docs(evpn): align support claims with implemented boundaries

### DIFF
--- a/docs/explanation/comparison.md
+++ b/docs/explanation/comparison.md
@@ -74,7 +74,8 @@ IPv4/IPv6 `Prefix` routes.
 [^mpls-rr]: RR/controller-feed only. No VRF import, MPLS label forwarding,
     CE-facing attachment, or MPLS FIB programming.
 
-[^evpn]: rustbgpd EVPN is **alpha** and Linux/VXLAN-only. Shipped and
+[^evpn]: rustbgpd EVPN is **alpha**; its local VTEP and dataplane support are
+    Linux/VXLAN-only. Shipped and
     FRR-interop-tested: the Route Reflector role (Types 1-5 reflection);
     a bidirectional single-homed VTEP (Type 2 local-MAC / MAC+IP
     origination from kernel FDB / neighbor events, Type 3 IMET per
@@ -96,13 +97,16 @@ IPv4/IPv6 `Prefix` routes.
     agree: an IPv4 tenant prefix under an IPv6 VTEP is refused at
     origination and dropped at import. Both IPv6 receipts are single-homed;
     a multi-homed IPv6 underlay is untested here. Still ahead: Linux
-    softswitch local-bias split-horizon, the remaining ADR-0063 runtime
-    mixed-edit tail, true shared-VNI / non-zero Ethernet Tag service,
+    softswitch local-bias split-horizon, true shared-VNI / non-zero Ethernet
+    Tag service,
     managed netdev ergonomics, and demand-shaped route types 6-11, PBB-EVPN,
     multicast EVPN, MPLS/SRv6 service
     encapsulation, and VPWS/E-Tree remain demand-shaped service-provider
     breadth, not part of the current VXLAN/Linux alpha lane. See
     [evpn-enablement.md](../project/evpn-enablement.md) for the full gate ladder.
+    Supported decomposable runtime edits commit live; L3VNI/device/table IP-VRF identity
+    changes remain restart-required, dependency cycles fail closed, and
+    residual mid-sequence failures fail-stop at the last committed generation.
     Route types 6–11 are not reflected: unsupported typed NLRIs are
     discarded before the RIB under RFC 7606 §5.4. The
     [per-type discard counter and warnings](../reference/operations.md)

--- a/docs/explanation/use-cases.md
+++ b/docs/explanation/use-cases.md
@@ -708,8 +708,11 @@ than reflected; see the
   nexthop groups (M40 FRR-validated). Shipped since: receive-side
   RFC 9135 overlay-index Type 5 recursion, native GW-IP + ESI
   overlay-index Type 5 origination, single-active (M71) / all-active
-  (M72) ESI overlay-index Type 5 receive; remaining EVPN work is the
-  ADR-0063 runtime mixed-edit tail, Linux softswitch local-bias, and
+  (M72) ESI overlay-index Type 5 receive. Supported decomposable runtime edits
+  commit live; L3VNI/device/table IP-VRF identity changes remain restart-required. See the
+  [runtime convergence contract](../project/evpn-enablement.md#p15--evpn-vtep-mode-validation-depth)
+  for dependency-cycle rejection and mid-sequence fail-stop behavior.
+  Remaining EVPN work includes Linux softswitch local-bias and
   service-provider route families.
 
 **Why the API-first shape matters for DC fabric:**
@@ -784,8 +787,8 @@ measurement path.
   groups (M40 FRR-validated). Shipped since: receive-side RFC 9135
   overlay-index Type 5 recursion, native GW-IP + ESI overlay-index
   Type 5 origination, single-active (M71) / all-active (M72) ESI
-  overlay-index Type 5 receive; remaining EVPN work is the ADR-0063
-  runtime mixed-edit tail, Linux softswitch local-bias, and
+  overlay-index Type 5 receive; remaining EVPN work includes
+  Linux softswitch local-bias and
   service-provider route families. See
   [docs/project/evpn-enablement.md](../project/evpn-enablement.md)
   for the full enablement ladder and
@@ -903,8 +906,7 @@ Be honest about where rustbgpd isn't the right tool:
 	  receive with M72 GoBGP proof, duplicate-MAC remote suppression +
 	  manual clear, and production-default DF/non-DF BUM suppression
 	  have also shipped. **Still missing for full VTEP parity:**
-	  Linux softswitch local-bias split-horizon, the remaining ADR-0063
-	  runtime mixed-edit tail,
+	  Linux softswitch local-bias split-horizon,
 	  optional import-side ES-Import RT filtering, EVPN over MPLS/PBB,
 	  and EVPN route types 6-11. For a single-homed L2VNI fabric without
 	  MPLS/PBB or service-provider EVPN requirements, rustbgpd is a fit today.

--- a/docs/explanation/use-cases.md
+++ b/docs/explanation/use-cases.md
@@ -710,7 +710,7 @@ than reflected; see the
   overlay-index Type 5 origination, single-active (M71) / all-active
   (M72) ESI overlay-index Type 5 receive. Supported decomposable runtime edits
   commit live; L3VNI/device/table IP-VRF identity changes remain restart-required. See the
-  [runtime convergence contract](../project/evpn-enablement.md#p15--evpn-vtep-mode-validation-depth)
+  [runtime convergence contract](../project/evpn-enablement.md#gate-7b--kernel-reconciliation--origination)
   for dependency-cycle rejection and mid-sequence fail-stop behavior.
   Remaining EVPN work includes Linux softswitch local-bias and
   service-provider route families.

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -60,9 +60,12 @@ surfaces; it does not promote the rest of the project out of alpha.
 ## EVPN
 
 EVPN remains alpha. Its local VTEP and dataplane support are Linux/VXLAN-only.
-The reflector also implements scoped
-[SRv6 service framing and eligibility](path-attribute-registry.md#srv6-service-eligibility)
-without SRv6 service origination or forwarding.
+The reflector implements scoped
+[SRv6 service framing](path-attribute-registry.md#srv6-service-framing-within-prefix-sid)
+and [eligibility](path-attribute-registry.md#srv6-service-eligibility) checks,
+with unchanged-next-hop reflection of eligible raw attributes. SRv6 PE import,
+service origination, SID reconstruction, next-hop rewriting, and forwarding
+remain unimplemented.
 
 Shipped and interop-tested:
 

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -59,7 +59,10 @@ surfaces; it does not promote the rest of the project out of alpha.
 
 ## EVPN
 
-EVPN is Linux / VXLAN-only and remains alpha.
+EVPN remains alpha. Its local VTEP and dataplane support are Linux/VXLAN-only.
+The reflector also implements scoped
+[SRv6 service framing and eligibility](path-attribute-registry.md#srv6-service-eligibility)
+without SRv6 service origination or forwarding.
 
 Shipped and interop-tested:
 
@@ -86,7 +89,7 @@ Shipped and interop-tested:
 Known EVPN gaps:
 
 - L3VNI/device/table IP-VRF identity changes remain restart-required by design.
-  Other decomposable EVPN runtime edits commit live in ordered primitive steps;
+  Supported decomposable EVPN runtime edits commit live in ordered primitive steps;
   unsupported dependency cycles fail closed before commit, and residual
   mid-sequence convergence failures fail-stop on the last committed generation.
 - True RFC VLAN-aware bundle VTEP origination and dataplane for non-zero

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -3385,18 +3385,21 @@ Two complementary origination paths exist:
   Type 2 routes will trip the same Cease/MAX_PREFIXES that a peer
   flooding unicast prefixes would. The cap is the union of unicast
   unique prefixes + FlowSpec rules + EVPN keys.
-- **GR / LLGR works for EVPN.** When a VTEP restarts, its reflected
-  EVPN routes are marked stale and ranked below fresh alternatives
-  (RFC 4724 §4.2 / RFC 9494 §4.7) — no fabric-wide flap.
+- **GR / LLGR stale handling is implemented for EVPN.** When negotiated
+  for the family, restart handling marks retained EVPN routes stale and
+  ranks them below fresh alternatives (RFC 4724 §4.2 / RFC 9494 §4.7).
+  Unit and integration tests cover the transitions; the
+  [live FRR VTEP restart evidence](../interop.md#p15--evpn-route-reflector-validation-depth)
+  remains pending.
 - **Late-joining peer.** A VTEP that connects to a converged RR
   receives the existing EVPN routes in its initial dump before the
   EoR marker. (This was not always the case — see commit history for
   the regression test.)
-- **MAC mobility correctness.** A MAC that moves between VTEPs
-  produces a strictly-increasing MAC Mobility sequence number; the
-  RR forwards the highest-sequence advertisement and downstream
-  VTEPs flip their best path accordingly. Sticky MACs (RFC 7432
-  §7.7) are not displaced by non-sticky ones.
+- **MAC mobility selection.** Local MAC moves increment the advertised
+  MAC Mobility sequence, saturating at `u32::MAX`. Same-segment peer
+  synchronization can adopt a higher sequence without incrementing it.
+  EVPN selection also considers freshness, sticky status, and the remaining
+  tie-breaks; a higher sequence alone does not guarantee a path change.
 
 For the full enablement story, gate ladder, and known limitations,
 see [docs/project/evpn-enablement.md](../project/evpn-enablement.md). For a step-by-step

--- a/docs/reference/rfc-notes.md
+++ b/docs/reference/rfc-notes.md
@@ -1686,7 +1686,7 @@ carries inactive (absent), unlimited (zero), or finite.
   (ADR-0087), single-active ESI overlay-index Type 5 receive, and
   all-active ESI overlay-index Type 5 receive with route-level ECMP plus
   L3VXLAN FDB-NHG programming. Remaining EVPN work is outside the core
-  overlay-index shape: runtime mixed-edit tails, Linux softswitch local-bias
+  overlay-index shape: Linux softswitch local-bias
   limits, true shared-VNI / non-zero Ethernet Tag service, managed netdev
   ergonomics, and service-provider route families.
 


### PR DESCRIPTION
EVPN overview pages applied the Linux/VXLAN restriction to the entire feature, listed supported runtime mixed edits as future work, and overstated restart and MAC-mobility guarantees.

Scope Linux/VXLAN to the local VTEP/dataplane and link the bounded SRv6 framing, eligibility, and unchanged-next-hop reflection contracts. Align runtime guidance with supported live edits and intentional restart/fail-stop limits. Describe negotiated GR/LLGR with its outstanding live restart evidence, and account for mobility sequence saturation, peer synchronization, and selection ordering.

Validation: source, regression-test, and existing receipt review; `just links`; public tracker, site manifest, and v1 inventory checks; normal commit/push hooks. EVPN remains alpha. No runtime behavior, version, or historical receipt changes.
