### PR TITLE
fix(soak): fail flagship verdicts on daemon errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The route-server and route-reflector flagship soak analyzers now require
+  valid daemon-log evidence and fail on every daemon `ERROR`, including
+  metrics listener failures that successful client probes can miss. Verdicts
+  also report `WARN` counts by message.
+
 - `rbgp policy stats` now allows backend waits up to one shared 2-second
   deadline, increased from 500 ms. This lets reads wait through longer
   `.rpol` reload transitions that temporarily queue RIB queries. Reloads or

--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -234,6 +234,17 @@ and `/readyz` stays green — a crippled daemon behind an entirely green
 client-side gate battery. The achieved limit is recorded as `nofile_soft` in
 `run.json`, so each receipt states the configuration it measured.
 
+Both flagship analyzers (scenarios 10 and 11) also require `rustbgpd.log`.
+The `daemon_log` gate streams the complete captured log and rejects missing,
+empty, malformed, or unterminated evidence and unexpected non-JSON output.
+Only blank lines and one complete startup banner matching the flagship
+configuration shape are accepted outside JSON. Every `ERROR` fails, including
+EMFILE, decoder failures, and errors during deliberate trips or terminal
+teardown: no scenario-justified ERROR exceptions are currently established.
+The verdict reports `WARN` counts by message without failing on warnings.
+All existing client-side gates still apply. These added requirements apply to
+new receipts; historical receipts retain their original acceptance contract.
+
 The measured window also carries mandatory management-plane load, started
 after convergence and before sampling. Five independent monotonic schedules
 exercise the shipped surfaces until the engine exits: HTTP `/metrics` every

--- a/tests/soak/analyze-soak-rr-flagship.py
+++ b/tests/soak/analyze-soak-rr-flagship.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Post-hoc analyzer for the route-reflector flagship soak.
 
-Reads samples.csv + cycles.log + run.json emitted by
+Reads samples.csv + cycles.log + run.json + rustbgpd.log emitted by
 run-soak-rr-flagship.sh and emits a JSON verdict against the
 precommitted gates in docs/soaks/soak-acceptance-gates.md (scenario 11):
 
@@ -29,6 +29,7 @@ precommitted gates in docs/soaks/soak-acceptance-gates.md (scenario 11):
   - RSS peak ceiling; late-window RSS/intern slope (evaluated only when
     the late window spans >= --min-slope-seconds)
   - no ABORT record in cycles.log
+  - complete daemon JSON log, no ERROR records; WARN counts reported
 
 Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
 harness/input error.
@@ -44,6 +45,8 @@ import re
 import sys
 from datetime import datetime, timezone
 from typing import Optional
