### PR TITLE
fix(cli): retain flowspec extended communities in json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   action interpretation and construction, including byte-rate API views and
   injection; raw extended-community storage and reflection remain unchanged.
 
+- `rbgp --json flowspec` now includes raw `extended_communities` as numeric
+  values, preserving their order and duplicates alongside the curated actions.
+
 - `rbgp doctor` attributes local process limits and config freshness to the
   connected Unix-socket peer, with process-start verification and reconnect
   updates. Co-resident daemons no longer contribute unrelated low-limit

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -207,6 +207,11 @@ rbgp fib-table set edge --table-id 1000 --metric 200 --families ipv4_unicast,ipv
 
 `rib add --nexthop` remains a compatibility alias for `--next-hop`.
 
+`rbgp --json flowspec` includes `extended_communities` as raw unsigned 64-bit
+integers in response order, including duplicates and values without a curated
+action. The field is an empty array when the route has none; `actions` retains
+its formatted summaries.
+
 For large accepted unicast listings, use `rbgp --json-lines rib`,
 `rbgp --json-lines rib received 192.0.2.1`, or
 `rbgp --json-lines rib advertised 192.0.2.1`. Routes are written as each

--- a/crates/cli/src/commands/flowspec.rs
+++ b/crates/cli/src/commands/flowspec.rs
@@ -83,6 +83,7 @@ pub async fn list(connection: Connection, family: Option<i32>, json: bool) -> Re
                     "afi_safi": output::format_family(route.afi_safi),
                     "as_path": route.as_path,
                     "communities": route.communities.iter().map(|c| output::format_community(*c)).collect::<Vec<_>>(),
+                    "extended_communities": route.extended_communities,
                 })
             })
             .collect();

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -182,6 +182,7 @@ pub(crate) struct MockState {
     pub(crate) list_vpn_response: Mutex<Option<server_proto::ListVpnRoutesResponse>>,
     pub(crate) last_list_labeled: Mutex<Option<server_proto::ListLabeledRoutesRequest>>,
     pub(crate) last_list_rtc: Mutex<Option<server_proto::ListRtcRoutesRequest>>,
+    pub(crate) list_flowspec_response: Mutex<server_proto::ListFlowSpecResponse>,
     pub(crate) last_list_evpn: Mutex<Option<server_proto::ListEvpnRequest>>,
     pub(crate) last_list_received_evpn: Mutex<Option<server_proto::ListPeerEvpnRoutesRequest>>,
     pub(crate) last_list_advertised_evpn: Mutex<Option<server_proto::ListPeerEvpnRoutesRequest>>,
@@ -2289,9 +2290,9 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         _request: Request<server_proto::ListFlowSpecRequest>,
     ) -> Result<Response<server_proto::ListFlowSpecResponse>, Status> {
-        Ok(Response::new(server_proto::ListFlowSpecResponse {
-            routes: vec![],
-        }))
+        Ok(Response::new(
+            self.state.list_flowspec_response.lock().await.clone(),
+        ))
     }
 
     async fn list_received_evpn_routes(

--- a/crates/cli/tests/flowspec_json.rs
+++ b/crates/cli/tests/flowspec_json.rs
@@ -1,0 +1,89 @@
+//! FlowSpec JSON projection through the existing mock gRPC server.
+
+use std::process::Command;
+
+use rustbgpd_api::proto;
+
+#[path = "../src/test_support.rs"]
+#[allow(
+    dead_code,
+    reason = "shared CLI mock includes services unused by this contract"
+)]
+mod test_support;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn flowspec_json_preserves_raw_extended_communities() {
+    let server = test_support::spawn_mock_server(None).await;
+    let raw = vec![0x800c_fde8_3f80_0000, u64::MAX, 0x800c_fde8_3f80_0000, 0];
+    *server.state.list_flowspec_response.lock().await = proto::ListFlowSpecResponse {
+        routes: vec![
+            proto::FlowSpecRouteEntry {
+                components: vec![proto::FlowSpecComponent {
+                    r#type: 1,
+                    prefix: "192.0.2.0/24".into(),
+                    ..Default::default()
+                }],
+                actions: vec![proto::FlowSpecAction {
+                    action: Some(proto::flow_spec_action::Action::TrafficRate(
+                        proto::FlowSpecTrafficRate { rate: 0.0 },
+                    )),
+                }],
+                peer_address: "192.0.2.1".into(),
+                afi_safi: proto::AddressFamily::Ipv4Flowspec.into(),
+                as_path: vec![65001],
+                communities: vec![(65000 << 16) | 100],
+                extended_communities: raw.clone(),
+            },
+            proto::FlowSpecRouteEntry::default(),
+        ],
+    };
+    let run = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_rbgp"))
+            .args(["--addr", &server.addr])
+            .args(args)
+            .env("NO_COLOR", "1")
+            .output()
+            .expect("run rbgp")
+    };
+    let output = run(&["--json", "flowspec"]);
+    assert!(output.status.success(), "{output:?}");
+    let rows: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(rows.as_array().unwrap().len(), 2);
+    assert_eq!(rows[0]["extended_communities"], serde_json::json!(raw));
+    assert_eq!(rows[1]["extended_communities"], serde_json::json!([]));
+    assert_eq!(
+        rows[0]["components"],
+        serde_json::json!(["dest=192.0.2.0/24"])
+    );
+    assert_eq!(rows[0]["actions"], serde_json::json!(["drop"]));
+    assert_eq!(rows[0]["peer_address"], "192.0.2.1");
+    assert_eq!(rows[0]["as_path"], serde_json::json!([65001]));
+    assert_eq!(rows[0]["communities"], serde_json::json!(["65000:100"]));
+
+    server
+        .state
+        .list_flowspec_response
+        .lock()
+        .await
+        .routes
+        .truncate(1);
+    let output = run(&["flowspec"]);
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "  match [dest=192.0.2.0/24] action [drop] from 192.0.2.1 (ipv4_flowspec)\n"
+    );
+    server
+        .state
+        .list_flowspec_response
+        .lock()
+        .await
+        .routes
+        .clear();
+    let output = run(&["--json", "flowspec"]);
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!([])
+    );
+}


### PR DESCRIPTION
`rbgp --json flowspec` omitted the raw extended communities already returned by the API, leaving values outside the curated action projection unavailable to JSON consumers. Include `extended_communities` as unsigned 64-bit numbers, preserving order, duplicates, and empty arrays.

The process regression uses the existing mock gRPC server and verifies exact large integer values, existing formatted fields, unchanged human output, and an empty listing. The CLI reference and changelog describe the added field.

Validation: the regression failed against the original serializer and passes with the field added; `just gate` passed, including strict workspace Clippy, full workspace tests, repository contracts, and library/binary docs.
