### PR TITLE
docs(docs): correct four operator procedures

### DIFF
--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -216,7 +216,7 @@ mtimes can lie about what the daemon actually accepted.
 ```bash
 rbgp summary                          # members Established
 rbgp rib received 198.51.100.2        # a member's accepted routes
-rbgp policy stats                     # hygiene/client terms firing
+rbgp policy stats --direction import  # hygiene/client terms firing
 rbgp policy explain --neighbor 198.51.100.2 --prefix 203.0.113.0/24
 ```
 

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -18,8 +18,7 @@ demotes to LLGR_STALE (RFC 9494) if `llgr_stale_time > 0`. Check the
 peer-group template carries what you think it does:
 
 ```toml
-[[peer_groups]]
-name = "rr-clients"
+[peer_groups.rr-clients]
 graceful_restart = true
 gr_stale_routes_time = 120
 llgr_stale_time = 300

--- a/docs/how-to/deployment.md
+++ b/docs/how-to/deployment.md
@@ -1483,7 +1483,7 @@ short version for first deployment:
 | Session won't establish | `rbgp neighbor <addr>` + `journalctl -u rustbgpd -p warning` |
 | Routes received but not installed | `rbgp rib`, then `rbgp rib received <peer> --rejected`; for the statement-level trace, `rbgp policy explain --neighbor <peer> --prefix <CIDR>` (opt-in: needs `[policy.explain] enabled = true`) |
 | Reload didn't change behavior | `rustbgpd --diff <file>` + cross-reference [reload matrix](../reference/reload-matrix.md) |
-| FIB programming failures | `bgp_fib_kernel_failures_total` Prometheus counter + `journalctl` for `kernel-dataplane` lines |
+| FIB programming failures | `bgp_fib_kernel_failures_total` Prometheus counter + `journalctl -u rustbgpd -g 'failed to apply general FIB route op'` |
 | FIB or BLACKHOLE planning stops before kernel access | `increase(bgp_dataplane_reconcile_planning_failures_total[10m]) > 0` + matching structured warning; status remains the last successful snapshot |
 | EVPN-specific issues | [`evpn-vtep-troubleshooting.md`](evpn-vtep-troubleshooting.md) |
 | Anything not above | [`OPERATIONS.md`](../reference/operations.md) "Debugging" section |

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -2508,7 +2508,7 @@ returns and survive a restart.
 The live mutation path is serialized with SIGHUP reload, so a reload cannot
 drop an accepted-but-not-yet-persisted range.
 
-When `rbgp neighbor list` has no live neighbor rows, human output queries the
+When `rbgp neighbor` has no live neighbor rows, human output queries the
 range inventory and distinguishes an unconfigured daemon from configured
 ranges that have not accepted a peer yet. JSON compatibility is unchanged:
 the same empty live-neighbor result is exactly `[]`, with no range lookup or


### PR DESCRIPTION
Four operator instructions used an invalid peer-group table, a nonexistent neighbor subcommand, the wrong policy-statistics direction, or a log string the daemon never emits. Correct them to the keyed peer-group table, bare neighbor inventory, import statistics, and the actual FIB apply warning.

Validation: the original peer-group snippet fails `rustbgpd --check` and the corrected snippet passes; CLI command forms and current policy/log source checked; offline links, public tracker IDs, site manifest, and IXP Manager documentation checks passed.
