### PR TITLE
fix(repo): skip rustdoc builds for prose-only pushes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 # --no-deps --document-private-items plus the rustbgpd and rbgp binaries).
 #
 # `cargo test --lib` + rustdoc are at pre-push (not pre-commit) so commits
-# stay fast; cargo fmt + clippy run on every commit.
+# stay fast; Rust hooks run only when their inputs change.
 #
 # Rustdoc warning denial comes from `.cargo/config.toml`
 # (build.rustdocflags), NOT an inline RUSTDOCFLAGS env: setting the env
@@ -57,7 +57,8 @@ repos:
         name: cargo doc
         entry: bash scripts/build-lock.sh cargo doc --locked --workspace --lib --no-deps --document-private-items
         language: system
-        always_run: true
+        files: &rustdoc-inputs '(^|/)([^/]+\.rs|Cargo\.toml|Cargo\.lock)$|^(\.cargo/config(\.toml)?|rust-toolchain(\.toml)?|proto/.*\.proto|examples/route-server/hygiene\.rpol)$'
+        types: [file]
         pass_filenames: false
         stages: [pre-push]
 
@@ -65,7 +66,8 @@ repos:
         name: cargo doc (rustbgpd binary)
         entry: bash scripts/build-lock.sh cargo doc --locked -p rustbgpd --bin rustbgpd --no-deps
         language: system
-        always_run: true
+        files: *rustdoc-inputs
+        types: [file]
         pass_filenames: false
         stages: [pre-push]
 
@@ -73,6 +75,7 @@ repos:
         name: cargo doc (rbgp binary)
         entry: bash scripts/build-lock.sh cargo doc --locked -p rustbgpctl --bin rbgp --no-deps
         language: system
-        always_run: true
+        files: *rustdoc-inputs
+        types: [file]
         pass_filenames: false
         stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,9 +237,11 @@ remain responsible for shell scripts.
 
 We ship a `.pre-commit-config.yaml` that runs `cargo fmt --all` and
 `cargo clippy --locked --workspace --all-targets -- -D warnings` on relevant
-commits, workspace library tests on relevant pushes, and rustdoc on every push. The
-hooks are a fast local subset, not an exact CI mirror or a guarantee that a
-pull request is ready. `cargo test` is gated to pre-push (not pre-commit) so
+commits, workspace library tests on relevant pushes, and rustdoc when Rust
+sources, manifests, lockfiles, protobuf schemas, embedded policy, or Cargo/toolchain
+configuration change. Prose-only pushes skip Rust builds; run `just links` and
+the relevant documentation contracts for those changes. The hooks are a local
+subset, not an exact CI mirror or a guarantee that a pull request is ready. `cargo test` is gated to pre-push (not pre-commit) so
 commits stay fast.
 
 Set it up once:


### PR DESCRIPTION
Prose-only pushes ran all three Rustdoc builds because the hooks used `always_run`, delaying publication and allowing an idle Git SSH connection to expire. Select those hooks only when Rust sources, manifests, lockfiles, protobuf schemas, the embedded policy, or Cargo/toolchain configuration change.

Update the contributor instructions to describe the boundary. Validation: native hook configuration validation, ten `prek --dry-run` selection cases covering prose and build inputs, an actual prose-only hook run, offline links, and the normal commit/push hooks. No Rust implementation changed.
