### PR TITLE
fix(cli): scope doctor process checks to the connected daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `rbgp doctor` attributes local process limits and config freshness to the
+  connected Unix-socket peer, with process-start verification and reconnect
+  updates. Co-resident daemons no longer contribute unrelated low-limit
+  failures. TCP and unavailable local identities do not trigger process scans
+  or borrow another daemon's config; an unreachable local socket retains the
+  packaged-file first-deploy fallback.
+
 - M83 waits for the latest BIRD session's captured OPEN, exact initial route
   inventory, and End-of-RIB before stopping packet capture. Incomplete capture
   snapshots remain pending within a bounded wait, and timeout retains diagnostics;

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -18,7 +18,8 @@ use serde::Serialize;
 use crate::commands::config::confirmation_status_label;
 use crate::commands::watch::bgp_event_json_value;
 use crate::connection::{
-    Connection, EFFECTIVE_CONFIG_RPC_TIMEOUT, READ_RPC_TIMEOUT, rpc_with_timeout,
+    Connection, EFFECTIVE_CONFIG_RPC_TIMEOUT, LocalProcess, READ_RPC_TIMEOUT, proc_start_ticks,
+    rpc_with_timeout,
 };
 use crate::error::CliError;
 use crate::output::{self, JsonNeighbor, outln};
@@ -687,32 +688,13 @@ fn parse_max_open_files(limits: &str) -> Option<(u64, u64)> {
     Some((soft, hard))
 }
 
-/// Local rustbgpd processes found by `/proc/<pid>/comm`, with their
-/// rlimit dumps. Empty on non-Linux hosts, remote daemons, or when the
-/// daemon runs in another namespace — the manifest records that.
-fn local_daemon_limits() -> Vec<(u32, String)> {
-    let mut found = Vec::new();
-    let Ok(entries) = fs::read_dir("/proc") else {
-        return found;
-    };
-    for entry in entries.flatten() {
-        let Some(pid) = entry
-            .file_name()
-            .to_str()
-            .and_then(|s| s.parse::<u32>().ok())
-        else {
-            continue;
-        };
-        let comm = fs::read_to_string(format!("/proc/{pid}/comm")).unwrap_or_default();
-        if comm.trim_end() != "rustbgpd" {
-            continue;
-        }
-        if let Ok(limits) = fs::read_to_string(format!("/proc/{pid}/limits")) {
-            found.push((pid, limits));
-        }
-    }
-    found.sort_by_key(|(pid, _)| *pid);
-    found
+/// Limits belong only to the process observed on this connection's UDS stream.
+/// TCP, inaccessible procfs, and changed process identities provide no local evidence.
+fn local_daemon_limits(connection: Option<&Connection>) -> Option<(u32, String)> {
+    let connection = connection?;
+    let process = connection.local_process()?;
+    let limits = process.read_file("limits")?;
+    (connection.local_process() == Some(process)).then_some((process.pid, limits))
 }
 
 /// Pure rlimit check: red when the soft `nofile` limit is below
@@ -1803,20 +1785,42 @@ fn parse_cmdline_config_path(cmdline: &[u8]) -> Option<String> {
         .find(|arg| !arg.starts_with('-'))
 }
 
-fn proc_cmdline_config_path(pid: u32) -> Option<PathBuf> {
-    let bytes = fs::read(format!("/proc/{pid}/cmdline")).ok()?;
-    Some(
-        parse_cmdline_config_path(&bytes)
-            .map_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH), PathBuf::from),
-    )
+fn proc_cmdline_config_path(process: LocalProcess) -> Option<PathBuf> {
+    let bytes = process.read_file("cmdline")?;
+    let path = parse_cmdline_config_path(bytes.as_bytes())
+        .map_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH), PathBuf::from);
+    Some(process_config_path(process.pid, &path))
+}
+
+/// Traverse the peer's procfs magic links directly: resolving them into host
+/// paths first would lose the peer's mount namespace.
+fn process_config_path(pid: u32, path: &Path) -> PathBuf {
+    if let Ok(relative) = path.strip_prefix("/") {
+        PathBuf::from(format!("/proc/{pid}/root")).join(relative)
+    } else {
+        PathBuf::from(format!("/proc/{pid}/cwd")).join(path)
+    }
+}
+
+/// A connected UDS peer may identify its config; an unreachable local UDS
+/// may use the packaged file only as first-deploy input. TCP has no local source.
+fn local_config_path(connection: Option<&Connection>, daemon_address: &str) -> Option<PathBuf> {
+    if !daemon_address.starts_with("unix://") {
+        return None;
+    }
+    let Some(connection) = connection else {
+        return Some(PathBuf::from(DEFAULT_CONFIG_PATH));
+    };
+    let process = connection.local_process()?;
+    let path = proc_cmdline_config_path(process)?;
+    (connection.local_process() == Some(process)).then_some(path)
 }
 
 /// Process start time (unix seconds) from `/proc/<pid>/stat` field 22
 /// plus the boot time; `stat` is the raw file contents.
 fn parse_proc_start_unix(stat: &str, btime: u64, clk_tck: u64) -> Option<u64> {
     // The comm field (2) may contain spaces; fields 3+ follow the last ')'.
-    let after_comm = stat.rsplit_once(')')?.1;
-    let starttime: u64 = after_comm.split_whitespace().nth(19)?.parse().ok()?;
+    let starttime = proc_start_ticks(stat)?;
     Some(btime + starttime / clk_tck.max(1))
 }
 
