### PR TITLE
fix(policy): reject zero ASNs in prepend policy actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,11 +86,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- AS_PATH prepend policy validation now rejects AS 0 in TOML and literal
-  `.rpol` actions, and rejects `.rpol` parameters resolving to AS 0 when a
-  chain is attached. Invalid policies previously reached evaluation before
-  the existing wire encoder rejected the resulting AS_PATH.
-
 - NOTIFICATION diagnostics now describe the maintained registered code/subcode
   table, including Connection Rejected and Other Configuration Change. Unknown
   pairs retain numeric values as `unassigned(code/subcode)` or
@@ -107,6 +102,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inventory, and End-of-RIB before stopping packet capture. Incomplete capture
   snapshots remain pending within a bounded wait, and timeout retains diagnostics;
   the final closed-file and wire-attribute checks remain mandatory.
+
+- AS_PATH prepend policy validation now rejects AS 0 in TOML and literal
+  `.rpol` actions, and rejects `.rpol` parameters resolving to AS 0 when a
+  chain is attached. Invalid policies previously reached evaluation before
+  the existing wire encoder rejected the resulting AS_PATH.
 
 - SIGHUP generations no longer reinstall unchanged RPOL chains solely because
   an unreferenced literal set changed in the same source file. The runtime keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- AS_PATH prepend policy validation now rejects AS 0 in TOML and literal
+  `.rpol` actions, and rejects `.rpol` parameters resolving to AS 0 when a
+  chain is attached. Invalid policies previously reached evaluation before
+  the existing wire encoder rejected the resulting AS_PATH.
+
 - NOTIFICATION diagnostics now describe the maintained registered code/subcode
   table, including Connection Rejected and Other Configuration Change. Unknown
   pairs retain numeric values as `unassigned(code/subcode)` or

--- a/crates/policy/README.md
+++ b/crates/policy/README.md
@@ -32,6 +32,11 @@ compilation pipeline:
 - **`datasets`** / **`sets`** — named prefix-set / community-set /
   AS-set datasets referenced from policy terms
 
+The frontend rejects literal AS 0 in prepend actions. Parameterized policies
+resolve their arguments at instantiation; the daemon checks the resulting
+chain at attachment with `CompiledChain::has_zero_as_path_prepend`, including
+loop bodies. The wire encoder independently rejects AS 0 under RFC 7607.
+
 ## Key types
 
 - **`RouteContext<'a>`** — borrowed match context (prefix, communities, AS_PATH, RPKI state)

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -1166,6 +1166,14 @@ impl CompiledChain {
         None
     }
 
+    /// Whether a resolved literal prepend uses AS 0, including inside loops.
+    /// The daemon rejects such chains at attachment after policy parameters
+    /// have been substituted; AS 0 is prohibited in `AS_PATH` by RFC 7607.
+    #[must_use]
+    pub fn has_zero_as_path_prepend(&self) -> bool {
+        self.any_action_mods(&|mods| matches!(mods.as_path_prepend, Some((0, _))))
+    }
+
     /// Does any term across all policies — recursing into
     /// [`TermAction::ForEach`] bodies (LAN-303) — satisfy `pred`?
     fn any_term_node(&self, pred: &impl Fn(&Term) -> bool) -> bool {

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -2576,6 +2576,16 @@ fn fixed_prepend_forms_unchanged() {
     }
 }
 
