### PR TITLE
docs(operations): explain srv6 route ineligibility

### DIFF
--- a/docs/how-to/explain.md
+++ b/docs/how-to/explain.md
@@ -39,6 +39,17 @@ For operators coming from FRR/BIRD, the
 [familiar command map](../../crates/cli/README.md#familiar-command-map)
 translates the usual show-commands into these.
 
+## SRv6 service candidates excluded from selection
+
+A route with a semantically unusable applicable SRv6 Service TLV remains in
+Adj-RIB-In but is excluded from selection and export. For unicast, run
+`rbgp rib --prefix <cidr> --explain`; for EVPN, use an exact selector such as
+`rbgp evpn explain ip-prefix --rd <rd> --prefix <cidr>`. Both report
+`srv6_sid_invalid`; this is not an import-policy rejection. VPN has no
+received-route query. See [the operator troubleshooting entry](../reference/operations.md#srv6-service-route-is-visible-but-cannot-be-selected)
+for the distinction from malformed Prefix-SID handling and the
+[canonical SRv6 contract](../reference/path-attribute-registry.md#srv6-service-eligibility).
+
 <a id="best-path-explain--decisive-comparison-attribution"></a>
 ## Best-path explain
 

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -66,6 +66,8 @@ and [eligibility](path-attribute-registry.md#srv6-service-eligibility) checks,
 with unchanged-next-hop reflection of eligible raw attributes. SRv6 PE import,
 service origination, SID reconstruction, next-hop rewriting, and forwarding
 remain unimplemented.
+See [SRv6 route troubleshooting](operations.md#srv6-service-route-is-visible-but-cannot-be-selected)
+for the retained-but-ineligible route case.
 
 Shipped and interop-tested:
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -999,6 +999,22 @@ capacity families are
 removed when the session goes down and republished from fresh actor state on
 reconnect; GR-retained RIB rows therefore never appear as live session usage.
 
+### SRv6 service route is visible but cannot be selected
+
+An accepted route with a semantically unusable applicable SRv6 Service TLV
+remains in Adj-RIB-In, but is excluded from best-path selection and export.
+For unicast, `rbgp rib --prefix <cidr> --explain` reports
+`srv6_sid_invalid`; an exact EVPN selector uses
+`rbgp evpn explain ip-prefix --rd <rd> --prefix <cidr>`. This is distinct from
+an import-policy rejection. VPN has no received-route query.
+
+This is not malformed-attribute handling. A malformed recognized Service TLV
+is treated as withdrawn; a malformed generic Prefix-SID attribute is discarded
+while the route remains. See [SRv6 Service framing](path-attribute-registry.md#srv6-service-framing-within-prefix-sid)
+and [service eligibility](path-attribute-registry.md#srv6-service-eligibility)
+for the canonical rules. These reflection checks do not add SRv6 PE import,
+service origination, SID reconstruction, next-hop rewriting, or forwarding.
+
 ---
 
 ## Key metrics to watch


### PR DESCRIPTION
Documents how a semantically unusable SRv6 Service TLV remains visible in Adj-RIB-In but is excluded from selection and export.

Links the unicast and exact EVPN explain paths to the canonical SRv6 framing and eligibility contract, including the distinct malformed-attribute dispositions and current reflection-only boundary.

Validation:
- `just links`
- `python3 scripts/check_public_tracker_ids.py`
- `git diff --check`
- parsed `rbgp evpn explain ip-prefix --rd 65000:100 --prefix 2001:db8:100::/64` (local daemon socket unavailable)