### PR TITLE
docs(config): distinguish the config epoch namespace

### DIFF
--- a/docs/reference/format-version-namespaces.md
+++ b/docs/reference/format-version-namespaces.md
@@ -2,15 +2,16 @@
 
 > **Document class: REFERENCE.** This maintained page defines a contract, specification, or reusable procedure; follow any stated version scope.
 
-rustbgpd does not have one global "v1/v2/v3" format lineage. Each durable or
-machine-readable surface below owns an independent version namespace with its
-own compatibility rules. None of these numbers is comparable with the product
-SemVer version, the protobuf package `rustbgpd.v1`, the frozen v1
-stable-surface inventory ([v1-stable-surface.json](v1-stable-surface.json)),
-or one another.
+rustbgpd does not have one global "v1/v2/v3" format lineage. Each surface
+below owns an independent namespace with its own compatibility rules. These
+markers are independent of the product SemVer version and of one another;
+a matching numeral does not imply a shared compatibility contract.
 
 | Surface | Current marker | What the number means | Compatibility owner |
 |---------|----------------|-----------------------|---------------------|
+| Configuration epoch | Root `config_epoch = 1` or `2` ([`src/config/schema.rs`](../../src/config/schema.rs)); absence means `1` | Behavior gate for an omitted `global.ebgp_requires_policy`, not a TOML format version. | [ADR-0119](../adr/0119-rfc-8212-secure-default-config-epoch.md), [ADR-0125 DR4](../adr/0125-v1-stability-contract.md) |
+| Protobuf package | `rustbgpd.v1` ([`proto/rustbgpd.proto`](../../proto/rustbgpd.proto)) | gRPC API package namespace; membership does not put every RPC in the frozen v1 inventory. | [Stability guide](stability.md), [ADR-0125](../adr/0125-v1-stability-contract.md) |
+| Stable-surface inventory | v1 contract ([`v1-stable-surface.json`](v1-stable-surface.json)) | Exact compatibility boundary for the inventoried route-server and route-reflector unicast surfaces, with explicit exclusions. | [v1 stable contract](v1-stable-contract.md), [ADR-0125](../adr/0125-v1-stability-contract.md) |
 | Commit-confirm authority | v3 (`VERSION = 3`, [`src/confirm_journal/v3.rs`](../../src/confirm_journal/v3.rs)) | Current durable pending-authority format. A retired journal (locator-free or v2) refuses boot with the artifact untouched instead of being decoded. | [ADR-0076 amendment](../adr/0076-config-transaction-model.md), [ADR-0122](../adr/0122-compatibility-debt-inventory.md) rows D1/D3 |
 | Config history | v2 (`VERSION = 2`, [`src/config_history/v2.rs`](../../src/config_history/v2.rs)) | Current JSON history codec. Retired TOML history is ignored and retained. | [ADR-0122](../adr/0122-compatibility-debt-inventory.md) row D1 |
 | Runtime snapshot token | `kv1:` / `kv2:` prefix ([`src/config/mod.rs`](../../src/config/mod.rs)) | Keyed, process-local change-detector tokens minted by one algorithm. The prefix discriminates whether live runtime context is bound into the preimage — `kv1:` config only, `kv2:` config plus the live update-group snapshot identity — not successive format generations. Production planning always binds context, so live tokens carry `kv2:`; callers compare tokens opaquely and re-plan after a daemon restart. | [ADR-0076](../adr/0076-config-transaction-model.md) |
@@ -18,6 +19,13 @@ or one another.
 | Support bundle | manifest `format: 2` (`support-bundle-manifest/2`) | Frozen machine-readable doctor bundle layout with additive-fields-only evolution. Not a config-transaction format. | [v1-stable-surface.json](v1-stable-surface.json) |
 | General FIB owned state | v5 current, loads v1–v5 ([`src/fib_runtime.rs`](../../src/fib_runtime.rs)) | Crash-restart ownership receipt: v1 single next-hop scalar, v2 equal-cost set, v3 per-next-hop weights, v4/v5 link-local ifindexes (landed together; no standalone v4 shipped). One serde model plus an on-load upgrader, not parallel readers. | [ADR-0066](../adr/0066-unicast-multipath-ecmp-fib.md), [ADR-0068](../adr/0068-weighted-multipath.md), [ADR-0069](../adr/0069-bgp-unnumbered.md), [ADR-0079](../adr/0079-kernel-state-crash-restart-reconciliation.md) |
 | GR restart marker | v3 current, accepts v1–v3 (`gr-restart.toml`, [`src/main.rs`](../../src/main.rs)) | Planned-restart marker: v1 carries the wall-clock expiry only, v2 binds the warm-checkpoint generation, v3 adds the restart clock domain (boot id, time namespace, boottime offsets and boottime expiry). The writer emits v3 and degrades to v2/v1 when clock sampling fails; the validator accepts each version only with its exact field set. | [ADR-0040](../adr/0040-gr-restarting-speaker.md), [ADR-0104](../adr/0104-shutdown-warm-checkpoint-publication.md) |
+
+With `global.ebgp_requires_policy` omitted, epoch-less or epoch-1 configs
+resolve to `false` (`legacy_omission`), while epoch 2 resolves to `true`
+(`epoch_2_default`). Explicit booleans retain their value under both epochs,
+and ADR-0125 DR4 keeps epoch-less and epoch-1 omission permissive forever.
+The v1 inventory classifies `Config.config_epoch` as `outside_v1`:
+`config_epoch = 1` does not make the field part of the frozen v1 contract.
 
 ## Why the compatibility behaviors differ
 


### PR DESCRIPTION
The version-namespace reference omitted `config_epoch` and mentioned the protobuf package and frozen v1 inventory only in its introduction. Add distinct rows and explain how epochs affect omitted RFC 8212 policy defaults, while explicit booleans retain their value and the epoch field remains outside the frozen v1 inventory.

Validation: current schema, protobuf declaration, inventory and ADR decisions checked; offline links, public tracker identifiers, site manifest and diff checks passed.
