### PR TITLE
feat(config): compensate dataset content reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- SIGHUP reloads of static neighbors, peer groups, inline policy, and changed
-  `.rpol` content now settle as one owned runtime generation. The daemon
+- SIGHUP reloads of static neighbors, peer groups, inline policy, changed
+  `.rpol` content, and dataset contents with unchanged bindings now settle as one owned
+  runtime generation. The daemon
   resolves the complete candidate once and derives one session action per
   peer, so a peer-group reshape and an explicit edit of one of its members
   rebuild that session exactly once and a replacement receives its final
   policies directly. The prior config, compiled `.rpol` registry, resolved
-  chains, and captured session configs are retained through the whole
+  chains, dataset snapshots and loader errors, and captured session configs
+  are retained through the whole
   operation: a later step failure restores them from memory and reports a
   clean rejection with the candidate file left in place, instead of adopting
   a partial result. Lost acknowledgement or a failed restore still fences the
@@ -138,16 +140,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   post-stop checks explicit.
 
 - A SIGHUP candidate that changes static neighbors, peer groups, inline
-  policy, or `.rpol` content **together with** dataset content or bindings,
+  policy, `.rpol` content, or dataset contents **together with**
   `[[dynamic_neighbors]]`, EVPN runtime tables, `[[fib_tables]]`, or
