### PR TITLE
fix(wire): complete notification diagnostic descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- NOTIFICATION diagnostics now describe the maintained registered code/subcode
+  table, including Connection Rejected and Other Configuration Change. Unknown
+  pairs retain numeric values as `unassigned(code/subcode)` or
+  `reserved(code/subcode)`, including inside Hard Reset notifications.
+
 - `rbgp doctor` attributes local process limits and config freshness to the
   connected Unix-socket peer, with process-start verification and reconnect
   updates. Co-resident daemons no longer contribute unrelated low-limit

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -8,18 +8,29 @@ use super::{
 pub(super) fn notification_description(
     notification: &rustbgpd_wire::NotificationMessage,
 ) -> String {
+    let describe = |code: NotificationCode, subcode| match rustbgpd_wire::notification::description(
+        code, subcode,
+    ) {
+        "Unknown" | "Unknown Error Code" => {
+            let raw = code.as_u8();
+            let status = if raw == 0 || (matches!(raw, 6 | 7) && subcode == 0) {
+                "reserved"
+            } else {
+                "unassigned"
+            };
+            format!("{status}({raw}/{subcode})")
+        }
+        description => description.to_string(),
+    };
     if notification.code == NotificationCode::Cease
         && notification.subcode == cease_subcode::HARD_RESET
         && notification.data.len() >= 2
     {
         let inner_code = NotificationCode::from_u8(notification.data[0]);
         let inner_subcode = notification.data[1];
-        return format!(
-            "Hard Reset: {}",
-            rustbgpd_wire::notification::description(inner_code, inner_subcode)
-        );
+        return format!("Hard Reset: {}", describe(inner_code, inner_subcode));
     }
-    rustbgpd_wire::notification::description(notification.code, notification.subcode).to_string()
+    describe(notification.code, notification.subcode)
 }
 
 fn sanitized_notification_reason(reason: &str) -> String {

--- a/crates/transport/src/session/tests/notification.rs
+++ b/crates/transport/src/session/tests/notification.rs
@@ -1484,3 +1484,52 @@ fn evpn_discard_warnings_are_bounded_per_type_and_connection() {
             < f64::EPSILON
     );
 }
+
+#[test]
+fn notification_descriptions_preserve_registered_and_numeric_inner_causes() {
+    for (code, subcode, expected) in [
+        (6, cease_subcode::CONNECTION_REJECTED, "Connection Rejected"),
+        (
+            6,
+            cease_subcode::OTHER_CONFIGURATION_CHANGE,
+            "Other Configuration Change",
+        ),
+        (5, 3, "Receive Unexpected Message in Established State"),
+        (7, 1, "Invalid Message Length"),
+        (9, 0, "Loss of LSDB Synchronization"),
+        (2, 5, "Deprecated OPEN Message Error Subcode 5"),
+        (6, 42, "unassigned(6/42)"),
+        (5, 42, "unassigned(5/42)"),
+        (4, 42, "unassigned(4/42)"),
+        (8, 42, "unassigned(8/42)"),
+        (255, 255, "unassigned(255/255)"),
+        (0, 0, "reserved(0/0)"),
+        (6, 0, "reserved(6/0)"),
+        (7, 0, "reserved(7/0)"),
+    ] {
+        let direct =
+            NotificationMessage::new(NotificationCode::from_u8(code), subcode, Bytes::new());
+        assert_eq!(
+            super::super::fsm::notification_description(&direct),
+            expected
+        );
+        let nested = NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::HARD_RESET,
+            Bytes::copy_from_slice(&[code, subcode]),
+        );
+        assert_eq!(
+            super::super::fsm::notification_description(&nested),
+            format!("Hard Reset: {expected}")
+        );
+    }
+    // A short Hard Reset envelope has no inner pair to render.
+    for data in [Bytes::new(), Bytes::from_static(&[6])] {
+        let notification =
+            NotificationMessage::new(NotificationCode::Cease, cease_subcode::HARD_RESET, data);
+        assert_eq!(
+            super::super::fsm::notification_description(&notification),
+            "Hard Reset"
+        );
+    }
+}

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -3,6 +3,15 @@
 This changelog covers the independently published `rustbgpd-wire` crate. Daemon
 and workspace changes remain in the repository-level `CHANGELOG.md`.
 
