### PR TITLE
fix(soak): make flagship stop ownership explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,9 @@ jobs:
           python3 -m unittest -v tests/soak/test_analyze_soak_rr_flagship.py
           python3 -m unittest -v tests/soak/test_management_plane_load.py
           python3 -m unittest -v tests/soak/test_fd_headroom.py
+          python3 -m unittest -v tests/soak/test_flagship_lifecycle.py
           python3 -m unittest -v tests/soak/test_analyze_soak.py
+          shellcheck -x tests/soak/flagship-lifecycle.sh
           shellcheck -x tests/soak/run-soak-rs-flagship.sh
           shellcheck -x tests/soak/run-soak-rr-flagship.sh
           python3 bench/scale/rebaseline/test_classifiers.py

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -51,6 +51,36 @@ exits `75` (`EX_TEMPFAIL`, "host busy") so an unattended caller (a cron
 wrapper around `bench/compare-criterion.sh`) can skip cleanly rather than
 fail.
 
+Do not unlink the lock path to clear contention: the kernel lock is held by a
+file descriptor, so unlinking can create a second, uncoordinated lock file.
+Wait for the holder to exit, or stop a flagship runner through its verified
+run directory as described below.
+
+## Stopping and archiving a flagship run
+
+The route-server and route-reflector flagship runners record their actual Bash
+PID, boot ID, and `/proc` start time in `runner.identity`. If a launch wrapper
+was backgrounded, do not signal that wrapper; stop the verified runner instead:
+
+```bash
+bash tests/soak/flagship-lifecycle.sh stop \
+    tests/soak/runs/soak-rs-flagship-<UTC>
+```
+
+The command returns only after the runner has stopped its owned processes,
+drained `soak.log`, and written `cleanup.complete`. A signal-interrupted run
+has `status=interrupted` and no analyzer verdict; retain it as interrupted
+evidence. A completed run whose analyzer rejects its gates has
+`status=failed` and retains its failing `verdict.json`.
+If the marker says `status=log_write_failed`, do not treat the directory as a
+quiesced archive: preserve it for diagnosis and repair the host write failure.
+After the stop command succeeds, copy the entire quiesced directory to the
+archive location without pruning files:
+
+```bash
+cp -a tests/soak/runs/soak-rs-flagship-<UTC> /path/to/soak-archive/
+```
+
 ---
 
 # M33 24-Hour Soak Harness
@@ -1023,7 +1053,7 @@ lands in `tests/soak/runs/soak-rs-flagship-<UTC>/` (`samples.csv`,
 `cycles.log`, `reloadstall.log`, `rustbgpd.log`,
 `management-plane-load.jsonl`, `management-plane-load.log`,
 `doctor-bundle.tar.gz`, `run.json`,
-`verdict.json`); the analyzer is `analyze-soak-rs-flagship.py` and the
+`verdict.json`, `runner.identity`, `cleanup.complete`); the analyzer is `analyze-soak-rs-flagship.py` and the
 precommitted gates are scenario 10 in
 `docs/soaks/soak-acceptance-gates.md`. Note the short scenario
 directory under `/tmp` is required by the gRPC UDS `sun_path` cap; the
@@ -1065,8 +1095,8 @@ Requires host ports 1790 (BGP) and 9179 (metrics) free — the runner
 refuses to start otherwise and never kills unknown processes — and
 file-descriptor headroom (see below). Output
 lands in `tests/soak/runs/soak-rr-flagship-<UTC>/` (`samples.csv`,
-`cycles.log`, `reloadstall.log`, `rustbgpd.log`, `run.json`,
-`verdict.json`); the analyzer is `analyze-soak-rr-flagship.py` and the
+`cycles.log`, `reloadstall.log`, `rustbgpd.log`, `run.json`, `verdict.json`,
+`runner.identity`, `cleanup.complete`); the analyzer is `analyze-soak-rr-flagship.py` and the
 precommitted gates are scenario 11 in
 `docs/soaks/soak-acceptance-gates.md`. The same short-`/tmp`-scenario
 and fresh-per-run rules as the route-server flagship soak apply.

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -69,13 +69,14 @@ bash tests/soak/flagship-lifecycle.sh stop \
 
 The command returns only after the runner has stopped its owned processes,
 drained `soak.log`, and written `cleanup.complete`. A signal-interrupted run
-has `status=interrupted` and no analyzer verdict; retain it as interrupted
-evidence. A completed run whose analyzer rejects its gates has
+has `status=interrupted`; interruption before analysis produces no verdict.
+Retain any existing verdict alongside the interruption marker. A completed run whose analyzer rejects its gates has
 `status=failed` and retains its failing `verdict.json`.
 If the marker says `status=log_write_failed`, do not treat the directory as a
 quiesced archive: preserve it for diagnosis and repair the host write failure.
 After the stop command succeeds, copy the entire quiesced directory to the