-  `honor_graceful_shutdown` / `honor_blackhole` is now rejected before any
-  effect; previously it ran step by step and adopted the steps that
-  succeeded. The rejection names each family; apply those families in their
-  own reload (for example refresh dataset files with an unchanged config
-  first, then reload the config change). Every family on its own keeps its
-  existing reload behavior, and a candidate that also changes listener
-  MD5/GTSM authentication or rotates TCP-AO keys keeps the sequential path,
-  which offers no restoration of earlier steps.
+  `honor_graceful_shutdown` / `honor_blackhole` is rejected before any effect.
+  Dataset content generations require unchanged names, kinds, file mappings,
+  and handles; binding changes require a restart. Dataset changes combined
+  with listener MD5/GTSM authentication or TCP-AO rotation also reject.
+  Without dataset changes, authentication-bearing candidates retain the
+  sequential path, which offers no restoration of earlier steps.
+- Dataset content generations reject malformed input before publication and
+  require local dependent-refresh settlement. Established import dependents
+  need Route Refresh; offline peers remain eligible when their state is known
+  and no GR/LLGR routes are retained. A failed generation restores dataset
+  contents at a new monotonically increasing generation, then refreshes every
+  potentially affected peer. Lost acknowledgements or unknown state fence the
+  daemon. This does not promise remote replay completion or atomic visibility
+  across datasets or BGP sessions.
 - Generation-class reload failures no longer produce a known-partial
   runtime receipt; the sequential path keeps its known-partial semantics.
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2537,7 +2537,7 @@ pub enum RibUpdate {
     /// Chain instances and their counters are preserved. The reply acknowledges
     /// recomputation and distribution responsibility, not remote receipt.
     ReevaluatePeerExportPolicies {
-        /// Established peers whose export chains reference a changed dataset.
+        /// Peers whose installed export policies must be re-evaluated.
         peers: Vec<IpAddr>,
         /// Response channel for success/failure.
         reply: oneshot::Sender<Result<(), RibCommandError>>,

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -550,13 +550,16 @@ What happens:
 1. The daemon re-reads the TOML config file and its `.rpol` and dataset
    files from disk, pins restart-required fields to the live values, and
    classifies the candidate before any credential, listener, session, or
-   catalog effect. `rustbgpd --diff` and `rbgp config diff` print the same
-   classification as `SIGHUP reload route`.
+   catalog effect. `rustbgpd --diff` and `rbgp config diff` print the route
+   for changes visible to the config diff as `SIGHUP reload route`. The diff
+   reports dataset bindings; SIGHUP also checks staged dataset contents and
+   loader errors when choosing the actual route.
 2. **Generation route** — a candidate whose reload-applied changes are
    static `[[neighbors]]`, `[peer_groups]`, inline policy definitions,
    neighbor sets, global chains, changed `.rpol` content (imports included),
-   `[policy.explain]`, or outbound prefix maxima settles as one owned
-   runtime generation. The daemon resolves the complete candidate once and
+   dataset contents with unchanged bindings, `[policy.explain]`, or outbound
+   prefix maxima settles as one owned runtime generation. The daemon resolves
+   the complete candidate once and
    derives one action per static neighbor — unchanged, hot update in place,
    replace (one delete/re-add with the final policies), add, or remove —
    while the peer manager resolves every live peer's final chains against
@@ -565,31 +568,52 @@ What happens:
    of one member therefore rebuilds that session exactly once; policy-only
    and bystander sessions keep their identity. Removed definitions are
    simply absent from the adopted candidate. The prior config, compiled
-   `.rpol` registry, resolved chains, and captured session configs are
-   retained through the operation: a later failure restores them from
-   memory, the reload reports a clean rejection, the candidate file stays on
+   `.rpol` registry, resolved chains, dataset snapshots and loader errors,
+   and captured session configs are retained through the operation: a later
+   failure restores them from memory, the reload reports a clean rejection,
+   the candidate file stays on
    disk for correction, and an identical retry re-derives the same plan.
 3. **Sequential route** — a candidate with no generation-class change
-   (dataset content refresh, `[[dynamic_neighbors]]`, EVPN runtime tables,
-   `[[fib_tables]]`, the honor knobs, TCP-AO rotation, listener MD5/GTSM
-   inventory, explain-only, `[gnmi_dialout]`) runs the existing
+   (`[[dynamic_neighbors]]`, EVPN runtime tables, `[[fib_tables]]`, the honor
+   knobs, TCP-AO rotation, listener MD5/GTSM inventory, explain-only,
+   `[gnmi_dialout]`) runs the existing
    per-subsystem steps. A generation-class change combined with a TCP-AO
    rotation or a listener MD5/GTSM authentication change also stays on
-   this path, logged as running without generation compensation: the
-   rotation is its own ordered protocol and the session reshape primitive
-   refuses authentication changes.
-4. **Rejected compound** — a generation-class change combined with dataset
-   content or bindings, `[[dynamic_neighbors]]`, EVPN runtime tables,
-   `[[fib_tables]]`, or `honor_graceful_shutdown` / `honor_blackhole` is
-   rejected before any effect, naming each family to reload on its own.
-   None of those families retains and restores priors, so their partial
-   effects could not be compensated.
+   this path when dataset contents are unchanged, logged as running without
+   generation compensation: the rotation is its own ordered protocol and
+   the session reshape primitive refuses authentication changes.
+4. **Rejected changes** — dataset names, kinds, file mappings, and live
+   handles must stay unchanged. Dataset content changes combined with TCP-AO
+   rotation or listener MD5/GTSM authentication changes reject before any
+   effect. A generation-class change combined with `[[dynamic_neighbors]]`,
+   EVPN runtime tables, `[[fib_tables]]`, or
+   `honor_graceful_shutdown` / `honor_blackhole` also rejects: those families
+   do not retain and restore priors. Apply independently reloadable families
+   in separate reloads; dataset binding changes require a restart.
 5. **Automatic Route Refresh on import-policy hot-apply** — when a
    peer's effective import chain changes (whether triggered by a
    SIGHUP reload or a gRPC mutation), the peer manager issues
    `soft_reset_in` (gated on Established) so routes already in
    `AdjRibIn` get re-evaluated against the new policy. Operators no
    longer need to run `softreset` manually after a chain swap.
+
+For a dataset content generation, every file must load successfully before
+publication. The daemon retains prior snapshots and loader errors, reserves
+generation numbers for both publication and compensation, settles policy
+changes, then publishes the prepared batch without yielding. A changed dataset
+advances from `g` to `g + 1`; compensation restores its prior contents as
+`g + 2`, so generations never move backward. Content-equal reloads do not
+advance the dataset generation. Evaluation still pins each dataset separately;
+this does not provide an atomic snapshot across multiple datasets.
+
+The generation refreshes the union of peers whose old or candidate chains
+reference changed datasets, including dynamic peers. Export recomputation
+preserves installed chain instances and counters. Established import dependents
+must support Route Refresh. A positively down peer needs no import replay when
+the RIB confirms it retains no GR/LLGR routes; any remaining export registration
+is still recomputed. Unknown session state, lost acknowledgement, or unresolved
+required refresh work cannot produce a successful settlement. Import refresh
+acknowledgements prove local dispatch, not completion of the remote peer's replay.
 
 gRPC credentials rotate only after the runtime generation is acknowledged,
 so a rejected or restored candidate has no credential effect. The generation

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -80,8 +80,29 @@ struct DatasetLoadSummary {
     failed: usize,
 }
 
+#[derive(Default)]
 pub(crate) struct StagedDatasetCommit {
     updates: Vec<StagedDatasetUpdate>,
+}
+
+/// An unpublished content-only generation, with every rollback pin captured
+/// before the owner starts changing policy or runtime state.
+#[derive(Default)]
+pub(crate) struct PreparedDatasetGeneration {
+    commit: StagedDatasetCommit,
+    rollback: DatasetRollback,
+}
+
+#[derive(Default)]
+pub(crate) struct DatasetRollback {
+    priors: Vec<DatasetPrior>,
+}
+
+struct DatasetPrior {
+    handle: Arc<rustbgpd_policy::datasets::DatasetHandle>,
+    snapshot: Arc<rustbgpd_policy::datasets::DatasetSnapshot>,
+    error: Option<String>,
+    content_changed: bool,
 }
 
 enum StagedDatasetUpdate {
@@ -98,6 +119,47 @@ enum StagedDatasetUpdate {
 impl StagedDatasetCommit {
     pub(crate) fn is_empty(&self) -> bool {
         self.updates.is_empty()
+    }
+
+    pub(crate) fn prepare_generation(
+        self,
+        prior: &Config,
+        candidate: &Config,
+    ) -> Result<PreparedDatasetGeneration, String> {
+        if prior.policy.datasets != candidate.policy.datasets
+            || prior.policy.dataset_bindings != candidate.policy.dataset_bindings
+        {
+            return Err(
+                "dataset generations require unchanged names, kinds, file mappings, and handles"
+                    .to_string(),
+            );
+        }
+        let mut priors = Vec::with_capacity(self.updates.len());
+        for update in &self.updates {
+            let (handle, data) = match update {
+                StagedDatasetUpdate::Refresh { handle, data } => (handle, data),
+                StagedDatasetUpdate::Failure { handle, reason } => {
+                    return Err(format!(
+                        "dataset {} failed to load: {reason}",
+                        handle.name()
+                    ));
+                }
+            };
+            let snapshot = handle.pin();
+            let content_changed = snapshot.data != *data;
+            let prior = DatasetPrior {
+                handle: Arc::clone(handle),
+                snapshot,
+                error: handle.status().last_error,
+                content_changed,
+            };
+            prior.validate_generation_headroom()?;
+            priors.push(prior);
+        }
+        Ok(PreparedDatasetGeneration {
+            commit: self,
+            rollback: DatasetRollback { priors },
+        })
     }
 
     pub(crate) fn commit(self) {
@@ -120,6 +182,52 @@ impl StagedDatasetCommit {
                     );
                     handle.record_error(reason);
                 }
+            }
+        }
+    }
+}
+
+impl DatasetPrior {
+    fn validate_generation_headroom(&self) -> Result<(), String> {
+        if self.content_changed && self.snapshot.generation.checked_add(2).is_none() {
+            return Err(format!(
+                "dataset {} has no generation headroom for publication and compensation",
+                self.handle.name()
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl PreparedDatasetGeneration {
+    pub(crate) fn changed_names(&self) -> Vec<String> {
+        self.rollback
+            .priors
+            .iter()
+            .filter(|prior| prior.content_changed)
+            .map(|prior| prior.handle.name().to_string())
+            .collect()
+    }
+
+    /// Publish the complete prepared batch without yielding to another owner.
+    /// Evaluators still pin individual datasets; this is not a global reader
+    /// snapshot or a claim that every peer observes the change simultaneously.
+    pub(crate) fn publish(self) -> DatasetRollback {
+        self.commit.commit();
+        self.rollback
+    }
+}
+
+impl DatasetRollback {
+    /// Restore all content before any asynchronous runtime compensation.
+    /// Republish changed data at the next generation rather than rewinding it.
+    pub(crate) fn restore(self) {
+        for prior in self.priors {
+            if prior.content_changed {
+                let _ = prior.handle.refresh(prior.snapshot.data.clone());
+            }
+            if let Some(error) = prior.error {
+                prior.handle.record_error(error);
             }
         }
     }
@@ -3113,8 +3221,10 @@ pub struct SighupReloadFamilies {
     /// Static `[[neighbors]]`, `[peer_groups]`, inline policy definitions,
     /// neighbor sets, global chains, or compiled `.rpol` content.
     pub generation: bool,
-    /// `[policy.datasets]` bindings or staged dataset content/error state.
+    /// Staged dataset content/error state, through unchanged live handles.
     pub datasets: bool,
+    /// Dataset names, kinds, file mappings, or handle identities changed.
+    pub dataset_bindings: bool,
     /// `[[dynamic_neighbors]]` ranges.
     pub dynamic_ranges: bool,
     /// `[[evpn_instances]]` / `[[evpn_ip_vrfs]]` / `[[ethernet_segments]]`.
@@ -3152,7 +3262,8 @@ impl SighupReloadFamilies {
             || diff.policy.rpol_changed;
         Self {
             generation,
-            datasets: diff.policy.datasets_changed,
+            datasets: false,
+            dataset_bindings: diff.policy.datasets_changed,
             dynamic_ranges: diff.dynamic_neighbors_reload_applied_changed,
             evpn_runtime: diff.evpn_instances_changed
                 || diff.evpn_ip_vrfs_changed
@@ -3220,14 +3331,20 @@ impl SighupReloadRoute {
 /// be folded into the generation.
 #[must_use]
 pub fn classify_sighup_reload(families: SighupReloadFamilies) -> SighupReloadRoute {
-    if !families.generation {
+    if !families.generation && !families.datasets && !families.dataset_bindings {
         return SighupReloadRoute::Sequential {
             reasons: Vec::new(),
         };
     }
     let mut rejected = Vec::new();
-    if families.datasets {
-        rejected.push("[policy.datasets] content or bindings".to_string());
+    if families.dataset_bindings {
+        rejected.push("[policy.datasets] names, kinds, file mappings, or handles".to_string());
+    }
+    if families.datasets && families.tcp_ao {
+        rejected.push("dataset content with TCP-AO keyring rotation".to_string());
+    }
+    if families.datasets && families.listener_auth {
+        rejected.push("dataset content with listener MD5/GTSM changes".to_string());
     }
     if families.dynamic_ranges {
         rejected.push("[[dynamic_neighbors]]".to_string());

--- a/src/config/tests/datasets.rs
+++ b/src/config/tests/datasets.rs
@@ -211,6 +211,156 @@ fn staged_dataset_reload_defers_live_handle_mutation_until_commit() {
 }
 
 #[test]
+fn dataset_generation_restores_content_and_error_through_stable_handle() {
+    let dir = dataset_config_dir("64500\n");
+    let path = dir.path().join("config.toml");
+    let path = path.to_str().unwrap();
+    let initial = Config::load_with_diagnostics(path).unwrap();
+    let live = Arc::clone(initial.policy.dataset_bindings.get("customers").unwrap());
+    live.record_error("prior source unavailable");
+    let prior = live.pin();
+    fs::write(dir.path().join("datasets/customers.list"), "64999\n").unwrap();
+    let mut candidate =
+        Config::load_with_diagnostics_and_staged_datasets(path, &initial.policy.dataset_bindings)
+            .unwrap();
+    let staged = candidate.prepare_staged_datasets(&initial.policy.dataset_bindings);
+    let prepared = staged.prepare_generation(&initial, &candidate).unwrap();
+    assert_eq!(prepared.changed_names(), ["customers"]);
+    assert!(Arc::ptr_eq(&prior, &live.pin()));
+    let rollback = prepared.publish();
+    assert_eq!(live.pin().generation, 2);
+    assert_ne!(live.pin().data, prior.data);
+    assert!(live.status().last_error.is_none());
+    // Compensation must use the retained data, not the now-overwritten file.
+    fs::write(dir.path().join("datasets/customers.list"), "invalid\n").unwrap();
+    rollback.restore();
+    assert_eq!(live.pin().generation, 3);
+    assert_eq!(live.pin().data, prior.data);
+    assert_eq!(
+        live.status().last_error.as_deref(),
+        Some("prior source unavailable")
+    );
+    assert!(Arc::ptr_eq(
+        &live,
+        candidate.policy.dataset_bindings.get("customers").unwrap()
+    ));
+    assert_eq!(Arc::strong_count(&prior), 1, "rollback pin released");
+}
+
+#[test]
+fn dataset_generation_equal_content_restores_error_without_advancing() {
+    let dir = dataset_config_dir("64500\n");
+    let path = dir.path().join("config.toml");
+    let path = path.to_str().unwrap();
+    let initial = Config::load_with_diagnostics(path).unwrap();
+    let live = Arc::clone(initial.policy.dataset_bindings.get("customers").unwrap());
+    live.record_error("prior error");
+    let prior = live.pin();
+    let mut candidate =
+        Config::load_with_diagnostics_and_staged_datasets(path, &initial.policy.dataset_bindings)
+            .unwrap();
+    let staged = candidate.prepare_staged_datasets(&initial.policy.dataset_bindings);
+    let prepared = staged.prepare_generation(&initial, &candidate).unwrap();
+    assert!(prepared.changed_names().is_empty());
+    let rollback = prepared.publish();
+    assert!(live.status().last_error.is_none());
+    assert!(Arc::ptr_eq(&prior, &live.pin()));
+    rollback.restore();
+    assert_eq!(live.status().last_error.as_deref(), Some("prior error"));
+    assert!(Arc::ptr_eq(&prior, &live.pin()));
+    assert_eq!(live.pin().generation, 1);
+}
+
+#[test]
+fn dataset_generation_rejects_invalid_batch_without_publishing_first_input() {
+    let dir = dataset_config_dir("64500\n");
+    let config_path = dir.path().join("config.toml");
+    let policy_path = dir.path().join("policies/core.rpol");
+    let config = fs::read_to_string(&config_path).unwrap();
+    fs::write(
+        &config_path,
+        format!("{config}\n[policy.datasets.suppliers]\npath = \"datasets/suppliers.list\"\n"),
+    )
+    .unwrap();
+    let policy = fs::read_to_string(&policy_path).unwrap();
+    fs::write(&policy_path, format!("dataset asn-set suppliers\n{policy}")).unwrap();
+    fs::write(dir.path().join("datasets/suppliers.list"), "64501\n").unwrap();
+    let initial = Config::load_with_diagnostics(config_path.to_str().unwrap()).unwrap();
+    fs::write(dir.path().join("datasets/customers.list"), "64999\n").unwrap();
+    fs::write(dir.path().join("datasets/suppliers.list"), "invalid\n").unwrap();
+    let mut candidate = Config::load_with_diagnostics_and_staged_datasets(
+        config_path.to_str().unwrap(),
+        &initial.policy.dataset_bindings,
+    )
+    .unwrap();
+    let staged = candidate.prepare_staged_datasets(&initial.policy.dataset_bindings);
+    assert!(staged.prepare_generation(&initial, &candidate).is_err());
+    for handle in initial.policy.dataset_bindings.handles() {
+        assert_eq!(handle.pin().generation, 1);
+        assert!(handle.status().last_error.is_none());
+    }
+}
+
+#[test]
+fn dataset_generation_rejects_changed_mapping_or_handle_identity() {
+    let dir = dataset_config_dir("64500\n");
+    let initial = load_dir(&dir).unwrap();
+    let mut candidate = initial.clone();
+    candidate
+        .policy
+        .datasets
+        .get_mut("customers")
+        .unwrap()
+        .path
+        .push_str(".next");
+    assert!(
+        StagedDatasetCommit {
+            updates: Vec::new()
+        }
+        .prepare_generation(&initial, &candidate)
+        .is_err()
+    );
+    candidate = initial.clone();
+    candidate.policy.dataset_bindings = initial.policy.dataset_bindings.detached_clone();
+    assert!(
+        StagedDatasetCommit {
+            updates: Vec::new()
+        }
+        .prepare_generation(&initial, &candidate)
+        .is_err()
+    );
+}
+
+#[test]
+fn dataset_generation_headroom_reserves_forward_and_compensation() {
+    use rustbgpd_policy::datasets::{DatasetData, DatasetHandle, DatasetKind, DatasetSnapshot};
+    use rustbgpd_policy::sets::AsnSet;
+    let data = DatasetData::Asn(AsnSet::new([64500]));
+    let handle = Arc::new(DatasetHandle::new(
+        "customers",
+        DatasetKind::Asn,
+        data.clone(),
+    ));
+    for (generation, changed, accepted) in [
+        (u64::MAX - 2, true, true),
+        (u64::MAX - 1, true, false),
+        (u64::MAX, true, false),
+        (u64::MAX, false, true),
+    ] {
+        let prior = DatasetPrior {
+            handle: Arc::clone(&handle),
+            snapshot: Arc::new(DatasetSnapshot {
+                generation,
+                data: data.clone(),
+            }),
+            error: None,
+            content_changed: changed,
+        };
+        assert_eq!(prior.validate_generation_headroom().is_ok(), accepted);
+    }
+}
+
+#[test]
 fn dataset_path_change_is_visible_and_transaction_unsupported() {
     let dir = dataset_config_dir("64500\n");
     let current = load_dir(&dir).expect("config with dataset input loads");

--- a/src/config/tests/reload_route.rs
+++ b/src/config/tests/reload_route.rs
@@ -205,10 +205,10 @@ fn route_is_generation_for_pure_generation_class_changes() {
 fn route_rejects_generation_changes_combined_with_uncompensated_families() {
     for (name, families) in [
         (
-            "datasets",
+            "dataset bindings",
             SighupReloadFamilies {
                 generation: true,
-                datasets: true,
+                dataset_bindings: true,
                 ..SighupReloadFamilies::default()
             },
         ),
@@ -255,7 +255,7 @@ fn route_rejects_generation_changes_combined_with_uncompensated_families() {
     // sequential-only families.
     let route = classify_sighup_reload(SighupReloadFamilies {
         generation: true,
-        datasets: true,
+        dataset_bindings: true,
         fib_tables: true,
         listener_auth: true,
         ..SighupReloadFamilies::default()
@@ -264,6 +264,44 @@ fn route_rejects_generation_changes_combined_with_uncompensated_families() {
         panic!("{route:?}");
     };
     assert_eq!(reasons.len(), 2, "{reasons:?}");
+}
+
+#[test]
+fn route_compensates_dataset_content_and_rejects_binding_or_auth_changes() {
+    for generation in [false, true] {
+        assert_eq!(
+            classify_sighup_reload(SighupReloadFamilies {
+                generation,
+                datasets: true,
+                ..SighupReloadFamilies::default()
+            }),
+            SighupReloadRoute::Generation
+        );
+        for (dataset_bindings, tcp_ao, listener_auth) in [
+            (true, false, false),
+            (false, true, false),
+            (false, false, true),
+        ] {
+            assert!(matches!(
+                classify_sighup_reload(SighupReloadFamilies {
+                    generation,
+                    datasets: true,
+                    dataset_bindings,
+                    tcp_ao,
+                    listener_auth,
+                    ..SighupReloadFamilies::default()
+                }),
+                SighupReloadRoute::Rejected { .. }
+            ));
+        }
+    }
+    assert!(matches!(
+        classify_sighup_reload(SighupReloadFamilies {
+            dataset_bindings: true,
+            ..SighupReloadFamilies::default()
+        }),
+        SighupReloadRoute::Rejected { .. }
+    ));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5920,6 +5920,12 @@ async fn run<T>(
                             ));
                         }
                     };
+                    // Dataset load failures reject before the runtime
+                    // generation command, so record their existing counter
+                    // here without changing any live dataset status.
+                    for (name, _) in &desired.config_ref().policy.dataset_events.failed {
+                        reload_metrics.record_policy_dataset_refresh_error(name);
+                    }
                     let outcome = reload_config_with_tcp_ao(
                         SighupReloadPlan {
                             baseline_runtime: snapshot,

--- a/src/peer_manager/generation.rs
+++ b/src/peer_manager/generation.rs
@@ -9,6 +9,9 @@
 //! what restores it, so a determinate failure unwinds from retained in-memory
 //! objects and never re-reads a file. A failed or unacknowledged unwind is
 //! reported as ambiguous so the owner fences instead of claiming restoration.
+//! The terminal outcome ends this manager operation and its recovery path;
+//! operation-owned dataset pins are then released, including after ambiguity.
+//! Concurrent evaluators keep their independently acquired snapshot pins.
 
 use std::collections::BTreeMap;
 
@@ -17,12 +20,14 @@ use rustbgpd_api::peer_types::{
 };
 use tracing::{error, info, warn};
 
-use crate::config::{Config, ReloadPeerAction, ReloadPeerActionKind};
+use crate::config::{
+    Config, DatasetRollback, PreparedDatasetGeneration, ReloadPeerAction, ReloadPeerActionKind,
+};
 use crate::policy_admin;
 
 use super::PeerManager;
 use super::lifecycle::PeerReshapeSnapshotOutcome;
-use super::policy::PolicySnapshotFailureKind;
+use super::policy::{DatasetDependent, DatasetRefreshFailure, PolicySnapshotFailureKind};
 
 /// Counts of the per-peer actions one generation applied.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -79,6 +84,8 @@ struct RemovedPeer {
 /// Forward effects applied so far, each with what restores it.
 #[derive(Default)]
 struct AppliedEffects {
+    dataset_prior: Option<DatasetRollback>,
+    dataset_dependents: Vec<DatasetDependent>,
     policy_priors: Option<Vec<ResolvedPeerPolicy>>,
     prior_config: Option<Config>,
     hot_priors: Vec<PeerManagerNeighborConfig>,
@@ -89,7 +96,8 @@ struct AppliedEffects {
 
 impl AppliedEffects {
     fn any(&self) -> bool {
-        self.policy_priors.is_some()
+        self.dataset_prior.is_some()
+            || self.policy_priors.is_some()
             || self.prior_config.is_some()
             || !self.hot_priors.is_empty()
             || self.reshape_priors.is_some()
@@ -109,9 +117,18 @@ impl PeerManager {
         &mut self,
         candidate: Config,
         actions: Vec<ReloadPeerAction>,
+        datasets: PreparedDatasetGeneration,
     ) -> ReloadGenerationOutcome {
         let resolved = match self.resolve_reload_generation(&candidate, &actions) {
             Ok(resolved) => resolved,
+            Err(error) => return ReloadGenerationOutcome::RejectedNoEffect(error),
+        };
+        let changed_datasets = datasets.changed_names();
+        let dependents = match self
+            .prepare_dataset_dependents(&candidate, &changed_datasets)
+            .await
+        {
+            Ok(dependents) => dependents,
             Err(error) => return ReloadGenerationOutcome::RejectedNoEffect(error),
         };
         let receipt = ReloadGenerationReceipt {
@@ -150,6 +167,21 @@ impl PeerManager {
                     }
                 };
             }
+        }
+
+        // The policy phase settled every prepared export destination before
+        // shared dataset handles advance. Publish the entire batch without
+        // yielding, then settle the union of old and candidate dependents.
+        applied.dataset_dependents = dependents;
+        applied.dataset_prior = Some(datasets.publish());
+        if let Err(error) = self
+            .refresh_dataset_generation_dependents(&applied.dataset_dependents)
+            .await
+        {
+            let ambiguous = matches!(error, DatasetRefreshFailure::Ambiguous(_));
+            return self
+                .fail_reload_generation(applied, error.to_string(), ambiguous)
+                .await;
         }
 
         // 2. The candidate becomes the snapshot every later session
@@ -219,6 +251,7 @@ impl PeerManager {
                 .apply_peer_reshape_snapshot_classified(
                     resolved.replace,
                     applied.prior_config.as_ref(),
+                    &mut applied.dataset_prior,
                 )
                 .await
             {
@@ -281,6 +314,9 @@ impl PeerManager {
             self.sync_dynamic_max_prefix_restart_for_group(name);
         }
         self.reconcile_stale_dynamic_max_prefix_restarts();
+        for name in &changed_datasets {
+            self.metrics.record_policy_dataset_loaded(name);
+        }
         self.metrics.record_policy_generation_loaded();
         self.publish_reload_generation_events(&prior_config, receipt.policy_updated);
         info!(%receipt, "reload generation applied");
@@ -444,6 +480,11 @@ impl PeerManager {
     /// Restore retained priors in reverse application order. Every step is
     /// attempted; the aggregated error names each one that failed.
     async fn unwind_reload_generation(&mut self, applied: AppliedEffects) -> Result<(), String> {
+        // Restore every content pin and error before any session or policy
+        // restoration can evaluate a chain against the prior generation.
+        if let Some(prior) = applied.dataset_prior {
+            prior.restore();
+        }
         // Rebuilt peers resolve global transport settings from this snapshot.
         // Restore it before any re-add, including diagnostic retention knobs.
         if let Some(prior_config) = applied.prior_config {
@@ -485,6 +526,12 @@ impl PeerManager {
             && let Err(error) = self.apply_resolved_policy_snapshot(priors).await
         {
             failures.push(format!("restore policy chains: {error}"));
+        }
+        if let Err(error) = self
+            .refresh_dataset_generation_dependents(&applied.dataset_dependents)
+            .await
+        {
+            failures.push(format!("restore dataset dependents: {error}"));
         }
         if failures.is_empty() {
             Ok(())

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -694,6 +694,16 @@ impl PeerManager {
         let max_prefixes = transport.max_prefixes;
 
         let session_id = self.allocate_session_id();
+        #[cfg(test)]
+        if let Some(observations) = &mut self.dataset_generations_at_peer_construction {
+            for handle in self.current_config.policy.dataset_bindings.handles() {
+                observations.push((
+                    peer_key.clone(),
+                    handle.name().to_string(),
+                    handle.pin().generation,
+                ));
+            }
+        }
         let handle = PeerHandle::spawn_at_tcp_ao_generation(
             transport.clone(),
             self.metrics.clone(),
@@ -904,7 +914,7 @@ impl PeerManager {
         config: PeerManagerNeighborConfig,
     ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let mut effect = ReconfigurePeerFailureEffect::NoEffect;
-        self.reconfigure_peer_classified(config, &mut effect, None)
+        self.reconfigure_peer_classified(config, &mut effect, None, &mut None)
             .await
     }
 
@@ -913,11 +923,18 @@ impl PeerManager {
         config: PeerManagerNeighborConfig,
         effect: &mut ReconfigurePeerFailureEffect,
         rollback_config: Option<&crate::config::Config>,
+        dataset_prior: &mut Option<crate::config::DatasetRollback>,
     ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let peer = PeerKey::new(config.address, config.interface.clone());
-        #[cfg(test)]
-        if let Some(remaining) = self.inject_reconfigure_failures.get_mut(&peer) {
+        #[cfg(any(test, debug_assertions))]
+        if (cfg!(test) || rollback_config.is_some())
+            && let Some(remaining) = self.inject_reconfigure_failures.get_mut(&peer)
+        {
             if *remaining == 0 {
+                // Unit tests retain their existing counter semantics. The
+                // debug daemon consumes its selected failure exactly once.
+                #[cfg(not(test))]
+                self.inject_reconfigure_failures.remove(&peer);
                 return Err(PeerLifecycleError::Internal(format!(
                     "injected reconfigure failure for {peer}"
                 )));
@@ -944,6 +961,9 @@ impl PeerManager {
             .add_peer_with_admin_state(config, false, was_enabled)
             .await
         {
+            if let Some(prior) = dataset_prior.take() {
+                prior.restore();
+            }
             return match self
                 .restore_reconfigured_peer(
                     peer.clone(),
@@ -973,6 +993,9 @@ impl PeerManager {
             .apply_reconfigured_peer_state(peer.clone(), graceful_shutdown)
             .await
         {
+            if let Some(prior) = dataset_prior.take() {
+                prior.restore();
+            }
             return match self
                 .restore_reconfigured_peer(
                     peer.clone(),
@@ -1247,7 +1270,7 @@ impl PeerManager {
         targets: Vec<PeerManagerNeighborConfig>,
     ) -> Result<Vec<PeerManagerNeighborConfig>, PeerLifecycleError> {
         match self
-            .apply_peer_reshape_snapshot_classified(targets, None)
+            .apply_peer_reshape_snapshot_classified(targets, None, &mut None)
             .await
         {
             PeerReshapeSnapshotOutcome::Success(priors) => Ok(priors),
@@ -1261,6 +1284,7 @@ impl PeerManager {
         &mut self,
         targets: Vec<PeerManagerNeighborConfig>,
         rollback_config: Option<&crate::config::Config>,
+        dataset_prior: &mut Option<crate::config::DatasetRollback>,
     ) -> PeerReshapeSnapshotOutcome {
         let mut seen = BTreeSet::new();
         for target in &targets {
@@ -1318,12 +1342,17 @@ impl PeerManager {
             let peer = PeerKey::new(target.address, target.interface.clone());
             let mut effect = ReconfigurePeerFailureEffect::NoEffect;
             match self
-                .reconfigure_peer_classified(target, &mut effect, rollback_config)
+                .reconfigure_peer_classified(target, &mut effect, rollback_config, dataset_prior)
                 .await
             {
                 Ok(previous) => priors.push(previous),
                 Err(error) => {
                     let had_prior_effects = !priors.is_empty();
+                    // Prior session construction must observe prior dataset
+                    // contents, including recovery owned by this inner batch.
+                    if let Some(prior) = dataset_prior.take() {
+                        prior.restore();
+                    }
                     let restore = self
                         .restore_peer_reshape_priors(priors, rollback_config)
                         .await;
@@ -2180,6 +2209,7 @@ impl PeerManager {
         let managed = self.peers.get(&peer).ok_or_else(|| SoftResetFailure {
             error: PeerLifecycleError::NotFound(peer.clone()),
             delivery_began: false,
+            acknowledgement_lost: false,
         })?;
 
         // An empty request means "everything this peer can be asked for".
@@ -2214,16 +2244,17 @@ impl PeerManager {
                     // definite session-side rejection on the very first family
                     // (no capability, not Established, the writer refused to
                     // queue) proves nothing was asked for.
-                    let delivery_began = !refreshed.is_empty()
-                        || matches!(
-                            e,
-                            PeerCommandError::TimedOut { .. } | PeerCommandError::ReplyDropped
-                        );
+                    let acknowledgement_lost = matches!(
+                        e,
+                        PeerCommandError::TimedOut { .. } | PeerCommandError::ReplyDropped
+                    );
+                    let delivery_began = !refreshed.is_empty() || acknowledgement_lost;
                     return Err(SoftResetFailure {
                         error: PeerLifecycleError::Internal(format!(
                             "send failed: route refresh to {address}: {e}"
                         )),
                         delivery_began,
+                        acknowledgement_lost,
                     });
                 }
             }
@@ -2242,4 +2273,7 @@ pub(super) struct SoftResetFailure {
     /// failing reply was ambiguous (timeout, dropped reply) and therefore
     /// cannot prove the request did not reach the peer.
     pub(super) delivery_began: bool,
+    /// A command may have been accepted without an authoritative reply. Keep
+    /// this distinct from a definite rejection after earlier family delivery.
+    pub(super) acknowledgement_lost: bool,
 }

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -161,11 +161,33 @@ pub(crate) struct PlannedTransactionConfig {
 
 pub(crate) use generation::ReloadGenerationOutcome;
 
+/// A debug-build-only, one-shot failure for a controlled SIGHUP regression.
+#[cfg(all(debug_assertions, not(test)))]
+fn debug_reconfigure_failures() -> std::collections::BTreeMap<PeerKey, u32> {
+    const VARIABLE: &str = "RUSTBGPD_TEST_SIGHUP_RECONFIGURE_FAILURE_PEER";
+    let value = match std::env::var(VARIABLE) {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return std::collections::BTreeMap::new(),
+        Err(error) => {
+            tracing::warn!(variable = VARIABLE, %error, "invalid debug-only reconfigure failure setting; injection disabled");
+            return std::collections::BTreeMap::new();
+        }
+    };
+    match value.parse::<IpAddr>() {
+        Ok(peer) => std::collections::BTreeMap::from([(PeerKey::new(peer, None), 0)]),
+        Err(error) => {
+            tracing::warn!(variable = VARIABLE, %error, "invalid debug-only reconfigure failure peer; injection disabled");
+            std::collections::BTreeMap::new()
+        }
+    }
+}
+
 pub(crate) enum InternalCommand {
     /// Apply one complete SIGHUP candidate as an owned runtime generation.
     ApplyReloadGeneration {
         candidate: Box<Config>,
         actions: Vec<crate::config::ReloadPeerAction>,
+        datasets: crate::config::PreparedDatasetGeneration,
         reply: oneshot::Sender<ReloadGenerationOutcome>,
     },
     ReplaceConfigSnapshot {
@@ -459,7 +481,7 @@ pub struct PeerManager {
     /// file, tests) keeps every candidate `Unverified`, i.e. the presence
     /// fence.
     accepted_rx: Option<watch::Receiver<Arc<crate::config::AcceptedConfigSnapshot>>>,
-    /// Test-only deterministic fault injection: `reconfigure_peer` against
+    /// Deterministic test/debug failure injection: `reconfigure_peer` against
     /// a mapped key fails up front, before the delete/re-add cycle, once the
     /// key's budget of remaining successful calls reaches zero (a value of 0
     /// fails the next call; a value of 1 lets one call succeed, then fails
@@ -468,8 +490,10 @@ pub struct PeerManager {
     /// the only mid-fanout failure class left, since config-shaped failures
     /// are all caught by validation, resolution, or the reshape preflight
     /// before any peer is touched.
-    #[cfg(test)]
+    #[cfg(any(test, debug_assertions))]
     inject_reconfigure_failures: std::collections::BTreeMap<PeerKey, u32>,
+    #[cfg(test)]
+    dataset_generations_at_peer_construction: Option<Vec<(PeerKey, String, u64)>>,
     /// The same deterministic fault injection for the in-place applier
     /// (`hot_update_peer_in_place`), so the peer-group hot path's
     /// mid-cohort failure and rollback contract can be exercised.
@@ -792,6 +816,10 @@ impl PeerManager {
             accepted_rx: None,
             #[cfg(test)]
             inject_reconfigure_failures: std::collections::BTreeMap::new(),
+            #[cfg(all(debug_assertions, not(test)))]
+            inject_reconfigure_failures: debug_reconfigure_failures(),
+            #[cfg(test)]
+            dataset_generations_at_peer_construction: None,
             #[cfg(test)]
             inject_hot_update_failures: std::collections::BTreeMap::new(),
         }
@@ -1849,11 +1877,11 @@ impl PeerManager {
                 }
                 internal = Self::receive_internal_command(&mut self.internal_rx) => {
                     match internal {
-                        Some(InternalCommand::ApplyReloadGeneration { candidate, actions, reply }) => {
+                        Some(InternalCommand::ApplyReloadGeneration { candidate, actions, datasets, reply }) => {
                             let policy_routes_prior =
                                 self.installed_policy_routes_reachability();
                             let outcome =
-                                Box::pin(self.apply_reload_generation(*candidate, actions)).await;
+                                Box::pin(self.apply_reload_generation(*candidate, actions, datasets)).await;
                             if matches!(outcome, ReloadGenerationOutcome::Applied(_)) {
                                 self.reap_retired_policy_routes(&policy_routes_prior);
                             }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -39,6 +39,27 @@ use super::{
 /// lines instead of either silence or one line per peer.
 const COHORT_SETUP_PROGRESS_INTERVAL: usize = 64;
 
+/// The union is retained even if a candidate chain stops referencing a dataset.
+/// Compensation must refresh everyone who could have evaluated either view.
+pub(super) struct DatasetDependent {
+    peer: PeerKey,
+    import: bool,
+    export: bool,
+}
+
+pub(super) enum DatasetRefreshFailure {
+    Rejected(String),
+    Ambiguous(String),
+}
+
+impl std::fmt::Display for DatasetRefreshFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected(message) | Self::Ambiguous(message) => formatter.write_str(message),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct InstalledPolicyRoutesReachability {
     scopes: BTreeMap<(String, String), InstalledPolicyRoutesScope>,
@@ -2746,6 +2767,285 @@ impl PeerManager {
         }
     }
 
+    /// Resolve and qualify all potentially affected peers before publication.
+    /// A positively down session owes no import replay only when the RIB
+    /// confirms it retains no stale routes. Unknown state cannot prove that.
+    pub(super) async fn prepare_dataset_dependents(
+        &mut self,
+        candidate: &Config,
+        changed: &[String],
+    ) -> Result<Vec<DatasetDependent>, String> {
+        if changed.is_empty() {
+            return Ok(Vec::new());
+        }
+        let references = |chain: &Option<PolicyChain>| {
+            chain
+                .as_ref()
+                .is_some_and(|chain| changed.iter().any(|name| chain.references_dataset(name)))
+        };
+        let mut dependents = Vec::new();
+        for (peer, managed) in &self.peers {
+            let mut import = references(&managed.import_policy);
+            let mut export = references(&managed.export_policy);
+            let neighbor = candidate
+                .neighbors
+                .iter()
+                .find(|neighbor| {
+                    neighbor.address == peer.address.to_string()
+                        && neighbor.interface == peer.interface
+                })
+                .cloned()
+                .or_else(|| {
+                    managed
+                        .is_dynamic
+                        .then(|| Self::policy_resolution_neighbor(candidate, peer.address, managed))
+                });
+            if let Some(neighbor) = neighbor {
+                match candidate.effective_policy_for_neighbor(&neighbor, managed.rfc8212_external) {
+                    Ok(chains) => {
+                        import |= references(&chains.import);
+                        export |= references(&chains.export);
+                    }
+                    // Generation resolution already rejected oversized chains.
+                    // Other unresolved dynamic chains stay at their prior
+                    // value, so the old references above are the full union.
+                    Err(_) if managed.is_dynamic => {}
+                    Err(error) => return Err(format!("dataset dependent {peer}: {error}")),
+                }
+            }
+            if import || export {
+                if (import && managed.pending_refresh) || (export && managed.pending_export_apply) {
+                    return Err(format!(
+                        "dataset dependent {peer} has unsettled policy refresh work"
+                    ));
+                }
+                dependents.push(DatasetDependent {
+                    peer: peer.clone(),
+                    import,
+                    export,
+                });
+            }
+        }
+        dependents.sort_by(|left, right| left.peer.cmp(&right.peer));
+        let mut window = CleanStateQueryWindow::default();
+        for dependent in &dependents {
+            self.qualify_dataset_dependent(dependent, &mut window)
+                .await?;
+        }
+        Ok(dependents)
+    }
+
+    /// Returns whether the current session owes Established refresh work.
+    async fn qualify_dataset_dependent(
+        &mut self,
+        dependent: &DatasetDependent,
+        window: &mut CleanStateQueryWindow,
+    ) -> Result<bool, String> {
+        let peer = &dependent.peer;
+        let commands = self
+            .peers
+            .get(peer)
+            .ok_or_else(|| format!("dataset dependent {peer} is no longer managed"))?
+            .handle
+            .commands_sender();
+        match self.query_clean_session_state(commands, window).await {
+            StateQueryOutcome::State(state) if state.fsm_state == SessionState::Established => {
+                if dependent.import
+                    && !state
+                        .negotiated_session
+                        .is_some_and(|negotiated| negotiated.peer_route_refresh)
+                {
+                    return Err(format!(
+                        "dataset dependent {peer} has no Route Refresh capability"
+                    ));
+                }
+                Ok(true)
+            }
+            StateQueryOutcome::State(_) => {
+                // The existing RFC 8212 presence-change preflight uses the
+                // same RIB proof: actor-local emptiness alone misses GR/LLGR.
+                let retained = tokio::time::timeout(
+                    RIB_REPLY_TIMEOUT,
+                    self.query_peer_retained_stale(peer.address),
+                )
+                .await
+                .map_err(|_| format!("dataset dependent {peer} retained-route query timed out"))?
+                .map_err(|error| error.message)?;
+                if retained != 0 {
+                    return Err(format!(
+                        "dataset dependent {peer} retains {retained} stale routes"
+                    ));
+                }
+                Ok(false)
+            }
+            StateQueryOutcome::SessionGone => {
+                Err(format!("dataset dependent {peer} session is gone"))
+            }
+            StateQueryOutcome::TimedOut => {
+                Err(format!("dataset dependent {peer} state is unknown"))
+            }
+        }
+    }
+
+    /// The down-peer exception is only used for a singleton batch, so typed
+    /// `NotFound` proves that exact peer has no old outbound object to retain.
+    async fn reevaluate_dataset_exports(
+        &mut self,
+        peers: Vec<IpAddr>,
+        known_down: bool,
+    ) -> Result<(), DatasetRefreshFailure> {
+        if peers.is_empty() {
+            return Ok(());
+        }
+        let rib_tx = self.rib_tx.clone();
+        let permit = match tokio::time::timeout(RIB_REPLY_TIMEOUT, rib_tx.reserve()).await {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(_)) => {
+                return Err(DatasetRefreshFailure::Rejected(
+                    "dataset export RIB unavailable before dispatch".to_string(),
+                ));
+            }
+            Err(_) => {
+                return Err(DatasetRefreshFailure::Rejected(
+                    "dataset export RIB capacity deadline before dispatch".to_string(),
+                ));
+            }
+        };
+        let (reply, response) = oneshot::channel();
+        permit.send(RibUpdate::ReevaluatePeerExportPolicies { peers, reply });
+        match self
+            .await_with_readiness_budget(response, RIB_REPLY_TIMEOUT)
+            .await
+        {
+            Some(Ok(Ok(()))) => Ok(()),
+            Some(Ok(Err(RibCommandError::NotFound(_)))) if known_down => Ok(()),
+            Some(Ok(Err(error @ RibCommandError::NotFound(_)))) => Err(
+                DatasetRefreshFailure::Rejected(format!("dataset export re-evaluation: {error}")),
+            ),
+            Some(Ok(Err(error @ RibCommandError::Internal(_)))) => Err(
+                DatasetRefreshFailure::Ambiguous(format!("dataset export re-evaluation: {error}")),
+            ),
+            Some(Err(_)) => Err(DatasetRefreshFailure::Ambiguous(
+                "dataset export RIB dropped acknowledgement".to_string(),
+            )),
+            None => Err(DatasetRefreshFailure::Ambiguous(
+                "dataset export RIB acknowledgement timed out".to_string(),
+            )),
+        }
+    }
+
+    /// Local command settlement only: import acknowledgements do not prove
+    /// remote replay completion, and export acknowledgement is not wire receipt.
+    /// Required pending markers remain armed on any uncertain outcome.
+    pub(super) async fn refresh_dataset_generation_dependents(
+        &mut self,
+        dependents: &[DatasetDependent],
+    ) -> Result<(), DatasetRefreshFailure> {
+        // Publication (or restoration) has already happened. Record the
+        // refresh now owed before a state query itself can become ambiguous.
+        // The generation captured and rejected prior required debt first.
+        for dependent in dependents {
+            let managed = self.peers.get_mut(&dependent.peer).ok_or_else(|| {
+                DatasetRefreshFailure::Ambiguous(format!(
+                    "dataset dependent {} is no longer managed",
+                    dependent.peer
+                ))
+            })?;
+            managed.pending_refresh |= dependent.import;
+            managed.pending_export_apply |= dependent.export;
+        }
+        let mut window = CleanStateQueryWindow::default();
+        let mut established = Vec::with_capacity(dependents.len());
+        for dependent in dependents {
+            established.push(
+                self.qualify_dataset_dependent(dependent, &mut window)
+                    .await
+                    .map_err(DatasetRefreshFailure::Ambiguous)?,
+            );
+        }
+        let mut exports = Vec::new();
+        for (dependent, is_established) in dependents.iter().zip(&established) {
+            if dependent.export {
+                if *is_established {
+                    exports.push(dependent.peer.address);
+                } else {
+                    self.reevaluate_dataset_exports(vec![dependent.peer.address], true)
+                        .await?;
+                    // A missing outbound registration is safe only while this
+                    // exact managed session still positively reports down.
+                    if self
+                        .qualify_dataset_dependent(dependent, &mut window)
+                        .await
+                        .map_err(DatasetRefreshFailure::Ambiguous)?
+                    {
+                        return Err(DatasetRefreshFailure::Rejected(format!(
+                            "dataset dependent {} established during down-peer export settlement",
+                            dependent.peer
+                        )));
+                    }
+                }
+            }
+        }
+        self.reevaluate_dataset_exports(exports, false).await?;
+        for (dependent, is_established) in dependents.iter().zip(&established) {
+            if dependent.import
+                && *is_established
+                && let Err(failure) = self
+                    .soft_reset_in_reporting_delivery(dependent.peer.clone(), Vec::new())
+                    .await
+            {
+                let message = format!(
+                    "dataset import refresh {}: {}",
+                    dependent.peer, failure.error
+                );
+                return Err(if failure.acknowledgement_lost {
+                    DatasetRefreshFailure::Ambiguous(message)
+                } else {
+                    DatasetRefreshFailure::Rejected(message)
+                });
+            }
+        }
+        for (dependent, was_established) in dependents.iter().zip(&established) {
+            let now_established = self
+                .qualify_dataset_dependent(dependent, &mut window)
+                .await
+                .map_err(DatasetRefreshFailure::Ambiguous)?;
+            if !was_established && now_established {
+                return Err(DatasetRefreshFailure::Rejected(format!(
+                    "dataset dependent {} established during refresh settlement",
+                    dependent.peer
+                )));
+            }
+            let managed = self
+                .peers
+                .get_mut(&dependent.peer)
+                .expect("generation retains managed peer");
+            // Preflight proved these required directions carried no old debt.
+            // Clear them only after both local legs and final state settled.
+            if dependent.import {
+                managed.pending_refresh = false;
+            }
+            if dependent.export {
+                managed.pending_export_apply = false;
+            }
+        }
+        if !dependents.is_empty() {
+            let refreshed = established
+                .iter()
+                .filter(|established| **established)
+                .count();
+            info!(
+                eligible = dependents.len(),
+                refreshed,
+                skipped_not_established = dependents.len() - refreshed,
+                skipped_state_unknown = 0,
+                failures = 0,
+                "processed dataset-swap dependency-scoped refresh"
+            );
+        }
+        Ok(())
+    }
+
     /// Apply one peer's resolved chains, then re-read the ADR-0112 gauges off
     /// whatever ended up installed.
     ///
@@ -4222,7 +4522,7 @@ impl PeerManager {
         }
 
         let priors = match self
-            .apply_peer_reshape_snapshot_classified(targets, None)
+            .apply_peer_reshape_snapshot_classified(targets, None, &mut None)
             .await
         {
             PeerReshapeSnapshotOutcome::Success(priors) => priors,

--- a/src/peer_manager/tests/config_mutation.rs
+++ b/src/peer_manager/tests/config_mutation.rs
@@ -813,7 +813,7 @@ async fn reconfigure_peer_restores_previous_peer_when_replacement_add_fails() {
     candidate.policy.reject_retention.capacity += 1;
     mgr.current_config = candidate.clone();
     let outcome = mgr
-        .apply_peer_reshape_snapshot_classified(vec![replacement], Some(&prior_config))
+        .apply_peer_reshape_snapshot_classified(vec![replacement], Some(&prior_config), &mut None)
         .await;
     let crate::peer_manager::lifecycle::PeerReshapeSnapshotOutcome::FullyCompensated(error) =
         outcome

--- a/src/peer_manager/tests/metrics.rs
+++ b/src/peer_manager/tests/metrics.rs
@@ -1555,7 +1555,7 @@ fn policy_route_retirement_actor_fences_are_definitive_and_staged() {
     assert!(replace.contains("self.staged_policy_routes_prior = None"));
     assert!(!replace.contains("reap_retired_policy_routes"));
     let generation = arm(
-        "Some(InternalCommand::ApplyReloadGeneration { candidate, actions, reply }) => {",
+        "Some(InternalCommand::ApplyReloadGeneration { candidate, actions, datasets, reply }) => {",
         "Some(InternalCommand::ReplaceConfigSnapshot",
     );
     assert!(generation.contains("ReloadGenerationOutcome::Applied(_)"));

--- a/src/peer_manager/tests/policy.rs
+++ b/src/peer_manager/tests/policy.rs
@@ -2,6 +2,60 @@ use super::*;
 
 use rustbgpd_api::runtime_config_settlement::RuntimeConfigPolicyFailureCode;
 
+#[tokio::test]
+async fn dataset_refresh_distinguishes_partial_delivery_from_lost_acknowledgement() {
+    for (accepted_first, drop_reply, report_timeout) in [
+        (false, false, false),
+        (true, false, false),
+        (false, true, false),
+        (false, false, true),
+    ] {
+        let mut manager = test_peer_manager();
+        let peer: IpAddr = "10.0.0.9".parse().unwrap();
+        let (commands, mut receiver) = mpsc::channel(8);
+        let session = tokio::spawn(async move {
+            let mut calls = 0;
+            while let Some(command) = receiver.recv().await {
+                if let PeerCommand::SendRouteRefresh { reply, .. } = command {
+                    calls += 1;
+                    if accepted_first && calls == 1 {
+                        let _ = reply.send(Ok(()));
+                    } else if !drop_reply {
+                        let error = if report_timeout {
+                            rustbgpd_transport::PeerCommandError::TimedOut {
+                                operation: "route refresh",
+                                deadline: Duration::from_millis(1),
+                            }
+                        } else {
+                            rustbgpd_transport::PeerCommandError::RouteRefreshUnsupported
+                        };
+                        let _ = reply.send(Err(error));
+                    }
+                }
+            }
+            Ok(())
+        });
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            PeerHandle::from_parts(commands, session),
+            false,
+        );
+        let failure = manager
+            .soft_reset_in_reporting_delivery(
+                key(peer),
+                vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
+            )
+            .await
+            .expect_err("scripted refresh failure");
+        assert_eq!(failure.acknowledgement_lost, drop_reply || report_timeout);
+        assert_eq!(
+            failure.delivery_began,
+            accepted_first || drop_reply || report_timeout
+        );
+    }
+}
+
 async fn subscribe_policy_events(
     tx: &mpsc::Sender<PeerManagerCommand>,
 ) -> broadcast::Receiver<Arc<PolicyEvent>> {

--- a/src/peer_manager/tests/reload_generation.rs
+++ b/src/peer_manager/tests/reload_generation.rs
@@ -4,7 +4,9 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Weak;
 
-use crate::config::{ReloadPeerAction, ReloadPeerActionKind, plan_reload_peer_actions};
+use crate::config::{
+    PreparedDatasetGeneration, ReloadPeerAction, ReloadPeerActionKind, plan_reload_peer_actions,
+};
 use crate::peer_manager::generation::ReloadGenerationOutcome;
 use rustbgpd_policy::PolicyAction;
 
@@ -14,6 +16,12 @@ struct GenerationSessionCounters {
     import_installs: AtomicU32,
     export_installs: AtomicU32,
     runtime_config_updates: AtomicU32,
+    route_refreshes: AtomicU32,
+    refresh_failures: Mutex<std::collections::VecDeque<rustbgpd_transport::PeerCommandError>>,
+    states: Mutex<std::collections::VecDeque<SessionState>>,
+    no_route_refresh: AtomicBool,
+    state_queries: AtomicU32,
+    drop_state_after: AtomicU32,
     export_owners: Mutex<Vec<PolicyOwners>>,
 }
 
@@ -42,10 +50,34 @@ fn generation_session(addr: IpAddr) -> (PeerHandle, Arc<GenerationSessionCounter
                     let _ = reply.send(Ok(()));
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
-                    let _ = reply.send(Ok(()));
+                    in_task.route_refreshes.fetch_add(1, Ordering::SeqCst);
+                    let outcome = in_task
+                        .refresh_failures
+                        .lock()
+                        .unwrap()
+                        .pop_front()
+                        .map_or(Ok(()), Err);
+                    let _ = reply.send(outcome);
                 }
                 PeerCommand::QueryState { reply } => {
-                    let mut state = policy_test_peer_state(addr, SessionState::Established);
+                    let query = in_task.state_queries.fetch_add(1, Ordering::SeqCst) + 1;
+                    let drop_after = in_task.drop_state_after.load(Ordering::SeqCst);
+                    if drop_after != 0 && query >= drop_after {
+                        drop(reply);
+                        continue;
+                    }
+                    let fsm = {
+                        let mut states = in_task.states.lock().unwrap();
+                        if states.len() > 1 {
+                            states.pop_front().unwrap()
+                        } else {
+                            states.front().copied().unwrap_or(SessionState::Established)
+                        }
+                    };
+                    let mut state = policy_test_peer_state(addr, fsm);
+                    state.negotiated_session = Some(test_negotiated_session(
+                        !in_task.no_route_refresh.load(Ordering::SeqCst),
+                    ));
                     state.negotiated_hold_time = Some(90);
                     state.four_octet_as = Some(true);
                     let _ = reply.send(state);
@@ -72,7 +104,8 @@ fn spawn_generation_rib(
                 | RibUpdate::ReplacePeerExportPoliciesAuthoritatively { reply, .. } => {
                     let _ = reply.send(Ok(()));
                 }
-                RibUpdate::RefreshPeerOutbound { reply, .. } => {
+                RibUpdate::RefreshPeerOutbound { reply, .. }
+                | RibUpdate::ReevaluatePeerExportPolicies { reply, .. } => {
                     if !drop_refresh_reply {
                         let _ = reply.send(Ok(()));
                     }
@@ -200,7 +233,12 @@ impl GenerationHarness {
 
     async fn apply(&mut self, candidate: &Config) -> ReloadGenerationOutcome {
         let actions = plan_reload_peer_actions(&self.mgr.current_config, candidate).unwrap();
-        Box::pin(self.mgr.apply_reload_generation(candidate.clone(), actions)).await
+        Box::pin(self.mgr.apply_reload_generation(
+            candidate.clone(),
+            actions,
+            PreparedDatasetGeneration::default(),
+        ))
+        .await
     }
 
     async fn shutdown(mut self) {
@@ -682,11 +720,11 @@ async fn inconsistent_actions_reject_before_any_effect() {
         key: key("10.0.0.2".parse().unwrap()),
         kind: ReloadPeerActionKind::Add,
     }];
-    let outcome = Box::pin(
-        harness
-            .mgr
-            .apply_reload_generation(candidate.clone(), actions),
-    )
+    let outcome = Box::pin(harness.mgr.apply_reload_generation(
+        candidate.clone(),
+        actions,
+        PreparedDatasetGeneration::default(),
+    ))
     .await;
     assert!(
         matches!(outcome, ReloadGenerationOutcome::RejectedNoEffect(_)),
@@ -704,7 +742,12 @@ async fn inconsistent_actions_reject_before_any_effect() {
     orphaning
         .neighbors
         .retain(|neighbor| neighbor.address != "10.0.0.9");
-    let outcome = Box::pin(harness.mgr.apply_reload_generation(orphaning, actions)).await;
+    let outcome = Box::pin(harness.mgr.apply_reload_generation(
+        orphaning,
+        actions,
+        PreparedDatasetGeneration::default(),
+    ))
+    .await;
     assert!(
         matches!(outcome, ReloadGenerationOutcome::RejectedNoEffect(_)),
         "{outcome:?}"
@@ -1106,4 +1149,659 @@ async fn assert_owned_sighup_lifetimes(compensate: bool) {
     persister.await.unwrap();
     harness.rib.abort();
     let _ = harness.rib.await;
+}
+
+/// The same bound handle feeds import, export, and the retained rollback pin.
+fn dataset_generation_fixture() -> RsFixture {
+    let fixture = RsFixture::new();
+    std::fs::write(fixture.dir.path().join("members.list"), "64500\n").unwrap();
+    std::fs::write(
+        fixture.dir.path().join("members.rpol"),
+        r"
+dataset asn-set members
+policy members-out {
+    term allowed { if route.origin-as in members { accept } }
+    term rest { reject }
+}",
+    )
+    .unwrap();
+    fixture.write_toml(
+        &fixture
+            .base_toml()
+            .replace(
+                "[peer_groups.members]",
+                "[policy.datasets.members]\npath = \"members.list\"\n\n[peer_groups.members]",
+            )
+            .replace(
+                "max_prefixes = 1000",
+                "max_prefixes = 1000\nimport_policy_chain = [\"members-out\"]",
+            ),
+    );
+    fixture
+}
+
+fn prepare_dataset_candidate(
+    fixture: &RsFixture,
+    prior: &Config,
+) -> (Config, crate::config::PreparedDatasetGeneration) {
+    std::fs::write(fixture.dir.path().join("members.list"), "64500\n64999\n").unwrap();
+    let mut candidate = Config::load_with_diagnostics_and_staged_datasets(
+        fixture.config_path.to_str().unwrap(),
+        &prior.policy.dataset_bindings,
+    )
+    .unwrap();
+    let staged = candidate.prepare_staged_datasets(&prior.policy.dataset_bindings);
+    let prepared = staged.prepare_generation(prior, &candidate).unwrap();
+    (candidate, prepared)
+}
+
+#[tokio::test]
+async fn dataset_generation_refreshes_without_reinstalling_equal_chains() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    let old = live.pin();
+    let mut harness = GenerationHarness::new(&prior);
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::Applied(_)),
+        "{outcome:?}"
+    );
+    assert_eq!(live.pin().generation, 2);
+    assert_eq!(live.pin().data.records(), 2);
+    assert_eq!(
+        Arc::strong_count(&old),
+        1,
+        "generation released its old snapshot pin"
+    );
+    for counters in harness.counters.values() {
+        assert_eq!(counters.import_installs.load(Ordering::SeqCst), 0);
+        assert_eq!(counters.export_installs.load(Ordering::SeqCst), 0);
+    }
+    assert!(
+        harness.counters[&"10.0.0.2".parse::<IpAddr>().unwrap()]
+            .route_refreshes
+            .load(Ordering::SeqCst)
+            > 0
+    );
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dataset_generation_known_refresh_rejection_restores_contents_and_prior_error() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    live.record_error("prior loader failure".to_string());
+    let mut harness = GenerationHarness::new(&prior);
+    harness.counters[&"10.0.0.2".parse::<IpAddr>().unwrap()]
+        .refresh_failures
+        .lock()
+        .unwrap()
+        .push_back(rustbgpd_transport::PeerCommandError::SendFailed(
+            "injected writer rejection".to_string(),
+        ));
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    std::fs::write(
+        fixture.dir.path().join("members.list"),
+        "invalid file after preparation",
+    )
+    .unwrap();
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::FullyCompensated(_)),
+        "{outcome:?}"
+    );
+    assert_eq!(live.pin().generation, 3);
+    assert_eq!(live.pin().data.records(), 1);
+    assert_eq!(
+        live.status().last_error.as_deref(),
+        Some("prior loader failure")
+    );
+    // The forward pass stopped at the first import failure. Compensation
+    // still refreshes the second peer from the complete captured union.
+    assert!(
+        harness.counters[&"2001:db8::3".parse::<IpAddr>().unwrap()]
+            .route_refreshes
+            .load(Ordering::SeqCst)
+            > 0
+    );
+    for managed in harness.mgr.peers.values() {
+        assert!(!managed.pending_refresh);
+        assert!(!managed.pending_export_apply);
+    }
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dataset_generation_lost_import_ack_fences_with_required_debt() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    let reader = live.pin();
+    let old_snapshot = Arc::downgrade(&reader);
+    let mut harness = GenerationHarness::new(&prior);
+    let peer = key("10.0.0.2".parse().unwrap());
+    harness.counters[&peer.address]
+        .refresh_failures
+        .lock()
+        .unwrap()
+        .push_back(rustbgpd_transport::PeerCommandError::ReplyDropped);
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::CompensationAmbiguous(_)),
+        "{outcome:?}"
+    );
+    assert_eq!(live.pin().generation, 2);
+    assert!(harness.mgr.peers[&peer].pending_refresh);
+    assert_eq!(reader.generation, 1);
+    assert_eq!(
+        reader.data.records(),
+        1,
+        "an evaluator keeps its own old view"
+    );
+    assert_eq!(
+        Arc::strong_count(&reader),
+        1,
+        "terminal recovery outcome releases the operation pin"
+    );
+    drop(reader);
+    assert!(
+        old_snapshot.upgrade().is_none(),
+        "no later compensation consumer retains the old snapshot"
+    );
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dataset_generation_clean_down_peer_does_not_block_content_refresh() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let mut harness = GenerationHarness::new(&prior);
+    let addr = "10.0.0.2".parse::<IpAddr>().unwrap();
+    harness.counters[&addr]
+        .states
+        .lock()
+        .unwrap()
+        .push_back(SessionState::Idle);
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::Applied(_)),
+        "{outcome:?}"
+    );
+    assert_eq!(
+        harness.counters[&addr]
+            .route_refreshes
+            .load(Ordering::SeqCst),
+        0
+    );
+    assert!(!harness.mgr.peers[&key(addr)].pending_refresh);
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dataset_generation_down_to_established_race_requires_restoring_refresh() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    let mut harness = GenerationHarness::new(&prior);
+    let addr = "10.0.0.2".parse::<IpAddr>().unwrap();
+    harness.counters[&addr].states.lock().unwrap().extend([
+        SessionState::Idle,
+        SessionState::Idle,
+        SessionState::Established,
+    ]);
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::FullyCompensated(_)),
+        "{outcome:?}"
+    );
+    assert_eq!(live.pin().generation, 3);
+    assert!(
+        harness.counters[&addr]
+            .route_refreshes
+            .load(Ordering::SeqCst)
+            > 0
+    );
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dataset_generation_preflight_rejects_missing_capability_and_existing_debt() {
+    for no_capability in [true, false] {
+        let fixture = dataset_generation_fixture();
+        let prior = fixture.load();
+        let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+        let mut harness = GenerationHarness::new(&prior);
+        let peer = key("10.0.0.2".parse().unwrap());
+        if no_capability {
+            harness.counters[&peer.address]
+                .no_route_refresh
+                .store(true, Ordering::SeqCst);
+        } else {
+            harness.mgr.peers.get_mut(&peer).unwrap().pending_refresh = true;
+        }
+        let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+        let outcome = Box::pin(harness.mgr.apply_reload_generation(
+            candidate,
+            Vec::new(),
+            prepared,
+        ))
+        .await;
+        assert!(
+            matches!(outcome, ReloadGenerationOutcome::RejectedNoEffect(_)),
+            "{outcome:?}"
+        );
+        assert_eq!(live.pin().generation, 1);
+        assert_eq!(
+            harness.counters[&peer.address]
+                .route_refreshes
+                .load(Ordering::SeqCst),
+            0
+        );
+        harness.shutdown().await;
+    }
+}
+
+type DatasetExportBatches = Arc<Mutex<Vec<Vec<IpAddr>>>>;
+
+/// Intercept only dataset commands; all policy-generation commands still use
+/// the existing generation RIB stub and its ownership receipts.
+fn intercept_dataset_rib(
+    harness: &mut GenerationHarness,
+    retained: usize,
+    missing: Option<IpAddr>,
+) -> (DatasetExportBatches, tokio::task::JoinHandle<()>) {
+    let (tx, mut rx) = mpsc::channel::<RibUpdate>(64);
+    let downstream = std::mem::replace(&mut harness.mgr.rib_tx, tx);
+    let exports = Arc::new(Mutex::new(Vec::new()));
+    let recorded = Arc::clone(&exports);
+    let task = tokio::spawn(async move {
+        while let Some(command) = rx.recv().await {
+            match command {
+                RibUpdate::QueryPeerRetainedStale { reply, .. } => {
+                    let _ = reply.send(retained);
+                }
+                RibUpdate::ReevaluatePeerExportPolicies { peers, reply } => {
+                    recorded.lock().unwrap().push(peers.clone());
+                    let outcome = if missing.is_some_and(|peer| peers.contains(&peer)) {
+                        Err(rustbgpd_rib::RibCommandError::not_found(
+                            "missing outbound registration",
+                        ))
+                    } else {
+                        Ok(())
+                    };
+                    let _ = reply.send(outcome);
+                }
+                other => {
+                    if downstream.send(other).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+    (exports, task)
+}
+
+#[tokio::test]
+async fn dataset_generation_clean_down_missing_export_is_vacuous_only_for_that_peer() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let mut harness = GenerationHarness::new(&prior);
+    let down = "10.0.0.2".parse::<IpAddr>().unwrap();
+    harness.counters[&down]
+        .states
+        .lock()
+        .unwrap()
+        .push_back(SessionState::Idle);
+    let (exports, relay) = intercept_dataset_rib(&mut harness, 0, Some(down));
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::Applied(_)),
+        "{outcome:?}"
+    );
+    let calls = exports.lock().unwrap().clone();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0], vec![down]);
+    assert_eq!(calls[1].len(), 2, "Established dependents remain one batch");
+    assert!(!calls[1].contains(&down));
+    harness.shutdown().await;
+    relay.await.unwrap();
+}
+
+#[tokio::test]
+async fn dataset_generation_down_peer_with_gr_retention_rejects_before_publication() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    let mut harness = GenerationHarness::new(&prior);
+    let down = "10.0.0.2".parse::<IpAddr>().unwrap();
+    harness.counters[&down]
+        .states
+        .lock()
+        .unwrap()
+        .push_back(SessionState::Idle);
+    let (exports, relay) = intercept_dataset_rib(&mut harness, 3, None);
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    let ReloadGenerationOutcome::RejectedNoEffect(error) = outcome else {
+        panic!("{outcome:?}")
+    };
+    assert!(error.contains("retains 3 stale routes"), "{error}");
+    assert_eq!(live.pin().generation, 1);
+    assert!(exports.lock().unwrap().is_empty());
+    harness.shutdown().await;
+    relay.await.unwrap();
+}
+
+#[tokio::test]
+async fn dataset_generation_lost_export_ack_fences_before_import_refresh() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let mut harness = GenerationHarness::new(&prior);
+    let (tx, rib) = spawn_generation_rib(true);
+    harness.mgr.rib_tx = tx;
+    harness.rib.abort();
+    harness.rib = rib;
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::CompensationAmbiguous(_)),
+        "{outcome:?}"
+    );
+    for counters in harness.counters.values() {
+        assert_eq!(counters.route_refreshes.load(Ordering::SeqCst), 0);
+    }
+    assert!(
+        harness
+            .mgr
+            .peers
+            .values()
+            .all(|managed| managed.pending_export_apply)
+    );
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dataset_generation_late_reshape_compensates_fresh_clean_down_session() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    let mut harness = GenerationHarness::new(&prior);
+    let prior_session = harness.session_id("10.0.0.2");
+    harness.mgr.dataset_generations_at_peer_construction = Some(Vec::new());
+    let (mut candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    candidate.peer_groups.get_mut("members").unwrap().hold_time = Some(60);
+    harness
+        .mgr
+        .inject_reconfigure_failures
+        .insert(key("2001:db8::3".parse().unwrap()), 0);
+    let actions = plan_reload_peer_actions(&prior, &candidate).unwrap();
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, actions, prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::FullyCompensated(_)),
+        "{outcome:?}"
+    );
+    assert_eq!(live.pin().generation, 3);
+    assert_eq!(
+        harness
+            .mgr
+            .dataset_generations_at_peer_construction
+            .as_ref()
+            .unwrap(),
+        &vec![
+            (key("10.0.0.2".parse().unwrap()), "members".to_string(), 2),
+            (key("10.0.0.2".parse().unwrap()), "members".to_string(), 3),
+        ],
+        "the inner prior-session construction must see restored contents"
+    );
+    assert_eq!(live.pin().data.records(), 1);
+    assert_ne!(
+        harness.session_id("10.0.0.2"),
+        prior_session,
+        "compensation recreated the first member"
+    );
+    assert_eq!(harness.mgr.current_config, prior);
+    assert!(!harness.mgr.peers[&key("10.0.0.2".parse().unwrap())].pending_refresh);
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dataset_generation_unknown_state_rejects_before_publish_and_fences_after() {
+    for drop_after in [1, 2] {
+        let fixture = dataset_generation_fixture();
+        let prior = fixture.load();
+        let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+        let mut harness = GenerationHarness::new(&prior);
+        let addr = "10.0.0.2".parse::<IpAddr>().unwrap();
+        harness.counters[&addr]
+            .drop_state_after
+            .store(drop_after, Ordering::SeqCst);
+        let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+        let outcome = Box::pin(harness.mgr.apply_reload_generation(
+            candidate,
+            Vec::new(),
+            prepared,
+        ))
+        .await;
+        if drop_after == 1 {
+            assert!(
+                matches!(outcome, ReloadGenerationOutcome::RejectedNoEffect(_)),
+                "{outcome:?}"
+            );
+            assert_eq!(live.pin().generation, 1);
+        } else {
+            assert!(
+                matches!(outcome, ReloadGenerationOutcome::CompensationAmbiguous(_)),
+                "{outcome:?}"
+            );
+            assert_eq!(live.pin().generation, 2);
+            assert!(harness.mgr.peers[&key(addr)].pending_refresh);
+            assert!(harness.mgr.peers[&key(addr)].pending_export_apply);
+        }
+        assert_eq!(
+            harness.counters[&addr]
+                .route_refreshes
+                .load(Ordering::SeqCst),
+            0
+        );
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn dataset_generation_restores_old_only_dependency_after_chain_change() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    let mut harness = GenerationHarness::new(&prior);
+    let (exports, relay) = intercept_dataset_rib(&mut harness, 0, None);
+    // The declaration and binding stay, but no candidate chain references it.
+    std::fs::write(
+        fixture.dir.path().join("members.rpol"),
+        "dataset asn-set members\npolicy members-out { term all { accept } }",
+    )
+    .unwrap();
+    let (mut candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    candidate.peer_groups.get_mut("members").unwrap().hold_time = Some(60);
+    harness
+        .mgr
+        .inject_reconfigure_failures
+        .insert(key("2001:db8::3".parse().unwrap()), 0);
+    let actions = plan_reload_peer_actions(&prior, &candidate).unwrap();
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, actions, prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::FullyCompensated(_)),
+        "{outcome:?}"
+    );
+    assert_eq!(live.pin().generation, 3);
+    let bystander = "10.0.0.9".parse::<IpAddr>().unwrap();
+    assert_eq!(
+        exports
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|peers| peers.contains(&bystander))
+            .count(),
+        2,
+        "the old-only export dependency is refreshed both forward and during restoration"
+    );
+    assert!(
+        harness.mgr.peers[&key(bystander)]
+            .export_policy
+            .as_ref()
+            .unwrap()
+            .references_dataset("members")
+    );
+    harness.shutdown().await;
+    relay.await.unwrap();
+}
+
+#[tokio::test]
+async fn dataset_generation_refreshes_candidate_only_dependencies() {
+    let fixture = dataset_generation_fixture();
+    let rpol_path = fixture.dir.path().join("members.rpol");
+    let referencing_policy = std::fs::read_to_string(&rpol_path).unwrap();
+    std::fs::write(
+        &rpol_path,
+        "dataset asn-set members\npolicy members-out { term all { accept } }",
+    )
+    .unwrap();
+    let prior = fixture.load();
+    let mut harness = GenerationHarness::new(&prior);
+    let (exports, relay) = intercept_dataset_rib(&mut harness, 0, None);
+    std::fs::write(&rpol_path, referencing_policy).unwrap();
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let outcome = Box::pin(
+        harness
+            .mgr
+            .apply_reload_generation(candidate, Vec::new(), prepared),
+    )
+    .await;
+    assert!(
+        matches!(outcome, ReloadGenerationOutcome::Applied(_)),
+        "{outcome:?}"
+    );
+    let calls = exports.lock().unwrap().clone();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0].len(),
+        3,
+        "all candidate-only export dependencies are recomputed"
+    );
+    for managed in harness.mgr.peers.values() {
+        assert!(!managed.pending_refresh);
+        assert!(!managed.pending_export_apply);
+    }
+    harness.shutdown().await;
+    relay.await.unwrap();
+}
+
+#[tokio::test]
+async fn dataset_generation_single_replacement_failure_restores_data_before_construction() {
+    let fixture = dataset_generation_fixture();
+    let prior = fixture.load();
+    let live = Arc::clone(prior.policy.dataset_bindings.get("members").unwrap());
+    let mut harness = GenerationHarness::new(&prior);
+    let addr: IpAddr = "fe80::1".parse().unwrap();
+    let interface = "rustbgpd-test-missing0";
+    let peer = scoped_key(addr, interface);
+    let mut original = make_config(addr, 65002);
+    original.interface = Some(interface.to_string());
+    original.scope_id = Some(42);
+    original.import_policy = harness.mgr.peers[&key("10.0.0.2".parse().unwrap())]
+        .import_policy
+        .clone();
+    harness.mgr.add_peer(original, false).await.unwrap();
+    harness.mgr.disable_peer(peer.clone(), None).await.unwrap();
+    let (candidate, prepared) = prepare_dataset_candidate(&fixture, &prior);
+    let mut dataset_prior = Some(prepared.publish());
+    harness.mgr.current_config = candidate;
+    harness.mgr.dataset_generations_at_peer_construction = Some(Vec::new());
+    let mut replacement = make_config(addr, 65002);
+    replacement.interface = Some(interface.to_string());
+    // Omitting the saved scope ID makes add fail after the old peer was
+    // deleted: this synthetic interface cannot resolve through the OS.
+    let outcome = harness
+        .mgr
+        .apply_peer_reshape_snapshot_classified(vec![replacement], Some(&prior), &mut dataset_prior)
+        .await;
+    assert!(
+        matches!(
+            outcome,
+            crate::peer_manager::lifecycle::PeerReshapeSnapshotOutcome::FullyCompensated(_)
+        ),
+        "replacement add failure must restore the prior peer"
+    );
+    assert!(
+        dataset_prior.is_none(),
+        "inner recovery consumed the receipt exactly once"
+    );
+    assert_eq!(live.pin().generation, 3);
+    assert_eq!(
+        harness
+            .mgr
+            .dataset_generations_at_peer_construction
+            .as_ref()
+            .unwrap(),
+        &vec![(peer, "members".to_string(), 3)],
+        "the restoring session is constructed only after old data is published"
+    );
+    harness.shutdown().await;
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -2263,7 +2263,9 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // credential, listener, session, or catalog effect.
     let route = config::classify_sighup_reload(config::SighupReloadFamilies {
         generation: !neighbors_unchanged || !peer_groups_unchanged || policy_generation_changed,
-        datasets: dataset_commit_pending || policy_diff.datasets_changed || dataset_events_pending,
+        datasets: dataset_commit_pending || dataset_events_pending,
+        dataset_bindings: policy_diff.datasets_changed
+            || current.policy.dataset_bindings != new_config.policy.dataset_bindings,
         dynamic_ranges: dynamic_neighbors_changed,
         evpn_runtime: evpn_runtime_pending,
         fib_tables: fib_tables_changed,
@@ -2294,8 +2296,11 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 Ok(actions) => actions,
                 Err(error) => return clean_reload_failure("generation.plan", error.to_string()),
             };
-            drop(dataset_commit);
-            return reload_generation_route(
+            let datasets = match dataset_commit.prepare_generation(current, &new_config) {
+                Ok(datasets) => datasets,
+                Err(error) => return clean_reload_failure("generation.datasets", error),
+            };
+            return Box::pin(reload_generation_route(
                 &mut progress,
                 current,
                 new_config,
@@ -2305,7 +2310,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 rib_tx,
                 tcp_ao_listener.zip(listener_replacement),
                 actions,
-            )
+                datasets,
+            ))
             .await;
         }
         config::SighupReloadRoute::Sequential { reasons } if !reasons.is_empty() => {
@@ -3952,6 +3958,7 @@ async fn reload_generation_route(
         ),
     )>,
     actions: Vec<config::ReloadPeerAction>,
+    datasets: config::PreparedDatasetGeneration,
 ) -> SighupReloadOutcome {
     let Some(peer_mgr_internal_tx) = peer_mgr_internal_tx else {
         return generation_step_rejected(
@@ -4034,6 +4041,7 @@ async fn reload_generation_route(
     permit.send(InternalCommand::ApplyReloadGeneration {
         candidate: Box::new(new_config.clone()),
         actions,
+        datasets,
         reply: reply_tx,
     });
     // The session-table acknowledgement fault keeps its `reconcile` name on
@@ -6826,6 +6834,7 @@ hold_time = 90
                 let InternalCommand::ApplyReloadGeneration {
                     candidate,
                     actions,
+                    datasets,
                     reply,
                 } = command
                 else {
@@ -6836,6 +6845,7 @@ hold_time = 90
                 };
                 let outcome = match script.pop_front().unwrap_or(GenerationReply::Applied) {
                     GenerationReply::Applied => {
+                        drop(datasets.publish());
                         Some(ReloadGenerationOutcome::Applied(ReloadGenerationReceipt {
                             policy_updated: 0,
                             hot_updated: count(config::ReloadPeerActionKind::HotUpdate),
@@ -7143,11 +7153,14 @@ metric = 200
         std::fs::remove_file(&path).ok();
     }
 
-    /// The dataset seam: changed dataset content or bindings together with
-    /// a neighbor edit is rejected at preflight, and the staged dataset
-    /// content is dropped without touching the live handle.
+    /// Content and neighbor changes share a generation; binding changes and
+    /// malformed inputs reject before touching the live dataset handle.
     #[tokio::test]
-    async fn reload_rejects_dataset_and_neighbor_compound_without_committing_staged_datasets() {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one file-backed fixture compares content, binding, and invalid-input candidates through the same reload caller"
+    )]
+    async fn reload_dataset_neighbor_generation_rejects_only_binding_changes() {
         let initial_toml = r#"
 [global]
 asn = 65001
@@ -7164,31 +7177,35 @@ address = "192.0.2.1"
 remote_asn = 65002
 import_policy_chain = ["origin-guard"]
 "#;
-        let dir = dataset_reload_dir(initial_toml, "64500\n");
-        let config_path = dir.path().join("config.toml");
-        let initial = Config::load_with_diagnostics(config_path.to_str().unwrap()).unwrap();
-        let live = std::sync::Arc::clone(initial.policy.dataset_bindings.get("customers").unwrap());
-        assert_eq!(live.pin().generation, 1);
-
-        let member_add = "\n[[neighbors]]\naddress = \"192.0.2.99\"\nremote_asn = 65099\n";
-        // Content change on the same binding, and a binding path change.
-        std::fs::write(dir.path().join("datasets/customers.list"), "64500\n64999\n").unwrap();
-        std::fs::write(
-            dir.path().join("datasets/customers-next.list"),
-            "64500\n64999\n",
-        )
-        .unwrap();
-        for (variant, desired_toml) in [
-            ("content", format!("{initial_toml}{member_add}")),
-            (
-                "binding",
-                format!(
-                    "{}{member_add}",
-                    initial_toml.replace("datasets/customers.list", "datasets/customers-next.list")
-                ),
-            ),
-        ] {
-            write_tier_test_config(&config_path, &desired_toml);
+        for variant in ["content", "binding", "malformed"] {
+            let dir = dataset_reload_dir(initial_toml, "64500\n");
+            let config_path = dir.path().join("config.toml");
+            let initial = Config::load_with_diagnostics(config_path.to_str().unwrap()).unwrap();
+            let live =
+                std::sync::Arc::clone(initial.policy.dataset_bindings.get("customers").unwrap());
+            let accepted = AcceptedConfigSnapshot::load(&config_path, None).unwrap();
+            std::fs::write(dir.path().join("datasets/customers.list"), "64500\n64999\n").unwrap();
+            std::fs::write(
+                dir.path().join("datasets/customers-next.list"),
+                "64500\n64999\n",
+            )
+            .unwrap();
+            if variant == "malformed" {
+                std::fs::write(
+                    dir.path().join("datasets/customers.list"),
+                    "invalid ASN input",
+                )
+                .unwrap();
+            }
+            let source = if variant == "binding" {
+                initial_toml.replace("datasets/customers.list", "datasets/customers-next.list")
+            } else {
+                initial_toml.to_string()
+            };
+            write_tier_test_config(
+                &config_path,
+                &format!("{source}\n[[neighbors]]\naddress = \"192.0.2.99\"\nremote_asn = 65099\n"),
+            );
             let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(8);
             let mock = tokio::spawn(async move {
                 let mut tags = Vec::new();
@@ -7198,44 +7215,68 @@ import_policy_chain = ["origin-guard"]
                 tags
             });
             let (internal_tx, generation) = spawn_generation_mock(Vec::new(), None);
-            let outcome = reload_config_generation(
-                config_path.to_str().unwrap(),
-                &initial,
+            let desired = Arc::new(
+                AcceptedConfigSnapshot::load_for_reload(
+                    &config_path,
+                    &accepted,
+                    &initial.policy.dataset_bindings,
+                )
+                .unwrap(),
+            );
+            let outcome = reload_config_with_tcp_ao(
+                SighupReloadPlan {
+                    baseline_runtime: initial.clone(),
+                    desired,
+                },
                 initial.global.telemetry.grpc_tcp.as_ref(),
                 initial.global.telemetry.grpc_uds.as_ref(),
                 &peer_mgr_tx,
-                &internal_tx,
+                Some(&internal_tx),
+                None,
+                None,
+                None,
                 None,
                 None,
             )
             .await;
             drop(peer_mgr_tx);
             drop(internal_tx);
-            let SighupReloadOutcome::CleanNoEffect(SighupReloadError::Failed(failure)) = &outcome
-            else {
-                panic!("{variant}: expected a clean preflight rejection");
-            };
-            assert_eq!(failure.bucket, "reload.preflight", "{variant}");
-            assert!(
-                failure.error.to_string().contains("[policy.datasets]"),
-                "{variant}: {}",
-                failure.error
-            );
-            assert!(mock.await.unwrap().is_empty(), "{variant}");
-            assert!(generation.await.unwrap().is_empty(), "{variant}");
-            assert_eq!(
-                live.pin().generation,
-                1,
-                "{variant}: staged content never committed"
-            );
-            assert_eq!(live.pin().data.records(), 1, "{variant}");
+            assert!(mock.await.unwrap().is_empty());
+            let calls = generation.await.unwrap();
+            if variant == "content" {
+                outcome.expect("content plus neighbor changes use the generation");
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].actions.len(), 1);
+                assert_eq!(calls[0].actions[0].kind, config::ReloadPeerActionKind::Add);
+                assert_eq!(live.pin().generation, 2);
+                assert_eq!(live.pin().data.records(), 2);
+            } else {
+                let SighupReloadOutcome::CleanNoEffect(SighupReloadError::Failed(failure)) =
+                    &outcome
+                else {
+                    panic!("expected clean binding rejection: {outcome:?}")
+                };
+                let expected_bucket = if variant == "binding" {
+                    "reload.preflight"
+                } else {
+                    "generation.datasets"
+                };
+                assert_eq!(failure.bucket, expected_bucket);
+                assert_eq!(
+                    live.status().last_error,
+                    None,
+                    "preflight rejection preserves live status"
+                );
+                assert!(calls.is_empty());
+                assert_eq!(live.pin().generation, 1);
+                assert_eq!(live.pin().data.records(), 1);
+            }
         }
     }
 
-    /// A dataset-only refresh keeps its sequential route with unchanged
-    /// datasets present, an `.rpol`-only edit with unchanged datasets
-    /// takes the generation route, and an `.rpol` edit with changed
-    /// dataset content is the rejected compound.
+    /// Dataset content changes, `.rpol` edits, and their combination use the
+    /// generation route. Binding changes and invalid datasets are rejected
+    /// separately before live effects.
     #[tokio::test]
     async fn reload_routes_rpol_edits_by_dataset_content_identity() {
         let initial_toml = r#"
@@ -7309,26 +7350,33 @@ import_policy_chain = ["origin-guard"]
             "policy movement is not a session action"
         );
 
-        // rpol plus dataset content: rejected compound.
-        std::fs::write(&rpol_path, edited_rpol.replace("med 5", "med 6")).unwrap();
+        // rpol plus dataset content also uses the generation.
+        let compound_rpol = edited_rpol.replace("med 5", "med 6");
+        std::fs::write(&rpol_path, &compound_rpol).unwrap();
         std::fs::write(dir.path().join("datasets/customers.list"), "64500\n64999\n").unwrap();
         let (outcome, tags, calls) = run(&adopted.runtime).await;
-        assert!(
-            matches!(
-                &outcome,
-                SighupReloadOutcome::CleanNoEffect(SighupReloadError::Failed(failure))
-                    if failure.bucket == "reload.preflight"
-            ),
-            "{outcome:?}"
-        );
-        assert!(tags.is_empty() && calls.is_empty(), "{tags:?}");
+        let compound = outcome.expect("rpol and dataset contents settle together");
+        assert!(tags.is_empty());
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].actions.is_empty());
 
-        // dataset-only: sequential, as before.
-        std::fs::write(&rpol_path, &edited_rpol).unwrap();
-        let (outcome, tags, calls) = run(&adopted.runtime).await;
-        outcome.expect("dataset-only refresh keeps its sequential route");
-        assert_eq!(tags, vec!["RefreshDatasetDependents".to_string()]);
-        assert!(calls.is_empty());
+        // Dataset-only changes keep the same owned publication route.
+        std::fs::write(dir.path().join("datasets/customers.list"), "64500\n65000\n").unwrap();
+        let (outcome, tags, calls) = run(&compound.runtime).await;
+        let dataset = outcome.expect("dataset-only refresh uses the generation route");
+        assert!(tags.is_empty());
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].actions.is_empty());
+        assert_eq!(
+            dataset
+                .policy
+                .dataset_bindings
+                .get("customers")
+                .unwrap()
+                .pin()
+                .generation,
+            3
+        );
     }
 
     /// Listener inbound authentication rides on neighbor records, so a
@@ -9510,7 +9558,7 @@ local_vtep_ip = "10.0.0.1"
     }
 
     #[tokio::test]
-    async fn reload_content_only_dataset_swap_refreshes_dependents_before_return() {
+    async fn reload_content_only_dataset_swap_dispatches_owned_generation() {
         let config_toml = r#"
 [global]
 asn = 65001
@@ -9532,29 +9580,16 @@ import_policy_chain = ["origin-guard"]
         let initial = Config::load_with_diagnostics(config_path.to_str().unwrap()).unwrap();
         let live = std::sync::Arc::clone(initial.policy.dataset_bindings.get("customers").unwrap());
         std::fs::write(dir.path().join("datasets/customers.list"), "64500\n64999\n").unwrap();
-        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(4);
-        let refresh = tokio::spawn(async move {
-            let command = peer_mgr_rx.recv().await.expect("dataset refresh command");
-            match command {
-                PeerManagerCommand::RefreshDatasetDependents {
-                    swapped,
-                    failed,
-                    reply,
-                } => {
-                    assert_eq!(swapped, vec!["customers"]);
-                    assert!(failed.is_empty());
-                    let _ = reply.send(Ok(()));
-                }
-                other => panic!("expected dataset refresh, got {}", cmd_tag(&other)),
-            }
-        });
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(4);
+        let (internal_tx, generation) = spawn_generation_mock(Vec::new(), None);
 
-        let returned = reload_config(
+        let returned = reload_config_generation(
             config_path.to_str().unwrap(),
             &initial,
             initial.global.telemetry.grpc_tcp.as_ref(),
             initial.global.telemetry.grpc_uds.as_ref(),
             &peer_mgr_tx,
+            &internal_tx,
             None,
             None,
         )
@@ -9562,7 +9597,10 @@ import_policy_chain = ["origin-guard"]
         .expect("content-only dataset reload succeeds");
         assert_tier_authorized_test_config(&returned);
         assert_tier_authorized_test_config(&returned.desired);
-        refresh.await.unwrap();
+        drop(internal_tx);
+        let calls = generation.await.unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].actions.is_empty());
 
         assert_eq!(live.pin().generation, 2);
         assert_eq!(live.pin().data.records(), 2);


### PR DESCRIPTION
SIGHUP now includes dataset content changes in the compensated runtime generation when dataset names, kinds, file mappings, and live handles remain unchanged. The daemon validates staged inputs before effects, retains prior snapshots and loader errors, publishes after policy settlement, and refreshes the union of old and candidate dependents. A later failure restores contents at a new generation (`g → g + 1 → g + 2`) before restoring sessions and policies. Lost acknowledgements, unknown state, or unresolved required refresh work fence the controller.

Binding changes and dataset changes combined with listener authentication or TCP-AO changes reject before effects. Refresh acknowledgement establishes local dispatch; it does not establish remote replay completion or atomic visibility across datasets or sessions.

Validation:

- Focused tests cover publication and error restoration, generation headroom, dependency changes, retained routes, acknowledgement ambiguity, and restoration before replacement-session construction.
- A local five-peer dual-stack wire probe passed dataset/RPOL/two-member reload, injected second-member failure with compensation, and unchanged-candidate retry. It checked advertisements, communities, effective configuration, dataset generations, and stable bystander sessions. The one-shot injection is available only in debug builds.
- Local baseline: tooling, links and contracts passed in the initial gate; after scoped lint corrections, strict workspace Clippy, `cargo test --locked --workspace` (9,224 passed; 16 ignored), and all `just docs` commands passed. `just gate-rib` also passed.

This delivers the dataset content generation implementation and bounded local wire proof. Compensation peak-memory and repeated-cycle retention measurements at the named IRR shape remain separate work; these probes do not establish production-scale resource bounds.