+
+from flagship_daemon_log import analyze_daemon_log
 
 REQUIRED = {
     "timestamp", "elapsed_sec", "rss_mb", "intern_size", "established",
@@ -369,7 +372,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Analyze the route-reflector flagship soak")
     parser.add_argument("run_dir",
-                        help="Run directory (samples.csv, cycles.log, run.json)")
+                        help="Run directory (samples.csv, cycles.log, run.json, rustbgpd.log)")
     parser.add_argument("--output", help="Write verdict JSON to this path")
     parser.add_argument("--min-slope-seconds", type=float, default=3600.0,
                         help="Minimum late-window span before the slope gates "
@@ -422,6 +425,11 @@ def main() -> int:
 
     cycles = parse_cycles(cycle_lines)
     result = analyze(rows, cycles, meta, args.min_slope_seconds)
+    result["gates"]["daemon_log"] = analyze_daemon_log(args.run_dir)
+    result["verdict"] = (
+        "pass" if all(gate["pass"] for gate in result["gates"].values())
+        else "fail"
+    )
     out = json.dumps(result, indent=2)
     print(out)
     if args.output:

--- a/tests/soak/analyze-soak-rs-flagship.py
+++ b/tests/soak/analyze-soak-rs-flagship.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Post-hoc analyzer for the route-server flagship soak.
 
-Reads samples.csv + cycles.log + run.json + management-plane-load.jsonl emitted by
+Reads samples.csv + cycles.log + run.json + rustbgpd.log and
+management-plane-load.jsonl emitted by
 run-soak-rs-flagship.sh and emits a JSON verdict against the
 precommitted gates in docs/soaks/soak-acceptance-gates.md (scenario 10):
 
@@ -23,6 +24,7 @@ precommitted gates in docs/soaks/soak-acceptance-gates.md (scenario 10):
   - RSS peak ceiling; late-window RSS/intern slope (evaluated only when
     the late window spans >= --min-slope-seconds)
   - no ABORT record in cycles.log
+  - complete daemon JSON log, no ERROR records; WARN counts reported
 
 Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
 harness/input error.
@@ -38,6 +40,8 @@ import re
 import sys
 from datetime import datetime, timezone
 from typing import Optional
+
+from flagship_daemon_log import analyze_daemon_log
 
 REQUIRED = {
     "timestamp", "elapsed_sec", "rss_mb", "intern_size", "established",
@@ -707,7 +711,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Analyze the route-server flagship soak")
     parser.add_argument("run_dir",
-                        help="Run directory (samples.csv, cycles.log, run.json)")
+                        help="Run directory (samples.csv, cycles.log, run.json, rustbgpd.log)")
     parser.add_argument("--output", help="Write verdict JSON to this path")
     parser.add_argument("--min-slope-seconds", type=float, default=3600.0,
                         help="Minimum late-window span before the slope gates "
@@ -772,6 +776,7 @@ def main() -> int:
     cycles = parse_cycles(cycle_lines)
     result = analyze(rows, cycles, meta, args.min_slope_seconds)
     result["gates"].update(analyze_management_load(management_raw, meta))
+    result["gates"]["daemon_log"] = analyze_daemon_log(args.run_dir)
     result["verdict"] = (
         "pass" if all(gate["pass"] for gate in result["gates"].values())
         else "fail"

--- a/tests/soak/flagship_daemon_log.py
+++ b/tests/soak/flagship_daemon_log.py
@@ -1,0 +1,110 @@
+"""Daemon evidence shared by the two flagship soak analyzers (stdlib only)."""
+
+import json
+import re
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+# print_startup_banner emits these lines to stderr even with JSON logging.
+# Only the flagship shapes are accepted, once, as a complete contiguous block.
+BANNER = re.compile(
+    r"  rustbgpd \d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)? \| AS \d+ \| router-id [0-9.]+\n"
+    r"  \|- \d+ peers \(\d+ [ei]BGP(?:, \d+ [ei]BGP)?\)"
+    r"(?: in \d+ peer groups?)?\n"
+    r"(?:  \|- \d+ named polic(?:y|ies)(?:, \d+ neighbor sets?)?\n)?"
+    r"  \|- grpc: (?:unix:///[^\s]+|tcp://[^\s]+)"
+    r"(?: \(read-only\))?(?: \(token auth\))?\n"
+    r"  \|- metrics: http://[^\s]+/metrics\n"
+)
+
+
+def unique_members(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON member {key}")
+        result[key] = value
+    return result
+
+
+def reject_constant(value):
+    raise ValueError(f"invalid JSON constant {value}")
+
+
+def analyze_daemon_log(run_dir):
+    """Fail closed; retain counts and bounded diagnostics, not multi-GB logs."""
+    warnings = Counter()
+    records = errors = defects = 0
+    examples = []
+    banner = []
+    banner_seen = False
+
+    def defect(message):
+        nonlocal defects
+        defects += 1
+        if len(examples) < 20:
+            examples.append(message)
+
+    try:
+        with (Path(run_dir) / "rustbgpd.log").open(encoding="utf-8") as stream:
+            for number, line in enumerate(stream, 1):
+                if not line.endswith("\n"):
+                    defect(f"line {number}: unterminated record")
+                if banner:
+                    if line == "\n":
+                        if not BANNER.fullmatch("".join(banner)):
+                            defect(f"line {number}: invalid startup banner")
+                        banner = []
+                        continue
+                    if len(banner) < 6 and line.startswith("  "):
+                        banner.append(line)
+                        continue
+                    defect(f"line {number}: incomplete startup banner")
+                    banner = []
+                if line == "\n":
+                    continue
+                if not banner_seen and line.startswith("  rustbgpd "):
+                    banner_seen = True
+                    banner = [line]
+                    continue
+                try:
+                    record = json.loads(line, object_pairs_hook=unique_members,
+                                        parse_constant=reject_constant)
+                    if not isinstance(record, dict):
+                        raise ValueError("record is not an object")
+                    level = record.get("level")
+                    fields = record.get("fields")
+                    if (level not in ("TRACE", "DEBUG", "INFO", "WARN", "ERROR")
+                            or not isinstance(fields, dict)
+                            or not isinstance(fields.get("message"), str)
+                            or not fields["message"]
+                            or not isinstance(record.get("target"), str)
+                            or not record["target"]):
+                        raise ValueError("invalid level, fields.message, or target")
+                    stamp = datetime.fromisoformat(record["timestamp"].replace("Z", "+00:00"))
+                    if stamp.tzinfo is None:
+                        raise ValueError("timestamp has no timezone")
+                except (ValueError, TypeError, KeyError, AttributeError) as exc:
+                    defect(f"line {number}: invalid daemon record: {exc}")
+                    continue
+                records += 1
+                if level == "WARN":
+                    warnings[fields["message"]] += 1
+                elif level == "ERROR":
+                    # No scenario-justified ERROR exceptions have been established.
+                    errors += 1
+                    if len(examples) < 20:
+                        examples.append(f"line {number}: {record['target']}: {fields}")
+    except (OSError, UnicodeError) as exc:
+        defect(f"cannot read rustbgpd.log: {exc}")
+    if banner:
+        defect("incomplete startup banner at end of file")
+    if not records:
+        defect("no daemon JSON records")
+    return {
+        "value": {"records": records, "errors": errors, "defects": defects,
+                  "warnings_by_message": dict(sorted(warnings.items())),
+                  "examples": examples},
+        "pass": records > 0 and errors == 0 and defects == 0,
+    }

--- a/tests/soak/test_analyze_soak_rr_flagship.py
+++ b/tests/soak/test_analyze_soak_rr_flagship.py
@@ -117,7 +117,23 @@ def long_rows(rss_of=None):
     return rows
 
 
-def run_analyzer(rows, cycles, meta, fields=FIELDS):
+def daemon_record(level="INFO", message="daemon ready", **fields):
+    return (json.dumps({
+        "timestamp": ts(120), "level": level, "target": "rustbgpd",
+        "fields": {"message": message, **fields},
+    }) + "\n").encode()
+
+
+CLEAN_DAEMON = daemon_record()
+DAEMON_BANNER = (
+    b"\n  rustbgpd 0.69.0 | AS 65000 | router-id 10.0.0.1\n"
+    b"  |- 12 peers (12 iBGP)\n"
+    b"  |- grpc: unix:///tmp/flagship/grpc.sock\n"
+    b"  |- metrics: http://127.0.0.1:9179/metrics\n\n"
+)
+
+
+def run_analyzer(rows, cycles, meta, fields=FIELDS, daemon=CLEAN_DAEMON):
     with tempfile.TemporaryDirectory() as tmp:
         run_dir = Path(tmp)
         with (run_dir / "samples.csv").open("w", newline="") as stream:
@@ -127,6 +143,8 @@ def run_analyzer(rows, cycles, meta, fields=FIELDS):
             writer.writerows(rows)
         (run_dir / "cycles.log").write_text("\n".join(cycles) + "\n")
         (run_dir / "run.json").write_text(json.dumps(meta))
+        if daemon is not None:
+            (run_dir / "rustbgpd.log").write_bytes(daemon)
         result = subprocess.run(
             ["python3", str(ANALYZER), str(run_dir)],
             text=True, capture_output=True, check=False,
@@ -136,6 +154,51 @@ def run_analyzer(rows, cycles, meta, fields=FIELDS):
 
 
 class RrFlagshipAnalyzerContracts(unittest.TestCase):
+    def test_daemon_evidence_fails_closed(self):
+        bad_logs = {
+            "missing": None, "empty": b"", "blank": b"\n",
+            "banner_only": DAEMON_BANNER,
+            "malformed": daemon_record() + b'{broken}\n',
+            "truncated_json": daemon_record() + b'{"level":',
+            "missing_newline": daemon_record().rstrip(b"\n"),
+            "panic": daemon_record() + b"thread 'main' panicked at bug.rs:1\n",
+            "invalid_utf8": daemon_record() + b"\xff\n",
+            "wrong_shape": b'[]\n',
+            "duplicate_level": daemon_record("ERROR").replace(
+                b'"level": "ERROR"', b'"level": "ERROR", "level": "INFO"'),
+            "non_json_nan": daemon_record(value=float("nan")),
+            "non_json_infinity": daemon_record(value=float("inf")),
+            "missing_fields": b'{"level":"INFO"}\n',
+            "fake_banner_line": daemon_record() + b"  |- ERROR hidden failure\n",
+            "banner_incomplete": DAEMON_BANNER.rstrip(b"\n") + b"\n",
+            "repeated_banner": DAEMON_BANNER + daemon_record() + DAEMON_BANNER,
+            "emfile": daemon_record("ERROR", "metrics server accept error",
+                                    error="Too many open files (os error 24)"),
+            "decode_error": daemon_record("ERROR", "decode error",
+                                               peer="127.1.0.1"),
+        }
+        for name, raw in bad_logs.items():
+            with self.subTest(name=name):
+                result, payload = run_analyzer(smoke_rows(), smoke_cycles(),
+                                               smoke_meta(), daemon=raw)
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertFalse(payload["gates"]["daemon_log"]["pass"])
+                self.assertEqual(payload["verdict"], "fail")
+
+    def test_daemon_banner_and_warnings_are_reported_without_failure(self):
+        raw = (daemon_record() + DAEMON_BANNER
+               + daemon_record("WARN", "max prefix exceeded", peer="127.1.0.1")
+               + daemon_record("WARN", "peer lagged, requesting resync") * 2)
+        result, payload = run_analyzer(smoke_rows(), smoke_cycles(), smoke_meta(),
+                                       daemon=raw)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        gate = payload["gates"]["daemon_log"]
+        self.assertTrue(gate["pass"])
+        self.assertEqual(gate["value"]["records"], 4)
+        self.assertEqual(gate["value"]["warnings_by_message"], {
+            "max prefix exceeded": 1, "peer lagged, requesting resync": 2,
+        })
+
     def test_clean_smoke_run_passes_with_slope_gates_annotated(self):
         result, payload = run_analyzer(smoke_rows(), smoke_cycles(),
                                        smoke_meta())

--- a/tests/soak/test_analyze_soak_rs_flagship.py
+++ b/tests/soak/test_analyze_soak_rs_flagship.py
@@ -221,7 +221,24 @@ def management_jsonl(meta, *, missing_operation=None, early=False,
     return raw + (b'{"record":' if truncated else b"")
 
 
-def run_analyzer(rows, cycles, meta, fields=FIELDS, management=None):
+def daemon_record(level="INFO", message="daemon ready", **fields):
+    return (json.dumps({
+        "timestamp": ts(70), "level": level, "target": "rustbgpd",
+        "fields": {"message": message, **fields},
+    }) + "\n").encode()
+
+
+CLEAN_DAEMON = daemon_record()
+DAEMON_BANNER = (
+    b"\n  rustbgpd 0.69.0 | AS 65000 | router-id 10.0.0.1\n"
+    b"  |- 12 peers (12 eBGP)\n"
+    b"  |- 2 named policies\n"
+    b"  |- grpc: unix:///tmp/flagship/grpc.sock\n"
+    b"  |- metrics: http://127.0.0.1:9179/metrics\n\n"
+)
+
+
+def run_analyzer(rows, cycles, meta, fields=FIELDS, management=None, daemon=CLEAN_DAEMON):
     with tempfile.TemporaryDirectory() as tmp:
         run_dir = Path(tmp)
         with (run_dir / "samples.csv").open("w", newline="") as stream:
@@ -233,6 +250,8 @@ def run_analyzer(rows, cycles, meta, fields=FIELDS, management=None):
         (run_dir / "run.json").write_text(json.dumps(meta))
         evidence = management_jsonl(meta) if management is None else management
         (run_dir / "management-plane-load.jsonl").write_bytes(evidence)
+        if daemon is not None:
+            (run_dir / "rustbgpd.log").write_bytes(daemon)
         result = subprocess.run(
             ["python3", str(ANALYZER), str(run_dir)],
             text=True, capture_output=True, check=False,
@@ -242,6 +261,52 @@ def run_analyzer(rows, cycles, meta, fields=FIELDS, management=None):
 
 
 class RsFlagshipAnalyzerContracts(unittest.TestCase):
+    def test_daemon_evidence_fails_closed(self):
+        bad_logs = {
+            "missing": None, "empty": b"", "blank": b"\n",
+            "banner_only": DAEMON_BANNER,
+            "malformed": daemon_record() + b'{broken}\n',
+            "truncated_json": daemon_record() + b'{"level":',
+            "missing_newline": daemon_record().rstrip(b"\n"),
+            "panic": daemon_record() + b"thread 'main' panicked at bug.rs:1\n",
+            "invalid_utf8": daemon_record() + b"\xff\n",
+            "wrong_shape": b'[]\n',
+            "duplicate_level": daemon_record("ERROR").replace(
+                b'"level": "ERROR"', b'"level": "ERROR", "level": "INFO"'),
+            "non_json_nan": daemon_record(value=float("nan")),
+            "non_json_infinity": daemon_record(value=float("inf")),
+            "missing_fields": b'{"level":"INFO"}\n',
+            "fake_banner_line": daemon_record() + b"  |- ERROR hidden failure\n",
+            "banner_incomplete": DAEMON_BANNER.rstrip(b"\n") + b"\n",
+            "repeated_banner": DAEMON_BANNER + daemon_record() + DAEMON_BANNER,
+            "emfile": daemon_record("ERROR", "metrics server accept error",
+                                    error="Too many open files (os error 24)"),
+            # The RS fixture includes deliberate trips. Those cannot exempt errors.
+            "trip_decode_error": daemon_record("ERROR", "decode error",
+                                               peer="127.1.0.1"),
+        }
+        for name, raw in bad_logs.items():
+            with self.subTest(name=name):
+                result, payload = run_analyzer(smoke_rows(), smoke_cycles(),
+                                               smoke_meta(), daemon=raw)
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertFalse(payload["gates"]["daemon_log"]["pass"])
+                self.assertEqual(payload["verdict"], "fail")
+
+    def test_daemon_banner_and_warnings_are_reported_without_failure(self):
+        raw = (daemon_record() + DAEMON_BANNER
+               + daemon_record("WARN", "max prefix exceeded", peer="127.1.0.1")
+               + daemon_record("WARN", "peer lagged, requesting resync") * 2)
+        result, payload = run_analyzer(smoke_rows(), smoke_cycles(), smoke_meta(),
+                                       daemon=raw)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        gate = payload["gates"]["daemon_log"]
+        self.assertTrue(gate["pass"])
+        self.assertEqual(gate["value"]["records"], 4)
+        self.assertEqual(gate["value"]["warnings_by_message"], {
+            "max prefix exceeded": 1, "peer lagged, requesting resync": 2,
+        })
+
     def test_management_prefix_matches_reloadstall_mapping(self):
         cases = {
             50: "20.0.50.0/24",


### PR DESCRIPTION
The flagship soak analyzers could pass while the daemon continuously logged errors, including metrics listener EMFILE failures hidden by successful client probes. Both analyzers now require `rustbgpd.log`, fail on every daemon ERROR, and report WARN counts by message alongside the existing client gates.

One streaming stdlib parser rejects missing, empty, malformed, duplicate-member, nonstandard-constant, truncated, and unexpected non-JSON evidence. It accepts blank lines and one bounded complete startup banner. No ERROR exemptions were needed for the observed max-prefix trips, reconnects, or terminal teardown. Historical receipts retain their original contract.

Validation:

- 33 route-server and 23 route-reflector analyzer tests pass, including full-command negative fixtures for EMFILE and errors inside a deliberate trip window.
- Route-server functional smoke: 12 peers × 50 routes, five reloads, two recovered max-prefix trips; all gates pass. Complete daemon log: 754 records, zero ERRORs or parser defects.
- Route-reflector functional smoke: 12 peers × 20 routes, 300-second hold, 21,150 churn cycles; exact 220 non-self routes per observer, all sessions up, zero decode errors; all gates pass. Complete daemon log: 332 records, zero ERRORs or parser defects.
- Smokes used development daemon/CLI binaries and a release load generator; these establish behavior and log vocabulary, not release performance. WARN reporting captured both intentional max-prefix events and terminal resync warnings without failing.
- Ruff, Python syntax, developer-tooling, offline links, public-doc checks, and normal commit/push hooks pass, including all three rustdoc hooks.
