### PR TITLE
docs(config): align sighup architecture with reload routes

### DIFF
--- a/.github/workflows/public-docs-contract.yml
+++ b/.github/workflows/public-docs-contract.yml
@@ -58,6 +58,11 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_site_manifest.py
           python3 scripts/check_site_manifest.py
+      - name: Check SIGHUP architecture route coverage
+        if: matrix.contract == 'public'
+        run: |
+          python3 -m unittest -v scripts/test_check_sighup_architecture.py
+          python3 scripts/check_sighup_architecture.py
       - name: Check IXP Manager docs against the pinned contract
         if: matrix.contract == 'public'
         run: |

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -299,40 +299,32 @@ of taking its default process action. The ordering is a contract, asserted by
 
 ### Config Reload (SIGHUP)
 
-1. Signal handler sets a reload flag in the main `select!` loop.
-2. `reload_config()` re-reads the TOML and diffs the new config against
-   the current snapshot bucket-by-bucket: neighbor sets, named policies,
-   peer groups, global import / export chains, and `[[neighbors]]` deltas.
-3. For each bucket (in dependency order — definitions first, then
-   `[[neighbors]]` reconcile, then deletes in reverse-dependency order
-   so transient `still referenced` rejections don't fire), the binary
-   sends a single-shot command to the peer manager that goes through
-   `apply_policy_change` / `apply_peer_group_change`. Runtime effect
-   matches the existing gRPC API path: hot-applied policy chains, peer
-   re-add for changed peer-group memberships.
-4. Reload halts at the first step failure and returns a partial-state
-   snapshot via `halt_partial`, so the daemon's in-memory config tracks
-   what the peer manager actually applied (operator fixes the failing
-   TOML and reloads again to converge against the half-applied state).
-   Exception: the neighbor-reconcile step returns `None` on partial
-   failure because live state is genuinely ambiguous after a
-   delete-then-readd partial; earlier reload steps still land at the
-   manager and remain in effect.
-5. When an effective import policy changes via SIGHUP (or any gRPC
-   `SetPolicy` / `SetPeerGroup` / chain mutation),
-   `PeerManager::update_runtime_policies` automatically issues a Route
-   Refresh (RFC 2918) to the affected Established peers so routes
-   already in `AdjRibIn` get re-evaluated against the new policy.
-   `pending_refresh` / `pending_export_apply` flags on `ManagedPeer`
-   carry unfired retry intent across calls (e.g. peer mid-reconnect at
-   refresh time, transient mpsc backpressure).
-6. Global config changes that are not hot-reloadable
-   (`[global]` ASN/router-id/families, `[rpki]`, `[bmp]`, `[mrt]`,
-   `[global.telemetry.grpc_*]` listener config)
-   are surfaced under "Restart-required" in `rustbgpd --diff` and logged
-   at reload time. The runtime listener config for `grpc_tcp` / `grpc_uds`
-   is pinned back to the live values so subsequent diffs keep flagging
-   the drift until an actual restart happens.
+The main signal loop starts a retained reload task under the runtime-config
+coordinator. It resolves the candidate TOML and staged file contents, then
+`classify_sighup_reload()` selects a `SighupReloadRoute` before runtime,
+credential, or catalog effects:
+
+| Route | Settlement |
+|---|---|
+| `Generation` | One resolved candidate produces one action per static neighbor and final policy chains for live peers. Prior config, policy, dataset, and session snapshots remain owned until the candidate settles or a later failure restores the prior generation. |
+| `Sequential` | Per-subsystem steps run in dependency order without generation compensation. A failure halts the sequence; an authoritative receipt can retain the known-partial runtime state for the next reload. |
+| `Rejected` | Preflight rejects an unsupported combination before any effect. The running configuration remains in place. |
+
+The [operations guide](../reference/operations.md#configuration-reload-sighup)
+describes the current family combinations, dataset compensation, and failure
+handling. The [reload matrix](../reference/reload-matrix.md#sighup-reload-routes)
+separates whole-candidate routing from individual field reload classes.
+Generation settlement never returns a known-partial receipt. Lost accepted
+acknowledgements or non-authoritative state instead recovery-fence the daemon;
+they are not reported as successful application or restoration.
+
+Effective import-chain changes request Route Refresh from affected Established
+peers. Retry intent survives reconnects and temporary backpressure, while a
+generation cannot report success with required refresh work unresolved. A local
+refresh acknowledgement proves dispatch, not completion of the peer's replay.
+
+Daemon restart-required fields stay pinned to their live values on every route.
+`rustbgpd --diff` and subsequent reloads keep reporting that drift until restart.
 
 ### Config Transactions
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -557,7 +557,7 @@ What happens:
 2. **Generation route** — a candidate whose reload-applied changes are
    static `[[neighbors]]`, `[peer_groups]`, inline policy definitions,
    neighbor sets, global chains, changed `.rpol` content (imports included),
-   dataset contents with unchanged bindings, `[policy.explain]`, or outbound
+   dataset contents with unchanged bindings, or outbound
    prefix maxima settles as one owned runtime generation. The daemon resolves
    the complete candidate once and
    derives one action per static neighbor — unchanged, hot update in place,
@@ -573,6 +573,8 @@ What happens:
    failure restores them from memory, the reload reports a clean rejection,
    the candidate file stays on
    disk for correction, and an identical retry re-derives the same plan.
+   `[policy.explain]` is carried with such a candidate; an explain-only change
+   stays sequential.
 3. **Sequential route** — a candidate with no generation-class change
    (`[[dynamic_neighbors]]`, EVPN runtime tables, `[[fib_tables]]`, the honor
    knobs, TCP-AO rotation, listener MD5/GTSM inventory, explain-only,

--- a/docs/reference/reload-matrix.md
+++ b/docs/reference/reload-matrix.md
@@ -38,11 +38,13 @@ in `src/config/mod.rs` says how a whole candidate is executed, and
 
 | Route | Candidate | Guarantee |
 |---|---|---|
-| **generation** | Only static `[[neighbors]]`, `[peer_groups]`, inline policy / neighbor sets / global chains, `.rpol` content, `[policy.explain]`, or outbound prefix maxima changed | One owned runtime generation: one action per static neighbor from one resolved candidate; a later failure restores the retained prior generation and rejects cleanly |
-| **sequential** | No generation-class change, or a generation-class change together with a TCP-AO rotation or a listener MD5/GTSM authentication change | The existing per-subsystem steps; a failure halts with a known-partial receipt |
-| **rejected** | A generation-class change together with dataset content or bindings, `[[dynamic_neighbors]]`, EVPN runtime tables, `[[fib_tables]]`, or `honor_graceful_shutdown` / `honor_blackhole` | No effect; reload those families on their own |
+| **generation** | Static `[[neighbors]]`, `[peer_groups]`, inline policy / neighbor sets / global chains, `.rpol` content, dataset contents with unchanged bindings, or outbound prefix maxima changed without an incompatible family | One owned runtime generation: one action per static neighbor from one resolved candidate; a later failure restores retained config, policy, dataset, and session state and rejects cleanly |
+| **sequential** | No generation-class or dataset change, or a generation-class change together with TCP-AO rotation or listener MD5/GTSM changes while dataset contents are unchanged | The existing per-subsystem steps; a failure halts with an authoritative known-partial receipt or recovery-fences if state is ambiguous |
+| **rejected** | Dataset bindings changed; dataset content combined with TCP-AO rotation or listener MD5/GTSM changes; or a generation-class/dataset-content change combined with `[[dynamic_neighbors]]`, EVPN runtime tables, `[[fib_tables]]`, or `honor_graceful_shutdown` / `honor_blackhole` | No effect; apply independently reloadable families separately. Dataset binding changes require a restart |
 
-Restart-required fields are pinned on every route.
+Daemon restart-required fields are pinned on every route.
+An explain-only change stays sequential; `[policy.explain]` is carried with the
+candidate when another change selects the generation route.
 
 ## Session-establishment caveat
 
@@ -336,7 +338,7 @@ chains all add/change/remove cleanly via reload.
 | `rpol_files` | live | SIGHUP recompiles the referenced `.rpol` files and hot-applies materially changed chains to exactly the affected peers (Route Refresh for changed import chains). Config transactions reject a candidate whose compiled `.rpol` registry changed as unsupported — the files live outside the candidate TOML (`src/config/mod.rs`, transaction classification) — so apply `.rpol` changes via SIGHUP. |
 | `rpol_roots` | live | Extra `import` resolution roots; a change takes effect through the same SIGHUP recompile path (it matters only when it changes the resolved module graph's content, which reloads as an rpol content change). |
 | `rpol_max_graph_bytes` | live | Read from the incoming config on every load (`load_rpol_files` consumes it before compiling each unit), so the value in the reloaded file governs that same SIGHUP's recompile — no restart, no second reload. A candidate/reloaded config whose units exceed its own budget is rejected whole; the running generation is untouched. |
-| `[policy.datasets]` | live | Snapshot files are re-read on every SIGHUP: content-equal re-reads are no-ops, changed content swaps atomically and refreshes only the referencing peers, and a file that fails to load keeps the prior snapshot (WARN + `bgp_policy_dataset_refresh_errors_total`). Introducing a dataset declaration (or a kind change) must load cleanly or the reload is rejected. |
+| `[policy.datasets]` | live contents / restart-required bindings | With unchanged names, kinds, file mappings, and handles, SIGHUP stages content for generation settlement and refreshes referencing peers. Content-equal re-reads are no-ops; malformed input rejects before publication. Compensation restores prior contents at a new generation. Binding changes reject SIGHUP and require a restart; see [dataset settlement](operations.md#configuration-reload-sighup). |
 | `[policy.explain] enabled` (ADR-0073) | restart-required (per peer) | Read by `build_transport_config` when a session is constructed, so the new value is adopted into the config snapshot (sessions established *after* the reload honor it) but live sessions keep their current import-explain write behavior until they re-establish. Logged as `WARN` during reload when changed. Diagnostic retention only — never affects which routes are accepted. |
 | `[policy.explain] cache_size` (ADR-0073) | restart-required (per peer) | Same — the per-session LRU is sized at session construction. A live session's cache is not resized in place; the new capacity applies on its next establishment. |
 | `[policy.reject_retention] enabled` | restart-required (per peer) | Same contract as `[policy.explain]`: read by `build_transport_config` at session construction. Live sessions keep their current rejected-route retention behavior until they re-establish. Diagnostic retention only — never affects which routes are accepted. |

--- a/justfile
+++ b/justfile
@@ -51,6 +51,8 @@ check-fast:
     python3 -m unittest -v scripts/test_check_clippy_reasons.py
     python3 scripts/check-clippy-reasons.py
     python3 scripts/check-v1-stable-surface.py
+    python3 -m unittest -v scripts/test_check_sighup_architecture.py
+    python3 scripts/check_sighup_architecture.py
     python3 scripts/reflow-release-notes.py --selftest
 
 # Check the slower repository contracts: public tracker ids, documentation paths, and metric consumers (minutes, no compilation).

--- a/scripts/check_sighup_architecture.py
+++ b/scripts/check_sighup_architecture.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Check architecture route coverage against the Rust enum and classifier.
+
+This checks the structured route inventory and detailed-reference links, not
+the meaning of family conditions or settlement prose. Those still need source
+review and the classifier's Rust regressions; no behavior model is duplicated.
+"""
+
+import importlib.util
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SECTION = "### Config Reload (SIGHUP)"
+HEADER = "| Route | Settlement |"
+LINKS = (
+    "../reference/operations.md#configuration-reload-sighup",
+    "../reference/reload-matrix.md#sighup-reload-routes",
+)
+SPEC = importlib.util.spec_from_file_location(
+    "dashboard_check", Path(__file__).with_name("check-grafana-dashboard.py")
+)
+RUST = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RUST)
+
+
+def source_routes(source: str) -> set[str]:
+    # Limit the shared lexer to the two rustfmt-shaped top-level items. A
+    # changed item shape fails closed in rust_braced_body below.
+    items = re.findall(
+        r"^pub (?:enum SighupReloadRoute\b|fn classify_sighup_reload\b).*?^}",
+        source, re.MULTILINE | re.DOTALL,
+    )
+    syntax, _ = RUST.rust_lex("\n".join(items))
+    enum = RUST.rust_braced_body(
+        syntax, r"\bpub enum SighupReloadRoute\s*\{", "SighupReloadRoute"
+    )
+    variants = set(re.findall(r"^    (\w+)\s*(?:,|\{|\()", enum, re.MULTILINE))
+    classifier = RUST.rust_braced_body(
+        syntax,
+        r"\bpub fn classify_sighup_reload\([^)]*\)\s*->\s*SighupReloadRoute\s*\{",
+        "classify_sighup_reload",
+    )
+    returned = set(re.findall(r"\bSighupReloadRoute::(\w+)", classifier))
+    if not variants or variants != returned:
+        raise ValueError(
+            f"enum/classifier route mismatch: enum={sorted(variants)}, "
+            f"classifier={sorted(returned)}"
+        )
+    return variants
+
+
+def check(document: str, source: str) -> list[str]:
+    try:
+        expected = source_routes(source)
+        sections = re.findall(rf"^{re.escape(SECTION)}\n(.*?)(?=^### |\Z)",
+                              document, re.MULTILINE | re.DOTALL)
+        if len(sections) != 1:
+            raise ValueError("expected one Config Reload (SIGHUP) section")
+        section = sections[0]
+        tables = re.findall(
+            rf"^{re.escape(HEADER)}\n\|[-| ]+\|\n((?:\|[^\n]+\|\n)+)",
+            section, re.MULTILINE,
+        )
+        if len(tables) != 1:
+            raise ValueError("expected one Route / Settlement table")
+        rows = []
+        for line in tables[0].splitlines():
+            row = re.fullmatch(r"\| `(\w+)` \| ([^|]+) \|", line)
+            if row is None or not row[2].strip():
+                raise ValueError(f"malformed route row: {line}")
+            rows.append(row[1])
+    except ValueError as error:
+        return [str(error)]
+    counts = Counter(rows)
+    errors = [f"missing route: {name}" for name in sorted(expected - counts.keys())]
+    errors += [f"unknown route: {name}" for name in sorted(counts.keys() - expected)]
+    errors += [f"duplicate route: {name}" for name, count in counts.items() if count > 1]
+    for target in LINKS:
+        if not re.search(rf"\[[^\]\n]+\]\({re.escape(target)}\)", section):
+            errors.append(f"missing detailed-reference link: {target}")
+    return errors
+
+
+def main() -> int:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT
+    try:
+        errors = check(
+            (root / "docs/explanation/architecture.md").read_text(encoding="utf-8"),
+            (root / "src/config/mod.rs").read_text(encoding="utf-8"),
+        )
+    except OSError as error:
+        errors = [str(error)]
+    for error in errors:
+        print(f"SIGHUP architecture check: {error}", file=sys.stderr)
+    if not errors:
+        print("SIGHUP architecture route coverage and reference links passed")
+    return bool(errors)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_sighup_architecture.py
+++ b/scripts/test_check_sighup_architecture.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Negative proofs for the SIGHUP architecture route inventory."""
+
+import unittest
+from pathlib import Path
+
+from scripts import check_sighup_architecture as checker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCUMENT = (ROOT / "docs/explanation/architecture.md").read_text(encoding="utf-8")
+SOURCE = (ROOT / "src/config/mod.rs").read_text(encoding="utf-8")
+
+
+class SighupArchitectureTests(unittest.TestCase):
+    @staticmethod
+    def row(name):
+        return next(line for line in DOCUMENT.splitlines() if line.startswith(f"| `{name}` |"))
+
+    def assert_fails(self, document, diagnostic, source=SOURCE):
+        errors = checker.check(document, source)
+        self.assertTrue(any(diagnostic in error for error in errors), errors)
+
+    def test_current_source_and_document_pass(self):
+        self.assertEqual(checker.check(DOCUMENT, SOURCE), [])
+
+    def test_missing_and_duplicate_rows_fail(self):
+        for name in checker.source_routes(SOURCE):
+            with self.subTest(name=name):
+                row = self.row(name)
+                self.assert_fails(DOCUMENT.replace(row + "\n", ""), f"missing route: {name}")
+                self.assert_fails(DOCUMENT.replace(row, row + "\n" + row),
+                                  f"duplicate route: {name}")
+
+    def test_new_source_route_requires_a_documented_row(self):
+        source = SOURCE.replace("pub enum SighupReloadRoute {",
+                                "pub enum SighupReloadRoute {\n    Deferred,")
+        source = source.replace("if !families.generation &&",
+                                "if false { return SighupReloadRoute::Deferred; }\n"
+                                "    if !families.generation &&", 1)
+        self.assert_fails(DOCUMENT, "missing route: Deferred", source)
+
+    def test_classifier_and_enum_must_agree(self):
+        source = SOURCE.replace("pub enum SighupReloadRoute {",
+                                "pub enum SighupReloadRoute {\n    Deferred,")
+        self.assert_fails(DOCUMENT, "enum/classifier route mismatch", source)
+
+    def test_unknown_or_malformed_documented_route_fails(self):
+        self.assert_fails(DOCUMENT.replace("| `Rejected` |", "| `Deferred` |"),
+                          "unknown route: Deferred")
+        self.assert_fails(DOCUMENT.replace("| `Rejected` |", "| Rejected |"),
+                          "malformed route row")
+
+    def test_loose_words_or_rows_outside_the_section_do_not_count(self):
+        row = self.row("Rejected")
+        document = DOCUMENT.replace(row, "Rejected remains mentioned here.") + "\n" + row + "\n"
+        self.assert_fails(document, "missing route: Rejected")
+
+    def test_missing_section_table_or_reference_link_fails(self):
+        self.assert_fails(DOCUMENT.replace(checker.SECTION, "### Old reload"),
+                          "expected one Config Reload")
+        self.assert_fails(DOCUMENT.replace(checker.HEADER, "| Old | Table |"),
+                          "expected one Route / Settlement table")
+        for link in checker.LINKS:
+            self.assert_fails(DOCUMENT.replace(link, "elsewhere.md"),
+                              "missing detailed-reference link")
+
+    def test_comments_and_strings_do_not_invent_classifier_routes(self):
+        source = SOURCE.replace("if !families.generation &&",
+                                '// SighupReloadRoute::Deferred\n'
+                                '    let _ = "SighupReloadRoute::Deferred";\n'
+                                '    if !families.generation &&', 1)
+        self.assertEqual(checker.check(DOCUMENT, source), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3288,8 +3288,8 @@ pub enum SighupReloadRoute {
     /// keeps the candidate off the compensated generation executor; an empty
     /// list means the candidate has no generation-class change at all.
     Sequential { reasons: Vec<String> },
-    /// Rejected before any runtime, credential, or catalog effect. Each
-    /// reason names a family that must be reloaded on its own.
+    /// Rejected before any runtime, credential, or catalog effect. Reasons
+    /// name incompatible families or dataset bindings requiring a restart.
     Rejected { reasons: Vec<String> },
 }
 
@@ -3319,16 +3319,16 @@ impl SighupReloadRoute {
 
 /// Route a SIGHUP candidate by the families it touches.
 ///
-/// A candidate with no generation-class change keeps the sequential path
-/// every isolated capability already has. A generation-class change combined
-/// with dataset content, dynamic ranges, EVPN runtime, FIB tables, or the
-/// honor knobs is rejected: none of those families retains and restores
-/// priors, so their partial effects could not be compensated. A
-/// generation-class change combined with a TCP-AO rotation or a listener
-/// inbound-auth change stays sequential: the rotation is its own ordered
-/// protocol and the listener inventory is a converging replacement, and the
-/// session reshape primitive refuses authentication changes, so neither can
-/// be folded into the generation.
+/// Dataset contents with unchanged bindings participate in generation
+/// compensation; dataset binding changes are rejected. A generation-class
+/// or dataset-content change combined with dynamic ranges, EVPN runtime,
+/// FIB tables, or the honor knobs is rejected because those families do not
+/// retain and restore priors. Dataset content combined with TCP-AO rotation
+/// or listener inbound-auth changes is also rejected. Without dataset
+/// changes, those authentication edits keep a generation-class candidate on
+/// the sequential path: they have separate ordered protocols and cannot be
+/// folded into the session reshape primitive. Candidates with no generation,
+/// dataset-content, or dataset-binding change keep the sequential path.
 #[must_use]
 pub fn classify_sighup_reload(families: SighupReloadFamilies) -> SighupReloadRoute {
     if !families.generation && !families.datasets && !families.dataset_bindings {


### PR DESCRIPTION
The architecture guide still described every SIGHUP reload as a sequence of independent steps. Summarize generation settlement, sequential application, and preflight rejection, with links to the detailed operations guide and reload matrix. Align the maintained matrix and Rust documentation with compensated dataset contents, rejected binding changes, and explain-only sequential reloads.

Add a small check to the existing documentation workflow and local fast gate. It compares the structured route table with the actual enum and classifier references and requires both detailed-reference links. This checks route coverage; it does not duplicate the classifier or claim to verify family-condition semantics.

Validation: eight positive/negative checker tests, the live checker, formatting, focused Ruff, actionlint, offline documentation links, and diff checks pass. The Rust file changes only documentation comments; runtime source is unchanged.