+#[test]
+fn prepend_literal_as_zero_is_rejected_per_rfc7607() {
+    let (_, rendered) = diagnostics_of("policy p { term t { prepend as 0 3; accept } }");
+    assert!(
+        rendered.contains("AS 0 cannot be prepended (RFC 7607)"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("ASN cannot be 0"), "{rendered}");
+}
+
 fn path_first_ctx(segments: Vec<rustbgpd_wire::AsPathSegment>) -> RouteContext<'static> {
     let path = Box::leak(Box::new(rustbgpd_wire::AsPath { segments }));
     RouteContext {

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -1042,6 +1042,15 @@ impl<'a> Checker<'a> {
                     && let PrependAsArg::Value(arg) = asn
                 {
                     self.check_u32_arg(arg, scope);
+                    if let U32Arg::Lit(asn, span) = arg
+                        && *asn == 0
+                    {
+                        self.diags.push(Diagnostic::new(
+                            *span,
+                            "AS 0 cannot be prepended (RFC 7607)",
+                            "ASN cannot be 0",
+                        ));
+                    }
                 }
                 match count {
                     U32Arg::Lit(value, span) => {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2972,7 +2972,7 @@ These fields modify matching routes. Only valid with `action = "permit"`.
 | `set_next_hop`         | string      | `"self"` or an IP address                          |
 | `set_community_add`    | [string]    | Communities to add (standard, EC, or LC format)    |
 | `set_community_remove` | [string]    | Communities to remove                              |
-| `set_as_path_prepend`  | table       | `{ asn = 65001, count = 3 }` (count 1-10)         |
+| `set_as_path_prepend`  | table       | `{ asn = 65001, count = 3 }` (ASN 1–4294967295, count 1–10) |
 
 ### Community formats
 

--- a/docs/reference/rpol-language.md
+++ b/docs/reference/rpol-language.md
@@ -1053,8 +1053,13 @@ Two consequences worth internalizing:
 | `add large-community 65000:1:2` / `remove ...` | large communities |
 | `remove large-community 65000:*:*` | every arrived large community with global administrator 65000 |
 | `add ext-community RT:65001:100` / `remove ...` | extended communities (RT/RO, or well-known: `add ext-community OV_INVALID`) |
-| `prepend as <asn> <count>` | prepend `<count>` copies of `<asn>` (count: literal 1–255) |
+| `prepend as <asn> <count>` | prepend `<count>` copies of `<asn>` (ASN: 1–4294967295; count: literal 1–255) |
 | `prepend as self\|peer\|origin\|path-first <count>` | prepend a computed ASN (see below) |
+
+Literal AS 0 is a compile error. A parameter that resolves to AS 0 in a
+prepend action is rejected when the daemon attaches the policy chain,
+including prepends inside loops. These checks reject invalid policy before
+evaluation; the wire encoder also rejects AS 0 under RFC 7607.
 
 The kind keyword must match the literal's kind (`add community
 RT:...` is a compile error pointing at `add ext-community`). Within a

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -451,6 +451,11 @@ fn resolve_rpol_chain_ref(
             // as a real error for direct callers.
             reason: format!("chain reference {reference:?}: {missing}"),
         })?;
+    if compiled.has_zero_as_path_prepend() {
+        return Err(ConfigError::InvalidPolicyEntry {
+            reason: format!("chain reference {reference:?}: AS 0 cannot be prepended (RFC 7607)"),
+        });
+    }
     // Attach-time stamp backing `prepend as self` (LAN-296): the
     // daemon's `[global] asn`. Deterministic from config, so reloads
     // of an unchanged file still diff as no-ops.

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -571,7 +571,12 @@ fn parse_modifications(
     };
 
     // Parse AS_PATH prepend
-    let as_path_prepend = if let Some(ref pp) = e.set_as_path_prepend {
+    let as_path_prepend = if let Some(pp) = &e.set_as_path_prepend {
+        if pp.asn == 0 {
+            return Err(ConfigError::InvalidPolicyEntry {
+                reason: "set_as_path_prepend ASN cannot be 0 (RFC 7607)".into(),
+            });
+        }
         if pp.count == 0 || pp.count > 10 {
             return Err(ConfigError::InvalidPolicyEntry {
                 reason: format!("set_as_path_prepend count must be 1-10, got {}", pp.count),

--- a/src/config/tests/policy_parsing.rs
+++ b/src/config/tests/policy_parsing.rs
@@ -570,6 +570,19 @@ fn set_route_community_rejects_ipv4_local_that_exceeds_u16() {
 }
 
 #[test]
+fn set_as_path_prepend_rejects_as0_per_rfc7607() {
+    let toml = community_toml(
+        r#"action = "permit"
+            prefix = "10.0.0.0/8"
+            set_as_path_prepend = { asn = 0, count = 2 }"#,
+    );
+    let ConfigError::InvalidPolicyEntry { reason } = parse(&toml).unwrap_err() else {
+        panic!("expected invalid policy entry");
+    };
+    assert_eq!(reason, "set_as_path_prepend ASN cannot be 0 (RFC 7607)");
+}
+
+#[test]
 fn ov_well_known_ext_community_names_in_toml_policy() {
     // RFC 8097 origin-validation states ride the well-known-name path
     // in match and set positions.

--- a/src/config/tests/rpol.rs
+++ b/src/config/tests/rpol.rs
@@ -536,6 +536,51 @@ fn rpol_max_graph_bytes_out_of_range_is_a_load_error() {
     }
 }
 
+#[test]
+fn rpol_parameterized_as0_prepend_rejected_at_attachment() {
+    for action in [
+        "prepend as n 1;",
+        "for value in route.as-path { prepend as n 1; }",
+    ] {
+        let source = format!("policy p(n: u32) {{ term t {{ {action} accept }} }}");
+        for (import, export) in [(r#""p(0)""#, ""), ("", r#""p(0)""#)] {
+            let dir = rpol_directional_config_dir(&source, import, export);
+            let error = load_dir(&dir).expect_err("AS 0 prepend must reject attachment");
+            assert!(error.contains("p(0)"), "{error}");
+            assert!(
+                error.contains("AS 0 cannot be prepended (RFC 7607)"),
+                "{error}"
+            );
+        }
+    }
+}
+
+#[test]
+fn rpol_parameterized_prepend_accepts_valid_asns_and_zero_med() {
+    let source = "policy p(asn: u32, metric: u32) {
+        term t { set med metric; prepend as asn 1; accept }
+    }";
+    for asn in [1, u32::MAX] {
+        let reference = format!("\"p({asn}, 0)\"");
+        let dir = rpol_directional_config_dir(source, &reference, &reference);
+        let config = load_dir(&dir).expect("nonzero ASN and zero MED are valid");
+        let (import, export) = config
+            .effective_policy_chains_for_neighbor(&config.neighbors[0])
+            .expect("valid parameterized chains resolve");
+        let ctx = route_server_test_context(
+            route_server_test_prefix("192.0.2.0/24"),
+            rustbgpd_wire::RpkiValidation::NotFound,
+            rustbgpd_wire::AspaValidation::Unknown,
+        );
+        for chain in [import, export] {
+            let result = chain.expect("configured chain").evaluate(&ctx);
+            assert_eq!(result.action, rustbgpd_policy::PolicyAction::Permit);
+            assert_eq!(result.modifications.as_path_prepend, Some((asn, 1)));
+            assert_eq!(result.modifications.set_med, Some(0));
+        }
+    }
+}
+
 /// Direction legality is enforced when the chain is attached: a
 /// `prepend as peer` member is import-only, and binding it as an
 /// export chain fails the config load with the exact diagnostic.


### PR DESCRIPTION
Reject AS 0 in TOML prepend actions and literal `.rpol` prepends. Parameterized policies such as `p(0)` are rejected at the shared chain attachment boundary when the resolved action prepends zero, including actions inside loops. Valid ASNs and zero values used for unrelated parameters remain accepted.

The wire encoder already rejects AS 0. This catches invalid policy before installation instead of allowing it to produce an unencodable AS_PATH.

Validation: removing the attachment guard makes the new regression fail because `p(0)` loads; restoring it passes both parameterized configuration tests. The original TOML and `.rpol` literal checks, 19 existing prepend tests, strict policy/daemon Clippy, formatting, and diff checks pass. Normal commit/push hooks also pass workspace Clippy, workspace library tests, and library/daemon/CLI rustdoc.
