### PR TITLE
fix(transport): gate unchanged IPv6 next-hop reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- IPv4-unicast reflection with an unchanged IPv6 next hop now suppresses
+  export to peers without Extended Next Hop support, instead of emitting
+  classic IPv4 NLRI without NEXT_HOP. Ordinary eBGP and export-policy rewrites
+  that supply an IPv4 next hop remain eligible.
+
 - NOTIFICATION diagnostics now describe the maintained registered code/subcode
   table, including Connection Rejected and Other Configuration Change. Unknown
   pairs retain numeric values as `unassigned(code/subcode)` or

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -965,7 +965,7 @@ impl SessionExportProfile {
                 })
             }
             Prefix::V4(prefix) => {
-                if self.scoped_link_local_peer {
+                if self.scoped_link_local_peer || route.next_hop.is_ipv6() {
                     return Err(ExportProbeError::Ipv4RequiresExtendedNextHop);
                 }
                 Ok(PreparedUnicastCandidate::Ipv4Body {
@@ -1650,7 +1650,7 @@ impl std::fmt::Display for ExportProbeError {
             Self::Encode(error) => error.fmt(formatter),
             Self::MissingIpv6NextHop => formatter.write_str("no usable local IPv6 next-hop"),
             Self::Ipv4RequiresExtendedNextHop => formatter
-                .write_str("IPv4 on a scoped link-local session requires Extended Next Hop"),
+                .write_str("IPv4 with an IPv6 next-hop requires peer Extended Next Hop support"),
             Self::Vpnv4RequiresExtendedNextHop => formatter
                 .write_str("VPNv4 with an IPv6 next-hop requires peer Extended Next Hop support"),
             Self::UnmodeledEvpnRouteType => {

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -965,7 +965,12 @@ impl SessionExportProfile {
                 })
             }
             Prefix::V4(prefix) => {
-                if self.scoped_link_local_peer || route.next_hop.is_ipv6() {
+                if self.scoped_link_local_peer
+                    || !attrs
+                        .with_next_hop
+                        .iter()
+                        .any(|attr| matches!(attr, PathAttribute::NextHop(_)))
+                {
                     return Err(ExportProbeError::Ipv4RequiresExtendedNextHop);
                 }
                 Ok(PreparedUnicastCandidate::Ipv4Body {
@@ -1649,8 +1654,9 @@ impl std::fmt::Display for ExportProbeError {
         match self {
             Self::Encode(error) => error.fmt(formatter),
             Self::MissingIpv6NextHop => formatter.write_str("no usable local IPv6 next-hop"),
-            Self::Ipv4RequiresExtendedNextHop => formatter
-                .write_str("IPv4 with an IPv6 next-hop requires peer Extended Next Hop support"),
+            Self::Ipv4RequiresExtendedNextHop => {
+                formatter.write_str("IPv4 export requires peer Extended Next Hop support")
+            }
             Self::Vpnv4RequiresExtendedNextHop => formatter
                 .write_str("VPNv4 with an IPv6 next-hop requires peer Extended Next Hop support"),
             Self::UnmodeledEvpnRouteType => {

--- a/crates/transport/src/session/tests/mod.rs
+++ b/crates/transport/src/session/tests/mod.rs
@@ -1,7 +1,7 @@
 // Sibling modules reach the session's own submodules with `super::`, which for
 // them resolves to `session::tests`. Bind the names they path-qualify here so
 // those paths keep resolving to `session::*`.
-use super::export::{ExportCandidate, ExportWithdrawal};
+use super::export::{ExportCandidate, ExportProbeError, ExportWithdrawal};
 use super::*;
 use super::{export, import_decision_cache, io, shared_group, tcp_ao_key_metadata, writer};
 use crate::PeerCommandError;

--- a/crates/transport/src/session/tests/next_hop.rs
+++ b/crates/transport/src/session/tests/next_hop.rs
@@ -475,6 +475,35 @@ async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri
 }
 
 #[tokio::test]
+async fn ipv4_route_with_ipv6_next_hop_without_extended_nexthop_rejects_export() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65001);
+    let negotiated = negotiated_session(65001, false);
+    session.negotiated = Some(Arc::new(negotiated));
+    let profile = session.publish_export_profile();
+    let mut route = make_route(100);
+    route.next_hop = IpAddr::V6("2001:db8::1".parse().unwrap());
+    let Err(error) = profile.probe_announcement(ExportCandidate::Unicast {
+        route: &route,
+        next_hop_override: None,
+    }) else {
+        panic!("expected ExportProbeError::Ipv4RequiresExtendedNextHop");
+    };
+    assert_eq!(error, ExportProbeError::Ipv4RequiresExtendedNextHop);
+
+    let (mut ebgp_session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let negotiated = negotiated_session(65002, false);
+    ebgp_session.negotiated = Some(Arc::new(negotiated));
+    let profile = ebgp_session.publish_export_profile();
+    let Err(error) = profile.probe_announcement(ExportCandidate::Unicast {
+        route: &route,
+        next_hop_override: None,
+    }) else {
+        panic!("expected ExportProbeError::Ipv4RequiresExtendedNextHop");
+    };
+    assert_eq!(error, ExportProbeError::Ipv4RequiresExtendedNextHop);
+}
+
+#[tokio::test]
 async fn route_server_client_ipv6_preserves_next_hop() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;

--- a/crates/transport/src/session/tests/next_hop.rs
+++ b/crates/transport/src/session/tests/next_hop.rs
@@ -475,32 +475,78 @@ async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri
 }
 
 #[tokio::test]
-async fn ipv4_route_with_ipv6_next_hop_without_extended_nexthop_rejects_export() {
-    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65001);
-    let negotiated = negotiated_session(65001, false);
-    session.negotiated = Some(Arc::new(negotiated));
-    let profile = session.publish_export_profile();
+async fn ipv4_route_with_ipv6_next_hop_gates_reflection_on_extended_nexthop() {
     let mut route = make_route(100);
-    route.next_hop = IpAddr::V6("2001:db8::1".parse().unwrap());
-    let Err(error) = profile.probe_announcement(ExportCandidate::Unicast {
-        route: &route,
-        next_hop_override: None,
-    }) else {
-        panic!("expected ExportProbeError::Ipv4RequiresExtendedNextHop");
-    };
-    assert_eq!(error, ExportProbeError::Ipv4RequiresExtendedNextHop);
+    route.next_hop = "2001:db8::1".parse().unwrap();
+    Arc::make_mut(&mut route.attributes).retain(|attr| !matches!(attr, PathAttribute::NextHop(_)));
 
-    let (mut ebgp_session, _rib_rx) = make_test_session_with_rib(65001, 65002);
-    let negotiated = negotiated_session(65002, false);
-    ebgp_session.negotiated = Some(Arc::new(negotiated));
-    let profile = ebgp_session.publish_export_profile();
-    let Err(error) = profile.probe_announcement(ExportCandidate::Unicast {
-        route: &route,
-        next_hop_override: None,
-    }) else {
-        panic!("expected ExportProbeError::Ipv4RequiresExtendedNextHop");
-    };
-    assert_eq!(error, ExportProbeError::Ipv4RequiresExtendedNextHop);
+    for (remote_asn, route_server_client) in [(65001, false), (65002, true)] {
+        for extended_nexthop in [false, true] {
+            let (mut session, _rib_rx) = make_test_session_with_rib(65001, remote_asn);
+            session.config.route_server_client = route_server_client;
+            session.negotiated = Some(Arc::new(negotiated_session(remote_asn, extended_nexthop)));
+            let profile = session.publish_export_profile();
+            let result = profile.probe_announcement(ExportCandidate::Unicast {
+                route: &route,
+                next_hop_override: None,
+            });
+            if extended_nexthop {
+                result.unwrap();
+                let export::PreparedUnicastCandidate::Mp { next_hop, .. } =
+                    profile.prepare_unicast_candidate(&route, None).unwrap()
+                else {
+                    panic!("IPv6 next-hop reflection must use MP_REACH");
+                };
+                assert_eq!(next_hop, route.next_hop);
+            } else {
+                let Err(error) = result else {
+                    panic!("unchanged IPv6 next-hop requires Extended Next Hop");
+                };
+                assert_eq!(error, ExportProbeError::Ipv4RequiresExtendedNextHop);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn ipv4_route_with_ipv6_next_hop_allows_ipv4_rewrite_without_extended_nexthop() {
+    use rustbgpd_policy::NextHopAction;
+
+    let mut route = make_route(100);
+    route.next_hop = "2001:db8::1".parse().unwrap();
+    Arc::make_mut(&mut route.attributes).retain(|attr| !matches!(attr, PathAttribute::NextHop(_)));
+    let local_ipv4 = Ipv4Addr::new(10, 0, 0, 1);
+    let specific_ipv4 = Ipv4Addr::new(192, 0, 2, 99);
+
+    for (remote_asn, route_server_client, nh_override, expected) in [
+        (65002, false, None, local_ipv4),
+        (65001, false, Some(NextHopAction::Self_), local_ipv4),
+        (65002, true, Some(NextHopAction::Self_), local_ipv4),
+        (
+            65001,
+            false,
+            Some(NextHopAction::Specific(IpAddr::V4(specific_ipv4))),
+            specific_ipv4,
+        ),
+    ] {
+        let (mut session, _rib_rx) = make_test_session_with_rib(65001, remote_asn);
+        session.config.route_server_client = route_server_client;
+        session.negotiated = Some(Arc::new(negotiated_session(remote_asn, false)));
+        let profile = session.publish_export_profile();
+        profile
+            .probe_announcement(ExportCandidate::Unicast {
+                route: &route,
+                next_hop_override: nh_override.as_ref(),
+            })
+            .unwrap();
+        let export::PreparedUnicastCandidate::Ipv4Body { attrs, .. } = profile
+            .prepare_unicast_candidate(&route, nh_override.as_ref())
+            .unwrap()
+        else {
+            panic!("IPv4 rewrite without Extended Next Hop must use body NLRI");
+        };
+        assert!(attrs.contains(&PathAttribute::NextHop(expected)));
+    }
 }
 
 #[tokio::test]

--- a/docs/reference/rfc-notes.md
+++ b/docs/reference/rfc-notes.md
@@ -1099,6 +1099,11 @@ carries inactive (absent), unlimited (zero), or finite.
 - Negotiation: exact 6-byte tuple matching (NLRI AFI, NLRI SAFI, NH AFI).
 - When negotiated, IPv4 unicast uses `MP_REACH_NLRI` / `MP_UNREACH_NLRI`
   with IPv6 next hop instead of body NLRI.
+- IPv4-unicast reflection with an unchanged IPv6 next hop requires the
+  recipient's Extended Next Hop receive capability (§5). Without it, export
+  is suppressed rather than sending classic IPv4 NLRI without NEXT_HOP.
+  Ordinary eBGP, next-hop-self, and explicit IPv4 export-policy rewrites
+  remain eligible when they supply a classic IPv4 NEXT_HOP.
 - VPNv4 reflection preserves the 24- or 48-octet next-hop encoding (§3/§5)
   and requires the recipient's VPNv4 IPv6-next-hop receive capability. A
   rejected replacement withdraws any previously advertised route; ordinary


### PR DESCRIPTION
IPv4-unicast routes reflected with an unchanged IPv6 next hop could fall back to classic IPv4 NLRI without NEXT_HOP when the recipient lacked Extended Next Hop support. Reject that export at the shared prepared-candidate check, preserving valid IPv4 rewrites by ordinary eBGP, next-hop-self, and explicit export policy. The existing scoped-link-local restriction remains enforced.

Regression coverage checks iBGP and route-server reflection with and without the capability, preserved IPv6 next hops with MP_REACH, and valid IPv4 rewrites without the capability. The changelog and RFC 8950 notes describe the resulting behavior.

Validation: the new rewrite regression fails on the original PR implementation and passes with the fix. Both new tests and all 19 next-hop tests pass, as do strict transport Clippy across all targets, formatting, and offline documentation links.
