### PR TITLE
docs(docs): clarify reload proof and bmp replay boundaries

### DIFF
--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -186,7 +186,7 @@ configured. Key series:
 | Metric | Meaning |
 |--------|---------|
 | `bgp_event_outbox_degraded` | 1 = latched durability-impacting loss, committed-event delivery skip, or DB open/recovery/quarantine failure; expected shutdown `reason=closed` drops are excluded. Inspect the drop reason and daemon log: replay can remain available |
-| `bmp_collector_drops_total` | per-collector queue/dump failures; live fan-out Full/Closed automatically resets only that collector generation and replays state after the one-second reconnect |
+| `bmp_collector_drops_total` | per-collector queue/dump failures; live fan-out Full/Closed automatically resets only that collector generation, replays cached Peer Up state, and rebuilds configured Loc-RIB state after the one-second reconnect |
 | `bmp_source_drops_total` | per-peer BMP events dropped at the source tap, including a periodic stats report whose session-state query timed out |
 | `bmp_replay_attempts_total` | PeerUp-cache replays on collector reconnect |
 | `bgp_rib_outbound_registered_peers` | feed coverage: peers whose routes the views carry |
@@ -204,11 +204,16 @@ slow consumer. That is the signal to resume via the durable cursor
 (`--from-event-id <last-processed>`) rather than the live ring.
 
 **A BMP collector shows nothing after a network blip.** The daemon
