### PR TITLE
feat(bench): parameterize dual-stack reload inventories

### DIFF
--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -32,7 +32,8 @@
 #              GEN_* / RELOADSTALL_* pass through to the generator and the
 #                harness unchanged (dual-stack: GEN_DUALSTACK=1 +
 #                RELOADSTALL_DUALSTACK=1; filtering: GEN_FILTER_COUNT=K +
-#                RELOADSTALL_FILTER_COUNT=K).
+#                RELOADSTALL_FILTER_COUNT=K). RELOADSTALL_IPV4_PREFIXES selects
+#                an exact IPv4 inventory in dual-stack mode; IPv6 gets the rest.
 set -u
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
@@ -94,6 +95,26 @@ resolve_competitor_image() {
     }
 }
 
+matrix_workload_inputs() {
+    jq -cn --arg peers "$N_PEERS" --arg total "$TOTAL" --arg port "$PORT" \
+        --arg reloads "$RELOADS" --arg control "$CONTROL_SECS" \
+        --arg changed "$CHANGED_PEERS" --arg flapstorm "$FLAPSTORM" \
+        --arg threads "$BIRD_THREADS" --arg probes "$PROBE_PREFIXES" \
+        '{N_PEERS:$peers,TOTAL_PREFIXES:$total,PORT:$port,RELOADS:$reloads,
+          CONTROL_SECS:$control,CHANGED_PEERS:$changed,FLAPSTORM:$flapstorm,
+          BIRD_THREADS:$threads,PROBE_PREFIXES:$probes}
+         + (env | with_entries(select(.key | test("^(GEN_|RELOADSTALL_)"))))'
+}
+
+recheck_workload_inputs() {
+    local current
+    current=$(matrix_workload_inputs) || return 1
+    if ! jq -e --argjson current "$current" '.workload.inputs == $current' "$1" >/dev/null; then
+        echo "workload inputs changed or are missing; use a fresh ARTIFACTS_DIR" >&2
+        return 1
+    fi
+}
+
 matrix_prepare_event() { :; }
 recheck_source_git_identity() {
     local repo=$1 provenance_file=$2 stored current_commit current_tree current_dirty=false status
@@ -147,7 +168,8 @@ if [ "${1:-}" = --self-test-prepare-order ]; then
         matrix_prepare_event "$1:live-verify"
         verify_live_competitor_identity "$1" "$status.provenance" &&
             [ -n "${MATRIX_SELF_TEST_REPO:-}" ] &&
-            recheck_source_git_identity "$MATRIX_SELF_TEST_REPO" "$status.provenance"
+            recheck_source_git_identity "$MATRIX_SELF_TEST_REPO" "$status.provenance" &&
+            recheck_workload_inputs "$status.provenance"
     }
     inspect_competitor_image() {
         [ -z "${MATRIX_SELF_TEST_IMAGE_TRACE:-}" ] || printf '%s\n' "$1" >>"$MATRIX_SELF_TEST_IMAGE_TRACE"
@@ -196,7 +218,8 @@ write_cell_provenance() {
     for relative in "${COMMON_SOURCES[@]}"; do
         common=$(jq -c --arg key "$relative" --arg value "${SOURCE_HASHES[$relative]}" '. + {($key):$value}' <<<"$common") || return 1
     done
-    local workload
+    local workload inputs
+    inputs=$(matrix_workload_inputs) || return 1
     if [ "$workload_kind" = binary ]; then
         workload=$(jq -cn --arg binary "$workload_name" --arg sha256 "$workload_hash" '{binary:$binary,sha256:$sha256}') || return 1
     else
@@ -208,8 +231,8 @@ write_cell_provenance() {
         --argjson common "$common" --arg generator_path "$generator" \
         --arg generator_hash "${SOURCE_HASHES[$generator]}" \
         --arg reloadstall_hash "${SOURCE_HASHES[bench/scale/target/release/reloadstall]}" \
-        --argjson workload "$workload" \
-        '{schema:1,cell:$cell,git:{commit:$commit,tree:$tree,dirty:$dirty},toolchain:$toolchain,host:$host,sources:{common:$common,generator:{($generator_path):$generator_hash},reloadstall:{path:"bench/scale/target/release/reloadstall",sha256:$reloadstall_hash}},workload:$workload}' \
+        --argjson workload "$workload" --argjson inputs "$inputs" \
+        '{schema:1,cell:$cell,git:{commit:$commit,tree:$tree,dirty:$dirty},toolchain:$toolchain,host:$host,sources:{common:$common,generator:{($generator_path):$generator_hash},reloadstall:{path:"bench/scale/target/release/reloadstall",sha256:$reloadstall_hash}},workload:($workload + {inputs:$inputs})}' \
         >"$ART/$cell/provenance.json" || return 1
     python3 "$REPO/bench/scale/matrix/verify-provenance.py" \
         "$ART/$cell/provenance.json" "$cell" "$COMPETITOR_GENERATION"
@@ -228,7 +251,7 @@ recheck_cell_provenance() {
     else
         verify_live_competitor_identity "$cell" "$file" || return 1
     fi
-    recheck_source_git_identity "$REPO" "$file"
+    recheck_source_git_identity "$REPO" "$file" && recheck_workload_inputs "$file"
 }
 
 # Operator-query probes (rustbgpd cell): one `rbgp health` timing loop and

--- a/bench/scale/matrix/verify-provenance.py
+++ b/bench/scale/matrix/verify-provenance.py
@@ -30,6 +30,11 @@ COMPETITOR_GENERATIONS = {
     },
 }
 
+INPUT_KEYS = {
+    "N_PEERS", "TOTAL_PREFIXES", "PORT", "RELOADS", "CONTROL_SECS",
+    "CHANGED_PEERS", "FLAPSTORM", "BIRD_THREADS", "PROBE_PREFIXES",
+}
+
 def fail(message):
     raise ValueError(message)
 
@@ -62,7 +67,17 @@ def verify(path, expected_cell, competitor_generation="historical"):
     hashed_map(sources["generator"], {GENERATORS[cell]})
     if set(sources["reloadstall"]) != {"path", "sha256"} or sources["reloadstall"]["path"] != "bench/scale/target/release/reloadstall" or not HASH.fullmatch(sources["reloadstall"]["sha256"]):
         fail("malformed reloadstall identity")
-    workload = data["workload"]
+    if not isinstance(data["workload"], dict):
+        fail("malformed workload identity")
+    workload = data["workload"].copy()
+    # Historical receipts remain valid offline; live resume additionally requires
+    # exact equality with the runner's current effective workload inputs.
+    if "inputs" in workload:
+        inputs = workload.pop("inputs")
+        if not isinstance(inputs, dict) or not INPUT_KEYS <= inputs.keys():
+            fail("missing workload input fields")
+        if any(not isinstance(v, str) or (k not in INPUT_KEYS and not k.startswith(("GEN_", "RELOADSTALL_"))) for k, v in inputs.items()):
+            fail("malformed workload inputs")
     if cell == "rustbgpd":
         if set(workload) != {"binary", "sha256"} or workload["binary"] != "target/release/rustbgpd" or not HASH.fullmatch(workload["sha256"]):
             fail("malformed rustbgpd workload")

--- a/bench/scale/reloadstall/README.md
+++ b/bench/scale/reloadstall/README.md
@@ -201,9 +201,13 @@ generator's historical output byte for byte.
   `ipv6_unicast` on its one IPv4-transport session. The daemon's OPEN must
   carry both multiprotocol capabilities, or establishment fails (an
   un-negotiated family is never reported as delivered). `<total_prefixes>`
-  becomes the **total across both families**, split evenly: each stub
-  announces `total / (2 * n_peers)` IPv4 /24s in the body NLRI plus the same
-  count of IPv6 /48s (`3001:HHHH:LLLL::/48`) in `MP_REACH_NLRI` with a
+  becomes the **total across both families**, split evenly by default. Set
+  `RELOADSTALL_IPV4_PREFIXES=N` for an exact IPv4 inventory; IPv6 receives
+  `total - N`. Each family is divided into contiguous slices: every member
+  receives `family_total / n_peers` prefixes, and the first
+  `family_total % n_peers` members receive one extra. Every member must have
+  at least one prefix in each family. IPv4 /24s use body NLRI and IPv6 /48s
+  (`3001:HHHH:LLLL::/48`) use `MP_REACH_NLRI` with a
   synthetic `fd09::x:y` next hop; churners flap one 16-prefix block per
   family (`3002:c:j::/48` for IPv6). Every observer keeps an independent
   per-family unique-prefix bitmap: initial convergence, reload completion,
@@ -212,7 +216,7 @@ generator's historical output byte for byte.
   slower family. A second `first_exact_bitmap6` receipt and a
   `reloadstall_dualstack_csv` row per reload (per-family completion,
   leading stall, family-restricted max-gap, withdrawal accounting, and
-  per-family stable-marker counts) are printed after the historical lines,
+  per-family stable-marker counts, explicit IPv4/IPv6 totals) are printed after the historical lines,
   which keep their format (`prefixes` is the total). Requires the reload
   mode: no flapstorm, trips, iBGP-RR, overlap, received-view, or
   `--convergence-only`.
@@ -226,6 +230,34 @@ generator's historical output byte for byte.
   observer (`bystander_withdrawn`), or any base withdrawal at a stable
   observer (`stable_withdrawn`) fails the reload; duplicate named
   withdrawals are counted and published. Works with or without dual-stack.
+
+For 700 members and 400,400 total routes, `RELOADSTALL_IPV4_PREFIXES=360360`
+selects exactly 90/10: 360,360 IPv4 and 40,040 IPv6. Members 0–559 own
+515 IPv4 prefixes and the rest own 514; members 0–139 own 58 IPv6 prefixes
+and the rest own 57. The filtering count must fit member 0 in **both**
+families (at most 58 for this shape; the historical equal-family count of
+64 does not fit). Omitting the count selects 50/50, or specify
+`RELOADSTALL_IPV4_PREFIXES=200200` explicitly. Odd totals require an explicit
+IPv4 count. The IPv4 count knob is rejected without dual-stack mode.
+Use a fresh `ARTIFACTS_DIR` for each mix and policy shape. The matrix runner
+compares effective workload inputs before resuming a passing cell; changed or
+missing input identity fails closed. Historical receipts remain verifiable
+offline, but cannot be resumed without that identity.
+
+Churn tasks start before the control window and remain active throughout
+all reloads. Each dual-stack reload prints `reloadstall_churn_overlap`:
+per-family successful socket-write counts and first/last monotonic timestamps
+inside the trigger-to-last-changed-observer-completion window. Only the dedicated
+churn blocks count; base announcements, refresh replies, channel enqueues,
+and writes after completion do not. `overlap_observed=false` reports a window
+with no write in one or both families; it does not change route-correctness
+acceptance or extend completion. A concurrent-churn campaign must require
+`overlap_observed=true` for each reload as a separate proof gate. Socket writes
+show sender progress; receiver inventory and stable-marker checks remain the
+independent delivery proof.
+
+The existing 20-member 50/50 receipt is historical. These inventory options
+and overlap rows do not establish asymmetric or 700-member scale proof.
 
 `gen-scenario.py` grows the matching pair: `GEN_DUALSTACK=1` emits
 `families = ["ipv4_unicast", "ipv6_unicast"]` on every neighbor, and

--- a/bench/scale/reloadstall/gen-scenario.py
+++ b/bench/scale/reloadstall/gen-scenario.py
@@ -62,7 +62,8 @@ Dual-stack extension: setting `GEN_DUALSTACK=1` gives every neighbor
 `families = ["ipv4_unicast", "ipv6_unicast"]`, matching the harness's
 `RELOADSTALL_DUALSTACK=1` stubs (IPv6 base table `3001:HHHH:LLLL::/48`,
 `base_prefix6`). Absent, the emitted config is byte-for-byte the historical
-IPv4-only one.
+IPv4-only one. Inventory counts belong to the harness: its optional
+`RELOADSTALL_IPV4_PREFIXES` changes the mix without changing this config.
 
 Filtering extension: setting `GEN_FILTER_COUNT=K` (K >= 1) makes generation B
 a filtering change instead of a permit-set-preserving one: `member-out`

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -99,9 +99,10 @@
 //!   IPv6 unicast on one session (the daemon's OPEN must carry both MP
 //!   capabilities or establishment fails: an un-negotiated family can
 //!   never be reported as delivered). `<total_prefixes>` is then the
-//!   TOTAL across both families, split evenly: each stub announces
-//!   `total / (2 * n_peers)` IPv4 /24s (body NLRI, `20.x.y.0/24`) plus the
-//!   same count of IPv6 /48s (`MP_REACH_NLRI`, `3001:HHHH:LLLL::/48`);
+//!   TOTAL across both families, split evenly by default. Set
+//!   `RELOADSTALL_IPV4_PREFIXES` for an exact IPv4 count; IPv6 gets the rest.
+//!   Each family uses contiguous quotient/remainder member slices, with IPv4
+//!   /24s (body NLRI) and IPv6 /48s (`MP_REACH_NLRI`, `3001:HHHH:LLLL::/48`);
 //!   churners flap one 16-prefix block per family. Every observer keeps
 //!   an independent per-family unique-prefix bitmap: initial convergence,
 //!   reload completion, and stable-marker evidence each require BOTH
@@ -616,7 +617,11 @@ impl GenerationProgress {
 struct Ctx {
     t0: Instant,
     n_peers: u32,
+    // Uniform IPv4-only modes retain their historical per-member size.
     per_peer: u32,
+    totals: [u32; 2],
+    // Armed only during a dual-stack reload; timestamps follow successful socket writes.
+    churn_writes: Mutex<Option<Vec<(u64, u8)>>>,
     daemon: SocketAddr,
     obs: Vec<Obs>,
     /// Per-stub extra announced base indices beyond the contiguous own slice
@@ -633,6 +638,88 @@ struct Ctx {
     /// window: gap stats are not consumed there, and 24 h of events at
     /// churn cadence across 1000 observers would exhaust host memory.
     record_events: AtomicBool,
+}
+
+/// Contiguous disjoint slices: the first remainder members receive one extra.
+fn member_slice(total: u32, peers: u32, member: u32) -> (u32, u32) {
+    let quotient = total / peers;
+    let remainder = total % peers;
+    (
+        member * quotient + member.min(remainder),
+        quotient + u32::from(member < remainder),
+    )
+}
+
+fn family_totals(
+    total: u32,
+    peers: u32,
+    dual: bool,
+    ipv4: Option<u32>,
+) -> Result<[u32; 2], &'static str> {
+    if !dual {
+        if ipv4.is_some() {
+            return Err("RELOADSTALL_IPV4_PREFIXES requires RELOADSTALL_DUALSTACK");
+        }
+        if !total.is_multiple_of(peers) {
+            return Err("total must divide evenly");
+        }
+        return Ok([total, 0]);
+    }
+    if ipv4.is_none() && !total.is_multiple_of(2) {
+        return Err(
+            "equal dual-stack total must be even; set RELOADSTALL_IPV4_PREFIXES for an exact mix",
+        );
+    }
+    let v4 = ipv4.unwrap_or(total / 2);
+    let v6 = total
+        .checked_sub(v4)
+        .ok_or("IPv4 count exceeds total prefixes")?;
+    if v4 < peers || v6 < peers {
+        return Err("both families must contain at least one base prefix per member");
+    }
+    Ok([v4, v6])
+}
+
+/// Classify only the dedicated churn blocks, never base-table or refresh traffic.
+fn churn_family(message: &Message, churner: u32) -> u8 {
+    let Message::Update(update) = message else {
+        return 0;
+    };
+    let Ok(parsed) = update.parse(true, false, &[]) else {
+        return 0;
+    };
+    let nlri = split_unicast_families(&parsed);
+    let v4 = [&nlri.v4_ann, &nlri.v4_wd].iter().any(|prefixes| {
+        prefixes
+            .iter()
+            .copied()
+            .eq((0..CHURN_BLOCK).map(|j| churn_prefix(churner, j)))
+    });
+    let v6 = [&nlri.v6_ann, &nlri.v6_wd].iter().any(|prefixes| {
+        prefixes
+            .iter()
+            .copied()
+            .eq((0..CHURN_BLOCK).map(|j| churn_prefix6(churner, j)))
+    });
+    (u8::from(v4) * FAMILY_V4) | (u8::from(v6) * FAMILY_V6)
+}
+
+fn churn_window(
+    writes: &[(u64, u8)],
+    family: u8,
+    start: u64,
+    end: u64,
+) -> (usize, Option<u64>, Option<u64>) {
+    let times: Vec<u64> = writes
+        .iter()
+        .filter(|&&(t, f)| start <= t && t <= end && f & family != 0)
+        .map(|&(t, _)| t)
+        .collect();
+    (
+        times.len(),
+        times.iter().min().copied(),
+        times.iter().max().copied(),
+    )
 }
 
 fn now_us(ctx: &Ctx) -> u64 {
@@ -927,8 +1014,8 @@ fn observe_generation6(
 /// IPv6 slice of the base table owned by stub `i` (dual-stack; no overlap
 /// dimension, so this is everything the stub announces in that family).
 fn own_slice6(ctx: &Ctx, i: u32) -> Vec<Ipv6Prefix> {
-    let lo = i * ctx.per_peer;
-    (lo..lo + ctx.per_peer).map(base_prefix6).collect()
+    let (lo, len) = member_slice(ctx.totals[1], ctx.n_peers, i);
+    (lo..lo + len).map(base_prefix6).collect()
 }
 
 fn base_attrs(i: u32) -> Vec<PathAttribute> {
@@ -1008,8 +1095,8 @@ fn withdraw_msg(prefixes: &[Ipv4Prefix]) -> Message {
 
 /// Slice of the base table owned by stub `i`.
 fn own_slice(ctx: &Ctx, i: u32) -> Vec<Ipv4Prefix> {
-    let lo = i * ctx.per_peer;
-    (lo..lo + ctx.per_peer).map(base_prefix).collect()
+    let (lo, len) = member_slice(ctx.totals[0], ctx.n_peers, i);
+    (lo..lo + len).map(base_prefix).collect()
 }
 
 /// Everything stub `i` announces: its own slice plus its overlap
@@ -1313,6 +1400,15 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                 Some(msg) = tx_rx.recv() => {
                     let Ok(bytes) = encode_message(&msg) else { break };
                     if writer.write_all(&bytes).await.is_err() { break; }
+                    if dualstack() && i >= writer_ctx.n_peers - CHURNERS {
+                        let written_at = now_us(&writer_ctx);
+                        let family = churn_family(&msg, i - (writer_ctx.n_peers - CHURNERS));
+                        if family != 0 {
+                            if let Some(writes) = writer_ctx.churn_writes.lock().unwrap().as_mut() {
+                                writes.push((written_at, family));
+                            }
+                        }
+                    }
                 }
                 _ = ka_tick.tick() => {
                     let bytes = encode_message(&Message::Keepalive).unwrap();
@@ -1392,9 +1488,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                                 continue;
                             }
                         };
-                        // Per-family total: in dual-stack mode `per_peer` is
-                        // per family, so this is one family's base space.
-                        let total_prefixes = rctx.n_peers * rctx.per_peer;
+                        let [total_prefixes, total_prefixes6] = rctx.totals;
                         let nlri = split_unicast_families(&parsed);
                         let mut base = 0u32;
                         let mut other =
@@ -1410,7 +1504,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                             }
                         }
                         for prefix in &nlri.v6_ann {
-                            if base_prefix6_index(*prefix, total_prefixes).is_some() {
+                            if base_prefix6_index(*prefix, total_prefixes6).is_some() {
                                 base += 1;
                             } else {
                                 other += 1;
@@ -1455,7 +1549,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                                             expected,
                                             communities,
                                             &nlri.v6_ann,
-                                            total_prefixes,
+                                            total_prefixes6,
                                             t_us,
                                         );
                                     }
@@ -1474,7 +1568,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                             let withdrawn6: Vec<usize> = nlri
                                 .v6_wd
                                 .iter()
-                                .filter_map(|p| base_prefix6_index(*p, total_prefixes))
+                                .filter_map(|p| base_prefix6_index(*p, total_prefixes6))
                                 .collect();
                             ob.base_withdrawn
                                 .fetch_add(withdrawn4.len() as u64, Ordering::Relaxed);
@@ -1521,7 +1615,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                                     let mut generation6 = ob.generation6.lock().unwrap();
                                     for prefix in tracked6 {
                                         if let Some(index) =
-                                            base_prefix6_index(*prefix, total_prefixes)
+                                            base_prefix6_index(*prefix, total_prefixes6)
                                         {
                                             generation6.observe(index, t_us);
                                         }
@@ -2554,21 +2648,18 @@ fn main() {
             "RELOADSTALL_DUALSTACK requires the reload mode without flapstorm, trips, \
              iBGP-RR, overlap, received-view, or --convergence-only"
         );
-        assert_eq!(
-            total_all % 2,
-            0,
-            "dual-stack total_prefixes is the TOTAL across both families and must be even"
-        );
     }
-    // Per-family base-table size: dual-stack splits the positional total
-    // evenly (400,400 total = 200,200 per family), never per family.
-    let total = if dualstack_enabled {
-        total_all / 2
-    } else {
-        total_all
-    };
+    let ipv4_count = std::env::var("RELOADSTALL_IPV4_PREFIXES")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<u32>()
+                .expect("RELOADSTALL_IPV4_PREFIXES must be an unsigned integer")
+        });
+    let totals = family_totals(total_all, n_peers, dualstack_enabled, ipv4_count)
+        .unwrap_or_else(|error| panic!("{error}"));
+    let [total, total6] = totals;
     let per_peer = total / n_peers;
-    assert_eq!(total % n_peers, 0, "total must divide evenly");
     if filter_count > 0 {
         assert!(
             reloads > 0
@@ -2581,8 +2672,11 @@ fn main() {
              iBGP-RR, overlap, or --convergence-only"
         );
         assert!(
-            filter_count <= per_peer,
-            "RELOADSTALL_FILTER_COUNT must fit member 0's per-family slice ({per_peer})"
+            totals
+                .iter()
+                .take(if dualstack_enabled { 2 } else { 1 })
+                .all(|&family_total| filter_count <= member_slice(family_total, n_peers, 0).1),
+            "RELOADSTALL_FILTER_COUNT must fit member 0's slice in every family"
         );
     }
     if trip_every > 0 {
@@ -2684,6 +2778,8 @@ fn main() {
             t0: Instant::now(),
             n_peers,
             per_peer,
+            totals,
+            churn_writes: Mutex::new(None),
             daemon: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), port),
             obs: (0..n_peers).map(|_| Obs::new()).collect(),
             extras,
@@ -2698,8 +2794,8 @@ fn main() {
         );
         if dualstack() {
             println!(
-                "# dualstack total_prefixes={total_all} per_family={total} \
-                 per_peer_per_family={per_peer} filter_count={filter_count}"
+                "# dualstack total_prefixes={total_all} ipv4_prefixes={total} ipv6_prefixes={total6} \
+                 distribution=quotient-remainder filter_count={filter_count}"
             );
         }
 
@@ -2745,7 +2841,11 @@ fn main() {
         let targets: Vec<u64> = ctx
             .extras
             .iter()
-            .map(|extra| expected - extra.len() as u64)
+            .enumerate()
+            .map(|(i, extra)| u64::from(total - member_slice(total, n_peers, i as u32).1) - extra.len() as u64)
+            .collect();
+        let targets6: Vec<u64> = (0..n_peers)
+            .map(|i| u64::from(total6 - member_slice(total6, n_peers, i).1))
             .collect();
         let exact_initial = convergence_only || needs_first_exact_bitmap(reloads, flapstorm); // FIRST_EXACT_ARM:
         // The iBGP-RR soak gates its initial convergence on the same
@@ -2756,13 +2856,14 @@ fn main() {
         let exact_initial = exact_initial || dualstack();
         if exact_initial {
             for (i, observer) in ctx.obs.iter().enumerate() {
-                let own_start = u32::try_from(i).unwrap() * per_peer;
+                let (own_start, own_len) = member_slice(total, n_peers, i as u32);
                 let mut generation = observer.generation.lock().unwrap();
-                generation.reset(total, expected, own_start, per_peer);
+                generation.reset(total, u64::from(total - own_len), own_start, own_len);
                 generation.exclude_extra(&ctx.extras[i]);
                 if dualstack() {
                     let mut generation6 = observer.generation6.lock().unwrap();
-                    generation6.reset(total, expected, own_start, per_peer);
+                    let (own_start6, own_len6) = member_slice(total6, n_peers, i as u32);
+                    generation6.reset(total6, u64::from(total6 - own_len6), own_start6, own_len6);
                 }
                 let mode = &observer.flap_mode;
                 mode.store(FLAP_TRACK_ANNOUNCES, Ordering::Release);
@@ -2797,7 +2898,7 @@ fn main() {
                 })
                 .collect();
             // Dual-stack: the IPv6 bitmap must ALSO reach its own target at
-            // every observer (same per-family target; no overlap dimension).
+            // every observer (its family-specific target; no overlap dimension).
             let counts6: Vec<u64> = if dualstack() {
                 ctx.obs
                     .iter()
@@ -2812,7 +2913,7 @@ fn main() {
                 .all(|(count, target)| count >= target)
                 && counts6
                     .iter()
-                    .zip(&targets)
+                    .zip(&targets6)
                     .all(|(count, target)| count >= target)
             {
                 break (counts, counts6);
@@ -2839,7 +2940,7 @@ fn main() {
                 let below6: Vec<(usize, u64)> = counts6
                     .iter()
                     .enumerate()
-                    .filter(|&(i, &c)| c < targets[i])
+                    .filter(|&(i, &c)| c < targets6[i])
                     .map(|(i, &c)| (i, c))
                     .collect();
                 eprintln!(
@@ -2869,6 +2970,14 @@ fn main() {
                     observer.flap_mode.store(FLAP_OFF, Ordering::Release);
                 }
             } // FIRST_EXACT_RECEIPT
+            if dualstack() {
+                println!(
+                    "first_exact_bitmap,mode=reload,peers={n_peers},total={total},per_peer_min={},per_peer_max={},expected_min={},expected_max={},completed={},min_unique={},max_unique={}",
+                    total / n_peers, total.div_ceil(n_peers), targets.iter().min().unwrap(), targets.iter().max().unwrap(),
+                    unique.iter().zip(&targets).filter(|(count, target)| count >= target).count(),
+                    unique.iter().min().unwrap(), unique.iter().max().unwrap()
+                );
+            } else {
             println!(
                 "first_exact_bitmap,mode={},peers={n_peers},total={total},per_peer={per_peer},expected={expected},completed={},min_unique={},max_unique={}",
                 if convergence_only {
@@ -2888,12 +2997,17 @@ fn main() {
                 unique.iter().min().unwrap(),
                 unique.iter().max().unwrap()
             );
+            }
             if dualstack() {
                 println!(
-                    "first_exact_bitmap6,mode=reload,peers={n_peers},total={total},per_peer={per_peer},expected={expected},completed={},min_unique={},max_unique={}",
+                    "first_exact_bitmap6,mode=reload,peers={n_peers},total={total6},per_peer_min={},per_peer_max={},expected_min={},expected_max={},completed={},min_unique={},max_unique={}",
+                    total6 / n_peers,
+                    total6.div_ceil(n_peers),
+                    targets6.iter().min().unwrap(),
+                    targets6.iter().max().unwrap(),
                     unique6
                         .iter()
-                        .zip(&targets)
+                        .zip(&targets6)
                         .filter(|(count, target)| count >= target)
                         .count(),
                     unique6.iter().min().unwrap(),
@@ -2901,11 +3015,19 @@ fn main() {
                 );
             }
         }
+        if dualstack() {
+            println!(
+                "converged exact per-family observer inventories at {:.1}s rss_mib={}",
+                ctx.t0.elapsed().as_secs_f64(),
+                rss_mib(pid)
+            );
+        } else {
         println!(
             "converged (>= {expected}/observer) at {:.1}s rss_mib={}",
             ctx.t0.elapsed().as_secs_f64(),
             rss_mib(pid)
         );
+        }
 
         if convergence_only {
             let evidence_dir = evidence_dir.as_deref().unwrap();
@@ -3076,7 +3198,7 @@ fn main() {
         if dualstack() {
             println!(
                 "reloadstall_dualstack_csv_header,reload,peers_total,peers_changed,\
-                 prefixes_total,prefixes_per_family,generation,filter_count,\
+                 prefixes_total,ipv4_prefixes,ipv6_prefixes,generation,filter_count,\
                  v4_completion_p50_s,v4_completion_p95_s,v4_completion_max_s,\
                  v6_completion_p50_s,v6_completion_p95_s,v6_completion_max_s,\
                  v4_maxgap_p50_ms,v4_maxgap_p95_ms,v4_maxgap_max_ms,\
@@ -3139,21 +3261,25 @@ fn main() {
                 .enumerate()
             {
                 observer.expected_community.store(0, Ordering::Release);
-                let own_start = u32::try_from(i).unwrap() * per_peer;
+                let (own_start, own_len) = member_slice(total, n_peers, i as u32);
                 let mut generation = observer.generation.lock().unwrap();
-                generation.reset(total, expected, own_start, per_peer);
+                generation.reset(total, u64::from(total - own_len), own_start, own_len);
                 generation.exclude_extra(&ctx.extras[i]);
                 generation.set_filtered(&filtered);
                 drop(generation);
                 if dualstack() {
                     let mut generation6 = observer.generation6.lock().unwrap();
-                    generation6.reset(total, expected, own_start, per_peer);
+                    let (own_start6, own_len6) = member_slice(total6, n_peers, i as u32);
+                    generation6.reset(total6, u64::from(total6 - own_len6), own_start6, own_len6);
                     generation6.set_filtered(&filtered);
                 }
             }
             // The tracker stays disarmed until its trigger timestamp exists,
             // so a delayed UPDATE from an older A/B generation cannot become
             // pre-trigger evidence (or underflow the duration below).
+            if dualstack() {
+                *ctx.churn_writes.lock().unwrap() = Some(Vec::new());
+            }
             let t_hup = now_us(&ctx);
             for observer in ctx.obs.iter().take(changed_peers as usize) {
                 observer
@@ -3281,6 +3407,15 @@ fn main() {
                 .filter_map(|i| completion_us(&ctx, i))
                 .max()
                 .expect("changed_peers is non-zero and every observer completed");
+            if dualstack() {
+                let writes = ctx.churn_writes.lock().unwrap().take().unwrap();
+                let v4 = churn_window(&writes, FAMILY_V4, t_hup, reload_end_us);
+                let v6 = churn_window(&writes, FAMILY_V6, t_hup, reload_end_us);
+                println!(
+                    "reloadstall_churn_overlap,reload={r},trigger_us={t_hup},completion_us={reload_end_us},v4_writes={},v4_first_us={:?},v4_last_us={:?},v6_writes={},v6_first_us={:?},v6_last_us={:?},overlap_observed={}",
+                    v4.0, v4.1, v4.2, v6.0, v6.1, v6.2, v4.0 > 0 && v6.0 > 0
+                );
+            }
             // Reset the evidence threshold only after the changed cohort has
             // fully received the target generation. Fresh stable-marker churn
             // after this point proves stable observers retained stable-out
@@ -3477,7 +3612,7 @@ fn main() {
                 let stable_v6 =
                     stable_marker_peers_since_family(&ctx, changed_peers, marker_since_us, true);
                 println!(
-                    "reloadstall_dualstack_csv,{r},{n_peers},{changed_peers},{total_all},{total},{},{filter_count},\
+                    "reloadstall_dualstack_csv,{r},{n_peers},{changed_peers},{total_all},{total},{total6},{},{filter_count},\
                      {:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},\
                      {:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{},{},{},{},{filtered_leaked},{bystander_withdrawn},\
                      {stable_withdrawn},{duplicate_withdrawn},{stable_v4},{stable_v6},{up},{parse_errors}",
@@ -4301,6 +4436,106 @@ mod tests {
         );
     }
 
+    #[test]
+    fn family_mix_is_exact_and_rejects_invalid_or_empty_families() {
+        assert_eq!(
+            family_totals(400_400, 700, true, None),
+            Ok([200_200, 200_200])
+        );
+        assert_eq!(
+            family_totals(400_400, 700, true, Some(360_360)),
+            Ok([360_360, 40_040])
+        );
+        assert_eq!(family_totals(401, 20, true, Some(361)), Ok([361, 40]));
+        for ipv4 in [Some(0), Some(19), Some(382), Some(401), Some(402), None] {
+            assert!(family_totals(401, 20, true, ipv4).is_err());
+        }
+        assert!(family_totals(400, 20, false, Some(360)).is_err());
+        assert!(family_totals(401, 20, false, None).is_err());
+        assert_eq!(family_totals(400, 20, false, None), Ok([400, 0]));
+    }
+
+    #[test]
+    fn asymmetric_slices_cover_exact_inventory_and_track_each_observer() {
+        for (peers, totals) in [(700, [360_360, 40_040]), (20, [361, 40])] {
+            for total in totals {
+                let mut end = 0;
+                for member in 0..peers {
+                    let (start, len) = member_slice(total, peers, member);
+                    assert_eq!(start, end);
+                    assert!((total / peers..=total.div_ceil(peers)).contains(&len));
+                    end = start + len;
+                }
+                assert_eq!(end, total);
+            }
+        }
+        // Exercise both sides of the remainder boundary with independent targets.
+        for member in 0..20 {
+            for total in [361, 40] {
+                let (start, len) = member_slice(total, 20, member);
+                let mut generation = GenerationProgress::default();
+                generation.reset(total, u64::from(total - len), start, len);
+                let missing = (0..total)
+                    .find(|i| !(start..start + len).contains(i))
+                    .unwrap();
+                for index in 0..total {
+                    if index != missing {
+                        generation.observe(index as usize, 10);
+                        generation.observe(index as usize, 11);
+                    }
+                }
+                assert_eq!(generation.unique, u64::from(total - len - 1));
+                assert_eq!(generation.completed_at_us, None);
+                generation.observe(missing as usize, 12);
+                assert_eq!(generation.completed_at_us, Some(12));
+                // Named withdrawals exclude the actual own slice, not member * floor.
+                generation.reset(total, u64::from(total - len), start, len);
+                generation.set_filtered(&[0]);
+                assert_eq!(generation.filtered.len(), usize::from(member != 0));
+            }
+        }
+    }
+
+    #[test]
+    fn churn_overlap_counts_only_known_written_blocks_inside_completion() {
+        let block: Vec<_> = (0..CHURN_BLOCK).map(|j| churn_prefix(3, j)).collect();
+        let block6: Vec<_> = (0..CHURN_BLOCK).map(|j| churn_prefix6(3, j)).collect();
+        for message in [
+            announce_msgs(7, &block).pop().unwrap(),
+            withdraw_msg(&block),
+        ] {
+            assert_eq!(churn_family(&message, 3), FAMILY_V4);
+            assert_eq!(churn_family(&message, 2), 0);
+        }
+        for message in [
+            announce6_msgs(7, &block6).pop().unwrap(),
+            withdraw6_msg(&block6),
+        ] {
+            assert_eq!(churn_family(&message, 3), FAMILY_V6);
+        }
+        assert_eq!(
+            churn_family(&announce_msgs(7, &[base_prefix(0)]).pop().unwrap(), 3),
+            0
+        );
+        assert_eq!(churn_family(&Message::Keepalive, 3), 0);
+        let writes = [
+            (9, FAMILY_V4),
+            (10, FAMILY_V4),
+            (12, FAMILY_V6),
+            (19, FAMILY_V4),
+            (21, FAMILY_V6),
+        ];
+        assert_eq!(
+            churn_window(&writes, FAMILY_V4, 10, 20),
+            (2, Some(10), Some(19))
+        );
+        assert_eq!(
+            churn_window(&writes, FAMILY_V6, 10, 20),
+            (1, Some(12), Some(12))
+        );
+        assert_eq!(churn_window(&writes, FAMILY_V6, 13, 20), (0, None, None));
+    }
+
     // ---- dual-stack negative cases: packet totals never masquerade as delivery ----
 
     #[test]
@@ -4573,6 +4808,8 @@ mod tests {
             t0: Instant::now(),
             n_peers: 1,
             per_peer: 1,
+            totals: [1, 1],
+            churn_writes: Mutex::new(None),
             daemon: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1),
             obs: vec![Obs::new()],
             extras: vec![Vec::new()],

--- a/bench/tests/test-scale-provenance.sh
+++ b/bench/tests/test-scale-provenance.sh
@@ -34,6 +34,12 @@ def value(cell="rustbgpd", generation="historical"):
     generator = {"rustbgpd":"bench/scale/reloadstall/gen-scenario.py", "bird":"bench/scale/reloadstall/gen-bird-scenario.py", "openbgpd":"bench/scale/reloadstall/gen-obgpd-scenario.py"}[cell]
     workload = {"binary":"target/release/rustbgpd", "sha256":h} if cell == "rustbgpd" else {"image_ref":refs[generation][cell], "image_id":"sha256:"+h}
     return {"schema":1,"cell":cell,"git":{"commit":"b"*40,"tree":"c"*40,"dirty":False},"toolchain":"rustc","host":"host","sources":{"common":common,"generator":{generator:h},"reloadstall":{"path":"bench/scale/target/release/reloadstall","sha256":h}},"workload":workload}
+inputs = {
+    "N_PEERS":"700", "TOTAL_PREFIXES":"400400", "PORT":"1790", "RELOADS":"4",
+    "CONTROL_SECS":"30", "CHANGED_PEERS":"", "FLAPSTORM":"", "BIRD_THREADS":"8",
+    "PROBE_PREFIXES":"",
+}
+(tmp / "inputs.json").write_text(json.dumps(inputs))
 verify = root / "bench/scale/matrix/verify-provenance.py"
 def accepted(name, data, want, expected=None, generation=None):
     path=tmp/(name+".json"); path.write_text(json.dumps(data))
@@ -43,6 +49,13 @@ def accepted(name, data, want, expected=None, generation=None):
     got=subprocess.run(command, capture_output=True).returncode == 0
     assert got == want, (name, got)
 accepted("valid", value(), True)
+v=value(); v["workload"]=list(v["workload"].items()); accepted("malformed-workload-object",v,False)
+v=value(); v["workload"]["inputs"]=inputs.copy(); accepted("with-inputs",v,True)
+v=value(); v["workload"]["inputs"]={}; accepted("missing-input-fields",v,False)
+v=value(); v["workload"]["inputs"]={**inputs,"GEN_DUALSTACK":"1","RELOADSTALL_IPV4_PREFIXES":"360360"}; accepted("asymmetric-inputs",v,True)
+v=value(); v["workload"]["inputs"]={**inputs,"RELOADSTALL_IPV4_PREFIXES":360360}; accepted("malformed-input-value",v,False)
+v=value(); v["workload"]["inputs"]={**inputs,"UNTRACKED":"value"}; accepted("unknown-input-key",v,False)
+
 accepted("historical-bird-default", value("bird"), True)
 accepted("historical-open-explicit", value("openbgpd"), True, generation="historical")
 accepted("current-bird", value("bird", "current"), True, generation="current")
@@ -191,8 +204,8 @@ fixture_image_id="sha256:$(printf '%064d' 0)"
 changed_image_id="sha256:$(printf '%064d' 1)"
 write_source_identity() {
   jq -n --arg commit "$1" --arg tree "$2" --argjson dirty "$3" \
-    --arg image_ref "$4" --arg image_id "$5" \
-    '{git:{commit:$commit,tree:$tree,dirty:$dirty},workload:{image_ref:$image_ref,image_id:$image_id}}' \
+    --arg image_ref "$4" --arg image_id "$5" --slurpfile inputs "$tmp/inputs.json" \
+    '{git:{commit:$commit,tree:$tree,dirty:$dirty},workload:{image_ref:$image_ref,image_id:$image_id,inputs:$inputs[0]}}' \
     >"$status.provenance"
 }
 resume_generation=historical
@@ -205,6 +218,12 @@ run_resume_check() {
       "$trace" bird "$status" >/dev/null
 }
 
+reject_resume() {
+  local rejected_rc=0
+  run_resume_check || rejected_rc=$?
+  [[ $rejected_rc == 1 ]]
+}
+
 write_source_identity "$source_commit" "$source_tree" false bird:3.3.1 "$fixture_image_id"
 resume_rc=0
 run_resume_check || resume_rc=$?
@@ -212,15 +231,15 @@ run_resume_check || resume_rc=$?
 [[ $(tail -n2 "$trace") == $'bird:resume-verify\nbird:live-verify' ]]
 
 resume_generation=current
-if run_resume_check; then exit 1; fi
+reject_resume
 resume_generation=historical
 
 write_source_identity "$source_commit" "$source_tree" false openbgpd/openbgpd:9.1 "$fixture_image_id"
-if run_resume_check; then exit 1; fi
+reject_resume
 
 write_source_identity "$source_commit" "$source_tree" false bird:3.3.1 "$fixture_image_id"
 resume_image_id=$changed_image_id
-if run_resume_check; then exit 1; fi
+reject_resume
 resume_image_id=$fixture_image_id
 
 resume_generation=current
@@ -232,18 +251,38 @@ resume_generation=historical
 write_source_identity "$source_commit" "$source_tree" false bird:3.3.1 "$fixture_image_id"
 
 git -C "$source_repo" commit --allow-empty -qm changed-head
-if run_resume_check; then exit 1; fi
+reject_resume
 git -C "$source_repo" reset -q --hard "$source_commit"
 
 write_source_identity "$source_commit" "$(printf 'f%.0s' {1..40})" false bird:3.3.1 "$fixture_image_id"
-if run_resume_check; then exit 1; fi
+reject_resume
 
 write_source_identity "$source_commit" "$source_tree" false bird:3.3.1 "$fixture_image_id"
 printf 'dirty\n' >>"$source_repo/input"
-if run_resume_check; then exit 1; fi
+reject_resume
 git -C "$source_repo" restore input
 
 resume_rc=0
 run_resume_check || resume_rc=$?
 [[ $resume_rc == 10 ]]
+# Effective defaults and explicit equivalent values identify the same workload.
+resume_rc=0
+N_PEERS=700 TOTAL_PREFIXES=400400 run_resume_check || resume_rc=$?
+[[ $resume_rc == 10 ]]
+for override in N_PEERS=20 TOTAL_PREFIXES=11440 GEN_DUALSTACK=1 \
+    GEN_FILTER_COUNT=32 RELOADSTALL_FILTER_COUNT=32 RELOADSTALL_IPV4_PREFIXES=360360; do
+  (export "${override?}"; reject_resume)
+done
+cp "$status.provenance" "$tmp/with-inputs.json"
+for expression in 'del(.workload.inputs)' '.workload.inputs = null' \
+    '.workload.inputs.N_PEERS = 700'; do
+  jq "$expression" "$tmp/with-inputs.json" >"$status.provenance"
+  reject_resume
+done
+jq '.workload.inputs.RELOADSTALL_IPV4_PREFIXES = "200200"' \
+  "$tmp/with-inputs.json" >"$status.provenance"
+resume_rc=0
+RELOADSTALL_IPV4_PREFIXES=200200 run_resume_check || resume_rc=$?
+[[ $resume_rc == 10 ]]
+RELOADSTALL_IPV4_PREFIXES=360360 reject_resume
 echo "scale provenance tests pass"


### PR DESCRIPTION
Dual-stack reloadstall runs can now select an exact IPv4 inventory with `RELOADSTALL_IPV4_PREFIXES`; IPv6 receives the remaining positional total. Each family uses contiguous quotient/remainder member slices, so 400,400 total routes at 90/10 remain exactly 360,360 IPv4 and 40,040 IPv6. Initial and reload completion, own-slice exclusions, filtering withdrawals, and decode bounds use the independent family totals. IPv4-only defaults and generated configurations remain unchanged.

Each dual-stack reload also reports successful socket writes of the existing dedicated churn blocks between the trigger and the last changed observer’s completion, including per-family counts and first/last timestamps. A window without both families reports `overlap_observed=false` without changing route-correctness acceptance or extending completion. Existing historical receipts are preserved; this change does not establish 700-member scale proof.

The matrix runner now stores effective workload inputs and rejects live resumes when they change or are missing. Historical receipts remain valid for offline verification. The existing provenance tests cover changed inventory mixes, peer/route totals, filtering inputs, missing/malformed identity, and explicit values matching the effective defaults.

Validation: 42 reloadstall tests, strict reloadstall Clippy, `just gate-deps`, and all five `just gate-rib` checks passed. Generator outputs compare byte-for-byte with main for historical IPv4 and dual-stack filtering scenarios. Repository links/contracts/Clippy, full workspace tests, and all three rustdoc commands passed. The first gate invocation hit the inherited 1,024-file limit in the doctor integration test; that test passed alone and in the full workspace rerun with a 65,536-file limit.

Quiet 20-member correctness cells passed for 11,440 total routes (10,296 IPv4 + 1,144 IPv6), 16 changed and 4 stable observers, with two B/A reloads each for permit-preserving and filtering changes (filter count 32). All four reloads observed socket-write churn in both families. The filtering B reload delivered exactly 480/480 named withdrawals per family; every reload retained 20 sessions, fresh markers at all 4 stable observers in both families, zero parse errors, and zero leaked/bystander/stable withdrawals. Each daemon log retained one legacy-config posture warning and 190 dirty-resync warnings, all of the latter after normal harness session teardown began; no ERROR records. No 200- or 700-member cell was run, and these checks make no timing claim.