+## Unreleased
+
+- Complete the registered NOTIFICATION descriptions, including deprecated
+  allocations and FSM state-specific errors, and add Cease constants for
+  Connection Rejected and Other Configuration Change. A documentation-driven
+  registry test checks labels and fallback coverage. The `description()`
+  signature and numeric enum round trips are unchanged; reserved or unassigned
+  subcodes no longer inherit generic FSM/timer descriptions.
+
 ## 0.20.0 - 2026-09-07
 
 - Added `decode_prefix_sid_services` and the `Srv6Service`,

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -12,7 +12,7 @@ description = "BGP message codec — encode/decode OPEN, KEEPALIVE, UPDATE, NOTI
 readme = "README.md"
 # Repository governance audit: it reads the workspace-level canonical registry
 # document, which is intentionally outside this published crate package.
-exclude = ["tests/path_attribute_registry.rs"]
+exclude = ["tests/path_attribute_registry.rs", "tests/notification_registry.rs"]
 
 [features]
 # Enables allocation counters in the codec diagnostic binary. The ordinary

--- a/crates/wire/src/notification.rs
+++ b/crates/wire/src/notification.rs
@@ -1,6 +1,6 @@
 /// RFC 4271 §4.5 — NOTIFICATION error codes.
 ///
-/// Known codes (1–6) have named variants. Unknown codes from the wire are
+/// Codes 1–6 and 8 have named variants. Unknown codes from the wire are
 /// preserved via `Unknown(u8)` so the original byte is never lost.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -21,7 +21,7 @@ pub enum NotificationCode {
     /// BGP data to the peer within the `SendHoldTime` (code 8, RFC 9687 §5;
     /// subcode is always 0 per §6).
     SendHoldTimerExpired,
-    /// A code value not defined in RFC 4271. The raw byte is preserved
+    /// A code value without a named variant in this API. The raw byte is preserved
     /// for logging and re-encoding.
     Unknown(u8),
 }
