### PR TITLE
test(api): cover staged reload read completion

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -3458,6 +3458,78 @@ mod tests {
         );
     }
 
+    /// Inventory may arrive before a policy transition while its following
+    /// RIB snapshot waits for settlement. Each stage retains its own budget.
+    #[tokio::test(start_paused = true)]
+    async fn list_neighbors_completes_after_staged_operator_and_rib_replies() {
+        let (peer_tx, _peer_rx) = mpsc::channel(1);
+        let (operator_tx, mut operator_rx) = mpsc::channel(1);
+        let (svc, mut rib_rx) = read_service(peer_tx);
+        let svc = svc.with_operator_queries(operator_tx);
+        let first: IpAddr = "10.0.0.1".parse().unwrap();
+        let second: IpAddr = "10.0.0.2".parse().unwrap();
+        let started = tokio::time::Instant::now();
+        let read = tokio::spawn(async move {
+            svc.list_neighbors(Request::new(proto::ListNeighborsRequest {}))
+                .await
+        });
+        let Some(PeerManagerOperatorQuery::ListPeers { reply }) =
+            tokio::time::timeout(Duration::from_secs(3), operator_rx.recv())
+                .await
+                .expect("neighbor inventory must use the operator lane")
+        else {
+            panic!("expected peer inventory");
+        };
+        assert!(rib_rx.try_recv().is_err());
+        tokio::time::advance(Duration::from_millis(800)).await;
+        reply
+            .send(vec![peer_info(second), peer_info(first)])
+            .unwrap();
+        let Some(RibUpdate::QueryNeighborRibSnapshots {
+            peers,
+            comparison,
+            reply,
+        }) = tokio::time::timeout(Duration::from_secs(3), rib_rx.recv())
+            .await
+            .expect("RIB lookup must follow the inventory reply")
+        else {
+            panic!("expected aggregate neighbor snapshots");
+        };
+        assert_eq!(peers, vec![first, second]);
+        assert!(comparison.is_none());
+        assert_eq!(started.elapsed(), Duration::from_millis(800));
+        // Model the atomic transition holding the second reply. This is
+        // within the RIB stage's own 2 s budget, not a shared RPC deadline.
+        tokio::time::advance(Duration::from_millis(1_100)).await;
+        assert!(!read.is_finished());
+        reply
+            .send(NeighborRibSnapshotResponse {
+                snapshots: vec![
+                    NeighborRibSnapshot {
+                        peer: first,
+                        advertised_count: 7,
+                        policy_stats: rustbgpd_rib::NeighborPolicyStats::default(),
+                        outbound: empty_outbound_state(),
+                    },
+                    NeighborRibSnapshot {
+                        peer: second,
+                        advertised_count: 9,
+                        policy_stats: rustbgpd_rib::NeighborPolicyStats::default(),
+                        outbound: empty_outbound_state(),
+                    },
+                ],
+                comparison: None,
+            })
+            .unwrap();
+        let neighbors = read.await.unwrap().unwrap().into_inner().neighbors;
+        assert_eq!(started.elapsed(), Duration::from_millis(1_900));
+        assert_eq!(neighbors.len(), 2);
+        assert_eq!(neighbors[0].config.as_ref().unwrap().address, "10.0.0.1");
+        assert_eq!(neighbors[1].config.as_ref().unwrap().address, "10.0.0.2");
+        assert_eq!(neighbors[0].prefixes_sent, 7);
+        assert_eq!(neighbors[1].prefixes_sent, 9);
+    }
+
     /// Load-bearing: broadly reclassifying RIB snapshot contract failures as
     /// actor unavailability changes this status away from `INTERNAL`.
     #[tokio::test]

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -3990,6 +3990,92 @@ policy customer-in(peer_lp: u32) {
         .expect("a fenced export-policy transition must not fail an operator stats read");
     }
 
