### PR TITLE
fix(rib): reevaluate grouped exports after dataset refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--ignore-attribute unknown` for the OTC attribute a route server attaches
   on the wire.
 
+- Dataset content refreshes now recompute shared export-policy results before
+  refreshing advertisements. Grouped peers previously replayed cached results,
+  leaving newly denied routes advertised and newly permitted routes absent.
+  Each affected group is recomputed once, including per-client-best groups;
+  unrelated groups and installed policy counters are preserved.
+
 ## [0.69.0] — 2026-09-07
 
 ### Added

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -1157,7 +1157,7 @@ pub enum PeerManagerCommand {
     /// LAN-305: one or more external dataset snapshots swapped content
     /// during a reload. Refresh exactly the peers whose chains
     /// reference a swapped dataset — Route Refresh inbound for import
-    /// chains, forced outbound re-emission for export chains — and
+    /// chains, batched export-policy re-evaluation for export chains — and
     /// count failed refreshes (prior snapshot retained) in metrics.
     /// Chains themselves are untouched: they share the swapped
     /// handles and pin the new generation at their next walk.

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1823,6 +1823,7 @@ impl RibManager {
             | RibUpdate::ReplacePeerExportPoliciesAuthoritatively { .. }
             | RibUpdate::RestorePeerExportPoliciesAuthoritatively { .. }
             | RibUpdate::ApplyOutboundPrefixLimits { .. }
+            | RibUpdate::ReevaluatePeerExportPolicies { .. }
             | RibUpdate::RefreshPeerOutbound { .. } => self.advance_advertised_pages(),
             RibUpdate::PeerUp { .. }
             | RibUpdate::PeerDeleted { .. }
@@ -2688,6 +2689,9 @@ impl RibManager {
             }
             RibUpdate::RefreshPeerOutbound { peer, reply } => {
                 self.handle_refresh_peer_outbound(peer, reply);
+            }
+            RibUpdate::ReevaluatePeerExportPolicies { peers, reply } => {
+                self.handle_reevaluate_peer_export_policies(&peers, reply);
             }
             RibUpdate::EndOfRib {
                 peer,

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -1008,6 +1008,235 @@ const D: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 4);
 const E: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 5);
 const F: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 6);
 
+fn dataset_prefix_data(prefix: Prefix, permit: bool) -> rustbgpd_policy::datasets::DatasetData {
+    use rustbgpd_policy::datasets::DatasetData;
+    use rustbgpd_policy::sets::{PrefixSet, PrefixSetEntry};
+    DatasetData::Prefix(PrefixSet::new(permit.then_some(PrefixSetEntry {
+        prefix,
+        ge: None,
+        le: None,
+    })))
+}
+
+fn dataset_prefix_policy(
+    prefix: Prefix,
+    permit: bool,
+) -> (Arc<rustbgpd_policy::datasets::DatasetHandle>, PolicyChain) {
+    use rustbgpd_policy::datasets::{DatasetBindings, DatasetHandle, DatasetKind};
+    use rustbgpd_policy::rpol::RpolFile;
+    use rustbgpd_policy::sets::SetStore;
+    let handle = Arc::new(DatasetHandle::new(
+        "allowed",
+        DatasetKind::Prefix,
+        dataset_prefix_data(prefix, permit),
+    ));
+    let mut bindings = DatasetBindings::new();
+    bindings.insert(Arc::clone(&handle));
+    let compiled = RpolFile::parse(
+        "dataset prefix-set allowed\npolicy p { term t { if route.prefix in allowed { accept } reject } }",
+    )
+    .expect("dataset policy parses")
+    .compile_policy_bound("p", &[], &mut SetStore::new(), &bindings)
+    .expect("policy compiles")
+    .expect("dataset binding is complete");
+    let chain = PolicyChain::from_named(vec![rustbgpd_policy::NamedPolicy::from_rpol(
+        "p".to_string(),
+        Arc::new(compiled),
+    )]);
+    (handle, chain)
+}
+
+async fn check_dataset_export_refresh(per_client_best: bool) {
+    let prefix = Prefix::V4(pfx(1, 0));
+    for force_ungrouped in [true, false] {
+        for initially_permitted in [true, false] {
+            let (handle, chain) = dataset_prefix_policy(prefix, initially_permitted);
+            let mut oracle = Oracle::spawn(force_ungrouped, None);
+            oracle.peer_up(A, true, false, None, 64).await;
+            for peer in [B, C] {
+                oracle
+                    .peer_up_families_generation_with_features(
+                        peer,
+                        SESSION,
+                        true,
+                        false,
+                        Some(chain.clone()),
+                        64,
+                        ipv4_sendable(),
+                        OraclePeerFeatures {
+                            per_client_best,
+                            ..OraclePeerFeatures::default()
+                        },
+                    )
+                    .await;
+            }
+            oracle
+                .peer_up(
+                    D,
+                    true,
+                    false,
+                    Some(permit_all_with(RouteModifications::default())),
+                    64,
+                )
+                .await;
+            let group = oracle.group_label(B).await;
+            assert_eq!(group.starts_with("group:"), !force_ungrouped);
+            assert_eq!(group, oracle.group_label(C).await);
+            oracle
+                .routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+                .await;
+            if per_client_best {
+                // B must receive A's runner-up while C receives B's best.
+                oracle
+                    .routes(B, vec![ibgp_route(pfx(1, 0), B, 200, vec![])], vec![])
+                    .await;
+            }
+            oracle.drain_available();
+            let initial = fold(&oracle.collected);
+            for peer in [B, C] {
+                assert_eq!(
+                    initial[&IpAddr::V4(peer)].contains_key(&(prefix, 0)),
+                    initially_permitted
+                );
+            }
+            let bystander = oracle.collected[&IpAddr::V4(D)].clone();
+            let bystander_evals = oracle.export_policy_evals_for(D).await;
+            let prior_evals = oracle.export_policy_evals_for(B).await;
+
+            assert_eq!(
+                handle.refresh(dataset_prefix_data(prefix, !initially_permitted)),
+                Some(2)
+            );
+            let (reply, result) = oneshot::channel();
+            oracle
+                .tx
+                .send(RibUpdate::ReevaluatePeerExportPolicies {
+                    peers: vec![IpAddr::V4(B), IpAddr::V4(C)],
+                    reply,
+                })
+                .await
+                .unwrap();
+            result.await.unwrap().unwrap();
+            let next_evals = oracle.export_policy_evals_for(B).await;
+            assert!(
+                next_evals > prior_evals,
+                "installed counter instance must keep advancing"
+            );
+            if !force_ungrouped {
+                assert_eq!(
+                    next_evals - prior_evals,
+                    if per_client_best { 2 } else { 1 },
+                    "shared group must be evaluated once, not once per member"
+                );
+            }
+            assert_eq!(oracle.export_policy_evals_for(D).await, bystander_evals);
+            let streams = oracle.finish().await;
+            assert_eq!(
+                streams[&IpAddr::V4(D)],
+                bystander,
+                "unrelated group was re-emitted"
+            );
+            let final_state = fold(&streams);
+            for peer in [B, C] {
+                let advertised = final_state[&IpAddr::V4(peer)].contains_key(&(prefix, 0));
+                assert_eq!(
+                    advertised, !initially_permitted,
+                    "stale dataset verdict: ungrouped={force_ungrouped} pcb={per_client_best} initial={initially_permitted} peer={peer}"
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn dataset_content_refresh_rechecks_grouped_export_verdicts() {
+    check_dataset_export_refresh(false).await;
+}
+
+#[tokio::test]
+async fn dataset_content_refresh_rechecks_per_client_best_export_verdicts() {
+    check_dataset_export_refresh(true).await;
+}
+
+#[tokio::test]
+async fn dataset_content_refresh_missing_target_has_no_effects() {
+    let prefix = Prefix::V4(pfx(1, 0));
+    let (handle, chain) = dataset_prefix_policy(prefix, true);
+    let mut oracle = Oracle::spawn(false, None);
+    oracle.peer_up(A, true, false, None, 64).await;
+    oracle.peer_up(B, true, false, Some(chain), 64).await;
+    oracle
+        .routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+        .await;
+    oracle.drain_available();
+    let before = oracle.collected[&IpAddr::V4(B)].clone();
+    let evals = oracle.export_policy_evals_for(B).await;
+    handle.refresh(dataset_prefix_data(prefix, false)).unwrap();
+    let (reply, result) = oneshot::channel();
+    oracle
+        .tx
+        .send(RibUpdate::ReevaluatePeerExportPolicies {
+            peers: vec![IpAddr::V4(B), IpAddr::V4(F)],
+            reply,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        result.await.unwrap(),
+        Err(crate::update::RibCommandError::NotFound(_))
+    ));
+    assert_eq!(oracle.export_policy_evals_for(B).await, evals);
+    let streams = oracle.finish().await;
+    assert_eq!(streams[&IpAddr::V4(B)], before);
+}
+
+#[tokio::test]
+async fn dataset_content_refresh_rechecks_grouped_vpn_export_verdicts() {
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 210, 1, 0), 24));
+    for initially_permitted in [true, false] {
+        let (handle, chain) = dataset_prefix_policy(prefix, initially_permitted);
+        let mut oracle = Oracle::spawn(false, Some(Ipv4Addr::new(192, 0, 2, 1)));
+        oracle
+            .peer_up_families(A, false, true, None, 64, vpn_sendable())
+            .await;
+        for peer in [B, C] {
+            oracle
+                .peer_up_families(peer, false, true, Some(chain.clone()), 64, vpn_sendable())
+                .await;
+        }
+        assert!(oracle.group_label(B).await.starts_with("group:"));
+        assert_eq!(oracle.group_label(B).await, oracle.group_label(C).await);
+        oracle
+            .vpn_routes(A, vec![vpn_route(vpn_nlri(1, 100), A, 100, vec![])], vec![])
+            .await;
+        oracle.drain_available();
+        let initial = fold_vpn(&oracle.collected);
+        for peer in [B, C] {
+            assert_eq!(!initial[&IpAddr::V4(peer)].is_empty(), initially_permitted);
+        }
+        handle
+            .refresh(dataset_prefix_data(prefix, !initially_permitted))
+            .unwrap();
+        let (reply, result) = oneshot::channel();
+        oracle
+            .tx
+            .send(RibUpdate::ReevaluatePeerExportPolicies {
+                peers: vec![IpAddr::V4(B), IpAddr::V4(C)],
+                reply,
+            })
+            .await
+            .unwrap();
+        result.await.unwrap().unwrap();
+        let final_state = fold_vpn(&oracle.finish().await);
+        for peer in [B, C] {
+            assert_eq!(
+                final_state[&IpAddr::V4(peer)].is_empty(),
+                initially_permitted
+            );
+        }
+    }
+}
+
 async fn run_grouped_and_ungrouped<S>(
     cluster_id: Option<Ipv4Addr>,
     scenario: S,

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -29,8 +29,8 @@
 //! `PolicyChain` `PartialEq`), never `Arc` identity — a SIGHUP / rpol
 //! overlay / ADR-0076 txn that reinstalls a content-identical chain
 //! keeps the key stable, does not count as a regroup, and (new in this
-//! slice) skips the resync entirely: the staged output is a pure
-//! function of the key.
+//! slice) skips the resync entirely. Mutable dataset contents are not part
+//! of that key; dataset swaps explicitly re-evaluate affected staged output.
 
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -64,15 +64,15 @@ pub(in crate::manager) use payload::{
 };
 use payload::{BatchedTransitionCounters, VpnDenialRecord, bump_counter_row};
 
-use super::helpers::{LOCAL_PEER, routes_equal, vpn_routes_equal};
+use super::helpers::{LOCAL_PEER, prefix_family, routes_equal, vpn_routes_equal};
 use super::{PolicyFilteredRouteKey, RibManager, RtcMembership};
 use crate::adj_rib_out::AdjRibOut;
 use crate::route::{Route, VpnRibRoute, VpnRibRouteKey};
 use crate::update::{
-    ExactExportKey, RouteQueryKey, UpdateGroupClassification, UpdateGroupClassifierInput,
-    UpdateGroupComparisonDifference, UpdateGroupComparisonMembership, UpdateGroupComparisonVerdict,
-    UpdateGroupPeerComparison, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group,
-    route_query_key,
+    ExactExportKey, RibCommandError, RouteQueryKey, UpdateGroupClassification,
+    UpdateGroupClassifierInput, UpdateGroupComparisonDifference, UpdateGroupComparisonMembership,
+    UpdateGroupComparisonVerdict, UpdateGroupPeerComparison, UpdateGroupPeerSnapshot,
+    UpdateGroupSnapshot, classify_update_group, route_query_key,
 };
 
 fn send_update_group_snapshot(
@@ -1393,6 +1393,71 @@ impl RibManager {
         {
             group.dirty_members.remove(&peer);
         }
+    }
+
+    /// Dataset updates preserve policy identity, so refresh the shared staged
+    /// verdicts explicitly. Mark members dirty before staging: the existing
+    /// tombstone and source-flip residue then preserves every owed withdrawal.
+    pub(in crate::manager) fn handle_reevaluate_peer_export_policies(
+        &mut self,
+        peers: &[IpAddr],
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
+    ) {
+        if let Some(peer) = peers
+            .iter()
+            .find(|peer| !self.outbound_peers.contains_key(peer))
+        {
+            let _ = reply.send(Err(RibCommandError::not_found(format!(
+                "peer {peer} not registered for outbound updates"
+            ))));
+            return;
+        }
+        let groups: HashSet<usize> = peers
+            .iter()
+            .filter_map(|peer| self.grouped_member_of(*peer))
+            .collect();
+        let mut targets: HashSet<IpAddr> = peers.iter().copied().collect();
+        for gid in &groups {
+            if let Some(group) = self.group_ribs.get(gid) {
+                targets.extend(group.members.iter().copied());
+            }
+        }
+        for peer in targets {
+            self.mark_outbound_dirty(peer);
+        }
+        if !groups.is_empty() {
+            let mut prefixes: HashSet<Prefix> =
+                self.unicast_prefix_peers.prefixes.keys().copied().collect();
+            prefixes.extend(self.loc_rib.iter().map(|route| route.prefix));
+            let mut vpn_keys: HashSet<_> = self.loc_rib.iter_vpn().map(VpnRibRoute::key).collect();
+            for gid in &groups {
+                if let Some(group) = self.group_ribs.get(gid) {
+                    prefixes.extend(group.table.iter().map(|route| route.prefix));
+                    vpn_keys.extend(group.table.iter_vpn().map(VpnRibRoute::key));
+                }
+            }
+            self.record_deferred_unicast(&prefixes);
+            prefixes.retain(|prefix| !self.selection_deferred(prefix_family(prefix)));
+            self.record_deferred_vpn(&vpn_keys);
+            vpn_keys.retain(|key| !self.selection_deferred(key.afi_safi()));
+            let vpn_keys: HashSet<_> = vpn_keys.into_iter().map(|key| key.nlri_key).collect();
+            let mut memo = super::distribution::ExportMemo::default();
+            // Staging commits the tables and retains withdrawal residue for
+            // dirty members; their resync below consumes that committed state.
+            for gid in groups {
+                let _ = self.stage_group_prefixes(gid, &prefixes, &mut memo);
+                if self
+                    .group_ribs
+                    .get(&gid)
+                    .is_some_and(GroupRibOut::stages_vpn)
+                {
+                    let _ = self.stage_group_vpn_keys(gid, &vpn_keys);
+                }
+            }
+            self.refresh_lane_gauge();
+        }
+        self.distribute_changes(&HashSet::new(), &HashSet::new());
+        let _ = reply.send(Ok(()));
     }
 
     /// Mark a peer's outbound channel dirty for the resync timer, and —

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2531,6 +2531,17 @@ pub enum RibUpdate {
         /// The destination export chain passed to the matching prepare.
         export_policy: Option<PolicyChain>,
     },
+    /// Re-evaluate installed export policies after their shared dataset
+    /// contents change. Each affected group is staged once, then its members
+    /// receive the resulting view; ungrouped peers re-evaluate individually.
+    /// Chain instances and their counters are preserved. The reply acknowledges
+    /// recomputation and distribution responsibility, not remote receipt.
+    ReevaluatePeerExportPolicies {
+        /// Established peers whose export chains reference a changed dataset.
+        peers: Vec<IpAddr>,
+        /// Response channel for success/failure.
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
+    },
     /// Force re-emission of all currently-advertised routes to a peer
     /// without changing policy. Used when an outbound *attribute*
     /// surface changes (e.g. RFC 8326 `GRACEFUL_SHUTDOWN` community

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2788,7 +2788,11 @@ path = "/var/lib/rustbgpd/datasets/customers.list"
   Enhanced Route Refresh can bracket the replay with BoRR/EoRR but does
   not delta-reduce it; recovery of previously rejected routes depends
   on negotiated Route Refresh and the peer's replay. Export-chain
-  references instead force outbound re-emission. A file that fails to
+  references instead re-evaluate export policy and refresh the resulting
+  advertisements. Shared update groups recompute once per affected group,
+  including per-client-best selection; changed verdicts withdraw denied
+  routes and announce newly permitted routes without reinstalling chains
+  or resetting their counters. A file that fails to
   load or parse **keeps the
   prior snapshot** with a WARN, a
   `bgp_policy_dataset_refresh_errors_total{dataset}` counter

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -2584,7 +2584,7 @@ impl PeerManager {
     /// structurally reference a swapped dataset are touched — Route
     /// Refresh inbound where the *import* chain references one (the
     /// peer re-sends, routes re-evaluate against the new generation),
-    /// forced outbound re-emission (`RibUpdate::RefreshPeerOutbound`)
+    /// batched export re-evaluation (`RibUpdate::ReevaluatePeerExportPolicies`)
     /// where the *export* chain does. Chains are never replaced:
     /// they share the swapped handles, so counters, generations, and
     /// unrelated peers are untouched. `failed` datasets (prior
@@ -2632,6 +2632,7 @@ impl PeerManager {
             .collect();
 
         let mut failures = Vec::new();
+        let mut export_peers = Vec::new();
         let mut refreshed = 0usize;
         let mut skipped_not_established = 0usize;
         let mut skipped_state_unknown = 0usize;
@@ -2690,32 +2691,39 @@ impl PeerManager {
                 }
             }
             if *export {
-                let (reply_tx, reply_rx) = oneshot::channel();
-                let outcome = if self
-                    .rib_tx
-                    .send(RibUpdate::RefreshPeerOutbound {
-                        peer: peer_key.address,
-                        reply: reply_tx,
-                    })
-                    .await
-                    .is_err()
-                {
-                    Err("RIB manager unavailable".to_string())
-                } else {
-                    match tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx).await {
-                        Ok(Ok(result)) => result.map_err(|error| error.to_string()),
-                        Ok(Err(_)) => Err("RIB manager dropped reply".to_string()),
-                        Err(_) => Err(format!(
-                            "RIB manager did not reply within {:?}",
-                            super::RIB_REPLY_TIMEOUT
-                        )),
-                    }
-                };
-                if let Err(error) = outcome {
-                    failures.push(format!("{peer_key} (export): {error}"));
-                }
+                export_peers.push(peer_key.address);
             }
             refreshed += 1;
+        }
+        if !export_peers.is_empty() {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let outcome = if self
+                .rib_tx
+                .send(RibUpdate::ReevaluatePeerExportPolicies {
+                    peers: export_peers.clone(),
+                    reply: reply_tx,
+                })
+                .await
+                .is_err()
+            {
+                Err("RIB manager unavailable".to_string())
+            } else {
+                match tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx).await {
+                    Ok(Ok(result)) => result.map_err(|error| error.to_string()),
+                    Ok(Err(_)) => Err("RIB manager dropped reply".to_string()),
+                    Err(_) => Err(format!(
+                        "RIB manager did not reply within {:?}",
+                        super::RIB_REPLY_TIMEOUT
+                    )),
+                }
+            };
+            if let Err(error) = outcome {
+                failures.extend(
+                    export_peers
+                        .iter()
+                        .map(|peer| format!("{peer} (export): {error}")),
+                );
+            }
         }
         info!(
             swapped = ?swapped,

--- a/src/peer_manager/tests/policy.rs
+++ b/src/peer_manager/tests/policy.rs
@@ -698,6 +698,67 @@ async fn dataset_state_timeout_arms_import_and_export_replay() {
     assert!(managed.pending_export_apply);
 }
 
+#[tokio::test]
+async fn dataset_export_refresh_batches_only_dependent_peers_for_reevaluation() {
+    use rustbgpd_policy::datasets::{DatasetBindings, DatasetData, DatasetHandle, DatasetKind};
+    use rustbgpd_policy::rpol::RpolFile;
+    use rustbgpd_policy::sets::{AsnSet, SetStore};
+
+    let dataset = Arc::new(DatasetHandle::new(
+        "customers",
+        DatasetKind::Asn,
+        DatasetData::Asn(AsnSet::new([64500])),
+    ));
+    let mut bindings = DatasetBindings::new();
+    bindings.insert(Arc::clone(&dataset));
+    let compiled = RpolFile::parse(
+        "dataset asn-set customers\npolicy p { term t { if route.origin-as in customers { accept } reject } }",
+    ).unwrap().compile_policy_bound("p", &[], &mut SetStore::new(), &bindings).unwrap().unwrap();
+    let chain = PolicyChain::from_named(vec![rustbgpd_policy::NamedPolicy::from_rpol(
+        "p".to_string(),
+        Arc::new(compiled),
+    )]);
+    let mut mgr = test_peer_manager();
+    let (rib_tx, mut rib_rx) = mpsc::channel(8);
+    mgr.rib_tx = rib_tx;
+    let rib = tokio::spawn(async move {
+        let mut batches = Vec::new();
+        while let Some(command) = rib_rx.recv().await {
+            let RibUpdate::ReevaluatePeerExportPolicies { mut peers, reply } = command else {
+                panic!(
+                    "dataset refresh must recompute export policy, not replay its cached output"
+                );
+            };
+            peers.sort();
+            batches.push(peers);
+            reply.send(Ok(())).unwrap();
+        }
+        batches
+    });
+    let peers: Vec<IpAddr> = (1..=3)
+        .map(|last| Ipv4Addr::new(10, 0, 0, last).into())
+        .collect();
+    for (index, peer) in peers.iter().enumerate() {
+        insert_test_managed_peer(
+            &mut mgr,
+            *peer,
+            acking_policy_handle(*peer, SessionState::Established),
+            false,
+        );
+        if index < 2 {
+            mgr.peers.get_mut(&key(*peer)).unwrap().export_policy = Some(chain.clone());
+        }
+    }
+    dataset
+        .refresh(DatasetData::Asn(AsnSet::new([64501])))
+        .unwrap();
+    mgr.refresh_dataset_dependents(&["customers".to_string()], &[])
+        .await
+        .unwrap();
+    drop(mgr);
+    assert_eq!(rib.await.unwrap(), vec![peers[..2].to_vec()]);
+}
+
 /// ADR-0110 reap discipline: a dataset removed from config on a
 /// successful rpol sync drops BOTH its per-dataset series (loaded
 /// timestamp and failure counter); a dataset introduced by the sync


### PR DESCRIPTION
Dataset-only reloads preserve policy-chain identity, so grouped peers previously replayed cached export results: newly denied routes stayed advertised and newly permitted routes stayed absent. Refresh dependent peers through an explicit export reevaluation batch, staging each affected group once while preserving installed counters and owed withdrawals. Ordinary groups, per-client-best selection, VPN export, and the existing ungrouped resync path are covered.

Validation:
- Four dataset RIB regressions and all 34 update-group oracle tests pass.
- The production caller regression passes, fails when its old method is restored, and passes again with the fix.
- A local daemon with four BGP peers passed dataset-only SIGHUP permit → deny → permit: both peers in one stable shared group received the expected withdrawal and announcement, with no reconnect or additional bystander UPDATE.
- The full local gate baseline passes: links and contracts, strict workspace Clippy, workspace tests, and rustdoc. Doctor integration runs use a soft file-descriptor limit of 65536.
- `just gate-rib` passes all feature-gated bench checks.
- After integrating current main, the production caller test and all four dataset regressions pass again; normal commit and push hooks validate the integrated head.
