### PR TITLE
build(repo): serialize local checks and add fuzz recipes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,16 @@
 # manual `cargo doc` runs, so each flavor invalidated the other's doc
 # cache and pushes paid a full workspace re-doc.
 #
-# Setup: see CONTRIBUTING.md "Pre-commit hooks".
+# Every hook that compiles runs under `scripts/build-lock.sh`, so a commit or
+# push waits for a concurrent `just gate` instead of compiling the same
+# workspace at the same time. `cargo fmt` is exempt: it never builds.
+#
+# These hooks are the only local fmt/clippy pass. prek's shim also runs
+# `.git/hooks/<hook>.legacy` when one exists, and an older setup left a
+# `cargo fmt --check` plus `cargo clippy` script there, so every commit ran
+# both checks twice. `just hooks` installs the shim and clears the leftover.
+#
+# Setup: see CONTRIBUTING.md "Pre-commit hooks", or run `just hooks`.
 default_install_hook_types: [pre-commit, pre-push]
 
 repos:
@@ -29,7 +38,7 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --locked --workspace --all-targets -- -D warnings
+        entry: bash scripts/build-lock.sh cargo clippy --locked --workspace --all-targets -- -D warnings
         language: system
         files: '(^|/)([^/]+\.rs|Cargo\.toml|Cargo\.lock)$'
         types: [file]
@@ -37,7 +46,7 @@ repos:
 
       - id: cargo-test
         name: cargo test
-        entry: cargo test --locked --workspace --lib
+        entry: bash scripts/build-lock.sh cargo test --locked --workspace --lib
         language: system
         files: '(^|/)([^/]+\.rs|Cargo\.toml|Cargo\.lock)$'
         types: [file]
@@ -46,7 +55,7 @@ repos:
 
       - id: cargo-doc
         name: cargo doc
-        entry: cargo doc --locked --workspace --lib --no-deps --document-private-items
+        entry: bash scripts/build-lock.sh cargo doc --locked --workspace --lib --no-deps --document-private-items
         language: system
         always_run: true
         pass_filenames: false
@@ -54,7 +63,7 @@ repos:
 
       - id: cargo-doc-rustbgpd-bin
         name: cargo doc (rustbgpd binary)
-        entry: cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps
+        entry: bash scripts/build-lock.sh cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps
         language: system
         always_run: true
         pass_filenames: false
@@ -62,7 +71,7 @@ repos:
 
       - id: cargo-doc-rbgp-bin
         name: cargo doc (rbgp binary)
-        entry: cargo doc --locked -p rustbgpctl --bin rbgp --no-deps
+        entry: bash scripts/build-lock.sh cargo doc --locked -p rustbgpctl --bin rbgp --no-deps
         language: system
         always_run: true
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `just fuzz-list` and `just fuzz <crate> <target>` run the cargo-fuzz
+  inventory from the crate that owns each `fuzz/Cargo.toml`, which is the only
+  directory cargo-fuzz can resolve a target from. Both recipes read the target
+  list from the existing inventory check and select the reviewed nightly from
+  `fuzz/rust-nightly.txt`. `just hooks` installs the commit and push hooks.
+
 ### Changed
+
+- Local checks that compile now serialize on one lock in the target directory,
+  so `just gate` and a concurrent commit or push wait for each other instead of
+  building the same workspace twice at once. Separate worktrees with separate
+  target directories are unaffected.
 
 - Published-crate documentation now refreshes with one command after registry
   verification. Preparation and CI use an offline version record; release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,9 +235,9 @@ remain responsible for shell scripts.
 
 ### Pre-commit hooks
 
-We ship a `.pre-commit-config.yaml` that runs `cargo fmt` and
-`cargo clippy --locked --workspace --all-targets -- -D warnings` on every
-commit and `cargo test --locked --workspace --lib` on every push. The
+We ship a `.pre-commit-config.yaml` that runs `cargo fmt --all` and
+`cargo clippy --locked --workspace --all-targets -- -D warnings` on relevant
+commits, workspace library tests on relevant pushes, and rustdoc on every push. The
 hooks are a fast local subset, not an exact CI mirror or a guarantee that a
 pull request is ready. `cargo test` is gated to pre-push (not pre-commit) so
 commits stay fast.
@@ -251,13 +251,18 @@ cargo install --locked prek
 # Or via standalone installer (no Rust toolchain needed)
 curl -LsSf https://github.com/j178/prek/releases/latest/download/prek-installer.sh | sh
 