+    /// A dataset lookup can reach the operator lane after the export reply
+    /// has already spent part of the aggregate budget. Model that ordering
+    /// with held replies; the generation tests cover the actual actor fence.
+    #[tokio::test(start_paused = true)]
+    async fn get_policy_stats_completes_after_staged_export_and_dataset_replies() {
+        let (peer_tx, _peer_rx) = mpsc::channel(1);
+        let (operator_tx, mut operator_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None)
+            .with_operator_queries(operator_tx)
+            .with_rib_query(rib_tx);
+        let started = tokio::time::Instant::now();
+        let read = tokio::spawn(async move {
+            PolicyServiceRpc::get_policy_stats(
+                &svc,
+                Request::new(policy_stats_rpc_request("", "export")),
+            )
+            .await
+        });
+        let Some(rustbgpd_rib::RibUpdate::QueryExportPolicyTermHits { peer, reply }) =
+            tokio::time::timeout(Duration::from_secs(3), rib_rx.recv())
+                .await
+                .expect("stats must request export counters first")
+        else {
+            panic!("expected export counters");
+        };
+        assert!(peer.is_none());
+        assert!(operator_rx.try_recv().is_err());
+        tokio::time::advance(Duration::from_millis(800)).await;
+        reply
+            .send(vec![rustbgpd_rib::update::ExportPolicyTermHits {
+                peer: Some("10.0.0.2".parse().unwrap()),
+                evals: 7,
+                eval_errors: 0,
+                last_error: None,
+                terms: Vec::new(),
+            }])
+            .unwrap();
+        let Some(PeerManagerOperatorQuery::QueryPolicyDatasets { reply }) =
+            tokio::time::timeout(Duration::from_secs(3), operator_rx.recv())
+                .await
+                .expect("dataset lookup must follow the export reply")
+        else {
+            panic!("expected dataset lookup on the operator lane");
+        };
+        assert_eq!(started.elapsed(), Duration::from_millis(800));
+        // The closed admission interval consumes 1100 of the remaining
+        // 1200 ms; it must not discard the already collected export rows.
+        tokio::time::advance(Duration::from_millis(1_100)).await;
+        assert!(!read.is_finished());
+        reply
+            .send(vec![crate::peer_types::PolicyDatasetStatusRow {
+                status: rustbgpd_policy::datasets::DatasetStatus {
+                    name: "customers".into(),
+                    kind: rustbgpd_policy::datasets::DatasetKind::Asn,
+                    generation: 7,
+                    records: 42,
+                    last_error: None,
+                },
+                path: "customers.list".into(),
+            }])
+            .unwrap();
+        let response = read.await.unwrap().unwrap().into_inner();
+        assert_eq!(started.elapsed(), Duration::from_millis(1_900));
+        assert_eq!(
+            response.chains,
+            vec![proto::PolicyChainStats {
+                peer_address: "10.0.0.2".into(),
+                direction: "export".into(),
+                routes_evaluated: 7,
+                ..Default::default()
+            }]
+        );
+        assert_eq!(
+            response.datasets,
+            vec![proto::PolicyDatasetStatus {
+                name: "customers".into(),
+                kind: "asn-set".into(),
+                generation: 7,
+                records: 42,
+                path: "customers.list".into(),
+                ..Default::default()
+            }]
+        );
+    }
+
     /// LAN-661: explicit-peer validation, export, import, and dataset reads
     /// are sequential but spend one shared RPC budget rather than receiving
     /// independent timeouts.


### PR DESCRIPTION
Add two paused-time regressions for operator reads whose first backend reply arrives before the second lookup finishes waiting. Policy stats preserves collected export rows while the dataset lookup uses the remaining aggregate budget; neighbor inventory preserves peer order and merges the later RIB snapshot within the separate stage budgets.

Both tests coordinate requests and held replies through channels, then return complete results after 800 ms plus 1,100 ms of virtual time. They cover API composition alongside the existing actor-fence and deadline regressions; they do not simulate the scale workload.

Validation: both exact new tests and four existing API deadline, transition, and neighbor snapshot tests pass. Normal commit and push hooks cover formatting, strict workspace Clippy, library tests, and rustdoc. This changes tests only, so operator documentation and the changelog remain unchanged.