@@ -2446,6 +2450,7 @@ async fn run_with_deadlines(
         None;
     let mut tcp_ao_support = crate::proto::TcpAoSupport::Unspecified.into();
     let daemon_reachable = connection.is_ok();
+    let local_connection = connection.as_ref().ok().cloned();
 
     // ---- daemon-backed sections -------------------------------------
     match connection {
@@ -3006,46 +3011,45 @@ async fn run_with_deadlines(
     )?;
 
     // ---- daemon rlimits (local processes only) ------------------------
-    let daemon_limits = local_daemon_limits();
-    if daemon_limits.is_empty() {
+    if let Some((pid, limits)) = local_daemon_limits(local_connection.as_ref()) {
+        match parse_max_open_files(&limits) {
+            Some((soft, hard)) => {
+                let check = nofile_check(pid, soft, hard, run_context);
+                reporter.record(check.name, check.status, check.detail)?;
+            }
+            None => reporter.record(
+                format!("daemon.rlimit.nofile.{pid}"),
+                CheckStatus::Warn,
+                format!("daemon pid {pid}: could not parse Max open files from /proc limits"),
+            )?,
+        }
+        bundle.add(
+            &format!("system/daemon-limits-{pid}.txt"),
+            limits.into_bytes(),
+        );
+        sections.insert("rlimits", "collected".to_string());
+    } else {
         sections.insert(
             "rlimits",
-            "unavailable: no local rustbgpd process found".to_string(),
+            "unavailable: connected daemon has no verified local UDS process limits".to_string(),
         );
-    } else {
-        for (pid, limits) in &daemon_limits {
-            match parse_max_open_files(limits) {
-                Some((soft, hard)) => {
-                    let check = nofile_check(*pid, soft, hard, run_context);
-                    reporter.record(check.name, check.status, check.detail)?;
-                }
-                None => reporter.record(
-                    format!("daemon.rlimit.nofile.{pid}"),
-                    CheckStatus::Warn,
-                    format!("daemon pid {pid}: could not parse Max open files from /proc limits"),
-                )?,
-            }
-            bundle.add(
-                &format!("system/daemon-limits-{pid}.txt"),
-                limits.clone().into_bytes(),
-            );
-        }
-        sections.insert("rlimits", "collected".to_string());
     }
 
     // ---- first-deploy probes (LAN-482) --------------------------------
-    // Target source: the daemon's effective config when it is up;
-    // otherwise the local config file (the path a local daemon process
-    // was started with, else the packaged default). The local file is
-    // only parsed for probe targets — it is never copied into the bundle.
+    // Effective config is authoritative. Local fallback files are used only
+    // for a verified UDS peer, or first-deploy input when that UDS is down.
     let local_config_source: Option<(String, String)> = if effective_toml.is_none() {
-        let path = daemon_limits
-            .first()
-            .and_then(|(pid, _)| proc_cmdline_config_path(*pid))
-            .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH));
-        fs::read_to_string(&path)
-            .ok()
-            .map(|text| (text, path.display().to_string()))
+        let process = local_connection
+            .as_ref()
+            .and_then(Connection::local_process);
+        local_config_path(local_connection.as_ref(), opts.daemon_address).and_then(|path| {
+            let text = fs::read_to_string(&path).ok()?;
+            (local_connection
+                .as_ref()
+                .and_then(Connection::local_process)
+                == process)
+                .then(|| (text, path.display().to_string()))
+        })
     } else {
         None
     };
@@ -3135,18 +3139,24 @@ async fn run_with_deadlines(
 
     // ---- config freshness (local daemon processes only) ---------------
     let freshness_state_dir = PathBuf::from(state_dir.as_deref().unwrap_or(DEFAULT_STATE_DIR));
-    for (pid, _) in &daemon_limits {
-        let Some(config_path) = proc_cmdline_config_path(*pid) else {
-            continue;
-        };
-        let (Some(mtime), Some(reference)) = (
+    if let Some(connection) = local_connection.as_ref()
+        && let Some(process) = connection.local_process()
+        && let Some(config_path) = proc_cmdline_config_path(process)
+        && let (Some(mtime), Some(reference)) = (
             mtime_unix(&config_path),
-            config_freshness_reference(&freshness_state_dir, *pid),
-        ) else {
-            continue;
-        };
-        let check =
-            config_freshness_check(*pid, &config_path.display().to_string(), mtime, reference);
+            config_freshness_reference(
+                &process_config_path(process.pid, &freshness_state_dir),
+                process.pid,
+            ),
+        )
+        && connection.local_process() == Some(process)
+    {
+        let check = config_freshness_check(
+            process.pid,
+            &config_path.display().to_string(),
+            mtime,
+            reference,
+        );
         reporter.record(check.name, check.status, check.detail)?;
     }
 
@@ -4198,6 +4208,146 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
         let container = nofile_check(42, 1024, 524_288, "container");
         assert!(container.detail.contains("ulimit"), "{}", container.detail);
         assert!(nofile_check(42, 4096, 524_288, "unknown").status == CheckStatus::Ok);
+    }
+
+    /// Subprocess fixture: two independently limited UDS peers, deliberately
+    /// named rustbgpd so the former host-wide discovery would select both.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn local_identity_fixture() {
+        let Some(socket) = std::env::var_os("RUSTBGPD_DOCTOR_IDENTITY_SOCKET") else {
+            return;
+        };
+        fs::write("/proc/self/comm", "rustbgpd").unwrap();
+        let path = PathBuf::from(socket);
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let _server = crate::test_support::spawn_mock_uds_server(&path, None).await;
+                fs::write(path.with_extension("ready"), "ready").unwrap();
+                std::future::pending::<()>().await;
+            });
+    }
+
+    #[cfg(target_os = "linux")]
+    struct IdentityFixture(std::process::Child);
+
+    #[cfg(target_os = "linux")]
+    impl Drop for IdentityFixture {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn spawn_identity_fixture(path: &Path, nofile: u64) -> IdentityFixture {
+        let _ = fs::remove_file(path.with_extension("ready"));
+        let child = std::process::Command::new("sh")
+            .args(["-c", "ulimit -n \"$1\"; exec \"$2\" --exact commands::doctor::tests::local_identity_fixture --nocapture", "doctor-identity-fixture"])
+            .arg(nofile.to_string())
+            .arg(std::env::current_exe().unwrap())
+            .env("RUSTBGPD_DOCTOR_IDENTITY_SOCKET", path)
+            .stdout(std::process::Stdio::null())
+            .spawn().unwrap();
+        let mut fixture = IdentityFixture(child);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !path.with_extension("ready").exists() {
+                assert!(
+                    fixture.0.try_wait().unwrap().is_none(),
+                    "identity fixture exited before binding"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        fixture
+    }
+
+    #[test]
+    fn process_config_paths_stay_in_the_connected_process_filesystem() {
+        assert_eq!(
+            process_config_path(42, Path::new("/etc/rustbgpd/config.toml")),
+            PathBuf::from("/proc/42/root/etc/rustbgpd/config.toml"),
+        );
+        assert_eq!(
+            process_config_path(42, Path::new("configs/router.toml")),
+            PathBuf::from("/proc/42/cwd/configs/router.toml"),
+        );
+    }
+
+    #[tokio::test]
+    async fn local_config_fallback_requires_a_local_down_endpoint_or_verified_process() {
+        assert_eq!(
+            local_config_path(None, "unix:///missing.sock"),
+            Some(PathBuf::from(DEFAULT_CONFIG_PATH))
+        );
+        assert!(local_config_path(None, "http://192.0.2.1:50051").is_none());
+        let server = crate::test_support::spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        assert!(local_config_path(Some(&connection), &server.addr).is_none());
+        // Even an address presented as UDS cannot turn unavailable transport
+        // identity into evidence that the packaged file belongs to its daemon.
+        assert!(local_config_path(Some(&connection), "unix:///unknown.sock").is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn connected_process_limits_ignore_other_daemons_and_follow_reconnect() {
+        let dir = tempfile::tempdir().unwrap();
+        let selected_path = dir.path().join("selected.sock");
+        let good = spawn_identity_fixture(&selected_path, 4096).await;
+        let bad_path = dir.path().join("other.sock");
+        let bad = spawn_identity_fixture(&bad_path, 1024).await;
+        let connection = connect(&format!("unix://{}", selected_path.display()), None)
+            .await
+            .unwrap();
+        let (pid, limits) = local_daemon_limits(Some(&connection)).unwrap();
+        assert_eq!(pid, good.0.id());
+        let (soft, hard) = parse_max_open_files(&limits).unwrap();
+        assert_eq!(soft, 4096);
+        assert!(nofile_check(pid, soft, hard, "unknown").status == CheckStatus::Ok);
+
+        let other = connect(&format!("unix://{}", bad_path.display()), None)
+            .await
+            .unwrap();
+        let (pid, limits) = local_daemon_limits(Some(&other)).unwrap();
+        assert_eq!(pid, bad.0.id());
+        let (soft, hard) = parse_max_open_files(&limits).unwrap();
+        assert_eq!(soft, 1024);
+        assert!(nofile_check(pid, soft, hard, "unknown").status == CheckStatus::Fail);
+        let tcp = crate::test_support::spawn_mock_server(None).await;
+        let tcp_connection = connect(&tcp.addr, None).await.unwrap();
+        assert!(local_daemon_limits(Some(&tcp_connection)).is_none());
+        assert!(local_daemon_limits(None).is_none());
+
+        drop(good);
+        assert!(local_daemon_limits(Some(&connection)).is_none());
+        let replacement = spawn_identity_fixture(&selected_path, 1024).await;
+        let mut client =
+            GlobalServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let _ = client.get_global(crate::proto::GetGlobalRequest {}).await;
+                if connection
+                    .local_process()
+                    .is_some_and(|process| process.pid == replacement.0.id())
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        let (pid, limits) = local_daemon_limits(Some(&connection)).unwrap();
+        assert_eq!(pid, replacement.0.id());
+        let (soft, hard) = parse_max_open_files(&limits).unwrap();
+        assert_eq!(soft, 1024);
+        assert!(nofile_check(pid, soft, hard, "unknown").status == CheckStatus::Fail);
     }
 
     #[test]

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1786,8 +1786,8 @@ fn parse_cmdline_config_path(cmdline: &[u8]) -> Option<String> {
 }
 
 fn proc_cmdline_config_path(process: LocalProcess) -> Option<PathBuf> {
-    let bytes = process.read_file("cmdline")?;
-    let path = parse_cmdline_config_path(bytes.as_bytes())
+    let bytes = process.read_bytes("cmdline")?;
+    let path = parse_cmdline_config_path(&bytes)
         .map_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH), PathBuf::from);
     Some(process_config_path(process.pid, &path))
 }
@@ -5054,6 +5054,10 @@ paths = ["x"]
 
     #[test]
     fn cmdline_config_path_takes_first_non_flag_argument() {
+        assert_eq!(
+            parse_cmdline_config_path(b"rustbgpd\xff\0/etc/rustbgpd/prod.toml\0--label\0bad\xff\0"),
+            Some("/etc/rustbgpd/prod.toml".to_string()),
+        );
         assert_eq!(
             parse_cmdline_config_path(b"rustbgpd\0/etc/rustbgpd/prod.toml\0"),
             Some("/etc/rustbgpd/prod.toml".to_string())

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -7,6 +7,7 @@
 use std::fs;
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use hyper_util::rt::TokioIo;
@@ -84,11 +85,51 @@ pub(crate) const EFFECTIVE_CONFIG_MAX_DECODE_BYTES: usize =
 pub(crate) struct Connection {
     channel: Channel,
     token: Option<AsciiMetadataValue>,
+    local_process: Arc<Mutex<Option<LocalProcess>>>,
+}
+
+/// Identity observed on the actual UDS transport, including Linux PID reuse evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct LocalProcess {
+    pub(crate) pid: u32,
+    start_ticks: u64,
+}
+
+pub(crate) fn proc_start_ticks(stat: &str) -> Option<u64> {
+    stat.rsplit_once(')')?
+        .1
+        .split_whitespace()
+        .nth(19)?
+        .parse()
+        .ok()
+}
+
+impl LocalProcess {
+    fn capture(pid: u32) -> Option<Self> {
+        if pid == 0 {
+            return None;
+        }
+        let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        Some(Self {
+            pid,
+            start_ticks: proc_start_ticks(&stat)?,
+        })
+    }
+
+    /// Read only while the same process still occupies the observed PID.
+    pub(crate) fn read_file(self, name: &str) -> Option<String> {
+        if Self::capture(self.pid)? != self {
+            return None;
+        }
+        let text = fs::read_to_string(format!("/proc/{}/{name}", self.pid)).ok()?;
+        (Self::capture(self.pid)? == self).then_some(text)
+    }
 }
 
 impl Connection {
-    pub(crate) const fn new(channel: Channel, token: Option<AsciiMetadataValue>) -> Self {
-        Self { channel, token }
+    pub(crate) fn local_process(&self) -> Option<LocalProcess> {
+        let process = (*self.local_process.lock().ok()?)?;
+        (LocalProcess::capture(process.pid)? == process).then_some(process)
     }
 
     pub(crate) fn channel(&self) -> Channel {
@@ -164,11 +205,16 @@ enum EndpointTarget {
 
 pub(crate) async fn connect(addr: &str, token_file: Option<&str>) -> Result<Connection, CliError> {
     let token = load_bearer_token(token_file)?;
+    let local_process = Arc::default();
     let channel = match parse_endpoint_target(addr)? {
         EndpointTarget::Tcp(uri) => connect_tcp(&uri, addr).await?,
-        EndpointTarget::Uds(path) => connect_uds(&path, addr).await?,
+        EndpointTarget::Uds(path) => connect_uds(&path, addr, Arc::clone(&local_process)).await?,
     };
-    Ok(Connection::new(channel, token))
+    Ok(Connection {
+        channel,
+        token,
+        local_process,
+    })
 }
 
 /// Map a connect-time transport error to a short human failure class,
@@ -267,15 +313,34 @@ async fn connect_tcp(uri: &str, display_addr: &str) -> Result<Channel, CliError>
         .map_err(|e| connect_error(display_addr, &e))
 }
 
-async fn connect_uds(path: &Path, display_addr: &str) -> Result<Channel, CliError> {
+async fn connect_uds(
+    path: &Path,
+    display_addr: &str,
+    local_process: Arc<Mutex<Option<LocalProcess>>>,
+) -> Result<Channel, CliError> {
     let endpoint = Endpoint::try_from("http://[::]:50051")
         .map_err(|e| CliError::Argument(format!("invalid UDS endpoint: {e}")))?
         .connect_timeout(CONNECT_TIMEOUT);
     let path = path.to_path_buf();
     let connect = endpoint.connect_with_connector(service_fn(move |_: Uri| {
         let path = path.clone();
+        let local_process = Arc::clone(&local_process);
         async move {
+            // Reconnect attempts invalidate the previous transport's identity,
+            // including attempts that fail before a replacement is available.
+            if let Ok(mut identity) = local_process.lock() {
+                *identity = None;
+            }
             let stream = UnixStream::connect(path).await?;
+            let process = stream
+                .peer_cred()
+                .ok()
+                .and_then(|cred| cred.pid())
+                .and_then(|pid| u32::try_from(pid).ok())
+                .and_then(LocalProcess::capture);
+            if let Ok(mut identity) = local_process.lock() {
+                *identity = process;
+            }
             Ok::<_, std::io::Error>(TokioIo::new(stream))
         }
     }));
@@ -296,6 +361,57 @@ mod tests {
     use tonic::metadata::MetadataValue;
 
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn uds_identity_comes_from_the_connected_stream_and_rejects_pid_reuse() {
+        let dir = tempfile::tempdir().unwrap();
+        let server =
+            crate::test_support::spawn_mock_uds_server(&dir.path().join("grpc.sock"), None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let process = connection.local_process().unwrap();
+        assert_eq!(process.pid, std::process::id());
+        assert_eq!(
+            process.read_file("limits").unwrap(),
+            fs::read_to_string("/proc/self/limits").unwrap()
+        );
+        let reused_pid = LocalProcess {
+            start_ticks: process.start_ticks + 1,
+            ..process
+        };
+        assert!(reused_pid.read_file("limits").is_none());
+        *connection.local_process.lock().unwrap() = Some(reused_pid);
+        assert!(connection.local_process().is_none());
+    }
+
+    #[tokio::test]
+    async fn tcp_identity_is_unavailable_even_with_a_local_server() {
+        let server = crate::test_support::spawn_mock_server(None).await;
+        assert!(
+            connect(&server.addr, None)
+                .await
+                .unwrap()
+                .local_process()
+                .is_none()
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn failed_uds_reconnect_clears_previous_process_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = Arc::new(Mutex::new(LocalProcess::capture(std::process::id())));
+        assert!(
+            connect_uds(
+                &dir.path().join("missing.sock"),
+                "missing",
+                Arc::clone(&identity)
+            )
+            .await
+            .is_err()
+        );
+        assert!(identity.lock().unwrap().is_none());
+    }
 
     #[tokio::test]
     async fn read_deadline_cancels_pending_response_and_names_method_and_budget() {

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -118,11 +118,15 @@ impl LocalProcess {
 
     /// Read only while the same process still occupies the observed PID.
     pub(crate) fn read_file(self, name: &str) -> Option<String> {
+        String::from_utf8(self.read_bytes(name)?).ok()
+    }
+
+    pub(crate) fn read_bytes(self, name: &str) -> Option<Vec<u8>> {
         if Self::capture(self.pid)? != self {
             return None;
         }
-        let text = fs::read_to_string(format!("/proc/{}/{name}", self.pid)).ok()?;
-        (Self::capture(self.pid)? == self).then_some(text)
+        let bytes = fs::read(format!("/proc/{}/{name}", self.pid)).ok()?;
+        (Self::capture(self.pid)? == self).then_some(bytes)
     }
 }
 
@@ -382,6 +386,47 @@ mod tests {
         assert!(reused_pid.read_file("limits").is_none());
         *connection.local_process.lock().unwrap() = Some(reused_pid);
         assert!(connection.local_process().is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_bytes_preserve_non_utf8_cmdline_and_check_process_identity() {
+        use std::os::unix::{ffi::OsStringExt, process::CommandExt};
+
+        struct Child(std::process::Child);
+        impl Drop for Child {
+            fn drop(&mut self) {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        fs::write(&config, "[global]\nasn = 65001\n").unwrap();
+        // cat reads the config and then waits on its owned stdin pipe. Its
+        // argv0 need not be UTF-8, unlike the Rust test harness's arguments.
+        let child = Child(
+            std::process::Command::new("cat")
+                .arg0(std::ffi::OsString::from_vec(b"rustbgpd\xff".to_vec()))
+                .arg(&config)
+                .arg("-")
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::null())
+                .spawn()
+                .unwrap(),
+        );
+        let process = LocalProcess::capture(child.0.id()).unwrap();
+        let cmdline = process.read_bytes("cmdline").unwrap();
+        let mut args = cmdline.split(|byte| *byte == 0);
+        assert_eq!(args.next().unwrap(), b"rustbgpd\xff");
+        assert_eq!(args.next().unwrap(), config.as_os_str().as_encoded_bytes());
+        assert!(process.read_file("cmdline").is_none());
+        let reused_pid = LocalProcess {
+            start_ticks: process.start_ticks + 1,
+            ..process
+        };
+        assert!(reused_pid.read_bytes("cmdline").is_none());
     }
 
     #[tokio::test]

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -2230,6 +2230,16 @@ failure cannot distinguish a failed bind from routing or filtering. Explicit
 daemon loopback addresses cannot be checked remotely. Run doctor on the
 daemon host to verify these binds, including for `--pre-upgrade` diagnostics.
 
+On Linux, local process limits and config freshness belong only to the peer
+identified by the connected Unix-domain socket. Doctor checks the process start
+time before using `/proc` evidence and refreshes identity on reconnect. Config
+paths and freshness markers are read through that process's filesystem view. Other
+`rustbgpd` instances on the host do not contribute these checks or limits files.
+TCP connections and unavailable local identity leave process limits unavailable.
+When effective config cannot be read, doctor uses the verified local peer's
+config path; an unreachable Unix socket can still use the packaged default file
+as local first-deploy input. TCP does not fall back to a CLI-host config file.
+
 First-deploy checks (network probes are bounded to a 2s timeout; all are read-only):
 
 | Check | What it probes | Red/yellow advice |


### PR DESCRIPTION
`rbgp doctor` now uses the connected Unix-socket peer's PID and process start time for local limits, config fallback, and freshness evidence. Co-resident daemons cannot contribute unrelated low-limit failures. Reconnects refresh the identity, and config paths and freshness markers are read through the selected process's filesystem view.

TCP and unavailable local identities leave process evidence unavailable. An unreachable local Unix socket retains the packaged-config first-deploy fallback. The nofile threshold and remediation text are unchanged.

Validation: full `just gate` on the main change, including 771 CLI tests. The byte-read follow-up passed 29 connection tests, the command-line parser regression, strict workspace Clippy, and all normal push hooks (workspace library tests and rustdoc included). No dependency changes.