-# Both prek installation methods use the configured hook types
-prek install
+# Install both configured hook types and replace superseded legacy hooks
+just hooks  # equivalent to prek install --overwrite
 
 # Or with the original Python pre-commit
 pipx install pre-commit
 pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
+
+Before installing, preserve any custom Git hooks you still need. Without
+`--overwrite`, prek retains older hooks as `<hook>.legacy` and runs them before
+the configured hooks, which can duplicate fmt and Clippy. `just hooks` removes
+those legacy hooks; it keeps the checks in `.pre-commit-config.yaml`.
 
 After install, hooks run automatically. To run them manually
 against staged files: `prek run` (or `pre-commit run`).

--- a/docs/how-to/fuzzing.md
+++ b/docs/how-to/fuzzing.md
@@ -51,21 +51,35 @@ reachable input space: decode → encode → decode must reproduce the value.
 
 ## Running locally
 
-Requires the reviewed nightly and cargo-fuzz release
-(`cargo install cargo-fuzz --version 0.13.2 --locked`).
+Requires the reviewed nightly in `fuzz/rust-nightly.txt` and cargo-fuzz 0.13.2
+(`cargo install cargo-fuzz --version 0.13.2 --locked`). From the repository root:
 
 ```sh
-cd crates/wire
-cargo +nightly fuzz list
-cargo +nightly fuzz run encode_update fuzz/corpus/encode_update fuzz/seeds/encode_update -- -max_total_time=300 -max_len=4096
+rustup toolchain install "$(cat fuzz/rust-nightly.txt)"
+just fuzz-list
+just fuzz wire encode_update fuzz/corpus/encode_update fuzz/seeds/encode_update -- -max_total_time=300 -max_len=4096
 ```
 
-Run the same `list`/`run` flow from `crates/bfd`, `crates/policy`,
-`crates/evpn`, `crates/mrt`, or `crates/rpki`, choosing a target and length
-bound for that crate.
+The recipe selects the pinned toolchain and changes to the target's owning
+crate. Corpus and artifact paths are relative to that crate. Choose another
+crate and target from `just fuzz-list`, with its appropriate input bound.
 
-A crash writes a reproducer under `fuzz/artifacts/<target>/`; replay it with
-`cargo +nightly fuzz run <target> fuzz/artifacts/<target>/<file>`.
+Without just, select the same toolchain before changing directories:
+
+```sh
+export RUSTUP_TOOLCHAIN="$(cat fuzz/rust-nightly.txt)"
+cd crates/wire
+cargo fuzz list
+cargo fuzz run encode_update fuzz/corpus/encode_update fuzz/seeds/encode_update -- -max_total_time=300 -max_len=4096
+```
+
+A crash writes a reproducer under `fuzz/artifacts/<target>/`. From the owning
+crate with the pinned toolchain selected, replay and minimize it:
+
+```sh
+cargo fuzz run <target> fuzz/artifacts/<target>/<file>
+cargo fuzz tmin <target> fuzz/artifacts/<target>/<file>
+```
 
 ## Corpus layout
 

--- a/justfile
+++ b/justfile
@@ -16,6 +16,11 @@ lab name phase:
 
 # Run the broad local correctness baseline in diagnostic order.
 gate:
+    bash scripts/build-lock.sh just _gate
+
+# The gate body. `gate` runs it under the build lock so a concurrent commit or
+# push waits instead of compiling the same workspace at the same time.
+_gate:
     just links
     just check-devtools
     just check-fast
@@ -23,6 +28,16 @@ gate:
     just check-clippy
     cargo test --locked --workspace
     just docs
+
+# prek's shim also runs `.git/hooks/<hook>.legacy`, so a hook script left by an
+# earlier setup keeps running alongside the configured hooks forever. This
+# repository's leftover was an older `cargo fmt --check` plus `cargo clippy`
+# script — the two checks .pre-commit-config.yaml already runs — so every commit
+# paid for them twice. `--overwrite` removes it.
+
+# Install the prek commit and push hooks, clearing any superseded legacy hook.
+hooks:
+    prek install --overwrite
 
 # Check the pinned developer tooling versions.
 check-devtools:
@@ -149,3 +164,32 @@ test-ignored:
 # Run the privileged network-namespace tests in Docker; selectors are listed in crates/evpn-linux/tests/docker/run-netns-tests.sh.
 netns selector='all':
     bash crates/evpn-linux/tests/docker/run-netns-tests.sh "{{selector}}"
+
+# Fuzz targets are built and run from the crate that owns their
+# `fuzz/Cargo.toml`; cargo-fuzz finds no targets from the repository root.
+# `scripts/check_fuzz_target_inventory.py` is the fail-closed inventory, so
+# both recipes read the crate/target pairs from it instead of keeping a
+# second list that can drift.
+
+# List every cargo-fuzz crate and target as '<crate> <target>' rows.
+fuzz-list:
+    python3 scripts/check_fuzz_target_inventory.py --print-targets
+
+# Run one cargo-fuzz target from its owning crate; extra arguments reach libFuzzer.
+[positional-arguments]
+fuzz crate target *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    crate="crates/${1#crates/}"
+    target="$2"
+    shift 2
+    if ! python3 scripts/check_fuzz_target_inventory.py --print-targets \
+        | grep -qxF "${crate} ${target}"; then
+        echo "unknown fuzz target: ${crate} ${target}" >&2
+        echo "run 'just fuzz-list' for the inventory" >&2
+        exit 2
+    fi
+    RUSTUP_TOOLCHAIN="$(cat fuzz/rust-nightly.txt)"
+    export RUSTUP_TOOLCHAIN
+    cd "${crate}"
+    exec cargo fuzz run "${target}" "$@"

--- a/justfile
+++ b/justfile
@@ -47,6 +47,7 @@ check-devtools:
 # Check formatting and the cheap repository contracts (seconds, no compilation).
 check-fast:
     cargo fmt --all -- --check
+    python3 -m unittest -v scripts/test_build_lock.py
     python3 -m unittest -v scripts/test_check_clippy_reasons.py
     python3 scripts/check-clippy-reasons.py
     python3 scripts/check-v1-stable-surface.py

