### PR TITLE
ci(bench): wait for Alice neighbor cache readiness

### DIFF
--- a/tests/compat/ixp-manager-birdseye/README.md
+++ b/tests/compat/ixp-manager-birdseye/README.md
@@ -147,8 +147,9 @@ synthetic ROAs and must report exactly one deliberate mismatch: the covering
 `203.0.113.0/24` originated by AS64520. Alice runs with
 `enable_prefix_lookup = true` and one-minute store refresh intervals, so its
 routes store reads the adapter's `/routes/table/<table>` and
-`/routes/table/<table>/filtered` dumps; the harness waits for a refresh that
-saw the expected accepted and filtered totals, prints the refresh duration
+`/routes/table/<table>/filtered` dumps. Before either consumer phase, the
+harness waits for the expected accepted/filtered totals and the exact set of
+up neighbors in Alice's separate caches. It prints the refresh duration
 Alice logged, and the consumer proves one accepted prefix-lookup hit. Only
 after that baseline and both populated captures are frozen, the same live
 leg adds a fifth route-server client through the runtime API into a peer

--- a/tests/compat/ixp-manager-birdseye/alice-consumer.py
+++ b/tests/compat/ixp-manager-birdseye/alice-consumer.py
@@ -60,12 +60,16 @@ def nested_label(document, section, community):
 
 
 def main():
-    filtered_flag_invalid = len(sys.argv) == 4 and sys.argv[3] != "--filtered-peer"
-    if len(sys.argv) not in (3, 4) or filtered_flag_invalid:
-        fail("usage: alice-consumer.py BASE_URL EXPECTED_VERSION [--filtered-peer]")
+    flags = sys.argv[3:]
+    if (
+        len(sys.argv) < 3
+        or len(flags) != len(set(flags))
+        or set(flags) - {"--filtered-peer", "--stores-ready"}
+    ):
+        fail("usage: alice-consumer.py BASE_URL EXPECTED_VERSION [--filtered-peer] [--stores-ready]")
     base = sys.argv[1].rstrip("/")
     expected_version = sys.argv[2]
-    filtered_peer = len(sys.argv) == 4
+    filtered_peer = "--filtered-peer" in flags
 
     status = get_json(base, "/status")
     if status.get("version") != expected_version:
@@ -74,6 +78,27 @@ def main():
     expected_totals = {"imported": 7, "filtered": 2 if filtered_peer else 0}
     if store_totals != expected_totals:
         fail(f"routes store totals drifted: {store_totals!r}")
+
+    neighbors = get_json(base, "/routeservers/rs0/neighbors").get("neighbors")
+    if not isinstance(neighbors, list):
+        fail("neighbors is not an array")
+    expected_peers = {
+        "pb_as64496",
+        "pb6_as64496",
+        "pb_as64497",
+        "pb6_as64497",
+    }
+    if filtered_peer:
+        expected_peers.add("pb_as64498")
+    by_id = {neighbor.get("id"): neighbor for neighbor in neighbors}
+    if len(neighbors) != len(expected_peers) or set(by_id) != expected_peers:
+        fail(f"neighbor IDs drifted: {[neighbor.get('id') for neighbor in neighbors]}")
+    down = sorted(peer for peer, neighbor in by_id.items() if neighbor.get("state") != "up")
+    if down:
+        fail(f"neighbors not up: {down}")
+
+    if "--stores-ready" in flags:
+        return
 
     config = get_json(base, "/config")
     if config.get("prefix_lookup_enabled") is not True:
@@ -113,24 +138,6 @@ def main():
         fail(f"expected exactly route server rs0, got {route_servers!r}")
     if route_servers[0].get("group") != "rustbgpd-contract":
         fail(f"route server group drifted: {route_servers[0]!r}")