-archive location without pruning files:
+archive location without pruning files. For a run that finishes naturally,
+wait for the runner to exit and check its cleanup marker before copying:
 
 ```bash
 cp -a tests/soak/runs/soak-rs-flagship-<UTC> /path/to/soak-archive/

--- a/tests/soak/flagship-lifecycle.sh
+++ b/tests/soak/flagship-lifecycle.sh
@@ -97,7 +97,7 @@ pid, boot, start = sys.argv[1:]
 try:
     fd = os.pidfd_open(int(pid))
 except OSError as error:
-    raise SystemExit(f"runner is gone: {error}")
+    raise SystemExit(f"cannot open runner pidfd: {error}")
 try:
     if open("/proc/sys/kernel/random/boot_id", encoding="utf-8").read().strip() != boot:
         raise SystemExit("runner boot identity changed")
@@ -121,7 +121,7 @@ stop_flagship_runner() {
         return 1
     fi
     if ! flagship_send_term "$run_dir"; then
-        echo "error: runner identity changed before it could be signalled: $run_dir" >&2
+        echo "error: could not signal the verified runner: $run_dir" >&2
         return 1
     fi
     for ((i = 0; i < 600; i++)); do

--- a/tests/soak/flagship-lifecycle.sh
+++ b/tests/soak/flagship-lifecycle.sh
@@ -26,7 +26,7 @@ flagship_identity_matches() {
 }
 
 start_flagship_lifecycle() {
-    local boot start identity_tmp runner_pid=$BASHPID
+    local boot start identity_tmp coproc_input runner_pid=$BASHPID
     # shellcheck disable=SC2153 # both flagship runners assign RUN_DIR.
     FLAGSHIP_IDENTITY_FILE="$RUN_DIR/runner.identity"
     FLAGSHIP_CLEANUP_MARKER="$RUN_DIR/cleanup.complete"
@@ -34,8 +34,13 @@ start_flagship_lifecycle() {
     exec {FLAGSHIP_STDOUT_FD}>&1
     exec {FLAGSHIP_STDERR_FD}>&2
     # Keep the file writer alive if a launch wrapper closes its output pipe.
-    exec > >(tee -p -a "$SOAK_LOG") 2>&1
+    coproc FLAGSHIP_LOG_WRITER { exec tee -p -a "$SOAK_LOG" >&"$FLAGSHIP_STDOUT_FD"; }
     FLAGSHIP_TEE_PID=$!
+    coproc_input=${FLAGSHIP_LOG_WRITER[1]}
+    exec {FLAGSHIP_TEE_INPUT_FD}>&"$coproc_input"
+    exec {coproc_input}>&-
+    exec 1>&"$FLAGSHIP_TEE_INPUT_FD"
+    exec 2>&"$FLAGSHIP_TEE_INPUT_FD"
     IFS= read -r boot </proc/sys/kernel/random/boot_id
     start=$(flagship_proc_start_ticks "$runner_pid") || return 1
     identity_tmp="${FLAGSHIP_IDENTITY_FILE}.tmp"
@@ -44,7 +49,7 @@ start_flagship_lifecycle() {
 }
 
 finish_flagship_cleanup() {
-    local rc=$1 interrupted=${2:-0} status tee_rc
+    local rc=$1 interrupted=${2:-0} status tee_rc fd_path fd
     [[ -n ${FLAGSHIP_TEE_PID:-} ]] || return 0
     if ((interrupted != 0)); then
         status=interrupted
@@ -55,12 +60,26 @@ finish_flagship_cleanup() {
     fi
     exec 1>&"$FLAGSHIP_STDOUT_FD"
     exec 2>&"$FLAGSHIP_STDERR_FD"
+    # An EXIT trap inside a redirected command can retain Bash's saved
+    # stdout on an internal descriptor. We are exiting, so close every
+    # remaining descriptor for this owned writer's input pipe as well.
+    for fd_path in /proc/"$BASHPID"/fd/*; do
+        fd=${fd_path##*/}
+        [[ $fd == "$FLAGSHIP_TEE_INPUT_FD" ]] && continue
+        [[ $fd_path -ef /proc/$BASHPID/fd/$FLAGSHIP_TEE_INPUT_FD ]] || continue
+        exec {fd}>&-
+    done
+    exec {FLAGSHIP_TEE_INPUT_FD}>&-
+    # Always collect the exit status, even if Bash has already reaped the
+    # process. The callers ignore INT/TERM throughout cleanup so this wait
+    # cannot return early because of a repeated stop request.
     wait "$FLAGSHIP_TEE_PID" || tee_rc=$?
     if [[ -n ${tee_rc:-} ]]; then
         status=log_write_failed
         ((rc == 0)) && rc=1
     fi
-    printf 'status=%s\nexit_status=%s\n' "$status" "$rc" >"$FLAGSHIP_CLEANUP_MARKER"
+    printf 'status=%s\nexit_status=%s\n' "$status" "$rc" >"${FLAGSHIP_CLEANUP_MARKER}.tmp" || return 1
+    mv "${FLAGSHIP_CLEANUP_MARKER}.tmp" "$FLAGSHIP_CLEANUP_MARKER" || return 1
     exec {FLAGSHIP_STDOUT_FD}>&-
     exec {FLAGSHIP_STDERR_FD}>&-
     [[ -z ${tee_rc:-} ]]

--- a/tests/soak/flagship-lifecycle.sh
+++ b/tests/soak/flagship-lifecycle.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Shared lifecycle ownership for the two bare-host flagship runners.
+
+flagship_proc_start_ticks() {
+    local stat
+    [[ ${1:-} =~ ^[1-9][0-9]*$ ]] || return 1
+    [[ -r /proc/$1/stat ]] || return 1
+    IFS= read -r stat <"/proc/$1/stat" || return 1
+    stat=${stat##*) }
+    # shellcheck disable=SC2086 # /proc fields are deliberately split here.
+    set -- $stat
+    [[ ${20:-} =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "${20}"
+}
+
+flagship_identity_matches() {
+    local run_dir=$1 identity pid boot start extra current_boot current_start
+    identity="$run_dir/runner.identity"
+    [[ -r $identity ]] || return 1
+    IFS=' ' read -r pid boot start extra <"$identity" || return 1
+    [[ -z $extra && $pid =~ ^[1-9][0-9]*$ && $start =~ ^[0-9]+$ ]] || return 1
+    IFS= read -r current_boot </proc/sys/kernel/random/boot_id || return 1
+    [[ $boot == "$current_boot" ]] || return 1
+    current_start=$(flagship_proc_start_ticks "$pid") || return 1
+    [[ $start == "$current_start" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+start_flagship_lifecycle() {
+    local boot start identity_tmp runner_pid=$BASHPID
+    # shellcheck disable=SC2153 # both flagship runners assign RUN_DIR.
+    FLAGSHIP_IDENTITY_FILE="$RUN_DIR/runner.identity"
+    FLAGSHIP_CLEANUP_MARKER="$RUN_DIR/cleanup.complete"
+    rm -f "$FLAGSHIP_CLEANUP_MARKER"
+    exec {FLAGSHIP_STDOUT_FD}>&1
+    exec {FLAGSHIP_STDERR_FD}>&2
+    # Keep the file writer alive if a launch wrapper closes its output pipe.
+    exec > >(tee -p -a "$SOAK_LOG") 2>&1
+    FLAGSHIP_TEE_PID=$!
+    IFS= read -r boot </proc/sys/kernel/random/boot_id
+    start=$(flagship_proc_start_ticks "$runner_pid") || return 1
+    identity_tmp="${FLAGSHIP_IDENTITY_FILE}.tmp"
+    printf '%s %s %s\n' "$runner_pid" "$boot" "$start" >"$identity_tmp"
+    mv "$identity_tmp" "$FLAGSHIP_IDENTITY_FILE"
+}
+
+finish_flagship_cleanup() {
+    local rc=$1 interrupted=${2:-0} status tee_rc
+    [[ -n ${FLAGSHIP_TEE_PID:-} ]] || return 0
+    if ((interrupted != 0)); then
+        status=interrupted
+    elif ((rc == 0)); then
+        status=normal
+    else
+        status=failed
+    fi
+    exec 1>&"$FLAGSHIP_STDOUT_FD"
+    exec 2>&"$FLAGSHIP_STDERR_FD"
+    wait "$FLAGSHIP_TEE_PID" || tee_rc=$?
+    if [[ -n ${tee_rc:-} ]]; then
+        status=log_write_failed
+        ((rc == 0)) && rc=1
+    fi
+    printf 'status=%s\nexit_status=%s\n' "$status" "$rc" >"$FLAGSHIP_CLEANUP_MARKER"
+    exec {FLAGSHIP_STDOUT_FD}>&-
+    exec {FLAGSHIP_STDERR_FD}>&-
+    [[ -z ${tee_rc:-} ]]
+}
+
+flagship_send_term() {
+    local run_dir=$1 pid boot start
+    read -r pid boot start <"$run_dir/runner.identity"
+    python3 - "$pid" "$boot" "$start" <<'PY'
+import os
+import signal
+import sys
+
+pid, boot, start = sys.argv[1:]
+try:
+    fd = os.pidfd_open(int(pid))
+except OSError as error:
+    raise SystemExit(f"runner is gone: {error}")
+try:
+    if open("/proc/sys/kernel/random/boot_id", encoding="utf-8").read().strip() != boot:
+        raise SystemExit("runner boot identity changed")
+    stat = open(f"/proc/{pid}/stat", encoding="utf-8").read().rsplit(") ", 1)[1].split()
+    if len(stat) < 20 or stat[19] != start:
+        raise SystemExit("runner start identity changed")
+    signal.pidfd_send_signal(fd, signal.SIGTERM)
+finally:
+    os.close(fd)
+PY
+}
+
+flagship_cleanup_drained() {
+    [[ -r $1/cleanup.complete ]] && grep -qx 'status=normal\|status=interrupted\|status=failed' "$1/cleanup.complete"
+}
+
+stop_flagship_runner() {
+    local run_dir=$1 marker="$1/cleanup.complete" i
+    if ! flagship_identity_matches "$run_dir"; then
+        echo "error: runner identity is stale or does not match: $run_dir" >&2
+        return 1
+    fi
+    if ! flagship_send_term "$run_dir"; then
+        echo "error: runner identity changed before it could be signalled: $run_dir" >&2
+        return 1
+    fi
+    for ((i = 0; i < 600; i++)); do
+        if flagship_cleanup_drained "$run_dir" && ! flagship_identity_matches "$run_dir"; then
+            echo "runner cleanup completed: $run_dir"
+            return 0
+        fi
+        if [[ -f $marker ]] && ! flagship_identity_matches "$run_dir"; then
+            echo "error: runner log writer did not drain: $run_dir" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    echo "error: runner cleanup did not complete within 60 seconds: $run_dir" >&2
+    return 1
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    if [[ ${1:-} != stop || $# != 2 ]]; then
+        echo "usage: $0 stop <run-dir>" >&2
+        exit 2
+    fi
+    stop_flagship_runner "$2"
+fi

--- a/tests/soak/host-lock.sh
+++ b/tests/soak/host-lock.sh
@@ -54,7 +54,7 @@ acquire_rustbgpd_host_lock() {
     exec {RUSTBGPD_HOST_LOCK_FD}>"$host_lock"
     if ! flock -n "$RUSTBGPD_HOST_LOCK_FD"; then
         echo "error: ${host_lock} is held by another process (soak or bench)" >&2
-        echo "       wait for it to finish or remove the lock if stale" >&2
+        echo "       wait for its holder to finish; do not unlink a held lock file" >&2
         return 75 # EX_TEMPFAIL — host busy, retry later
     fi
     echo "acquired host lock: ${host_lock}"

--- a/tests/soak/run-soak-rr-flagship.sh
+++ b/tests/soak/run-soak-rr-flagship.sh
@@ -122,7 +122,9 @@ RUN_INTERRUPTED=0
 cleanup() {
     local rc=$?
     trap - EXIT
-    trap ':' INT TERM
+    # Owned children already have their signal handlers. Ignore repeated
+    # stop requests here so child and log-writer waits finish before marking.
+    trap '' INT TERM
     set +e
     terminate "$H_PID"
     H_PID=""
@@ -136,7 +138,7 @@ cleanup() {
         log "owned processes stopped; draining soak log"
     fi
     if ! finish_flagship_cleanup "$rc" "$RUN_INTERRUPTED"; then
-        echo "ERROR: soak log writer failed; see cleanup.complete" >&2
+        echo "ERROR: could not finish soak evidence; inspect the log and cleanup marker" >&2
         ((rc == 0)) && rc=1
     fi
     exit "$rc"
@@ -146,11 +148,6 @@ abort() {
     cycle_log "ABORT: $*"
     log "ABORT: $*"
     exit 1
-}
-
-interrupt_run() {
-    RUN_INTERRUPTED=1
-    exit 143
 }
 
 ports_free() {
@@ -231,18 +228,29 @@ sample_row() {
     fi
     SCRAPE_FAILS=0
     pid_running "$H_PID" || return 0
-    # Same column set as the RS flagship sampler; this scenario
-    # configures no max-prefix bounds, so max_prefix_exceeded_total must
-    # stay 0 on every row (the analyzer gates it exactly).
+    # Keep each command substitution in its own command. Bash 5.2 can fail
+    # to parse a signal trap while expanding several substitutions in one
+    # printf; a stop request must still run the ordered cleanup below.
+    local timestamp rss_mb intern_size established flaps messages_sent max_prefix
+    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ) || :
+    rss_mb=$(tree_rss_mb) || :
+    intern_size=$(prom_get bgp_rib_attr_intern_global_size) || :
+    established=$(prom_sum bgp_peer_session_established) || :
+    flaps=$(prom_sum bgp_session_flaps_total) || :
+    messages_sent=$(prom_sum bgp_messages_sent_total) || :
+    max_prefix=$(prom_sum bgp_max_prefix_exceeded_total) || :
+    # Same column set as the RS flagship sampler; this scenario configures
+    # no max-prefix bounds, so max_prefix_exceeded_total must stay 0 on every
+    # row (the analyzer gates it exactly).
     printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$timestamp" \
         "$elapsed" \
-        "$(tree_rss_mb)" \
-        "$(prom_get bgp_rib_attr_intern_global_size)" \
-        "$(prom_sum bgp_peer_session_established)" \
-        "$(prom_sum bgp_session_flaps_total)" \
-        "$(prom_sum bgp_messages_sent_total)" \
-        "$(prom_sum bgp_max_prefix_exceeded_total)" \
+        "$rss_mb" \
+        "$intern_size" \
+        "$established" \
+        "$flaps" \
+        "$messages_sent" \
+        "$max_prefix" \
         "$code" \
         "$ms" \
         >>"$SAMPLES_CSV"
@@ -278,7 +286,8 @@ write_run_json() {
 main() {
     mkdir -p "$RUN_DIR"
     trap cleanup EXIT
-    trap interrupt_run INT TERM
+    trap 'RUN_INTERRUPTED=1; exit 130' INT
+    trap 'RUN_INTERRUPTED=1; exit 143' TERM
     start_flagship_lifecycle
     acquire_rustbgpd_host_lock
     for tool in cargo curl awk python3 ss flock git ps df mktemp timeout; do

--- a/tests/soak/run-soak-rr-flagship.sh
+++ b/tests/soak/run-soak-rr-flagship.sh
@@ -82,6 +82,8 @@ PROM_TMP="$RUN_DIR/.metrics.prom"
 source "$SOAK_SCRIPT_DIR/host-lock.sh"
 # shellcheck source=tests/soak/fd-headroom.sh
 source "$SOAK_SCRIPT_DIR/fd-headroom.sh"
+# shellcheck source=tests/soak/flagship-lifecycle.sh
+source "$SOAK_SCRIPT_DIR/flagship-lifecycle.sh"
 
 log() {
     printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
@@ -116,9 +118,11 @@ terminate() {
 H_PID=""
 DAEMON_PID=""
 SCEN=""
+RUN_INTERRUPTED=0
 cleanup() {
     local rc=$?
     trap - EXIT
+    trap ':' INT TERM
     set +e
     terminate "$H_PID"
     H_PID=""
@@ -128,6 +132,12 @@ cleanup() {
     rm -f "$PROM_TMP"
     if ((rc != 0)); then
         log "FAILED rc=$rc — artifacts preserved in $RUN_DIR"
+    else
+        log "owned processes stopped; draining soak log"
+    fi
+    if ! finish_flagship_cleanup "$rc" "$RUN_INTERRUPTED"; then
+        echo "ERROR: soak log writer failed; see cleanup.complete" >&2
+        ((rc == 0)) && rc=1
     fi
     exit "$rc"
 }
@@ -136,6 +146,11 @@ abort() {
     cycle_log "ABORT: $*"
     log "ABORT: $*"
     exit 1
+}
+
+interrupt_run() {
+    RUN_INTERRUPTED=1
+    exit 143
 }
 
 ports_free() {
@@ -262,11 +277,10 @@ write_run_json() {
 
 main() {
     mkdir -p "$RUN_DIR"
-    exec > >(tee -a "$SOAK_LOG") 2>&1
-    acquire_rustbgpd_host_lock
     trap cleanup EXIT
-    trap 'exit 130' INT
-    trap 'exit 143' TERM
+    trap interrupt_run INT TERM
+    start_flagship_lifecycle
+    acquire_rustbgpd_host_lock
     for tool in cargo curl awk python3 ss flock git ps df mktemp timeout; do
         require_tool "$tool"
     done

--- a/tests/soak/run-soak-rs-flagship.sh
+++ b/tests/soak/run-soak-rs-flagship.sh
@@ -240,7 +240,9 @@ stop_management_load() {
 cleanup() {
     local rc=$?
     trap - EXIT
-    trap ':' INT TERM
+    # Owned children already have their signal handlers. Ignore repeated
+    # stop requests here so child and log-writer waits finish before marking.
+    trap '' INT TERM
     set +e
     stop_management_load
     terminate "$H_PID"
@@ -255,7 +257,7 @@ cleanup() {
         log "owned processes stopped; draining soak log"
     fi
     if ! finish_flagship_cleanup "$rc" "$RUN_INTERRUPTED"; then
-        echo "ERROR: soak log writer failed; see cleanup.complete" >&2
+        echo "ERROR: could not finish soak evidence; inspect the log and cleanup marker" >&2
         ((rc == 0)) && rc=1
     fi
     exit "$rc"
@@ -265,11 +267,6 @@ abort() {
     cycle_log "ABORT: $*"
     log "ABORT: $*"
     exit 1
-}
-
-interrupt_run() {
-    RUN_INTERRUPTED=1
-    exit 143
 }
 
 ports_free() {
@@ -449,15 +446,26 @@ sample_row() {
     fi
     SCRAPE_FAILS=0
     pid_running "$H_PID" || return 0
+    # Keep each command substitution in its own command. Bash 5.2 can fail
+    # to parse a signal trap while expanding several substitutions in one
+    # printf; a stop request must still run the ordered cleanup below.
+    local timestamp rss_mb intern_size established flaps messages_sent max_prefix
+    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ) || :
+    rss_mb=$(tree_rss_mb) || :
+    intern_size=$(prom_get bgp_rib_attr_intern_global_size) || :
+    established=$(prom_sum bgp_peer_session_established) || :
+    flaps=$(prom_sum bgp_session_flaps_total) || :
+    messages_sent=$(prom_sum bgp_messages_sent_total) || :
+    max_prefix=$(prom_sum bgp_max_prefix_exceeded_total) || :
     printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$timestamp" \
         "$elapsed" \
-        "$(tree_rss_mb)" \
-        "$(prom_get bgp_rib_attr_intern_global_size)" \
-        "$(prom_sum bgp_peer_session_established)" \
-        "$(prom_sum bgp_session_flaps_total)" \
-        "$(prom_sum bgp_messages_sent_total)" \
-        "$(prom_sum bgp_max_prefix_exceeded_total)" \
+        "$rss_mb" \
+        "$intern_size" \
+        "$established" \
+        "$flaps" \
+        "$messages_sent" \
+        "$max_prefix" \
         "$code" \
         "$ms" \
         >>"$SAMPLES_CSV"
@@ -552,7 +560,8 @@ write_run_json() {
 main() {
     mkdir -p "$RUN_DIR"
     trap cleanup EXIT
-    trap interrupt_run INT TERM
+    trap 'RUN_INTERRUPTED=1; exit 130' INT
+    trap 'RUN_INTERRUPTED=1; exit 143' TERM
     start_flagship_lifecycle
     acquire_rustbgpd_host_lock
     for tool in cargo curl awk python3 ss flock git ps df mktemp timeout; do

--- a/tests/soak/run-soak-rs-flagship.sh
+++ b/tests/soak/run-soak-rs-flagship.sh
@@ -148,6 +148,8 @@ PROM_TMP="$RUN_DIR/.metrics.prom"
 source "$SOAK_SCRIPT_DIR/host-lock.sh"
 # shellcheck source=tests/soak/fd-headroom.sh
 source "$SOAK_SCRIPT_DIR/fd-headroom.sh"
+# shellcheck source=tests/soak/flagship-lifecycle.sh
+source "$SOAK_SCRIPT_DIR/flagship-lifecycle.sh"
 
 log() {
     printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
@@ -185,6 +187,7 @@ DAEMON_PID=""
 SCEN=""
 MEASURED_START_MONOTONIC=""
 MEASURED_END_MONOTONIC=""
+RUN_INTERRUPTED=0
 
 monotonic_now() {
     python3 -c 'import time; print(f"{time.monotonic():.9f}")'
@@ -237,6 +240,7 @@ stop_management_load() {
 cleanup() {
     local rc=$?
     trap - EXIT
+    trap ':' INT TERM
     set +e
     stop_management_load
     terminate "$H_PID"
@@ -247,6 +251,12 @@ cleanup() {
     rm -f "$PROM_TMP"
     if ((rc != 0)); then
         log "FAILED rc=$rc — artifacts preserved in $RUN_DIR"
+    else
+        log "owned processes stopped; draining soak log"
+    fi
+    if ! finish_flagship_cleanup "$rc" "$RUN_INTERRUPTED"; then
+        echo "ERROR: soak log writer failed; see cleanup.complete" >&2
+        ((rc == 0)) && rc=1
     fi
     exit "$rc"
 }
@@ -255,6 +265,11 @@ abort() {
     cycle_log "ABORT: $*"
     log "ABORT: $*"
     exit 1
+}
+
+interrupt_run() {
+    RUN_INTERRUPTED=1
+    exit 143
 }
 
 ports_free() {
@@ -536,11 +551,10 @@ write_run_json() {
 
 main() {
     mkdir -p "$RUN_DIR"
-    exec > >(tee -a "$SOAK_LOG") 2>&1
-    acquire_rustbgpd_host_lock
     trap cleanup EXIT
-    trap 'exit 130' INT
-    trap 'exit 143' TERM
+    trap interrupt_run INT TERM
+    start_flagship_lifecycle
+    acquire_rustbgpd_host_lock
     for tool in cargo curl awk python3 ss flock git ps df mktemp timeout; do
         require_tool "$tool"
     done

--- a/tests/soak/test_flagship_lifecycle.py
+++ b/tests/soak/test_flagship_lifecycle.py
@@ -291,9 +291,10 @@ class FlagshipLifecycleContracts(unittest.TestCase):
                     if runner.startswith("run-soak-rs"):
                         self.assertIn("clean_sigterm", (run_dir / "management-plane-load.jsonl").read_text())
                     self.assertFalse((run_dir / "verdict.json").exists())
-                    self.assertIn(
+                    self.assertEqual(
                         (run_dir / "cleanup.complete").read_text().splitlines()[0],
-                        {"status=interrupted", "status=failed"},
+                        "status=interrupted",
+                        (run_dir / "soak.log").read_text(),
                     )
                     first_log = (run_dir / "soak.log").read_bytes()
                     time.sleep(0.1)
@@ -350,6 +351,44 @@ class FlagshipLifecycleContracts(unittest.TestCase):
                         check=False,
                     ).returncode,
                     0,
+                )
+            finally:
+                terminate_group(process.pid, process)
+
+    def test_repeated_stop_waits_for_a_slow_log_writer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            fake_bin = directory / "bin"
+            fake_bin.mkdir()
+            tee = fake_bin / "tee"
+            tee.write_text(
+                "#!/usr/bin/env bash\n"
+                "output=${!#}\n"
+                "cat >>\"$output\"\n"
+                "sleep 0.5\n"
+            )
+            tee.chmod(0o755)
+            script, port, environment = self.write_stub(directory)
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+            process = subprocess.Popen(
+                ["bash", str(script), str(HERE / "run-soak-rs-flagship.sh"),
+                 str(directory / "run"), str(port), "interrupt"],
+                text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=environment,
+                start_new_session=True,
+            )
+            try:
+                identity = directory / "run" / "runner.identity"
+                wait_for(identity)
+                wait_for(directory / "run" / "children")
+                process.send_signal(signal.SIGTERM)
+                time.sleep(0.05)
+                process.send_signal(signal.SIGTERM)
+                time.sleep(0.1)
+                self.assertFalse((directory / "run" / "cleanup.complete").exists())
+                self.assertEqual(process.wait(timeout=5), 143)
+                self.assertEqual(
+                    (directory / "run" / "cleanup.complete").read_text().splitlines()[0],
+                    "status=interrupted",
                 )
             finally:
                 terminate_group(process.pid, process)

--- a/tests/soak/test_flagship_lifecycle.py
+++ b/tests/soak/test_flagship_lifecycle.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Subprocess contracts for flagship runner stop ownership."""
+
+import os
+import signal
+import socket
+import subprocess
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).parent
+LIFECYCLE = HERE / "flagship-lifecycle.sh"
+RUNNERS = ("run-soak-rs-flagship.sh", "run-soak-rr-flagship.sh")
+
+
+def free_port():
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+def wait_for(path):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"timed out waiting for {path}")
+
+
+def wait_for_children(path, expected):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.exists() and len(path.read_text().split()) == expected:
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"timed out waiting for {expected} children in {path}")
+
+
+def process_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def terminate_group(group, process):
+    try:
+        os.killpg(group, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    process.wait(timeout=5)
+    if process.stdout:
+        process.stdout.close()
+    if process.stderr:
+        process.stderr.close()
+
+
+class FlagshipLifecycleContracts(unittest.TestCase):
+    def write_actual_main_stub(self, directory, runner):
+        root = directory / "repo"
+        fake_bin = directory / "bin"
+        port = free_port()
+        (root / "target/release").mkdir(parents=True)
+        (root / "bench/scale/reloadstall").mkdir(parents=True)
+        fake_bin.mkdir()
+        for path, content in {
+            root / "target/release/rustbgpd": textwrap.dedent("""\
+                #!/usr/bin/env python3
+                import os
+                import socket
+                import sys
+                import time
+                if "--check" in sys.argv:
+                    raise SystemExit(0)
+                with open(os.path.join(os.environ["STUB_RUN_DIR"], "children"), "a", encoding="utf-8") as output:
+                    output.write(f"{os.getpid()}\\n")
+                sock = socket.socket()
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind(("127.0.0.1", int(os.environ["STUB_PORT"])))
+                sock.listen()
+                while True:
+                    time.sleep(1)
+                """),
+            root / "target/release/rbgp": "#!/usr/bin/env bash\nexit 0\n",
+            root / "bench/scale/target/release/reloadstall": (
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$$\" >>\"$STUB_RUN_DIR/children\"\nprintf 'converged (stub)\\n'\nexec sleep 300\n"
+            ),
+            root / "bench/scale/reloadstall/gen-scenario.py": textwrap.dedent("""\
+                #!/usr/bin/env python3
+                import pathlib
+                import sys
+                directory = pathlib.Path(sys.argv[2])
+                directory.mkdir(parents=True, exist_ok=True)
+                for name in ("config.toml", "member.rpol", "gen-a.rpol", "gen-b.rpol"):
+                    (directory / name).write_text("stub\\n")
+                """),
+            fake_bin / "cargo": "#!/usr/bin/env bash\nexit 0\n",
+            fake_bin / "curl": textwrap.dedent("""\
+                #!/usr/bin/env bash
+                for argument in "$@"; do
+                    [[ $argument == -w ]] && { printf '200 0.001\\n'; exit 0; }
+                done
+                cat <<'EOF'
+                bgp_rib_attr_intern_global_size 1
+                bgp_peer_session_established 9
+                bgp_session_flaps_total 0
+                bgp_messages_sent_total 1
+                bgp_max_prefix_exceeded_total 0
+                EOF
+                """),
+            fake_bin / "ss": "#!/usr/bin/env bash\nexit 0\n",
+            fake_bin / "git": "#!/usr/bin/env bash\nprintf stub-head\\n\n",
+        }.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+            path.chmod(0o755)
+
+        run_dir = directory / "run"
+        script = directory / "actual-main-stub.sh"
+        script.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            source "$1"
+            REPO_ROOT=$2
+            RUN_DIR=$3
+            SAMPLES_CSV="$RUN_DIR/samples.csv"
+            SOAK_LOG="$RUN_DIR/soak.log"
+            CYCLES_LOG="$RUN_DIR/cycles.log"
+            RUN_JSON="$RUN_DIR/run.json"
+            RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
+            RELOADSTALL_LOG="$RUN_DIR/reloadstall.log"
+            MANAGEMENT_LOAD_JSONL="$RUN_DIR/management-plane-load.jsonl"
+            MANAGEMENT_LOAD_LOG="$RUN_DIR/management-plane-load.log"
+            DOCTOR_BUNDLE="$RUN_DIR/doctor-bundle.tar.gz"
+            PROM_TMP="$RUN_DIR/.metrics.prom"
+            require_fd_headroom() { RUSTBGPD_NOFILE_SOFT_JSON=65536; }
+            if declare -F start_management_load >/dev/null; then
+                start_management_load() {
+                    python3 - "$MANAGEMENT_LOAD_JSONL" <<'PY' &
+            import os
+            import signal
+            import sys
+            import time
+            def stop(_signum, _frame):
+                with open(sys.argv[1], "w", encoding="utf-8") as output:
+                    output.write('{"record":"summary","result":"clean_sigterm"}\\n')
+                raise SystemExit(0)
+            with open(os.path.join(os.environ["STUB_RUN_DIR"], "children"), "a", encoding="utf-8") as output:
+                output.write(f"{os.getpid()}\\n")
+            signal.signal(signal.SIGTERM, stop)
+            while True:
+                time.sleep(1)
+            PY
+                    MANAGEMENT_LOAD_PID=$!
+                }
+            fi
+            main
+            """))
+        script.chmod(0o755)
+        environment = os.environ | {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "RUSTBGPD_HOST_LOCK": str(directory / "host.lock"),
+            "SOAK_PEERS": "9",
+            "SOAK_ROUTES_PER_PEER": "1",
+            "SOAK_SECONDS": "60",
+            "RELOAD_INTERVAL_SEC": "60",
+            "TRIP_INTERVAL_SEC": "60",
+            "TRIP_RESTART_SECONDS": "10",
+            "TRIP_FINAL_QUIESCE_SEC": "30",
+            "CONVERGE_CAP_SEC": "5",
+            "STUB_RUN_DIR": str(run_dir),
+            "STUB_PORT": str(port),
+        }
+        return script, run_dir, port, environment
+
+    def write_stub(self, directory):
+        port = free_port()
+        script = directory / "runner-stub.sh"
+        script.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            source "$1"
+            RUN_DIR=$2
+            SOAK_LOG="$RUN_DIR/soak.log"
+            PROM_TMP="$RUN_DIR/.metrics.prom"
+            LISTEN_PORT=$3
+            H_PID=""
+            DAEMON_PID=""
+            MANAGEMENT_LOAD_PID=""
+            SCEN=""
+            mkdir -p "$RUN_DIR"
+            start_flagship_lifecycle
+            acquire_rustbgpd_host_lock
+            trap cleanup EXIT
+            trap 'RUN_INTERRUPTED=1; exit 143' TERM
+            python3 - "$LISTEN_PORT" <<'PY' &
+            import socket
+            import sys
+            import time
+            sock = socket.socket()
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("127.0.0.1", int(sys.argv[1])))
+            sock.listen()
+            while True:
+                time.sleep(1)
+            PY
+            DAEMON_PID=$!
+            sleep 300 &
+            H_PID=$!
+            if declare -F stop_management_load >/dev/null; then
+                python3 - "$RUN_DIR/management-plane-load.jsonl" <<'PY' &
+            import signal
+            import sys
+            import time
+            def stop(_signum, _frame):
+                with open(sys.argv[1], "w", encoding="utf-8") as output:
+                    output.write('{"record":"summary","result":"clean_sigterm"}\\n')
+                raise SystemExit(0)
+            signal.signal(signal.SIGTERM, stop)
+            while True:
+                time.sleep(1)
+            PY
+                MANAGEMENT_LOAD_PID=$!
+            fi
+            printf '%s %s %s\\n' "$DAEMON_PID" "$H_PID" "$MANAGEMENT_LOAD_PID" >"$RUN_DIR/children"
+            if [[ $4 == normal ]]; then
+                printf '{}\\n' >"$RUN_DIR/verdict.json"
+                exit 0
+            fi
+            while :; do sleep 1; done
+            """))
+        script.chmod(0o755)
+        environment = os.environ | {
+            "RUSTBGPD_HOST_LOCK": str(directory / "host.lock"),
+        }
+        return script, port, environment
+
+    def start_stub(self, directory, runner, mode):
+        script, port, environment = self.write_stub(directory)
+        process = subprocess.Popen(
+            ["bash", str(script), str(HERE / runner), str(directory / "run"),
+             str(port), mode],
+            text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=environment,
+            start_new_session=True,
+        )
+        return process, port, environment, process.pid
+
+    def test_stop_targets_the_actual_runner_and_waits_for_cleanup(self):
+        for runner in RUNNERS:
+            with self.subTest(runner=runner), tempfile.TemporaryDirectory() as tmp:
+                directory = Path(tmp)
+                script, run_dir, port, environment = self.write_actual_main_stub(directory, runner)
+                outer = subprocess.Popen(
+                    ["bash", "-c", 'bash "$1" "$2" "$3" "$4" & sleep 300', "outer",
+                     str(script), str(HERE / runner), str(directory / "repo"), str(run_dir)],
+                    text=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    env=environment, start_new_session=True,
+                )
+                outer_pgid = os.getpgid(outer.pid)
+                try:
+                    identity = run_dir / "runner.identity"
+                    wait_for(identity)
+                    wait_for_children(run_dir / "children", 3 if runner.startswith("run-soak-rs") else 2)
+                    actual_pid = int(identity.read_text().split()[0])
+                    self.assertNotEqual(outer.pid, actual_pid)
+                    outer.terminate()
+                    outer.wait(timeout=5)
+                    self.assertTrue(process_alive(actual_pid))
+                    self.assertFalse((run_dir / "cleanup.complete").exists())
+
+                    result = subprocess.run(
+                        ["bash", str(LIFECYCLE), "stop", str(run_dir)],
+                        text=True, capture_output=True, check=False, timeout=25,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertFalse(process_alive(actual_pid))
+                    children = [int(pid) for pid in (run_dir / "children").read_text().split() if pid]
+                    self.assertTrue(all(not process_alive(pid) for pid in children))
+                    self.assertEqual(
+                        subprocess.run(
+                            ["flock", "-n", str(directory / "host.lock"), "true"],
+                            check=False,
+                        ).returncode,
+                        0,
+                    )
+                    with socket.socket() as listener:
+                        listener.bind(("127.0.0.1", port))
+                    if runner.startswith("run-soak-rs"):
+                        self.assertIn("clean_sigterm", (run_dir / "management-plane-load.jsonl").read_text())
+                    self.assertFalse((run_dir / "verdict.json").exists())
+                    self.assertIn(
+                        (run_dir / "cleanup.complete").read_text().splitlines()[0],
+                        {"status=interrupted", "status=failed"},
+                    )
+                    first_log = (run_dir / "soak.log").read_bytes()
+                    time.sleep(0.1)
+                    self.assertEqual((run_dir / "soak.log").read_bytes(), first_log)
+                finally:
+                    if (run_dir / "runner.identity").exists() and not (run_dir / "cleanup.complete").exists():
+                        subprocess.run(["bash", str(LIFECYCLE), "stop", str(run_dir)], check=False, timeout=15)
+                    try:
+                        os.killpg(outer_pgid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                    outer.wait(timeout=5)
+
+    def test_normal_exit_marks_cleanup_after_log_drain(self):
+        for runner in RUNNERS:
+            with self.subTest(runner=runner), tempfile.TemporaryDirectory() as tmp:
+                process, port, _environment, group = self.start_stub(Path(tmp), runner, "normal")
+                try:
+                    process.wait(timeout=10)
+                    run_dir = Path(tmp) / "run"
+                    self.assertEqual((run_dir / "cleanup.complete").read_text().splitlines()[0], "status=normal")
+                    self.assertTrue((run_dir / "verdict.json").exists())
+                    with socket.socket() as listener:
+                        listener.bind(("127.0.0.1", port))
+                finally:
+                    terminate_group(group, process)
+
+    def test_failed_tee_refuses_a_quiesced_cleanup_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            fake_bin = directory / "bin"
+            fake_bin.mkdir()
+            tee = fake_bin / "tee"
+            tee.write_text("#!/usr/bin/env bash\ncat >/dev/null\nexit 1\n")
+            tee.chmod(0o755)
+            script, port, environment = self.write_stub(directory)
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+            process = subprocess.Popen(
+                ["bash", str(script), str(HERE / "run-soak-rs-flagship.sh"),
+                 str(directory / "run"), str(port), "normal"],
+                text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=environment,
+                start_new_session=True,
+            )
+            try:
+                process.wait(timeout=10)
+                marker = (directory / "run" / "cleanup.complete").read_text()
+                self.assertEqual(process.returncode, 1)
+                self.assertIn("status=log_write_failed", marker)
+                self.assertIn("exit_status=1", marker)
+                self.assertNotEqual(
+                    subprocess.run(
+                        ["bash", "-c", 'source "$1"; flagship_cleanup_drained "$2"',
+                         "lifecycle", str(LIFECYCLE), str(directory / "run")],
+                        check=False,
+                    ).returncode,
+                    0,
+                )
+            finally:
+                terminate_group(process.pid, process)
+
+    def test_stale_identity_refuses_to_signal_an_unrelated_process(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            run_dir.mkdir()
+            unrelated = subprocess.Popen(["sleep", "30"])
+            try:
+                start = subprocess.check_output(
+                    ["bash", "-c", 'source "$1"; flagship_proc_start_ticks "$2"',
+                     "lifecycle", str(LIFECYCLE), str(unrelated.pid)], text=True,
+                ).strip()
+                boot = Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+                (run_dir / "runner.identity").write_text(
+                    f"{unrelated.pid} {boot} {int(start) + 1}\n"
+                )
+                result = subprocess.run(
+                    ["bash", str(LIFECYCLE), "stop", str(run_dir)],
+                    text=True, capture_output=True, check=False,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertTrue(process_alive(unrelated.pid))
+            finally:
+                unrelated.terminate()
+                unrelated.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Flagship soak runs now record the actual runner identity, stop that verified process, and publish cleanup completion only after owned processes and `soak.log` have drained. The runners preserve `SIGINT` 130 and `SIGTERM` 143 exits, and avoid a Bash 5.2 trap parsing failure during multi-substitution CSV emission.

The lifecycle test covers a terminated outer wrapper, stale identity rejection, writer failure, a slow writer receiving repeated TERM, lock release, child cleanup, and stable artifacts. The README describes the verified stop and archive procedure.

Validation:

- `python3 -m unittest -v tests/soak/test_flagship_lifecycle.py`
- 10 staggered repeats of the actual-main stop contract for both RS and RR runners
- `python3 -m unittest -v tests/soak/test_management_plane_load.py`
- `python3 -m unittest -v tests/soak/test_analyze_soak_rs_flagship.py tests/soak/test_analyze_soak_rr_flagship.py`
- `shellcheck -x tests/soak/flagship-lifecycle.sh tests/soak/run-soak-rs-flagship.sh tests/soak/run-soak-rr-flagship.sh`
- `just links`

The interrupted real-main path is exercised with local fixture binaries. The normal lifecycle case uses the sourceable helper stub; runtime acceptance gates remain unchanged.