--- a/scripts/build-lock.sh
+++ b/scripts/build-lock.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Repository build mutex for the local check loop.
+#
+# `just gate` and the pre-commit / pre-push hooks each compile the whole
+# workspace into the same target directory. Running two of them at once
+# doubles peak CPU and memory for no extra coverage, and the contention has
+# already stalled an interactive session mid-release. Every heavy local check
+# takes an exclusive `flock` on one file first, so the second caller waits for
+# the first instead of racing it.
+#
+#   - Path: ${RUSTBGPD_BUILD_LOCK:-${CARGO_TARGET_DIR:-target}/build.lock}.
+#     The lock lives beside the artifacts it protects, so two worktrees with
+#     separate target directories still build in parallel while a gate and a
+#     push in one tree serialize. Worktrees that share a target directory
+#     share the lock, which is the intended behavior: they share the
+#     contention too.
+#   - Wait rather than fail. `tests/soak/host-lock.sh` guards measurement
+#     runs, where a concurrent workload corrupts the reading and failing fast
+#     is correct. Here the second caller wants its checks to run, so the wait
+#     is unbounded and announced once on stderr.
+#   - A crashed holder cannot wedge the repository. `flock` is a property of
+#     the open file description, so the kernel drops it when the holder exits
+#     for any reason. There is no stale lock file to clean up, and the file
+#     itself is disposable.
+#   - The fd is allocated to the caller's shell (`exec {fd}>...`), so the lock
+#     lives for the rest of the caller's process and is released on exit. The
+#     caller does not unlock explicitly.
+#
+# Source it to hold the lock across several commands:
+#
+#     source scripts/build-lock.sh
+#     acquire_rustbgpd_build_lock
+#
+# Or execute it to hold the lock around one command:
+#
+#     bash scripts/build-lock.sh cargo doc --locked --workspace --lib
+
+acquire_rustbgpd_build_lock() {
+    local build_lock="${RUSTBGPD_BUILD_LOCK:-${CARGO_TARGET_DIR:-target}/build.lock}"
+    mkdir -p "$(dirname "$build_lock")"
+    # shellcheck disable=SC1083  # bash {fd} redirection is intentional
+    exec {RUSTBGPD_BUILD_LOCK_FD}>"$build_lock"
+    if ! flock -n "$RUSTBGPD_BUILD_LOCK_FD"; then
+        echo "waiting for ${build_lock}: another gate, commit, or push is building" >&2
+        flock "$RUSTBGPD_BUILD_LOCK_FD"
+    fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    set -euo pipefail
+    if [ "$#" -eq 0 ]; then
+        echo "usage: bash scripts/build-lock.sh <command> [args...]" >&2
+        exit 2
+    fi
+    acquire_rustbgpd_build_lock
+    exec "$@"
+fi

--- a/scripts/build-lock.sh
+++ b/scripts/build-lock.sh
@@ -18,13 +18,12 @@
 #     runs, where a concurrent workload corrupts the reading and failing fast
 #     is correct. Here the second caller wants its checks to run, so the wait
 #     is unbounded and announced once on stderr.
-#   - A crashed holder cannot wedge the repository. `flock` is a property of
-#     the open file description, so the kernel drops it when the holder exits
-#     for any reason. There is no stale lock file to clean up, and the file
-#     itself is disposable.
-#   - The fd is allocated to the caller's shell (`exec {fd}>...`), so the lock
-#     lives for the rest of the caller's process and is released on exit. The
-#     caller does not unlock explicitly.
+#   - The kernel releases the lock when the last inherited descriptor closes,
+#     including descriptors held by child builds after the parent exits. No
+#     stale lock needs reaping. Never unlink the file while builds are active:
+#     a new file would create a separate lock and defeat serialization.
+#   - The fd is allocated to the caller's shell (`exec {fd}>...`), so sourced
+#     callers hold it for their lifetime without an explicit unlock.
 #
 # Source it to hold the lock across several commands:
 #

--- a/scripts/test_build_lock.py
+++ b/scripts/test_build_lock.py
@@ -1,0 +1,45 @@
+"""Exercise the build mutex with real processes and an isolated lock file."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+class BuildLockTest(unittest.TestCase):
+    def test_serialization_release_and_command_status(self):
+        script = str(Path(__file__).with_name("build-lock.sh").resolve())
+        with tempfile.TemporaryDirectory() as directory:
+            env = {**os.environ, "RUSTBGPD_BUILD_LOCK": f"{directory}/build.lock"}
+            holder = subprocess.Popen(
+                ["bash", script, "bash", "-c", "echo ready; read -r release"],
+                env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True,
+            )
+            self.addCleanup(holder.stdout.close)
+            self.addCleanup(holder.stdin.close)
+            waiter = None
+            try:
+                self.assertEqual(holder.stdout.readline(), "ready\n")
+                waiter = subprocess.Popen(["bash", script, "true"], env=env)
+                with self.assertRaises(subprocess.TimeoutExpired):
+                    waiter.wait(timeout=0.2)
+                # Separate artifact directories must not block each other.
+                separate = {**env, "RUSTBGPD_BUILD_LOCK": f"{directory}/other.lock"}
+                subprocess.run(["bash", script, "true"], env=separate, check=True, timeout=5)
+                holder.kill()
+                holder.wait(timeout=5)
+                self.assertEqual(waiter.wait(timeout=5), 0)
+                result = subprocess.run(
+                    ["bash", script, "bash", "-c", "exit 23"], env=env, timeout=5,
+                )
+                self.assertEqual(result.returncode, 23)
+            finally:
+                for process in (holder, waiter):
+                    if process is not None and process.poll() is None:
+                        process.kill()
+                        process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Serialize `just gate` and compiling Git hooks with a lock beside their Cargo artifacts, preventing duplicate builds against a shared target directory. Separate target directories remain independent; the kernel releases the lock when the last inherited descriptor closes.

Add `just hooks` to install prek with `--overwrite`, removing superseded legacy hooks that otherwise duplicate fmt and Clippy. Document how to preserve intentional custom hooks before installation.

Add `just fuzz-list` and `just fuzz <crate> <target>` using the existing target inventory and reviewed toolchain pin. Update the fuzzing guide with root-level recipes and pinned replay commands.

Validation: the broad local gate passed before review fixes. Follow-up checks passed for lock serialization, killed-holder release, independent locks and command exit status; the toolchain checker and its five tests; offline links; and recipe directory, pin, argument forwarding and invalid-target behavior. A real `just fuzz wire decode_update -- -runs=1` smoke run passed.

Retain the existing rustdoc checks: measurement found a warm no-op around 0.27 seconds, while a broken intra-doc link passed `cargo check` and failed `cargo doc`. Removing rustdoc would lose validation coverage.