-
-    neighbors = get_json(base, "/routeservers/rs0/neighbors").get("neighbors")
-    if not isinstance(neighbors, list):
-        fail("neighbors is not an array")
-    expected_peers = {
-        "pb_as64496",
-        "pb6_as64496",
-        "pb_as64497",
-        "pb6_as64497",
-    }
-    if filtered_peer:
-        expected_peers.add("pb_as64498")
-    by_id = {neighbor.get("id"): neighbor for neighbor in neighbors}
-    if set(by_id) != expected_peers:
-        fail(f"neighbor IDs drifted: {sorted(str(value) for value in by_id)}")
-    down = sorted(peer for peer, neighbor in by_id.items() if neighbor.get("state") != "up")
-    if down:
-        fail(f"neighbors not up: {down}")
 
     expected_routes = {
         "pb_as64496": {

--- a/tests/compat/ixp-manager-birdseye/run-oracle-leg.sh
+++ b/tests/compat/ixp-manager-birdseye/run-oracle-leg.sh
@@ -266,25 +266,25 @@ while [ "$(date +%s)" -lt "$alice_deadline" ]; do
   sleep 1
 done
 alice_ready || exit 1
-# Alice's routes store (prefix lookup) refreshes on its own interval with
-# random jitter, so every lookup assertion waits for a refresh that already
-# saw the expected accepted and filtered totals.
-alice_store_ready() {
-  curl --fail --silent --max-time 2 "$alice_api/status" | python3 -c \
-    'import json,sys; totals=json.load(sys.stdin)["routes"]["total_routes"]; expected={"imported": int(sys.argv[1]), "filtered": int(sys.argv[2])}; raise SystemExit(totals != expected)' \
-    "$1" "$2" >/dev/null 2>&1
-}
+# Alice refreshes route and neighbor caches independently. Correct route
+# totals can coexist with an earlier snapshot of down BGP neighbors.
 wait_alice_store() {
   store_deadline=$(($(date +%s) + 180))
-  while [ "$(date +%s)" -lt "$store_deadline" ]; do
-    if alice_store_ready "$1" "$2"; then return 0; fi
+  while :; do
+    store_remaining=$((store_deadline - $(date +%s)))
+    [ "$store_remaining" -gt 0 ] || break
+    [ "$store_remaining" -le 5 ] || store_remaining=5
+    if timeout "${store_remaining}s" python3 "$root/alice-consumer.py" \
+      "$alice_api" "$alice_version" --stores-ready "$@" \
+      >"$tmp/alice-store-readiness.log" 2>&1; then return 0; fi
     kill -0 "$daemon_pid" 2>/dev/null \
       && kill -0 "$adapter_pid" 2>/dev/null \
       && topology_containers_running \
       && container_running "$alice" || return 1
     sleep 1
   done
-  echo "Alice routes store did not reach imported=$1 filtered=$2: $(curl --silent --max-time 2 "$alice_api/status")" >&2
+  echo 'Alice route and neighbor stores did not become ready:' >&2
+  cat "$tmp/alice-store-readiness.log" >&2
   return 1
 }
 # Alice's logged refresh duration starts at its refresh lock, before its
@@ -332,7 +332,7 @@ fi
 # stable snapshot before reading.
 sleep 3
 
-wait_alice_store 7 0 || exit 1
+wait_alice_store || exit 1
 alice_refresh_cost 'four peers, 7 accepted, 0 filtered' || exit 1
 alice_proof="alice consumer proof: Alice-LG $alice_version read rs0 with 4 up neighbors, 7 accepted routes, 0 filtered routes, the labeled split-horizon noexport route, and one accepted prefix-lookup hit"
 timeout 60s python3 "$root/alice-consumer.py" "$alice_api" "$alice_version" >"$tmp/alice-consumer.out"
@@ -537,7 +537,7 @@ while [ "$(date +%s)" -lt "$alice_deadline" ]; do
 done
 alice_ready || exit 1
 
-wait_alice_store 7 2 || exit 1
+wait_alice_store --filtered-peer || exit 1
 alice_refresh_cost 'five peers, 7 accepted, 2 filtered' || exit 1
 filtered_alice_proof="alice filtered proof: Alice-LG $alice_version read rs0 with 5 up neighbors, preserved 7 accepted routes and 4 empty baseline filtered views, joined an AS-path-loop and an import-policy rejection to their exact labels, and found both through prefix lookup"
 timeout 60s python3 "$root/alice-consumer.py" \

--- a/tests/compat/ixp-manager-birdseye/run.sh
+++ b/tests/compat/ixp-manager-birdseye/run.sh
@@ -3,6 +3,7 @@ set -eu
 
 root=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 repo=$(CDPATH='' cd -- "$root/../../.." && pwd)
+python3 "$root/test_alice_consumer.py"
 tmp=$(mktemp -d)
 network=rustbgpd-ixp-contract-$$
 mysql=rustbgpd-ixp-mysql-$$

--- a/tests/compat/ixp-manager-birdseye/test_alice_consumer.py
+++ b/tests/compat/ixp-manager-birdseye/test_alice_consumer.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Readiness must cover Alice's independently refreshed neighbor cache."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+spec = importlib.util.spec_from_file_location(
+    "alice_consumer", Path(__file__).with_name("alice-consumer.py")
+)
+consumer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(consumer)
+
+
+class StoreReadinessTests(unittest.TestCase):
+    def neighbors(self, filtered=False):
+        peers = ["pb_as64496", "pb6_as64496", "pb_as64497", "pb6_as64497"]
+        if filtered:
+            peers.append("pb_as64498")
+        return [{"id": peer, "state": "up"} for peer in peers]
+
+    def check(self, neighbors, filtered=False, totals=None, ready_only=True):
+        if totals is None:
+            totals = {"imported": 7, "filtered": 2 if filtered else 0}
+        documents = {
+            "/status": {
+                "version": "6.2.0",
+                "routes": {"total_routes": totals},
+            },
+            "/routeservers/rs0/neighbors": {"neighbors": neighbors},
+        }
+        args = ["alice-consumer.py", "http://fixture", "6.2.0"]
+        if ready_only:
+            args.append("--stores-ready")
+        if filtered:
+            args.append("--filtered-peer")
+        with patch.object(consumer.sys, "argv", args), patch.object(
+            consumer, "get_json", side_effect=lambda base, path: documents[path]
+        ):
+            consumer.main()
+
+    def test_route_totals_do_not_hide_stale_neighbors(self):
+        stale = self.neighbors()
+        stale[2]["state"] = stale[3]["state"] = "down"
+        with self.assertRaisesRegex(SystemExit, "neighbors not up"):
+            self.check(stale)
+        self.check(self.neighbors())
+
+    def test_neighbor_inventory_must_be_exact(self):
+        wrong = self.neighbors()
+        wrong[0]["id"] = "unexpected"
+        for neighbors in [
+            None, self.neighbors()[:-1], wrong,
+            self.neighbors() + self.neighbors()[:1],
+        ]:
+            with self.subTest(neighbors=neighbors), self.assertRaises(SystemExit):
+                self.check(neighbors)
+
+    def test_fifth_peer_needs_its_own_complete_cache_and_totals(self):
+        with self.assertRaisesRegex(SystemExit, "neighbor IDs drifted"):
+            self.check(self.neighbors(), filtered=True)
+        with self.assertRaisesRegex(SystemExit, "routes store totals drifted"):
+            self.check(
+                self.neighbors(True), filtered=True,
+                totals={"imported": 7, "filtered": 0},
+            )
+        stale = self.neighbors(True)
+        stale[-1]["state"] = "down"
+        with self.assertRaisesRegex(SystemExit, "neighbors not up"):
+            self.check(stale, filtered=True)
+        self.check(self.neighbors(True), filtered=True)
+
+    def test_full_consumer_continues_past_readiness(self):
+        with self.assertRaisesRegex(KeyError, "/config"):
+            self.check(self.neighbors(), ready_only=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Alice refreshes its route and neighbor caches independently. The pinned IXP harness could see the expected route totals while Alice still reported peers down from its initial snapshot, then fail the strict consumer immediately after readiness passed.

Reuse the consumer’s version, route-total, and exact all-up neighbor checks in the existing bounded waiter for both the four-peer and five-peer phases. Keep the full consumer proof, upstream pins, refresh configuration, and 180-second timeout. Add focused regressions for stale and invalid neighbor inventories.

Validation: four Python regressions, shell syntax, documentation links and contracts, and the complete pinned IXP Manager/Bird’s Eye lab with fixture capture disabled passed. The lab covered both Alice phases, the MANRS check, all 25 populated oracle journeys, and backend failure responses.
