### PR TITLE
fix(bench): retain matrix health probe errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The IXP matrix retains timestamped health-probe errors alongside its latency
+  CSV, so failed operator checks identify the daemon error in the receipt.
+
 - Export policy changes now update the accepting session’s collision-recovery
   record. Promoting a surviving session preserves its accepted policy, including
   explicit permit-all and rollback. Superseded session records release their

--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -28,7 +28,8 @@
 #                when set, a 50 ms `rbgp health` loop and a 250 ms
 #                `rbgp rib --prefix` loop over the listed prefixes run against
 #                the cell's gRPC UDS for the whole harness run, logging
-#                latency and exit code to probes.csv / queries.csv)
+#                latency and exit code to probes.csv / queries.csv; health
+#                stderr is retained with start timestamps in probes.csv.stderr.log)
 #              GEN_* / RELOADSTALL_* pass through to the generator and the
 #                harness unchanged (dual-stack: GEN_DUALSTACK=1 +
 #                RELOADSTALL_DUALSTACK=1; filtering: GEN_FILTER_COUNT=K +
@@ -261,10 +262,12 @@ recheck_cell_provenance() {
 probe_health_loop() {
     local addr=$1 out=$2
     echo "epoch_s,latency_ms,exit" >"$out"
+    : >"$out.stderr.log"
     while :; do
         local t0 t1 rc
         t0=$(date +%s.%N)
-        "$RBGP" --addr "$addr" health >/dev/null 2>&1
+        printf "probe_start epoch_s=%s\n" "$t0" >>"$out.stderr.log"
+        "$RBGP" --addr "$addr" health >/dev/null 2>>"$out.stderr.log"
         rc=$?
         t1=$(date +%s.%N)
         awk -v a="$t0" -v b="$t1" -v rc="$rc" \


### PR DESCRIPTION
Matrix health probe failures currently retain only an exit code and duration, losing the daemon error needed to distinguish peer-manager and RIB-manager timeouts. Retain timestamped stderr in `probes.csv.stderr.log`, resetting it when the probe loop starts. Probe arguments, cadence, deadlines, and CSV output are unchanged.

Validation: Bash syntax, ShellCheck, repository links, and a controlled probe-loop check covering error retention, timestamps, and log truncation passed. A local 200-peer dual-stack diagnostic using the same stderr capture identified RIB-manager 200ms probe timeouts. This change preserves diagnostic evidence; it does not fix those timeouts. Normal commit and push hooks passed.
