### PR TITLE
fix(repo): pin container image uid and drop healthcheck text matching

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -102,6 +102,49 @@ jobs:
           docker run --rm --entrypoint rustbgpd rustbgpd:verify --version
           docker run --rm --entrypoint rbgp rustbgpd:verify --version
           docker run --rm --entrypoint birdwatcher-adapter rustbgpd:verify --help
+          # docs/how-to/deployment.md tells operators to chown host bind
+          # mounts to 999, so the built image must actually run as 999.
+          test "$(docker run --rm --entrypoint id rustbgpd:verify -u)" = "999"
+          test "$(docker run --rm --entrypoint id rustbgpd:verify -g)" = "999"
+      - name: Verify declared healthcheck reports both states
+        run: |
+          set -euo pipefail
+          await_health() {
+            name="$1"
+            want="$2"
+            deadline=$((SECONDS + 120))
+            while [ "$SECONDS" -lt "$deadline" ]; do
+              observed="$(docker inspect --format '{{.State.Health.Status}}' "$name")"
+              if [ "$observed" = "$want" ]; then
+                return 0
+              fi
+              if [ "$observed" != starting ]; then
+                break
+              fi
+              sleep 2
+            done
+            echo "::error::$name reported '$observed', expected '$want'"
+            docker inspect --format '{{json .State.Health}}' "$name"
+            return 1
+          }
+          # Unhealthy: no daemon behind the control socket. The probe must
+          # fail on the CLI's exit status alone.
+          docker run -d --name health-down \
+            --health-interval=2s --health-retries=1 --health-start-period=0s \
+            --entrypoint sleep rustbgpd:verify infinity
+          await_health health-down unhealthy
+          # Healthy: the image's own default command against the image's
+          # own container-shaped starter config.
+          docker run --rm --entrypoint rustbgpd rustbgpd:verify --init-config edge > "$RUNNER_TEMP/config.toml"
+          chmod 0644 "$RUNNER_TEMP/config.toml"
+          docker run -d --name health-up \
+            --health-interval=2s --health-retries=3 --health-start-period=60s \
+            -v "$RUNNER_TEMP/config.toml:/etc/rustbgpd/config.toml:ro" \
+            rustbgpd:verify
+          await_health health-up healthy
+      - name: Remove healthcheck containers
+        if: always()
+        run: docker rm -f health-down health-up 2>/dev/null || true
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
         uses: docker/login-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The container image now pins its account to uid/gid 999 and declares a
+  numeric `USER`, so a base-image rebuild cannot shift the uid that
+  deployment docs tell operators to chown host bind mounts to, and
+  Kubernetes `runAsNonRoot` verifies the image without the pod spec
+  repeating `runAsUser`. The container workflow asserts the built image's
+  uid and gid.
+
+- The image healthcheck now uses `rbgp health`'s exit status instead of
+  matching pretty-printed JSON text. The previous probe required a space
+  after the colon in `"healthy": true`, so a change of JSON writer would
+  have reported every healthy daemon unhealthy. The container workflow
+  now exercises the declared healthcheck in both the reachable and
+  unreachable directions.
+
 - Published-crate documentation now refreshes with one command after registry
   verification. Preparation and CI use an offline version record; release
   updates no longer require editing contract tests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,12 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd --system --user-group --home-dir /var/lib/rustbgpd \
+    # uid/gid pinned, not allocated. docs/how-to/deployment.md tells
+    # operators to chown host bind mounts to 999; an unpinned system
+    # account shifts whenever the base image adds an earlier one, and
+    # every pre-chown'd directory silently becomes EACCES.
+    && groupadd --system --gid 999 rustbgpd \
+    && useradd --system --uid 999 --gid 999 --home-dir /var/lib/rustbgpd \
        --shell /usr/sbin/nologin rustbgpd \
     && mkdir -p /var/lib/rustbgpd \
     && chown rustbgpd:rustbgpd /var/lib/rustbgpd
@@ -151,16 +156,23 @@ COPY --from=builder-release /out/birdwatcher-adapter /usr/local/bin/birdwatcher-
 COPY --from=builder-release /out/rbgp.bash-completion /usr/share/bash-completion/completions/rbgp
 COPY LICENSE-MIT LICENSE-APACHE /
 
-USER rustbgpd
+# Numeric, not the account name: Kubernetes `runAsNonRoot: true` cannot
+# resolve a name-form USER and fails the container at admission unless
+# the pod spec repeats `runAsUser`.
+USER 999:999
 
 EXPOSE 179 9179
 
-# Liveness via the local gRPC control socket: `rbgp health` succeeds
-# only when the daemon answers the Health RPC; the grep additionally
-# requires the daemon to self-report healthy. rbgp's default address is
-# the default UDS (`unix:///var/lib/rustbgpd/grpc.sock`); configs that
-# move the socket set RUSTBGPD_ADDR on the container to match.
+# Liveness via the local gRPC control socket. `rbgp health` exits
+# non-zero unless the daemon answers the Health RPC, which it does only
+# after the peer-manager and RIB readiness probe returns; that exit
+# status is the whole signal. The former `grep '"healthy": true'` added
+# nothing — the response field is a constant — while making the probe
+# depend on serde_json's pretty-printer emitting a space after the
+# colon. rbgp's default address is the default UDS
+# (`unix:///var/lib/rustbgpd/grpc.sock`); configs that move the socket
+# set RUSTBGPD_ADDR on the container to match.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD rbgp --json health | grep -q '"healthy": true' || exit 1
+  CMD rbgp health
 
 CMD ["rustbgpd", "/etc/rustbgpd/config.toml"]