@@ -137,6 +137,10 @@ pub mod cease_subcode {
     pub const PEER_DECONFIGURED: u8 = 3;
     /// Subcode 4: Administrative Reset (RFC 9003).
     pub const ADMINISTRATIVE_RESET: u8 = 4;
+    /// Subcode 5: Connection Rejected.
+    pub const CONNECTION_REJECTED: u8 = 5;
+    /// Subcode 6: Other Configuration Change.
+    pub const OTHER_CONFIGURATION_CHANGE: u8 = 6;
     /// Subcode 8: Out of Resources.
     pub const OUT_OF_RESOURCES: u8 = 8;
     /// RFC 4271 §6.8
@@ -280,51 +284,64 @@ pub fn extract_shutdown_communication(
 }
 
 /// Human-readable description for a NOTIFICATION code/subcode pair.
+///
+/// Describes registered values, including codes without named enum variants;
+/// this does not imply protocol support. Reserved/unassigned pairs return
+/// `"Unknown"` or `"Unknown Error Code"`; callers should retain the numeric pair.
+/// The repository's notification registry integration test checks these labels
+/// against `docs/reference/notification-registry.md`.
 #[must_use]
 pub fn description(code: NotificationCode, subcode: u8) -> &'static str {
-    match (code, subcode) {
-        // Message Header Error
-        (NotificationCode::MessageHeader, 1) => "Connection Not Synchronized",
-        (NotificationCode::MessageHeader, 2) => "Bad Message Length",
-        (NotificationCode::MessageHeader, 3) => "Bad Message Type",
-        // OPEN Message Error
-        (NotificationCode::OpenMessage, 1) => "Unsupported Version Number",
-        (NotificationCode::OpenMessage, 2) => "Bad Peer AS",
-        (NotificationCode::OpenMessage, 3) => "Bad BGP Identifier",
-        (NotificationCode::OpenMessage, 4) => "Unsupported Optional Parameter",
-        (NotificationCode::OpenMessage, 6) => "Unacceptable Hold Time",
-        (NotificationCode::OpenMessage, 7) => "Unsupported Capability",
-        (NotificationCode::OpenMessage, 11) => "Role Mismatch",
-        // UPDATE Message Error
-        (NotificationCode::UpdateMessage, 1) => "Malformed Attribute List",
-        (NotificationCode::UpdateMessage, 2) => "Unrecognized Well-known Attribute",
-        (NotificationCode::UpdateMessage, 3) => "Missing Well-known Attribute",
-        (NotificationCode::UpdateMessage, 4) => "Attribute Flags Error",
-        (NotificationCode::UpdateMessage, 5) => "Attribute Length Error",
-        (NotificationCode::UpdateMessage, 6) => "Invalid ORIGIN Attribute",
-        (NotificationCode::UpdateMessage, 8) => "Invalid NEXT_HOP Attribute",
-        (NotificationCode::UpdateMessage, 9) => "Optional Attribute Error",
-        (NotificationCode::UpdateMessage, 10) => "Invalid Network Field",
-        (NotificationCode::UpdateMessage, 11) => "Malformed AS_PATH",
-        // Hold Timer Expired
-        (NotificationCode::HoldTimerExpired, _) => "Hold Timer Expired",
-        // Send Hold Timer Expired (RFC 9687 §5/§6, subcode always 0)
-        (NotificationCode::SendHoldTimerExpired, _) => "Send Hold Timer Expired",
-        // FSM Error
-        (NotificationCode::FsmError, _) => "Finite State Machine Error",
-        // Cease
-        (NotificationCode::Cease, 1) => "Maximum Number of Prefixes Reached",
-        (NotificationCode::Cease, 2) => "Administrative Shutdown",
-        (NotificationCode::Cease, 3) => "Peer De-configured",
-        (NotificationCode::Cease, 4) => "Administrative Reset",
-        (NotificationCode::Cease, 8) => "Out of Resources",
-        (NotificationCode::Cease, 7) => "Connection Collision Resolution",
-        (NotificationCode::Cease, 9) => "Hard Reset",
-        (NotificationCode::Cease, 10) => "BFD Down",
-        // Unknown code
-        (NotificationCode::Unknown(_), _) => "Unknown Error Code",
-        // Fallback for known code with unknown subcode
-        (_, _) => "Unknown",
+    match (code.as_u8(), subcode) {
+        (1, 0) => "Message Header Error: Unspecific",
+        (1, 1) => "Connection Not Synchronized",
+        (1, 2) => "Bad Message Length",
+        (1, 3) => "Bad Message Type",
+        (2, 0) => "OPEN Message Error: Unspecific",
+        (2, 1) => "Unsupported Version Number",
+        (2, 2) => "Bad Peer AS",
+        (2, 3) => "Bad BGP Identifier",
+        (2, 4) => "Unsupported Optional Parameter",
+        (2, 5) => "Deprecated OPEN Message Error Subcode 5",
+        (2, 6) => "Unacceptable Hold Time",
+        (2, 7) => "Unsupported Capability",
+        (2, 8) => "Deprecated OPEN Message Error Subcode 8",
+        (2, 9) => "Deprecated OPEN Message Error Subcode 9",
+        (2, 10) => "Deprecated OPEN Message Error Subcode 10",
+        (2, 11) => "Role Mismatch",
+        (3, 0) => "UPDATE Message Error: Unspecific",
+        (3, 1) => "Malformed Attribute List",
+        (3, 2) => "Unrecognized Well-known Attribute",
+        (3, 3) => "Missing Well-known Attribute",
+        (3, 4) => "Attribute Flags Error",
+        (3, 5) => "Attribute Length Error",
+        (3, 6) => "Invalid ORIGIN Attribute",
+        (3, 7) => "Deprecated UPDATE Message Error Subcode 7",
+        (3, 8) => "Invalid NEXT_HOP Attribute",
+        (3, 9) => "Optional Attribute Error",
+        (3, 10) => "Invalid Network Field",
+        (3, 11) => "Malformed AS_PATH",
+        (4, 0) => "Hold Timer Expired",
+        (5, 0) => "Finite State Machine Error",
+        (5, 1) => "Receive Unexpected Message in OpenSent State",
+        (5, 2) => "Receive Unexpected Message in OpenConfirm State",
+        (5, 3) => "Receive Unexpected Message in Established State",
+        (6, 1) => "Maximum Number of Prefixes Reached",
+        (6, 2) => "Administrative Shutdown",
+        (6, 3) => "Peer De-configured",
+        (6, 4) => "Administrative Reset",
+        (6, 5) => "Connection Rejected",
+        (6, 6) => "Other Configuration Change",
+        (6, 7) => "Connection Collision Resolution",
+        (6, 8) => "Out of Resources",
+        (6, 9) => "Hard Reset",
+        (6, 10) => "BFD Down",
+        (7, 1) => "Invalid Message Length",
+        (8, 0) => "Send Hold Timer Expired",
+        (9, 0) => "Loss of LSDB Synchronization",
+        // Reserved and unassigned values keep the static API fallback.
+        (1..=9, _) => "Unknown",
+        (_, _) => "Unknown Error Code",
     }
 }
 
@@ -370,29 +387,6 @@ mod tests {
         assert_eq!(decoded.code, NotificationCode::Cease);
         assert_eq!(decoded.subcode, cease_subcode::BFD_DOWN);
         assert_eq!(description(decoded.code, decoded.subcode), "BFD Down");
-    }
-
-    #[test]
-    fn description_returns_nonempty_for_known_pairs() {
-        let pairs = [
-            (NotificationCode::MessageHeader, 1),
-            (NotificationCode::MessageHeader, 2),
-            (NotificationCode::MessageHeader, 3),
-            (NotificationCode::OpenMessage, 1),
-            (NotificationCode::OpenMessage, 6),
-            (NotificationCode::UpdateMessage, 1),
-            (NotificationCode::UpdateMessage, 11),
-            (NotificationCode::Cease, 2),
-            (NotificationCode::Cease, 4),
-        ];
-        for (code, subcode) in pairs {
-            let desc = description(code, subcode);
-            assert!(
-                !desc.is_empty(),
-                "empty description for ({code}, {subcode})"
-            );
-            assert_ne!(desc, "Unknown", "got Unknown for ({code}, {subcode})");
-        }
     }
 
     #[test]

--- a/crates/wire/tests/notification_registry.rs
+++ b/crates/wire/tests/notification_registry.rs
@@ -1,0 +1,55 @@
+use std::collections::BTreeMap;
+
+use rustbgpd_wire::notification::{NotificationCode, description};
+
+#[test]
+fn documented_notification_registry_matches_descriptions() {
+    let doc = include_str!("../../../docs/reference/notification-registry.md");
+    let table = doc
+        .split_once("<!-- notification-descriptions:start -->")
+        .unwrap()
+        .1
+        .split_once("<!-- notification-descriptions:end -->")
+        .unwrap()
+        .0;
+    let mut descriptions = BTreeMap::new();
+    for row in table.lines().filter(|line| line.starts_with('|')).skip(2) {
+        let cells: Vec<_> = row.trim_matches('|').split('|').map(str::trim).collect();
+        assert_eq!(cells.len(), 5, "malformed registry row: {row}");
+        assert!(
+            cells.iter().all(|cell| !cell.is_empty()),
+            "blank cell: {row}"
+        );
+        let code: u8 = cells[0].parse().unwrap();
+        let subcode: u8 = cells[1].parse().unwrap();
+        assert!(matches!(cells[3], "active" | "deprecated"), "{row}");
+        assert!(!matches!(cells[2], "Unknown" | "Unknown Error Code"));
+        assert!(
+            descriptions.insert((code, subcode), cells[2]).is_none(),
+            "duplicate: {row}"
+        );
+    }
+    assert!(!descriptions.is_empty(), "registry table is empty");
+    for code in u8::MIN..=u8::MAX {
+        let notification_code = NotificationCode::from_u8(code);
+        assert_eq!(notification_code.as_u8(), code);
+        for subcode in u8::MIN..=u8::MAX {
+            let actual = description(notification_code, subcode);
+            if let Some(expected) = descriptions.get(&(code, subcode)) {
+                assert_eq!(actual, *expected, "registered pair {code}/{subcode}");
+            } else {
+                assert!(
+                    matches!(actual, "Unknown" | "Unknown Error Code"),
+                    "undocumented pair {code}/{subcode}: {actual}"
+                );
+            }
+        }
+    }
+    // Description coverage must not change the decoder's public enum variants.
+    for code in [7, 9] {
+        assert_eq!(
+            NotificationCode::from_u8(code),
+            NotificationCode::Unknown(code)
+        );
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ Look up commands, configuration, and compatibility boundaries.
 | [Format and version namespaces](reference/format-version-namespaces.md) | Independent versions for stored and exchanged formats. |
 | [RFC implementation notes](reference/rfc-notes.md) | Protocol interpretations and deviations. |
 | [ASPA conformance](reference/aspa-conformance.md) | Verification procedures and route-server scope. |
+| [NOTIFICATION registry](reference/notification-registry.md) | Error code and subcode descriptions for session diagnostics. |
 | [Path-attribute registry](reference/path-attribute-registry.md) | Implementation, propagation, and evidence by attribute. |
 | [Familiar command map](../crates/cli/README.md#familiar-command-map) | Translate FRR and BIRD commands to the CLI. |
 

--- a/docs/reference/notification-registry.md
+++ b/docs/reference/notification-registry.md
@@ -1,0 +1,89 @@
+# NOTIFICATION registry
+
+Use this table to interpret BGP NOTIFICATION code/subcode pairs in session logs,
+neighbor last errors, and lifecycle events.
+
+The table follows the [IANA BGP error codes and subcodes registry][IANA], checked
+2026-09-08. Descriptions preserve existing diagnostic labels where applicable;
+FSM subcode 0 retains `Finite State Machine Error` for IANA's `Unspecified Error`.
+Deprecated allocations remain labeled as deprecated. Description coverage does
+not imply support for the associated protocol: codes 7 and 9 still use the
+wire API's `NotificationCode::Unknown` variant, preserving numeric round trips.
+
+Codes 4 and 9 have no defined subcodes, so subcode 0 follows [RFC 4271 §4.5][RFC4271].
+Code 8 explicitly requires subcode 0 in [RFC 9687 §6][RFC9687]. Code 0 and subcode 0
+under codes 6 and 7 are reserved. Other pairs absent from the table are unassigned
+in this registry snapshot. Operator rendering uses `reserved(6/0)` or
+`unassigned(6/42)` with the actual numbers, including a Hard Reset's inner pair.
+The static wire `description()` API retains its `Unknown` / `Unknown Error Code`
+fallback; callers should keep numeric values when rendering it.
+
+The integration test reads every row and checks the exact description, then
+checks that other pairs have no named description. Updating a documented row
+requires a matching implementation. This is a maintained snapshot, not an
+automatic check for new IANA allocations; review upstream before adding rows.
+
+<!-- notification-descriptions:start -->
+| Code | Subcode | Description | Status | Reference |
+| --- | --- | --- | --- | --- |
+| 1 | 0 | Message Header Error: Unspecific | active | [Errata4493][Errata4493] |
+| 1 | 1 | Connection Not Synchronized | active | [RFC4271][RFC4271] |
+| 1 | 2 | Bad Message Length | active | [RFC4271][RFC4271] |
+| 1 | 3 | Bad Message Type | active | [RFC4271][RFC4271] |
+| 2 | 0 | OPEN Message Error: Unspecific | active | [Errata4493][Errata4493] |
+| 2 | 1 | Unsupported Version Number | active | [RFC4271][RFC4271] |
+| 2 | 2 | Bad Peer AS | active | [RFC4271][RFC4271] |
+| 2 | 3 | Bad BGP Identifier | active | [RFC4271][RFC4271] |
+| 2 | 4 | Unsupported Optional Parameter | active | [RFC4271][RFC4271] |
+| 2 | 5 | Deprecated OPEN Message Error Subcode 5 | deprecated | [RFC4271][RFC4271] |
+| 2 | 6 | Unacceptable Hold Time | active | [RFC4271][RFC4271] |
+| 2 | 7 | Unsupported Capability | active | [RFC5492][RFC5492] |
+| 2 | 8 | Deprecated OPEN Message Error Subcode 8 | deprecated | [RFC9234][RFC9234] |
+| 2 | 9 | Deprecated OPEN Message Error Subcode 9 | deprecated | [RFC9234][RFC9234] |
+| 2 | 10 | Deprecated OPEN Message Error Subcode 10 | deprecated | [RFC9234][RFC9234] |
+| 2 | 11 | Role Mismatch | active | [RFC9234][RFC9234] |
+| 3 | 0 | UPDATE Message Error: Unspecific | active | [Errata4493][Errata4493] |
+| 3 | 1 | Malformed Attribute List | active | [RFC4271][RFC4271] |
+| 3 | 2 | Unrecognized Well-known Attribute | active | [RFC4271][RFC4271] |
+| 3 | 3 | Missing Well-known Attribute | active | [RFC4271][RFC4271] |
+| 3 | 4 | Attribute Flags Error | active | [RFC4271][RFC4271] |
+| 3 | 5 | Attribute Length Error | active | [RFC4271][RFC4271] |
+| 3 | 6 | Invalid ORIGIN Attribute | active | [RFC4271][RFC4271] |
+| 3 | 7 | Deprecated UPDATE Message Error Subcode 7 | deprecated | [RFC4271][RFC4271] |
+| 3 | 8 | Invalid NEXT_HOP Attribute | active | [RFC4271][RFC4271] |
+| 3 | 9 | Optional Attribute Error | active | [RFC4271][RFC4271] |
+| 3 | 10 | Invalid Network Field | active | [RFC4271][RFC4271] |
+| 3 | 11 | Malformed AS_PATH | active | [RFC4271][RFC4271] |
+| 4 | 0 | Hold Timer Expired | active | [RFC4271][RFC4271] |
+| 5 | 0 | Finite State Machine Error | active | [RFC6608][RFC6608] |
+| 5 | 1 | Receive Unexpected Message in OpenSent State | active | [RFC6608][RFC6608] |
+| 5 | 2 | Receive Unexpected Message in OpenConfirm State | active | [RFC6608][RFC6608] |
+| 5 | 3 | Receive Unexpected Message in Established State | active | [RFC6608][RFC6608] |
+| 6 | 1 | Maximum Number of Prefixes Reached | active | [RFC4486][RFC4486] |
+| 6 | 2 | Administrative Shutdown | active | [RFC4486][RFC4486], [RFC9003][RFC9003] |
+| 6 | 3 | Peer De-configured | active | [RFC4486][RFC4486] |
+| 6 | 4 | Administrative Reset | active | [RFC4486][RFC4486], [RFC9003][RFC9003] |
+| 6 | 5 | Connection Rejected | active | [RFC4486][RFC4486] |
+| 6 | 6 | Other Configuration Change | active | [RFC4486][RFC4486] |
+| 6 | 7 | Connection Collision Resolution | active | [RFC4486][RFC4486] |
+| 6 | 8 | Out of Resources | active | [RFC4486][RFC4486] |
+| 6 | 9 | Hard Reset | active | [RFC8538][RFC8538] |
+| 6 | 10 | BFD Down | active | [RFC9384][RFC9384] |
+| 7 | 1 | Invalid Message Length | active | [RFC7313][RFC7313] |
+| 8 | 0 | Send Hold Timer Expired | active | [RFC9687][RFC9687] |
+| 9 | 0 | Loss of LSDB Synchronization | active | [RFC9815][RFC9815], [RFC4271][RFC4271] |
+<!-- notification-descriptions:end -->
+
+[IANA]: https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml
+[Errata4493]: https://www.rfc-editor.org/errata/eid4493
+[RFC4271]: https://www.rfc-editor.org/rfc/rfc4271
+[RFC4486]: https://www.rfc-editor.org/rfc/rfc4486
+[RFC5492]: https://www.rfc-editor.org/rfc/rfc5492
+[RFC6608]: https://www.rfc-editor.org/rfc/rfc6608
+[RFC7313]: https://www.rfc-editor.org/rfc/rfc7313
+[RFC8538]: https://www.rfc-editor.org/rfc/rfc8538
+[RFC9003]: https://www.rfc-editor.org/rfc/rfc9003
+[RFC9234]: https://www.rfc-editor.org/rfc/rfc9234
+[RFC9384]: https://www.rfc-editor.org/rfc/rfc9384
+[RFC9687]: https://www.rfc-editor.org/rfc/rfc9687
+[RFC9815]: https://www.rfc-editor.org/rfc/rfc9815


### PR DESCRIPTION
A peer's Cease/Connection Rejected notification previously appeared as `Unknown`, and generic FSM/timer descriptions hid unassigned subcodes. Complete the registered diagnostic mappings and render missing pairs as `unassigned(code/subcode)` or `reserved(code/subcode)` in the shared session helper, including Hard Reset inner causes.

Add an operator registry checked against the [IANA error code/subcode assignments](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml), including the missing Cease reasons from [RFC 4486 §4](https://www.rfc-editor.org/rfc/rfc4486#section-4), and a regression that checks exact descriptions for every documented pair and fallback behavior for every remaining byte pair. This checks the maintained document; it does not discover future IANA allocations automatically. The public wire description signature and enum round trips remain unchanged, including numeric codes 7 and 9. The registry integration test is excluded from the independently packaged wire crate, following the existing path-attribute registry pattern.

Validation: focused wire and transport regressions pass; deleting the Connection Rejected mapping makes the registry test fail at 6/5. Full `just gate` passes, including repository contracts, strict workspace Clippy, all workspace tests and doctests, and library/binary rustdoc. `cargo package --list` confirms the workspace-only registry test is excluded.