-redials with backoff capped by `reconnect_interval`, replays cached Peer Up
-state, and performs a fresh EoR-closed table dump only for collectors with
-`monitor = ["loc_rib"]`. Adj-RIB-In and Adj-RIB-Out remain live-only after a
-reconnect; see [Known issues](../reference/known-issues.md). Check the collector-side
-listener first, then the daemon log for connection and bootstrap failures.
+redials with backoff capped by `reconnect_interval` and replays cached Peer Up
+state. It performs a fresh EoR-closed table dump only for collectors with
+`monitor = ["loc_rib"]`. Adj-RIB-In and Adj-RIB-Out have no automatic
+reconnect dump. For a late outbound collector, follow the
+[outbound capture procedure](paired-route-servers.md#inter-rs-consistency-rbgp-diff-advertised).
+Its experimental `replay-out` operation reannounces the selected peer's routes
+on the live BGP session; successful scheduling alone does not prove a complete
+capture. See [Known issues](../reference/known-issues.md). Check the
+collector-side listener first, then the daemon log for connection and
+bootstrap failures.
 
 **pmacct rejects the v4 stream (`BMPv4 BGP PDU TLV != 1`).** Known and
 expected — see the caveat in the config above. Move that collector to

--- a/docs/cookbook/paired-route-servers.md
+++ b/docs/cookbook/paired-route-servers.md
@@ -106,8 +106,9 @@ For automatic capture, start the listener before RS2's member sessions
 establish — before RS2 starts (in practice its maintenance-window restart)
 or before its member sessions are cleared — and leave it running. Live
 updates fold into the same capture. After a dropped BMP connection, a new
-capture needs another complete boundary from establishment or explicit
-replay below.
+capture needs another complete boundary from establishment or the explicit
+outbound replay below. Reconnect does not automatically reconstruct the prior
+`rib_out_post` stream.
 
 ```bash
 # Terminal 1: start before RS2's member sessions come up; leave running.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -9,6 +9,25 @@ resolved.
 
 ---
 
+## Open issues
+
+- **Fleet policy stats can time out during reload.** The daemon's
+  `GetPolicyStats` RPC shares one absolute 2 s deadline across peer validation,
+  export counters, import counters, and dataset reads. Fleet calls such as
+  `rbgp policy stats --direction both` can return `DEADLINE_EXCEEDED` during
+  reload activity, with no partial rows. Check reload settlement before
+  retrying the read. Fleet stats responsiveness during reload remains under
+  investigation.
+  See the [policy stats contract](api.md#policyservice).
+
+- **700-member dual-stack reload acceptance remains open.** The
+  [post-change filtering run](../perf/ixp-dualstack-policy-noops-2026-09.md#700-member-follow-through)
+  completed all four reloads but failed the health and warning checks. Its
+  passing 200-member cell and the older IPv4-only receipts do not establish
+  the full dual-stack operating shape. The
+  [earlier stopped campaign](../perf/ixp-dualstack-2026-09-08.md) retains its
+  separate incomplete-reload and health failures.
+
 ## Resolved
 
 - **Add-Path export explain covers exact candidates (resolved).** For
@@ -208,7 +227,7 @@ resolved.
   §4.3; the socket is by definition not draining). Details in
   `docs/reference/rfc-notes.md` (RFC 9687 section).
 
-- **BMP Adj-RIB-In/Adj-RIB-Out streams are live-only — no table dump on
+- **BMP Adj-RIB-In/Adj-RIB-Out streams have no automatic table dump on
   collector (re)connect.** A collector that connects mid-life receives
   the cached Peer Up replay but no synthesized Route Monitoring dump of
   those views: the RFC 8671 post-policy Adj-RIB-Out stream
@@ -234,10 +253,13 @@ resolved.
   the session-side attribute rewrites (`ORIGINATOR_ID`/`CLUSTER_LIST`
   on reflection, GShut community, LLGR §4.6 form) and not be
   byte-faithful to what was advertised; pre-policy Adj-RIB-In is
-  unreconstructable post-import. Collectors needing those exact views
-  should connect before sessions establish (or trigger a route
-  refresh). Because these streams are live-only, a Route Monitoring
-  event lost to BMP-channel saturation can never be replayed — so the
+  unreconstructable post-import. Connect before BGP sessions establish for
+  automatic complete boundaries. For established IPv4/IPv6 unicast sessions,
+  [explicit outbound replay](api.md#replay-one-peers-unicast-routes-with-terminal-eors)
+  can create a new outbound boundary for eligible collectors. It reannounces
+  routes on the live BGP session; require terminal BMP EoRs, not just a
+  successful scheduling response. An individual Route Monitoring event lost
+  to BMP-channel saturation cannot be recovered from history, so the
   daemon guarantees such a loss is collector-detectable, never silent:
   per-peer `PeerUp`/`PeerDown` delivery from sessions to the BMP
   manager is reliable, and a Route Monitoring event dropped on a full

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -938,9 +938,15 @@ matchability, or a startup gate.
 Each BMP client reconnects independently with backoff (default
 `reconnect_interval` = 30s). During disconnection, BMP events for that
 collector are dropped. No routing state is affected — BMP is purely
-observational. On reconnect, the client sends a fresh Initiation message;
-the collector rebuilds state from subsequent Peer Up and Route Monitoring
-messages.
+observational. On reconnect, the client sends a fresh Initiation message and
+the manager replays cached Peer Up state. A configured Loc-RIB view then gets
+a fresh table dump closed by End-of-RIB. Adj-RIB-In and Adj-RIB-Out resume
+live updates without an automatic reconnect dump. For established IPv4/IPv6
+unicast sessions, the experimental
+[`replay-out` operation](api.md#replay-one-peers-unicast-routes-with-terminal-eors)
+can rebuild an eligible collector's outbound inventory by reannouncing routes
+on the live BGP session. The CLI confirms scheduling; terminal BMP EoRs are
+required for a complete capture.
 
 During coordinated shutdown, the BMP manager first queues final Peer Down
 messages. Connected clients drain that queue, send BMP Termination, and flush.


### PR DESCRIPTION
BMP reconnect restores cached Peer Up state and configured Loc-RIB state; complete outbound captures need an initial session boundary or explicit replay. Clarify that replay reannounces routes on the live BGP session and that scheduling success does not establish completion.

Add the unresolved fleet-statistics deadline and 700-member dual-stack operating acceptance to known issues, linking the later completed-but-failed run separately from the earlier stopped campaign.

Validation: checked the wording against implementation, regressions, and retained receipts; offline links and six documentation contracts passed. Normal push hooks passed all three rustdoc commands.