--- a/docs/how-to/deployment.md
+++ b/docs/how-to/deployment.md
@@ -653,7 +653,10 @@ For your own deployment:
   `v`**: use `ghcr.io/lance0/rustbgpd:0.68.0`, not
   `ghcr.io/lance0/rustbgpd:v0.68.0`. That existing `:0.68.0` image is
   amd64-only; it is not backfilled when a later release publishes multiple
-  platforms. The production image runs as uid/gid 999, and its
+  platforms. The production image runs as uid/gid 999 — pinned in the
+  `Dockerfile` runtime stage (`useradd --uid 999 --gid 999` and
+  `USER 999:999`), not allocated by the base image, and asserted against
+  the built image by the container workflow — and its
   default command is exactly `rustbgpd /etc/rustbgpd/config.toml`. If the config
   is mounted under another container filename, pass that filename explicitly
   after the image, for example `rustbgpd /etc/rustbgpd/router.toml`.
@@ -830,7 +833,7 @@ sudo systemctl enable --now rustbgpd-container
 ```
 
 The image's declared healthcheck remains active under systemd supervision and
-runs `rbgp --json health` against the default state-directory UDS. An
+runs `rbgp health` against the default state-directory UDS. An
 `unhealthy` result remains observable with
 `docker inspect --format '{{.State.Health.Status}}' rustbgpd`, but Docker health
 status does not terminate the attached process and therefore does not drive
@@ -865,13 +868,17 @@ systemd's `Restart=on-failure`. If the config moves the socket, set
   seconds later. This standalone command has no restart policy; use bounded
   supervisor retries and inspect durable config authority before recovery.
 
-- **Health**: the image declares a `HEALTHCHECK` that runs `rbgp
-  --json health` against the daemon's local gRPC socket and requires a
-  self-reported healthy status — `docker ps` / orchestrators see the
-  container flip `healthy` once the daemon answers. It probes rbgp's
-  default endpoint (`unix:///var/lib/rustbgpd/grpc.sock`, the daemon
-  default); if your config moves the socket, set `RUSTBGPD_ADDR` on
-  the container to match.
+- **Health**: the image declares a `HEALTHCHECK` that runs `rbgp health`
+  against the daemon's local gRPC socket and uses that command's exit
+  status — `rbgp` exits non-zero when the Health RPC is unreachable, is
+  refused, or does not complete its readiness probe. `docker ps` /
+  orchestrators see the container flip `healthy` once the daemon answers.
+  The probe deliberately does not match on response text: the response's
+  `healthy` field is a constant, so grepping it added no signal the exit
+  status did not already carry, while tying liveness to the JSON
+  formatter's whitespace. It probes rbgp's default endpoint
+  (`unix:///var/lib/rustbgpd/grpc.sock`, the daemon default); if your
+  config moves the socket, set `RUSTBGPD_ADDR` on the container to match.
 
 - **Logs**: `[global.telemetry] log_format = "json"` is required and emits
   structured JSON; pipe it to your log aggregator.

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -402,9 +402,17 @@ def check_container_deployment_docs(
         errors.append("container image contract: production runtime stage missing")
         return
     for statement in (
+        # The uid/gid the deployment docs tell operators to chown host
+        # bind mounts to, pinned rather than allocated by the base image.
+        "--gid 999 rustbgpd",
+        "--uid 999 --gid 999",
         "chown rustbgpd:rustbgpd /var/lib/rustbgpd",
-        "USER rustbgpd",
-        "CMD rbgp --json health | grep -q '\"healthy\": true' || exit 1",
+        # Numeric so Kubernetes `runAsNonRoot` can verify it without the
+        # pod spec repeating `runAsUser`.
+        "USER 999:999",
+        # Exit status, not stdout text: the probe must not depend on the
+        # JSON formatter's whitespace.
+        "CMD rbgp health",
         'CMD ["rustbgpd", "/etc/rustbgpd/config.toml"]',
     ):
         if statement not in runtime:

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -438,8 +438,26 @@ MUTATIONS = (
     ),
     (
         "Dockerfile",
-        "USER rustbgpd",
+        "USER 999:999",
         "USER root",
+        "container image contract",
+    ),
+    (
+        "Dockerfile",
+        "USER 999:999",
+        "USER rustbgpd",
+        "container image contract",
+    ),
+    (
+        "Dockerfile",
+        "--uid 999 --gid 999",
+        "--user-group",
+        "container image contract",
+    ),
+    (
+        "Dockerfile",
+        "CMD rbgp health",
+        "CMD rbgp --json health | grep -q '\"healthy\": true' || exit 1",
         "container image contract",
     ),
     (


### PR DESCRIPTION
Pin the runtime account to UID/GID 999 and use numeric `USER 999:999`, matching the documented bind-mount ownership. Replace JSON text matching in the Docker healthcheck with `rbgp health` exit status, which already propagates connection and readiness-probe failures.

The container workflow now checks the actual image identity and exercises both healthy and unavailable-daemon states. Update the deployment guide and install-contract checker alongside mutation tests.

Validation: all 16 install-contract tests, contract checker, actionlint, links and documentation contracts passed. Built the runtime image and independently verified UID/GID 999, numeric USER, and the declared healthcheck returning unhealthy without a daemon and healthy with the generated edge configuration.
